### PR TITLE
Refactor/eventbus

### DIFF
--- a/.cursor/rules/main-render-ipc.mdc
+++ b/.cursor/rules/main-render-ipc.mdc
@@ -11,22 +11,4 @@ The IPC in the renderer process is implemented in [usePresenter.ts](mdc:src/rend
 
 The IPC messages from the main process to notify the view mainly rely on the EventBus [index.ts](mdc:src/main/presenter/index.ts) to listen for events that need to be notified and then send them to the renderer through the mainWindow.
 
-## Event flow diagram
 
-```
-BaseLLMProvider                ConfigPresenter                  Presenter(Main)                  Settings(Renderer)
-     |                              |                                 |                                |
-     |--- model:list-updated ------>|                                 |                                |
-     |                              |--- config:model-list-changed--->|                                |
-     |                              |                                 |--- config:model-list-changed-->|
-     |                              |                                 |                                |--- refreshProviderModels()
-     |                              |                                 |                                |
-     |--- model:status-changed----->|                                 |                                |
-     |                              |--- model:status-changed-------->|                                |
-     |                              |                                 |--- model:status-changed------->|
-     |                              |                                 |                                |--- updateLocalModelStatus()
-     |                              |                                 |                                |
-     |                              |--- config:provider-changed----->|                                |
-     |                              |                                 |--- config:provider-changed---->|
-     |                              |                                 |                                |--- refreshAllModels()
-```

--- a/.cursor/rules/main-render-ipc.mdc
+++ b/.cursor/rules/main-render-ipc.mdc
@@ -1,6 +1,7 @@
 ---
 description: explain the IPC communication event mechanism between the main and renderer process of this electron project.
 globs: src/main/presenter/**/*.ts,src/renderer/stores/**/*.ts,src/shared/*.d.ts
+alwaysApply: false
 ---
 This is an Electron project. The renderer process is mainly used for UI rendering, while the main process is primarily responsible for data and logic processing. The shared/*.d.ts is used to define the types of objects exposed by the main process to the renderer process.
 
@@ -9,3 +10,23 @@ The IPC in the renderer process is implemented in [usePresenter.ts](mdc:src/rend
 [eventbus.ts](mdc:src/main/eventbus.ts)  is primarily used for intercommunication between main processes and decouples modules with events.
 
 The IPC messages from the main process to notify the view mainly rely on the EventBus [index.ts](mdc:src/main/presenter/index.ts) to listen for events that need to be notified and then send them to the renderer through the mainWindow.
+
+## Event flow diagram
+
+```
+BaseLLMProvider                ConfigPresenter                  Presenter(Main)                  Settings(Renderer)
+     |                              |                                 |                                |
+     |--- model:list-updated ------>|                                 |                                |
+     |                              |--- config:model-list-changed--->|                                |
+     |                              |                                 |--- config:model-list-changed-->|
+     |                              |                                 |                                |--- refreshProviderModels()
+     |                              |                                 |                                |
+     |--- model:status-changed----->|                                 |                                |
+     |                              |--- model:status-changed-------->|                                |
+     |                              |                                 |--- model:status-changed------->|
+     |                              |                                 |                                |--- updateLocalModelStatus()
+     |                              |                                 |                                |
+     |                              |--- config:provider-changed----->|                                |
+     |                              |                                 |--- config:provider-changed---->|
+     |                              |                                 |                                |--- refreshAllModels()
+```

--- a/docs/event-system-design.md
+++ b/docs/event-system-design.md
@@ -22,8 +22,7 @@
    - `config:model-list-changed`：配置中的模型列表变更
 
 2. **模型相关事件**：
-   - `model:list-updated`：模型列表更新（替代provider-models-updated）
-   - `model:status-changed`：模型状态变更
+   全部去掉，模型状态和名称事件都有config来发起,和上层settings保持语义一致
 
 3. **会话相关事件**：
    - `conversation:created`
@@ -75,31 +74,19 @@ BaseLLMProvider                ConfigPresenter                  Presenter(Main) 
 ### 重构后的事件流
 
 ```
-BaseLLMProvider                ConfigPresenter                  Presenter(Main)                  Settings(Renderer)
-     |                              |                                 |                                |
-     |--- model:list-updated ------>|                                 |                                |
-     |                              |--- config:model-list-changed--->|                                |
-     |                              |                                 |--- config:model-list-changed-->|
-     |                              |                                 |                                |--- refreshProviderModels()
-     |                              |                                 |                                |
-     |--- model:status-changed----->|                                 |                                |
-     |                              |--- model:status-changed-------->|                                |
-     |                              |                                 |--- model:status-changed------->|
-     |                              |                                 |                                |--- updateLocalModelStatus()
-     |                              |                                 |                                |
-     |                              |--- config:provider-changed----->|                                |
-     |                              |                                 |--- config:provider-changed---->|
-     |                              |                                 |                                |--- refreshAllModels()
+ConfigPresenter                  Presenter(Main)                  Settings(Renderer)
+     |                                 |                                |
+     |                                |
+     |--- config:model-list-changed--->|                                |
+     |                                 |--- config:model-list-changed-->|
+     |                                 |                                |--- refreshProviderModels()
+     |                                 |                                |
+     |                                 |                                |
+     |--- model:status-changed-------->|                                |
+     |                                 |--- model:status-changed------->|
+     |                                 |                                |--- updateLocalModelStatus()
+     |                                 |                                |
+     |--- config:provider-changed----->|                                |
+     |                                 |--- config:provider-changed---->|
+     |                                 |                                |--- refreshAllModels()
 ```
-
-## 实施计划
-
-1. 创建事件常量文件（`src/main/events.ts`），定义所有事件名称
-2. 更新 BaseLLMProvider 中的事件名称
-3. 更新 ConfigPresenter 中的事件名称
-4. 更新主进程 Presenter 中的事件监听和转发
-5. 更新渲染进程中的事件监听
-
-## 兼容性考虑
-
-为确保平滑迁移，可以在一段时间内同时支持新旧事件名称，通过同时触发两个事件来实现向后兼容。随着代码库的更新，可以逐步移除对旧事件的支持。

--- a/docs/event-system-design.md
+++ b/docs/event-system-design.md
@@ -45,7 +45,7 @@
 明确每个组件的事件触发责任：
 
 - **ConfigPresenter**：仅负责配置相关事件
-- **BaseLLMProvider**：仅负责模型操作相关事件
+- **BaseLLMProvider**：仅负责模型操作,不发起事件
 - **ThreadPresenter**：仅负责会话相关事件
 - **UpgradePresenter**：仅负责应用更新相关事件
 

--- a/docs/event-system-design.md
+++ b/docs/event-system-design.md
@@ -1,0 +1,105 @@
+# 事件系统设计文档
+
+## 问题背景
+
+当前项目中的`provider-models-updated`事件存在混乱的情况，这个事件同时由两个不同的来源触发：
+
+1. **BaseLLMProvider**: 在处理模型时触发（如`addCustomModel`, `removeCustomModel`等方法）
+2. **ConfigPresenter**: 在配置更改时触发（如`addCustomModel`, `removeCustomModel`等方法）
+
+这种设计导致了多种问题：
+- 事件循环触发（导致死循环问题）
+- 事件语义不清晰（同一事件表示不同的业务含义）
+- 代码耦合度高且难以维护
+
+## 事件分类与命名规范
+
+将事件按功能领域分类，并采用统一的命名规范：
+
+1. **配置相关事件**：
+   - `config:provider-changed`：提供者配置变更
+   - `config:system-changed`：系统配置变更
+   - `config:model-list-changed`：配置中的模型列表变更
+
+2. **模型相关事件**：
+   - `model:list-updated`：模型列表更新（替代provider-models-updated）
+   - `model:status-changed`：模型状态变更
+
+3. **会话相关事件**：
+   - `conversation:created`
+   - `conversation:activated`
+   - `conversation:cleared`
+
+4. **通信相关事件**：
+   - `stream:response`
+   - `stream:end`
+   - `stream:error`
+
+5. **应用更新相关事件**：
+   - `update:status-changed`
+   - `update:progress`
+   - `update:error`
+   - `update:will-restart`
+
+## 责任分离
+
+明确每个组件的事件触发责任：
+
+- **ConfigPresenter**：仅负责配置相关事件
+- **BaseLLMProvider**：仅负责模型操作相关事件
+- **ThreadPresenter**：仅负责会话相关事件
+- **UpgradePresenter**：仅负责应用更新相关事件
+
+## 事件流时序图
+
+### 当前事件流
+
+```
+BaseLLMProvider                ConfigPresenter                  Presenter(Main)                  Settings(Renderer)
+     |                              |                                 |                                |
+     |--- provider-models-updated-->|                                 |                                |
+     |                              |--- provider-models-updated----->|                                |
+     |                              |                                 |--- provider-models-updated---->|
+     |                              |                                 |                                |--- refreshProviderModels()
+     |                              |                                 |                                |
+     |--- model-status-changed----->|                                 |                                |
+     |                              |--- model-status-changed-------->|                                |
+     |                              |                                 |--- model-status-changed------->|
+     |                              |                                 |                                |--- updateLocalModelStatus()
+     |                              |                                 |                                |
+     |                              |--- provider-setting-changed---->|                                |
+     |                              |                                 |--- provider-setting-changed--->|
+     |                              |                                 |                                |--- refreshAllModels()
+```
+
+### 重构后的事件流
+
+```
+BaseLLMProvider                ConfigPresenter                  Presenter(Main)                  Settings(Renderer)
+     |                              |                                 |                                |
+     |--- model:list-updated ------>|                                 |                                |
+     |                              |--- config:model-list-changed--->|                                |
+     |                              |                                 |--- config:model-list-changed-->|
+     |                              |                                 |                                |--- refreshProviderModels()
+     |                              |                                 |                                |
+     |--- model:status-changed----->|                                 |                                |
+     |                              |--- model:status-changed-------->|                                |
+     |                              |                                 |--- model:status-changed------->|
+     |                              |                                 |                                |--- updateLocalModelStatus()
+     |                              |                                 |                                |
+     |                              |--- config:provider-changed----->|                                |
+     |                              |                                 |--- config:provider-changed---->|
+     |                              |                                 |                                |--- refreshAllModels()
+```
+
+## 实施计划
+
+1. 创建事件常量文件（`src/main/events.ts`），定义所有事件名称
+2. 更新 BaseLLMProvider 中的事件名称
+3. 更新 ConfigPresenter 中的事件名称
+4. 更新主进程 Presenter 中的事件监听和转发
+5. 更新渲染进程中的事件监听
+
+## 兼容性考虑
+
+为确保平滑迁移，可以在一段时间内同时支持新旧事件名称，通过同时触发两个事件来实现向后兼容。随着代码库的更新，可以逐步移除对旧事件的支持。

--- a/src/main/events.ts
+++ b/src/main/events.ts
@@ -1,0 +1,60 @@
+/**
+ * 事件系统常量定义
+ *
+ * 按功能领域分类事件名，采用统一的命名规范：
+ * - 使用冒号分隔域和具体事件
+ * - 使用小写并用连字符连接多个单词
+ */
+
+// 配置相关事件
+export const CONFIG_EVENTS = {
+  PROVIDER_CHANGED: 'config:provider-changed', // 替代 provider-setting-changed
+  SYSTEM_CHANGED: 'config:system-changed',
+  MODEL_LIST_CHANGED: 'config:model-list-changed' // 替代 provider-models-updated（ConfigPresenter）
+}
+
+// 模型相关事件
+export const MODEL_EVENTS = {
+  LIST_UPDATED: 'model:list-updated', // 替代 provider-models-updated（BaseLLMProvider）
+  STATUS_CHANGED: 'model:status-changed' // 替代 model-status-changed
+}
+
+// 会话相关事件
+export const CONVERSATION_EVENTS = {
+  CREATED: 'conversation:created',
+  ACTIVATED: 'conversation:activated', // 替代 conversation-activated
+  CLEARED: 'conversation:cleared', // 替代 active-conversation-cleared
+  MESSAGE_EDITED: 'conversation:message-edited' // 替代 message-edited
+}
+
+// 通信相关事件
+export const STREAM_EVENTS = {
+  RESPONSE: 'stream:response', // 替代 stream-response
+  END: 'stream:end', // 替代 stream-end
+  ERROR: 'stream:error' // 替代 stream-error
+}
+
+// 应用更新相关事件
+export const UPDATE_EVENTS = {
+  STATUS_CHANGED: 'update:status-changed', // 替代 update-status-changed
+  PROGRESS: 'update:progress', // 替代 update-progress
+  ERROR: 'update:error', // 替代 update-error
+  WILL_RESTART: 'update:will-restart' // 替代 update-will-restart
+}
+
+// 窗口相关事件
+export const WINDOW_EVENTS = {
+  READY_TO_SHOW: 'window:ready-to-show' // 替代 main-window-ready-to-show
+}
+
+// 旧事件名称 - 用于兼容性
+export const LEGACY_EVENTS = {
+  PROVIDER_SETTING_CHANGED: 'provider-setting-changed',
+  PROVIDER_MODELS_UPDATED: 'provider-models-updated',
+  MODEL_STATUS_CHANGED: 'model-status-changed',
+  CONVERSATION_ACTIVATED: 'conversation-activated',
+  ACTIVE_CONVERSATION_CLEARED: 'active-conversation-cleared',
+  UPDATE_STATUS_CHANGED: 'update-status-changed',
+  MAIN_WINDOW_READY_TO_SHOW: 'main-window-ready-to-show',
+  MESSAGE_EDITED: 'message-edited'
+}

--- a/src/main/events.ts
+++ b/src/main/events.ts
@@ -14,12 +14,6 @@ export const CONFIG_EVENTS = {
   MODEL_STATUS_CHANGED: 'config:model-status-changed' // 替代 model-status-changed（ConfigPresenter）
 }
 
-// 模型相关事件
-export const MODEL_EVENTS = {
-  LIST_UPDATED: 'model:list-updated', // 替代 provider-models-updated（BaseLLMProvider）
-  STATUS_CHANGED: 'model:status-changed' // 替代 model-status-changed
-}
-
 // 会话相关事件
 export const CONVERSATION_EVENTS = {
   CREATED: 'conversation:created',

--- a/src/main/events.ts
+++ b/src/main/events.ts
@@ -23,7 +23,7 @@ export const MODEL_EVENTS = {
 export const CONVERSATION_EVENTS = {
   CREATED: 'conversation:created',
   ACTIVATED: 'conversation:activated', // 替代 conversation-activated
-  CLEARED: 'conversation:cleared', // 替代 active-conversation-cleared
+  DEACTIVATED: 'conversation:deactivated', // 替代 active-conversation-cleared
   MESSAGE_EDITED: 'conversation:message-edited' // 替代 message-edited
 }
 
@@ -39,7 +39,8 @@ export const UPDATE_EVENTS = {
   STATUS_CHANGED: 'update:status-changed', // 替代 update-status-changed
   PROGRESS: 'update:progress', // 替代 update-progress
   ERROR: 'update:error', // 替代 update-error
-  WILL_RESTART: 'update:will-restart' // 替代 update-will-restart
+  WILL_RESTART: 'update:will-restart', // 替代 update-will-restart
+  FORCE_QUIT_APP: 'update:force-quit-app' // 替代 force-quit-app
 }
 
 // 窗口相关事件
@@ -51,10 +52,5 @@ export const WINDOW_EVENTS = {
 export const LEGACY_EVENTS = {
   PROVIDER_SETTING_CHANGED: 'provider-setting-changed',
   PROVIDER_MODELS_UPDATED: 'provider-models-updated',
-  MODEL_STATUS_CHANGED: 'model-status-changed',
-  CONVERSATION_ACTIVATED: 'conversation-activated',
-  ACTIVE_CONVERSATION_CLEARED: 'active-conversation-cleared',
-  UPDATE_STATUS_CHANGED: 'update-status-changed',
-  MAIN_WINDOW_READY_TO_SHOW: 'main-window-ready-to-show',
-  MESSAGE_EDITED: 'message-edited'
+  MODEL_STATUS_CHANGED: 'model-status-changed'
 }

--- a/src/main/events.ts
+++ b/src/main/events.ts
@@ -10,7 +10,8 @@
 export const CONFIG_EVENTS = {
   PROVIDER_CHANGED: 'config:provider-changed', // 替代 provider-setting-changed
   SYSTEM_CHANGED: 'config:system-changed',
-  MODEL_LIST_CHANGED: 'config:model-list-changed' // 替代 provider-models-updated（ConfigPresenter）
+  MODEL_LIST_CHANGED: 'config:model-list-changed', // 替代 provider-models-updated（ConfigPresenter）
+  MODEL_STATUS_CHANGED: 'config:model-status-changed' // 替代 model-status-changed（ConfigPresenter）
 }
 
 // 模型相关事件
@@ -46,11 +47,4 @@ export const UPDATE_EVENTS = {
 // 窗口相关事件
 export const WINDOW_EVENTS = {
   READY_TO_SHOW: 'window:ready-to-show' // 替代 main-window-ready-to-show
-}
-
-// 旧事件名称 - 用于兼容性
-export const LEGACY_EVENTS = {
-  PROVIDER_SETTING_CHANGED: 'provider-setting-changed',
-  PROVIDER_MODELS_UPDATED: 'provider-models-updated',
-  MODEL_STATUS_CHANGED: 'model-status-changed'
 }

--- a/src/main/presenter/configPresenter/index.ts
+++ b/src/main/presenter/configPresenter/index.ts
@@ -6,7 +6,7 @@ import { getModelConfig } from '../llmProviderPresenter/modelConfigs'
 import path from 'path'
 import { app } from 'electron'
 import fs from 'fs'
-import { CONFIG_EVENTS, LEGACY_EVENTS } from '@/events'
+import { CONFIG_EVENTS } from '@/events'
 
 // 定义应用设置的接口
 interface IAppSettings {

--- a/src/main/presenter/configPresenter/index.ts
+++ b/src/main/presenter/configPresenter/index.ts
@@ -149,8 +149,6 @@ export class ConfigPresenter implements IConfigPresenter {
     this.setSetting<LLM_PROVIDER[]>(PROVIDERS_STORE_KEY, providers)
     // 触发新事件
     eventBus.emit(CONFIG_EVENTS.PROVIDER_CHANGED)
-    // 兼容旧事件
-    eventBus.emit(LEGACY_EVENTS.PROVIDER_SETTING_CHANGED)
   }
 
   getProviderById(id: string): LLM_PROVIDER | undefined {
@@ -230,8 +228,6 @@ export class ConfigPresenter implements IConfigPresenter {
     this.setCustomModels(providerId, models)
     // 触发新事件
     eventBus.emit(CONFIG_EVENTS.MODEL_LIST_CHANGED, providerId)
-    // 兼容旧事件
-    eventBus.emit(LEGACY_EVENTS.PROVIDER_MODELS_UPDATED, providerId)
   }
 
   removeCustomModel(providerId: string, modelId: string): void {
@@ -240,8 +236,6 @@ export class ConfigPresenter implements IConfigPresenter {
     this.setCustomModels(providerId, filteredModels)
     // 触发新事件
     eventBus.emit(CONFIG_EVENTS.MODEL_LIST_CHANGED, providerId)
-    // 兼容旧事件
-    eventBus.emit(LEGACY_EVENTS.PROVIDER_MODELS_UPDATED, providerId)
   }
 
   updateCustomModel(providerId: string, modelId: string, updates: Partial<MODEL_META>): void {
@@ -256,15 +250,13 @@ export class ConfigPresenter implements IConfigPresenter {
         models[index].enabled = updates.enabled as boolean
         this.setCustomModels(providerId, models)
         // 只有enable状态更改时使用model-status-changed事件
-        eventBus.emit(LEGACY_EVENTS.MODEL_STATUS_CHANGED, providerId, modelId, updates.enabled)
+        eventBus.emit(CONFIG_EVENTS.MODEL_STATUS_CHANGED, providerId, modelId, updates.enabled)
       } else {
         // 其他属性变更使用provider-models-updated事件
         Object.assign(models[index], updates)
         this.setCustomModels(providerId, models)
         // 触发新事件
         eventBus.emit(CONFIG_EVENTS.MODEL_LIST_CHANGED, providerId)
-        // 兼容旧事件
-        eventBus.emit(LEGACY_EVENTS.PROVIDER_MODELS_UPDATED, providerId)
       }
     }
   }

--- a/src/main/presenter/configPresenter/index.ts
+++ b/src/main/presenter/configPresenter/index.ts
@@ -3,6 +3,10 @@ import { IConfigPresenter, LLM_PROVIDER, MODEL_META } from '@shared/presenter'
 import ElectronStore from 'electron-store'
 import { DEFAULT_PROVIDERS } from './providers'
 import { getModelConfig } from '../llmProviderPresenter/modelConfigs'
+import path from 'path'
+import { app } from 'electron'
+import fs from 'fs'
+import { CONFIG_EVENTS, LEGACY_EVENTS } from '@/events'
 
 // 定义应用设置的接口
 interface IAppSettings {
@@ -10,6 +14,13 @@ interface IAppSettings {
   language: string
   providers: LLM_PROVIDER[]
   closeToQuit: boolean // 是否点击关闭按钮时退出程序
+  [key: string]: unknown // 允许任意键，使用unknown类型替代any
+}
+
+// 为模型存储创建接口
+interface IModelStore {
+  models: MODEL_META[]
+  custom_models: MODEL_META[]
 }
 
 const defaultProviders = DEFAULT_PROVIDERS.map((provider) => ({
@@ -24,15 +35,22 @@ const defaultProviders = DEFAULT_PROVIDERS.map((provider) => ({
 // 定义 storeKey 常量
 const PROVIDERS_STORE_KEY = 'providers'
 const CUSTOM_MODELS_KEY = 'custom_models'
+const PROVIDER_MODELS_DIR = 'provider_models'
 
 export class ConfigPresenter implements IConfigPresenter {
   private store: ElectronStore<IAppSettings>
+  private providersModelStores: Map<string, ElectronStore<IModelStore>> = new Map()
+  private userDataPath: string
 
   constructor() {
     this.store = new ElectronStore<IAppSettings>({
       name: 'app-settings',
       watch: true
     })
+
+    this.userDataPath = app.getPath('userData')
+    this.initProviderModelsDir()
+
     const existingProviders = this.getSetting<LLM_PROVIDER[]>(PROVIDERS_STORE_KEY) || []
     const newProviders = defaultProviders.filter(
       (defaultProvider) =>
@@ -41,6 +59,62 @@ export class ConfigPresenter implements IConfigPresenter {
 
     if (newProviders.length > 0) {
       this.setProviders([...existingProviders, ...newProviders])
+    }
+
+    // 迁移旧的模型数据
+    this.migrateModelData()
+  }
+
+  private initProviderModelsDir(): void {
+    const modelsDir = path.join(this.userDataPath, PROVIDER_MODELS_DIR)
+    if (!fs.existsSync(modelsDir)) {
+      fs.mkdirSync(modelsDir, { recursive: true })
+    }
+  }
+
+  private getProviderModelStore(providerId: string): ElectronStore<IModelStore> {
+    if (!this.providersModelStores.has(providerId)) {
+      const store = new ElectronStore<IModelStore>({
+        name: `models_${providerId}`,
+        cwd: path.join(this.userDataPath, PROVIDER_MODELS_DIR),
+        defaults: {
+          models: [],
+          custom_models: []
+        }
+      })
+      this.providersModelStores.set(providerId, store)
+    }
+    return this.providersModelStores.get(providerId)!
+  }
+
+  private migrateModelData(): void {
+    // 迁移旧的模型数据
+    const providers = this.getProviders()
+
+    for (const provider of providers) {
+      // 迁移provider模型
+      const oldProviderModelsKey = `${provider.id}_models`
+      const oldModels = this.getSetting<MODEL_META[]>(oldProviderModelsKey)
+
+      if (oldModels && oldModels.length > 0) {
+        const store = this.getProviderModelStore(provider.id)
+        // 保存模型列表到新存储
+        store.set('models', oldModels)
+        // 清除旧存储
+        this.store.delete(oldProviderModelsKey)
+      }
+
+      // 迁移custom模型
+      const oldCustomModelsKey = `${CUSTOM_MODELS_KEY}_${provider.id}`
+      const oldCustomModels = this.getSetting<MODEL_META[]>(oldCustomModelsKey)
+
+      if (oldCustomModels && oldCustomModels.length > 0) {
+        const store = this.getProviderModelStore(provider.id)
+        // 保存自定义模型列表到新存储
+        store.set('custom_models', oldCustomModels)
+        // 清除旧存储
+        this.store.delete(oldCustomModelsKey)
+      }
     }
   }
 
@@ -73,7 +147,10 @@ export class ConfigPresenter implements IConfigPresenter {
 
   setProviders(providers: LLM_PROVIDER[]): void {
     this.setSetting<LLM_PROVIDER[]>(PROVIDERS_STORE_KEY, providers)
-    eventBus.emit('provider-setting-changed')
+    // 触发新事件
+    eventBus.emit(CONFIG_EVENTS.PROVIDER_CHANGED)
+    // 兼容旧事件
+    eventBus.emit(LEGACY_EVENTS.PROVIDER_SETTING_CHANGED)
   }
 
   getProviderById(id: string): LLM_PROVIDER | undefined {
@@ -93,8 +170,9 @@ export class ConfigPresenter implements IConfigPresenter {
   }
 
   getProviderModels(providerId: string): MODEL_META[] {
-    const key = `${providerId}_models`
-    let models = this.getSetting<MODEL_META[]>(key) || []
+    const store = this.getProviderModelStore(providerId)
+    let models = store.get('models') || []
+
     models = models.map((model) => {
       const config = getModelConfig(model.id)
       if (config) {
@@ -107,8 +185,8 @@ export class ConfigPresenter implements IConfigPresenter {
   }
 
   setProviderModels(providerId: string, models: MODEL_META[]): void {
-    const key = `${providerId}_models`
-    this.setSetting(key, models)
+    const store = this.getProviderModelStore(providerId)
+    store.set('models', models)
   }
 
   getEnabledProviders(): LLM_PROVIDER[] {
@@ -130,13 +208,13 @@ export class ConfigPresenter implements IConfigPresenter {
   }
 
   getCustomModels(providerId: string): MODEL_META[] {
-    const key = `${CUSTOM_MODELS_KEY}_${providerId}`
-    return this.getSetting<MODEL_META[]>(key) || []
+    const store = this.getProviderModelStore(providerId)
+    return store.get('custom_models') || []
   }
 
   setCustomModels(providerId: string, models: MODEL_META[]): void {
-    const key = `${CUSTOM_MODELS_KEY}_${providerId}`
-    this.setSetting(key, models)
+    const store = this.getProviderModelStore(providerId)
+    store.set('custom_models', models)
   }
 
   addCustomModel(providerId: string, model: MODEL_META): void {
@@ -150,21 +228,44 @@ export class ConfigPresenter implements IConfigPresenter {
     }
 
     this.setCustomModels(providerId, models)
+    // 触发新事件
+    eventBus.emit(CONFIG_EVENTS.MODEL_LIST_CHANGED, providerId)
+    // 兼容旧事件
+    eventBus.emit(LEGACY_EVENTS.PROVIDER_MODELS_UPDATED, providerId)
   }
 
   removeCustomModel(providerId: string, modelId: string): void {
     const models = this.getCustomModels(providerId)
-    const filteredModels = models.filter((m) => m.id !== modelId)
+    const filteredModels = models.filter((model) => model.id !== modelId)
     this.setCustomModels(providerId, filteredModels)
+    // 触发新事件
+    eventBus.emit(CONFIG_EVENTS.MODEL_LIST_CHANGED, providerId)
+    // 兼容旧事件
+    eventBus.emit(LEGACY_EVENTS.PROVIDER_MODELS_UPDATED, providerId)
   }
 
   updateCustomModel(providerId: string, modelId: string, updates: Partial<MODEL_META>): void {
     const models = this.getCustomModels(providerId)
-    const modelIndex = models.findIndex((m) => m.id === modelId)
-
-    if (modelIndex !== -1) {
-      models[modelIndex] = { ...models[modelIndex], ...updates }
-      this.setCustomModels(providerId, models)
+    const index = models.findIndex((model) => model.id === modelId)
+    if (index !== -1) {
+      // 检查更新是否仅包含enabled属性
+      if (
+        Object.keys(updates).length === 1 &&
+        Object.prototype.hasOwnProperty.call(updates, 'enabled')
+      ) {
+        models[index].enabled = updates.enabled as boolean
+        this.setCustomModels(providerId, models)
+        // 只有enable状态更改时使用model-status-changed事件
+        eventBus.emit(LEGACY_EVENTS.MODEL_STATUS_CHANGED, providerId, modelId, updates.enabled)
+      } else {
+        // 其他属性变更使用provider-models-updated事件
+        Object.assign(models[index], updates)
+        this.setCustomModels(providerId, models)
+        // 触发新事件
+        eventBus.emit(CONFIG_EVENTS.MODEL_LIST_CHANGED, providerId)
+        // 兼容旧事件
+        eventBus.emit(LEGACY_EVENTS.PROVIDER_MODELS_UPDATED, providerId)
+      }
     }
   }
 

--- a/src/main/presenter/configPresenter/index.ts
+++ b/src/main/presenter/configPresenter/index.ts
@@ -34,7 +34,7 @@ const defaultProviders = DEFAULT_PROVIDERS.map((provider) => ({
 
 // 定义 storeKey 常量
 const PROVIDERS_STORE_KEY = 'providers'
-const CUSTOM_MODELS_KEY = 'custom_models'
+
 const PROVIDER_MODELS_DIR = 'provider_models'
 // 模型状态键前缀
 const MODEL_STATUS_KEY_PREFIX = 'model_status_'
@@ -107,7 +107,7 @@ export class ConfigPresenter implements IConfigPresenter {
       }
 
       // 迁移custom模型
-      const oldCustomModelsKey = `${CUSTOM_MODELS_KEY}_${provider.id}`
+      const oldCustomModelsKey = `custom_models_${provider.id}`
       const oldCustomModels = this.getSetting<MODEL_META[]>(oldCustomModelsKey)
 
       if (oldCustomModels && oldCustomModels.length > 0) {

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -13,7 +13,6 @@ import { DevicePresenter } from './devicePresenter'
 import { UpgradePresenter } from './upgradePresenter'
 import {
   CONFIG_EVENTS,
-  MODEL_EVENTS,
   CONVERSATION_EVENTS,
   STREAM_EVENTS,
   WINDOW_EVENTS,
@@ -82,11 +81,6 @@ export class Presenter implements IPresenter {
       this.windowPresenter.mainWindow?.webContents.send(CONVERSATION_EVENTS.DEACTIVATED, msg)
     })
 
-    // 模型相关事件
-    eventBus.on(MODEL_EVENTS.LIST_UPDATED, (providerId: string) => {
-      // 当模型列表更新时，直接转发事件到渲染进程，并附带providerId参数
-      this.windowPresenter.mainWindow?.webContents.send(MODEL_EVENTS.LIST_UPDATED, providerId)
-    })
     // 处理从ConfigPresenter过来的模型列表更新事件
     eventBus.on(CONFIG_EVENTS.MODEL_LIST_CHANGED, (providerId: string) => {
       // 转发事件到渲染进程
@@ -97,9 +91,9 @@ export class Presenter implements IPresenter {
     })
 
     eventBus.on(
-      MODEL_EVENTS.STATUS_CHANGED,
+      CONFIG_EVENTS.MODEL_STATUS_CHANGED,
       (providerId: string, modelId: string, enabled: boolean) => {
-        this.windowPresenter.mainWindow?.webContents.send(MODEL_EVENTS.STATUS_CHANGED, {
+        this.windowPresenter.mainWindow?.webContents.send(CONFIG_EVENTS.MODEL_STATUS_CHANGED, {
           providerId,
           modelId,
           enabled
@@ -136,6 +130,7 @@ export class Presenter implements IPresenter {
     for (const provider of providers) {
       if (provider.enable) {
         const customModels = this.configPresenter.getCustomModels(provider.id)
+        console.log('syncCustomModels', provider.id, customModels)
         for (const model of customModels) {
           await this.llmproviderPresenter.addCustomModel(provider.id, {
             id: model.id,

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -34,7 +34,7 @@ export class Presenter implements IPresenter {
   constructor() {
     this.configPresenter = new ConfigPresenter()
     this.windowPresenter = new WindowPresenter(this.configPresenter)
-    this.llmproviderPresenter = new LLMProviderPresenter()
+    this.llmproviderPresenter = new LLMProviderPresenter(this.configPresenter)
     this.devicePresenter = new DevicePresenter()
     // 初始化 SQLite 数据库
     const dbDir = path.join(app.getPath('userData'), 'app_db')
@@ -140,7 +140,6 @@ export class Presenter implements IPresenter {
           await this.llmproviderPresenter.addCustomModel(provider.id, {
             id: model.id,
             name: model.name,
-            enabled: model.enabled,
             contextLength: model.contextLength,
             maxTokens: model.maxTokens
           })

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -52,10 +52,6 @@ export class Presenter implements IPresenter {
     eventBus.on(WINDOW_EVENTS.READY_TO_SHOW, () => {
       this.init()
     })
-    // 兼容旧事件
-    eventBus.on(LEGACY_EVENTS.MAIN_WINDOW_READY_TO_SHOW, () => {
-      this.init()
-    })
 
     // 配置相关事件
     eventBus.on(CONFIG_EVENTS.PROVIDER_CHANGED, () => {
@@ -89,28 +85,10 @@ export class Presenter implements IPresenter {
     // 会话相关事件
     eventBus.on(CONVERSATION_EVENTS.ACTIVATED, (msg) => {
       this.windowPresenter.mainWindow?.webContents.send(CONVERSATION_EVENTS.ACTIVATED, msg)
-      // 兼容旧事件
-      this.windowPresenter.mainWindow?.webContents.send(LEGACY_EVENTS.CONVERSATION_ACTIVATED, msg)
-    })
-    // 兼容旧事件
-    eventBus.on(LEGACY_EVENTS.CONVERSATION_ACTIVATED, (msg) => {
-      this.windowPresenter.mainWindow?.webContents.send(LEGACY_EVENTS.CONVERSATION_ACTIVATED, msg)
     })
 
-    eventBus.on(CONVERSATION_EVENTS.CLEARED, (msg) => {
-      this.windowPresenter.mainWindow?.webContents.send(CONVERSATION_EVENTS.CLEARED, msg)
-      // 兼容旧事件
-      this.windowPresenter.mainWindow?.webContents.send(
-        LEGACY_EVENTS.ACTIVE_CONVERSATION_CLEARED,
-        msg
-      )
-    })
-    // 兼容旧事件
-    eventBus.on(LEGACY_EVENTS.ACTIVE_CONVERSATION_CLEARED, (msg) => {
-      this.windowPresenter.mainWindow?.webContents.send(
-        LEGACY_EVENTS.ACTIVE_CONVERSATION_CLEARED,
-        msg
-      )
+    eventBus.on(CONVERSATION_EVENTS.DEACTIVATED, (msg) => {
+      this.windowPresenter.mainWindow?.webContents.send(CONVERSATION_EVENTS.DEACTIVATED, msg)
     })
 
     // 模型相关事件
@@ -179,25 +157,13 @@ export class Presenter implements IPresenter {
 
     // 更新相关事件
     eventBus.on(UPDATE_EVENTS.STATUS_CHANGED, (msg) => {
-      console.log('update-status-changed', msg)
+      console.log(UPDATE_EVENTS.STATUS_CHANGED, msg)
       this.windowPresenter.mainWindow?.webContents.send(UPDATE_EVENTS.STATUS_CHANGED, msg)
-      // 兼容旧事件
-      this.windowPresenter.mainWindow?.webContents.send(LEGACY_EVENTS.UPDATE_STATUS_CHANGED, msg)
-    })
-    // 兼容旧事件
-    eventBus.on(LEGACY_EVENTS.UPDATE_STATUS_CHANGED, (msg) => {
-      this.windowPresenter.mainWindow?.webContents.send(LEGACY_EVENTS.UPDATE_STATUS_CHANGED, msg)
     })
 
     // 消息编辑事件
     eventBus.on(CONVERSATION_EVENTS.MESSAGE_EDITED, (msgId: string) => {
       this.windowPresenter.mainWindow?.webContents.send(CONVERSATION_EVENTS.MESSAGE_EDITED, msgId)
-      // 兼容旧事件
-      this.windowPresenter.mainWindow?.webContents.send(LEGACY_EVENTS.MESSAGE_EDITED, msgId)
-    })
-    // 兼容旧事件
-    eventBus.on(LEGACY_EVENTS.MESSAGE_EDITED, (msgId: string) => {
-      this.windowPresenter.mainWindow?.webContents.send(LEGACY_EVENTS.MESSAGE_EDITED, msgId)
     })
   }
 

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -58,14 +58,6 @@ export class Presenter implements IPresenter {
       const providers = this.configPresenter.getProviders()
       this.llmproviderPresenter.setProviders(providers)
       this.windowPresenter.mainWindow?.webContents.send(CONFIG_EVENTS.PROVIDER_CHANGED)
-      // 兼容旧事件
-      this.windowPresenter.mainWindow?.webContents.send(LEGACY_EVENTS.PROVIDER_SETTING_CHANGED)
-    })
-    // 兼容旧事件
-    eventBus.on(LEGACY_EVENTS.PROVIDER_SETTING_CHANGED, () => {
-      const providers = this.configPresenter.getProviders()
-      this.llmproviderPresenter.setProviders(providers)
-      this.windowPresenter.mainWindow?.webContents.send(LEGACY_EVENTS.PROVIDER_SETTING_CHANGED)
     })
 
     // 流式响应事件
@@ -95,11 +87,6 @@ export class Presenter implements IPresenter {
     eventBus.on(MODEL_EVENTS.LIST_UPDATED, (providerId: string) => {
       // 当模型列表更新时，直接转发事件到渲染进程，并附带providerId参数
       this.windowPresenter.mainWindow?.webContents.send(MODEL_EVENTS.LIST_UPDATED, providerId)
-      // 兼容旧事件
-      this.windowPresenter.mainWindow?.webContents.send(
-        LEGACY_EVENTS.PROVIDER_MODELS_UPDATED,
-        providerId
-      )
     })
     // 处理从ConfigPresenter过来的模型列表更新事件
     eventBus.on(CONFIG_EVENTS.MODEL_LIST_CHANGED, (providerId: string) => {
@@ -108,46 +95,12 @@ export class Presenter implements IPresenter {
         CONFIG_EVENTS.MODEL_LIST_CHANGED,
         providerId
       )
-      // 兼容旧事件
-      this.windowPresenter.mainWindow?.webContents.send(
-        LEGACY_EVENTS.PROVIDER_MODELS_UPDATED,
-        providerId
-      )
-    })
-    // 兼容旧事件
-    eventBus.on(LEGACY_EVENTS.PROVIDER_MODELS_UPDATED, (providerId: string) => {
-      // 当模型列表更新时，获取provider实例
-      const provider = this.llmproviderPresenter.getProviderById(providerId)
-      if (provider) {
-        // 直接转发事件到渲染进程，并附带providerId参数
-        this.windowPresenter.mainWindow?.webContents.send(
-          LEGACY_EVENTS.PROVIDER_MODELS_UPDATED,
-          providerId
-        )
-      }
     })
 
     eventBus.on(
       MODEL_EVENTS.STATUS_CHANGED,
       (providerId: string, modelId: string, enabled: boolean) => {
         this.windowPresenter.mainWindow?.webContents.send(MODEL_EVENTS.STATUS_CHANGED, {
-          providerId,
-          modelId,
-          enabled
-        })
-        // 兼容旧事件
-        this.windowPresenter.mainWindow?.webContents.send(LEGACY_EVENTS.MODEL_STATUS_CHANGED, {
-          providerId,
-          modelId,
-          enabled
-        })
-      }
-    )
-    // 兼容旧事件
-    eventBus.on(
-      LEGACY_EVENTS.MODEL_STATUS_CHANGED,
-      (providerId: string, modelId: string, enabled: boolean) => {
-        this.windowPresenter.mainWindow?.webContents.send(LEGACY_EVENTS.MODEL_STATUS_CHANGED, {
           providerId,
           modelId,
           enabled

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -17,8 +17,7 @@ import {
   CONVERSATION_EVENTS,
   STREAM_EVENTS,
   WINDOW_EVENTS,
-  UPDATE_EVENTS,
-  LEGACY_EVENTS
+  UPDATE_EVENTS
 } from '@/events'
 
 export class Presenter implements IPresenter {

--- a/src/main/presenter/llmProviderPresenter/baseProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/baseProvider.ts
@@ -105,20 +105,12 @@ export abstract class BaseLLMProvider {
     if (model) {
       // 应用更新
       Object.assign(model, updates)
-
-      // 如果是启用状态变更，触发专门的事件
-      if (Object.prototype.hasOwnProperty.call(updates, 'enabled')) {
-        eventBus.emit(MODEL_EVENTS.STATUS_CHANGED, this.provider.id, modelId, !!model.enabled)
-      } else {
-        // 其他更新仍然触发模型列表更新事件
-        eventBus.emit(MODEL_EVENTS.LIST_UPDATED, this.provider.id)
-      }
-
+      // 其他更新仍然触发模型列表更新事件
+      eventBus.emit(MODEL_EVENTS.LIST_UPDATED, this.provider.id)
       return true
     }
     return false
   }
-
   public getCustomModels(): MODEL_META[] {
     return this.customModels
   }
@@ -136,20 +128,10 @@ export abstract class BaseLLMProvider {
       name: model.id,
       group: 'default',
       providerId: this.provider.id,
-      enabled: true,
       isCustom: false,
       contextLength: 4096,
       maxTokens: 2048
     }))
-  }
-
-  public async updateModelStatus(modelId: string, enabled: boolean): Promise<void> {
-    const modelIndex = this.models.findIndex((m) => m.id === modelId)
-    if (modelIndex !== -1) {
-      this.models[modelIndex].enabled = enabled
-      // 触发模型状态更改事件
-      eventBus.emit(MODEL_EVENTS.STATUS_CHANGED, this.provider.id, modelId, enabled)
-    }
   }
 
   protected async openAICompletion(
@@ -401,7 +383,6 @@ export abstract class BaseLLMProvider {
         })
         this.models = models
         // 避免在这里触发事件，而是通过ConfigPresenter来管理模型更新
-        // eventBus.emit('provider-models-updated', this.provider.id)
       }
       return {
         isOk: true,

--- a/src/main/presenter/llmProviderPresenter/baseProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/baseProvider.ts
@@ -1,8 +1,6 @@
 import { LLM_PROVIDER, MODEL_META, LLMResponse, LLMResponseStream } from '@shared/presenter'
 import OpenAI from 'openai'
 import { ChatCompletionMessage } from 'openai/resources'
-import { eventBus } from '@/eventbus'
-import { MODEL_EVENTS } from '@/events'
 
 interface ChatMessage {
   role: 'system' | 'user' | 'assistant'
@@ -85,8 +83,6 @@ export abstract class BaseLLMProvider {
       this.customModels.push(newModel)
     }
 
-    // 触发模型列表更新事件
-    eventBus.emit(MODEL_EVENTS.LIST_UPDATED, this.provider.id)
     return newModel
   }
 
@@ -94,7 +90,6 @@ export abstract class BaseLLMProvider {
     const index = this.customModels.findIndex((model) => model.id === modelId)
     if (index !== -1) {
       this.customModels.splice(index, 1)
-      eventBus.emit(MODEL_EVENTS.LIST_UPDATED, this.provider.id)
       return true
     }
     return false
@@ -105,8 +100,6 @@ export abstract class BaseLLMProvider {
     if (model) {
       // 应用更新
       Object.assign(model, updates)
-      // 其他更新仍然触发模型列表更新事件
-      eventBus.emit(MODEL_EVENTS.LIST_UPDATED, this.provider.id)
       return true
     }
     return false

--- a/src/main/presenter/llmProviderPresenter/baseProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/baseProvider.ts
@@ -2,7 +2,7 @@ import { LLM_PROVIDER, MODEL_META, LLMResponse, LLMResponseStream } from '@share
 import OpenAI from 'openai'
 import { ChatCompletionMessage } from 'openai/resources'
 import { eventBus } from '@/eventbus'
-import { MODEL_EVENTS, LEGACY_EVENTS } from '@/events'
+import { MODEL_EVENTS } from '@/events'
 
 interface ChatMessage {
   role: 'system' | 'user' | 'assistant'

--- a/src/main/presenter/llmProviderPresenter/baseProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/baseProvider.ts
@@ -87,8 +87,6 @@ export abstract class BaseLLMProvider {
 
     // 触发模型列表更新事件
     eventBus.emit(MODEL_EVENTS.LIST_UPDATED, this.provider.id)
-    // 兼容旧事件
-    eventBus.emit(LEGACY_EVENTS.PROVIDER_MODELS_UPDATED, this.provider.id)
     return newModel
   }
 
@@ -97,8 +95,6 @@ export abstract class BaseLLMProvider {
     if (index !== -1) {
       this.customModels.splice(index, 1)
       eventBus.emit(MODEL_EVENTS.LIST_UPDATED, this.provider.id)
-      // 兼容旧事件
-      eventBus.emit(LEGACY_EVENTS.PROVIDER_MODELS_UPDATED, this.provider.id)
       return true
     }
     return false
@@ -113,18 +109,9 @@ export abstract class BaseLLMProvider {
       // 如果是启用状态变更，触发专门的事件
       if (Object.prototype.hasOwnProperty.call(updates, 'enabled')) {
         eventBus.emit(MODEL_EVENTS.STATUS_CHANGED, this.provider.id, modelId, !!model.enabled)
-        // 兼容旧事件
-        eventBus.emit(
-          LEGACY_EVENTS.MODEL_STATUS_CHANGED,
-          this.provider.id,
-          modelId,
-          !!model.enabled
-        )
       } else {
         // 其他更新仍然触发模型列表更新事件
         eventBus.emit(MODEL_EVENTS.LIST_UPDATED, this.provider.id)
-        // 兼容旧事件
-        eventBus.emit(LEGACY_EVENTS.PROVIDER_MODELS_UPDATED, this.provider.id)
       }
 
       return true
@@ -162,8 +149,6 @@ export abstract class BaseLLMProvider {
       this.models[modelIndex].enabled = enabled
       // 触发模型状态更改事件
       eventBus.emit(MODEL_EVENTS.STATUS_CHANGED, this.provider.id, modelId, enabled)
-      // 兼容旧事件
-      eventBus.emit(LEGACY_EVENTS.MODEL_STATUS_CHANGED, this.provider.id, modelId, enabled)
     }
   }
 

--- a/src/main/presenter/llmProviderPresenter/index.ts
+++ b/src/main/presenter/llmProviderPresenter/index.ts
@@ -8,6 +8,7 @@ import { OpenAICompatibleProvider } from './providers/openAICompatibleProvider'
 import { PPIOProvider } from './providers/ppioProvider'
 import { getModelConfig } from './modelConfigs'
 import { STREAM_EVENTS } from '@/events'
+import { ConfigPresenter } from '../configPresenter'
 // 导入其他provider...
 
 // 流的状态
@@ -33,6 +34,11 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
   // 配置
   private config: ProviderConfig = {
     maxConcurrentStreams: 10
+  }
+  private configPresenter: ConfigPresenter
+
+  constructor(configPresenter: ConfigPresenter) {
+    this.configPresenter = configPresenter
   }
 
   getProviders(): LLM_PROVIDER[] {
@@ -130,8 +136,7 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
   }
 
   async updateModelStatus(providerId: string, modelId: string, enabled: boolean): Promise<void> {
-    const provider = this.getProviderInstance(providerId)
-    await provider.updateModelStatus(modelId, enabled)
+    this.configPresenter.setModelStatus(providerId, modelId, enabled)
   }
 
   isGenerating(eventId: string): boolean {
@@ -397,7 +402,9 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
     updates: Partial<MODEL_META>
   ): Promise<boolean> {
     const provider = this.getProviderInstance(providerId)
-    return provider.updateCustomModel(modelId, updates)
+    const res = provider.updateCustomModel(modelId, updates)
+    this.configPresenter.updateCustomModel(providerId, modelId, updates)
+    return res
   }
 
   async getCustomModels(providerId: string): Promise<MODEL_META[]> {

--- a/src/main/presenter/llmProviderPresenter/index.ts
+++ b/src/main/presenter/llmProviderPresenter/index.ts
@@ -7,6 +7,7 @@ import { eventBus } from '@/eventbus'
 import { OpenAICompatibleProvider } from './providers/openAICompatibleProvider'
 import { PPIOProvider } from './providers/ppioProvider'
 import { getModelConfig } from './modelConfigs'
+import { STREAM_EVENTS } from '@/events'
 // 导入其他provider...
 
 // 流的状态
@@ -229,18 +230,18 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
         if (abortController.signal.aborted) {
           break
         }
-        eventBus.emit('stream-response', {
+        eventBus.emit(STREAM_EVENTS.RESPONSE, {
           eventId,
           ...chunk
         })
       }
 
       if (!abortController.signal.aborted) {
-        eventBus.emit('stream-end', { eventId })
+        eventBus.emit(STREAM_EVENTS.END, { eventId })
       }
     } catch (error) {
       console.error('Stream error:', error)
-      eventBus.emit('stream-error', {
+      eventBus.emit(STREAM_EVENTS.ERROR, {
         eventId,
         error: error instanceof Error ? error.message : String(error)
       })
@@ -267,7 +268,7 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
           if (stream.abortController.signal.aborted) {
             break
           }
-          eventBus.emit(`stream-response`, {
+          eventBus.emit(STREAM_EVENTS.RESPONSE, {
             content: response.content,
             reasoning_content: response.reasoning_content,
             eventId
@@ -303,7 +304,7 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
           if (stream.abortController.signal.aborted) {
             break
           }
-          eventBus.emit(`stream-response`, {
+          eventBus.emit(STREAM_EVENTS.RESPONSE, {
             content: response.content,
             reasoning_content: response.reasoning_content,
             eventId

--- a/src/main/presenter/llmProviderPresenter/index.ts
+++ b/src/main/presenter/llmProviderPresenter/index.ts
@@ -69,7 +69,6 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
     this.currentProviderId = providerId
     // 确保新的 provider 实例已经初始化
     this.getProviderInstance(providerId)
-    eventBus.emit('provider-changed', { providerId })
   }
 
   setProviders(providers: LLM_PROVIDER[]): void {
@@ -152,7 +151,7 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
     if (stream) {
       stream.abortController.abort()
       this.activeStreams.delete(eventId)
-      eventBus.emit('generation-stopped', { eventId })
+      eventBus.emit(STREAM_EVENTS.END, { eventId, userStop: true })
     }
   }
 
@@ -197,9 +196,9 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
 
     try {
       await operation()
-      eventBus.emit(`stream-end`, { eventId })
+      eventBus.emit(STREAM_EVENTS.END, { eventId })
     } catch (error) {
-      eventBus.emit(`stream-error`, { error: String(error), eventId })
+      eventBus.emit(STREAM_EVENTS.ERROR, { error: String(error), eventId })
       throw error
     } finally {
       this.activeStreams.delete(eventId)

--- a/src/main/presenter/threadPresenter/index.ts
+++ b/src/main/presenter/threadPresenter/index.ts
@@ -23,7 +23,7 @@ import { getModelConfig } from '../llmProviderPresenter/modelConfigs'
 import { SearchManager } from './searchManager'
 import { getArtifactsPrompt } from '../llmProviderPresenter/promptUtils'
 import { ContentEnricher } from './contentEnricher'
-import { STREAM_EVENTS } from '@/events'
+import { CONVERSATION_EVENTS, STREAM_EVENTS } from '@/events'
 
 const DEFAULT_SETTINGS: CONVERSATION_SETTINGS = {
   systemPrompt: '',
@@ -387,7 +387,7 @@ export class ThreadPresenter implements IThreadPresenter {
     const conversation = await this.getConversation(conversationId)
     if (conversation) {
       this.activeConversationId = conversationId
-      eventBus.emit('conversation-activated', { conversationId })
+      eventBus.emit(CONVERSATION_EVENTS.ACTIVATED, { conversationId })
     } else {
       throw new Error(`Conversation ${conversationId} not found`)
     }
@@ -1084,7 +1084,7 @@ export class ThreadPresenter implements IThreadPresenter {
   }
   async clearActiveThread(): Promise<void> {
     this.activeConversationId = null
-    eventBus.emit('active-conversation-cleared')
+    eventBus.emit(CONVERSATION_EVENTS.DEACTIVATED)
   }
 
   async clearAllMessages(conversationId: string): Promise<void> {

--- a/src/main/presenter/threadPresenter/index.ts
+++ b/src/main/presenter/threadPresenter/index.ts
@@ -23,6 +23,7 @@ import { getModelConfig } from '../llmProviderPresenter/modelConfigs'
 import { SearchManager } from './searchManager'
 import { getArtifactsPrompt } from '../llmProviderPresenter/promptUtils'
 import { ContentEnricher } from './contentEnricher'
+import { STREAM_EVENTS } from '@/events'
 
 const DEFAULT_SETTINGS: CONVERSATION_SETTINGS = {
   systemPrompt: '',
@@ -100,7 +101,7 @@ export class ThreadPresenter implements IThreadPresenter {
     // 初始化时处理所有未完成的消息
     this.initializeUnfinishedMessages()
 
-    eventBus.on('stream-response', async (msg) => {
+    eventBus.on(STREAM_EVENTS.RESPONSE, async (msg) => {
       const { eventId, content, reasoning_content } = msg
       const state = this.generatingMessages.get(eventId)
       if (state) {
@@ -156,7 +157,7 @@ export class ThreadPresenter implements IThreadPresenter {
         }
       }
     })
-    eventBus.on('stream-end', async (msg) => {
+    eventBus.on(STREAM_EVENTS.END, async (msg) => {
       const { eventId } = msg
       const state = this.generatingMessages.get(eventId)
       if (state) {
@@ -214,7 +215,7 @@ export class ThreadPresenter implements IThreadPresenter {
         this.generatingMessages.delete(eventId)
       }
     })
-    eventBus.on('stream-error', async (msg) => {
+    eventBus.on(STREAM_EVENTS.ERROR, async (msg) => {
       const { eventId, error } = msg
       const state = this.generatingMessages.get(eventId)
       if (state) {

--- a/src/main/presenter/threadPresenter/messageManager.ts
+++ b/src/main/presenter/threadPresenter/messageManager.ts
@@ -8,6 +8,7 @@ import {
 } from '@shared/presenter'
 import { Message } from '@shared/chat'
 import { eventBus } from '@/eventbus'
+import { CONVERSATION_EVENTS } from '@/events'
 
 export class MessageManager implements IMessageManager {
   private sqlitePresenter: ISQLitePresenter
@@ -92,9 +93,9 @@ export class MessageManager implements IMessageManager {
       throw new Error(`Message ${messageId} not found`)
     }
     const msg = this.convertToMessage(message)
-    eventBus.emit('message-edited', messageId)
+    eventBus.emit(CONVERSATION_EVENTS.MESSAGE_EDITED, messageId)
     if (msg.parentId) {
-      eventBus.emit('message-edited', msg.parentId)
+      eventBus.emit(CONVERSATION_EVENTS.MESSAGE_EDITED, msg.parentId)
     }
     return msg
   }

--- a/src/main/presenter/upgradePresenter/index.ts
+++ b/src/main/presenter/upgradePresenter/index.ts
@@ -2,6 +2,7 @@ import electronUpdater from 'electron-updater'
 import { app } from 'electron'
 import { IUpgradePresenter, UpdateStatus, UpdateProgress } from '@shared/presenter'
 import { eventBus } from '@/eventbus'
+import { UPDATE_EVENTS } from '@/events'
 
 const { autoUpdater } = electronUpdater
 
@@ -43,7 +44,7 @@ export class UpgradePresenter implements IUpgradePresenter {
       this._lock = false
       this._status = 'error'
       this._error = e.message
-      eventBus.emit('update-status-changed', {
+      eventBus.emit(UPDATE_EVENTS.STATUS_CHANGED, {
         status: this._status,
         error: this._error
       })
@@ -53,7 +54,7 @@ export class UpgradePresenter implements IUpgradePresenter {
     autoUpdater.on('checking-for-update', () => {
       console.log('checking-for-update')
       this._status = 'checking'
-      eventBus.emit('update-status-changed', { status: this._status })
+      eventBus.emit(UPDATE_EVENTS.STATUS_CHANGED, { status: this._status })
     })
 
     // 无可用更新
@@ -61,14 +62,14 @@ export class UpgradePresenter implements IUpgradePresenter {
       console.log('update-not-available')
       this._lock = false
       this._status = 'not-available'
-      eventBus.emit('update-status-changed', { status: this._status })
+      eventBus.emit(UPDATE_EVENTS.STATUS_CHANGED, { status: this._status })
     })
 
     // 有可用更新
     autoUpdater.on('update-available', (info) => {
       this._status = 'available'
       this._updateInfo = info
-      eventBus.emit('update-status-changed', {
+      eventBus.emit(UPDATE_EVENTS.STATUS_CHANGED, {
         status: this._status,
         info: {
           version: info.version,
@@ -88,7 +89,7 @@ export class UpgradePresenter implements IUpgradePresenter {
         transferred: progressObj.transferred,
         total: progressObj.total
       }
-      eventBus.emit('update-progress', this._progress)
+      eventBus.emit(UPDATE_EVENTS.PROGRESS, this._progress)
     })
 
     // 下载完成
@@ -96,7 +97,7 @@ export class UpgradePresenter implements IUpgradePresenter {
       this._lock = false
       this._status = 'downloaded'
       this._updateInfo = info
-      eventBus.emit('update-status-changed', {
+      eventBus.emit(UPDATE_EVENTS.STATUS_CHANGED, {
         status: this._status,
         info: {
           version: info.version,
@@ -115,10 +116,6 @@ export class UpgradePresenter implements IUpgradePresenter {
     } catch (error: Error | unknown) {
       this._status = 'error'
       this._error = error instanceof Error ? error.message : String(error)
-      // eventBus.emit('update-status-changed', {
-      //   status: this._status,
-      //   error: this._error
-      // })
     }
   }
   startDownloadUpdate() {
@@ -131,7 +128,7 @@ export class UpgradePresenter implements IUpgradePresenter {
     } catch (error: Error | unknown) {
       this._status = 'error'
       this._error = error instanceof Error ? error.message : String(error)
-      eventBus.emit('update-status-changed', {
+      eventBus.emit(UPDATE_EVENTS.STATUS_CHANGED, {
         status: this._status,
         error: this._error
       })
@@ -142,9 +139,9 @@ export class UpgradePresenter implements IUpgradePresenter {
     console.log('try to quit and install')
     try {
       // 发送即将重启的消息
-      eventBus.emit('update-will-restart')
+      eventBus.emit(UPDATE_EVENTS.WILL_RESTART)
       // 通知需要完全退出应用
-      eventBus.emit('force-quit-app')
+      eventBus.emit(UPDATE_EVENTS.FORCE_QUIT_APP)
       autoUpdater.quitAndInstall()
       // 如果30s还没完成，就强制退出重启
       setTimeout(() => {
@@ -152,7 +149,7 @@ export class UpgradePresenter implements IUpgradePresenter {
       }, 30151)
     } catch (e) {
       console.error('Failed to quit and install', e)
-      eventBus.emit('update-error', {
+      eventBus.emit(UPDATE_EVENTS.ERROR, {
         error: e instanceof Error ? e.message : String(e)
       })
     }
@@ -161,7 +158,7 @@ export class UpgradePresenter implements IUpgradePresenter {
   restartToUpdate() {
     console.log('Restarting update')
     if (this._status !== 'downloaded') {
-      eventBus.emit('update-error', {
+      eventBus.emit(UPDATE_EVENTS.ERROR, {
         error: '更新尚未下载完成'
       })
       return false
@@ -171,7 +168,7 @@ export class UpgradePresenter implements IUpgradePresenter {
       return true
     } catch (e) {
       console.error('Failed to restart update', e)
-      eventBus.emit('update-error', {
+      eventBus.emit(UPDATE_EVENTS.ERROR, {
         error: e instanceof Error ? e.message : String(e)
       })
       return false
@@ -181,7 +178,7 @@ export class UpgradePresenter implements IUpgradePresenter {
   restartApp() {
     try {
       // 发送即将重启的消息
-      eventBus.emit('app-will-restart')
+      eventBus.emit(UPDATE_EVENTS.WILL_RESTART)
       // 给UI层一点时间保存状态
       setTimeout(() => {
         app.relaunch()
@@ -189,7 +186,7 @@ export class UpgradePresenter implements IUpgradePresenter {
       }, 1000)
     } catch (e) {
       console.error('Failed to restart', e)
-      eventBus.emit('app-restart-error', {
+      eventBus.emit(UPDATE_EVENTS.ERROR, {
         error: e instanceof Error ? e.message : String(e)
       })
     }

--- a/src/main/presenter/windowPresenter.ts
+++ b/src/main/presenter/windowPresenter.ts
@@ -7,6 +7,7 @@ import { IWindowPresenter } from '@shared/presenter'
 import { eventBus } from '@/eventbus'
 import { ConfigPresenter } from './configPresenter'
 import { TrayPresenter } from './trayPresenter'
+import { WINDOW_EVENTS } from '@/events'
 
 export const MAIN_WIN = 'main'
 export class WindowPresenter implements IWindowPresenter {
@@ -82,7 +83,7 @@ export class WindowPresenter implements IWindowPresenter {
 
     mainWindow.on('ready-to-show', () => {
       mainWindow.show()
-      eventBus.emit('main-window-ready-to-show', mainWindow)
+      eventBus.emit(WINDOW_EVENTS.READY_TO_SHOW, mainWindow)
     })
 
     // 处理关闭按钮点击

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -3,15 +3,12 @@ import { onMounted, ref, watch } from 'vue'
 import { RouterView, useRoute, useRouter } from 'vue-router'
 import AppBar from './components/AppBar.vue'
 import SideBar from './components/SideBar.vue'
-import { useSettingsStore } from './stores/settings'
 import { usePresenter } from './composables/usePresenter'
 const route = useRoute()
 const configPresenter = usePresenter('configPresenter')
 
 const router = useRouter()
 const activeTab = ref('chat')
-const settingsStore = useSettingsStore()
-console.info(settingsStore.providers)
 
 const getInitComplete = async () => {
   const initComplete = await configPresenter.getSetting('init_complete')

--- a/src/renderer/src/components/ChatView.vue
+++ b/src/renderer/src/components/ChatView.vue
@@ -25,6 +25,8 @@ import MessageList from './message/MesasgeList.vue'
 import ChatInput from './ChatInput.vue'
 import { useRoute } from 'vue-router'
 import { UserMessageContent } from '@shared/chat'
+import { STREAM_EVENTS } from '@/events'
+
 const route = useRoute()
 
 const messageList = ref()
@@ -74,16 +76,16 @@ const handleFileUpload = (files: FileList) => {
 
 // 监听流式响应
 onMounted(async () => {
-  window.electron.ipcRenderer.on('stream-response', (_, msg) => {
+  window.electron.ipcRenderer.on(STREAM_EVENTS.RESPONSE, (_, msg) => {
     // console.log('stream-response', msg)
     chatStore.handleStreamResponse(msg)
   })
 
-  window.electron.ipcRenderer.on('stream-end', (_, msg) => {
+  window.electron.ipcRenderer.on(STREAM_EVENTS.END, (_, msg) => {
     chatStore.handleStreamEnd(msg)
   })
 
-  window.electron.ipcRenderer.on('stream-error', (_, msg) => {
+  window.electron.ipcRenderer.on(STREAM_EVENTS.ERROR, (_, msg) => {
     chatStore.handleStreamError(msg)
   })
 
@@ -111,8 +113,8 @@ watch(
 
 // 清理事件监听
 onUnmounted(async () => {
-  window.electron.ipcRenderer.removeAllListeners('stream-response')
-  window.electron.ipcRenderer.removeAllListeners('stream-end')
-  window.electron.ipcRenderer.removeAllListeners('stream-error')
+  window.electron.ipcRenderer.removeAllListeners(STREAM_EVENTS.RESPONSE)
+  window.electron.ipcRenderer.removeAllListeners(STREAM_EVENTS.END)
+  window.electron.ipcRenderer.removeAllListeners(STREAM_EVENTS.ERROR)
 })
 </script>

--- a/src/renderer/src/components/ModelSelect.vue
+++ b/src/renderer/src/components/ModelSelect.vue
@@ -39,7 +39,7 @@ import Input from './ui/input/Input.vue'
 // import Badge from './ui/badge/Badge.vue'
 import { useChatStore } from '@/stores/chat'
 import { usePresenter } from '@/composables/usePresenter'
-import type { MODEL_META } from '@shared/presenter'
+import type { RENDERER_MODEL_META } from '@shared/presenter'
 import ModelIcon from './icons/ModelIcon.vue'
 
 const { t } = useI18n()
@@ -47,9 +47,9 @@ const keyword = ref('')
 const chatStore = useChatStore()
 const configP = usePresenter('configPresenter')
 
-const providers = ref<{ id: string; name: string; models: MODEL_META[] }[]>([])
+const providers = ref<{ id: string; name: string; models: RENDERER_MODEL_META[] }[]>([])
 const emit = defineEmits<{
-  (e: 'update:model', model: MODEL_META, providerId: string): void
+  (e: 'update:model', model: RENDERER_MODEL_META, providerId: string): void
 }>()
 const filteredProviders = computed(() => {
   if (!keyword.value) return providers.value
@@ -67,7 +67,7 @@ const isSelected = (providerId: string, modelId: string) => {
   return chatStore.chatConfig.providerId === providerId && chatStore.chatConfig.modelId === modelId
 }
 
-const handleModelSelect = async (providerId: string, model: MODEL_META) => {
+const handleModelSelect = async (providerId: string, model: RENDERER_MODEL_META) => {
   await chatStore.updateChatConfig({
     providerId,
     modelId: model.id,

--- a/src/renderer/src/components/settings/CommonSettings.vue
+++ b/src/renderer/src/components/settings/CommonSettings.vue
@@ -122,7 +122,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { ChevronDown } from 'lucide-vue-next'
 import ModelSelect from '@/components/ModelSelect.vue'
 import ModelIcon from '@/components/icons/ModelIcon.vue'
-import type { MODEL_META } from '@shared/presenter'
+import type { RENDERER_MODEL_META } from '@shared/presenter'
 
 const devicePresenter = usePresenter('devicePresenter')
 const settingsStore = useSettingsStore()
@@ -166,7 +166,7 @@ const handleResetData = () => {
   closeDialog()
 }
 
-const handleSearchModelSelect = (model: MODEL_META, providerId: string) => {
+const handleSearchModelSelect = (model: RENDERER_MODEL_META, providerId: string) => {
   settingsStore.setSearchAssistantModel(model, providerId)
   modelSelectOpen.value = false
 }

--- a/src/renderer/src/components/settings/ModelProviderSettingsDetail.vue
+++ b/src/renderer/src/components/settings/ModelProviderSettingsDetail.vue
@@ -221,7 +221,7 @@ import {
 } from '@/components/ui/dialog'
 import ProviderModelList from './ProviderModelList.vue'
 import { useSettingsStore } from '@/stores/settings'
-import type { LLM_PROVIDER, MODEL_META } from '@shared/presenter'
+import type { LLM_PROVIDER, RENDERER_MODEL_META } from '@shared/presenter'
 import ModelConfigItem from './ModelConfigItem.vue'
 
 const { t } = useI18n()
@@ -234,10 +234,10 @@ const settingsStore = useSettingsStore()
 const apiKey = ref(props.provider.apiKey || '')
 const apiHost = ref(props.provider.baseUrl || '')
 
-const providerModels = ref<MODEL_META[]>([])
-const customModels = ref<MODEL_META[]>([])
+const providerModels = ref<RENDERER_MODEL_META[]>([])
+const customModels = ref<RENDERER_MODEL_META[]>([])
 
-const modelToDisable = ref<MODEL_META | null>(null)
+const modelToDisable = ref<RENDERER_MODEL_META | null>(null)
 const showConfirmDialog = ref(false)
 const showModelListDialog = ref(false)
 const showDisableAllConfirmDialog = ref(false)
@@ -346,22 +346,18 @@ const handleApiHostChange = async (value: string) => {
 }
 
 const handleModelEnabledChange = async (
-  model: MODEL_META,
+  model: RENDERER_MODEL_META,
   enabled: boolean,
   comfirm: boolean = false
 ) => {
   if (!enabled && comfirm) {
     disableModel(model)
   } else {
-    if (model.isCustom) {
-      await settingsStore.updateCustomModel(props.provider.id, model.id, { enabled })
-    } else {
-      await settingsStore.updateModelStatus(props.provider.id, model.id, enabled)
-    }
+    await settingsStore.updateModelStatus(props.provider.id, model.id, enabled)
   }
 }
 
-const disableModel = (model: MODEL_META) => {
+const disableModel = (model: RENDERER_MODEL_META) => {
   modelToDisable.value = model
   showConfirmDialog.value = true
 }

--- a/src/renderer/src/components/settings/ProviderModelList.vue
+++ b/src/renderer/src/components/settings/ProviderModelList.vue
@@ -106,7 +106,7 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Icon } from '@iconify/vue'
 import ModelConfigItem from './ModelConfigItem.vue'
-import type { MODEL_META } from '@shared/presenter'
+import type { RENDERER_MODEL_META } from '@shared/presenter'
 import { useSettingsStore } from '@/stores/settings'
 
 const { t } = useI18n()
@@ -122,13 +122,13 @@ const modelSearchQuery = ref('')
 const settingsStore = useSettingsStore()
 
 const props = defineProps<{
-  providerModels: { providerId: string; models: MODEL_META[] }[]
-  customModels: MODEL_META[]
+  providerModels: { providerId: string; models: RENDERER_MODEL_META[] }[]
+  customModels: RENDERER_MODEL_META[]
   providers: { id: string; name: string }[]
 }>()
 
 const emit = defineEmits<{
-  enabledChange: [model: MODEL_META, enabled: boolean]
+  enabledChange: [model: RENDERER_MODEL_META, enabled: boolean]
 }>()
 
 const filteredProviderModels = computed(() => {
@@ -149,7 +149,7 @@ const filteredProviderModels = computed(() => {
 })
 
 const filteredCustomModels = computed(() => {
-  const customModelsList: MODEL_META[] = []
+  const customModelsList: RENDERER_MODEL_META[] = []
   for (const model of props.customModels) {
     customModelsList.push(model)
   }
@@ -158,7 +158,7 @@ const filteredCustomModels = computed(() => {
     return customModelsList
   }
 
-  const filteredModels: MODEL_META[] = []
+  const filteredModels: RENDERER_MODEL_META[] = []
   for (const model of customModelsList) {
     if (
       model.name.toLowerCase().includes(modelSearchQuery.value.toLowerCase()) ||
@@ -204,7 +204,7 @@ const confirmAdd = async (idx: number) => {
   }
 }
 
-const handleModelEnabledChange = (model: MODEL_META, enabled: boolean) => {
+const handleModelEnabledChange = (model: RENDERER_MODEL_META, enabled: boolean) => {
   emit('enabledChange', model, enabled)
 }
 

--- a/src/renderer/src/events.ts
+++ b/src/renderer/src/events.ts
@@ -14,12 +14,6 @@ export const CONFIG_EVENTS = {
   MODEL_STATUS_CHANGED: 'config:model-status-changed' // 替代 model-status-changed（ConfigPresenter）
 }
 
-// 模型相关事件
-export const MODEL_EVENTS = {
-  LIST_UPDATED: 'model:list-updated', // 替代 provider-models-updated（BaseLLMProvider）
-  STATUS_CHANGED: 'model:status-changed' // 替代 model-status-changed
-}
-
 // 会话相关事件
 export const CONVERSATION_EVENTS = {
   CREATED: 'conversation:created',

--- a/src/renderer/src/events.ts
+++ b/src/renderer/src/events.ts
@@ -1,0 +1,63 @@
+/**
+ * 事件系统常量定义
+ *
+ * 按功能领域分类事件名，采用统一的命名规范：
+ * - 使用冒号分隔域和具体事件
+ * - 使用小写并用连字符连接多个单词
+ */
+
+// 配置相关事件
+export const CONFIG_EVENTS = {
+  PROVIDER_CHANGED: 'config:provider-changed', // 替代 provider-setting-changed
+  SYSTEM_CHANGED: 'config:system-changed',
+  MODEL_LIST_CHANGED: 'config:model-list-changed' // 替代 provider-models-updated（ConfigPresenter）
+}
+
+// 模型相关事件
+export const MODEL_EVENTS = {
+  LIST_UPDATED: 'model:list-updated', // 替代 provider-models-updated（BaseLLMProvider）
+  STATUS_CHANGED: 'model:status-changed' // 替代 model-status-changed
+}
+
+// 会话相关事件
+export const CONVERSATION_EVENTS = {
+  CREATED: 'conversation:created',
+  ACTIVATED: 'conversation:activated', // 替代 conversation-activated
+  CLEARED: 'conversation:cleared', // 替代 active-conversation-cleared
+  MESSAGE_EDITED: 'conversation:message-edited' // 替代 message-edited
+}
+
+// 通信相关事件
+export const STREAM_EVENTS = {
+  RESPONSE: 'stream:response', // 替代 stream-response
+  END: 'stream:end', // 替代 stream-end
+  ERROR: 'stream:error' // 替代 stream-error
+}
+
+// 应用更新相关事件
+export const UPDATE_EVENTS = {
+  STATUS_CHANGED: 'update:status-changed', // 替代 update-status-changed
+  PROGRESS: 'update:progress', // 替代 update-progress
+  ERROR: 'update:error', // 替代 update-error
+  WILL_RESTART: 'update:will-restart' // 替代 update-will-restart
+}
+
+// 窗口相关事件
+export const WINDOW_EVENTS = {
+  READY_TO_SHOW: 'window:ready-to-show' // 替代 main-window-ready-to-show
+}
+
+// 旧事件名称 - 用于兼容性
+export const LEGACY_EVENTS = {
+  PROVIDER_SETTING_CHANGED: 'provider-setting-changed',
+  PROVIDER_MODELS_UPDATED: 'provider-models-updated',
+  MODEL_STATUS_CHANGED: 'model-status-changed',
+  CONVERSATION_ACTIVATED: 'conversation-activated',
+  ACTIVE_CONVERSATION_CLEARED: 'active-conversation-cleared',
+  STREAM_RESPONSE: 'stream-response',
+  STREAM_END: 'stream-end',
+  STREAM_ERROR: 'stream-error',
+  UPDATE_STATUS_CHANGED: 'update-status-changed',
+  MAIN_WINDOW_READY_TO_SHOW: 'main-window-ready-to-show',
+  MESSAGE_EDITED: 'message-edited'
+}

--- a/src/renderer/src/events.ts
+++ b/src/renderer/src/events.ts
@@ -10,7 +10,8 @@
 export const CONFIG_EVENTS = {
   PROVIDER_CHANGED: 'config:provider-changed', // 替代 provider-setting-changed
   SYSTEM_CHANGED: 'config:system-changed',
-  MODEL_LIST_CHANGED: 'config:model-list-changed' // 替代 provider-models-updated（ConfigPresenter）
+  MODEL_LIST_CHANGED: 'config:model-list-changed', // 替代 provider-models-updated（ConfigPresenter）
+  MODEL_STATUS_CHANGED: 'config:model-status-changed' // 替代 model-status-changed（ConfigPresenter）
 }
 
 // 模型相关事件
@@ -46,11 +47,4 @@ export const UPDATE_EVENTS = {
 // 窗口相关事件
 export const WINDOW_EVENTS = {
   READY_TO_SHOW: 'window:ready-to-show' // 替代 main-window-ready-to-show
-}
-
-// 旧事件名称 - 用于兼容性
-export const LEGACY_EVENTS = {
-  PROVIDER_SETTING_CHANGED: 'provider-setting-changed',
-  PROVIDER_MODELS_UPDATED: 'provider-models-updated',
-  MODEL_STATUS_CHANGED: 'model-status-changed'
 }

--- a/src/renderer/src/events.ts
+++ b/src/renderer/src/events.ts
@@ -23,7 +23,7 @@ export const MODEL_EVENTS = {
 export const CONVERSATION_EVENTS = {
   CREATED: 'conversation:created',
   ACTIVATED: 'conversation:activated', // 替代 conversation-activated
-  CLEARED: 'conversation:cleared', // 替代 active-conversation-cleared
+  DEACTIVATED: 'conversation:deactivated', // 替代 active-conversation-cleared
   MESSAGE_EDITED: 'conversation:message-edited' // 替代 message-edited
 }
 
@@ -39,7 +39,8 @@ export const UPDATE_EVENTS = {
   STATUS_CHANGED: 'update:status-changed', // 替代 update-status-changed
   PROGRESS: 'update:progress', // 替代 update-progress
   ERROR: 'update:error', // 替代 update-error
-  WILL_RESTART: 'update:will-restart' // 替代 update-will-restart
+  WILL_RESTART: 'update:will-restart', // 替代 update-will-restart
+  FORCE_QUIT_APP: 'update:force-quit-app' // 替代 force-quit-app
 }
 
 // 窗口相关事件
@@ -51,13 +52,5 @@ export const WINDOW_EVENTS = {
 export const LEGACY_EVENTS = {
   PROVIDER_SETTING_CHANGED: 'provider-setting-changed',
   PROVIDER_MODELS_UPDATED: 'provider-models-updated',
-  MODEL_STATUS_CHANGED: 'model-status-changed',
-  CONVERSATION_ACTIVATED: 'conversation-activated',
-  ACTIVE_CONVERSATION_CLEARED: 'active-conversation-cleared',
-  STREAM_RESPONSE: 'stream-response',
-  STREAM_END: 'stream-end',
-  STREAM_ERROR: 'stream-error',
-  UPDATE_STATUS_CHANGED: 'update-status-changed',
-  MAIN_WINDOW_READY_TO_SHOW: 'main-window-ready-to-show',
-  MESSAGE_EDITED: 'message-edited'
+  MODEL_STATUS_CHANGED: 'model-status-changed'
 }

--- a/src/renderer/src/stores/chat.ts
+++ b/src/renderer/src/stores/chat.ts
@@ -9,6 +9,7 @@ import type {
 } from '@shared/chat'
 import type { CONVERSATION, CONVERSATION_SETTINGS } from '@shared/presenter'
 import { usePresenter } from '@/composables/usePresenter'
+import { CONVERSATION_EVENTS } from '@/events'
 // import DeepSeekLogo from '@/assets/llm-icons/deepseek-color.svg'
 // import BaiduLogo from '@/assets/llm-icons/baidu-color.svg'
 // import GoogleLogo from '@/assets/llm-icons/google-color.svg'
@@ -680,8 +681,8 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  window.electron.ipcRenderer.on('conversation-activated', (_, msg) => {
-    console.log('conversation-activated', msg)
+  window.electron.ipcRenderer.on(CONVERSATION_EVENTS.ACTIVATED, (_, msg) => {
+    console.log(CONVERSATION_EVENTS.ACTIVATED, msg)
     activeThreadId.value = msg.conversationId
     loadMessages()
     loadChatConfig() // 加载对话配置
@@ -718,8 +719,7 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   // 注册消息编辑事件处理
-  window.electron.ipcRenderer.on('message-edited', (_, msgId: string) => {
-    // console.log('message-edited', msgId)
+  window.electron.ipcRenderer.on(CONVERSATION_EVENTS.MESSAGE_EDITED, (_, msgId: string) => {
     handleMessageEdited(msgId)
   })
 

--- a/src/renderer/src/stores/settings.ts
+++ b/src/renderer/src/stores/settings.ts
@@ -4,7 +4,7 @@ import type { LLM_PROVIDER, MODEL_META } from '@shared/presenter'
 import { usePresenter } from '@/composables/usePresenter'
 import { useI18n } from 'vue-i18n'
 import { SearchEngineTemplate } from '@shared/chat'
-import { CONFIG_EVENTS, MODEL_EVENTS, LEGACY_EVENTS, UPDATE_EVENTS } from '@/events'
+import { CONFIG_EVENTS, MODEL_EVENTS, UPDATE_EVENTS } from '@/events'
 
 export const useSettingsStore = defineStore('settings', () => {
   const configP = usePresenter('configPresenter')

--- a/src/renderer/src/stores/settings.ts
+++ b/src/renderer/src/stores/settings.ts
@@ -313,12 +313,6 @@ export const useSettingsStore = defineStore('settings', () => {
       providers.value = await configP.getProviders()
       await refreshAllModels()
     })
-    // 兼容旧事件
-    window.electron.ipcRenderer.on(LEGACY_EVENTS.PROVIDER_SETTING_CHANGED, async () => {
-      providers.value = await configP.getProviders()
-      await refreshAllModels()
-    })
-
     // 监听模型列表更新事件
     window.electron.ipcRenderer.on(MODEL_EVENTS.LIST_UPDATED, async (event, providerId: string) => {
       // 只刷新指定的provider模型，而不是所有模型
@@ -342,31 +336,10 @@ export const useSettingsStore = defineStore('settings', () => {
         }
       }
     )
-    // 兼容旧事件
-    window.electron.ipcRenderer.on(
-      LEGACY_EVENTS.PROVIDER_MODELS_UPDATED,
-      async (event, providerId: string) => {
-        // 只刷新指定的provider模型，而不是所有模型
-        if (providerId) {
-          await refreshProviderModels(providerId)
-        } else {
-          // 兼容旧代码，如果没有提供providerId，则刷新所有模型
-          await refreshAllModels()
-        }
-      }
-    )
 
     // 处理模型启用状态变更事件
     window.electron.ipcRenderer.on(
       MODEL_EVENTS.STATUS_CHANGED,
-      async (event, msg: { providerId: string; modelId: string; enabled: boolean }) => {
-        // 只更新模型启用状态，而不是刷新所有模型
-        updateLocalModelStatus(msg.providerId, msg.modelId, msg.enabled)
-      }
-    )
-    // 兼容旧事件
-    window.electron.ipcRenderer.on(
-      LEGACY_EVENTS.MODEL_STATUS_CHANGED,
       async (event, msg: { providerId: string; modelId: string; enabled: boolean }) => {
         // 只更新模型启用状态，而不是刷新所有模型
         updateLocalModelStatus(msg.providerId, msg.modelId, msg.enabled)

--- a/src/renderer/src/stores/settings.ts
+++ b/src/renderer/src/stores/settings.ts
@@ -4,7 +4,7 @@ import type { LLM_PROVIDER, MODEL_META } from '@shared/presenter'
 import { usePresenter } from '@/composables/usePresenter'
 import { useI18n } from 'vue-i18n'
 import { SearchEngineTemplate } from '@shared/chat'
-import { CONFIG_EVENTS, MODEL_EVENTS, LEGACY_EVENTS } from '@/events'
+import { CONFIG_EVENTS, MODEL_EVENTS, LEGACY_EVENTS, UPDATE_EVENTS } from '@/events'
 
 export const useSettingsStore = defineStore('settings', () => {
   const configP = usePresenter('configPresenter')
@@ -527,10 +527,10 @@ export const useSettingsStore = defineStore('settings', () => {
   // 监听更新状态
   const setupUpdateListener = () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    window.electron.ipcRenderer.on('update-status-changed', (_, event: any) => {
+    window.electron.ipcRenderer.on(UPDATE_EVENTS.STATUS_CHANGED, (_, event: any) => {
       const { status, info, error } = event
       hasUpdate.value = status === 'available' || status === 'downloaded'
-      console.log('update-status-changed', status, info, error)
+      console.log(UPDATE_EVENTS.STATUS_CHANGED, status, info, error)
       // 根据不同状态更新UI
       switch (status) {
         case 'available':
@@ -564,21 +564,21 @@ export const useSettingsStore = defineStore('settings', () => {
 
     // 监听更新进度
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    window.electron.ipcRenderer.on('update-progress', (_, progressData: any) => {
-      console.log('update-progress', progressData)
+    window.electron.ipcRenderer.on(UPDATE_EVENTS.PROGRESS, (_, progressData: any) => {
+      console.log(UPDATE_EVENTS.PROGRESS, progressData)
       // 这里可以添加进度处理逻辑，如果需要显示进度条
     })
 
     // 监听更新错误
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    window.electron.ipcRenderer.on('update-error', (_, errorData: any) => {
-      console.error('Update error:', errorData.error)
+    window.electron.ipcRenderer.on(UPDATE_EVENTS.ERROR, (_, errorData: any) => {
+      console.error(UPDATE_EVENTS.ERROR, errorData.error)
       hasUpdate.value = false
       updateInfo.value = null
     })
 
     // 监听更新即将重启
-    window.electron.ipcRenderer.on('update-will-restart', () => {
+    window.electron.ipcRenderer.on(UPDATE_EVENTS.WILL_RESTART, () => {
       console.log('Application will restart to install update')
     })
   }

--- a/src/renderer/src/views/ChatTabView.vue
+++ b/src/renderer/src/views/ChatTabView.vue
@@ -25,13 +25,13 @@ import ChatView from '@/components/ChatView.vue'
 import { useChatStore } from '@/stores/chat'
 import { computed } from 'vue'
 import { useSettingsStore } from '@/stores/settings'
-import { MODEL_META } from '@shared/presenter'
+import { RENDERER_MODEL_META } from '@shared/presenter'
 import NewThread from '@/components/NewThread.vue'
 const settingsStore = useSettingsStore()
 
 const chatStore = useChatStore()
 const activeModel = computed(() => {
-  let model: MODEL_META | undefined
+  let model: RENDERER_MODEL_META | undefined
   const modelId = chatStore.activeThread?.settings.modelId
   if (modelId) {
     for (const group of settingsStore.enabledModels) {

--- a/src/shared/presenter.d.ts
+++ b/src/shared/presenter.d.ts
@@ -110,7 +110,7 @@ export interface IConfigPresenter {
   getProviderModels(providerId: string): MODEL_META[]
   setProviderModels(providerId: string, models: MODEL_META[]): void
   getEnabledProviders(): LLM_PROVIDER[]
-  getAllEnabledModels(): Promise<{ providerId: string; models: MODEL_META[] }[]>
+  getAllEnabledModels(): Promise<{ providerId: string; models: RENDERER_MODEL_META[] }[]>
   // 自定义模型管理
   getCustomModels(providerId: string): MODEL_META[]
   setCustomModels(providerId: string, models: MODEL_META[]): void
@@ -120,14 +120,24 @@ export interface IConfigPresenter {
   // 关闭行为设置
   getCloseToQuit(): boolean
   setCloseToQuit(value: boolean): void
+  getModelStatus(providerId: string, modelId: string): boolean
+  setModelStatus(providerId: string, modelId: string, enabled: boolean): void
 }
-
-export type MODEL_META = {
+export type RENDERER_MODEL_META = {
   id: string
   name: string
   group: string
   providerId: string
   enabled: boolean
+  isCustom: boolean
+  contextLength: number
+  maxTokens: number
+}
+export type MODEL_META = {
+  id: string
+  name: string
+  group: string
+  providerId: string
   isCustom: boolean
   contextLength: number
   maxTokens: number


### PR DESCRIPTION
## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**

1. 解决 #31 的bug
2. 为了正确处理模型状态需要分开存储状态和模型信息，重新设计了config的保存位置
3. 发现底层ipc事件错乱，导致renderer层反复刷掉正确状态，梳理了ipc整个逻辑

**请描述你希望的解决方案**

## 事件分类与命名规范

将事件按功能领域分类，并采用统一的命名规范：

1. **配置相关事件**：
   - `config:provider-changed`：提供者配置变更
   - `config:system-changed`：系统配置变更
   - `config:model-list-changed`：配置中的模型列表变更

2. **模型相关事件**：
   全部去掉，模型状态和名称事件都有config来发起,和上层settings保持语义一致

3. **会话相关事件**：
   - `conversation:created`
   - `conversation:activated`
   - `conversation:cleared`

4. **通信相关事件**：
   - `stream:response`
   - `stream:end`
   - `stream:error`

5. **应用更新相关事件**：
   - `update:status-changed`
   - `update:progress`
   - `update:error`
   - `update:will-restart`

## 责任分离

明确每个组件的事件触发责任：

- **ConfigPresenter**：仅负责配置相关事件
- **BaseLLMProvider**：仅负责模型操作,不发起事件
- **ThreadPresenter**：仅负责会话相关事件
- **UpgradePresenter**：仅负责应用更新相关事件


### 重构后的事件流

```mermaid
sequenceDiagram
    participant ConfigPresenter
    participant Presenter(Main)
    participant Settings(Renderer)

    ConfigPresenter->Presenter(Main): config:model-list-changed
    Presenter(Main)->Settings(Renderer): config:model-list-changed
    Settings(Renderer)-->Settings(Renderer): refreshProviderModels()

    ConfigPresenter->Presenter(Main): model:status-changed
    Presenter(Main)->Settings(Renderer): model:status-changed
    Settings(Renderer)-->Settings(Renderer): updateLocalModelStatus()

    ConfigPresenter->Presenter(Main): config:provider-changed
    Presenter(Main)->Settings(Renderer): config:provider-changed
    Settings(Renderer)-->Settings(Renderer): refreshAllModels()

```

