### PR TITLE
右键上下文菜单栏的国际化

### DIFF
--- a/src/main/presenter/contextMenuPresenter/index.ts
+++ b/src/main/presenter/contextMenuPresenter/index.ts
@@ -6,9 +6,7 @@ import { BrowserWindow, MenuItemConstructorOptions } from 'electron'
 import contextMenu from 'electron-context-menu'
 import { eventBus } from '@/eventbus'
 import { WindowPresenter } from '../windowPresenter'
-import {IContextMenuPresenter} from "@shared/presenter";
-
-
+import { IContextMenuPresenter } from '@shared/presenter'
 
 /**
  * 上下文菜单管理器类
@@ -46,17 +44,11 @@ export class ContextMenuPresenter implements IContextMenuPresenter {
   ): void {
     // 加入定时器
     // 如果已存在相同选择器的菜单，先移除并等待一小段时间
-    if (this.disposeFunctions.has(selector)) {
-      // 调用清理函数
-      // 打印清理函数对象
-      this.disposeFunctions.get(selector)?.()
-      // 从Map中删除
-      this.disposeFunctions.delete(selector)
-    }
+    this.removeContextMenu(selector)
 
     // 确保 customLabels 是有效的对象，增加默认值防止空值
     const menuLabels = customLabels || {}
-    console.log('注册菜单 ', menuLabels)
+    console.log('注册菜单 ', selector, menuLabels)
     const dispose = contextMenu({
       window: this.windowPresenter.mainWindow,
       labels: menuLabels,
@@ -149,6 +141,7 @@ export class ContextMenuPresenter implements IContextMenuPresenter {
     })
 
     // 保存清理函数
+    console.log('保存清理函数 ', selector, dispose)
     this.disposeFunctions.set(selector, dispose)
   }
 
@@ -157,8 +150,10 @@ export class ContextMenuPresenter implements IContextMenuPresenter {
    * @param selector - 要移除菜单的CSS选择器
    */
   removeContextMenu(selector: string): void {
+    console.log('移除菜单 ', selector)
     if (this.disposeFunctions.has(selector)) {
       // 调用清理函数
+      console.log('调用清理函数 ', this.disposeFunctions.get(selector))
       this.disposeFunctions.get(selector)?.()
       // 从Map中删除
       this.disposeFunctions.delete(selector)

--- a/src/main/presenter/contextMenuPresenter/index.ts
+++ b/src/main/presenter/contextMenuPresenter/index.ts
@@ -6,17 +6,9 @@ import { BrowserWindow, MenuItemConstructorOptions } from 'electron'
 import contextMenu from 'electron-context-menu'
 import { eventBus } from '@/eventbus'
 import { WindowPresenter } from '../windowPresenter'
+import {IContextMenuPresenter} from "@shared/presenter";
 
-// 定义上下文菜单展示器接口
-export interface IContextMenuPresenter {
-  registerContextMenu(
-    selector: string,
-    menuItems: { label: string; action: string }[],
-    customLabels?: Partial<Record<string, string>>
-  ): void
-  removeContextMenu(selector: string): void
-  dispose(): void
-}
+
 
 /**
  * 上下文菜单管理器类

--- a/src/main/presenter/contextMenuPresenter/index.ts
+++ b/src/main/presenter/contextMenuPresenter/index.ts
@@ -2,16 +2,29 @@
  * 上下文菜单管理器
  * 负责创建和管理应用程序中的右键菜单
  */
-import { IContextMenuPresenter } from '@shared/presenter'
 import { BrowserWindow, MenuItemConstructorOptions } from 'electron'
 import contextMenu from 'electron-context-menu'
 import { eventBus } from '@/eventbus'
+import { WindowPresenter } from '../windowPresenter'
+
+// 定义上下文菜单展示器接口
+export interface IContextMenuPresenter {
+  registerContextMenu(
+    selector: string,
+    menuItems: { label: string; action: string }[],
+    customLabels?: Partial<Record<string, string>>
+  ): void
+  removeContextMenu(selector: string): void
+  dispose(): void
+}
 
 /**
  * 上下文菜单管理器类
  * 实现了IContextMenuPresenter接口，提供右键菜单的注册、移除和管理功能
  */
 export class ContextMenuPresenter implements IContextMenuPresenter {
+  private windowPresenter: WindowPresenter
+
   /**
    * 存储所有已注册菜单的清理函数
    * 键为选择器，值为清理函数
@@ -22,49 +35,45 @@ export class ContextMenuPresenter implements IContextMenuPresenter {
    * 构造函数
    * 初始化时注册默认的上下文菜单
    */
-  constructor() {
+  constructor(windowPresenter: WindowPresenter) {
     // 注册默认的上下文菜单
     // this.registerDefaultContextMenu()
+    this.windowPresenter = windowPresenter
   }
 
   /**
    * 为特定选择器注册上下文菜单
    * @param selector - CSS选择器，用于定位应用菜单的元素
    * @param menuItems - 菜单项配置数组，每项包含标签和动作
+   * @param customLabels - 可选的自定义标签，用于国际化支持
    */
-  registerContextMenu(selector: string, menuItems: { label: string; action: string }[]): void {
-    console.log('========== registerContextMenu ', selector)
-    // 如果已存在相同选择器的菜单，先移除
+  registerContextMenu(
+    selector: string,
+    menuItems: { label: string; action: string }[],
+    customLabels?: Partial<Record<string, string>>
+  ): void {
+    // 加入定时器
+    // 如果已存在相同选择器的菜单，先移除并等待一小段时间
     if (this.disposeFunctions.has(selector)) {
+      // 调用清理函数
+      // 打印清理函数对象
       this.disposeFunctions.get(selector)?.()
+      // 从Map中删除
       this.disposeFunctions.delete(selector)
     }
+
+    // 确保 customLabels 是有效的对象，增加默认值防止空值
+    const menuLabels = customLabels || {}
+    console.log('注册菜单 ', menuLabels)
     const dispose = contextMenu({
-      selector,
-
-      // 完全禁用所有默认标签
-      labels: {
-        copy: '复制',
-        paste: '粘贴',
-        cut: '',
-        save: '',
-        saveImageAs: '',
-        copyLink: '',
-        copyImage: '',
-        copyImageAddress: '',
-        inspect: '',
-        searchWithGoogle: '',
-        lookUpSelection: '',
-        selectAll: '',
-        saveImageAs: ''
-      },
-
-      // 完全自定义菜单
+      window: this.windowPresenter.mainWindow,
+      labels: menuLabels,
+      // 确保菜单项直接使用标签值
       menu: (actions, props, browserWindow, dictionarySuggestions) => {
         const menu: MenuItemConstructorOptions[] = []
 
         // 添加自定义复制选项
-        const hasCopyItem = menuItems.some((item) => item.action === 'copy')
+        // const hasCopyItem = menuItems.some((item) => item.action === 'copy')
         // 只有在有选中文本时才添加复制选项
         if (props.selectionText.trim().length > 0) {
           menu.push({
@@ -79,23 +88,23 @@ export class ContextMenuPresenter implements IContextMenuPresenter {
               }
 
               // 如果是自定义复制项，则触发相关事件
-              if (hasCopyItem) {
-                // 触发事件总线事件
-                eventBus.emit('context-menu-action', {
-                  action: 'copy',
-                  data: props.selectionText,
-                  selector
-                })
+              // if (hasCopyItem) {
+              //   // 触发事件总线事件
+              //   eventBus.emit('context-menu-action', {
+              //     action: 'copy',
+              //     data: props.selectionText,
+              //     selector
+              //   })
 
-                // 发送到渲染进程
-                if (browserWindow instanceof BrowserWindow) {
-                  browserWindow.webContents.send('context-menu-action', {
-                    action: 'copy',
-                    data: props.selectionText,
-                    selector
-                  })
-                }
-              }
+              //   // 发送到渲染进程
+              //   if (browserWindow instanceof BrowserWindow) {
+              //     browserWindow.webContents.send('context-menu-action', {
+              //       action: 'copy',
+              //       data: props.selectionText,
+              //       selector
+              //     })
+              //   }
+              // }
             }
           })
         }
@@ -112,21 +121,21 @@ export class ContextMenuPresenter implements IContextMenuPresenter {
                 browserWindow.paste()
               }
 
-              // 触发事件
-              eventBus.emit('context-menu-action', {
-                action: 'paste',
-                data: '',
-                selector
-              })
+              // // 触发事件
+              // eventBus.emit('context-menu-action', {
+              //   action: 'paste',
+              //   data: '',
+              //   selector
+              // })
 
-              // 同时发送到渲染进程
-              if (browserWindow instanceof BrowserWindow) {
-                browserWindow.webContents.send('context-menu-action', {
-                  action: 'paste',
-                  data: '',
-                  selector
-                })
-              }
+              // // 同时发送到渲染进程
+              // if (browserWindow instanceof BrowserWindow) {
+              //   browserWindow.webContents.send('context-menu-action', {
+              //     action: 'paste',
+              //     data: '',
+              //     selector
+              //   })
+              // }
             }
           })
         } else if (props.isEditable) {

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -49,7 +49,7 @@ export class Presenter implements IPresenter {
     this.shortcutPresenter = new ShortcutPresenter(this.windowPresenter, this.configPresenter)
     this.filePresenter = new FilePresenter()
     // this.llamaCppPresenter = new LlamaCppPresenter()
-    this.contextMenuPresenter = new ContextMenuPresenter()
+    this.contextMenuPresenter = new ContextMenuPresenter(this.windowPresenter)
     this.setupEventBus()
   }
   setupEventBus() {

--- a/src/renderer/src/components/ChatInput.vue
+++ b/src/renderer/src/components/ChatInput.vue
@@ -295,9 +295,41 @@ const initSettings = async () => {
 }
 
 const contextMenuPresenter = usePresenter('contextMenuPresenter')
-contextMenuPresenter.registerContextMenu('textarea.textarea-selector', [
-  { label: '复制', action: 'copy' }
-])
+
+// 创建一个注册菜单的函数
+const registerContextMenuWithLocale = () => {
+  const copyText = t('common.copy');
+  const pasteText = t('common.paste');
+
+  // 移除旧菜单
+  contextMenuPresenter.removeContextMenu('textarea.textarea-selector')
+
+  // 延迟注册新菜单以确保旧菜单完全清理
+  setTimeout(() => {
+    contextMenuPresenter.registerContextMenu(
+      'textarea.textarea-selector',
+      [
+        { label: copyText, action: 'copy' },
+        { label: pasteText, action: 'paste' },
+      ],
+      {
+        copy: copyText,
+        paste: pasteText
+      }
+    );
+  }, 50);
+}
+
+onMounted(() => {
+  initSettings()
+
+  // 初次注册菜单, 加入定时器
+  setTimeout(() => {
+    console.log(`初次注册菜单`)
+    registerContextMenuWithLocale()
+  }, 200)
+
+})
 
 const handleDragEnter = (e: DragEvent) => {
   dragCounter.value++
@@ -348,13 +380,6 @@ const handleDrop = async (e: DragEvent) => {
   }
 }
 
-onMounted(() => {
-  initSettings()
-  
-  nextTick(() => {
-    textareaRef.value?.focus()
-  })
-})
 </script>
 
 <style scoped></style>

--- a/src/shared/presenter.d.ts
+++ b/src/shared/presenter.d.ts
@@ -463,3 +463,14 @@ export interface FileMetaData {
   fileCreated: Date
   fileModified: Date
 }
+
+// 定义上下文菜单展示器接口
+export interface IContextMenuPresenter {
+  registerContextMenu(
+    selector: string,
+    menuItems: { label: string; action: string }[],
+    customLabels?: Partial<Record<string, string>>
+  ): void
+  removeContextMenu(selector: string): void
+  dispose(): void
+}


### PR DESCRIPTION
修改内容
1、右键上下文菜单栏，文案增加国际化
2、增加了一些延迟逻辑，等待组件注销完成，才重新创建

存在问题
1、切换语言的时候，会销毁并且，重新注册新的语言的菜单栏，但是无法成功
2、多次切换，会有一个报错：MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 destroyed listeners added to [WebContents]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit