### PR TITLE
artifacts的全局配置功能

### DIFF
--- a/src/main/events.ts
+++ b/src/main/events.ts
@@ -14,7 +14,8 @@ export const CONFIG_EVENTS = {
   MODEL_STATUS_CHANGED: 'config:model-status-changed', // 替代 model-status-changed（ConfigPresenter）
   SETTING_CHANGED: 'config:setting-changed', // 替代 setting-changed（ConfigPresenter）
   PROXY_MODE_CHANGED: 'config:proxy-mode-changed',
-  CUSTOM_PROXY_URL_CHANGED: 'config:custom-proxy-url-changed'
+  CUSTOM_PROXY_URL_CHANGED: 'config:custom-proxy-url-changed',
+  ARTIFACTS_EFFECT_CHANGED: 'config:artifacts-effect-changed'
 }
 
 // 会话相关事件

--- a/src/main/presenter/configPresenter/index.ts
+++ b/src/main/presenter/configPresenter/index.ts
@@ -24,6 +24,7 @@ interface IAppSettings {
   appVersion?: string // 用于版本检查和数据迁移
   proxyMode?: string // 代理模式：system, none, custom
   customProxyUrl?: string // 自定义代理地址
+  artifactsEffectEnabled?: boolean // artifacts动画效果是否启用
   [key: string]: unknown // 允许任意键，使用unknown类型替代any
 }
 
@@ -440,5 +441,23 @@ export class ConfigPresenter implements IConfigPresenter {
   setCustomProxyUrl(url: string): void {
     this.setSetting('customProxyUrl', url)
     eventBus.emit(CONFIG_EVENTS.CUSTOM_PROXY_URL_CHANGED, url)
+  }
+
+  getArtifactsEffectEnabled(): boolean {
+    const value = this.getSetting<boolean>('artifactsEffectEnabled')
+    console.log('getArtifactsEffectEnabled 原始值:', value, '类型:', typeof value)
+    // 只有当值是undefined或null时才使用默认值true
+    // 注意：false是一个有效的boolean值，应该被保留而不是替换为默认值
+    return value === undefined || value === null ? true : value
+  }
+
+  setArtifactsEffectEnabled(enabled: boolean): void {
+    console.log('ConfigPresenter.setArtifactsEffectEnabled:', enabled, typeof enabled)
+
+    // 确保传入的是布尔值
+    const boolValue = Boolean(enabled)
+
+    this.setSetting('artifactsEffectEnabled', boolValue)
+    eventBus.emit(CONFIG_EVENTS.ARTIFACTS_EFFECT_CHANGED, boolValue)
   }
 }

--- a/src/renderer/src/components/ChatView.vue
+++ b/src/renderer/src/components/ChatView.vue
@@ -26,8 +26,10 @@ import ChatInput from './ChatInput.vue'
 import { useRoute } from 'vue-router'
 import { UserMessageContent } from '@shared/chat'
 import { STREAM_EVENTS } from '@/events'
+import { useSettingsStore } from '@/stores/settings'
 
 const route = useRoute()
+const settingsStore = useSettingsStore()
 
 const messageList = ref()
 
@@ -69,19 +71,22 @@ onMounted(async () => {
   if (route.query.modelId && route.query.providerId) {
     const threadId = await chatStore.createThread('新会话', {
       modelId: route.query.modelId as string,
-      providerId: route.query.providerId as string
+      providerId: route.query.providerId as string,
+      artifacts: settingsStore.artifactsEffectEnabled ? 1 : 0
     })
     chatStore.setActiveThread(threadId)
   }
 })
 
+// 监听路由变化，创建新线程
 watch(
   () => route.query,
   async () => {
     if (route.query.modelId && route.query.providerId) {
       const threadId = await chatStore.createThread('新会话', {
         modelId: route.query.modelId as string,
-        providerId: route.query.providerId as string
+        providerId: route.query.providerId as string,
+        artifacts: settingsStore.artifactsEffectEnabled ? 1 : 0
       })
       chatStore.setActiveThread(threadId)
     }

--- a/src/renderer/src/components/NewThread.vue
+++ b/src/renderer/src/components/NewThread.vue
@@ -92,6 +92,7 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import ChatInput from './ChatInput.vue'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Button } from '@/components/ui/button'
@@ -108,7 +109,7 @@ import ChatConfig from './ChatConfig.vue'
 import { usePresenter } from '@/composables/usePresenter'
 const configPresenter = usePresenter('configPresenter')
 const { t } = useI18n()
-
+const router = useRouter()
 const chatStore = useChatStore()
 const settingsStore = useSettingsStore()
 const activeModel = ref({
@@ -127,7 +128,7 @@ const temperature = ref(0.6)
 const contextLength = ref(16384)
 const maxTokens = ref(4096)
 const systemPrompt = ref('')
-const artifacts = ref(0)
+const artifacts = ref(settingsStore.artifactsEffectEnabled ? 1 : 0)
 
 const name = computed(() => {
   return activeModel.value?.name ? activeModel.value.name.split('/').pop() : ''

--- a/src/renderer/src/components/settings/CommonSettings.vue
+++ b/src/renderer/src/components/settings/CommonSettings.vue
@@ -6,6 +6,7 @@
           <Icon icon="lucide:languages" class="w-4 h-4 text-muted-foreground" />
           <span class="text-sm font-medium">{{ t('settings.common.language') }}</span>
         </span>
+        <!-- 语言选择 -->
         <div class="flex-shrink-0 min-w-64 max-w-96">
           <Select v-model="selectedLanguage" class="">
             <SelectTrigger>
@@ -19,6 +20,7 @@
           </Select>
         </div>
       </div>
+      <!-- 搜索引擎选择 -->
       <div class="flex flex-row p-2 items-center gap-2 px-2">
         <span class="flex flex-row items-center gap-2 flex-grow w-full">
           <Icon icon="lucide:search" class="w-4 h-4 text-muted-foreground" />
@@ -41,6 +43,7 @@
           </Select>
         </div>
       </div>
+      <!-- 搜索助手模型选择 -->
       <div class="flex flex-row p-2 items-center gap-2 px-2">
         <span class="flex flex-row items-center gap-2 flex-grow w-full">
           <Icon icon="lucide:bot" class="w-4 h-4 text-muted-foreground" />
@@ -65,6 +68,7 @@
           </Popover>
         </div>
       </div>
+      <!-- 代理模式选择 -->
       <div class="flex flex-row p-2 items-center gap-2 px-2">
         <span class="flex flex-row items-center gap-2 flex-grow w-full">
           <Icon icon="lucide:globe" class="w-4 h-4 text-muted-foreground" />
@@ -103,6 +107,21 @@
           {{ t('settings.common.invalidProxyUrl') }}
         </div>
       </div>
+      <!-- artifacts效果开关 -->
+      <div class="flex flex-row p-2 items-center gap-2 px-2">
+        <span class="flex flex-row items-center gap-2 flex-grow w-full">
+          <Icon icon="lucide:sparkles" class="w-4 h-4 text-muted-foreground" />
+          <span class="text-sm font-medium">Artifacts</span>
+        </span>
+        <div class="flex-shrink-0">
+          <Switch
+            id="artifacts-effect-switch"
+            :checked="artifactsEffectEnabled"
+            @update:checked="val => settingsStore.setArtifactsEffectEnabled(Boolean(val))"
+          />
+        </div>
+      </div>
+      <!-- 重置数据 -->
       <Dialog v-model:open="isDialogOpen">
         <DialogTrigger as-child>
           <div
@@ -162,6 +181,7 @@ import ModelSelect from '@/components/ModelSelect.vue'
 import ModelIcon from '@/components/icons/ModelIcon.vue'
 import { Input } from '@/components/ui/input'
 import type { RENDERER_MODEL_META } from '@shared/presenter'
+import { Switch } from '@/components/ui/switch'
 
 const devicePresenter = usePresenter('devicePresenter')
 const configPresenter = usePresenter('configPresenter')
@@ -210,6 +230,17 @@ const validateProxyUrl = () => {
     configPresenter.setCustomProxyUrl(customProxyUrl.value)
   }
 }
+
+const artifactsEffectEnabled = computed({
+  get: () => {
+    console.log('获取artifactsEffectEnabled值:', settingsStore.artifactsEffectEnabled)
+    return settingsStore.artifactsEffectEnabled
+  },
+  set: (value) => {
+    console.log('设置artifactsEffectEnabled值:', value)
+    settingsStore.setArtifactsEffectEnabled(value)
+  }
+})
 
 onMounted(async () => {
   selectedLanguage.value = settingsStore.language

--- a/src/renderer/src/events.ts
+++ b/src/renderer/src/events.ts
@@ -11,7 +11,8 @@ export const CONFIG_EVENTS = {
   PROVIDER_CHANGED: 'config:provider-changed', // 替代 provider-setting-changed
   SYSTEM_CHANGED: 'config:system-changed',
   MODEL_LIST_CHANGED: 'config:model-list-changed', // 替代 provider-models-updated（ConfigPresenter）
-  MODEL_STATUS_CHANGED: 'config:model-status-changed' // 替代 model-status-changed（ConfigPresenter）
+  MODEL_STATUS_CHANGED: 'config:model-status-changed', // 替代 model-status-changed（ConfigPresenter）
+  ARTIFACTS_EFFECT_CHANGED: 'config:artifacts-effect-changed' // artifacts效果设置变更
 }
 
 // 会话相关事件

--- a/src/shared/presenter.d.ts
+++ b/src/shared/presenter.d.ts
@@ -143,6 +143,9 @@ export interface IConfigPresenter {
   setProxyMode(mode: string): void
   getCustomProxyUrl(): string
   setCustomProxyUrl(url: string): void
+  // artifacts效果设置
+  getArtifactsEffectEnabled(): boolean
+  setArtifactsEffectEnabled(enabled: boolean): void
 }
 export type RENDERER_MODEL_META = {
   id: string


### PR DESCRIPTION
artifacts的全局配置功能
1、通用配置中增加 Artifacts配置，默认为true
2、新会话的时候，读取全局Artifacts配置来开启会话

全局Artifacts开关关闭的时候，开启新会话的效果
<img width="1226" alt="image" src="https://github.com/user-attachments/assets/317b214a-e8b8-4876-8d72-a989d12aeacf" />

全局Artifacts开关开启的时候，开启新会话的效果
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/7d6cb893-8a48-4a09-ac3c-39e9b01bf50b" />
