### PR TITLE
修复上传文件后，对话框的文件依然存在的问题

### DIFF
--- a/src/renderer/src/components/ChatInput.vue
+++ b/src/renderer/src/components/ChatInput.vue
@@ -290,6 +290,24 @@ const emitSend = () => {
 
     emit('send', messageContent)
     inputText.value = ''
+    
+    // 清理已上传的文件
+    if (selectedFiles.value.length > 0) {
+      // 清理每个文件资源
+      selectedFiles.value.forEach(file => {
+        if (file.path) {
+          filePresenter.onFileRemoved(file.path).catch((err) => {
+            console.error('清理文件资源失败:', err)
+          })
+        }
+      })
+      // 清空文件列表
+      selectedFiles.value = []
+      // 重置文件输入控件
+      if (fileInput.value) {
+        fileInput.value.value = ''
+      }
+    }
   }
 }
 


### PR DESCRIPTION
修复上传文件后，对话框的文件依然存在的问题

修复前的：
![image](https://github.com/user-attachments/assets/7818fd6d-2412-4c93-8b4d-8bae3f7b8e04)

修复后：
![image](https://github.com/user-attachments/assets/3197aff4-de5a-4cd9-b733-9ac636306d20)

