### PR TITLE
增加了一个复制模型回复为图片的按钮

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "electron-vite": "^3.0.0",
     "eslint": "^8.57.0",
     "eslint-plugin-vue": "^9.26.0",
+    "html-to-image": "^1.11.13",
     "prettier": "^3.3.2",
     "tailwindcss": "3.4.17",
     "tiny-runtime-injector": "^0.0.1",

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -5,6 +5,7 @@ declare global {
     electron: ElectronAPI
     api: {
       copyText(text: string): void
+      copyImage(image: string): void
       getPathForFile(file: File): string
     }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,10 +1,14 @@
-import { clipboard, contextBridge, webUtils } from 'electron'
+import { clipboard, contextBridge, nativeImage, webUtils } from 'electron'
 import { exposeElectronAPI } from '@electron-toolkit/preload'
 
 // Custom APIs for renderer
 const api = {
   copyText: (text: string) => {
     clipboard.writeText(text)
+  },
+  copyImage: (image: string) => {
+    const img = nativeImage.createFromDataURL(image)
+    clipboard.writeImage(img)
   },
   getPathForFile: (file: File) => {
     return webUtils.getPathForFile(file)

--- a/src/renderer/src/components/message/MessageItemAssistant.vue
+++ b/src/renderer/src/components/message/MessageItemAssistant.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['flex flex-row py-4 pl-4 pr-11 group gap-2 w-full', 'justify-start']">
+  <div ref="messageNode" :class="['flex flex-row py-4 pl-4 pr-11 group gap-2 w-full', 'justify-start']">
     <ModelIcon
       :model-id="message.model_id"
       custom-class="flex-shrink-0 w-5 h-5 block rounded-md bg-background"
@@ -46,6 +46,7 @@
         @retry="handleAction('retry')"
         @delete="handleAction('delete')"
         @copy="handleAction('copy')"
+        @copyImage="handleAction('copyImage')"
         @prev="handleAction('prev')"
         @next="handleAction('next')"
       />
@@ -54,7 +55,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, watch, useTemplateRef } from 'vue'
 import { AssistantMessage } from '@shared/chat'
 import MessageBlockContent from './MessageBlockContent.vue'
 import MessageBlockThink from './MessageBlockThink.vue'
@@ -65,6 +66,8 @@ import MessageInfo from './MessageInfo.vue'
 import { useChatStore } from '@/stores/chat'
 import ModelIcon from '@/components/icons/ModelIcon.vue'
 import { Icon } from '@iconify/vue'
+import { toBlob } from 'html-to-image';
+
 
 const props = defineProps<{
   message: AssistantMessage
@@ -73,8 +76,12 @@ const props = defineProps<{
 const chatStore = useChatStore()
 const currentVariantIndex = ref(0)
 
+const messageNode = useTemplateRef('messageNode')
+
 // 获取当前会话ID
 const currentThreadId = computed(() => chatStore.activeThreadId || '')
+
+
 
 // 计算当前消息的所有变体（包括缓存中的）
 const allVariants = computed(() => {
@@ -129,7 +136,7 @@ onMounted(() => {
   currentVariantIndex.value = allVariants.value.length
 })
 
-const handleAction = (action: 'retry' | 'delete' | 'copy' | 'prev' | 'next') => {
+const handleAction = (action: 'retry' | 'delete' | 'copy' | 'prev' | 'next' | 'copyImage') => {
   if (action === 'retry') {
     chatStore.retryMessage(props.message.id)
   } else if (action === 'delete') {
@@ -152,6 +159,22 @@ const handleAction = (action: 'retry' | 'delete' | 'copy' | 'prev' | 'next') => 
   } else if (action === 'next') {
     if (currentVariantIndex.value < totalVariants.value - 1) {
       currentVariantIndex.value++
+    }
+  } else if (action === 'copyImage') {
+    if (messageNode.value) {
+      toBlob(messageNode.value, {
+        quality: 1,
+        backgroundColor: '#FFFFFF',
+      }).then((blob) => {
+        if (blob) {
+          const rd = new FileReader()
+          rd.onloadend = () => {
+            const url = rd.result as string
+            window.api.copyImage(url)
+          }
+          rd.readAsDataURL(blob)
+        }
+      })
     }
   }
 }

--- a/src/renderer/src/components/message/MessageToolbar.vue
+++ b/src/renderer/src/components/message/MessageToolbar.vue
@@ -55,6 +55,15 @@
           <Icon icon="lucide:copy" class="w-4 h-4" />
         </Button>
         <Button
+          variant="ghost"
+          v-show="isAssistant"
+          size="icon"
+          class="w-4 h-4 text-muted-foreground hover:text-primary hover:bg-transparent"
+          @click="emit('copyImage')"
+        >
+          <Icon icon="lucide:images" class="w-4 h-4" />
+        </Button>
+        <Button
           v-show="isAssistant"
           variant="ghost"
           size="icon"
@@ -120,6 +129,7 @@ const emit = defineEmits<{
   (e: 'retry'): void
   (e: 'delete'): void
   (e: 'copy'): void
+  (e: 'copyImage'): void
   (e: 'prev'): void
   (e: 'next'): void
   (e: 'edit'): void


### PR DESCRIPTION
## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
请对问题进行清晰扼要的描述。
*例如：我增加了 [...] 的功能 *

增加了一个复制模型回复为图片的按钮。

复制为文本贴到其他地方会丢失格式，模型的回复比较长，截图不方便，该按钮用于复制整个当前的回复为图片。

**请描述你希望的解决方案**
请对你希望实现的效果进行清晰扼要的描述。

通过 https://github.com/bubkoo/html-to-image 将node转换为图片

**桌面应用程序的 UI/UX 更改**
如果此 PR 引入了 UI/UX 更改，请详细描述它们。
* 如果适用，请包含屏幕截图或 GIF 以直观地演示更改。
* 解释 UI/UX 决策背后的原因，以及它们如何改善桌面应用程序的用户体验。



**平台兼容性注意事项**
如果此 PR 具有特定的平台兼容性考虑因素（Windows、macOS、Linux），请在此处描述。
* 是否有任何平台特定的行为或代码调整？
* 你是否已在所有相关平台上进行过测试？

无兼容性相关问题

**附加背景**
在此处添加关于此 Pull Request 的任何其他背景信息。
