### PR TITLE
fix python code file upload, but overrall the file upload logic is no…

### DIFF
--- a/src/main/presenter/filePresenter/CodeFileAdapter.ts
+++ b/src/main/presenter/filePresenter/CodeFileAdapter.ts
@@ -10,6 +10,7 @@ export class CodeFileAdapter extends BaseFileAdapter {
     super(filePath)
     this.maxFileSize = maxFileSize
     this.fileContent = undefined
+    this.mimeType = 'text/code' //set a default mime type
   }
 
   protected getFileDescription(): string | undefined {
@@ -138,33 +139,11 @@ export class CodeFileAdapter extends BaseFileAdapter {
   }
 
   public async getLLMContent(): Promise<string | undefined> {
-    const fullPath = path.join(this.filePath)
-    const stats = await fs.stat(fullPath)
     const content = await this.getContent()
     const language = this.getLanguageFromExt()
-
-    const fileDescription = `# File Description
-
-  ## Basic File Information
-
-  * **File Name:** ${path.basename(this.filePath)}
-  * **File Type:** ${this.getFileDescription()}
-  * **File Format:** ${path.extname(this.filePath).substring(1)}
-  * **Programming Language:** ${language}
-  * **File Size:** ${stats.size} bytes
-  * **Creation Date:** ${stats.birthtime.toISOString().split('T')[0]}
-  * **Updated Date:** ${stats.mtime.toISOString().split('T')[0]}
-  `
-    if (content) {
-      return `${fileDescription}
-
-## File Content
+    return `
   \`\`\`${language}
   ${content}
-  \`\`\`
-  `
-    } else {
-      return fileDescription
-    }
+  \`\`\``
   }
 }

--- a/src/main/presenter/filePresenter/mime.ts
+++ b/src/main/presenter/filePresenter/mime.ts
@@ -31,6 +31,7 @@ export const getMimeTypeAdapterMap = (): Map<string, FileAdapterConstructor> => 
   map.set('video/mp2t', CodeFileAdapter)
   map.set('application/x-sh', CodeFileAdapter)
   map.set('text/x-python', CodeFileAdapter)
+  map.set('text/x-python-script', CodeFileAdapter)
   map.set('text/x-java', CodeFileAdapter)
   map.set('text/x-c', CodeFileAdapter)
   map.set('text/x-cpp', CodeFileAdapter)

--- a/src/renderer/src/components/ChatInput.vue
+++ b/src/renderer/src/components/ChatInput.vue
@@ -274,7 +274,7 @@ const handleFileSelect = async (e: Event) => {
     for (const file of files) {
       const path = window.api.getPathForFile(file)
       try {
-        const fileInfo: MessageFile = await filePresenter.prepareFile(path)
+        const fileInfo: MessageFile = await filePresenter.prepareFile(path, file.type)
         if (fileInfo) {
           selectedFiles.value.push(fileInfo)
         } else {

--- a/src/shared/presenter.d.ts
+++ b/src/shared/presenter.d.ts
@@ -524,7 +524,7 @@ export interface IFilePresenter {
   readFile(relativePath: string): Promise<string>
   writeFile(operation: FileOperation): Promise<void>
   deleteFile(relativePath: string): Promise<void>
-  prepareFile(absPath: string): Promise<MessageFile>
+  prepareFile(absPath: string, typeInfo?: string): Promise<MessageFile>
   onFileRemoved(filePath: string): Promise<boolean>
 }
 


### PR DESCRIPTION
## Pull Request Description

**Is your feature request related to a problem? Please describe.**

1. before the fix, the code file adapter give the LLM too many meta info, that LLM will treat it as part of the source code file,
after the fix, gemini2.0-flash still  can't handle it very well, but deepseek is fine.
1. fix python code file upload

overrall the file upload logic is not well understand by the LLM models, what I suggest  is write some prompt for your file upload xml notations.

**Describe the solution you'd like**

fix the mime type mismatch, reduced the file description.

**still have issues on google gemini**

<img width="503" alt="image" src="https://github.com/user-attachments/assets/070b5418-5011-4090-be16-3ef2da001272" />
<img width="507" alt="image" src="https://github.com/user-attachments/assets/63a31cb7-ea0c-4700-9933-7a29ff0389a1" />

what I suggest  is write some prompt for your file upload xml notations.

deepseek is fine:
<img width="730" alt="image" src="https://github.com/user-attachments/assets/c19bed42-2f65-4e1b-bd0d-b3a547d384f0" />

update: gemini 1.5 pro,gemini1.5-flash is okay with that.

**UI/UX changes for Desktop Application**

No UI/UX changed

**Platform Compatibility Notes**

tested on macOS.

