### PR TITLE
support streamableHttp mcp

### DIFF
--- a/src/main/presenter/configPresenter/mcpConfHelper.ts
+++ b/src/main/presenter/configPresenter/mcpConfHelper.ts
@@ -13,7 +13,7 @@ interface IMcpSettings {
   mcpEnabled: boolean // 添加MCP启用状态字段
   [key: string]: unknown // 允许任意键
 }
-export type MCPServerType = 'stdio' | 'sse' | 'inmemory'
+export type MCPServerType = 'stdio' | 'sse' | 'inmemory' | 'http'
 // const filesystemPath = path.join(app.getAppPath(), 'resources', 'mcp', 'filesystem.mjs')
 
 // 抽取inmemory类型的服务为常量

--- a/src/main/presenter/deeplinkPresenter/index.ts
+++ b/src/main/presenter/deeplinkPresenter/index.ts
@@ -17,7 +17,7 @@ interface MCPInstallConfig {
       autoApprove?: string[]
       disable?: boolean
       url?: string
-      type?: 'sse' | 'stdio'
+      type?: 'sse' | 'stdio' | 'http'
     }
   >
 }

--- a/src/main/presenter/mcpPresenter/mcpClient.ts
+++ b/src/main/presenter/mcpPresenter/mcpClient.ts
@@ -11,6 +11,7 @@ import { app } from 'electron'
 import fs from 'fs'
 import { proxyConfig } from '@/presenter/proxyConfig'
 import { getInMemoryServer } from './inMemoryServers/builder'
+import { StreamableHttpClientTransport } from './streamableHttp'
 
 // 确保 TypeScript 能够识别 SERVER_STATUS_CHANGED 属性
 type MCPEventsType = typeof MCP_EVENTS & {
@@ -267,8 +268,13 @@ export class McpClient {
           env,
           stderr: 'pipe'
         })
-      } else if (this.serverConfig.baseUrl) {
+      } else if (this.serverConfig.baseUrl && this.serverConfig.type === 'sse') {
         this.transport = new SSEClientTransport(new URL(this.serverConfig.baseUrl as string))
+      } else if (this.serverConfig.baseUrl && this.serverConfig.type === 'http') {
+        this.transport = new StreamableHttpClientTransport(
+          new URL(this.serverConfig.baseUrl as string),
+          { useSSE: false }
+        )
       } else {
         throw new Error(`不支持的传输类型: ${this.serverConfig.type}`)
       }

--- a/src/main/presenter/mcpPresenter/mcpClient.ts
+++ b/src/main/presenter/mcpPresenter/mcpClient.ts
@@ -273,7 +273,7 @@ export class McpClient {
       } else if (this.serverConfig.baseUrl && this.serverConfig.type === 'http') {
         this.transport = new StreamableHttpClientTransport(
           new URL(this.serverConfig.baseUrl as string),
-          { useSSE: false }
+          { useSSE: !!this.serverConfig.useSSE }
         )
       } else {
         throw new Error(`不支持的传输类型: ${this.serverConfig.type}`)

--- a/src/main/presenter/mcpPresenter/streamableHttp.ts
+++ b/src/main/presenter/mcpPresenter/streamableHttp.ts
@@ -1,0 +1,343 @@
+import { EventSource, type ErrorEvent, type EventSourceInit } from 'eventsource'
+import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { JSONRPCMessage, JSONRPCMessageSchema } from '@modelcontextprotocol/sdk/types.js'
+import {
+  auth,
+  AuthResult,
+  OAuthClientProvider,
+  UnauthorizedError
+} from '@modelcontextprotocol/sdk/client/auth.js'
+
+export class StreamableHttpError extends Error {
+  constructor(
+    public readonly code: number | undefined,
+    message: string | undefined,
+    public readonly event?: ErrorEvent
+  ) {
+    super(`Streamable HTTP error: ${message}`)
+  }
+}
+
+/**
+ * Configuration options for the `StreamableHttpClientTransport`.
+ */
+export type StreamableHttpClientTransportOptions = {
+  /**
+   * An OAuth client provider to use for authentication.
+   *
+   * When an `authProvider` is specified and the connection is started:
+   * 1. The connection is attempted with any existing access token from the `authProvider`.
+   * 2. If the access token has expired, the `authProvider` is used to refresh the token.
+   * 3. If token refresh fails or no access token exists, and auth is required, `OAuthClientProvider.redirectToAuthorization` is called, and an `UnauthorizedError` will be thrown from `connect`/`start`.
+   *
+   * After the user has finished authorizing via their user agent, and is redirected back to the MCP client application, call `StreamableHttpClientTransport.finishAuth` with the authorization code before retrying the connection.
+   *
+   * If an `authProvider` is not provided, and auth is required, an `UnauthorizedError` will be thrown.
+   *
+   * `UnauthorizedError` might also be thrown when sending any message over the transport, indicating that the session has expired, and needs to be re-authed and reconnected.
+   */
+  authProvider?: OAuthClientProvider
+
+  /**
+   * Customizes the initial SSE request to the server (the request that begins the stream).
+   *
+   * NOTE: Setting this property will prevent an `Authorization` header from
+   * being automatically attached to the SSE request, if an `authProvider` is
+   * also given. This can be worked around by setting the `Authorization` header
+   * manually.
+   */
+  eventSourceInit?: EventSourceInit
+
+  /**
+   * Customizes recurring POST requests to the server.
+   */
+  requestInit?: RequestInit
+
+  /**
+   * Whether to use SSE for receiving responses to requests.
+   * If true, the client will establish an SSE connection to receive responses.
+   * If false, the client will use direct HTTP responses.
+   * @default true
+   */
+  useSSE?: boolean
+}
+
+/**
+ * Client transport for Streamable HTTP: this implements the MCP Streamable HTTP transport specification.
+ * It supports both SSE streaming and direct HTTP responses, with session management and message resumability.
+ *
+ * Usage example:
+ *
+ * ```typescript
+ * // With SSE streaming (default)
+ * const sseTransport = new StreamableHttpClientTransport(new URL("http://example.com/mcp"));
+ *
+ * // With direct HTTP responses
+ * const httpTransport = new StreamableHttpClientTransport(new URL("http://example.com/mcp"), {
+ *   useSSE: false
+ * });
+ * ```
+ */
+export class StreamableHttpClientTransport implements Transport {
+  private _eventSource?: EventSource
+  private _endpoint?: URL
+  private _abortController?: AbortController
+  private _url: URL
+  private _eventSourceInit?: EventSourceInit
+  private _requestInit?: RequestInit
+  private _authProvider?: OAuthClientProvider
+  private _useSSE: boolean
+  private _sessionId?: string
+  private _lastEventId?: string
+  private _pendingRequests: Map<string, (response: JSONRPCMessage) => void> = new Map()
+
+  onclose?: () => void
+  onerror?: (error: Error) => void
+  onmessage?: (message: JSONRPCMessage) => void
+
+  constructor(url: URL, opts?: StreamableHttpClientTransportOptions) {
+    this._url = url
+    this._eventSourceInit = opts?.eventSourceInit
+    this._requestInit = opts?.requestInit
+    this._authProvider = opts?.authProvider
+    this._useSSE = opts?.useSSE !== false
+  }
+
+  private async _authThenStart(): Promise<void> {
+    if (!this._authProvider) {
+      throw new UnauthorizedError('No auth provider')
+    }
+
+    let result: AuthResult
+    try {
+      result = await auth(this._authProvider, { serverUrl: this._url })
+    } catch (error) {
+      this.onerror?.(error as Error)
+      throw error
+    }
+
+    if (result !== 'AUTHORIZED') {
+      throw new UnauthorizedError()
+    }
+
+    return await this._startOrAuth()
+  }
+
+  private async _commonHeaders(): Promise<HeadersInit> {
+    const headers: HeadersInit = {}
+    if (this._authProvider) {
+      const tokens = await this._authProvider.tokens()
+      if (tokens) {
+        headers['Authorization'] = `Bearer ${tokens.access_token}`
+      }
+    }
+
+    if (this._sessionId) {
+      headers['mcp-session-id'] = this._sessionId
+    }
+
+    return headers
+  }
+
+  private _startOrAuth(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (this._useSSE) {
+        this._eventSource = new EventSource(
+          this._url.href,
+          this._eventSourceInit ?? {
+            fetch: (url, init) =>
+              this._commonHeaders().then((headers) =>
+                fetch(url, {
+                  ...init,
+                  headers: {
+                    ...headers,
+                    Accept: 'text/event-stream'
+                  }
+                })
+              )
+          }
+        )
+        this._abortController = new AbortController()
+
+        this._eventSource.onerror = (event) => {
+          if (event.code === 401 && this._authProvider) {
+            this._authThenStart().then(resolve, reject)
+            return
+          }
+
+          const error = new StreamableHttpError(event.code, event.message, event)
+          reject(error)
+          this.onerror?.(error)
+        }
+
+        this._eventSource.onopen = () => {
+          // The connection is open, but we need to wait for the endpoint to be received.
+        }
+
+        this._eventSource.addEventListener('endpoint', (event: Event) => {
+          const messageEvent = event as MessageEvent
+
+          try {
+            this._endpoint = new URL(messageEvent.data, this._url)
+            if (this._endpoint.origin !== this._url.origin) {
+              throw new Error(
+                `Endpoint origin does not match connection origin: ${this._endpoint.origin}`
+              )
+            }
+          } catch (error) {
+            reject(error)
+            this.onerror?.(error as Error)
+
+            void this.close()
+            return
+          }
+
+          resolve()
+        })
+
+        this._eventSource.onmessage = (event: Event) => {
+          const messageEvent = event as MessageEvent
+          let message: JSONRPCMessage
+          try {
+            message = JSONRPCMessageSchema.parse(JSON.parse(messageEvent.data))
+          } catch (error) {
+            this.onerror?.(error as Error)
+            return
+          }
+
+          // Check if this is a response to a pending request
+          if ('id' in message && message.id !== null && message.id !== undefined) {
+            const requestId = String(message.id)
+            const resolveRequest = this._pendingRequests.get(requestId)
+            if (resolveRequest) {
+              resolveRequest(message)
+              this._pendingRequests.delete(requestId)
+              return
+            }
+          }
+
+          this.onmessage?.(message)
+        }
+      } else {
+        // For non-SSE mode, we just need to set the endpoint and resolve
+        this._endpoint = this._url
+        resolve()
+      }
+    })
+  }
+
+  async start() {
+    if (this._eventSource) {
+      throw new Error(
+        'StreamableHttpClientTransport already started! If using Client class, note that connect() calls start() automatically.'
+      )
+    }
+
+    return await this._startOrAuth()
+  }
+
+  /**
+   * Call this method after the user has finished authorizing via their user agent and is redirected back to the MCP client application. This will exchange the authorization code for an access token, enabling the next connection attempt to successfully auth.
+   */
+  async finishAuth(authorizationCode: string): Promise<void> {
+    if (!this._authProvider) {
+      throw new UnauthorizedError('No auth provider')
+    }
+
+    const result = await auth(this._authProvider, {
+      serverUrl: this._url,
+      authorizationCode
+    })
+    if (result !== 'AUTHORIZED') {
+      throw new UnauthorizedError('Failed to authorize')
+    }
+  }
+
+  async close(): Promise<void> {
+    this._abortController?.abort()
+    this._eventSource?.close()
+    this.onclose?.()
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    if (!this._endpoint) {
+      throw new Error('Not connected')
+    }
+
+    try {
+      const commonHeaders = await this._commonHeaders()
+      const headers = new Headers({
+        ...commonHeaders,
+        ...this._requestInit?.headers
+      })
+      headers.set('content-type', 'application/json')
+
+      // Set Accept header based on whether we're using SSE
+      if (this._useSSE) {
+        headers.set('Accept', 'text/event-stream')
+      } else {
+        headers.set('Accept', 'application/json')
+      }
+
+      const init = {
+        ...this._requestInit,
+        method: 'POST',
+        headers,
+        body: JSON.stringify(message),
+        signal: this._abortController?.signal
+      }
+
+      const response = await fetch(this._endpoint, init)
+
+      // Check for session ID in response headers
+      const sessionId = response.headers.get('mcp-session-id')
+      if (sessionId) {
+        this._sessionId = sessionId
+      }
+
+      if (!response.ok) {
+        if (response.status === 401 && this._authProvider) {
+          const result = await auth(this._authProvider, {
+            serverUrl: this._url
+          })
+          if (result !== 'AUTHORIZED') {
+            throw new UnauthorizedError()
+          }
+
+          // Purposely _not_ awaited, so we don't call onerror twice
+          return this.send(message)
+        }
+
+        const text = await response.text().catch(() => null)
+        throw new Error(`Error POSTing to endpoint (HTTP ${response.status}): ${text}`)
+      }
+
+      // If we're not using SSE and this is a request with an ID, wait for the response
+      if (!this._useSSE && 'id' in message && message.id !== null && message.id !== undefined) {
+        const requestId = String(message.id)
+
+        // Parse the response as JSON
+        const responseData = await response.json()
+        const responseMessage = JSONRPCMessageSchema.parse(responseData)
+
+        // Check if this is a response to our request
+        if ('id' in responseMessage && String(responseMessage.id) === requestId) {
+          this.onmessage?.(responseMessage)
+        } else {
+          // If it's not a response to our request, it might be a notification
+          this.onmessage?.(responseMessage)
+        }
+      }
+    } catch (error) {
+      this.onerror?.(error as Error)
+      throw error
+    }
+  }
+
+  /**
+   * Returns the session ID for this transport.
+   */
+  get sessionId(): string | undefined {
+    return this._sessionId
+  }
+}

--- a/src/renderer/src/components/mcp-config/mcpServerForm.vue
+++ b/src/renderer/src/components/mcp-config/mcpServerForm.vue
@@ -39,7 +39,7 @@ const args = ref(props.initialConfig?.args?.join(' ') || '')
 const env = ref(JSON.stringify(props.initialConfig?.env || {}, null, 2))
 const descriptions = ref(props.initialConfig?.descriptions || '')
 const icons = ref(props.initialConfig?.icons || '📁')
-const type = ref<'sse' | 'stdio' | 'inmemory'>(props.initialConfig?.type || 'stdio')
+const type = ref<'sse' | 'stdio' | 'inmemory' | 'http'>(props.initialConfig?.type || 'stdio')
 const baseUrl = ref(props.initialConfig?.baseUrl || '')
 
 // 判断是否是inmemory类型
@@ -65,7 +65,7 @@ const currentStep = ref(props.editMode ? 'detailed' : 'simple')
 const jsonConfig = ref('')
 
 // 当type变更时处理baseUrl的显示逻辑
-const showBaseUrl = computed(() => type.value === 'sse')
+const showBaseUrl = computed(() => type.value === 'sse' || type.value === 'http')
 // 添加计算属性来控制命令相关字段的显示
 const showCommandFields = computed(() => type.value === 'stdio')
 
@@ -103,7 +103,7 @@ const parseJsonConfig = () => {
     icons.value = serverConfig.icons || '📁'
     type.value = serverConfig.type || 'stdio'
     baseUrl.value = serverConfig.url || ''
-    if (type.value !== 'stdio' && type.value !== 'sse') {
+    if (type.value !== 'stdio' && type.value !== 'sse' && type.value !== 'http') {
       if (baseUrl.value) {
         type.value = 'sse'
       } else {
@@ -148,7 +148,7 @@ const goToDetailedForm = () => {
 const isNameValid = computed(() => name.value.trim().length > 0)
 const isCommandValid = computed(() => {
   // 对于SSE类型，命令不是必需的
-  if (type.value === 'sse') return true
+  if (type.value === 'sse' || type.value === 'http') return true
   // 对于STDIO类型，命令是必需的
   return command.value.trim().length > 0
 })
@@ -161,7 +161,7 @@ const isEnvValid = computed(() => {
   }
 })
 const isBaseUrlValid = computed(() => {
-  if (type.value !== 'sse') return true
+  if (type.value !== 'sse' && type.value !== 'http') return true
   return baseUrl.value.trim().length > 0
 })
 
@@ -170,7 +170,7 @@ const isFormValid = computed(() => {
   if (!isNameValid.value) return false
 
   // 对于SSE类型，只需要名称和baseUrl有效
-  if (type.value === 'sse') {
+  if (type.value === 'sse' || type.value === 'http') {
     return isNameValid.value && isBaseUrlValid.value
   }
 
@@ -204,6 +204,15 @@ const handleSubmit = () => {
 
   if (type.value === 'sse') {
     // SSE类型的服务器
+    serverConfig = {
+      ...baseConfig,
+      command: '', // 提供空字符串作为默认值
+      args: [], // 提供空数组作为默认值
+      env: {}, // 提供空对象作为默认值
+      baseUrl: baseUrl.value.trim()
+    }
+  } else if (type.value === 'http') {
+    // HTTP类型的服务器
     serverConfig = {
       ...baseConfig,
       command: '', // 提供空字符串作为默认值
@@ -337,6 +346,7 @@ watch(
             <SelectContent>
               <SelectItem value="stdio">{{ t('settings.mcp.serverForm.typeStdio') }}</SelectItem>
               <SelectItem value="sse">{{ t('settings.mcp.serverForm.typeSse') }}</SelectItem>
+              <SelectItem value="http">{{ t('settings.mcp.serverForm.typeHttp') }}</SelectItem>
               <SelectItem
                 value="inmemory"
                 v-if="props.editMode && props.initialConfig?.type === 'inmemory'"

--- a/src/renderer/src/components/mcp-config/mcpServerForm.vue
+++ b/src/renderer/src/components/mcp-config/mcpServerForm.vue
@@ -41,6 +41,7 @@ const descriptions = ref(props.initialConfig?.descriptions || '')
 const icons = ref(props.initialConfig?.icons || '📁')
 const type = ref<'sse' | 'stdio' | 'inmemory' | 'http'>(props.initialConfig?.type || 'stdio')
 const baseUrl = ref(props.initialConfig?.baseUrl || '')
+const useSSE = ref(props.initialConfig?.useSSE || false)
 
 // 判断是否是inmemory类型
 const isInMemoryType = computed(() => type.value === 'inmemory')
@@ -103,6 +104,7 @@ const parseJsonConfig = () => {
     icons.value = serverConfig.icons || '📁'
     type.value = serverConfig.type || 'stdio'
     baseUrl.value = serverConfig.url || ''
+    useSSE.value = serverConfig.useSSE || false
     if (type.value !== 'stdio' && type.value !== 'sse' && type.value !== 'http') {
       if (baseUrl.value) {
         type.value = 'sse'
@@ -218,7 +220,8 @@ const handleSubmit = () => {
       command: '', // 提供空字符串作为默认值
       args: [], // 提供空数组作为默认值
       env: {}, // 提供空对象作为默认值
-      baseUrl: baseUrl.value.trim()
+      baseUrl: baseUrl.value.trim(),
+      useSSE: useSSE.value
     }
   } else {
     // STDIO类型的服务器
@@ -368,6 +371,19 @@ watch(
             :disabled="isFieldReadOnly"
             required
           />
+        </div>
+
+        <!-- HTTP类型的SSE选项 -->
+        <div class="space-y-2" v-if="type === 'http'">
+          <div class="flex items-center space-x-2">
+            <Checkbox id="use-sse" v-model:checked="useSSE" :disabled="isFieldReadOnly" />
+            <label
+              for="use-sse"
+              class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            >
+              {{ t('settings.mcp.serverForm.useSSE') }}
+            </label>
+          </div>
         </div>
 
         <!-- 命令 -->

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -195,8 +195,8 @@
       "nameRequired": "Server name is required",
       "type": "Server Type",
       "typePlaceholder": "Select server type",
-      "typeStdio": "Standard I/O",
-      "typeSse": "Server-Sent Events",
+      "typeStdio": "Standard input and output (Stdio)",
+      "typeSse": "Server Send Events (SSE)",
       "typeInMemory": "In-Memory",
       "baseUrl": "Base URL",
       "baseUrlPlaceholder": "Enter server base URL (e.g. http://localhost:3000)",
@@ -234,7 +234,9 @@
       "configImported": "Configuration imported successfully",
       "parseError": "Parse Error",
       "skipToManual": "Skip to Manual Configuration",
-      "parseAndContinue": "Parse & Continue"
+      "parseAndContinue": "Parse & Continue",
+      "jsonParseError": "JSON parsing failed",
+      "typeHttp": "Streaming HTTP Requests (HTTP)"
     },
     "deleteServer": "Delete Server",
     "editServer": "Edit Server",

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -236,7 +236,8 @@
       "skipToManual": "Skip to Manual Configuration",
       "parseAndContinue": "Parse & Continue",
       "jsonParseError": "JSON parsing failed",
-      "typeHttp": "Streaming HTTP Requests (HTTP)"
+      "typeHttp": "Streaming HTTP Requests (HTTP)",
+      "useSSE": "Enable SSE transfer"
     },
     "deleteServer": "Delete Server",
     "editServer": "Edit Server",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -235,7 +235,8 @@
       "skipToManual": "手動設定へスキップ",
       "parseAndContinue": "解析して続行",
       "jsonParseError": "JSONの解析は失敗しました",
-      "typeHttp": "ストリーミングHTTPリクエスト（HTTP）"
+      "typeHttp": "ストリーミングHTTPリクエスト（HTTP）",
+      "useSSE": "SSE転送を有効にします"
     },
     "deleteServer": "サーバーを削除",
     "editServer": "サーバーを編集",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -195,8 +195,8 @@
       "nameRequired": "サーバー名は必須です",
       "type": "サーバータイプ",
       "typePlaceholder": "サーバータイプを選択",
-      "typeStdio": "標準入出力",
-      "typeSse": "サーバー送信イベント",
+      "typeStdio": "標準入力と出力（STDIO）",
+      "typeSse": "サーバー送信イベント（SSE）",
       "baseUrl": "ベースURL",
       "baseUrlPlaceholder": "サーバーのベースURLを入力（例：http://localhost:3000）",
       "command": "コマンド",
@@ -233,7 +233,9 @@
       "configImported": "設定が正常にインポートされました",
       "parseError": "解析エラー",
       "skipToManual": "手動設定へスキップ",
-      "parseAndContinue": "解析して続行"
+      "parseAndContinue": "解析して続行",
+      "jsonParseError": "JSONの解析は失敗しました",
+      "typeHttp": "ストリーミングHTTPリクエスト（HTTP）"
     },
     "deleteServer": "サーバーを削除",
     "editServer": "サーバーを編集",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -235,7 +235,8 @@
       "skipToManual": "수동 구성으로 건너뛰기",
       "parseAndContinue": "파싱 및 계속",
       "jsonParseError": "JSON 파싱이 실패했습니다",
-      "typeHttp": "스트리밍 HTTP 요청 (HTTP)"
+      "typeHttp": "스트리밍 HTTP 요청 (HTTP)",
+      "useSSE": "SSE 전송을 활성화합니다"
     },
     "deleteServer": "서버 삭제",
     "editServer": "서버 편집",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -194,8 +194,8 @@
       "nameRequired": "서버 이름이 필요합니다",
       "type": "서버 유형",
       "typePlaceholder": "서버 유형 선택",
-      "typeStdio": "표준 입출력",
-      "typeSse": "서버 전송 이벤트",
+      "typeStdio": "표준 입력 및 출력 (STDIO)",
+      "typeSse": "서버 보내기 이벤트 (SSE)",
       "typeInMemory": "인메모리",
       "baseUrl": "기본 URL",
       "baseUrlPlaceholder": "서버 기본 URL 입력(예: http://localhost:3000)",
@@ -233,7 +233,9 @@
       "configImported": "구성을 성공적으로 가져왔습니다",
       "parseError": "파싱 오류",
       "skipToManual": "수동 구성으로 건너뛰기",
-      "parseAndContinue": "파싱 및 계속"
+      "parseAndContinue": "파싱 및 계속",
+      "jsonParseError": "JSON 파싱이 실패했습니다",
+      "typeHttp": "스트리밍 HTTP 요청 (HTTP)"
     },
     "deleteServer": "서버 삭제",
     "editServer": "서버 편집",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -233,7 +233,8 @@
       "skipToManual": "Перейти к ручной настройке",
       "parseAndContinue": "Обработать и продолжить",
       "jsonParseError": "JSON SAINING не удалось",
-      "typeHttp": "Потоковые http -запросы (http)"
+      "typeHttp": "Потоковые http -запросы (http)",
+      "useSSE": "Включить передачу SSE"
     },
     "deleteServer": "Удалить сервер",
     "editServer": "Редактировать сервер",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -192,8 +192,8 @@
       "nameRequired": "Имя сервера обязательно",
       "type": "Тип сервера",
       "typePlaceholder": "Выберите тип сервера",
-      "typeStdio": "Стандартный ввод-вывод",
-      "typeSse": "Server-Sent Events",
+      "typeStdio": "Стандартный вход и выход (Stdio)",
+      "typeSse": "Сервер отправлять события (SSE)",
       "typeInMemory": "In-Memory",
       "baseUrl": "Базовый URL",
       "baseUrlPlaceholder": "Введите базовый URL сервера (например, http://localhost:3000)",
@@ -231,7 +231,9 @@
       "configImported": "Конфигурация успешно импортирована",
       "parseError": "Ошибка обработки",
       "skipToManual": "Перейти к ручной настройке",
-      "parseAndContinue": "Обработать и продолжить"
+      "parseAndContinue": "Обработать и продолжить",
+      "jsonParseError": "JSON SAINING не удалось",
+      "typeHttp": "Потоковые http -запросы (http)"
     },
     "deleteServer": "Удалить сервер",
     "editServer": "Редактировать сервер",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -206,9 +206,10 @@
       "nameRequired": "服务器名称不能为空",
       "type": "服务器类型",
       "typePlaceholder": "选择服务器类型",
-      "typeStdio": "标准输入输出",
-      "typeSse": "服务器发送事件",
-      "typeInMemory": "内存",
+      "typeStdio": "标准输入输出(Stdio)",
+      "typeSse": "服务器发送事件(SSE)",
+      "typeInMemory": "内存(InMemory)",
+      "typeHttp": "可流式传输的HTTP请求(HTTP)",
       "baseUrl": "基础URL",
       "baseUrlPlaceholder": "输入服务器基础URL（如：http://localhost:3000）",
       "command": "命令",
@@ -245,7 +246,8 @@
       "configImported": "配置导入成功",
       "parseError": "解析错误",
       "skipToManual": "跳过至手动配置",
-      "parseAndContinue": "解析并继续"
+      "parseAndContinue": "解析并继续",
+      "jsonParseError": "JSON解析失败"
     },
     "deleteServer": "删除服务器",
     "editServer": "编辑服务器",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -247,7 +247,8 @@
       "parseError": "解析错误",
       "skipToManual": "跳过至手动配置",
       "parseAndContinue": "解析并继续",
-      "jsonParseError": "JSON解析失败"
+      "jsonParseError": "JSON解析失败",
+      "useSSE": "启用SSE传输"
     },
     "deleteServer": "删除服务器",
     "editServer": "编辑服务器",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -234,7 +234,8 @@
       "skipToManual": "跳過至手動配置",
       "parseAndContinue": "解析並繼續",
       "jsonParseError": "JSON解析失敗",
-      "typeHttp": "可流式傳輸的HTTP請求(HTTP)"
+      "typeHttp": "可流式傳輸的HTTP請求(HTTP)",
+      "useSSE": "啟用SSE傳輸"
     },
     "deleteServer": "刪除伺服器",
     "editServer": "編輯伺服器",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -193,8 +193,8 @@
       "nameRequired": "伺服器名稱不能為空",
       "type": "伺服器類型",
       "typePlaceholder": "選擇伺服器類型",
-      "typeStdio": "標準輸入輸出",
-      "typeSse": "伺服器發送事件",
+      "typeStdio": "標準輸入輸出(Stdio)",
+      "typeSse": "服務器發送事件(SSE)",
       "typeInMemory": "記憶體",
       "baseUrl": "基礎URL",
       "baseUrlPlaceholder": "輸入伺服器基礎URL（如：http://localhost:3000）",
@@ -232,7 +232,9 @@
       "configImported": "配置導入成功",
       "parseError": "解析錯誤",
       "skipToManual": "跳過至手動配置",
-      "parseAndContinue": "解析並繼續"
+      "parseAndContinue": "解析並繼續",
+      "jsonParseError": "JSON解析失敗",
+      "typeHttp": "可流式傳輸的HTTP請求(HTTP)"
     },
     "deleteServer": "刪除伺服器",
     "editServer": "編輯伺服器",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -241,7 +241,8 @@
       "skipToManual": "跳過至手動配置",
       "parseAndContinue": "解析並繼續",
       "jsonParseError": "JSON解析失敗",
-      "typeHttp": "可流式傳輸的HTTP請求(HTTP)"
+      "typeHttp": "可流式傳輸的HTTP請求(HTTP)",
+      "useSSE": "啟用SSE傳輸"
     },
     "deleteServer": "刪除伺服器",
     "editServer": "編輯伺服器",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -201,8 +201,8 @@
       "nameRequired": "伺服器名稱不能為空",
       "type": "伺服器類型",
       "typePlaceholder": "選擇伺服器類型",
-      "typeStdio": "標準輸入輸出",
-      "typeSse": "伺服器發送事件",
+      "typeStdio": "標準輸入輸出(Stdio)",
+      "typeSse": "服務器發送事件(SSE)",
       "baseUrl": "基礎網址",
       "baseUrlPlaceholder": "輸入伺服器基礎網址（如：http://localhost:3000）",
       "command": "命令",
@@ -239,7 +239,9 @@
       "configImported": "配置導入成功",
       "parseError": "解析錯誤",
       "skipToManual": "跳過至手動配置",
-      "parseAndContinue": "解析並繼續"
+      "parseAndContinue": "解析並繼續",
+      "jsonParseError": "JSON解析失敗",
+      "typeHttp": "可流式傳輸的HTTP請求(HTTP)"
     },
     "deleteServer": "刪除伺服器",
     "editServer": "編輯伺服器",

--- a/src/shared/presenter.d.ts
+++ b/src/shared/presenter.d.ts
@@ -611,7 +611,7 @@ export interface MCPServerConfig {
   autoApprove: string[]
   disable?: boolean
   baseUrl?: string
-  type: 'sse' | 'stdio' | 'inmemory'
+  type: 'sse' | 'stdio' | 'inmemory' | 'http'
 }
 
 export interface MCPConfig {

--- a/src/shared/presenter.d.ts
+++ b/src/shared/presenter.d.ts
@@ -612,6 +612,7 @@ export interface MCPServerConfig {
   disable?: boolean
   baseUrl?: string
   type: 'sse' | 'stdio' | 'inmemory' | 'http'
+  useSSE?: boolean
 }
 
 export interface MCPConfig {


### PR DESCRIPTION

## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
支持了 Streamable HTTP 的 Transport
可基于 https://github.com/chatmcp/mcp-server-perplexity 服务进行测试

**请描述你希望的解决方案**
基于官方目前正在开发的 pr https://github.com/modelcontextprotocol/typescript-sdk/pull/230/files
进行了对于 client 的 transport 实现，后续可以替换成官方的，减少兼容性问题


