### PR TITLE
feat: 在连接失败时使用 Electron 的 dialog 模块显示错误弹窗

### DIFF
--- a/src/main/presenter/mcpPresenter/mcpClient.ts
+++ b/src/main/presenter/mcpPresenter/mcpClient.ts
@@ -12,6 +12,7 @@ import fs from 'fs'
 import { proxyConfig } from '@/presenter/proxyConfig'
 import { getInMemoryServer } from './inMemoryServers/builder'
 import { StreamableHTTPClientTransport} from './streamableHttp'
+import { dialog } from 'electron'
 
 // 确保 TypeScript 能够识别 SERVER_STATUS_CHANGED 属性
 type MCPEventsType = typeof MCP_EVENTS & {
@@ -337,6 +338,13 @@ export class McpClient {
       this.cleanupResources()
 
       console.error(`连接到MCP服务器 ${this.serverName} 失败:`, error)
+      // 使用 Electron 的 dialog 模块显示错误弹窗
+      dialog.showErrorBox(
+        'MCP 服务器连接失败',
+        `无法连接到 MCP 服务器 ${this.serverName}。\n错误信息: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
 
       // 触发服务器状态变更事件
       eventBus.emit((MCP_EVENTS as MCPEventsType).SERVER_STATUS_CHANGED, {


### PR DESCRIPTION
# 问题描述
在现有的 MCP 客户端代码中，当连接 MCP 服务器失败时，仅在控制台输出错误信息，用户无法直观地得知连接失败的情况，缺乏友好的错误提示机制。本次提交增加了使用 Electron 的 dialog 模块显示错误弹窗的功能，以解决用户无法及时得知连接失败的问题。

# 解决方案
在 McpClient 类的 connect 方法中，当连接 MCP 服务器失败时，使用 dialog.showErrorBox 方法弹出错误提示框，显示连接失败的服务器名称和具体错误信息。代码如下：


mcpClient.ts
```ts
// ... existing code ...
catch (error) {
  // 清除超时
  if (this.connectionTimeout) {
    clearTimeout(this.connectionTimeout)
    this.connectionTimeout = null
  }

  // 清理资源
  this.cleanupResources()

  console.error(`连接到MCP服务器 ${this.serverName} 失败:`, error)
  
  // 使用 Electron 的 dialog 模块显示错误弹窗
  dialog.showErrorBox(
    'MCP 服务器连接失败',
    `无法连接到 MCP 服务器 ${this.serverName}。\n错误信息: ${
      error instanceof Error ? error.message : String(error)
    }`
  )

  // 触发服务器状态变更事件
  eventBus.emit((MCP_EVENTS as MCPEventsType).SERVER_STATUS_CHANGED, {
    name: this.serverName,
    status: 'stopped'
  })

  throw error
}
// ... existing code ...
```
# 桌面应用程序的 UI/UX 更改
具体更改：在连接 MCP 服务器失败时，弹出一个错误提示框，显示连接失败的服务器名称和具体错误信息。
效果演示：用户在遇到连接失败时，会看到一个标题为 “MCP 服务器连接失败” 的弹窗，其中包含具体的错误信息。
<img width="1024" alt="image" src="https://github.com/user-attachments/assets/a3af32a2-c3a6-4f8a-a21b-f7b2da254487" />
决策原因：通过弹出错误提示框，用户可以直观地得知连接失败的情况，避免因未查看控制台信息而错过错误提示，提高了用户体验。


# 平台兼容性注意事项
平台特定行为：dialog.showErrorBox 是 Electron 提供的跨平台 API，在 Windows、macOS 和 Linux 平台上都能正常工作，无需进行额外的平台特定代码调整。
测试情况：已在 Windows、macOS 和 Linux 平台上进行了测试，确保错误提示框在不同平台上都能正常显示。
# 附加背景
本次更改旨在提高 MCP 客户端的用户体验，让用户能够及时得知连接失败的情况。通过添加错误提示框，用户可以更方便地排查问题，提高使用效率。