### PR TITLE
make search as mcp server inmemory

### DIFF
--- a/src/main/presenter/configPresenter/mcpConfHelper.ts
+++ b/src/main/presenter/configPresenter/mcpConfHelper.ts
@@ -38,6 +38,18 @@ const DEFAULT_INMEMORY_SERVERS: Record<string, MCPServerConfig> = {
     command: 'artifacts',
     env: {},
     disable: false
+  },
+  bochaSearch: {
+    args: [],
+    descriptions: 'DeepChat内置网络搜索服务',
+    icons: '🔍',
+    autoApprove: ['all'],
+    type: 'inmemory' as MCPServerType,
+    command: 'bochaSearch',
+    env: {
+      apiKey: 'YOUR_BOCHA_API_KEY' // 需要用户提供实际的API Key
+    },
+    disable: false
   }
 }
 

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -82,7 +82,9 @@ export class Presenter implements IPresenter {
 
     // 流式响应事件
     eventBus.on(STREAM_EVENTS.RESPONSE, (msg) => {
-      this.windowPresenter.mainWindow?.webContents.send(STREAM_EVENTS.RESPONSE, msg)
+      const dataToRender = { ...msg }
+      delete dataToRender.tool_call_response_raw // 删除 rawData 字段,此处不需要上发给 renderer，节约性能
+      this.windowPresenter.mainWindow?.webContents.send(STREAM_EVENTS.RESPONSE, dataToRender)
     })
 
     eventBus.on(STREAM_EVENTS.END, (msg) => {

--- a/src/main/presenter/llmProviderPresenter/providers/anthropicProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/anthropicProvider.ts
@@ -819,7 +819,6 @@ ${context}
                         role: 'user',
                         content: contentBlocks
                       })
-
                       yield {
                         content: '',
                         tool_call: 'end',
@@ -829,7 +828,8 @@ ${context}
                         tool_call_id: `anthropic-${toolCall.id}`,
                         tool_call_server_name: mcpToolCall.server.name,
                         tool_call_server_icons: mcpToolCall.server.icons,
-                        tool_call_server_description: mcpToolCall.server.description
+                        tool_call_server_description: mcpToolCall.server.description,
+                        tool_call_response_raw: toolResponse.rawData
                       }
                     } catch (error) {
                       console.error('工具调用失败:', error)

--- a/src/main/presenter/llmProviderPresenter/providers/geminiProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/geminiProvider.ts
@@ -928,7 +928,8 @@ export class GeminiProvider extends BaseLLMProvider {
                 tool_call_id: toolCallId,
                 tool_call_server_name: mcpToolCall.server.name,
                 tool_call_server_icons: mcpToolCall.server.icons,
-                tool_call_server_description: mcpToolCall.server.description
+                tool_call_server_description: mcpToolCall.server.description,
+                tool_call_response_raw: toolResponse.rawData
               }
 
               // 设置需要继续对话的标志

--- a/src/main/presenter/llmProviderPresenter/providers/ollamaProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/ollamaProvider.ts
@@ -495,7 +495,8 @@ export class OllamaProvider extends BaseLLMProvider {
                   tool_call_id: `ollama-${toolCall.id}`,
                   tool_call_server_name: mcpTool.server.name,
                   tool_call_server_icons: mcpTool.server.icons,
-                  tool_call_server_description: mcpTool.server.description
+                  tool_call_server_description: mcpTool.server.description,
+                  tool_call_response_raw: toolCallResponse.rawData
                 }
                 // 将工具响应添加到消息中
                 conversationMessages.push({

--- a/src/main/presenter/llmProviderPresenter/providers/openAICompatibleProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/openAICompatibleProvider.ts
@@ -557,7 +557,8 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
               tool_call_params: toolCall.function.arguments,
               tool_call_server_name: mcpTool.server.name,
               tool_call_server_icons: mcpTool.server.icons,
-              tool_call_server_description: mcpTool.server.description
+              tool_call_server_description: mcpTool.server.description,
+              tool_call_response_raw: toolCallResponse.rawData
             }
             // 将工具响应添加到消息中
             if (supportsFunctionCall) {

--- a/src/main/presenter/mcpPresenter/inMemoryServers/bochaSearchServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/bochaSearchServer.ts
@@ -1,0 +1,193 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ToolSchema
+} from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { zodToJsonSchema } from 'zod-to-json-schema'
+import { Transport } from '@modelcontextprotocol/sdk/shared/transport'
+import axios from 'axios'
+
+// Schema definitions
+const BochaWebSearchArgsSchema = z.object({
+  query: z.string().describe('Search query (max 400 chars, 50 words)'),
+  count: z.number().optional().default(10).describe('Number of results (1-50, default 10)'),
+  page: z.number().optional().default(1).describe('Page number (default 1)')
+})
+
+const ToolInputSchema = ToolSchema.shape.inputSchema
+type ToolInput = z.infer<typeof ToolInputSchema>
+
+// 定义Bocha API返回的数据结构
+interface BochaSearchResponse {
+  msg: string | null
+  data: {
+    _type: string
+    queryContext: {
+      originalQuery: string
+    }
+    webPages: {
+      webSearchUrl: string
+      totalEstimatedMatches: number
+      value: Array<{
+        id: string | null
+        name: string
+        url: string
+        displayUrl: string
+        snippet: string
+        siteName: string
+        siteIcon: string
+        dateLastCrawled: string
+        cachedPageUrl: string | null
+        language: string | null
+        isFamilyFriendly: boolean | null
+        isNavigational: boolean | null
+      }>
+      isFamilyFriendly: boolean | null
+    }
+    videos: unknown | null
+  }
+}
+
+export class BochaSearchServer {
+  private server: Server
+  private apiKey: string
+
+  constructor(env?: Record<string, string>) {
+    if (!env?.apiKey) {
+      throw new Error('需要提供Bocha API Key')
+    }
+    this.apiKey = env.apiKey
+
+    // 创建服务器实例
+    this.server = new Server(
+      {
+        name: 'deepchat-inmemory/bocha-search-server',
+        version: '0.1.0'
+      },
+      {
+        capabilities: {
+          tools: {}
+        }
+      }
+    )
+
+    // 设置请求处理器
+    this.setupRequestHandlers()
+  }
+
+  // 启动服务器
+  public startServer(transport: Transport): void {
+    this.server.connect(transport)
+  }
+
+  // 设置请求处理器
+  private setupRequestHandlers(): void {
+    // 设置工具列表处理器
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+      return {
+        tools: [
+          {
+            name: 'bocha_web_search',
+            description:
+              'Performs a web search using the Bocha AI Search API, ideal for general queries, news, articles, and online content.。' +
+              'Use this for broad information gathering, recent events, or when you need diverse web sources.' +
+              'Supports pagination, content filtering, and freshness controls. ' +
+              'Maximum 50 results per request, with page for pagination.',
+            inputSchema: zodToJsonSchema(BochaWebSearchArgsSchema) as ToolInput
+          }
+        ]
+      }
+    })
+
+    // 设置工具调用处理器
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      try {
+        const { name, arguments: args } = request.params
+
+        switch (name) {
+          case 'bocha_web_search': {
+            const parsed = BochaWebSearchArgsSchema.safeParse(args)
+            if (!parsed.success) {
+              throw new Error(`无效的搜索参数: ${parsed.error}`)
+            }
+
+            const { query, count } = parsed.data
+
+            // 调用Bocha API
+            const response = await axios.post(
+              'https://api.bochaai.com/v1/web-search',
+              {
+                query,
+                summary: true,
+                freshness: 'noLimit',
+                count
+              },
+              {
+                headers: {
+                  Authorization: `Bearer ${this.apiKey}`,
+                  'Content-Type': 'application/json'
+                }
+              }
+            )
+
+            // 处理响应数据
+            const searchResponse = response.data as BochaSearchResponse
+
+            if (!searchResponse.data?.webPages?.value) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: '搜索未返回任何结果。'
+                  }
+                ]
+              }
+            }
+
+            // 将结果转换为MCP资源格式
+            const results = searchResponse.data.webPages.value.map((item, index) => {
+              // 构建blob内容
+              const blobContent = {
+                title: item.name,
+                url: item.url,
+                rank: index + 1,
+                content: item.snippet,
+                icon: item.siteIcon
+              }
+
+              return {
+                type: 'resource',
+                resource: {
+                  uri: item.url,
+                  mimeType: 'application/deepchat-webpage',
+                  text: JSON.stringify(blobContent)
+                }
+              }
+            })
+
+            // 添加搜索摘要
+            const summary = {
+              type: 'text',
+              text: `为您找到关于"${query}"的${results.length}个结果`
+            }
+
+            return {
+              content: [summary, ...results]
+            }
+          }
+
+          default:
+            throw new Error(`未知工具: ${name}`)
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        return {
+          content: [{ type: 'text', text: `错误: ${errorMessage}` }],
+          isError: true
+        }
+      }
+    })
+  }
+}

--- a/src/main/presenter/mcpPresenter/inMemoryServers/builder.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/builder.ts
@@ -1,12 +1,19 @@
 import { ArtifactsServer } from './artifactsServer'
 import { FileSystemServer } from './filesystem'
+import { BochaSearchServer } from './bochaSearchServer'
 
-export function getInMemoryServer(serverName: string, args: string[]) {
+export function getInMemoryServer(
+  serverName: string,
+  args: string[],
+  env?: Record<string, string>
+) {
   switch (serverName) {
     case 'buildInFileSystem':
       return new FileSystemServer(args)
     case 'Artifacts':
       return new ArtifactsServer()
+    case 'bochaSearch':
+      return new BochaSearchServer(env)
     default:
       throw new Error(`Unknown in-memory server: ${serverName}`)
   }

--- a/src/main/presenter/mcpPresenter/mcpClient.ts
+++ b/src/main/presenter/mcpPresenter/mcpClient.ts
@@ -97,7 +97,7 @@ export class McpClient {
     const runtimePath = path
       .join(app.getAppPath(), 'runtime', 'node')
       .replace('app.asar', 'app.asar.unpacked')
-    console.log('runtimePath', runtimePath)
+    console.info('runtimePath', runtimePath)
     // 检查运行时文件是否存在
     if (process.platform === 'win32') {
       const nodeExe = path.join(runtimePath, 'node.exe')
@@ -130,13 +130,13 @@ export class McpClient {
       if (this.serverConfig.type === 'inmemory') {
         const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
         const _args = Array.isArray(this.serverConfig.args) ? this.serverConfig.args : []
-        const _server = getInMemoryServer(this.serverName, _args)
+        const _env = this.serverConfig.env ? (this.serverConfig.env as Record<string, string>) : {}
+        const _server = getInMemoryServer(this.serverName, _args, _env)
         _server.startServer(serverTransport)
         this.transport = clientTransport
       } else if (this.serverConfig.type === 'stdio') {
         // 创建合适的transport
         const command = this.serverConfig.command as string
-        console.log('final command', command)
         const HOME_DIR = app.getPath('home')
 
         // 定义允许的环境变量白名单

--- a/src/main/presenter/threadPresenter/index.ts
+++ b/src/main/presenter/threadPresenter/index.ts
@@ -9,7 +9,8 @@ import {
   MODEL_META,
   ISQLitePresenter,
   IConfigPresenter,
-  ILlmProviderPresenter
+  ILlmProviderPresenter,
+  MCPToolResponse
 } from '../../../shared/presenter'
 import { presenter } from '@/presenter'
 import { MessageManager } from './messageManager'
@@ -88,6 +89,7 @@ export class ThreadPresenter implements IThreadPresenter {
         tool_call_server_name,
         tool_call_server_icons,
         tool_call_server_description,
+        tool_call_response_raw,
         tool_call,
         totalUsage
       } = msg
@@ -145,6 +147,84 @@ export class ThreadPresenter implements IThreadPresenter {
         }
 
         const lastBlock = state.message.content[state.message.content.length - 1]
+
+        // 检查tool_call_response_raw中是否包含搜索结果
+        if (tool_call_response_raw && tool_call === 'end') {
+          try {
+            // 检查返回的内容中是否有deepchat-webpage类型的资源
+            const hasSearchResults = tool_call_response_raw.content?.some(
+              (item: { type: string; resource?: { mimeType: string } }) =>
+                item?.type === 'resource' &&
+                item?.resource?.mimeType === 'application/deepchat-webpage'
+            )
+
+            if (hasSearchResults) {
+              // 解析搜索结果
+              const searchResults = tool_call_response_raw.content
+                .filter(
+                  (item: {
+                    type: string
+                    resource?: { mimeType: string; text: string; uri?: string }
+                  }) =>
+                    item.type === 'resource' &&
+                    item.resource?.mimeType === 'application/deepchat-webpage'
+                )
+                .map((item: { resource: { text: string; uri?: string } }) => {
+                  try {
+                    const blobContent = JSON.parse(item.resource.text) as {
+                      title?: string
+                      url?: string
+                      content?: string
+                      icon?: string
+                    }
+                    return {
+                      title: blobContent.title || '',
+                      url: blobContent.url || item.resource.uri || '',
+                      content: blobContent.content || '',
+                      description: blobContent.content || '',
+                      icon: blobContent.icon || ''
+                    }
+                  } catch (e) {
+                    console.error('解析搜索结果失败:', e)
+                    return null
+                  }
+                })
+                .filter(Boolean)
+
+              if (searchResults.length > 0) {
+                // 添加搜索结果块
+                const searchBlock: AssistantMessageBlock = {
+                  type: 'search',
+                  content: '',
+                  status: 'success',
+                  timestamp: Date.now(),
+                  extra: {
+                    total: searchResults.length
+                  }
+                }
+
+                // 将搜索块插入到内容的最前面
+                state.message.content.unshift(searchBlock)
+
+                // 保存搜索结果
+                for (const result of searchResults) {
+                  await this.sqlitePresenter.addMessageAttachment(
+                    eventId,
+                    'search_result',
+                    JSON.stringify(result)
+                  )
+                }
+
+                await this.messageManager.editMessage(
+                  eventId,
+                  JSON.stringify(state.message.content)
+                )
+              }
+            }
+          } catch (error) {
+            console.error('处理搜索结果时出错:', error)
+          }
+        }
 
         // 处理工具调用
         if (tool_call) {
@@ -993,7 +1073,7 @@ export class ThreadPresenter implements IThreadPresenter {
       }
 
       // 3. 检查是否是 maximum_tool_calls_reached
-      let toolCallResponse: { content: string } | null = null
+      let toolCallResponse: { content: string; rawData: MCPToolResponse } | null = null
       const toolCall = lastActionBlock.tool_call
 
       if (lastActionBlock.action_type === 'maximum_tool_calls_reached' && toolCall) {
@@ -1079,7 +1159,8 @@ export class ThreadPresenter implements IThreadPresenter {
           tool_call_params: toolCall.params,
           tool_call_server_name: toolCall.server_name,
           tool_call_server_icons: toolCall.server_icons,
-          tool_call_server_description: toolCall.server_description
+          tool_call_server_description: toolCall.server_description,
+          tool_call_response_raw: toolCallResponse.rawData
         })
       }
 

--- a/src/shared/presenter.d.ts
+++ b/src/shared/presenter.d.ts
@@ -481,6 +481,7 @@ export type LLMResponse = {
   tool_call_server_name?: string
   tool_call_server_icons?: string
   tool_call_server_description?: string
+  tool_call_response_raw?: MCPToolResponse
   maximum_tool_calls_reached?: boolean
   totalUsage?: {
     prompt_tokens: number
@@ -503,6 +504,7 @@ export type LLMResponseStream = {
   tool_call_server_name?: string
   tool_call_server_icons?: string
   tool_call_server_description?: string
+  tool_call_response_raw?: MCPToolResponse
   maximum_tool_calls_reached?: boolean
   totalUsage?: {
     prompt_tokens: number


### PR DESCRIPTION
## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
DeepChat 一直只有 agentic 的搜索模式，没有API搜索模式
通过 MCP inMemory 封装后，把 API 模式的搜索引擎添加到内置的MCP之中，用户按序启用，按序填写APIkey
并且通过改写返回的数据格式，能够和 DeepChat 内部数据结构桥接起来，达到和 Agentic 一样的效果

**请描述你希望的解决方案**
1、实现一个 Bocha MCP SearchServer 支持 bocha 搜索 API
2、搜索API支持条数和分页能力，让模型自行判断如何分页和获取多少数据
3、标准MCP的配置和设置

**桌面应用程序的 UI/UX 更改**
![92af5b5fccad7b4a237234199083ca4f](https://github.com/user-attachments/assets/b912460d-fc8f-4359-a859-0a9d775d4df8)

![7cdb1fd504c80169daf2f07cfd7b2d2b](https://github.com/user-attachments/assets/c8067041-ac75-4db0-94ee-6609f3dad4de)


