### PR TITLE
refactor(settings): 调整McpSettings组件布局, 提升用户操作体验 #223

### DIFF
--- a/src/renderer/src/components/settings/McpSettings.vue
+++ b/src/renderer/src/components/settings/McpSettings.vue
@@ -1,37 +1,43 @@
 <template>
-  <div class="w-full h-full overflow-y-auto flex flex-col">
-    <!-- MCP全局开关 -->
-    <div class="p-4 flex-shrink-0">
-      <div class="flex items-center justify-between">
-        <div>
-          <h3 class="text-sm font-medium">{{ t('settings.mcp.enabledTitle') }}</h3>
-          <p class="text-xs text-muted-foreground mt-1">
-            {{ t('settings.mcp.enabledDescription') }}
-          </p>
+  <div class="w-full h-full flex flex-col">
+    <!-- 固定部分 -->
+    <div class="flex-shrink-0 bg-background sticky top-0 z-10">
+      <!-- MCP全局开关 -->
+      <div class="p-4 flex-shrink-0">
+        <div class="flex items-center justify-between">
+          <div>
+            <h3 class="text-sm font-medium">{{ t('settings.mcp.enabledTitle') }}</h3>
+            <p class="text-xs text-muted-foreground mt-1">
+              {{ t('settings.mcp.enabledDescription') }}
+            </p>
+          </div>
+          <Switch :checked="mcpEnabled" @update:checked="handleMcpEnabledChange" />
         </div>
-        <Switch :checked="mcpEnabled" @update:checked="handleMcpEnabledChange" />
+      </div>
+
+      <!-- MCP Marketplace 入口 -->
+      <div class="px-4 pb-4 flex-shrink-0">
+        <Button
+          variant="outline"
+          class="w-full flex items-center justify-center gap-2"
+          @click="openMcpMarketplace"
+        >
+          <Icon icon="lucide:shopping-bag" class="w-4 h-4" />
+          <span>{{ t('settings.mcp.marketplace') }}</span>
+          <Icon icon="lucide:external-link" class="w-3.5 h-3.5 text-muted-foreground" />
+        </Button>
       </div>
     </div>
 
-    <!-- MCP Marketplace 入口 -->
-    <div class="px-4 pb-4 flex-shrink-0">
-      <Button
-        variant="outline"
-        class="w-full flex items-center justify-center gap-2"
-        @click="openMcpMarketplace"
-      >
-        <Icon icon="lucide:shopping-bag" class="w-4 h-4" />
-        <span>{{ t('settings.mcp.marketplace') }}</span>
-        <Icon icon="lucide:external-link" class="w-3.5 h-3.5 text-muted-foreground" />
-      </Button>
-    </div>
-
+    <!-- 可滚动部分 -->
     <!-- MCP配置 -->
-    <div v-if="mcpEnabled" class="border-t flex-grow">
-      <McpConfig />
-    </div>
-    <div v-else class="p-4 text-center text-secondary-foreground text-sm">
-      {{ t('settings.mcp.enableToAccess') }}
+    <div class="flex-grow overflow-y-auto">
+      <div v-if="mcpEnabled" class="border-t h-full">
+        <McpConfig class="h-full" />
+      </div>
+      <div v-else class="p-4 text-center text-secondary-foreground text-sm">
+        {{ t('settings.mcp.enableToAccess') }}
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
**你的功能请求是否与某个问题有关？请描述一下。**

修复了 MCP 设置页面的布局问题，主要解决了以下几个问题：
1. 顶部开关和 Marketplace 按钮固定显示
2. 下方内容区域可以独立滚动
3. 优化了整体布局结构，确保高度自适应

**请描述你希望的解决方案**

通过调整 flex 布局和滚动区域的设置，实现了：
1. 使用 `sticky` 定位让顶部控件固定
2. 使用 `flex-grow` 和 `overflow-y-auto` 让下方内容区域自适应并可滚动
3. 添加了适当的高度类确保各个组件正确显示

**桌面应用程序的 UI/UX 更改**

本次改动主要涉及 MCP 设置页面的布局优化：
- 顶部的 MCP 开关和 Marketplace 入口始终可见，方便用户操作
- 内容区域可以独立滚动，提升了用户体验
- 保持了整体设计风格的一致性

**平台兼容性注意事项**

本次改动主要涉及 CSS 样式调整，使用了标准的 flex 布局和滚动容器配置，对所有平台（Windows、macOS、Linux）都具有良好的兼容性。

已在 macOS 平台上完成测试，布局表现正常。

**附加背景**

这次改动是对 MCP 设置页面用户体验的优化，确保页面在不同内容长度下都能正确显示和交互。改动较小但能显著提升用户体验。

