### PR TITLE
fix: modify CONTRIBUTING md, specify Windows Build Tools version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,8 @@ We use GitHub to host code, to track issues and feature requests, as well as acc
      GUI Installation:
      - Install [Visual Studio Community](https://visualstudio.microsoft.com/vs/community/)
      - Select "Desktop development with C++" workload during installation
-     - Ensure "Windows 10/11 SDK" and "MSVC v143 build tools" components are selected
-   - Install Git for Windows
+     - Ensure "Windows 10/11 SDK" and "MSVC v143 build tools" components are selected（Vistual Studio 2022 recommended)
+   - Install Git for Windowss
 
    **macOS:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ We use GitHub to host code, to track issues and feature requests, as well as acc
      - Install [Visual Studio Community](https://visualstudio.microsoft.com/vs/community/)
      - Select "Desktop development with C++" workload during installation
      - Ensure "Windows 10/11 SDK" and "MSVC v143 build tools" components are selected（Vistual Studio 2022 recommended)
-   - Install Git for Windowss
+   - Install Git for Windows
 
    **macOS:**
 

--- a/CONTRIBUTING.zh.md
+++ b/CONTRIBUTING.zh.md
@@ -56,7 +56,7 @@
      图形化安装:
      - 安装 [Visual Studio Community](https://visualstudio.microsoft.com/vs/community/)
      - 在安装时选择"使用 C++ 的桌面开发"工作负载
-     - 确保选中"Windows 10/11 SDK"和"MSVC v143 生成工具"组件
+     - 确保选中"Windows 10/11 SDK"和"MSVC v143 生成工具"组件（推荐使用最新版本 Vistual Studio 2022)
    - 安装 Git for Windows
 
    **macOS:**


### PR DESCRIPTION
## Pull Request Description

During npm install, I thought any version of Visual Studio would work, but the installation took a very long time and eventually failed with an error related to the Windows build tools. After checking, I realized that only the 2022 version supports installing MSVC. I simply added a note in the CONTRIBUTING document suggesting the appropriate version.

---

## Pull Request Description (中文)

在npm install的时候以为是任意vistual studio就行，但是npm install过了很久，然后报windows build tool有问题。看了下是2022版本才可以安装MSVC，单纯只是在 CONTRIBUTING 文档加了一下建议版本。
