### PR TITLE
Update Bocha Search MCP Server

### DIFF
--- a/src/main/presenter/mcpPresenter/inMemoryServers/bochaSearchServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/bochaSearchServer.ts
@@ -36,6 +36,7 @@ interface BochaSearchResponse {
         url: string
         displayUrl: string
         snippet: string
+        summary: string
         siteName: string
         siteIcon: string
         dateLastCrawled: string
@@ -153,7 +154,7 @@ export class BochaSearchServer {
                 title: item.name,
                 url: item.url,
                 rank: index + 1,
-                content: item.snippet,
+                content: item.summary,
                 icon: item.siteIcon
               }
 


### PR DESCRIPTION
## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
优化 Bocha Search MCP Server 返回结果中的网页文本长度。

**请描述你希望的解决方案**
将搜索结果转换成MCP资源格式时，使用 item.summary 字段代替 item.snippet 作为 content，以提供更长的网页文本摘要信息。

**桌面应用程序的 UI/UX 更改**
暂无

**平台兼容性注意事项**
暂无

**附加背景**
在 Bocha Web Search API 的 Response 中，summary 字段可以提供比 snippet 字段更长的网页文本摘要，可以给大模型提供更完整的上下文信息。