### PR TITLE
Save and restore window size & position

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "electron-log": "^5.3.3",
     "electron-store": "^8.2.0",
     "electron-updater": "^6.1.7",
+    "electron-window-state": "^5.0.3",
     "fflate": "^0.8.2",
     "file-type": "^20.5.0",
     "https-proxy-agent": "^7.0.6",

--- a/src/main/presenter/windowPresenter.ts
+++ b/src/main/presenter/windowPresenter.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, shell, app, nativeImage } from 'electron'
+import windowStateManager from 'electron-window-state'
 import { join } from 'path'
 import icon from '../../../resources/icon.png?asset'
 import iconWin from '../../../resources/icon.ico?asset'
@@ -64,9 +65,15 @@ export class WindowPresenter implements IWindowPresenter {
 
   createMainWindow(): BrowserWindow {
     const iconFile = nativeImage.createFromPath(process.platform === 'win32' ? iconWin : icon)
+    const mainWindowState = windowStateManager({
+      defaultWidth: 1024,
+      defaultHeight: 620
+    })
     const mainWindow = new BrowserWindow({
-      width: 1024,
-      height: 620,
+      width: mainWindowState.width,
+      height: mainWindowState.height,
+      x: mainWindowState.x,
+      y: mainWindowState.y,
       show: false,
       autoHideMenuBar: true,
       icon: iconFile,
@@ -82,6 +89,8 @@ export class WindowPresenter implements IWindowPresenter {
       },
       frame: false
     })
+
+    mainWindowState.manage(mainWindow)
 
     // 获取内容保护设置的值
     const contentProtectionEnabled = this.configPresenter.getContentProtectionEnabled()


### PR DESCRIPTION
## Pull Request Description

**Is your feature request related to a problem? Please describe.**
When opening the app, the window always resets to the same size and position, which is rather small.

**Describe the solution you'd like**
Application window restores previous size and position when reopened.

**UI/UX changes for Desktop Application**
When moving or resizing the application, the size and position are saved and restored to the last size/position when the application is re-opened.

**Platform Compatibility Notes**
Unsure if this has any significant compatibility issues, I don't think it does but I will test on Windows once I have a dev environment set up (currently tested on macOS)
