### PR TITLE
fix(openai): fix missing token usage stats in streaming; update Qwen model context window

### DIFF
--- a/src/main/presenter/configPresenter/modelDefaultSettings.ts
+++ b/src/main/presenter/configPresenter/modelDefaultSettings.ts
@@ -1061,6 +1061,36 @@ export const defaultModelsSettings = [
     reasoning: false
   },
   {
+    id: 'qwen-plus-16k',
+    name: 'Qwen Plus 16K',
+    temperature: 0.7,
+    maxTokens: 16384,
+    contextLength: 131072,
+    match: ['qwen-plus-latest', 'qwen-plus-2025-04-28'],
+    vision: false,
+    functionCall: true,
+    reasoning: true
+  },
+  {
+    id: 'qwen-plus-8k',
+    name: 'Qwen Plus 8K',
+    temperature: 0.7,
+    maxTokens: 8192,
+    contextLength: 131072,
+    match: [
+      'qwen-plus',
+      'qwen-plus-0919',
+      'qwen-plus-2025-01-25',
+      'qwen-plus-0112',
+      'qwen-plus-1220',
+      'qwen-plus-1127',
+      'qwen-plus-1125'
+    ],
+    vision: false,
+    functionCall: false,
+    reasoning: false
+  },
+  {
     id: 'qwen',
     name: 'Qwen',
     temperature: 0.7,

--- a/src/main/presenter/llmProviderPresenter/providers/openAICompatibleProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/openAICompatibleProvider.ts
@@ -481,6 +481,11 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
       temperature,
       max_tokens: maxTokens
     }
+
+    // 添加stream_options，适用于/v1/chat/completions
+    // 诸如qwen等模型需要，如不添加则无法获取token usages
+    requestParams.stream_options = { include_usage: true }  
+
     OPENAI_REASONING_MODELS.forEach((noTempId) => {
       if (modelId.startsWith(noTempId)) delete requestParams.temperature
     })


### PR DESCRIPTION
1. 增补include_usage标准选项，修正qwen等openai兼容接口模型消息看不到上下行token usage统计的bug
2. 增补qwen-plus等最新模型配置，上下文窗口提高到128K，避免被默认32K坑死