### PR TITLE
fix(thread): fix tool_call responses history in context messages

### DIFF
--- a/src/main/presenter/threadPresenter/index.ts
+++ b/src/main/presenter/threadPresenter/index.ts
@@ -1619,11 +1619,20 @@ export class ThreadPresenter implements IThreadPresenter {
         // 处理助手消息
         const assistantBlocks = msg.content as AssistantMessageBlock[]
 
-        // 提取文本内容块
+        // 提取文本内容块，同时将工具调用的响应内容提取出来
         const textContent = assistantBlocks
           .filter((block) => block.type === 'content' || block.type === 'tool_call')
-          .map((block) => block.content)
+          .map((block) => {
+            if (block.type === 'content') {
+              return block.content
+            } else if (block.type === 'tool_call' && block.tool_call?.response) {
+              return block.tool_call.response
+            } else {
+              return '[Missing response]' // 若 tool_call 或 response 是 undefined，返回空字符串
+            }
+          })
           .join('\n')
+
         // 查找图像块
         const imageBlocks = assistantBlocks.filter(
           (block) => block.type === 'image' && block.image_data


### PR DESCRIPTION
继续秉持“用最少的代码修最大的bug“的原则... XD
修正上下文对话流中不包含工具调用结果的bug。这个可以适用于原生不支持function calling的模型。
> ``CRITICAL WARNING`` : Merge时考虑清楚了——用于知识管理、搜索引擎scrapping问答等场合极爽，但还是请注意账单风险XD 不过话说越来越多模型支持cache计价，也不用太担心了。