### PR TITLE
fix: fix shortcutKey to settings page

### DIFF
--- a/src/main/presenter/shortcutPresenter.ts
+++ b/src/main/presenter/shortcutPresenter.ts
@@ -91,7 +91,13 @@ export class ShortcutPresenter {
 
     // Command+, 或 Ctrl+, 打开设置
     globalShortcut.register(this.shortcutKeys.GoSettings, () => {
-      eventBus.emit(SHORTCUT_EVENTS.GO_SETTINGS)
+      const focusedWindow = presenter.windowPresenter.getFocusedWindow()
+      if (focusedWindow?.isFocused()) {
+        presenter.windowPresenter.sendToActiveTab(
+          focusedWindow.id,
+          SHORTCUT_EVENTS.GO_SETTINGS
+        )
+      }
     })
 
     // Command+L 或 Ctrl+L 清除聊天历史


### PR DESCRIPTION
## Pull Request Description

**Is your feature request related to a problem? Please describe.**

When I turn on multiple tabs, jumping to the settings page with shortcut keys causes all tabs to navigate



**Describe the solution you'd like**

Only the currently activated Tab navigate


**UI/UX changes for Desktop Application**

before:
https://github.com/user-attachments/assets/0798d6bd-69b2-49f1-adf7-98d28df36584

after:
https://github.com/user-attachments/assets/215ab756-6c66-479d-ab5d-be1a112b402b



**Platform Compatibility Notes**

I only tested it on Mac, Windows and Linux in theory, and I saw this writing method in the logic of other shortcut keys. If necessary, please help test it in other environments