### PR TITLE
fix device code copy utton of github copilot login

### DIFF
--- a/src/main/presenter/githubCopilotDeviceFlow.ts
+++ b/src/main/presenter/githubCopilotDeviceFlow.ts
@@ -236,11 +236,13 @@ export class GitHubCopilotDeviceFlow {
         instructionWindow.webContents.executeJavaScript(`
           window.electronAPI = {
             openExternal: (url) => {
-              window.postMessage({ type: 'open-external', url }, '*');
+              // 通过 console.log 发送消息，主进程通过 console-message 事件接收
+              console.log(JSON.stringify({ type: 'open-external', url }));
             },
             copyToClipboard: (text) => {
-              window.postMessage({ type: 'copy-to-clipboard', text }, '*');
-            }
+              // 通过 console.log 发送消息，主进程通过 console-message 事件接收
+              console.log(JSON.stringify({ type: 'copy-to-clipboard', text }));
+            },
           };
         `)
       })
@@ -263,6 +265,7 @@ export class GitHubCopilotDeviceFlow {
             if (mainWindow) {
               mainWindow.webContents.executeJavaScript(`window.api.copyText('${msg.text}')`)
             }
+
           }
         } catch (e) {}
       })
@@ -415,3 +418,4 @@ export function createGitHubCopilotDeviceFlow(): GitHubCopilotDeviceFlow {
 
   return new GitHubCopilotDeviceFlow(config)
 }
+


### PR DESCRIPTION
## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
修复 Github Copilot Provider Device Flow 登陆时，点击复制按钮，复制 Device Code 的功能。
<img width="340" alt="image" src="https://github.com/user-attachments/assets/01f9dd2e-ae8a-4afd-857b-2c19111183ef" />


**请描述你希望的解决方案**
使用 PostMessage 方法来完成 Device ID 的传递，然后复制到剪贴版。
