### PR TITLE
feat(mcp): 添加路径展开功能，支持用户主目录和环境变量的解析

### DIFF
--- a/src/main/presenter/mcpPresenter/mcpClient.ts
+++ b/src/main/presenter/mcpPresenter/mcpClient.ts
@@ -72,6 +72,29 @@ export class McpClient {
     return { key: pathKey, value: pathValue }
   }
 
+  // 展开路径中的各种符号和变量
+  private expandPath(inputPath: string): string {
+    let expandedPath = inputPath
+
+    // 处理 ~ 符号 (用户主目录)
+    if (expandedPath.startsWith('~/') || expandedPath === '~') {
+      const homeDir = app.getPath('home')
+      expandedPath = expandedPath.replace('~', homeDir)
+    }
+
+    // 处理环境变量展开
+    expandedPath = expandedPath.replace(/\$\{([^}]+)\}/g, (match, varName) => {
+      return process.env[varName] || match
+    })
+
+    // 处理简单的 $VAR 格式 (不含花括号)
+    expandedPath = expandedPath.replace(/\$([A-Z_][A-Z0-9_]*)/g, (match, varName) => {
+      return process.env[varName] || match
+    })
+
+    return expandedPath
+  }
+
   // 获取系统特定的默认路径
   private getDefaultPaths(homeDir: string): string[] {
     if (process.platform === 'darwin') {
@@ -157,7 +180,13 @@ export class McpClient {
         this.transport = clientTransport
       } else if (this.serverConfig.type === 'stdio') {
         // 创建合适的transport
-        const command = this.serverConfig.command as string
+        let command = this.serverConfig.command as string
+        let args = this.serverConfig.args as string[]
+
+        // 处理路径展开 (包括 ~ 和环境变量)
+        command = this.expandPath(command)
+        args = args.map((arg) => this.expandPath(arg))
+
         const HOME_DIR = app.getPath('home')
 
         // 定义允许的环境变量白名单
@@ -277,7 +306,7 @@ export class McpClient {
         console.log('mcp env', env)
         this.transport = new StdioClientTransport({
           command,
-          args: this.serverConfig.args as string[],
+          args,
           env,
           stderr: 'pipe'
         })


### PR DESCRIPTION
## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
修复了 MCP 服务器配置中使用 `~` 开头的路径会报错的问题。之前当 MCP 服务器配置使用 `~/`  路径时（如 `~/.local/mcp/path/index.js`），会因为 `child_process` 无法识别 `~` 符号而导致启动失败，而使用完整绝对路径（如 `/Users/xxx/.local/mcp/my-refine-app/index.js`）则正常工作。

在 cursor 中，配置 mcp 是可以采用 
```
command: 'node',
args: [ '~/.local/mcp/some-path/index.js' ],
```
可以借鉴

**请描述你希望的解决方案**
在 `McpClient` 类中新增了 `expandPath()` 方法，支持多种路径展开：

- **波浪号展开**: `~` 和 `~/path` 自动展开为用户主目录路径
- **环境变量展开**: 支持 `${VAR}` 和 `$VAR` 格式的环境变量替换

在创建 `StdioClientTransport` 之前，自动对 `command` 和 `args` 中的所有路径进行展开处理，确保传递给 `child_process` 的都是完整的绝对路径。

**桌面应用程序的 UI/UX 更改**
此 PR 没有引入 UI/UX 更改，属于后端功能改进。用户体验的改善体现在：
- 用户可以在 MCP 服务器配置中使用更简洁、更符合习惯的路径格式（如 `~/.local/bin/server`）
- 减少因路径配置错误导致的 MCP 服务器启动失败
- 支持使用环境变量的动态路径配置，提高配置的灵活性

**平台兼容性注意事项**
- **跨平台兼容**: 使用 Electron 的 `app.getPath('home')` 获取用户主目录，确保在 Windows、macOS、Linux 上都能正确工作
- **环境变量处理**: 环境变量展开在所有平台上都使用相同的逻辑，通过 `process.env` 访问
- **路径分隔符**: 依赖 Node.js 的 `path` 模块自动处理不同平台的路径分隔符差异

**附加背景**
- 移除了对复杂用户路径（`~otheruser` 格式）的警告处理，简化了代码逻辑
- 此功能特别有用于 Node.js 生态中的 MCP 服务器，因为许多工具和包通常安装在用户主目录下
- 支持的环境变量格式包括：`${HOME}/.local/bin`、`$USER_config.json` 等
- 保持向后兼容，现有的绝对路径配置继续正常工作