### PR TITLE
refactor: mcp store split from settings store

### DIFF
--- a/src/renderer/src/components/mcp-config/components/McpServers.vue
+++ b/src/renderer/src/components/mcp-config/components/McpServers.vue
@@ -13,7 +13,6 @@ import {
   DialogDescription
 } from '@/components/ui/dialog'
 import { useMcpStore } from '@/stores/mcp'
-import { useSettingsStore } from '@/stores/settings'
 import { useI18n } from 'vue-i18n'
 import { useToast } from '@/components/ui/toast'
 import { useRouter } from 'vue-router'
@@ -25,7 +24,6 @@ import McpResourceViewer from './McpResourceViewer.vue'
 import type { MCPServerConfig } from '@shared/presenter'
 
 const mcpStore = useMcpStore()
-const settingsStore = useSettingsStore()
 const { t } = useI18n()
 const { toast } = useToast()
 const router = useRouter()
@@ -44,7 +42,7 @@ const selectedServerForPrompts = ref<string>('')
 const selectedServerForResources = ref<string>('')
 // 监听 MCP 安装缓存
 watch(
-  () => settingsStore.mcpInstallCache,
+  () => mcpStore.mcpInstallCache,
   (newCache) => {
     if (newCache) {
       // 打开添加服务器对话框
@@ -58,7 +56,7 @@ watch(isAddServerDialogOpen, (newIsAddServerDialogOpen) => {
   // 当添加服务器对话框关闭时，清理缓存
   if (!newIsAddServerDialogOpen) {
     // 清理缓存
-    settingsStore.clearMcpInstallCache()
+    mcpStore.clearMcpInstallCache()
   }
 })
 // 计算属性：区分内置服务和普通服务
@@ -381,7 +379,7 @@ const handleViewResources = async (serverName: string) => {
                 </DialogDescription>
               </DialogHeader>
               <McpServerForm
-                :default-json-config="settingsStore.mcpInstallCache || undefined"
+                :default-json-config="mcpStore.mcpInstallCache || undefined"
                 @submit="handleAddServer"
               />
             </DialogContent>

--- a/src/renderer/src/stores/mcp.ts
+++ b/src/renderer/src/stores/mcp.ts
@@ -108,7 +108,21 @@ export const useMcpStore = defineStore('mcp', () => {
   const toolCount = computed(() => tools.value.length)
   const hasTools = computed(() => toolCount.value > 0)
 
+  // MCP 安装缓存
+  const mcpInstallCache = ref<string | null>(null)
+
   // ==================== 方法 ====================
+
+  // 清理 MCP 安装缓存
+  const clearMcpInstallCache = () => {
+    mcpInstallCache.value = null
+  }
+
+  // 赋值 MCP 安装缓存
+  const setMcpInstallCache = (cache: string) => {
+    mcpInstallCache.value = cache
+  }
+
   // 加载MCP配置
   const loadConfig = async () => {
     try {
@@ -502,12 +516,11 @@ export const useMcpStore = defineStore('mcp', () => {
   }
 
   // 立即初始化
-  onMounted(async () => {
-    await init()
-  })
+  onMounted(init)
 
   return {
     // 状态
+    mcpInstallCache,
     config,
     serverStatuses,
     serverLoadingStates,
@@ -547,6 +560,8 @@ export const useMcpStore = defineStore('mcp', () => {
     callTool,
     setMcpEnabled,
     getPrompt,
-    readResource
+    readResource,
+    clearMcpInstallCache,
+    setMcpInstallCache
   }
 })

--- a/src/renderer/src/stores/settings.ts
+++ b/src/renderer/src/stores/settings.ts
@@ -169,14 +169,6 @@ export const useSettingsStore = defineStore('settings', () => {
     }
   }
 
-  // MCP 安装缓存
-  const mcpInstallCache = ref<string | null>(null)
-
-  // 清理 MCP 安装缓存
-  const clearMcpInstallCache = () => {
-    mcpInstallCache.value = null
-  }
-
   // 监听 deeplink 事件
   window.electron.ipcRenderer.on(DEEPLINK_EVENTS.MCP_INSTALL, async (_, data) => {
     const { mcpConfig } = data
@@ -211,7 +203,7 @@ export const useSettingsStore = defineStore('settings', () => {
 
     // 存储 MCP 配置数据到缓存
     if (data) {
-      mcpInstallCache.value = mcpConfig
+      mcpStore.setMcpInstallCache(mcpConfig)
     }
   })
 
@@ -1253,7 +1245,6 @@ export const useSettingsStore = defineStore('settings', () => {
     await configP.setLoggingEnabled(enabled)
   }
 
-
   ///////////////////////////////////////////////////////////////////////////////////////
   const setCopyWithCotEnabled = async (enabled: boolean) => {
     copyWithCotEnabled.value = Boolean(enabled)
@@ -1451,8 +1442,6 @@ export const useSettingsStore = defineStore('settings', () => {
     testSearchEngine,
     refreshSearchEngines,
     findModelByIdOrName,
-    mcpInstallCache,
-    clearMcpInstallCache,
     isUpdating: upgradeStore.isUpdating,
     loadSavedOrder,
     updateProvidersOrder,


### PR DESCRIPTION
## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**

- [x] mcp
- [ ] models (wip)

link #431 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Unified MCP installation cache management under a single store for improved consistency and maintainability.
- **Chores**
	- Removed redundant cache handling logic from settings, delegating all related operations to the MCP store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->