### PR TITLE
docs(README): add details about pnpm under win32

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -265,6 +265,8 @@ $ pnpm run installRuntime
 $ pip install setuptools
 ```
 
+* For Windows: 非管理者ユーザーがシンボリックリンクやハードリンクを作成できるようにするには、設定で「開発者モード」を有効にするか、管理者アカウントを使用してください。それ以外の場合、pnpm の操作は失敗します。
+
 ### 開発を開始
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ $ pnpm run installRuntime
 $ pip install setuptools
 ```
 
+* For Windows: To allow non-admin users to create symlinks and hardlinks, enable `Developer Mode` in Settings or use an administrator account. Otherwise `pnpm` ops will fail.
+
 ### Start Development
 
 ```bash

--- a/README.zh.md
+++ b/README.zh.md
@@ -265,6 +265,8 @@ $ pnpm run installRuntime
 $ pip install setuptools
 ```
 
+* For Windows: 为允许非管理员用户创建符号链接和硬链接，请在设置中开启``开发者模式``或使用管理员账号，否则 ``pnpm`` 操作将失败。
+
 ### 开始开发
 
 ```bash


### PR DESCRIPTION
docs(README): add details about pnpm under win32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added notes to the installation and development instructions in all README files for Windows users, explaining the need to enable Developer Mode or use administrator privileges to ensure pnpm operations work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->