### PR TITLE
增加e2b沙盒支持 Feature/add e2b support

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.53.0",
+    "@e2b/code-interpreter": "^1.5.1",
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^4.0.0",
     "@google/genai": "^1.5.1",

--- a/src/main/presenter/configPresenter/mcpConfHelper.ts
+++ b/src/main/presenter/configPresenter/mcpConfHelper.ts
@@ -248,7 +248,7 @@ export class McpConfHelper {
   // 设置MCP服务器配置
   async setMcpServers(servers: Record<string, MCPServerConfig>): Promise<void> {
     this.mcpStore.set('mcpServers', servers)
-    eventBus.emit(MCP_EVENTS.CONFIG_CHANGED, {
+    eventBus.send(MCP_EVENTS.CONFIG_CHANGED, SendTarget.ALL_WINDOWS, {
       mcpServers: servers,
       defaultServers: this.mcpStore.get('defaultServers') || [],
       mcpEnabled: this.mcpStore.get('mcpEnabled')

--- a/src/main/presenter/mcpPresenter/inMemoryServers/builder.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/builder.ts
@@ -31,7 +31,7 @@ export function getInMemoryServer(
     case 'imageServer':
       return new ImageServer(args[0], args[1])
     case 'powerpack':
-      return new PowerpackServer()
+      return new PowerpackServer(env)
     case 'difyKnowledge':
       return new DifyKnowledgeServer(
         env as {

--- a/src/main/presenter/mcpPresenter/inMemoryServers/powerpackServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/powerpackServer.ts
@@ -11,6 +11,7 @@ import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { nanoid } from 'nanoid'
 import { runCode, type CodeFile } from '../pythonRunner'
+import { Sandbox } from '@e2b/code-interpreter'
 
 // Schema 定义
 const GetTimeArgsSchema = z.object({
@@ -51,6 +52,20 @@ const RunPythonCodeArgsSchema = z.object({
     .describe('Code execution timeout in milliseconds, default 5 seconds')
 })
 
+// E2B 代码执行 Schema
+const E2BRunCodeArgsSchema = z.object({
+  code: z
+    .string()
+    .describe(
+      'Python code to execute in E2B secure sandbox. Supports Jupyter Notebook syntax and has access to common Python libraries.'
+    ),
+  language: z
+    .string()
+    .optional()
+    .default('python')
+    .describe('Programming language for code execution, currently supports python')
+})
+
 // 限制和安全配置
 const CODE_EXECUTION_FORBIDDEN_PATTERNS = [
   // 允许os模块用于系统信息读取，但仍然禁止其他危险模块
@@ -70,12 +85,62 @@ const CODE_EXECUTION_FORBIDDEN_PATTERNS = [
   /process\.env/gi
 ]
 
+// E2B 管理器
+class E2BManager {
+  private static instance: E2BManager
+  private initialized = false
+  private apiKey: string = ''
+
+  static getInstance(): E2BManager {
+    if (!E2BManager.instance) {
+      E2BManager.instance = new E2BManager()
+    }
+    return E2BManager.instance
+  }
+
+  async initialize(apiKey: string): Promise<void> {
+    if (this.initialized) return
+
+    try {
+      // 设置 API Key
+      this.apiKey = apiKey
+      process.env.E2B_API_KEY = apiKey
+      this.initialized = true
+    } catch (error) {
+      throw new Error(
+        `Failed to initialize E2B: ${error instanceof Error ? error.message : 'Unknown error'}\n\nPlease ensure @e2b/code-interpreter is installed:\nnpm install @e2b/code-interpreter`
+      )
+    }
+  }
+
+  async createSandbox(): Promise<Sandbox> {
+    if (!this.initialized) {
+      throw new Error('E2B not initialized. Please call initialize() first.')
+    }
+
+    return await Sandbox.create()
+  }
+
+  isInitialized(): boolean {
+    return this.initialized
+  }
+}
+
 export class PowerpackServer {
   private server: Server
   private bunRuntimePath: string | null = null
   private nodeRuntimePath: string | null = null
+  private e2bManager: E2BManager
+  private useE2B: boolean = false
+  private e2bApiKey: string = ''
 
-  constructor() {
+  constructor(env?: Record<string, any>) {
+    // 从环境变量中获取 E2B 配置
+    this.parseE2BConfig(env)
+
+    // 初始化 E2B 管理器
+    this.e2bManager = E2BManager.getInstance()
+
     // 查找内置的运行时路径
     this.setupRuntimes()
 
@@ -94,6 +159,20 @@ export class PowerpackServer {
 
     // 设置请求处理器
     this.setupRequestHandlers()
+  }
+
+  // 解析 E2B 配置
+  private parseE2BConfig(env?: Record<string, any>): void {
+    if (env) {
+      this.useE2B = env.USE_E2B === true || env.USE_E2B === 'true'
+      this.e2bApiKey = env.E2B_API_KEY || ''
+
+      // 如果启用了 E2B 但没有提供 API Key，记录警告
+      if (this.useE2B && !this.e2bApiKey) {
+        console.warn('E2B is enabled but no API key provided. E2B functionality will be disabled.')
+        this.useE2B = false
+      }
+    }
   }
 
   // 设置运行时路径
@@ -130,17 +209,37 @@ export class PowerpackServer {
       }
     }
 
-    if (!this.bunRuntimePath && !this.nodeRuntimePath) {
-      console.warn('未找到内置运行时（Bun或Node.js），代码执行功能将不可用')
+    if (!this.bunRuntimePath && !this.nodeRuntimePath && !this.useE2B) {
+      console.warn('No runtime found (Bun, Node.js, or E2B), code execution will be unavailable')
+    } else if (this.useE2B) {
+      console.info('Using E2B for code execution')
     } else if (this.bunRuntimePath) {
-      console.info('使用内置Bun运行时')
+      console.info('Using built-in Bun runtime')
     } else if (this.nodeRuntimePath) {
-      console.info('使用内置Node.js运行时')
+      console.info('Using built-in Node.js runtime')
+    }
+  }
+
+  // 初始化 E2B（如果需要）
+  private async initializeE2B(): Promise<void> {
+    if (this.useE2B && !this.e2bManager.isInitialized()) {
+      try {
+        await this.e2bManager.initialize(this.e2bApiKey)
+        console.info('E2B initialized successfully')
+      } catch (error) {
+        console.error('Failed to initialize E2B:', error)
+        throw error
+      }
     }
   }
 
   // 启动服务器
-  public startServer(transport: Transport): void {
+  public async startServer(transport: Transport): Promise<void> {
+    // 如果启用了 E2B，先初始化
+    if (this.useE2B) {
+      await this.initializeE2B()
+    }
+
     this.server.connect(transport)
   }
 
@@ -247,6 +346,65 @@ export class PowerpackServer {
     }
   }
 
+  // 使用 E2B 执行代码
+  private async executeE2BCode(code: string): Promise<string> {
+    if (!this.useE2B || !this.e2bManager.isInitialized()) {
+      throw new Error('E2B is not initialized')
+    }
+
+    let sandbox: Sandbox | null = null
+    try {
+      sandbox = await this.e2bManager.createSandbox()
+      const result = await sandbox.runCode(code)
+
+      // 格式化结果
+      const output: string[] = []
+
+      // 添加执行结果
+      if (result.results && result.results.length > 0) {
+        for (const res of result.results) {
+          if ((res as any).isError) {
+            const error = (res as any).error
+            output.push(`Error: ${error?.name || 'Unknown'}: ${error?.value || 'Unknown error'}`)
+            if (error?.traceback) {
+              output.push(error.traceback.join('\n'))
+            }
+          } else if (res.text) {
+            output.push(res.text)
+          } else if ((res as any).data) {
+            output.push(JSON.stringify((res as any).data, null, 2))
+          }
+        }
+      }
+
+      // 添加日志输出
+      if (result.logs) {
+        if (result.logs.stdout.length > 0) {
+          output.push('STDOUT:')
+          output.push(...result.logs.stdout)
+        }
+        if (result.logs.stderr.length > 0) {
+          output.push('STDERR:')
+          output.push(...result.logs.stderr)
+        }
+      }
+
+      return output.join('\n') || 'Code executed successfully (no output)'
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      throw new Error(`E2B execution failed: ${errorMessage}`)
+    } finally {
+      // 清理沙箱
+      if (sandbox) {
+        try {
+          await sandbox.kill()
+        } catch (error) {
+          console.error('Failed to close E2B sandbox:', error)
+        }
+      }
+    }
+  }
+
   // 设置请求处理器
   private setupRequestHandlers(): void {
     // 设置工具列表处理器
@@ -271,35 +429,48 @@ export class PowerpackServer {
         }
       ]
 
-      // 只有在JavaScript运行时可用时才添加代码执行工具
-      if (this.bunRuntimePath || this.nodeRuntimePath) {
+      // 根据配置添加代码执行工具
+      if (this.useE2B) {
+        // 使用 E2B 执行代码
         tools.push({
-          name: 'run_node_code',
+          name: 'run_code',
           description:
-            'Execute simple JavaScript/TypeScript code in a secure sandbox environment (Bun or Node.js). Suitable for calculations, data transformations, encryption/decryption, and network operations. ' +
-            'The code needs to be output to the console, and the output content needs to be formatted as a string. ' +
-            'For security reasons, the code cannot perform file operations, modify system settings, spawn child processes, or execute external code from network. ' +
+            'Execute Python code in a secure E2B sandbox environment. Supports Jupyter Notebook syntax and has access to common Python libraries. ' +
+            'The code will be executed in an isolated environment with full Python ecosystem support. ' +
+            'This is safer than local execution as it runs in a controlled cloud sandbox. ' +
+            'Perfect for data analysis, calculations, visualizations, and any Python programming tasks.',
+          inputSchema: zodToJsonSchema(E2BRunCodeArgsSchema)
+        })
+      } else {
+        // 使用本地运行时执行代码
+        if (this.bunRuntimePath || this.nodeRuntimePath) {
+          tools.push({
+            name: 'run_node_code',
+            description:
+              'Execute simple JavaScript/TypeScript code in a secure sandbox environment (Bun or Node.js). Suitable for calculations, data transformations, encryption/decryption, and network operations. ' +
+              'The code needs to be output to the console, and the output content needs to be formatted as a string. ' +
+              'For security reasons, the code cannot perform file operations, modify system settings, spawn child processes, or execute external code from network. ' +
+              'Code execution has a timeout limit, default is 5 seconds, you can adjust it based on the estimated time of the code, generally not recommended to exceed 2 minutes. ' +
+              'When a problem can be solved by a simple and secure JavaScript/TypeScript code or you have generated a simple code for the user and want to execute it, please use this tool, providing more reliable information to the user.',
+            inputSchema: zodToJsonSchema(RunNodeCodeArgsSchema)
+          })
+        }
+
+        tools.push({
+          name: 'run_python_code',
+          description:
+            'Execute simple Python code in a secure sandbox environment. Suitable for calculations, data analysis, and scientific computing. ' +
+            'The code needs to be output to the print function, and the output content needs to be formatted as a string. ' +
+            'The code will be executed with Python 3.12. ' +
             'Code execution has a timeout limit, default is 5 seconds, you can adjust it based on the estimated time of the code, generally not recommended to exceed 2 minutes. ' +
-            'When a problem can be solved by a simple and secure JavaScript/TypeScript code or you have generated a simple code for the user and want to execute it, please use this tool, providing more reliable information to the user.',
-          inputSchema: zodToJsonSchema(RunNodeCodeArgsSchema)
+            'Dependencies may be defined via PEP 723 script metadata, e.g. to install "pydantic", the script should startwith a comment of the form:' +
+            `# /// script\n` +
+            `# dependencies = ['pydantic']\n ` +
+            `# ///\n` +
+            `print('hello world').`,
+          inputSchema: zodToJsonSchema(RunPythonCodeArgsSchema)
         })
       }
-
-      // 添加Python代码执行工具
-      tools.push({
-        name: 'run_python_code',
-        description:
-          'Execute simple Python code in a secure sandbox environment. Suitable for calculations, data analysis, and scientific computing. ' +
-          'The code needs to be output to the print function, and the output content needs to be formatted as a string. ' +
-          'The code will be executed with Python 3.12. ' +
-          'Code execution has a timeout limit, default is 5 seconds, you can adjust it based on the estimated time of the code, generally not recommended to exceed 2 minutes. ' +
-          'Dependencies may be defined via PEP 723 script metadata, e.g. to install "pydantic", the script should startwith a comment of the form:' +
-          `# /// script\n` +
-          `# dependencies = ['pydantic']\n ` +
-          `# ///\n` +
-          `print('hello world').`,
-        inputSchema: zodToJsonSchema(RunPythonCodeArgsSchema)
-      })
 
       return { tools }
     })
@@ -369,8 +540,36 @@ export class PowerpackServer {
             }
           }
 
+          case 'run_code': {
+            // E2B 代码执行
+            if (!this.useE2B) {
+              throw new Error('E2B is not enabled')
+            }
+
+            const parsed = E2BRunCodeArgsSchema.safeParse(args)
+            if (!parsed.success) {
+              throw new Error(`无效的代码参数: ${parsed.error}`)
+            }
+
+            const { code } = parsed.data
+            const result = await this.executeE2BCode(code)
+
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `代码执行结果 (E2B Sandbox):\n\n${result}`
+                }
+              ]
+            }
+          }
+
           case 'run_node_code': {
-            // 再次检查JavaScript运行时是否可用
+            // 本地 JavaScript 代码执行
+            if (this.useE2B) {
+              throw new Error('Local code execution is disabled when E2B is enabled')
+            }
+
             if (!this.bunRuntimePath && !this.nodeRuntimePath) {
               throw new Error('JavaScript runtime is not available, cannot execute code')
             }
@@ -394,6 +593,11 @@ export class PowerpackServer {
           }
 
           case 'run_python_code': {
+            // 本地 Python 代码执行
+            if (this.useE2B) {
+              throw new Error('Local code execution is disabled when E2B is enabled')
+            }
+
             const parsed = RunPythonCodeArgsSchema.safeParse(args)
             if (!parsed.success) {
               throw new Error(`无效的代码参数: ${parsed.error}`)

--- a/src/main/presenter/mcpPresenter/index.ts
+++ b/src/main/presenter/mcpPresenter/index.ts
@@ -381,7 +381,7 @@ export class McpPresenter implements IMCPPresenter {
       } catch (error) {
         console.error(`[MCP] Failed to restart server ${serverName}:`, error)
         // 即使重启失败，也要确保状态正确，标记为未运行
-        eventBus.emit(MCP_EVENTS.SERVER_STOPPED, serverName)
+        eventBus.send(MCP_EVENTS.SERVER_STOPPED, SendTarget.ALL_WINDOWS, serverName)
       }
     }
   }

--- a/src/main/presenter/mcpPresenter/mcpClient.ts
+++ b/src/main/presenter/mcpPresenter/mcpClient.ts
@@ -3,7 +3,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { type Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
-import { eventBus } from '@/eventbus'
+import { eventBus, SendTarget } from '@/eventbus'
 import { MCP_EVENTS } from '@/events'
 import path from 'path'
 import { presenter } from '@/presenter'
@@ -535,10 +535,14 @@ export class McpClient {
           console.info(`MCP server ${this.serverName} connected successfully`)
 
           // 触发服务器状态变更事件
-          eventBus.emit((MCP_EVENTS as MCPEventsType).SERVER_STATUS_CHANGED, {
-            name: this.serverName,
-            status: 'running'
-          })
+          eventBus.send(
+            (MCP_EVENTS as MCPEventsType).SERVER_STATUS_CHANGED,
+            SendTarget.ALL_WINDOWS,
+            {
+              name: this.serverName,
+              status: 'running'
+            }
+          )
         })
         .catch((error) => {
           console.error(`Failed to connect to MCP server ${this.serverName}:`, error)
@@ -560,7 +564,7 @@ export class McpClient {
       console.error(`Failed to connect to MCP server ${this.serverName}:`, error)
 
       // 触发服务器状态变更事件
-      eventBus.emit((MCP_EVENTS as MCPEventsType).SERVER_STATUS_CHANGED, {
+      eventBus.send((MCP_EVENTS as MCPEventsType).SERVER_STATUS_CHANGED, SendTarget.ALL_WINDOWS, {
         name: this.serverName,
         status: 'stopped'
       })
@@ -582,7 +586,7 @@ export class McpClient {
       console.log(`Disconnected from MCP server: ${this.serverName}`)
 
       // 触发服务器状态变更事件
-      eventBus.emit((MCP_EVENTS as MCPEventsType).SERVER_STATUS_CHANGED, {
+      eventBus.send((MCP_EVENTS as MCPEventsType).SERVER_STATUS_CHANGED, SendTarget.ALL_WINDOWS, {
         name: this.serverName,
         status: 'stopped'
       })

--- a/src/renderer/src/components/mcp-config/mcpServerForm.vue
+++ b/src/renderer/src/components/mcp-config/mcpServerForm.vue
@@ -62,6 +62,10 @@ const modelSelectOpen = ref(false)
 const selectedImageModel = ref<RENDERER_MODEL_META | null>(null)
 const selectedImageModelProvider = ref('')
 
+// E2B 配置相关
+const useE2B = ref(false)
+const e2bApiKey = ref('')
+
 // 判断是否是inmemory类型
 const isInMemoryType = computed(() => type.value === 'inmemory')
 // 判断是否是imageServer
@@ -70,6 +74,8 @@ const isImageServer = computed(() => isInMemoryType.value && name.value === 'ima
 const isBuildInFileSystem = computed(
   () => isInMemoryType.value && name.value === 'buildInFileSystem'
 )
+// 判断是否是powerpack服务器
+const isPowerpackServer = computed(() => isInMemoryType.value && name.value === 'powerpack')
 // 判断字段是否只读(inmemory类型除了args和env外都是只读的)
 const isFieldReadOnly = computed(() => props.editMode && isInMemoryType.value)
 
@@ -125,11 +131,14 @@ const jsonConfig = ref('')
 const showBaseUrl = computed(() => type.value === 'sse' || type.value === 'http')
 // 添加计算属性来控制命令相关字段的显示
 const showCommandFields = computed(() => type.value === 'stdio')
-// 控制参数输入框的显示 (stdio 或 非imageServer且非buildInFileSystem的inmemory)
+// 控制参数输入框的显示 (stdio 或 非imageServer且非buildInFileSystem且非powerpack的inmemory)
 const showArgsInput = computed(
   () =>
     showCommandFields.value ||
-    (isInMemoryType.value && !isImageServer.value && !isBuildInFileSystem.value)
+    (isInMemoryType.value &&
+      !isImageServer.value &&
+      !isBuildInFileSystem.value &&
+      !isPowerpackServer.value)
 )
 
 // 控制文件夹选择界面的显示 (仅针对 buildInFileSystem)
@@ -270,9 +279,19 @@ const validateKeyValueHeaders = (text: string): boolean => {
 // 新增：计算属性用于验证 Key=Value 格式
 const isCustomHeadersFormatValid = computed(() => validateKeyValueHeaders(customHeaders.value))
 
+// E2B 配置验证
+const isE2BConfigValid = computed(() => {
+  if (!isPowerpackServer.value) return true
+  if (!useE2B.value) return true
+  return e2bApiKey.value.trim().length > 0
+})
+
 const isFormValid = computed(() => {
   // 基本验证：名称必须有效
   if (!isNameValid.value) return false
+
+  // E2B 配置验证
+  if (!isE2BConfigValid.value) return false
 
   // 对于SSE类型，只需要名称和baseUrl有效
   if (type.value === 'sse' || type.value === 'http') {
@@ -439,6 +458,15 @@ const handleSubmit = (): void => {
     return
   }
 
+  // 如果是 powerpack 服务器，添加 E2B 配置到环境变量
+  if (isPowerpackServer.value) {
+    parsedEnv = {
+      ...parsedEnv,
+      USE_E2B: useE2B.value,
+      E2B_API_KEY: useE2B.value ? e2bApiKey.value.trim() : ''
+    }
+  }
+
   // 解析 customHeaders
   let parsedCustomHeaders = {}
   try {
@@ -563,6 +591,13 @@ watch(
       type.value = newConfig.type || 'stdio'
       baseUrl.value = newConfig.baseUrl || ''
       npmRegistry.value = newConfig.customNpmRegistry || ''
+
+      // 解析 E2B 配置（仅针对 powerpack 服务器）
+      if (props.serverName === 'powerpack' && newConfig.env) {
+        const envConfig = newConfig.env as Record<string, any>
+        useE2B.value = envConfig.USE_E2B === true || envConfig.USE_E2B === 'true'
+        e2bApiKey.value = envConfig.E2B_API_KEY || ''
+      }
 
       // Format customHeaders from initialConfig
       if (newConfig.customHeaders) {
@@ -895,6 +930,58 @@ HTTP-Referer=deepchatai.cn`
             :placeholder="t('settings.mcp.serverForm.envPlaceholder')"
             :class="{ 'border-red-500': !isEnvValid }"
           />
+        </div>
+
+        <!-- E2B 配置 (仅针对 powerpack 服务器) -->
+        <div
+          v-if="isPowerpackServer"
+          class="space-y-4 p-4 border border-border rounded-lg bg-background/50"
+        >
+          <div class="flex items-center justify-between">
+            <div class="space-y-1">
+              <Label class="text-sm font-medium">{{
+                t('settings.mcp.serverForm.useE2B') || '使用 E2B 代码执行'
+              }}</Label>
+              <div class="text-xs text-muted-foreground">
+                {{
+                  t('settings.mcp.serverForm.e2bDescription') ||
+                  '启用 E2B 云端沙盒环境执行代码，更安全且支持完整的 Python 生态系统'
+                }}
+              </div>
+            </div>
+            <div class="flex items-center space-x-2">
+              <Checkbox id="use-e2b" v-model:checked="useE2B" />
+            </div>
+          </div>
+
+          <!-- E2B API Key 输入框 -->
+          <div v-if="useE2B" class="space-y-2">
+            <Label class="text-xs text-muted-foreground" for="e2b-api-key">
+              {{ t('settings.mcp.serverForm.e2bApiKey') || 'E2B API Key' }}
+              <span class="text-red-500">*</span>
+            </Label>
+            <Input
+              id="e2b-api-key"
+              v-model="e2bApiKey"
+              type="password"
+              :placeholder="
+                t('settings.mcp.serverForm.e2bApiKeyPlaceholder') || '输入您的 E2B API Key'
+              "
+              required
+              :class="{ 'border-red-500': useE2B && !e2bApiKey.trim() }"
+            />
+            <div class="text-xs text-muted-foreground">
+              {{
+                t('settings.mcp.serverForm.e2bApiKeyHelp') || '您可以在 E2B 控制台获取 API Key：'
+              }}
+              <a href="https://e2b.dev/docs" target="_blank" class="text-primary hover:underline">
+                https://e2b.dev/docs
+              </a>
+            </div>
+            <div v-if="useE2B && !e2bApiKey.trim()" class="text-xs text-red-500">
+              {{ t('settings.mcp.serverForm.e2bApiKeyRequired') || 'E2B API Key 是必需的' }}
+            </div>
+          </div>
         </div>
 
         <!-- 描述 -->

--- a/src/renderer/src/components/mcp-config/mcpServerForm.vue
+++ b/src/renderer/src/components/mcp-config/mcpServerForm.vue
@@ -919,7 +919,7 @@ HTTP-Referer=deepchatai.cn`
         </div>
 
         <!-- 环境变量 -->
-        <div v-if="showCommandFields || isInMemoryType" class="space-y-2">
+        <div v-if="(showCommandFields || isInMemoryType) && !isPowerpackServer" class="space-y-2">
           <Label class="text-xs text-muted-foreground" for="server-env">{{
             t('settings.mcp.serverForm.env')
           }}</Label>

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -390,7 +390,7 @@
       "e2bDescription": "Execute Python code using E2B sandbox",
       "e2bApiKey": "E2B ApiKey",
       "e2bApiKeyPlaceholder": "Enter your E2B Api Keys here, such as e2b_1111xx*******",
-      "e2bApiKeyHelp": "Visit https://e2b.dev/dashboard/ to get your ApiKey",
+      "e2bApiKeyHelp": "Go to e2b.dev to get your ApiKey",
       "e2bApiKeyRequired": "ApiKey must be entered to enable E2B function"
     },
     "deleteServer": "Delete Server",

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -385,7 +385,13 @@
       "selectFolderError": "Folder selection error",
       "folders": "Folders allowed to access",
       "addFolder": "Add folder",
-      "noFoldersSelected": "No folders were selected"
+      "noFoldersSelected": "No folders were selected",
+      "useE2B": "Enable E2B Sandbox",
+      "e2bDescription": "Execute Python code using E2B sandbox",
+      "e2bApiKey": "E2B ApiKey",
+      "e2bApiKeyPlaceholder": "Enter your E2B Api Keys here, such as e2b_1111xx*******",
+      "e2bApiKeyHelp": "Visit https://e2b.dev/dashboard/ to get your ApiKey",
+      "e2bApiKeyRequired": "ApiKey must be entered to enable E2B function"
     },
     "deleteServer": "Delete Server",
     "editServer": "Edit Server",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -385,7 +385,13 @@
       "selectFolderError": "خطای انتخاب پوشه",
       "folders": "پوشه‌های مجاز برای دسترسی",
       "addFolder": "افزودن پوشه",
-      "noFoldersSelected": "هیچ پوشه‌ای انتخاب نشده است"
+      "noFoldersSelected": "هیچ پوشه‌ای انتخاب نشده است",
+      "useE2B": "ماسه جعبه E2B را فعال کنید",
+      "e2bDescription": "کد پایتون را با استفاده از جعبه ماسه ای E2B اجرا کنید",
+      "e2bApiKey": "e2b apikey",
+      "e2bApiKeyPlaceholder": "کلیدهای API E2B خود را در اینجا وارد کنید ، مانند E2B_11111XX *******",
+      "e2bApiKeyHelp": "برای دریافت apikey خود به https://e2b.dev/dashboard/ مراجعه کنید",
+      "e2bApiKeyRequired": "برای فعال کردن عملکرد E2B باید Apikey وارد شود"
     },
     "deleteServer": "پاک کردن کارساز",
     "editServer": "ویرایش کارساز",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -390,7 +390,7 @@
       "e2bDescription": "کد پایتون را با استفاده از جعبه ماسه ای E2B اجرا کنید",
       "e2bApiKey": "e2b apikey",
       "e2bApiKeyPlaceholder": "کلیدهای API E2B خود را در اینجا وارد کنید ، مانند E2B_11111XX *******",
-      "e2bApiKeyHelp": "برای دریافت apikey خود به https://e2b.dev/dashboard/ مراجعه کنید",
+      "e2bApiKeyHelp": "برای بدست آوردن apikey خود به e2b.dev بروید",
       "e2bApiKeyRequired": "برای فعال کردن عملکرد E2B باید Apikey وارد شود"
     },
     "deleteServer": "پاک کردن کارساز",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -377,7 +377,13 @@
       "selectFolderError": "Erreur de sélection du dossier",
       "folders": "Dossiers autorisés à accéder",
       "addFolder": "Ajouter un dossier",
-      "noFoldersSelected": "Aucun dossier n'a été sélectionné"
+      "noFoldersSelected": "Aucun dossier n'a été sélectionné",
+      "useE2B": "Activer E2B Sandbox",
+      "e2bDescription": "Exécuter le code Python à l'aide de Sandbox E2B",
+      "e2bApiKey": "E2B APIKEY",
+      "e2bApiKeyPlaceholder": "Entrez ici vos touches API E2B, comme E2B_1111XX *******",
+      "e2bApiKeyHelp": "Visitez https://e2b.dev/dashboard/ pour obtenir votre apikey",
+      "e2bApiKeyRequired": "Apikey doit être entré pour activer la fonction E2B"
     },
     "builtIn": "intégré",
     "builtInServerCannotBeRemoved": "Les services intégrés ne peuvent pas être supprimés, seuls les paramètres de modification et les variables d'environnement sont prises en charge.",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -382,7 +382,7 @@
       "e2bDescription": "Exécuter le code Python à l'aide de Sandbox E2B",
       "e2bApiKey": "E2B APIKEY",
       "e2bApiKeyPlaceholder": "Entrez ici vos touches API E2B, comme E2B_1111XX *******",
-      "e2bApiKeyHelp": "Visitez https://e2b.dev/dashboard/ pour obtenir votre apikey",
+      "e2bApiKeyHelp": "Allez sur e2b.dev pour obtenir votre apikey",
       "e2bApiKeyRequired": "Apikey doit être entré pour activer la fonction E2B"
     },
     "builtIn": "intégré",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -382,7 +382,7 @@
       "e2bDescription": "E2Bサンドボックスを使用してPythonコードを実行します",
       "e2bApiKey": "E2B Apikey",
       "e2bApiKeyPlaceholder": "e2b_1111xx *******など、E2B APIキーをこちらから入力してください。",
-      "e2bApiKeyHelp": "https://e2b.dev/dashboard/にアクセスして、Apikeyを取得してください",
+      "e2bApiKeyHelp": "e2b.devにアクセスして、アピケイを取得します",
       "e2bApiKeyRequired": "E2B関数を有効にするには、Apikeyを入力する必要があります"
     },
     "deleteServer": "サーバーを削除",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -377,7 +377,13 @@
       "selectFolderError": "フォルダーの選択エラー",
       "folders": "アクセスが許可されています",
       "addFolder": "フォルダーを追加します",
-      "noFoldersSelected": "フォルダーは選択されていません"
+      "noFoldersSelected": "フォルダーは選択されていません",
+      "useE2B": "E2Bサンドボックスを有効にします",
+      "e2bDescription": "E2Bサンドボックスを使用してPythonコードを実行します",
+      "e2bApiKey": "E2B Apikey",
+      "e2bApiKeyPlaceholder": "e2b_1111xx *******など、E2B APIキーをこちらから入力してください。",
+      "e2bApiKeyHelp": "https://e2b.dev/dashboard/にアクセスして、Apikeyを取得してください",
+      "e2bApiKeyRequired": "E2B関数を有効にするには、Apikeyを入力する必要があります"
     },
     "deleteServer": "サーバーを削除",
     "editServer": "サーバーを編集",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -377,7 +377,13 @@
       "selectFolderError": "폴더 선택 오류",
       "folders": "폴더에 액세스 할 수 있습니다",
       "addFolder": "폴더를 추가하십시오",
-      "noFoldersSelected": "폴더가 선택되지 않았습니다"
+      "noFoldersSelected": "폴더가 선택되지 않았습니다",
+      "useE2B": "E2B 샌드 박스를 활성화하십시오",
+      "e2bDescription": "E2B 샌드 박스를 사용하여 파이썬 코드를 실행하십시오",
+      "e2bApiKey": "E2B Apikey",
+      "e2bApiKeyPlaceholder": "E2B_1111XX *******와 같은 E2B API 키를 여기에 입력하십시오.",
+      "e2bApiKeyHelp": "Apikey를 얻으려면 https://e2b.dev/dashboard/를 방문하십시오",
+      "e2bApiKeyRequired": "E2B 기능을 활성화하려면 Apikey를 입력해야합니다"
     },
     "deleteServer": "서버 삭제",
     "editServer": "서버 편집",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -382,7 +382,7 @@
       "e2bDescription": "E2B 샌드 박스를 사용하여 파이썬 코드를 실행하십시오",
       "e2bApiKey": "E2B Apikey",
       "e2bApiKeyPlaceholder": "E2B_1111XX *******와 같은 E2B API 키를 여기에 입력하십시오.",
-      "e2bApiKeyHelp": "Apikey를 얻으려면 https://e2b.dev/dashboard/를 방문하십시오",
+      "e2bApiKeyHelp": "apikey를 얻으려면 e2b.dev로 이동하십시오",
       "e2bApiKeyRequired": "E2B 기능을 활성화하려면 Apikey를 입력해야합니다"
     },
     "deleteServer": "서버 삭제",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -382,7 +382,7 @@
       "e2bDescription": "Выполните код Python с помощью песочницы E2B",
       "e2bApiKey": "E2b apikey",
       "e2bApiKeyPlaceholder": "Введите здесь свои клавиши E2B API, такие как E2B_1111XX *******",
-      "e2bApiKeyHelp": "Посетите https://e2b.dev/dashboard/, чтобы получить свой apikey",
+      "e2bApiKeyHelp": "Перейдите в E2B.DEV, чтобы получить свой Apikey",
       "e2bApiKeyRequired": "Apikey должен быть введен, чтобы включить функцию E2B"
     },
     "deleteServer": "Удалить сервер",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -377,7 +377,13 @@
       "selectFolderError": "Ошибка выбора папки",
       "folders": "Папки разрешены доступа",
       "addFolder": "Добавить папку",
-      "noFoldersSelected": "Не было выбрано папки"
+      "noFoldersSelected": "Не было выбрано папки",
+      "useE2B": "Включить песочницу E2B",
+      "e2bDescription": "Выполните код Python с помощью песочницы E2B",
+      "e2bApiKey": "E2b apikey",
+      "e2bApiKeyPlaceholder": "Введите здесь свои клавиши E2B API, такие как E2B_1111XX *******",
+      "e2bApiKeyHelp": "Посетите https://e2b.dev/dashboard/, чтобы получить свой apikey",
+      "e2bApiKeyRequired": "Apikey должен быть введен, чтобы включить функцию E2B"
     },
     "deleteServer": "Удалить сервер",
     "editServer": "Редактировать сервер",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -384,7 +384,13 @@
       "selectFolderError": "文件夹选择错误",
       "folders": "允许访问的文件夹",
       "addFolder": "添加文件夹",
-      "noFoldersSelected": "未选择任何文件夹"
+      "noFoldersSelected": "未选择任何文件夹",
+      "useE2B": "启用E2B沙盒",
+      "e2bDescription": "使用E2B沙盒执行Python代码",
+      "e2bApiKey": "E2B ApiKey",
+      "e2bApiKeyPlaceholder": "这里输入你的E2B Api Keys，如 e2b_1111xx*****",
+      "e2bApiKeyHelp": "访问https://e2b.dev/dashboard/ 获取你的 ApiKey",
+      "e2bApiKeyRequired": "启用E2B功能必须要输入 ApiKey"
     },
     "deleteServer": "删除服务器",
     "editServer": "编辑服务器",
@@ -440,7 +446,6 @@
     "pressEnterToSave": "按Enter保存，Esc取消",
     "noModifierOnly": "不能仅使用修饰键作为快捷键",
     "keyConflict": "快捷键冲突，请选择其他组合",
-
     "zoomIn": "放大字体",
     "zoomOut": "缩小字体",
     "zoomReset": "重置字体",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -389,7 +389,7 @@
       "e2bDescription": "使用E2B沙盒执行Python代码",
       "e2bApiKey": "E2B ApiKey",
       "e2bApiKeyPlaceholder": "这里输入你的E2B Api Keys，如 e2b_1111xx*****",
-      "e2bApiKeyHelp": "访问https://e2b.dev/dashboard/ 获取你的 ApiKey",
+      "e2bApiKeyHelp": "前往 e2b.dev 获取你的 ApiKey",
       "e2bApiKeyRequired": "启用E2B功能必须要输入 ApiKey"
     },
     "deleteServer": "删除服务器",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -382,7 +382,7 @@
       "e2bDescription": "使用E2B沙盒執行Python代碼",
       "e2bApiKey": "E2B ApiKey",
       "e2bApiKeyPlaceholder": "這裡輸入你的E2B Api Keys，如 e2b_1111xx*****",
-      "e2bApiKeyHelp": "訪問https://e2b.dev/dashboard/ 獲取你的 ApiKey",
+      "e2bApiKeyHelp": "前往 e2b.dev 獲取你的 ApiKey",
       "e2bApiKeyRequired": "啟用E2B功能必須要輸入 ApiKey"
     },
     "deleteServer": "刪除伺服器",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -377,7 +377,13 @@
       "selectFolderError": "文件夾選擇錯誤",
       "folders": "允許訪問的文件夾",
       "addFolder": "添加文件夾",
-      "noFoldersSelected": "未選擇任何文件夾"
+      "noFoldersSelected": "未選擇任何文件夾",
+      "useE2B": "啟用E2B沙盒",
+      "e2bDescription": "使用E2B沙盒執行Python代碼",
+      "e2bApiKey": "E2B ApiKey",
+      "e2bApiKeyPlaceholder": "這裡輸入你的E2B Api Keys，如 e2b_1111xx*****",
+      "e2bApiKeyHelp": "訪問https://e2b.dev/dashboard/ 獲取你的 ApiKey",
+      "e2bApiKeyRequired": "啟用E2B功能必須要輸入 ApiKey"
     },
     "deleteServer": "刪除伺服器",
     "editServer": "編輯伺服器",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -382,7 +382,7 @@
       "e2bDescription": "使用E2B沙盒執行Python代碼",
       "e2bApiKey": "E2B ApiKey",
       "e2bApiKeyPlaceholder": "這裡輸入你的E2B Api Keys，如 e2b_1111xx*****",
-      "e2bApiKeyHelp": "訪問https://e2b.dev/dashboard/ 獲取你的 ApiKey",
+      "e2bApiKeyHelp": "前往 e2b.dev 獲取你的 ApiKey",
       "e2bApiKeyRequired": "啟用E2B功能必須要輸入 ApiKey"
     },
     "deleteServer": "刪除伺服器",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -377,7 +377,13 @@
       "selectFolderError": "文件夾選擇錯誤",
       "folders": "允許訪問的文件夾",
       "addFolder": "添加文件夾",
-      "noFoldersSelected": "未選擇任何文件夾"
+      "noFoldersSelected": "未選擇任何文件夾",
+      "useE2B": "啟用E2B沙盒",
+      "e2bDescription": "使用E2B沙盒執行Python代碼",
+      "e2bApiKey": "E2B ApiKey",
+      "e2bApiKeyPlaceholder": "這裡輸入你的E2B Api Keys，如 e2b_1111xx*****",
+      "e2bApiKeyHelp": "訪問https://e2b.dev/dashboard/ 獲取你的 ApiKey",
+      "e2bApiKeyRequired": "啟用E2B功能必須要輸入 ApiKey"
     },
     "deleteServer": "刪除伺服器",
     "editServer": "編輯伺服器",


### PR DESCRIPTION


## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
参考 https://raw.githubusercontent.com/e2b-dev/mcp-server/refs/heads/main/packages/js/src/index.ts 在powerpack增加了 e2b的支持


**桌面应用程序的 UI/UX 更改**
<img width="657" alt="image" src="https://github.com/user-attachments/assets/1b161b2b-818f-4f61-865b-bad7ad57bc00" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running Python code in a secure cloud sandbox (E2B) for the "powerpack" in-memory server type.
  - New UI options for enabling E2B and entering an API key when configuring powerpack servers.
  - Python code execution now supports both local and cloud-based (E2B) environments.

- **Bug Fixes**
  - Improved event handling to ensure server status updates and configuration changes are sent to all app windows.

- **Localization**
  - Added E2B sandbox configuration strings to all supported languages for improved internationalization.

- **Chores**
  - Added the E2B code interpreter package as a new dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->