### PR TITLE
fix French typo

### DIFF
--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -92,7 +92,7 @@ export const contextMenuTranslations: Record<string, TranslationMap> = {
     redo: 'Rétablir',
     saveImage: "Enregistrer l'image...",
     copyImage: "Copier l'image",
-    open: 'Ouvrir/Cache',
+    open: 'Ouvrir/Masquer',
     checkForUpdates: 'Vérifier les mises à jour',
     quit: 'Quitter',
     translate: 'Traduire',


### PR DESCRIPTION
## Pull Request Description

**Replace “cache” with “masquer” for better UI terminology**
*Replaced occurrences of “cache” with “masquer” in the UI text to more accurately reflect the intended meaning of “hide” in French.*

*In French UI/UX terminology, “masquer” is the appropriate verb to describe hiding UI elements, while “cache” is either a noun (“cache”) or an incorrect conjugation for this context. This change improves the clarity and correctness of the interface for French-speaking users.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the French translation for the context menu key "open" to improve accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->