### PR TITLE
fix(formatMessage): system prompt is spliced ​​twice

### DIFF
--- a/src/main/presenter/threadPresenter/index.ts
+++ b/src/main/presenter/threadPresenter/index.ts
@@ -1744,7 +1744,7 @@ export class ThreadPresenter implements IThreadPresenter {
           imageFiles.reduce((acc, file) => acc + file.token, 0)
       }
     }
-    // console.log('preparePromptContent', mergedMessages, promptTokens)
+    console.log('preparePromptContent', mergedMessages, promptTokens)
 
     return { finalContent: mergedMessages, promptTokens }
   }
@@ -1815,20 +1815,20 @@ export class ThreadPresenter implements IThreadPresenter {
   ): ChatMessage[] {
     const formattedMessages: ChatMessage[] = []
 
+    // 添加上下文消息
+    formattedMessages.push(
+      ...this.addContextMessages(contextMessages, vision, supportsFunctionCall)
+    )
+
     // 添加系统提示
     if (systemPrompt) {
       // formattedMessages.push(...this.addSystemPrompt(formattedMessages, systemPrompt, artifacts))
-      formattedMessages.push({
+      formattedMessages.unshift({
         role: 'system',
         content: systemPrompt
       })
       // console.log('-------------> system prompt \n', systemPrompt, artifacts, formattedMessages)
     }
-
-    // 添加上下文消息
-    formattedMessages.push(
-      ...this.addContextMessages(formattedMessages, contextMessages, vision, supportsFunctionCall)
-    )
 
     // 添加当前用户消息
     let finalContent = searchPrompt || userContent
@@ -1872,12 +1872,11 @@ export class ThreadPresenter implements IThreadPresenter {
 
   // 添加上下文消息
   private addContextMessages(
-    formattedMessages: ChatMessage[],
     contextMessages: Message[],
     vision: boolean,
     supportsFunctionCall: boolean
   ): ChatMessage[] {
-    const resultMessages = [...formattedMessages]
+    const resultMessages = [] as ChatMessage[]
 
     // 对于原生fc模型，支持正确的tool_call response history插入
     if (supportsFunctionCall) {


### PR DESCRIPTION
## Pull Request Description

**Is your feature request related to a problem? Please describe.**
When synthesizing the conversation context message, the system prompt word is spliced ​​twice. You can observe this by uncommenting the `preparePromptContent` log in the code.

**Describe the solution you'd like**
Fix the above bug.

**UI/UX changes for Desktop Application**
None

**Platform Compatibility Notes**
None

**Additional context**
None

---

## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
在合成对话上下文消息时，系统提示词被合并了两次。取消代码中 `preparePromptContent` 这条log的注释可以观察到。

**请描述你希望的解决方案**
修复以上问题。

**桌面应用程序的 UI/UX 更改**
无

**平台兼容性注意事项**
无

**附加背景**
无


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the order of system prompt and context messages to ensure the system prompt appears first in message sequences.

* **Other**
  * Enabled additional logging for prompt preparation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->