### PR TITLE
Fixed: the edit mode not work good

### DIFF
--- a/src/renderer/src/components/message/MessageItemUser.vue
+++ b/src/renderer/src/components/message/MessageItemUser.vue
@@ -31,10 +31,10 @@
             @click="previewFile(file.path)"
           />
         </div>
-        <div v-if="isEditMode" class="text-sm w-full whitespace-pre-wrap break-all">
+        <div v-if="isEditMode" class="text-sm w-full min-w-[40vw] whitespace-pre-wrap break-all">
           <textarea
             v-model="editedText"
-            class="text-sm bg-[#EFF6FF] dark:bg-muted rounded-lg p-2 border flex flex-col gap-1.5 resize"
+            class="text-sm bg-[#EFF6FF] dark:bg-muted rounded-lg p-2 border flex flex-col gap-1.5 resize min-w-[40vw] w-full"
             :style="{
               height: originalContentHeight + 18 + 'px',
               width: originalContentWidth + 20 + 'px'

--- a/src/renderer/src/components/message/MessageItemUser.vue
+++ b/src/renderer/src/components/message/MessageItemUser.vue
@@ -39,6 +39,8 @@
               height: originalContentHeight + 18 + 'px',
               width: originalContentWidth + 20 + 'px'
             }"
+            @keydown.enter.prevent="saveEdit"
+            @keydown.esc="cancelEdit"
           ></textarea>
         </div>
         <div v-else ref="originalContent">


### PR DESCRIPTION
## Pull Request Description

**Is your feature request related to a problem? Please describe.**
fixed the issue: https://github.com/ThinkInAIXYZ/deepchat/issues/577
when message.content.content is already exists, can't use message.content.text, you can find the preview mode in line 46-55, the other developer don't care the case when we in edit mode.

**Describe the solution you'd like**
1. cate the case with edit mode to fixed the bug.
2. add the enter and esc keyword listener to make edit mode smoother.
3. change the min width about the textarea. Reason: sometimes, the textarea is smaller than we want, beause the width is using with the preview text width, but the preview text width maybe too small.

**UI/UX changes for Desktop Application**
add the min width about the textarea, it has a min width now, and you can change the width which you design, i only do it with 40vw.

**Platform Compatibility Notes**
nothing to change.
i worked in windows.

**Additional context**
fixed the issue: https://github.com/ThinkInAIXYZ/deepchat/issues/577


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edit mode to correctly handle messages with structured content, ensuring edits apply to the appropriate text block.
* **New Features**
  * Added keyboard shortcuts in edit mode: press Enter to save edits and Escape to cancel.
* **Style**
  * Enhanced the editing UI by updating the textarea to have a minimum width and full width for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->