### PR TITLE
fixed: the mcpServer you need maybe undefined when you want to use

### DIFF
--- a/src/renderer/src/components/settings/DifyKnowledgeSettings.vue
+++ b/src/renderer/src/components/settings/DifyKnowledgeSettings.vue
@@ -183,7 +183,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch, toRaw } from 'vue'
+import { ref, computed, onMounted, watch, toRaw, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@iconify/vue'
 import { Button } from '@/components/ui/button'
@@ -402,11 +402,6 @@ watch(
   }
 )
 
-// 组件挂载时加载配置
-onMounted(async () => {
-  await loadDifyConfigFromMcp()
-})
-
 // 监听URL查询参数，设置活动标签页
 watch(
   () => route.query.subtab,
@@ -417,4 +412,26 @@ watch(
   },
   { immediate: true }
 )
+
+// 组件挂载时加载配置
+let unwatch: () => void // only use here, so declare it here
+onMounted(async () => {
+  unwatch = watch(
+    () => mcpStore.config.ready,
+    async (ready) => {
+      if (ready) {
+        unwatch() // only run once to avoid multiple calls
+        await loadDifyConfigFromMcp()
+      }
+    },
+    { immediate: true }
+  )
+})
+
+// cancel the watch to avoid memory leaks
+onUnmounted(() => {
+  if (unwatch) {
+    unwatch()
+  }
+})
 </script>

--- a/src/renderer/src/components/settings/FastGptKnowledgeSettings.vue
+++ b/src/renderer/src/components/settings/FastGptKnowledgeSettings.vue
@@ -183,7 +183,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch, toRaw } from 'vue'
+import { ref, computed, onMounted, watch, toRaw, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@iconify/vue'
 import { Button } from '@/components/ui/button'
@@ -355,6 +355,7 @@ const updateFastGptConfigToMcp = async () => {
 const loadFastGptConfigFromMcp = async () => {
   try {
     // 获取fastGptKnowledge服务器配置
+    console.log(mcpStore.config)
     const serverConfig = mcpStore.config.mcpServers['fastGptKnowledge']
     if (serverConfig && serverConfig.env) {
       // 解析配置 - env可能是JSON字符串
@@ -412,7 +413,24 @@ watch(
 )
 
 // 组件挂载时加载配置
+let unwatch: () => void // only use here, so declare it here
 onMounted(async () => {
-  await loadFastGptConfigFromMcp()
+  unwatch = watch(
+    () => mcpStore.config.ready,
+    async (ready) => {
+      if (ready) {
+        unwatch() // only run once to avoid multiple calls
+        await loadFastGptConfigFromMcp()
+      }
+    },
+    { immediate: true }
+  )
+})
+
+// cancel the watch to avoid memory leaks
+onUnmounted(() => {
+  if (unwatch) {
+    unwatch()
+  }
 })
 </script>

--- a/src/renderer/src/stores/mcp.ts
+++ b/src/renderer/src/stores/mcp.ts
@@ -116,10 +116,6 @@ export const useMcpStore = defineStore('mcp', () => {
         ready: true // config is loaded
       }
 
-      setTimeout(() => {
-        config.value.ready = false // 设置ready为true，表示配置加载完成
-      }, 1000)
-
       // 获取服务器运行状态
       await updateAllServerStatuses()
     } catch (error) {

--- a/src/renderer/src/stores/mcp.ts
+++ b/src/renderer/src/stores/mcp.ts
@@ -38,7 +38,8 @@ export const useMcpStore = defineStore('mcp', () => {
   const config = ref<MCPConfig>({
     mcpServers: {},
     defaultServers: [],
-    mcpEnabled: false // 添加MCP启用状态
+    mcpEnabled: false, // 添加MCP启用状态
+    ready: false // if init finished, the ready will be true
   })
 
   // MCP全局启用状态
@@ -108,12 +109,16 @@ export const useMcpStore = defineStore('mcp', () => {
         mcpPresenter.getMcpDefaultServers(),
         mcpPresenter.getMcpEnabled()
       ])
-
       config.value = {
         mcpServers: servers,
         defaultServers: defaultServers,
-        mcpEnabled: enabled
+        mcpEnabled: enabled,
+        ready: true // config is loaded
       }
+
+      setTimeout(() => {
+        config.value.ready = false // 设置ready为true，表示配置加载完成
+      }, 1000)
 
       // 获取服务器运行状态
       await updateAllServerStatuses()

--- a/src/shared/presenter.d.ts
+++ b/src/shared/presenter.d.ts
@@ -875,6 +875,7 @@ export interface MCPConfig {
   mcpServers: Record<string, MCPServerConfig>
   defaultServers: string[]
   mcpEnabled: boolean
+  ready: boolean
 }
 
 export interface MCPToolDefinition {


### PR DESCRIPTION
## Pull Request Description

**Is your feature request related to a problem? Please describe.**

https://github.com/ThinkInAIXYZ/deepchat/issues/551
In Setting -> KnowledgeBase Tab, server config is load undefined beacuse when mcpserver is initing and component load the server config, so it will be undefined.

**Describe the solution you'd like**
1. add a ready status in config.value and change value to true when servers is ready.  // Line 42 and Line 116
2. add a watch to handle config.value.ready is true // three knowledge setting file in end of the file.
3. in this time, load the server config.
4. maybe watch special value has a better way to do it, will change it in future.
5. setTimeout is too simple to do it, less code than this pr, but maybe the time is not enough to get the servers.
6. In other way, the servers will load quickly, everything better,  if the servers load slowly, the bug will reappear, beause the component don't has a loading status, maybe we can design a good enough workflow in the future.

**UI/UX changes for Desktop Application**
nothing

**Platform Compatibility Notes**
nothing

**Additional context**
https://github.com/ThinkInAIXYZ/deepchat/issues/551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readiness indicator for configuration loading, improving feedback on when settings are available.

* **Refactor**
  * Improved the loading process for configuration settings in multiple components to ensure they only load after configuration is ready.
  * Enhanced lifecycle management to prevent potential memory leaks during component unmounting.

* **Chores**
  * Added debug logging for configuration loading in FastGPT settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->