### PR TITLE
fix:openai return base64 image str not been recognized as base64

### DIFF
--- a/src/main/presenter/llmProviderPresenter/providers/openAICompatibleProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/openAICompatibleProvider.ts
@@ -414,7 +414,11 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
             // 处理 base64 数据
             const base64Data = result.data[0].b64_json
             // 直接使用 devicePresenter 缓存 base64 数据
-            imageUrl = await presenter.devicePresenter.cacheImage(base64Data)
+            imageUrl = await presenter.devicePresenter.cacheImage(
+              base64Data.startsWith('data:image/png;base64,')
+                ? base64Data
+                : 'data:image/png;base64,' + base64Data
+            )
           } else {
             // 原有的 URL 处理逻辑
             imageUrl = result.data[0]?.url || ''

--- a/src/main/presenter/llmProviderPresenter/providers/openAIResponsesProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/openAIResponsesProvider.ts
@@ -438,7 +438,11 @@ export class OpenAIResponsesProvider extends BaseLLMProvider {
             // 处理 base64 数据
             const base64Data = result.data[0].b64_json
             // 直接使用 devicePresenter 缓存 base64 数据
-            imageUrl = await presenter.devicePresenter.cacheImage(base64Data)
+            imageUrl = await presenter.devicePresenter.cacheImage(
+              base64Data.startsWith('data:image/png;base64,')
+                ? base64Data
+                : 'data:image/png;base64,' + base64Data
+            )
           } else {
             // 原有的 URL 处理逻辑
             imageUrl = result.data[0]?.url || ''


### PR DESCRIPTION
在使用OpenAI的图像生成API的时候,返回的图片不能被正确的显示
日志中debug显示为 图片格式不支持
<img width="1740" height="1014" alt="Weixin Image_20250728130057_52" src="https://github.com/user-attachments/assets/9267f595-a72d-4381-ab96-c82547f271db" />

参考内部实现,发现OpenAI返回的图片对象在 b64_json 字段中,
该字段openai只会返回base64字符串, 但是不会返回前面的转义标识符
因此在后续cache的时候会被认为是不支持的格式

以防未来这个字段也会返回
data:image/png;base64

在传递到cache方法的时候加了一个判断
添加之后OpenAI图片可以被正确的识别和返回

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image handling to ensure all generated images are correctly formatted and display reliably, regardless of their original format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->