### PR TITLE
fix: auto-scroll to cursor position after Shift+Enter line break

### DIFF
--- a/src/renderer/src/components/ChatInput.vue
+++ b/src/renderer/src/components/ChatInput.vue
@@ -261,8 +261,12 @@ const editor = new Editor({
     HardBreak.extend({
       addKeyboardShortcuts() {
         return {
-          'Shift-Enter': () => this.editor.commands.setHardBreak(),
-          'Alt-Enter': () => this.editor.commands.setHardBreak()
+          'Shift-Enter': () => {
+            return this.editor.chain().setHardBreak().scrollIntoView().run()
+          },
+          'Alt-Enter': () => {
+            return this.editor.chain().setHardBreak().scrollIntoView().run()
+          }
         }
       }
     }).configure({


### PR DESCRIPTION
close #666 
![PixPin_2025-07-31_19-06-03](https://github.com/user-attachments/assets/052b46f2-c84d-4655-b1cf-78a41718e47b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved keyboard shortcut handling for inserting line breaks in the chat input, ensuring the editor view scrolls into view after the action.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->