### PR TITLE
fix: implement separate drag zones for enabled/disabled providers

### DIFF
--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -203,6 +203,8 @@
   },
   "provider": {
     "enable": "Enable Service",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
     "urlPlaceholder": "Please enter API URL",
     "keyPlaceholder": "Please enter API Key",
     "verifyKey": "Verify Key",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -203,6 +203,8 @@
   },
   "provider": {
     "enable": "روشن کردن خدمات",
+    "enabled": "فعال",
+    "disabled": "غیرفعال",
     "urlPlaceholder": "لطفاً نشانی API را وارد کنید",
     "keyPlaceholder": "لطفاً کلید API را وارد کنید",
     "verifyKey": "پذیرش کلید",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -203,6 +203,8 @@
   },
   "provider": {
     "enable": "Activer le service",
+    "enabled": "Activé",
+    "disabled": "Désactivé",
     "urlPlaceholder": "Veuillez entrer l'URL de l'API",
     "keyPlaceholder": "Veuillez entrer la clé API",
     "verifyKey": "Vérifier la clé",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -203,6 +203,8 @@
   },
   "provider": {
     "enable": "サービスを有効にする",
+    "enabled": "有効",
+    "disabled": "無効",
     "urlPlaceholder": "API URLを入力してください",
     "keyPlaceholder": "API Keyを入力してください",
     "verifyKey": "キーを検証",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -203,6 +203,8 @@
   },
   "provider": {
     "enable": "서비스 활성화",
+    "enabled": "활성화됨",
+    "disabled": "비활성화됨",
     "urlPlaceholder": "API URL을 입력하세요",
     "keyPlaceholder": "API 키를 입력하세요",
     "verifyKey": "키 확인",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -203,6 +203,8 @@
   },
   "provider": {
     "enable": "Включить сервис",
+    "enabled": "Включен",
+    "disabled": "Отключен",
     "urlPlaceholder": "Введите API URL",
     "keyPlaceholder": "Введите API Key",
     "verifyKey": "Проверить ключ",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -203,6 +203,8 @@
   },
   "provider": {
     "enable": "开启服务",
+    "enabled": "已启用",
+    "disabled": "已禁用",
     "urlPlaceholder": "请输入API URL",
     "keyPlaceholder": "请输入API Key",
     "verifyKey": "验证密钥",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -203,6 +203,8 @@
   },
   "provider": {
     "enable": "開啟服務",
+    "enabled": "已啟用",
+    "disabled": "已禁用",
     "urlPlaceholder": "請輸入API URL",
     "keyPlaceholder": "請輸入API Key",
     "verifyKey": "驗證密鑰",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -203,6 +203,8 @@
   },
   "provider": {
     "enable": "啟用服務",
+    "enabled": "已啟用",
+    "disabled": "已停用",
     "urlPlaceholder": "請輸入 API URL",
     "keyPlaceholder": "請輸入 API 金鑰",
     "verifyKey": "驗證金鑰",


### PR DESCRIPTION
The provider drag-and-drop functionality was broken due to conflicts between drag ordering and timestamp-based sorting. When users dragged providers between enabled/disabled regions, they would immediately jump back to their original positions.
The current logic is as follows:
1. Differentiate between two drag-and-drop areas: enabled and disabled.
2. Drag-and-drop is restricted to the corresponding area.
3. Drag-and-drop has higher priority than timestamps.
4. Disabling an enabled provider automatically sorts it to the first position in the disabled list based on the timestamp.
5. Enabling a disabled provider automatically sorts it to the last position in the enabled list based on the timestamp.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider settings now display enabled and disabled providers in separate, clearly labeled sections with improved drag-and-drop reordering within each group.
  * Added support for localized labels for "enabled" and "disabled" provider states in multiple languages.

* **Improvements**
  * Provider order now respects user drag-and-drop preferences and maintains consistent order when toggling provider status.
  * Enhanced visual distinction and usability in the provider management interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->