### PR TITLE
fix: improve focus management for deeplink startup

### DIFF
--- a/src/main/presenter/deeplinkPresenter/index.ts
+++ b/src/main/presenter/deeplinkPresenter/index.ts
@@ -191,6 +191,15 @@ export class DeeplinkPresenter implements IDeeplinkPresenter {
     console.log('modelId:', modelId)
     console.log('systemPrompt:', systemPrompt)
     console.log('autoSend:', autoSend)
+
+    const focusedWindow = presenter.windowPresenter.getFocusedWindow()
+    if (focusedWindow) {
+      focusedWindow.show()
+      focusedWindow.focus()
+    } else {
+      presenter.windowPresenter.show()
+    }
+
     eventBus.sendToRenderer(DEEPLINK_EVENTS.START, SendTarget.DEFAULT_TAB, {
       msg,
       modelId,

--- a/src/main/presenter/tabPresenter.ts
+++ b/src/main/presenter/tabPresenter.ts
@@ -609,6 +609,9 @@ export class TabPresenter implements ITabPresenter {
     // Re-adding ensures it's on top in most view hierarchies
     window.contentView.addChildView(view)
     this.updateViewBounds(window, view)
+    if (!view.webContents.isDestroyed()) {
+      view.webContents.focus()
+    }
   }
 
   /**

--- a/src/renderer/src/components/ChatInput.vue
+++ b/src/renderer/src/components/ChatInput.vue
@@ -1021,7 +1021,16 @@ function onKeydown(e: KeyboardEvent) {
 defineExpose({
   setText: (text: string) => {
     inputText.value = text
-    editor.chain().setContent(text).focus('end').run()
+    nextTick(() => {
+      editor.chain().clearContent().insertContent(text).run()
+      nextTick(() => {
+        editor.view.updateState(editor.state)
+        setTimeout(() => {
+          const docSize = editor.state.doc.content.size
+          editor.chain().focus().setTextSelection(docSize).run()
+        }, 10)
+      })
+    })
   }
 })
 </script>


### PR DESCRIPTION
## Issues Fixed
- Users couldn't immediately type after deeplink startup due to focus not being properly transferred from shell to content
- Cursor position was incorrect (at beginning instead of end) when deeplink was used while already in a conversation