### PR TITLE
refactor: remove redundant nextTick in editor setText method

### DIFF
--- a/src/renderer/src/components/ChatInput.vue
+++ b/src/renderer/src/components/ChatInput.vue
@@ -1023,13 +1023,11 @@ defineExpose({
     inputText.value = text
     nextTick(() => {
       editor.chain().clearContent().insertContent(text).run()
-      nextTick(() => {
-        editor.view.updateState(editor.state)
-        setTimeout(() => {
-          const docSize = editor.state.doc.content.size
-          editor.chain().focus().setTextSelection(docSize).run()
-        }, 10)
-      })
+      editor.view.updateState(editor.state)
+      setTimeout(() => {
+        const docSize = editor.state.doc.content.size
+        editor.chain().focus().setTextSelection(docSize).run()
+      }, 10)
     })
   }
 })


### PR DESCRIPTION
Simplified the setText method in ChatInput component by removing unnecessary nested nextTick call. The editor operations are synchronous, so only one nextTick is needed for DOM updates.
