### PR TITLE
fix: prevent tooltip from overlapping HTML preview in ArtifactDialog

### DIFF
--- a/src/renderer/src/components/artifacts/ArtifactDialog.vue
+++ b/src/renderer/src/components/artifacts/ArtifactDialog.vue
@@ -9,7 +9,7 @@
   >
     <div
       v-if="artifactStore.isOpen"
-      class="absolute right-0 top-0 bottom-0 w-[calc(60%_-_104px)] border-l shadow-lg flex flex-col max-lg:!w-3/4 max-lg:bg-white max-lg:dark:!bg-black"
+      class="absolute right-0 top-0 bottom-0 w-[calc(60%_-_104px)] border-l shadow-lg flex flex-col max-lg:!w-3/4 max-lg:bg-white max-lg:dark:!bg-black z-[60]"
     >
       <!-- 顶部导航栏 -->
       <div


### PR DESCRIPTION
When scrolling through HTML code in chat messages, tooltips for code elements (like `<script>` tags) appear above the HTML preview window, blocking the preview content.
![285037f82e3188be06b1a56d5678b162](https://github.com/user-attachments/assets/7ecf69cd-3309-4e1d-bb30-dabe1592aa17)
Added `z-[60]` class to the ArtifactDialog root container to ensure the HTML preview window has a higher z-index than tooltips (which use z-50).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual layering of the artifact dialog to ensure it appears above other interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->