### PR TITLE
fix: unwatch is not a function error in knowledge settings components

### DIFF
--- a/src/renderer/src/components/settings/DifyKnowledgeSettings.vue
+++ b/src/renderer/src/components/settings/DifyKnowledgeSettings.vue
@@ -418,13 +418,13 @@ watch(
 )
 
 // 组件挂载时加载配置
-let unwatch: () => void // only use here, so declare it here
+let unwatch: (() => void) | undefined
 onMounted(async () => {
   unwatch = watch(
     () => mcpStore.config.ready,
     async (ready) => {
       if (ready) {
-        unwatch() // only run once to avoid multiple calls
+        unwatch?.() // only run once to avoid multiple calls
         await loadDifyConfigFromMcp()
       }
     },
@@ -434,8 +434,6 @@ onMounted(async () => {
 
 // cancel the watch to avoid memory leaks
 onUnmounted(() => {
-  if (unwatch) {
-    unwatch()
-  }
+  unwatch?.()
 })
 </script>

--- a/src/renderer/src/components/settings/FastGptKnowledgeSettings.vue
+++ b/src/renderer/src/components/settings/FastGptKnowledgeSettings.vue
@@ -417,13 +417,13 @@ watch(
 )
 
 // 组件挂载时加载配置
-let unwatch: () => void // only use here, so declare it here
+let unwatch: (() => void) | undefined
 onMounted(async () => {
   unwatch = watch(
     () => mcpStore.config.ready,
     async (ready) => {
       if (ready) {
-        unwatch() // only run once to avoid multiple calls
+        unwatch?.() // only run once to avoid multiple calls
         await loadFastGptConfigFromMcp()
       }
     },
@@ -433,8 +433,6 @@ onMounted(async () => {
 
 // cancel the watch to avoid memory leaks
 onUnmounted(() => {
-  if (unwatch) {
-    unwatch()
-  }
+  unwatch?.()
 })
 </script>

--- a/src/renderer/src/components/settings/RagflowKnowledgeSettings.vue
+++ b/src/renderer/src/components/settings/RagflowKnowledgeSettings.vue
@@ -435,13 +435,13 @@ watch(
 )
 
 // 组件挂载时加载配置
-let unwatch: () => void // only use here, so declare it here
+let unwatch: (() => void) | undefined
 onMounted(async () => {
   unwatch = watch(
     () => mcpStore.config.ready,
     async (ready) => {
       if (ready) {
-        unwatch() // only run once to avoid multiple calls
+        unwatch?.() // only run once to avoid multiple calls
         await loadRagflowConfigFromMcp()
       }
     },
@@ -451,8 +451,6 @@ onMounted(async () => {
 
 // cancel the watch to avoid memory leaks
 onUnmounted(() => {
-  if (unwatch) {
-    unwatch()
-  }
+  unwatch?.()
 })
 </script>


### PR DESCRIPTION
fix unwatch is not a function error in knowledge settings components
<img width="1600" height="1200" alt="8f588119f32089676fbb441c18bd2640" src="https://github.com/user-attachments/assets/95c5262f-905e-4fbb-bdf3-3e79b920dc63" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and prevented potential errors in knowledge settings by ensuring watcher cleanup functions are safely invoked only when defined. This enhances reliability when changing or unmounting settings components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->