### PR TITLE
docs: update Electron-Vite link format to full URL

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -324,7 +324,7 @@ deepchatへの貢献をご検討いただきありがとうございます！貢
 
 - [Vue](https://vuejs.org/)
 - [Electron](https://www.electronjs.org/)
-- [Electron-Vite](electron-vite.org)
+- [Electron-Vite](https://electron-vite.org/)
 - [Rolldown-Vite](https://github.com/vitejs/rolldown-vite)
 - [oxlint](https://github.com/oxc-project/oxc)
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ This project is built with the help of these awesome libraries:
 
 - [Vue](https://vuejs.org/)
 - [Electron](https://www.electronjs.org/)
-- [Electron-Vite](electron-vite.org)
+- [Electron-Vite](https://electron-vite.org/)
 - [Rolldown-Vite](https://github.com/vitejs/rolldown-vite)
 - [oxlint](https://github.com/oxc-project/oxc)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -324,7 +324,7 @@ DeepChat是一个活跃的开源社区项目，我们欢迎各种形式的贡献
 
 - [Vue](https://vuejs.org/)
 - [Electron](https://www.electronjs.org/)
-- [Electron-Vite](electron-vite.org)
+- [Electron-Vite](https://electron-vite.org/)
 - [Rolldown-Vite](https://github.com/vitejs/rolldown-vite)
 - [oxlint](https://github.com/oxc-project/oxc)
 


### PR DESCRIPTION
Minor modifications, Fix link typo.
微量修改，补充文档链接。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed broken links for the "Electron-Vite" library in the acknowledgments sections of the English, Japanese, and Chinese README files by adding the missing "https://" prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->