### PR TITLE
fix: built-in knowledge settings not loaded when first entering

### DIFF
--- a/src/main/presenter/knowledgePresenter/index.ts
+++ b/src/main/presenter/knowledgePresenter/index.ts
@@ -307,6 +307,9 @@ export class KnowledgePresenter implements IKnowledgePresenter {
     this.storePresenterCache.clear()
   }
 
+  /**
+   * @returns return true if user confirmed to destroy knowledge, otherwise false
+   */
   async beforeDestroy(): Promise<boolean> {
     const status = this.taskP.getStatus()
     if (status.totalTasks === 0) {
@@ -326,9 +329,6 @@ export class KnowledgePresenter implements IKnowledgePresenter {
     return choice === 'confirm'
   }
 
-  /**
-   * @returns return true if user confirmed to destroy knowledge, otherwise false
-   */
   async destroy(): Promise<void> {
     await this.closeAll()
   }

--- a/src/renderer/src/components/settings/BuiltinKnowledgeSettings.vue
+++ b/src/renderer/src/components/settings/BuiltinKnowledgeSettings.vue
@@ -886,23 +886,24 @@ watch(
 )
 
 // 组件挂载时加载配置
-let unwatch: () => void // only use here, so declare it here
+let unwatch: (() => void) | undefined
 onMounted(async () => {
   unwatch = watch(
     () => mcpStore.config.ready,
     async (ready) => {
       if (ready) {
-        unwatch() // only run once to avoid multiple calls
+        unwatch?.() // only run once to avoid multiple calls
         await loadBuiltinConfigFromMcp()
       }
-    }
+    },
+    { immediate: true }
   )
 })
 
 // cancel the watch to avoid memory leaks
 onUnmounted(() => {
   if (unwatch) {
-    unwatch()
+    unwatch?.()
   }
 })
 </script>

--- a/src/renderer/src/components/settings/BuiltinKnowledgeSettings.vue
+++ b/src/renderer/src/components/settings/BuiltinKnowledgeSettings.vue
@@ -486,7 +486,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, toRaw, computed, watch } from 'vue'
+import { ref, onMounted, toRaw, computed, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@iconify/vue'
 import { Button } from '@/components/ui/button'
@@ -862,10 +862,6 @@ const loadBuiltinConfigFromMcp = async () => {
   }
 }
 
-onMounted(async () => {
-  await loadBuiltinConfigFromMcp()
-})
-
 const route = useRoute()
 
 // 监听URL查询参数，设置活动标签页
@@ -878,4 +874,35 @@ watch(
   },
   { immediate: true }
 )
+
+// 监听MCP全局状态变化
+watch(
+  () => mcpStore.mcpEnabled,
+  async (enabled) => {
+    if (!enabled && isBuiltinMcpEnabled.value) {
+      await mcpStore.toggleServer('builtinKnowledge')
+    }
+  }
+)
+
+// 组件挂载时加载配置
+let unwatch: () => void // only use here, so declare it here
+onMounted(async () => {
+  unwatch = watch(
+    () => mcpStore.config.ready,
+    async (ready) => {
+      if (ready) {
+        unwatch() // only run once to avoid multiple calls
+        await loadBuiltinConfigFromMcp()
+      }
+    }
+  )
+})
+
+// cancel the watch to avoid memory leaks
+onUnmounted(() => {
+  if (unwatch) {
+    unwatch()
+  }
+})
 </script>


### PR DESCRIPTION
## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
请对问题进行清晰扼要的描述。
#551 [BUG] 首次打开知识库时配置丢失

**请描述你希望的解决方案**
请对你希望实现的效果进行清晰扼要的描述。
#599 内置知识库功能在当时未提交，此处修改被遗漏，现已补充

**桌面应用程序的 UI/UX 更改**
如果此 PR 引入了 UI/UX 更改，请详细描述它们。
* 如果适用，请包含屏幕截图或 GIF 以直观地演示更改。
* 解释 UI/UX 决策背后的原因，以及它们如何改善桌面应用程序的用户体验。
无

**平台兼容性注意事项**
如果此 PR 具有特定的平台兼容性考虑因素（Windows、macOS、Linux），请在此处描述。
* 是否有任何平台特定的行为或代码调整？无
* 你是否已在所有相关平台上进行过测试？无



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading timing for builtin knowledge configuration, ensuring it only loads when the system is ready.
  * Resolved potential issues with repeated loading and memory leaks by cleaning up watchers properly.
  * Enhanced handling of server toggling when MCP is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->