### PR TITLE
fix: fixed dirty data problems

### DIFF
--- a/src/renderer/src/components/mcpToolsList.vue
+++ b/src/renderer/src/components/mcpToolsList.vue
@@ -34,16 +34,22 @@ const getTools = (serverName: string) => {
 
 // 获取每个mcp服务的可用工具数量
 const getEnabledToolCountByServer = (serverName: string) => {
-  const enabledTools = chatStore.chatConfig.enabledMcpTools ?? []
   const serverTools = mcpStore.tools.filter((tool) => tool.server.name === serverName)
-  return serverTools.filter((tool) => enabledTools.includes(tool.function.name)).length
+  if (chatStore.chatConfig.enabledMcpTools) {
+    const enabledTools = chatStore.chatConfig.enabledMcpTools
+    return serverTools.filter((tool) => enabledTools.includes(tool.function.name)).length
+  }
+  return serverTools.length
 }
 
 // 获取可用工具总数
 const getTotalEnabledToolCount = () => {
-  const enabledMcpTools = chatStore.chatConfig.enabledMcpTools || []
-  const filterList = mcpStore.tools.filter((item) => enabledMcpTools.includes(item.function.name))
-  return filterList.length
+  if (chatStore.chatConfig.enabledMcpTools) {
+    const enabledMcpTools = chatStore.chatConfig.enabledMcpTools
+    const filterList = mcpStore.tools.filter((item) => enabledMcpTools.includes(item.function.name))
+    return filterList.length
+  }
+  return mcpStore.tools.length
 }
 
 // 处理单个服务开关状态变化

--- a/src/renderer/src/stores/mcp.ts
+++ b/src/renderer/src/stores/mcp.ts
@@ -1,4 +1,4 @@
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { defineStore } from 'pinia'
 import { usePresenter } from '@/composables/usePresenter'
 import { MCP_EVENTS } from '@/events'
@@ -521,9 +521,23 @@ export const useMcpStore = defineStore('mcp', () => {
     }
   }
 
+  // 监听活动线程变化，处理新会话的默认工具状态
+  const handleActiveThreadChange = () => {
+    watch(
+      () => chatStore.getActiveThreadId(),
+      (newThreadId, oldThreadId) => {
+        // 从有活动线程切换到无活动线程（新会话页面）
+        if (oldThreadId && !newThreadId && config.value.mcpEnabled && tools.value.length > 0) {
+          chatStore.chatConfig.enabledMcpTools = undefined
+        }
+      }
+    )
+  }
+
   // 立即初始化
   onMounted(async () => {
     await init()
+    handleActiveThreadChange()
   })
 
   return {


### PR DESCRIPTION
## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
请对问题进行清晰扼要的描述。

按会话启停mcp工具，旧会话工具列表被默认设置为空。
https://github.com/user-attachments/assets/19ab761b-da8d-4f6e-84f0-28b3aa7fe542

**请描述你希望的解决方案**
请对你希望实现的效果进行清晰扼要的描述。
- 启用工具列表默认改为NULL，旧会话工具列表从 [] 改为 NULL
- 当启用工具列表配置为NULL时，视作没有修改，启用全部
- 启用新会话时，重置工具列表，而不是沿用当前会话设置

**桌面应用程序的 UI/UX 更改**
如果此 PR 引入了 UI/UX 更改，请详细描述它们。
* 如果适用，请包含屏幕截图或 GIF 以直观地演示更改。
* 解释 UI/UX 决策背后的原因，以及它们如何改善桌面应用程序的用户体验。
无

**平台兼容性注意事项**
如果此 PR 具有特定的平台兼容性考虑因素（Windows、macOS、Linux），请在此处描述。
* 是否有任何平台特定的行为或代码调整？无
* 你是否已在所有相关平台上进行过测试？仅windows



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of enabled tools configuration, ensuring that empty tool lists are now treated as undefined rather than empty arrays.
  * Fixed logic so that when no enabled tools are configured, all tools are counted instead of none.

* **New Features**
  * The enabled tools list is now automatically reset when starting a new chat session.

* **Chores**
  * Updated internal data migration and default values for tool configuration to enhance consistency across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->