### PR TITLE
fix: a potential problem with mcp tools

### DIFF
--- a/src/renderer/src/stores/mcp.ts
+++ b/src/renderer/src/stores/mcp.ts
@@ -170,7 +170,8 @@ export const useMcpStore = defineStore('mcp', () => {
       }
       // 根据服务器的状态，关闭或者开启该服务器的所有工具
       const isRunning = serverStatuses.value[serverName] || false
-      const currentTools = chatStore.chatConfig.enabledMcpTools || []
+      const currentTools =
+        chatStore.chatConfig.enabledMcpTools || [...tools.value].map((tool) => tool.function.name)
       if (isRunning) {
         const serverTools = tools.value
           .filter((tool) => tool.server.name === serverName)


### PR DESCRIPTION
## Pull Request Description

**Is your feature request related to a problem? Please describe.**
A clear and concise description of what the problem is.
After creating a new chat from an old one, starting a new MCP service will cause currently enabled tools to be incorrectly disabled.
Details see below

**Describe the solution you'd like**
The error is caused by the incorrect default list selection when the session has no special settings for enabledMcpTools.
Details see below

**UI/UX changes for Desktop Application**
none

**Platform Compatibility Notes**
If this PR has specific platform compatibility considerations (Windows, macOS, Linux), please describe them here.
* Are there any platform-specific behaviors or code adjustments? no
* Have you tested on all relevant platforms? only windows

---

## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
请对问题进行清晰扼要的描述。
从旧的聊天中创建新聊天后，开启一个新的MCP服务，当前已启用的tools会被错误的关闭。

https://github.com/user-attachments/assets/d09f2b76-ff60-4e6f-a66e-4719d72e97f4

**请描述你希望的解决方案**

错误是当会话没有关于enabledMcpTools的特殊设置时，默认列表选择错误导致的。

<img width="557" height="19" alt="image" src="https://github.com/user-attachments/assets/5d4a1c36-4723-4643-a5af-3c2c37bd8bc6" />

⬇️

<img width="878" height="344" alt="image" src="https://github.com/user-attachments/assets/ce2d90e1-c0b5-4ff0-a1ed-6d544d8bb396" />

**桌面应用程序的 UI/UX 更改**
如果此 PR 引入了 UI/UX 更改，请详细描述它们。
无

**平台兼容性注意事项**
如果此 PR 具有特定的平台兼容性考虑因素（Windows、macOS、Linux），请在此处描述。
* 是否有任何平台特定的行为或代码调整？无
* 你是否已在所有相关平台上进行过测试？仅windows
