### PR TITLE
fix: add AlertDialogDescription to resolve accessibility warning

### DIFF
--- a/src/renderer/src/components/settings/PromptSetting.vue
+++ b/src/renderer/src/components/settings/PromptSetting.vue
@@ -135,6 +135,9 @@
                     <AlertDialogTitle>{{
                       t('promptSetting.confirmDelete', { name: prompt.name })
                     }}</AlertDialogTitle>
+                    <AlertDialogDescription>{{
+                      t('promptSetting.confirmDeleteDescription')
+                    }}</AlertDialogDescription>
                   </AlertDialogHeader>
                   <AlertDialogFooter>
                     <AlertDialogCancel>{{ t('common.cancel') }}</AlertDialogCancel>
@@ -514,6 +517,7 @@ import {
   AlertDialogContent,
   AlertDialogHeader,
   AlertDialogTitle,
+  AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogCancel,
   AlertDialogAction

--- a/src/renderer/src/i18n/en-US/promptSetting.json
+++ b/src/renderer/src/i18n/en-US/promptSetting.json
@@ -45,6 +45,7 @@
   "uploadSuccess": "Upload successful",
   "uploadedCount": "Uploaded {count} files",
   "confirmDelete": "Are you sure you want to delete prompt \"{name}\"?",
+  "confirmDeleteDescription": "This action cannot be undone. The prompt will be permanently deleted.",
   "deleteSuccess": "Prompt Deleted",
   "deleteFailed": "Failed to Delete Prompt",
   "inactive": "Inactive",

--- a/src/renderer/src/i18n/fa-IR/promptSetting.json
+++ b/src/renderer/src/i18n/fa-IR/promptSetting.json
@@ -45,6 +45,7 @@
   "uploadSuccess": "بارگذاری موفق",
   "uploadedCount": "{count} پرونده بارگذاری شد",
   "confirmDelete": "آیا مطمئن هستید که می‌خواهید دستورکار \"{name}\" را پاک کنید؟",
+  "confirmDeleteDescription": "این عمل قابل بازگشت نیست. دستورکار به طور دائم پاک خواهد شد.",
   "deleteSuccess": "پاک کردن موفق",
   "deleteFailed": "پاک کردن ناموفق",
   "inactive": "غیرفعال",

--- a/src/renderer/src/i18n/fr-FR/promptSetting.json
+++ b/src/renderer/src/i18n/fr-FR/promptSetting.json
@@ -45,6 +45,7 @@
   "uploadSuccess": "Téléchargement réussi",
   "uploadedCount": "{count} fichiers téléchargés",
   "confirmDelete": "Êtes-vous sûr de vouloir supprimer le prompt \"{name}\" ?",
+  "confirmDeleteDescription": "Cette action ne peut pas être annulée. Le prompt sera définitivement supprimé.",
   "deleteSuccess": "Suppression réussie",
   "deleteFailed": "Échec de la suppression",
   "inactive": "Inactif",

--- a/src/renderer/src/i18n/ja-JP/promptSetting.json
+++ b/src/renderer/src/i18n/ja-JP/promptSetting.json
@@ -45,6 +45,7 @@
   "uploadSuccess": "アップロード成功",
   "uploadedCount": "{count}個のファイルがアップロードされました",
   "confirmDelete": "プロンプト「{name}」を削除してもよろしいですか？",
+  "confirmDeleteDescription": "この操作は元に戻すことができません。プロンプトは完全に削除されます。",
   "deleteSuccess": "削除に成功しました",
   "deleteFailed": "削除に失敗しました",
   "inactive": "無効",

--- a/src/renderer/src/i18n/ko-KR/promptSetting.json
+++ b/src/renderer/src/i18n/ko-KR/promptSetting.json
@@ -45,6 +45,7 @@
   "uploadSuccess": "업로드 성공",
   "uploadedCount": "{count}개 파일 업로드됨",
   "confirmDelete": "프롬프트 \"{name}\"을(를) 삭제하시겠습니까?",
+  "confirmDeleteDescription": "이 작업은 되돌릴 수 없습니다. 프롬프트가 영구적으로 삭제됩니다.",
   "deleteSuccess": "삭제 성공",
   "deleteFailed": "삭제 실패",
   "inactive": "비활성",

--- a/src/renderer/src/i18n/ru-RU/promptSetting.json
+++ b/src/renderer/src/i18n/ru-RU/promptSetting.json
@@ -45,6 +45,7 @@
   "uploadSuccess": "Загрузка успешна",
   "uploadedCount": "Загружено {count} файлов",
   "confirmDelete": "Вы уверены, что хотите удалить промпт \"{name}\"?",
+  "confirmDeleteDescription": "Это действие нельзя отменить. Промпт будет удален навсегда.",
   "deleteSuccess": "Удаление успешно",
   "deleteFailed": "Ошибка удаления",
   "inactive": "Неактивен",

--- a/src/renderer/src/i18n/zh-CN/promptSetting.json
+++ b/src/renderer/src/i18n/zh-CN/promptSetting.json
@@ -45,6 +45,7 @@
   "uploadSuccess": "上传成功",
   "uploadedCount": "已上传 {count} 个文件",
   "confirmDelete": "确定要删除提示词「{name}」吗？",
+  "confirmDeleteDescription": "此操作不可撤销，删除后将无法恢复该提示词。",
   "deleteSuccess": "删除成功",
   "deleteFailed": "删除失败",
   "inactive": "已禁用",

--- a/src/renderer/src/i18n/zh-HK/promptSetting.json
+++ b/src/renderer/src/i18n/zh-HK/promptSetting.json
@@ -45,6 +45,7 @@
   "uploadSuccess": "上傳成功",
   "uploadedCount": "已上傳 {count} 個文件",
   "confirmDelete": "確定要刪除提示詞「{name}」嗎？",
+  "confirmDeleteDescription": "此操作不可撤銷，刪除後將無法恢復該提示詞。",
   "deleteSuccess": "刪除成功",
   "deleteFailed": "刪除失敗",
   "inactive": "已停用",

--- a/src/renderer/src/i18n/zh-TW/promptSetting.json
+++ b/src/renderer/src/i18n/zh-TW/promptSetting.json
@@ -45,6 +45,7 @@
   "uploadSuccess": "上傳成功",
   "uploadedCount": "已上傳 {count} 個文件",
   "confirmDelete": "確定要刪除提示詞「{name}」嗎？",
+  "confirmDeleteDescription": "此操作不可撤銷，刪除後將無法恢復該提示詞。",
   "deleteSuccess": "刪除成功",
   "deleteFailed": "刪除失敗",
   "inactive": "已停用",


### PR DESCRIPTION
add AlertDialogDescription to resolve accessibility warning
<img width="2082" height="1200" alt="bd2bde3a4bba36fcde13eea5ea17cedf" src="https://github.com/user-attachments/assets/62be770a-eeb2-4bce-8057-24a340ab6aab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a descriptive warning message to the prompt deletion confirmation dialog, clarifying that the action is irreversible and the prompt will be permanently deleted.

* **Localization**
  * Introduced the new warning message in English, Persian, French, Japanese, Korean, Russian, Simplified Chinese, Traditional Chinese (Hong Kong), and Traditional Chinese (Taiwan).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->