### PR TITLE
ci(vite): Bundle the main file into a single file to speed up loading.

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -23,7 +23,11 @@ export default defineConfig({
     },
     build: {
       rollupOptions: {
-        external: ['sharp']
+        external: ['sharp'],
+        output: {
+          inlineDynamicImports: true,
+          manualChunks: undefined,  // Disable automatic chunk splitting
+        }
       }
     }
   },


### PR DESCRIPTION
修改vite config，让main文件打包成独立的一个单文件，并且inline所有的动态import，从而一次性加载到electron运行时让程序变快

Modify the vite config to bundle the main file into a standalone single file and inline all dynamic imports, so that the program loads faster when loaded into the Electron runtime


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to change how output bundles are generated, ensuring dynamic imports are inlined and chunk splitting is disabled. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->