### PR TITLE
fix: add scrollable support to PopoverContent to prevent overflow

### DIFF
--- a/src/renderer/src/components/NewThread.vue
+++ b/src/renderer/src/components/NewThread.vue
@@ -78,7 +78,7 @@
                   <Icon icon="lucide:settings-2" class="w-4 h-4" />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent align="start" class="p-0 w-80">
+              <PopoverContent align="start" class="p-0 w-80" :enable-scrollable="true">
                 <ChatConfig
                   v-model:temperature="temperature"
                   v-model:context-length="contextLength"

--- a/src/renderer/src/components/TitleView.vue
+++ b/src/renderer/src/components/TitleView.vue
@@ -49,7 +49,7 @@
             <Icon icon="lucide:settings-2" class="w-4 h-4" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="end" class="p-0 w-80">
+        <PopoverContent align="end" class="p-0 w-80" :enable-scrollable="true">
           <ChatConfig
             v-model:system-prompt="systemPrompt"
             :temperature="temperature"

--- a/src/renderer/src/components/ui/popover/PopoverContent.vue
+++ b/src/renderer/src/components/ui/popover/PopoverContent.vue
@@ -10,16 +10,20 @@ defineOptions({
 })
 
 const props = withDefaults(
-  defineProps<PopoverContentProps & { class?: HTMLAttributes['class'] }>(),
+  defineProps<PopoverContentProps & {
+    class?: HTMLAttributes['class']
+    enableScrollable?: boolean
+  }>(),
   {
     align: 'center',
-    sideOffset: 4
+    sideOffset: 4,
+    enableScrollable: false
   }
 )
 const emits = defineEmits<PopoverContentEmits>()
 
 const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
+  const { class: _, enableScrollable: __, ...delegated } = props
 
   return delegated
 })
@@ -34,11 +38,15 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       :class="
         cn(
           'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          props.enableScrollable && 'max-h-96 overflow-hidden',
           props.class
         )
       "
     >
-      <slot />
+      <div v-if="props.enableScrollable" class="max-h-96 overflow-y-auto">
+        <slot />
+      </div>
+      <slot v-else />
     </PopoverContent>
   </PopoverPortal>
 </template>


### PR DESCRIPTION
old：
<img width="1986" height="1340" alt="image" src="https://github.com/user-attachments/assets/6843a9c4-0650-4296-b030-98c10bffa595" />

new：
<img width="1986" height="1340" alt="image" src="https://github.com/user-attachments/assets/938fa0ed-8f92-47c0-b458-1f2f01e91490" />
