### PR TITLE
feat: add Claude Opus 4.1 to anthropic default model list

### DIFF
--- a/src/main/presenter/llmProviderPresenter/providers/anthropicProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/anthropicProvider.ts
@@ -169,6 +169,18 @@ export class AnthropicProvider extends BaseLLMProvider {
     // 默认的模型列表（如API调用失败或数据格式不正确）
     return [
       {
+        id: 'claude-opus-4-1-20250805',
+        name: 'Claude Opus 4.1',
+        providerId: this.provider.id,
+        maxTokens: 32_000,
+        group: 'Claude 4.1',
+        isCustom: false,
+        contextLength: 200000,
+        vision: true,
+        functionCall: true,
+        reasoning: true
+      },
+      {
         id: 'claude-opus-4-20250514',
         name: 'Claude Opus 4',
         providerId: this.provider.id,


### PR DESCRIPTION
add Claude Opus 4.1 to anthropic default model list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Opus 4.1 with vision, function/tool use, advanced reasoning, up to 200k-token context and 32k-token outputs.
  * When live model discovery is unavailable, Claude Opus 4.1 is now the top default option, ahead of previous Opus versions, improving out-of-the-box availability. Existing models (Opus 4, Sonnet variants, Claude 3 series) remain available; only the default ordering has been updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->