### PR TITLE
feat: add ESC key to close floating chat window

### DIFF
--- a/src/main/presenter/windowPresenter/index.ts
+++ b/src/main/presenter/windowPresenter/index.ts
@@ -55,6 +55,17 @@ export class WindowPresenter implements IWindowPresenter {
       event.returnValue = event.sender.id
     })
 
+    ipcMain.on('close-floating-window', (event) => {
+      // 检查发送者是否是悬浮聊天窗口
+      const webContentsId = event.sender.id
+      if (
+        this.floatingChatWindow &&
+        this.floatingChatWindow.getWindow()?.webContents.id === webContentsId
+      ) {
+        this.hideFloatingChatWindow()
+      }
+    })
+
     // 监听应用即将退出的事件，设置退出标志，避免窗口关闭时触发隐藏逻辑
     app.on('before-quit', () => {
       console.log('App is quitting, setting isQuitting flag.')

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -169,6 +169,13 @@ const handleGoSettings = () => {
   }
 }
 
+// 处理ESC键 - 关闭悬浮聊天窗口
+const handleEscKey = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    window.electron.ipcRenderer.send('close-floating-window')
+  }
+}
+
 getInitComplete()
 
 onMounted(() => {
@@ -178,6 +185,8 @@ onMounted(() => {
   // 设置初始 body class
   document.body.classList.add(themeStore.themeMode)
   document.body.classList.add(settingsStore.fontSizeClass)
+
+  window.addEventListener('keydown', handleEscKey)
 
   // 监听全局错误通知事件
   window.electron.ipcRenderer.on(NOTIFICATION_EVENTS.SHOW_ERROR, (_event, error) => {
@@ -286,6 +295,8 @@ onBeforeUnmount(() => {
     clearTimeout(errorDisplayTimer.value)
     errorDisplayTimer.value = null
   }
+
+  window.removeEventListener('keydown', handleEscKey)
 
   // 移除快捷键事件监听
   window.electron.ipcRenderer.removeAllListeners(SHORTCUT_EVENTS.ZOOM_IN)


### PR DESCRIPTION
add ESC key to close floating chat window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Press Escape to instantly close the floating chat window.
  * Works across the app, reducing clicks and speeding navigation.
  * Consistent behavior across views without affecting other shortcuts.
  * Improves keyboard accessibility for users who prefer navigating without the mouse.
  * Closing the floating chat no longer requires targeting the close button, improving usability on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->