### PR TITLE
feat: add reasoning_effort parameter support for gpt-oss models

### DIFF
--- a/src/main/presenter/configPresenter/modelDefaultSettings.ts
+++ b/src/main/presenter/configPresenter/modelDefaultSettings.ts
@@ -671,24 +671,26 @@ export const defaultModelsSettings: DefaultModelSetting[] = [
   {
     id: 'gpt-oss-120b',
     name: 'GPT OSS 120B',
-    temperature: 0.7,
-    maxTokens: 131000,
-    contextLength: 131000,
+    temperature: 0.6,
+    maxTokens: 32000,
+    contextLength: 128000,
     match: ['gpt-oss-120b'],
     vision: false,
     functionCall: true,
-    reasoning: false
+    reasoning: true,
+    reasoningEffort: 'medium'
   },
   {
     id: 'gpt-oss-20b',
     name: 'GPT OSS 20B',
-    temperature: 0.7,
-    maxTokens: 33000,
-    contextLength: 131000,
+    temperature: 0.6,
+    maxTokens: 16000,
+    contextLength: 128000,
     match: ['gpt-oss-20b'],
     vision: false,
     functionCall: true,
-    reasoning: false
+    reasoning: true,
+    reasoningEffort: 'medium'
   },
   {
     id: 'o4-mini-high',

--- a/src/main/presenter/configPresenter/providerModelSettings.ts
+++ b/src/main/presenter/configPresenter/providerModelSettings.ts
@@ -377,24 +377,26 @@ export const providerModelSettings: Record<string, { models: ProviderModelSettin
       {
         id: 'gpt-oss:20b',
         name: 'GPT-OSS 20B',
-        temperature: 0.7,
-        maxTokens: 16384,
-        contextLength: 32768,
+        temperature: 0.6,
+        maxTokens: 16000,
+        contextLength: 128000,
         match: ['gpt-oss:20b'],
         vision: false,
         functionCall: true,
-        reasoning: true
+        reasoning: true,
+        reasoningEffort: 'medium'
       },
       {
         id: 'gpt-oss:120b',
         name: 'GPT-OSS 120B',
-        temperature: 0.7,
-        maxTokens: 32768,
-        contextLength: 65536,
+        temperature: 0.6,
+        maxTokens: 32000,
+        contextLength: 128000,
         match: ['gpt-oss:120b'],
         vision: false,
         functionCall: true,
-        reasoning: true
+        reasoning: true,
+        reasoningEffort: 'medium'
       },
       // DeepSeek推理模型系列
       {

--- a/src/main/presenter/llmProviderPresenter/providers/ollamaProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/ollamaProvider.ts
@@ -492,7 +492,8 @@ export class OllamaProvider extends BaseLLMProvider {
         messages: processedMessages,
         options: {
           temperature: temperature || 0.7,
-          num_predict: maxTokens
+          num_predict: maxTokens,
+          ...(modelConfig?.reasoningEffort && { reasoning_effort: modelConfig.reasoningEffort })
         },
         stream: true as const,
         ...(supportsFunctionCall && ollamaTools && ollamaTools.length > 0

--- a/src/renderer/src/components/ChatConfig.vue
+++ b/src/renderer/src/components/ChatConfig.vue
@@ -9,6 +9,13 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useLanguageStore } from '@/stores/language'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
 
 // Define props to receive config from parent
 const props = defineProps<{
@@ -21,6 +28,8 @@ const props = defineProps<{
   thinkingBudget?: number
   modelId?: string
   providerId?: string
+  reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high'
+  verbosity?: 'low' | 'medium' | 'high'
 }>()
 
 const systemPrompt = defineModel<string>('systemPrompt')
@@ -30,6 +39,8 @@ const emit = defineEmits<{
   'update:contextLength': [value: number]
   'update:maxTokens': [value: number]
   'update:thinkingBudget': [value: number | undefined]
+  'update:reasoningEffort': [value: 'minimal' | 'low' | 'medium' | 'high']
+  'update:verbosity': [value: 'low' | 'medium' | 'high']
   // 'update:artifacts': [value: 0 | 1]
 }>()
 
@@ -76,6 +87,11 @@ const showThinkingBudget = computed(() => {
 const isGPT5Model = computed(() => {
   const modelId = props.modelId?.toLowerCase() || ''
   return modelId.startsWith('gpt-5')
+})
+
+// 判断模型是否支持 reasoningEffort 参数
+const supportsReasoningEffort = computed(() => {
+  return props.reasoningEffort !== undefined
 })
 
 // 当前显示的思考预算值
@@ -274,6 +290,94 @@ const handleDynamicThinkingToggle = (enabled: boolean) => {
             </p>
           </div>
         </div>
+      </div>
+
+      <!-- Reasoning Effort (推理努力程度) -->
+      <div v-if="supportsReasoningEffort" class="space-y-4 px-2">
+        <div class="flex items-center space-x-2">
+          <Icon icon="lucide:brain" class="w-4 h-4 text-muted-foreground" />
+          <Label class="text-xs font-medium">{{
+            t('settings.model.modelConfig.reasoningEffort.label')
+          }}</Label>
+          <TooltipProvider :delayDuration="200">
+            <Tooltip>
+              <TooltipTrigger>
+                <Icon icon="lucide:help-circle" class="w-4 h-4 text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{{ t('settings.model.modelConfig.reasoningEffort.description') }}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+        <Select
+          :model-value="props.reasoningEffort"
+          @update:model-value="
+            (value) =>
+              emit('update:reasoningEffort', value as 'minimal' | 'low' | 'medium' | 'high')
+          "
+        >
+          <SelectTrigger class="text-xs">
+            <SelectValue
+              :placeholder="t('settings.model.modelConfig.reasoningEffort.placeholder')"
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="minimal">{{
+              t('settings.model.modelConfig.reasoningEffort.options.minimal')
+            }}</SelectItem>
+            <SelectItem value="low">{{
+              t('settings.model.modelConfig.reasoningEffort.options.low')
+            }}</SelectItem>
+            <SelectItem value="medium">{{
+              t('settings.model.modelConfig.reasoningEffort.options.medium')
+            }}</SelectItem>
+            <SelectItem value="high">{{
+              t('settings.model.modelConfig.reasoningEffort.options.high')
+            }}</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <!-- Verbosity (详细程度 - 仅 GPT-5 系列) -->
+      <div v-if="isGPT5Model && verbosity !== undefined" class="space-y-4 px-2">
+        <div class="flex items-center space-x-2">
+          <Icon icon="lucide:message-square-text" class="w-4 h-4 text-muted-foreground" />
+          <Label class="text-xs font-medium">{{
+            t('settings.model.modelConfig.verbosity.label')
+          }}</Label>
+          <TooltipProvider :delayDuration="200">
+            <Tooltip>
+              <TooltipTrigger>
+                <Icon icon="lucide:help-circle" class="w-4 h-4 text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{{ t('settings.model.modelConfig.verbosity.description') }}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+        <Select
+          :model-value="props.verbosity"
+          @update:model-value="
+            (value) => emit('update:verbosity', value as 'low' | 'medium' | 'high')
+          "
+        >
+          <SelectTrigger class="text-xs">
+            <SelectValue :placeholder="t('settings.model.modelConfig.verbosity.placeholder')" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="low">{{
+              t('settings.model.modelConfig.verbosity.options.low')
+            }}</SelectItem>
+            <SelectItem value="medium">{{
+              t('settings.model.modelConfig.verbosity.options.medium')
+            }}</SelectItem>
+            <SelectItem value="high">{{
+              t('settings.model.modelConfig.verbosity.options.high')
+            }}</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
       <!-- Artifacts Toggle -->

--- a/src/renderer/src/components/NewThread.vue
+++ b/src/renderer/src/components/NewThread.vue
@@ -90,6 +90,8 @@
                 v-model:max-tokens="maxTokens"
                 v-model:system-prompt="systemPrompt"
                 v-model:artifacts="artifacts"
+                v-model:reasoning-effort="reasoningEffort"
+                v-model:verbosity="verbosity"
                 :context-length-limit="contextLengthLimit"
                 :max-tokens-limit="maxTokensLimit"
                 :model-id="activeModel?.id"
@@ -157,6 +159,8 @@ const maxTokens = ref(4096)
 const maxTokensLimit = ref(4096)
 const systemPrompt = ref('')
 const artifacts = ref(settingsStore.artifactsEffectEnabled ? 1 : 0)
+const reasoningEffort = ref<'minimal' | 'low' | 'medium' | 'high' | undefined>(undefined)
+const verbosity = ref<'low' | 'medium' | 'high' | undefined>(undefined)
 
 const name = computed(() => {
   return activeModel.value?.name ? activeModel.value.name.split('/').pop() : ''
@@ -175,6 +179,8 @@ watch(
     maxTokens.value = config.maxTokens
     contextLengthLimit.value = config.contextLength
     maxTokensLimit.value = config.maxTokens
+    reasoningEffort.value = config.reasoningEffort
+    verbosity.value = config.verbosity
     // console.log('temperature', temperature.value)
     // console.log('contextLength', contextLength.value)
     // console.log('maxTokens', maxTokens.value)
@@ -404,8 +410,10 @@ const handleSend = async (content: UserMessageContent) => {
     contextLength: contextLength.value,
     maxTokens: maxTokens.value,
     artifacts: artifacts.value as 0 | 1,
+    reasoningEffort: reasoningEffort.value,
+    verbosity: verbosity.value,
     enabledMcpTools: chatStore.chatConfig.enabledMcpTools
-  })
+  } as any)
   console.log('threadId', threadId, activeModel.value)
   chatStore.sendMessage(content)
 }

--- a/src/renderer/src/components/TitleView.vue
+++ b/src/renderer/src/components/TitleView.vue
@@ -56,6 +56,8 @@
           :max-tokens="maxTokens"
           :artifacts="artifacts"
           :thinking-budget="thinkingBudget"
+          :reasoning-effort="reasoningEffort"
+          :verbosity="verbosity"
           :model-id="chatStore.chatConfig.modelId"
           :provider-id="chatStore.chatConfig.providerId"
           @update:temperature="updateTemperature"
@@ -63,6 +65,8 @@
           @update:max-tokens="updateMaxTokens"
           @update:artifacts="updateArtifacts"
           @update:thinking-budget="updateThinkingBudget"
+          @update:reasoning-effort="updateReasoningEffort"
+          @update:verbosity="updateVerbosity"
         />
       </ScrollablePopover>
     </div>
@@ -100,6 +104,32 @@ const maxTokens = ref(chatStore.chatConfig.maxTokens)
 const systemPrompt = ref(chatStore.chatConfig.systemPrompt)
 const artifacts = ref(chatStore.chatConfig.artifacts)
 const thinkingBudget = ref(chatStore.chatConfig.thinkingBudget)
+const reasoningEffort = ref((chatStore.chatConfig as any).reasoningEffort)
+const verbosity = ref((chatStore.chatConfig as any).verbosity)
+
+// 获取模型配置来初始化默认值
+const loadModelConfig = async () => {
+  const modelId = chatStore.chatConfig.modelId
+  const providerId = chatStore.chatConfig.providerId
+
+  if (modelId && providerId) {
+    try {
+      const config = await configPresenter.getModelDefaultConfig(modelId, providerId)
+      if (config.reasoningEffort !== undefined) {
+        reasoningEffort.value = config.reasoningEffort
+      } else {
+        reasoningEffort.value = undefined
+      }
+      if (config.verbosity !== undefined) {
+        verbosity.value = config.verbosity
+      } else {
+        verbosity.value = undefined
+      }
+    } catch (error) {
+      console.error('Failed to load model config:', error)
+    }
+  }
+}
 const contextLengthLimit = ref(chatStore.chatConfig.contextLength)
 const maxTokensLimit = ref(chatStore.chatConfig.maxTokens)
 
@@ -183,21 +213,49 @@ const updateThinkingBudget = (value: number | undefined) => {
   thinkingBudget.value = value
 }
 
+const updateReasoningEffort = (value: 'minimal' | 'low' | 'medium' | 'high') => {
+  reasoningEffort.value = value
+}
+
+const updateVerbosity = (value: 'low' | 'medium' | 'high') => {
+  verbosity.value = value
+}
+
 const onSidebarButtonClick = () => {
   chatStore.isSidebarOpen = !chatStore.isSidebarOpen
 }
 
 // Watch for changes and update store
 watch(
-  [temperature, contextLength, maxTokens, systemPrompt, artifacts, thinkingBudget],
-  ([newTemp, newContext, newMaxTokens, newSystemPrompt, newArtifacts, newThinkingBudget]) => {
+  [
+    temperature,
+    contextLength,
+    maxTokens,
+    systemPrompt,
+    artifacts,
+    thinkingBudget,
+    reasoningEffort,
+    verbosity
+  ],
+  ([
+    newTemp,
+    newContext,
+    newMaxTokens,
+    newSystemPrompt,
+    newArtifacts,
+    newThinkingBudget,
+    newReasoningEffort,
+    newVerbosity
+  ]) => {
     if (
       newTemp !== chatStore.chatConfig.temperature ||
       newContext !== chatStore.chatConfig.contextLength ||
       newMaxTokens !== chatStore.chatConfig.maxTokens ||
       newSystemPrompt !== chatStore.chatConfig.systemPrompt ||
       newArtifacts !== chatStore.chatConfig.artifacts ||
-      newThinkingBudget !== chatStore.chatConfig.thinkingBudget
+      newThinkingBudget !== chatStore.chatConfig.thinkingBudget ||
+      newReasoningEffort !== (chatStore.chatConfig as any).reasoningEffort ||
+      newVerbosity !== (chatStore.chatConfig as any).verbosity
     ) {
       chatStore.updateChatConfig({
         temperature: newTemp,
@@ -205,8 +263,10 @@ watch(
         maxTokens: newMaxTokens,
         systemPrompt: newSystemPrompt,
         artifacts: newArtifacts,
-        thinkingBudget: newThinkingBudget
-      })
+        thinkingBudget: newThinkingBudget,
+        reasoningEffort: newReasoningEffort,
+        verbosity: newVerbosity
+      } as any)
     }
   }
 )
@@ -214,13 +274,26 @@ watch(
 // Watch store changes to update local state
 watch(
   () => chatStore.chatConfig,
-  (newConfig) => {
+  async (newConfig, oldConfig) => {
     temperature.value = newConfig.temperature
     contextLength.value = newConfig.contextLength
     maxTokens.value = newConfig.maxTokens
     systemPrompt.value = newConfig.systemPrompt
     artifacts.value = newConfig.artifacts
     thinkingBudget.value = newConfig.thinkingBudget
+
+    if ((newConfig as any).reasoningEffort !== undefined) {
+      reasoningEffort.value = (newConfig as any).reasoningEffort
+    }
+    if ((newConfig as any).verbosity !== undefined) {
+      verbosity.value = (newConfig as any).verbosity
+    }
+    if (
+      oldConfig &&
+      (newConfig.modelId !== oldConfig.modelId || newConfig.providerId !== oldConfig.providerId)
+    ) {
+      await loadModelConfig()
+    }
   },
   { deep: true }
 )
@@ -289,6 +362,10 @@ onMounted(async () => {
 
     await loadRateLimitStatus()
   }
+
+  setTimeout(async () => {
+    await loadModelConfig()
+  }, 100)
 
   window.electron.ipcRenderer.on(RATE_LIMIT_EVENTS.CONFIG_UPDATED, handleRateLimitEvent)
   window.electron.ipcRenderer.on(RATE_LIMIT_EVENTS.REQUEST_EXECUTED, handleRateLimitEvent)

--- a/src/renderer/src/components/TitleView.vue
+++ b/src/renderer/src/components/TitleView.vue
@@ -116,12 +116,16 @@ const loadModelConfig = async () => {
     try {
       const config = await configPresenter.getModelDefaultConfig(modelId, providerId)
       if (config.reasoningEffort !== undefined) {
-        reasoningEffort.value = config.reasoningEffort
+        if (reasoningEffort.value === undefined) {
+          reasoningEffort.value = config.reasoningEffort
+        }
       } else {
         reasoningEffort.value = undefined
       }
       if (config.verbosity !== undefined) {
-        verbosity.value = config.verbosity
+        if (verbosity.value === undefined) {
+          verbosity.value = config.verbosity
+        }
       } else {
         verbosity.value = undefined
       }

--- a/src/renderer/src/components/settings/ModelConfigDialog.vue
+++ b/src/renderer/src/components/settings/ModelConfigDialog.vue
@@ -495,7 +495,7 @@ const isGPT5Model = computed(() => {
 })
 
 const supportsReasoningEffort = computed(() => {
-  return 'reasoningEffort' in config.value
+  return config.value.reasoningEffort !== undefined
 })
 
 // 是否显示思考预算配置

--- a/src/renderer/src/components/settings/ModelConfigDialog.vue
+++ b/src/renderer/src/components/settings/ModelConfigDialog.vue
@@ -133,8 +133,8 @@
             <Switch v-model:checked="config.reasoning" />
           </div>
 
-          <!-- GPT-5 系列模型的推理努力程度 -->
-          <div v-if="isGPT5Model" class="space-y-2">
+          <!-- 推理努力程度 -->
+          <div v-if="supportsReasoningEffort" class="space-y-2">
             <Label for="reasoningEffort">{{
               t('settings.model.modelConfig.reasoningEffort.label')
             }}</Label>
@@ -492,6 +492,10 @@ const getThinkingBudgetConfig = (modelId: string) => {
 const isGPT5Model = computed(() => {
   const modelId = props.modelId.toLowerCase()
   return modelId.startsWith('gpt-5')
+})
+
+const supportsReasoningEffort = computed(() => {
+  return 'reasoningEffort' in config.value
 })
 
 // 是否显示思考预算配置


### PR DESCRIPTION
- add reasoning_effort parameter support for gpt-oss models
- add reasoning effort UI support across all components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Reasoning Effort selector (minimal/low/medium/high) where supported.
  - Added Verbosity selector (low/medium/high) for GPT‑5 models.
  - Model defaults now auto-load into UI; reasoning effort and verbosity persist across new threads and title view.
  - Reasoning Effort sent to compatible providers when configured.

- Chores
  - Updated GPT‑OSS 20B/120B defaults: lower temperature, reduced token limits, standardized 128k context, enabled reasoning with medium effort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->