### PR TITLE
fix: resolve reasoningEffort parameter transmission issues

### DIFF
--- a/src/renderer/src/components/TitleView.vue
+++ b/src/renderer/src/components/TitleView.vue
@@ -104,8 +104,8 @@ const maxTokens = ref(chatStore.chatConfig.maxTokens)
 const systemPrompt = ref(chatStore.chatConfig.systemPrompt)
 const artifacts = ref(chatStore.chatConfig.artifacts)
 const thinkingBudget = ref(chatStore.chatConfig.thinkingBudget)
-const reasoningEffort = ref((chatStore.chatConfig as any).reasoningEffort)
-const verbosity = ref((chatStore.chatConfig as any).verbosity)
+const reasoningEffort = ref(chatStore.chatConfig.reasoningEffort)
+const verbosity = ref(chatStore.chatConfig.verbosity)
 
 // 获取模型配置来初始化默认值
 const loadModelConfig = async () => {
@@ -258,8 +258,8 @@ watch(
       newSystemPrompt !== chatStore.chatConfig.systemPrompt ||
       newArtifacts !== chatStore.chatConfig.artifacts ||
       newThinkingBudget !== chatStore.chatConfig.thinkingBudget ||
-      newReasoningEffort !== (chatStore.chatConfig as any).reasoningEffort ||
-      newVerbosity !== (chatStore.chatConfig as any).verbosity
+      newReasoningEffort !== chatStore.chatConfig.reasoningEffort ||
+      newVerbosity !== chatStore.chatConfig.verbosity
     ) {
       chatStore.updateChatConfig({
         temperature: newTemp,
@@ -285,13 +285,8 @@ watch(
     systemPrompt.value = newConfig.systemPrompt
     artifacts.value = newConfig.artifacts
     thinkingBudget.value = newConfig.thinkingBudget
-
-    if ((newConfig as any).reasoningEffort !== undefined) {
-      reasoningEffort.value = (newConfig as any).reasoningEffort
-    }
-    if ((newConfig as any).verbosity !== undefined) {
-      verbosity.value = (newConfig as any).verbosity
-    }
+    reasoningEffort.value = newConfig.reasoningEffort
+    verbosity.value = newConfig.verbosity
     if (
       oldConfig &&
       (newConfig.modelId !== oldConfig.modelId || newConfig.providerId !== oldConfig.providerId)

--- a/src/renderer/src/stores/chat.ts
+++ b/src/renderer/src/stores/chat.ts
@@ -57,7 +57,10 @@ export const useChatStore = defineStore('chat', () => {
     providerId: '',
     modelId: '',
     artifacts: 0,
-    enabledMcpTools: []
+    enabledMcpTools: [],
+    thinkingBudget: undefined,
+    reasoningEffort: undefined,
+    verbosity: undefined
   })
 
   // Deeplink 消息缓存

--- a/src/shared/presenter.d.ts
+++ b/src/shared/presenter.d.ts
@@ -625,6 +625,8 @@ export type CONVERSATION_SETTINGS = {
   artifacts: 0 | 1
   enabledMcpTools?: string[]
   thinkingBudget?: number
+  reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high'
+  verbosity?: 'low' | 'medium' | 'high'
 }
 
 export type CONVERSATION = {


### PR DESCRIPTION
fix: resolve reasoningEffort parameter transmission issues

- Add reasoningEffort and verbosity fields to CONVERSATION_SETTINGS type
- Add database migration v6 for new reasoning_effort and verbosity columns
- Fix Ollama provider to handle gpt-oss thinking field correctly
- Move reasoning_effort parameter to top-level in Ollama API calls
- Remove type assertions in TitleView component
- Unify optional field handling in database operations
- Add missing field initializations in chat store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversation settings for Reasoning Effort (minimal/low/medium/high) and Verbosity (low/medium/high), now persisted across sessions.
  * Enhanced responses to include model reasoning content when available; streaming chats can show live reasoning updates.
* **Chores**
  * Database updated to store Reasoning Effort and Verbosity for conversations.
  * Internal configuration extended to support new settings across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->