### PR TITLE
feat: add Vercel AI Gateway provider support

### DIFF
--- a/src/main/presenter/configPresenter/providers.ts
+++ b/src/main/presenter/configPresenter/providers.ts
@@ -183,6 +183,21 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
       defaultBaseUrl: 'https://api.302.ai/v1'
     }
   },
+  {
+    id: 'vercel-ai-gateway',
+    name: 'Vercel AI Gateway',
+    apiType: 'vercel-ai-gateway',
+    apiKey: '',
+    baseUrl: 'https://ai-gateway.vercel.sh/v1',
+    enable: false,
+    websites: {
+      official: 'https://vercel.com/ai',
+      apiKey: 'https://vercel.com/dashboard',
+      docs: 'https://vercel.com/docs/ai-gateway',
+      models: 'https://vercel.com/docs/ai-gateway/models-and-providers',
+      defaultBaseUrl: 'https://ai-gateway.vercel.sh/v1'
+    }
+  },
   // {
   //   id: 'ocoolai',
   //   name: 'OCoolAI',

--- a/src/main/presenter/llmProviderPresenter/index.ts
+++ b/src/main/presenter/llmProviderPresenter/index.ts
@@ -41,6 +41,7 @@ import { MinimaxProvider } from './providers/minimaxProvider'
 import { AihubmixProvider } from './providers/aihubmixProvider'
 import { _302AIProvider } from './providers/_302AIProvider'
 import { ModelscopeProvider } from './providers/modelscopeProvider'
+import { VercelAIGatewayProvider } from './providers/vercelAIGatewayProvider'
 
 // 速率限制配置接口
 interface RateLimitConfig {
@@ -209,6 +210,8 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
           return new TogetherProvider(provider, this.configPresenter)
         case 'groq':
           return new GroqProvider(provider, this.configPresenter)
+        case 'vercel-ai-gateway':
+          return new VercelAIGatewayProvider(provider, this.configPresenter)
         default:
           console.warn(`Unknown provider type: ${provider.apiType}`)
           return undefined

--- a/src/main/presenter/llmProviderPresenter/providers/vercelAIGatewayProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/vercelAIGatewayProvider.ts
@@ -1,0 +1,56 @@
+import { LLM_PROVIDER, LLMResponse, ChatMessage } from '@shared/presenter'
+import { OpenAICompatibleProvider } from './openAICompatibleProvider'
+import { ConfigPresenter } from '../../configPresenter'
+
+export class VercelAIGatewayProvider extends OpenAICompatibleProvider {
+  constructor(provider: LLM_PROVIDER, configPresenter: ConfigPresenter) {
+    super(provider, configPresenter)
+  }
+
+  async completions(
+    messages: ChatMessage[],
+    modelId: string,
+    temperature?: number,
+    maxTokens?: number
+  ): Promise<LLMResponse> {
+    return this.openAICompletion(messages, modelId, temperature, maxTokens)
+  }
+
+  async summaries(
+    text: string,
+    modelId: string,
+    temperature?: number,
+    maxTokens?: number
+  ): Promise<LLMResponse> {
+    return this.openAICompletion(
+      [
+        {
+          role: 'user',
+          content: `请总结以下内容，使用简洁的语言，突出重点：\n${text}`
+        }
+      ],
+      modelId,
+      temperature,
+      maxTokens
+    )
+  }
+
+  async generateText(
+    prompt: string,
+    modelId: string,
+    temperature?: number,
+    maxTokens?: number
+  ): Promise<LLMResponse> {
+    return this.openAICompletion(
+      [
+        {
+          role: 'user',
+          content: prompt
+        }
+      ],
+      modelId,
+      temperature,
+      maxTokens
+    )
+  }
+}


### PR DESCRIPTION
add Vercel AI Gateway provider support
<img width="2022" height="1376" alt="Electron 2025-08-15 22 08 43" src="https://github.com/user-attachments/assets/c99badba-7756-49cf-90b7-35742b59445e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Vercel AI Gateway as a selectable AI provider.
  - Supports chat completions, text generation, and summaries via the gateway.
  - Includes preset base URL and helpful links for setup.
  - Provider is disabled by default; enable and add your API key in settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->