### PR TITLE
fix: pass user reasoningEffort/verbosity settings to GPT-5 API requests

### DIFF
--- a/src/main/presenter/llmProviderPresenter/index.ts
+++ b/src/main/presenter/llmProviderPresenter/index.ts
@@ -443,7 +443,9 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
     temperature: number = 0.6,
     maxTokens: number = 4096,
     enabledMcpTools?: string[],
-    thinkingBudget?: number
+    thinkingBudget?: number,
+    reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high',
+    verbosity?: 'low' | 'medium' | 'high'
   ): AsyncGenerator<LLMAgentEvent, void, unknown> {
     console.log(`[Agent Loop] Starting agent loop for event: ${eventId} with model: ${modelId}`)
     if (!this.canStartNewStream()) {
@@ -459,6 +461,12 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
 
     if (thinkingBudget !== undefined) {
       modelConfig.thinkingBudget = thinkingBudget
+    }
+    if (reasoningEffort !== undefined) {
+      modelConfig.reasoningEffort = reasoningEffort
+    }
+    if (verbosity !== undefined) {
+      modelConfig.verbosity = verbosity
     }
 
     this.activeStreams.set(eventId, {

--- a/src/main/presenter/llmProviderPresenter/providers/openAICompatibleProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/openAICompatibleProvider.ts
@@ -563,6 +563,15 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
       }
     }
 
+    if (modelId.startsWith('gpt-5')) {
+      if (modelConfig.reasoningEffort) {
+        ;(requestParams as any).reasoning_effort = modelConfig.reasoningEffort
+      }
+      if (modelConfig.verbosity) {
+        ;(requestParams as any).verbosity = modelConfig.verbosity
+      }
+    }
+
     // 移除推理模型的温度参数
     OPENAI_REASONING_MODELS.forEach((noTempId) => {
       if (modelId.startsWith(noTempId)) delete requestParams.temperature

--- a/src/main/presenter/threadPresenter/index.ts
+++ b/src/main/presenter/threadPresenter/index.ts
@@ -1473,7 +1473,9 @@ export class ThreadPresenter implements IThreadPresenter {
         temperature: currentTemperature,
         maxTokens: currentMaxTokens,
         enabledMcpTools: currentEnabledMcpTools,
-        thinkingBudget: currentThinkingBudget
+        thinkingBudget: currentThinkingBudget,
+        reasoningEffort: currentReasoningEffort,
+        verbosity: currentVerbosity
       } = currentConversation.settings
       const stream = this.llmProviderPresenter.startStreamCompletion(
         currentProviderId, // 使用最新的设置
@@ -1483,7 +1485,9 @@ export class ThreadPresenter implements IThreadPresenter {
         currentTemperature, // 使用最新的设置
         currentMaxTokens, // 使用最新的设置
         currentEnabledMcpTools,
-        currentThinkingBudget
+        currentThinkingBudget,
+        currentReasoningEffort,
+        currentVerbosity
       )
       for await (const event of stream) {
         const msg = event.data
@@ -1581,8 +1585,16 @@ export class ThreadPresenter implements IThreadPresenter {
       this.throwIfCancelled(state.message.id)
 
       // 7. 准备提示内容
-      const { providerId, modelId, temperature, maxTokens, enabledMcpTools, thinkingBudget } =
-        conversation.settings
+      const {
+        providerId,
+        modelId,
+        temperature,
+        maxTokens,
+        enabledMcpTools,
+        thinkingBudget,
+        reasoningEffort,
+        verbosity
+      } = conversation.settings
       const modelConfig = this.configPresenter.getModelConfig(modelId, providerId)
 
       const { finalContent, promptTokens } = await this.preparePromptContent(
@@ -1651,7 +1663,9 @@ export class ThreadPresenter implements IThreadPresenter {
         temperature,
         maxTokens,
         enabledMcpTools,
-        thinkingBudget
+        thinkingBudget,
+        reasoningEffort,
+        verbosity
       )
       for await (const event of stream) {
         const msg = event.data
@@ -3659,8 +3673,16 @@ export class ThreadPresenter implements IThreadPresenter {
         throw new Error(errorMsg)
       }
 
-      const { providerId, modelId, temperature, maxTokens, enabledMcpTools, thinkingBudget } =
-        conversation.settings
+      const {
+        providerId,
+        modelId,
+        temperature,
+        maxTokens,
+        enabledMcpTools,
+        thinkingBudget,
+        reasoningEffort,
+        verbosity
+      } = conversation.settings
       const modelConfig = this.configPresenter.getModelConfig(modelId, providerId)
 
       if (!modelConfig) {
@@ -3715,7 +3737,9 @@ export class ThreadPresenter implements IThreadPresenter {
         temperature,
         maxTokens,
         enabledMcpTools,
-        thinkingBudget
+        thinkingBudget,
+        reasoningEffort,
+        verbosity
       )
 
       for await (const event of stream) {

--- a/src/shared/presenter.d.ts
+++ b/src/shared/presenter.d.ts
@@ -566,7 +566,9 @@ export interface ILlmProviderPresenter {
     temperature?: number,
     maxTokens?: number,
     enabledMcpTools?: string[],
-    thinkingBudget?: number
+    thinkingBudget?: number,
+    reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high',
+    verbosity?: 'low' | 'medium' | 'high'
   ): AsyncGenerator<LLMAgentEvent, void, unknown>
   generateCompletion(
     providerId: string,


### PR DESCRIPTION
pass user reasoningEffort/verbosity settings to GPT-5 API requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-conversation controls for Reasoning Effort and Verbosity, enabling finer control over response depth and detail.
  - These settings are honored across initial generation, tool-continued replies, and permission restarts in both streaming and non-streaming modes.
  - Enhanced compatibility with GPT‑5 models to utilize Reasoning Effort and Verbosity when available.
  - Updated conversation settings to include the new options, ensuring prompts and token budgeting adapt to user-selected preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->