### PR TITLE
chore(deps): bump electron to 37.3.0 fix #737

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.2.6",
-    "electron": "^36.7.4",
+    "electron": "^37.3.0",
     "electron-builder": "26.0.12",
     "electron-vite": "^4.0.0",
     "jsdom": "^26.1.0",


### PR DESCRIPTION
- Update electron to 37.3.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the app’s Electron runtime to the 37.x series. This modernizes the underlying platform used for desktop packaging and execution. Users should see no changes to features or settings, but may benefit from broader OS compatibility and runtime improvements. Build and packaging workflows now target this version, with no expected impact on existing functionality or user data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->