### PR TITLE
chore: bump better-sqlite3-multiple-ciphers to 12.2.0 for Electron 37

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "vite-plugin-vue-devtools": "^8.0.0",
     "vite-svg-loader": "^5.1.0",
     "vitest": "^3.2.4",
-    "vue": "^3.5.18",
+    "vue": "^3.5.19",
     "vue-i18n": "^11.1.11",
     "vue-renderer-markdown": "^0.0.34",
     "vue-router": "4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@jxa/run": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.17.2",
     "axios": "^1.7.9",
-    "better-sqlite3-multiple-ciphers": "11.10.0",
+    "better-sqlite3-multiple-ciphers": "12.2.0",
     "cheerio": "^1.0.0",
     "compare-versions": "^6.1.1",
     "dayjs": "^1.11.13",


### PR DESCRIPTION
- bump better-sqlite3-multiple-ciphers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the encrypted SQLite engine dependency to a newer major release for improved stability, performance, and platform compatibility.
  * Updated a development framework dependency to a minor patch release (no end-user visible changes).
  * No feature changes or settings; existing data unaffected and no action required from users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->