### PR TITLE
fix: sync provider order changes across all tabs

### DIFF
--- a/src/renderer/src/stores/settings.ts
+++ b/src/renderer/src/stores/settings.ts
@@ -654,8 +654,9 @@ export const useSettingsStore = defineStore('settings', () => {
   const setupProviderListener = () => {
     // 监听配置变更事件
     window.electron.ipcRenderer.on(CONFIG_EVENTS.PROVIDER_CHANGED, async () => {
-      console.log('changed')
+      console.log('Provider changed - updating providers and order')
       providers.value = await configP.getProviders()
+      await loadSavedOrder()
       await refreshAllModels()
     })
 
@@ -1514,6 +1515,7 @@ export const useSettingsStore = defineStore('settings', () => {
 
       // 强制更新 providers 以触发视图更新
       providers.value = [...providers.value]
+      await configP.setProviders(providers.value)
     } catch (error) {
       console.error('Failed to update provider order:', error)
     }


### PR DESCRIPTION
sync provider order changes across all tabs

https://github.com/user-attachments/assets/8fcd3637-7084-40e1-b9ad-b806da274273



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider ordering now persists reliably after you rearrange providers.
  * Saved provider order is correctly applied when providers change, ensuring consistent model lists.

* **Improvements**
  * Enhanced messaging around provider changes for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->