### PR TITLE
fix: resolve Gemini 2.5 thinking budget initialization and sync issues

### DIFF
--- a/src/main/presenter/threadPresenter/index.ts
+++ b/src/main/presenter/threadPresenter/index.ts
@@ -746,8 +746,9 @@ export class ThreadPresenter implements IThreadPresenter {
       mergedSettings.maxTokens = defaultModelsSettings.maxTokens
       mergedSettings.contextLength = defaultModelsSettings.contextLength
       mergedSettings.temperature = defaultModelsSettings.temperature ?? 0.7
-      // 重置 thinkingBudget 为模型默认配置，如果模型配置中没有则设为 undefined
-      mergedSettings.thinkingBudget = defaultModelsSettings.thinkingBudget
+      if (settings.thinkingBudget === undefined) {
+        mergedSettings.thinkingBudget = defaultModelsSettings.thinkingBudget
+      }
     }
     if (settings.artifacts) {
       mergedSettings.artifacts = settings.artifacts

--- a/src/renderer/src/components/ChatConfig.vue
+++ b/src/renderer/src/components/ChatConfig.vue
@@ -255,8 +255,7 @@ const handleDynamicThinkingToggle = (enabled: boolean) => {
               }}</Label>
             </div>
             <Switch
-              :checked="displayThinkingBudget === -1"
-              :disabled="displayThinkingBudget === undefined"
+              :checked="(props.thinkingBudget ?? -1) === -1"
               @update:checked="handleDynamicThinkingToggle"
             />
           </div>
@@ -277,7 +276,7 @@ const handleDynamicThinkingToggle = (enabled: boolean) => {
                   ? t('settings.model.modelConfig.useModelDefault')
                   : t('settings.model.modelConfig.thinkingBudget.placeholder')
               "
-              :disabled="displayThinkingBudget === -1 || displayThinkingBudget === undefined"
+              :disabled="(props.thinkingBudget ?? -1) === -1"
             />
             <p class="text-xs text-muted-foreground">
               {{

--- a/src/renderer/src/components/NewThread.vue
+++ b/src/renderer/src/components/NewThread.vue
@@ -90,6 +90,7 @@
                 v-model:max-tokens="maxTokens"
                 v-model:system-prompt="systemPrompt"
                 v-model:artifacts="artifacts"
+                v-model:thinking-budget="thinkingBudget"
                 v-model:reasoning-effort="reasoningEffort"
                 v-model:verbosity="verbosity"
                 :context-length-limit="contextLengthLimit"
@@ -159,6 +160,7 @@ const maxTokens = ref(4096)
 const maxTokensLimit = ref(4096)
 const systemPrompt = ref('')
 const artifacts = ref(settingsStore.artifactsEffectEnabled ? 1 : 0)
+const thinkingBudget = ref<number | undefined>(undefined)
 const reasoningEffort = ref<'minimal' | 'low' | 'medium' | 'high' | undefined>(undefined)
 const verbosity = ref<'low' | 'medium' | 'high' | undefined>(undefined)
 
@@ -179,6 +181,7 @@ watch(
     maxTokens.value = config.maxTokens
     contextLengthLimit.value = config.contextLength
     maxTokensLimit.value = config.maxTokens
+    thinkingBudget.value = config.thinkingBudget
     reasoningEffort.value = config.reasoningEffort
     verbosity.value = config.verbosity
     // console.log('temperature', temperature.value)
@@ -410,6 +413,7 @@ const handleSend = async (content: UserMessageContent) => {
     contextLength: contextLength.value,
     maxTokens: maxTokens.value,
     artifacts: artifacts.value as 0 | 1,
+    thinkingBudget: thinkingBudget.value,
     reasoningEffort: reasoningEffort.value,
     verbosity: verbosity.value,
     enabledMcpTools: chatStore.chatConfig.enabledMcpTools

--- a/src/renderer/src/components/TitleView.vue
+++ b/src/renderer/src/components/TitleView.vue
@@ -115,6 +115,13 @@ const loadModelConfig = async () => {
   if (modelId && providerId) {
     try {
       const config = await configPresenter.getModelDefaultConfig(modelId, providerId)
+      if (config.thinkingBudget !== undefined) {
+        if (thinkingBudget.value === undefined) {
+          thinkingBudget.value = config.thinkingBudget
+        }
+      } else {
+        thinkingBudget.value = undefined
+      }
       if (config.reasoningEffort !== undefined) {
         if (reasoningEffort.value === undefined) {
           reasoningEffort.value = config.reasoningEffort


### PR DESCRIPTION
resolve Gemini 2.5 thinking budget initialization and sync issues

old：

https://github.com/user-attachments/assets/16e43dd9-3e16-4313-8893-6b0170fa81bc

new：

https://github.com/user-attachments/assets/f15270b4-7723-47e2-a27e-7d7aaebf7c78



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Thinking Budget configuration to new threads and chat settings, including dynamic mode toggle and numeric input when a concrete value is set.
  * Thinking Budget is now included (optionally) when creating a thread.

* **Bug Fixes**
  * Preserves user-specified Thinking Budget (including 0) instead of overwriting with model defaults.
  * Dynamic mode can be toggled even when no prior budget is defined.
  * Initializes Thinking Budget from model defaults when available, without overriding an existing user choice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->