### PR TITLE
fix: improve message navigation scroll position to show content from top

### DIFF
--- a/src/renderer/src/components/message/MessageList.vue
+++ b/src/renderer/src/components/message/MessageList.vue
@@ -284,7 +284,7 @@ const scrollToMessage = (messageId: string) => {
     if (messageElement) {
       messageElement.scrollIntoView({
         behavior: 'smooth',
-        block: 'center'
+        block: 'start'
       })
 
       // 添加高亮效果


### PR DESCRIPTION
improve message navigation scroll position to show content from top

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted message navigation behavior: when jumping to a specific message, it now aligns at the top of the view instead of centered.
  * Smooth scrolling and post-scroll highlight remain unchanged.
  * No changes to public APIs or user settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->