### PR TITLE
fix: sync font size changes across all tabs in real-time

### DIFF
--- a/src/main/events.ts
+++ b/src/main/events.ts
@@ -32,7 +32,8 @@ export const CONFIG_EVENTS = {
   OAUTH_LOGIN_START: 'config:oauth-login-start', // OAuth登录开始
   OAUTH_LOGIN_SUCCESS: 'config:oauth-login-success', // OAuth登录成功
   OAUTH_LOGIN_ERROR: 'config:oauth-login-error', // OAuth登录失败
-  THEME_CHANGED: 'config:theme-changed' // 主题变更事件
+  THEME_CHANGED: 'config:theme-changed', // 主题变更事件
+  FONT_SIZE_CHANGED: 'config:font-size-changed' // 字体大小变更事件
 }
 
 // 会话相关事件

--- a/src/main/presenter/configPresenter/index.ts
+++ b/src/main/presenter/configPresenter/index.ts
@@ -276,6 +276,11 @@ export class ConfigPresenter implements IConfigPresenter {
       this.store.set(key, value)
       // 触发设置变更事件（仅主进程内部使用）
       eventBus.sendToMain(CONFIG_EVENTS.SETTING_CHANGED, key, value)
+
+      // 特殊处理：字体大小设置需要通知所有标签页
+      if (key === 'fontSizeLevel') {
+        eventBus.sendToRenderer(CONFIG_EVENTS.FONT_SIZE_CHANGED, SendTarget.ALL_WINDOWS, value)
+      }
     } catch (error) {
       console.error(`[Config] Failed to set setting ${key}:`, error)
     }

--- a/src/renderer/src/events.ts
+++ b/src/renderer/src/events.ts
@@ -21,7 +21,8 @@ export const CONFIG_EVENTS = {
   LANGUAGE_CHANGED: 'config:language-changed', // 新增：语言变更事件
   SOUND_ENABLED_CHANGED: 'config:sound-enabled-changed', // 新增：声音启用状态变更事件
   COPY_WITH_COT_CHANGED: 'config:copy-with-cot-enabled-changed',
-  THEME_CHANGED: 'config:theme-changed'
+  THEME_CHANGED: 'config:theme-changed',
+  FONT_SIZE_CHANGED: 'config:font-size-changed'
 }
 
 // 会话相关事件

--- a/src/renderer/src/stores/settings.ts
+++ b/src/renderer/src/stores/settings.ts
@@ -691,6 +691,9 @@ export const useSettingsStore = defineStore('settings', () => {
 
     // 设置拷贝事件监听器
     setupCopyWithCotEnabledListener()
+
+    // 设置字体大小事件监听器
+    setupFontSizeListener()
   }
 
   // 更新本地模型状态，不触发后端请求
@@ -1430,6 +1433,15 @@ export const useSettingsStore = defineStore('settings', () => {
       CONFIG_EVENTS.COPY_WITH_COT_CHANGED,
       (_event, enabled: boolean) => {
         copyWithCotEnabled.value = enabled
+      }
+    )
+  }
+
+  const setupFontSizeListener = () => {
+    window.electron.ipcRenderer.on(
+      CONFIG_EVENTS.FONT_SIZE_CHANGED,
+      (_event, newFontSizeLevel: number) => {
+        fontSizeLevel.value = newFontSizeLevel
       }
     )
   }


### PR DESCRIPTION
sync font size changes across all tabs in real-time

old:
![CleanShot 2025-08-26 at 14 23 15](https://github.com/user-attachments/assets/b7f20f63-e26a-4ff0-8ada-d21f0d5101d8)


now:
![CleanShot 2025-08-26 at 14 21 56](https://github.com/user-attachments/assets/e12cee11-71de-4496-9931-3b22c804d665)
