### PR TITLE
fix: correct provider icon alignment in message list

### DIFF
--- a/src/renderer/src/components/icons/ModelIcon.vue
+++ b/src/renderer/src/components/icons/ModelIcon.vue
@@ -174,13 +174,11 @@ const invert = computed(() => {
 </script>
 
 <template>
-  <div>
-    <img
-      :src="icons[iconKey]"
-      :alt="iconKey"
-      :class="[customClass, { invert }, invert ? 'opacity-50' : '']"
-    />
-  </div>
+  <img
+    :src="icons[iconKey]"
+    :alt="iconKey"
+    :class="[customClass, { invert }, invert ? 'opacity-50' : '']"
+  />
 </template>
 
 <style scoped>

--- a/src/renderer/src/components/message/MessageItemAssistant.vue
+++ b/src/renderer/src/components/message/MessageItemAssistant.vue
@@ -8,8 +8,7 @@
     >
       <ModelIcon
         :model-id="currentMessage.model_provider"
-        custom-class=" block"
-        class="w-3 h-3"
+        custom-class="w-3 h-3"
         :is-dark="themeStore.isDark"
         :alt="currentMessage.role"
       />


### PR DESCRIPTION
correct provider icon alignment in message list

old:
<img width="2056" height="1360" alt="Electron 2025-08-26 20 32 11" src="https://github.com/user-attachments/assets/23d53cfa-560c-4f2d-8c1e-e8ff1b9d41df" />

now:
<img width="2028" height="1462" alt="CleanShot 2025-08-26 at 20 45 51@2x" src="https://github.com/user-attachments/assets/d2884671-bfa2-4871-924c-32ae365033c7" />
