### PR TITLE
fix: sync message navigation sidebar with latest variant content

### DIFF
--- a/src/renderer/src/components/MessageNavigationSidebar.vue
+++ b/src/renderer/src/components/MessageNavigationSidebar.vue
@@ -160,8 +160,14 @@ const getFullMessageContent = (message: Message): string => {
     const userContent = message.content as import('@shared/chat').UserMessageContent
     return userContent.text || ''
   } else if (message.role === 'assistant') {
-    const assistantContent = message.content as import('@shared/chat').AssistantMessageBlock[]
-    return assistantContent
+    const assistantMessage = message as import('@shared/chat').AssistantMessage
+    let contentToDisplay =
+      assistantMessage.content as import('@shared/chat').AssistantMessageBlock[]
+    if (assistantMessage.variants && assistantMessage.variants.length > 0) {
+      const latestVariant = assistantMessage.variants[assistantMessage.variants.length - 1]
+      contentToDisplay = latestVariant.content as import('@shared/chat').AssistantMessageBlock[]
+    }
+    return contentToDisplay
       .filter((block: import('@shared/chat').AssistantMessageBlock) => block.type === 'content')
       .map((block: import('@shared/chat').AssistantMessageBlock) => block.content || '')
       .join(' ')


### PR DESCRIPTION
sync message navigation sidebar with latest variant content

https://github.com/user-attachments/assets/632065f4-7567-4ef2-93d0-35adb8c1d35a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message previews now display the most recent variant of assistant messages, ensuring users see the latest content.
  * Search results are more accurate by indexing the latest assistant message variant and filtering out non-content blocks.
  * Consistent content handling across messages with variants improves reliability in navigation and quick glance views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->