### PR TITLE
fix: resolve session state conflict between floating and main windows

### DIFF
--- a/src/renderer/src/stores/chat.ts
+++ b/src/renderer/src/stores/chat.ts
@@ -1108,6 +1108,13 @@ export const useChatStore = defineStore('chat', () => {
     window.electron.ipcRenderer.on(CONVERSATION_EVENTS.MESSAGE_EDITED, (_, msgId: string) => {
       handleMessageEdited(msgId)
     })
+
+    window.electron.ipcRenderer.on(CONVERSATION_EVENTS.DEACTIVATED, (_, msg) => {
+      if (msg.tabId !== getTabId()) {
+        return
+      }
+      setActiveThreadId(null)
+    })
   }
 
   onMounted(() => {


### PR DESCRIPTION
resolve session state conflict between floating and main windows


https://github.com/user-attachments/assets/10edeef6-f264-411e-bb72-b3fd4b7ed765



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved multi-window/tab behavior when opening an already active conversation: the app now intelligently switches to the existing tab or rebinds it to the current window, ensuring the right place becomes active.
  - Per-tab deactivation handling: the active conversation is cleared in a tab when it’s deactivated elsewhere, keeping UI state accurate.
- Bug Fixes
  - Resolves cases where tabs could show stale active conversations after cross-tab/window changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->