### PR TITLE
fix: Correctly parse Gemini reasoning for both new `thought` field an…

### DIFF
--- a/src/main/presenter/llmProviderPresenter/providers/geminiProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/geminiProvider.ts
@@ -934,6 +934,7 @@ export class GeminiProvider extends BaseLLMProvider {
     let isInThinkTag = false
     let toolUseDetected = false
     let usageMetadata: GenerateContentResponseUsageMetadata | undefined
+    let isNewThoughtFormatDetected = false
 
     // 流处理循环
     for await (const chunk of result) {
@@ -987,6 +988,7 @@ export class GeminiProvider extends BaseLLMProvider {
         for (const part of chunk.candidates[0].content.parts) {
           // 检查是否是思考内容 (新格式)
           if ((part as any).thought === true && part.text) {
+            isNewThoughtFormatDetected = true
             thoughtContent += part.text
           } else if (part.text) {
             content += part.text
@@ -1012,71 +1014,48 @@ export class GeminiProvider extends BaseLLMProvider {
           type: 'reasoning',
           reasoning_content: thoughtContent
         }
-        thoughtContent = '' // 清空已发送的思考内容
       }
 
       if (!content) continue
 
-      buffer += content
+      if (isNewThoughtFormatDetected) {
+        yield {
+          type: 'text',
+          content: content
+        }
+      } else {
+        buffer += content
 
-      // 处理思考标签
-      if (buffer.includes('<think>') && !isInThinkTag) {
-        const thinkStart = buffer.indexOf('<think>')
-
-        // 发送<think>标签前的文本
-        if (thinkStart > 0) {
-          yield {
-            type: 'text',
-            content: buffer.substring(0, thinkStart)
+        if (buffer.includes('<think>') && !isInThinkTag) {
+          const thinkStart = buffer.indexOf('<think>')
+          if (thinkStart > 0) {
+            yield { type: 'text', content: buffer.substring(0, thinkStart) }
           }
+          buffer = buffer.substring(thinkStart + 7)
+          isInThinkTag = true
         }
 
-        buffer = buffer.substring(thinkStart + 7)
-        isInThinkTag = true
-        continue
-      }
-
-      // 处理思考标签结束
-      if (isInThinkTag && buffer.includes('</think>')) {
-        const thinkEnd = buffer.indexOf('</think>')
-        const reasoningContent = buffer.substring(0, thinkEnd)
-
-        // 发送推理内容
-        if (reasoningContent) {
-          yield {
-            type: 'reasoning',
-            reasoning_content: reasoningContent
+        if (isInThinkTag && buffer.includes('</think>')) {
+          const thinkEnd = buffer.indexOf('</think>')
+          const reasoningContent = buffer.substring(0, thinkEnd)
+          if (reasoningContent) {
+            yield {
+              type: 'reasoning',
+              reasoning_content: reasoningContent
+            }
           }
+          buffer = buffer.substring(thinkEnd + 8)
+          isInThinkTag = false
         }
 
-        buffer = buffer.substring(thinkEnd + 8)
-        isInThinkTag = false
-
-        // 如果还有剩余内容，继续处理
-        if (buffer) {
+        if (!isInThinkTag && buffer) {
           yield {
             type: 'text',
             content: buffer
           }
           buffer = ''
         }
-
-        continue
       }
-
-      // 如果在思考标签内，不输出内容
-      if (isInThinkTag) {
-        continue
-      }
-
-      // 正常输出文本内容
-      yield {
-        type: 'text',
-        content: content
-      }
-
-      // 内容已经发送，清空buffer避免重复
-      buffer = ''
     }
 
     if (usageMetadata) {
@@ -1091,7 +1070,7 @@ export class GeminiProvider extends BaseLLMProvider {
     }
 
     // 处理剩余缓冲区内容
-    if (buffer) {
+    if (!isNewThoughtFormatDetected && buffer) {
       if (isInThinkTag) {
         yield {
           type: 'reasoning',


### PR DESCRIPTION
老版geminiProvider在处理完新版 API 的 `thought` 字段后，没有停止，而是继续用旧的、不健壮的 `<think>` 标签匹配逻辑去处理正文内容，导致了正文被错误地识别和分割。

<img width="1190" height="2848" alt="图片" src="https://github.com/user-attachments/assets/50110df2-615b-4b31-ac4f-35ba5e661e4a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Real-time streaming with smoother reasoning display and content updates.
  - Configurable safety settings mapped to harm categories and thresholds.
  - Thinking budget support on compatible models to balance speed and quality.
  - Enhanced tool-calling and multi-part message handling for richer interactions.
  - More accurate token usage reporting with resilient fallbacks.
  - Improved compatibility for streaming image generation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->