### PR TITLE
fix: correct Gemini 2.5 Flash Image Preview model capabilities and token limits

### DIFF
--- a/src/main/presenter/configPresenter/modelDefaultSettings.ts
+++ b/src/main/presenter/configPresenter/modelDefaultSettings.ts
@@ -349,6 +349,17 @@ export const defaultModelsSettings: DefaultModelSetting[] = [
     thinkingBudget: -1 // 动态思维
   },
   {
+    id: 'google/gemini-2.5-flash-image-preview',
+    name: 'Gemini 2.5 Flash Image Preview',
+    temperature: 0.7,
+    maxTokens: 32768,
+    contextLength: 32768,
+    match: ['google/gemini-2.5-flash-image-preview', 'gemini-2.5-flash-image-preview'],
+    vision: true,
+    functionCall: false,
+    reasoning: false
+  },
+  {
     id: 'models/gemini-2.5-flash',
     name: 'Gemini 2.5 Flash',
     temperature: 0.7,

--- a/src/main/presenter/configPresenter/providerModelSettings.ts
+++ b/src/main/presenter/configPresenter/providerModelSettings.ts
@@ -182,15 +182,15 @@ export const providerModelSettings: Record<string, { models: ProviderModelSettin
         reasoning: true
       },
       {
-        id: 'models/gemini-2.5-flash',
-        name: 'Gemini 2.5 Flash',
+        id: 'google/gemini-2.5-flash-image-preview',
+        name: 'Gemini 2.5 Flash Image Preview',
         temperature: 0.7,
-        maxTokens: 65536,
-        contextLength: 1048576,
-        match: ['models/gemini-2.5-flash', 'gemini-2.5-flash'],
+        maxTokens: 32768,
+        contextLength: 32768,
+        match: ['google/gemini-2.5-flash-image-preview', 'gemini-2.5-flash-image-preview'],
         vision: true,
-        functionCall: true,
-        reasoning: true
+        functionCall: false,
+        reasoning: false
       },
       {
         id: 'models/gemini-2.5-flash-lite-preview-06-17',
@@ -199,6 +199,17 @@ export const providerModelSettings: Record<string, { models: ProviderModelSettin
         maxTokens: 64000,
         contextLength: 1000000,
         match: ['models/gemini-2.5-flash-lite-preview-06-17', 'gemini-2.5-flash-lite-preview'],
+        vision: true,
+        functionCall: true,
+        reasoning: true
+      },
+      {
+        id: 'models/gemini-2.5-flash',
+        name: 'Gemini 2.5 Flash',
+        temperature: 0.7,
+        maxTokens: 65536,
+        contextLength: 1048576,
+        match: ['models/gemini-2.5-flash', 'gemini-2.5-flash'],
         vision: true,
         functionCall: true,
         reasoning: true
@@ -2314,6 +2325,17 @@ export const providerModelSettings: Record<string, { models: ProviderModelSettin
   // OpenRouter提供商特定模型配置
   openrouter: {
     models: [
+      {
+        id: 'google/gemini-2.5-flash-image-preview',
+        name: 'Gemini 2.5 Flash Image Preview',
+        temperature: 0.7,
+        maxTokens: 32768,
+        contextLength: 32768,
+        match: ['google/gemini-2.5-flash-image-preview', 'gemini-2.5-flash-image-preview'],
+        vision: true,
+        functionCall: false,
+        reasoning: false
+      },
       {
         id: 'deepseek-r1-0528:free',
         name: 'DeepSeek R1-0528:free',

--- a/src/main/presenter/llmProviderPresenter/providers/geminiProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/geminiProvider.ts
@@ -191,12 +191,13 @@ export class GeminiProvider extends BaseLLMProvider {
           const isVisionModel =
             displayName.toLowerCase().includes('vision') || modelName.includes('gemini-') // Gemini 系列一般都支持视觉
 
-          const isFunctionCallSupported = !modelName.includes('gemma-3') // Gemma 模型不支持函数调用
+          const isFunctionCallSupported =
+            !modelName.includes('gemma-3') && !modelName.includes('flash-image-preview') // Gemma 模型和 flash-image-preview 不支持函数调用
 
           // 判断是否支持推理（thinking）
           const isReasoningSupported =
             modelName.includes('thinking') ||
-            modelName.includes('2.5') ||
+            (modelName.includes('2.5') && !modelName.includes('flash-image-preview')) ||
             modelName.includes('2.0-flash') ||
             modelName.includes('exp-1206')
 


### PR DESCRIPTION
correct Gemini 2.5 Flash Image Preview model capabilities and token limits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added Gemini 2.5 Flash Image Preview model with vision/image input support across providers.

* Improvements
  * Restored standard Gemini 2.5 Flash as a separate selectable model with original token/context limits.
  * Updated capability handling: function calling is not offered on the Image Preview model; “thinking/reasoning” is only shown for eligible Gemini 2.5 variants.
  * Refreshed model lists and matching to ensure accurate selection and capabilities across providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->