### PR TITLE
fix: Solve the problem of the window becoming larger when dragging floating button under Windows

### DIFF
--- a/src/main/presenter/floatingButtonPresenter/index.ts
+++ b/src/main/presenter/floatingButtonPresenter/index.ts
@@ -220,7 +220,12 @@ export class FloatingButtonPresenter {
             const newX = dragState.windowX + deltaX
             const newY = dragState.windowY + deltaY
 
-            buttonWindow.setPosition(newX, newY)
+            buttonWindow.setBounds({
+              x: newX,
+              y: newY,
+              width: this.config.size.width,
+              height: this.config.size.height
+            })
           }
         }
       } catch (error) {


### PR DESCRIPTION
## Pull Request Description

**Is your feature request related to a problem? Please describe.**
Under Windows system, there is an issue where the application window unexpectedly becomes larger when dragging the floating button. This affects user experience during interactive operations involving the floating button. The root cause is identified as a bug in Electron's `setPosition` API.

**Describe the solution you'd like**
Fix the issue by replacing the usage of Electron's `setPosition` API with `setBounds` when handling floating button dragging on Windows. This API switch addresses the underlying Electron bug that caused unintended window resizing, ensuring the window maintains its original size while dragging the floating button.

**UI/UX changes for Desktop Application**
This PR primarily fixes a functional issue without introducing new UI elements. The key improvement is that the window size will remain stable when dragging the floating button, enhancing the smoothness of user interactions. No other visible UI changes are introduced.

**Platform Compatibility Notes**
- This issue is specific to the Windows platform, and the fix is targeted at Windows system behavior.
- The modification only involves switching between standard Electron APIs (`setPosition` to `setBounds`), which are compatible with Windows and do not affect the functionality of floating buttons on other platforms (macOS, Linux).
- Tested on Windows 10 and Windows 11 to confirm the issue is resolved.

**Additional context**
The floating button is an important interactive component for quick operations. This fix, by addressing an Electron API bug through a targeted API switch, ensures that its dragging behavior works as expected on Windows, preventing disruptive window size changes and improving overall operational stability.

---

## Pull Request Description (中文)

**你的功能请求是否与某个问题有关？请描述一下。**
在Windows系统下，拖动浮动按钮时会出现应用窗口意外变大的问题，影响了用户对浮动按钮进行交互操作时的体验。经定位，该问题由Electron的`setPosition` API存在的bug导致。

**请描述你希望的解决方案**
在Windows系统下处理浮动按钮拖动时，将Electron的`setPosition` API替换为`setBounds`。此次API切换可解决导致窗口意外 resize 的Electron底层bug，确保拖动浮动按钮时窗口保持原始尺寸。

**桌面应用程序的 UI/UX 更改**
此PR主要修复功能性问题，未引入新的UI元素。核心改进是拖动浮动按钮时窗口大小将保持稳定，提升用户交互的流畅度，无其他可见的UI变化。

**平台兼容性注意事项**
- 该问题特定于Windows平台，修复针对Windows系统行为。
- 修改仅涉及标准Electron API的切换（从`setPosition`到`setBounds`），兼容Windows系统，且不影响其他平台（macOS、Linux）上浮动按钮的功能。
- 已在Windows 10和Windows 11上测试，确认问题已解决。

**附加背景**
浮动按钮是用于快速操作的重要交互组件，此次修复通过针对性的API切换解决了Electron的API bug，确保其在Windows上的拖动行为符合预期，避免了破坏性的窗口尺寸变化，提升了整体操作稳定性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dragging the floating button now preserves its configured size, preventing unintended resizing during movement.
  * Position updates no longer affect dimensions, resulting in smoother, more predictable drag behavior.
  * Improved consistency with user-defined size settings for the floating button while it is being repositioned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->