### PR TITLE
chore: update vue-renderer-markdown to v0.0.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "vitest": "^3.2.4",
     "vue": "^3.5.19",
     "vue-i18n": "^11.1.11",
-    "vue-renderer-markdown": "^0.0.34",
+    "vue-renderer-markdown": "^0.0.35",
     "vue-router": "4",
     "vue-tsc": "^2.2.10",
     "vue-use-monaco": "^0.0.8",


### PR DESCRIPTION
update vue-renderer-markdown to v0.0.35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a markdown rendering library to the latest patch version to keep dependencies current and aligned with the ecosystem.
  * No user-facing changes; functionality and behavior remain the same.
  * Aims to improve stability and compatibility through dependency resolution updates.
  * No configuration changes required and no action needed from users.
  * No impact on saved data or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->