### PR TITLE
feat: ux update

### DIFF
--- a/src/renderer/src/components/settings/CommonSettings.vue
+++ b/src/renderer/src/components/settings/CommonSettings.vue
@@ -14,23 +14,39 @@
                 <SelectValue :placeholder="t('settings.common.searchEngineSelect')" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem v-for="engine in settingsStore.searchEngines" :key="engine.id" :value="engine.id">
+                <SelectItem
+                  v-for="engine in settingsStore.searchEngines"
+                  :key="engine.id"
+                  :value="engine.id"
+                >
                   {{ engine.name }}
                 </SelectItem>
               </SelectContent>
             </Select>
           </div>
-          <Button variant="outline" size="icon" :title="t('settings.common.addCustomSearchEngine')"
-            @click="openAddSearchEngineDialog">
+          <Button
+            variant="outline"
+            size="icon"
+            :title="t('settings.common.addCustomSearchEngine')"
+            @click="openAddSearchEngineDialog"
+          >
             <Icon icon="lucide:plus" class="w-4 h-4" />
           </Button>
-          <Button v-if="isCurrentEngineCustom" variant="outline" size="icon"
+          <Button
+            v-if="isCurrentEngineCustom"
+            variant="outline"
+            size="icon"
             :title="t('settings.common.deleteCustomSearchEngine')"
-            @click="currentEngine && openDeleteSearchEngineDialog(currentEngine)">
+            @click="currentEngine && openDeleteSearchEngineDialog(currentEngine)"
+          >
             <Icon icon="lucide:trash-2" class="w-4 h-4 text-destructive" />
           </Button>
-          <Button variant="outline" size="icon" :title="t('settings.common.testSearchEngine')"
-            @click="openTestSearchEngineDialog">
+          <Button
+            variant="outline"
+            size="icon"
+            :title="t('settings.common.testSearchEngine')"
+            @click="openTestSearchEngineDialog"
+          >
             <Icon icon="lucide:flask-conical" class="w-4 h-4" />
           </Button>
         </div>
@@ -46,23 +62,45 @@
           </div>
         </span>
         <div class="flex-shrink-0 flex items-center gap-1">
-          <Button variant="outline" size="icon" class="h-8 w-8 rounded-full" @click="decreaseWebContentLimit"
-            :disabled="webContentLengthLimit <= 0">
+          <Button
+            variant="outline"
+            size="icon"
+            class="h-8 w-8 rounded-full"
+            @click="decreaseWebContentLimit"
+            :disabled="webContentLengthLimit <= 0"
+          >
             <Icon icon="lucide:minus" class="h-3 w-3" />
           </Button>
           <div class="relative">
-            <div v-if="!isEditingLimit" @click="startEditingLimit"
-              class="min-w-16 h-8 flex items-center justify-center text-sm font-semibold cursor-pointer hover:bg-accent rounded px-2">
+            <div
+              v-if="!isEditingLimit"
+              @click="startEditingLimit"
+              class="min-w-16 h-8 flex items-center justify-center text-sm font-semibold cursor-pointer hover:bg-accent rounded px-2"
+            >
               {{ webContentLengthLimit }}
             </div>
-            <Input v-else ref="limitInputRef" type="number" :min="0" :max="10000" :model-value="webContentLengthLimit"
-              @update:model-value="handleWebContentLengthLimitChange" @blur="stopEditingLimit"
-              @keydown.enter="stopEditingLimit" @keydown.escape="stopEditingLimit"
+            <Input
+              v-else
+              ref="limitInputRef"
+              type="number"
+              :min="0"
+              :max="10000"
+              :model-value="webContentLengthLimit"
+              @update:model-value="handleWebContentLengthLimitChange"
+              @blur="stopEditingLimit"
+              @keydown.enter="stopEditingLimit"
+              @keydown.escape="stopEditingLimit"
               class="min-w-16 h-8 text-center text-sm font-semibold rounded px-2"
-              :class="{ 'bg-accent': isEditingLimit }" />
+              :class="{ 'bg-accent': isEditingLimit }"
+            />
           </div>
-          <Button variant="outline" size="icon" class="h-8 w-8 rounded-full" @click="increaseWebContentLimit"
-            :disabled="webContentLengthLimit >= 10000">
+          <Button
+            variant="outline"
+            size="icon"
+            class="h-8 w-8 rounded-full"
+            @click="increaseWebContentLimit"
+            :disabled="webContentLengthLimit >= 10000"
+          >
             <Icon icon="lucide:plus" class="h-3 w-3" />
           </Button>
           <span class="text-xs text-muted-foreground ml-1">字符</span>
@@ -80,17 +118,23 @@
             <PopoverTrigger as-child>
               <Button variant="outline" class="w-full justify-between">
                 <div class="flex items-center gap-2">
-                  <ModelIcon :model-id="selectedSearchModel?.id || ''" class="h-4 w-4" :is-dark="themeStore.isDark" />
+                  <ModelIcon
+                    :model-id="selectedSearchModel?.id || ''"
+                    class="h-4 w-4"
+                    :is-dark="themeStore.isDark"
+                  />
                   <span class="truncate">{{
                     selectedSearchModel?.name || t('settings.common.selectModel')
-                    }}</span>
+                  }}</span>
                 </div>
                 <ChevronDown class="h-4 w-4 opacity-50" />
               </Button>
             </PopoverTrigger>
             <PopoverContent class="w-80 p-0">
-              <ModelSelect :type="[ModelType.Chat, ModelType.ImageGeneration]"
-                @update:model="handleSearchModelSelect" />
+              <ModelSelect
+                :type="[ModelType.Chat, ModelType.ImageGeneration]"
+                @update:model="handleSearchModelSelect"
+              />
             </PopoverContent>
           </Popover>
         </div>
@@ -121,8 +165,13 @@
             <span class="text-sm font-medium">{{ t('settings.common.customProxyUrl') }}</span>
           </span>
           <div class="flex-shrink-0 min-w-64 max-w-96">
-            <Input v-model="customProxyUrl" :placeholder="t('settings.common.customProxyUrlPlaceholder')"
-              :class="{ 'border-red-500': showUrlError }" @input="validateProxyUrl" @blur="validateProxyUrl" />
+            <Input
+              v-model="customProxyUrl"
+              :placeholder="t('settings.common.customProxyUrlPlaceholder')"
+              :class="{ 'border-red-500': showUrlError }"
+              @input="validateProxyUrl"
+              @blur="validateProxyUrl"
+            />
           </div>
         </div>
         <div v-if="showUrlError" class="text-xs text-red-500 ml-6">
@@ -136,8 +185,11 @@
           <span class="text-sm font-medium">{{ t('settings.common.searchPreview') }}</span>
         </span>
         <div class="flex-shrink-0">
-          <Switch id="search-preview-switch" :checked="searchPreviewEnabled"
-            @update:checked="handleSearchPreviewChange" />
+          <Switch
+            id="search-preview-switch"
+            :checked="searchPreviewEnabled"
+            @update:checked="handleSearchPreviewChange"
+          />
         </div>
       </div>
 
@@ -148,7 +200,11 @@
           <span class="text-sm font-medium">{{ t('settings.common.loggingEnabled') }}</span>
         </span>
         <div class="flex-shrink-0">
-          <Switch id="logging-switch" :checked="loggingEnabled" @update:checked="handleLoggingChange" />
+          <Switch
+            id="logging-switch"
+            :checked="loggingEnabled"
+            @update:checked="handleLoggingChange"
+          />
         </div>
       </div>
 
@@ -170,7 +226,11 @@
           <span class="text-sm font-medium">{{ t('settings.common.copyWithCotEnabled') }}</span>
         </span>
         <div class="flex-shrink-0">
-          <Switch id="copy-with-cot-switch" :checked="copyWithCotEnabled" @update:checked="handleCopyWithCotChange" />
+          <Switch
+            id="copy-with-cot-switch"
+            :checked="copyWithCotEnabled"
+            @update:checked="handleCopyWithCotChange"
+          />
         </div>
       </div>
 
@@ -198,16 +258,21 @@
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <div class="p-2 flex flex-row items-center gap-2 hover:bg-accent rounded-lg cursor-pointer" @click="openLogFolder"
-        :dir="langStore.dir">
+      <div
+        class="p-2 flex flex-row items-center gap-2 hover:bg-accent rounded-lg cursor-pointer"
+        @click="openLogFolder"
+        :dir="langStore.dir"
+      >
         <Icon icon="lucide:external-link" class="w-4 h-4 text-muted-foreground" />
         <span class="text-sm font-medium">{{ t('settings.common.openLogFolder') }}</span>
       </div>
       <!-- 重置数据 -->
       <Dialog v-model:open="isDialogOpen">
         <DialogTrigger as-child>
-          <div class="p-2 flex flex-row items-center gap-2 hover:bg-accent rounded-lg cursor-pointer"
-            :dir="langStore.dir">
+          <div
+            class="p-2 flex flex-row items-center gap-2 hover:bg-accent rounded-lg cursor-pointer"
+            :dir="langStore.dir"
+          >
             <Icon icon="lucide:trash" class="w-4 h-4 text-muted-foreground" />
             <span class="text-sm font-medium">{{ t('settings.common.resetData') }}</span>
           </div>
@@ -247,17 +312,24 @@
           <Label for="search-engine-name" class="text-right">
             {{ t('settings.common.searchEngineName') }}
           </Label>
-          <Input id="search-engine-name" v-model="newSearchEngine.name" class="col-span-3"
-            :placeholder="t('settings.common.searchEngineNamePlaceholder')" />
+          <Input
+            id="search-engine-name"
+            v-model="newSearchEngine.name"
+            class="col-span-3"
+            :placeholder="t('settings.common.searchEngineNamePlaceholder')"
+          />
         </div>
         <div class="grid grid-cols-4 items-center gap-4">
           <Label for="search-engine-url" class="text-right">
             {{ t('settings.common.searchEngineUrl') }}
           </Label>
           <div class="col-span-3">
-            <Input id="search-engine-url" v-model="newSearchEngine.searchUrl"
+            <Input
+              id="search-engine-url"
+              v-model="newSearchEngine.searchUrl"
               :placeholder="t('settings.common.searchEngineUrlPlaceholder')"
-              :class="{ 'border-red-500': showSearchUrlError }" />
+              :class="{ 'border-red-500': showSearchUrlError }"
+            />
             <div v-if="showSearchUrlError" class="text-xs text-red-500 mt-1">
               {{ t('settings.common.searchEngineUrlError') }}
             </div>
@@ -521,12 +593,15 @@ watch(customProxyUrl, () => {
   }, 300)
 })
 
-watch(() => isEditingLimit.value, async (newValue) => {
-  if (newValue) {
-    await nextTick()
-    limitInputRef.value?.dom?.focus?.()
+watch(
+  () => isEditingLimit.value,
+  async (newValue) => {
+    if (newValue) {
+      await nextTick()
+      limitInputRef.value?.dom?.focus?.()
+    }
   }
-})
+)
 
 const isDialogOpen = ref(false)
 const modelSelectOpen = ref(false)
@@ -764,7 +839,7 @@ input::-webkit-inner-spin-button {
   /* <-- Apparently some margin are still there even though it's hidden */
 }
 
-input[type=number] {
+input[type='number'] {
   -moz-appearance: textfield;
   /* Firefox */
 }

--- a/src/renderer/src/components/settings/CommonSettings.vue
+++ b/src/renderer/src/components/settings/CommonSettings.vue
@@ -14,39 +14,23 @@
                 <SelectValue :placeholder="t('settings.common.searchEngineSelect')" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem
-                  v-for="engine in settingsStore.searchEngines"
-                  :key="engine.id"
-                  :value="engine.id"
-                >
+                <SelectItem v-for="engine in settingsStore.searchEngines" :key="engine.id" :value="engine.id">
                   {{ engine.name }}
                 </SelectItem>
               </SelectContent>
             </Select>
           </div>
-          <Button
-            variant="outline"
-            size="icon"
-            :title="t('settings.common.addCustomSearchEngine')"
-            @click="openAddSearchEngineDialog"
-          >
+          <Button variant="outline" size="icon" :title="t('settings.common.addCustomSearchEngine')"
+            @click="openAddSearchEngineDialog">
             <Icon icon="lucide:plus" class="w-4 h-4" />
           </Button>
-          <Button
-            v-if="isCurrentEngineCustom"
-            variant="outline"
-            size="icon"
+          <Button v-if="isCurrentEngineCustom" variant="outline" size="icon"
             :title="t('settings.common.deleteCustomSearchEngine')"
-            @click="currentEngine && openDeleteSearchEngineDialog(currentEngine)"
-          >
+            @click="currentEngine && openDeleteSearchEngineDialog(currentEngine)">
             <Icon icon="lucide:trash-2" class="w-4 h-4 text-destructive" />
           </Button>
-          <Button
-            variant="outline"
-            size="icon"
-            :title="t('settings.common.testSearchEngine')"
-            @click="openTestSearchEngineDialog"
-          >
+          <Button variant="outline" size="icon" :title="t('settings.common.testSearchEngine')"
+            @click="openTestSearchEngineDialog">
             <Icon icon="lucide:flask-conical" class="w-4 h-4" />
           </Button>
         </div>
@@ -62,44 +46,23 @@
           </div>
         </span>
         <div class="flex-shrink-0 flex items-center gap-1">
-          <Button
-            variant="outline"
-            size="icon"
-            class="h-8 w-8 rounded-full"
-            @click="decreaseWebContentLimit"
-            :disabled="webContentLengthLimit <= 0"
-          >
+          <Button variant="outline" size="icon" class="h-8 w-8 rounded-full" @click="decreaseWebContentLimit"
+            :disabled="webContentLengthLimit <= 0">
             <Icon icon="lucide:minus" class="h-3 w-3" />
           </Button>
           <div class="relative">
-            <div
-              v-if="!isEditingLimit"
-              @click="startEditingLimit"
-              class="min-w-16 h-8 flex items-center justify-center text-sm font-semibold cursor-pointer hover:bg-accent rounded px-2"
-            >
+            <div v-if="!isEditingLimit" @click="startEditingLimit"
+              class="min-w-16 h-8 flex items-center justify-center text-sm font-semibold cursor-pointer hover:bg-accent rounded px-2">
               {{ webContentLengthLimit }}
             </div>
-            <Input
-              v-else
-              ref="limitInputRef"
-              type="number"
-              :min="0"
-              :max="10000"
-              :model-value="webContentLengthLimit"
-              @update:model-value="handleWebContentLengthLimitChange"
-              @blur="stopEditingLimit"
-              @keydown.enter="stopEditingLimit"
-              @keydown.escape="stopEditingLimit"
-              class="min-w-16 h-8 text-center text-sm font-semibold"
-            />
+            <Input v-else ref="limitInputRef" type="number" :min="0" :max="10000" :model-value="webContentLengthLimit"
+              @update:model-value="handleWebContentLengthLimitChange" @blur="stopEditingLimit"
+              @keydown.enter="stopEditingLimit" @keydown.escape="stopEditingLimit"
+              class="min-w-16 h-8 text-center text-sm font-semibold rounded px-2"
+              :class="{ 'bg-accent': isEditingLimit }" />
           </div>
-          <Button
-            variant="outline"
-            size="icon"
-            class="h-8 w-8 rounded-full"
-            @click="increaseWebContentLimit"
-            :disabled="webContentLengthLimit >= 10000"
-          >
+          <Button variant="outline" size="icon" class="h-8 w-8 rounded-full" @click="increaseWebContentLimit"
+            :disabled="webContentLengthLimit >= 10000">
             <Icon icon="lucide:plus" class="h-3 w-3" />
           </Button>
           <span class="text-xs text-muted-foreground ml-1">字符</span>
@@ -117,23 +80,17 @@
             <PopoverTrigger as-child>
               <Button variant="outline" class="w-full justify-between">
                 <div class="flex items-center gap-2">
-                  <ModelIcon
-                    :model-id="selectedSearchModel?.id || ''"
-                    class="h-4 w-4"
-                    :is-dark="themeStore.isDark"
-                  />
+                  <ModelIcon :model-id="selectedSearchModel?.id || ''" class="h-4 w-4" :is-dark="themeStore.isDark" />
                   <span class="truncate">{{
                     selectedSearchModel?.name || t('settings.common.selectModel')
-                  }}</span>
+                    }}</span>
                 </div>
                 <ChevronDown class="h-4 w-4 opacity-50" />
               </Button>
             </PopoverTrigger>
             <PopoverContent class="w-80 p-0">
-              <ModelSelect
-                :type="[ModelType.Chat, ModelType.ImageGeneration]"
-                @update:model="handleSearchModelSelect"
-              />
+              <ModelSelect :type="[ModelType.Chat, ModelType.ImageGeneration]"
+                @update:model="handleSearchModelSelect" />
             </PopoverContent>
           </Popover>
         </div>
@@ -164,13 +121,8 @@
             <span class="text-sm font-medium">{{ t('settings.common.customProxyUrl') }}</span>
           </span>
           <div class="flex-shrink-0 min-w-64 max-w-96">
-            <Input
-              v-model="customProxyUrl"
-              :placeholder="t('settings.common.customProxyUrlPlaceholder')"
-              :class="{ 'border-red-500': showUrlError }"
-              @input="validateProxyUrl"
-              @blur="validateProxyUrl"
-            />
+            <Input v-model="customProxyUrl" :placeholder="t('settings.common.customProxyUrlPlaceholder')"
+              :class="{ 'border-red-500': showUrlError }" @input="validateProxyUrl" @blur="validateProxyUrl" />
           </div>
         </div>
         <div v-if="showUrlError" class="text-xs text-red-500 ml-6">
@@ -184,11 +136,8 @@
           <span class="text-sm font-medium">{{ t('settings.common.searchPreview') }}</span>
         </span>
         <div class="flex-shrink-0">
-          <Switch
-            id="search-preview-switch"
-            :checked="searchPreviewEnabled"
-            @update:checked="handleSearchPreviewChange"
-          />
+          <Switch id="search-preview-switch" :checked="searchPreviewEnabled"
+            @update:checked="handleSearchPreviewChange" />
         </div>
       </div>
 
@@ -199,11 +148,7 @@
           <span class="text-sm font-medium">{{ t('settings.common.loggingEnabled') }}</span>
         </span>
         <div class="flex-shrink-0">
-          <Switch
-            id="logging-switch"
-            :checked="loggingEnabled"
-            @update:checked="handleLoggingChange"
-          />
+          <Switch id="logging-switch" :checked="loggingEnabled" @update:checked="handleLoggingChange" />
         </div>
       </div>
 
@@ -225,11 +170,7 @@
           <span class="text-sm font-medium">{{ t('settings.common.copyWithCotEnabled') }}</span>
         </span>
         <div class="flex-shrink-0">
-          <Switch
-            id="copy-with-cot-switch"
-            :checked="copyWithCotEnabled"
-            @update:checked="handleCopyWithCotChange"
-          />
+          <Switch id="copy-with-cot-switch" :checked="copyWithCotEnabled" @update:checked="handleCopyWithCotChange" />
         </div>
       </div>
 
@@ -257,21 +198,16 @@
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <div
-        class="p-2 flex flex-row items-center gap-2 hover:bg-accent rounded-lg cursor-pointer"
-        @click="openLogFolder"
-        :dir="langStore.dir"
-      >
+      <div class="p-2 flex flex-row items-center gap-2 hover:bg-accent rounded-lg cursor-pointer" @click="openLogFolder"
+        :dir="langStore.dir">
         <Icon icon="lucide:external-link" class="w-4 h-4 text-muted-foreground" />
         <span class="text-sm font-medium">{{ t('settings.common.openLogFolder') }}</span>
       </div>
       <!-- 重置数据 -->
       <Dialog v-model:open="isDialogOpen">
         <DialogTrigger as-child>
-          <div
-            class="p-2 flex flex-row items-center gap-2 hover:bg-accent rounded-lg cursor-pointer"
-            :dir="langStore.dir"
-          >
+          <div class="p-2 flex flex-row items-center gap-2 hover:bg-accent rounded-lg cursor-pointer"
+            :dir="langStore.dir">
             <Icon icon="lucide:trash" class="w-4 h-4 text-muted-foreground" />
             <span class="text-sm font-medium">{{ t('settings.common.resetData') }}</span>
           </div>
@@ -311,24 +247,17 @@
           <Label for="search-engine-name" class="text-right">
             {{ t('settings.common.searchEngineName') }}
           </Label>
-          <Input
-            id="search-engine-name"
-            v-model="newSearchEngine.name"
-            class="col-span-3"
-            :placeholder="t('settings.common.searchEngineNamePlaceholder')"
-          />
+          <Input id="search-engine-name" v-model="newSearchEngine.name" class="col-span-3"
+            :placeholder="t('settings.common.searchEngineNamePlaceholder')" />
         </div>
         <div class="grid grid-cols-4 items-center gap-4">
           <Label for="search-engine-url" class="text-right">
             {{ t('settings.common.searchEngineUrl') }}
           </Label>
           <div class="col-span-3">
-            <Input
-              id="search-engine-url"
-              v-model="newSearchEngine.searchUrl"
+            <Input id="search-engine-url" v-model="newSearchEngine.searchUrl"
               :placeholder="t('settings.common.searchEngineUrlPlaceholder')"
-              :class="{ 'border-red-500': showSearchUrlError }"
-            />
+              :class="{ 'border-red-500': showSearchUrlError }" />
             <div v-if="showSearchUrlError" class="text-xs text-red-500 mt-1">
               {{ t('settings.common.searchEngineUrlError') }}
             </div>
@@ -402,7 +331,7 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
-import { ref, onMounted, watch, computed } from 'vue'
+import { ref, onMounted, watch, computed, nextTick } from 'vue'
 import { useSettingsStore } from '@/stores/settings'
 import {
   Dialog,
@@ -446,7 +375,7 @@ const showUrlError = ref(false)
 // 网页内容长度限制
 const webContentLengthLimit = ref(3000)
 const isEditingLimit = ref(false)
-const limitInputRef = ref<HTMLInputElement>()
+const limitInputRef = ref<{ dom: HTMLInputElement }>()
 
 // 新增搜索引擎相关
 const isAddSearchEngineDialogOpen = ref(false)
@@ -590,6 +519,13 @@ watch(customProxyUrl, () => {
   proxyUrlDebounceTimer = window.setTimeout(() => {
     validateProxyUrl()
   }, 300)
+})
+
+watch(() => isEditingLimit.value, async (newValue) => {
+  if (newValue) {
+    await nextTick()
+    limitInputRef.value?.dom?.focus?.()
+  }
 })
 
 const isDialogOpen = ref(false)
@@ -818,3 +754,18 @@ const testSearchEngine = async () => {
   }
 }
 </script>
+
+<style scoped>
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  /* display: none; <- Crashes Chrome on hover */
+  -webkit-appearance: none;
+  margin: 0;
+  /* <-- Apparently some margin are still there even though it's hidden */
+}
+
+input[type=number] {
+  -moz-appearance: textfield;
+  /* Firefox */
+}
+</style>

--- a/src/renderer/src/components/ui/input/Input.vue
+++ b/src/renderer/src/components/ui/input/Input.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { useTemplateRef, type HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'
 import { useVModel } from '@vueuse/core'
 
@@ -17,6 +17,12 @@ const modelValue = useVModel(props, 'modelValue', emits, {
   passive: true,
   defaultValue: props.defaultValue
 })
+
+const domRef = useTemplateRef('inputRef')
+
+defineExpose({
+  dom: domRef
+})
 </script>
 
 <template>
@@ -28,5 +34,6 @@ const modelValue = useVModel(props, 'modelValue', emits, {
         props.class
       )
     "
+    ref="inputRef"
   />
 </template>

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -22,6 +22,7 @@
   "compilerOptions": {
     "composite": true,
     "baseUrl": ".",
+    "module": "esnext",
     "paths": {
       "@/*": [
         "src/renderer/src/*"


### PR DESCRIPTION
## Pull Request Description

**UI/UX changes for Desktop Application**

before: 

We need to click on the input box to get focus. In addition, the upper and lower arrows that come with input number are not beautiful.

https://github.com/user-attachments/assets/2ff0f642-083d-49cd-be4c-376a2fbbd8c4


after:

After entering edit mode, automatically obtain focus

https://github.com/user-attachments/assets/f3a46473-1008-4e6c-86dc-89e263b70739




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - The “web content length limit” field now auto-focuses when you start editing for faster adjustments.
  - Improved edit-state styling (rounded corners, padding, accent background) for clearer visual feedback.

- Style
  - Removed browser spin buttons from number inputs for a cleaner look and fewer accidental changes.

- Chores
  - Updated TypeScript web build to use ESNext modules.
  - Improved input component focus support for more reliable editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->