### PR TITLE
feat: add enable_thinking parameter support for siliconcloud

### DIFF
--- a/src/main/presenter/configPresenter/providerModelSettings.ts
+++ b/src/main/presenter/configPresenter/providerModelSettings.ts
@@ -1852,6 +1852,50 @@ export const providerModelSettings: Record<string, { models: ProviderModelSettin
         reasoning: true
       },
       {
+        id: 'tencent/Hunyuan-A13B-Instruct',
+        name: 'tencent/Hunyuan-A13B-Instruct',
+        temperature: 0.6,
+        maxTokens: 8192,
+        contextLength: 100_000,
+        match: ['tencent/hunyuan-a13b-instruct', 'hunyuan-a13b-instruct'],
+        vision: false,
+        functionCall: true,
+        reasoning: true
+      },
+      {
+        id: 'zai-org/GLM-4.5V',
+        name: 'zai-org/GLM-4.5V',
+        temperature: 0.6,
+        maxTokens: 8192,
+        contextLength: 100_000,
+        match: ['zai-org/glm-4.5v', 'glm-4.5v'],
+        vision: true,
+        functionCall: true,
+        reasoning: true
+      },
+      {
+        id: 'deepseek-ai/DeepSeek-V3.1',
+        name: 'deepseek-ai/DeepSeek-V3.1',
+        temperature: 0.6,
+        maxTokens: 7000,
+        contextLength: 62000,
+        match: ['deepseek-ai/deepseek-v3.1', 'deepseek-v3.1'],
+        vision: false,
+        functionCall: true,
+        reasoning: true
+      },
+      {
+        id: 'Pro/deepseek-ai/DeepSeek-V3.1',
+        name: 'DeepSeek V3.1 Pro',
+        temperature: 0.6,
+        maxTokens: 7000,
+        contextLength: 62000,
+        match: ['pro/deepseek-ai/deepseek-v3.1'],
+        vision: false,
+        functionCall: true,
+        reasoning: true
+      },
+      {
         id: 'Pro/deepseek-ai/DeepSeek-V3',
         name: 'DeepSeek V3 Pro',
         temperature: 0.6,

--- a/src/main/presenter/llmProviderPresenter/providers/siliconcloudProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/siliconcloudProvider.ts
@@ -4,7 +4,10 @@ import {
   MODEL_META,
   ChatMessage,
   KeyStatus,
-  IConfigPresenter
+  IConfigPresenter,
+  LLMCoreStreamEvent,
+  ModelConfig,
+  MCPToolDefinition
 } from '@shared/presenter'
 import { OpenAICompatibleProvider } from './openAICompatibleProvider'
 
@@ -29,8 +32,79 @@ interface SiliconCloudKeyResponse {
 }
 
 export class SiliconcloudProvider extends OpenAICompatibleProvider {
+  // 支持 enable_thinking 参数的模型列表
+  private static readonly ENABLE_THINKING_MODELS: string[] = [
+    'qwen/qwen3-8b',
+    'qwen/qwen3-14b',
+    'qwen/qwen3-32b',
+    'qwen/qwen3-30b-a3b',
+    'qwen/qwen3-235b-a22b',
+    'tencent/hunyuan-a13b-instruct',
+    'zai-org/glm-4.5v',
+    'deepseek-ai/deepseek-v3.1',
+    'pro/deepseek-ai/deepseek-v3.1'
+  ]
+
   constructor(provider: LLM_PROVIDER, configPresenter: IConfigPresenter) {
     super(provider, configPresenter)
+  }
+
+  /**
+   * 检查模型是否支持 enable_thinking 参数
+   * @param modelId 模型ID
+   * @returns boolean 是否支持 enable_thinking
+   */
+  private supportsEnableThinking(modelId: string): boolean {
+    const normalizedModelId = modelId.toLowerCase()
+    return SiliconcloudProvider.ENABLE_THINKING_MODELS.some((supportedModel) =>
+      normalizedModelId.includes(supportedModel)
+    )
+  }
+
+  /**
+   * 重写 coreStream 方法以支持 SiliconCloud 的 enable_thinking 参数
+   */
+  async *coreStream(
+    messages: ChatMessage[],
+    modelId: string,
+    modelConfig: ModelConfig,
+    temperature: number,
+    maxTokens: number,
+    mcpTools: MCPToolDefinition[]
+  ): AsyncGenerator<LLMCoreStreamEvent> {
+    if (!this.isInitialized) throw new Error('Provider not initialized')
+    if (!modelId) throw new Error('Model ID is required')
+
+    const shouldAddEnableThinking = this.supportsEnableThinking(modelId) && modelConfig?.reasoning
+
+    if (shouldAddEnableThinking) {
+      // 原始的 create 方法
+      const originalCreate = this.openai.chat.completions.create.bind(this.openai.chat.completions)
+      // 替换 create 方法以添加 enable_thinking 参数
+      this.openai.chat.completions.create = ((params: any, options?: any) => {
+        const modifiedParams = {
+          ...params,
+          enable_thinking: true
+        }
+        return originalCreate(modifiedParams, options)
+      }) as any
+
+      try {
+        const effectiveModelConfig = { ...modelConfig, reasoning: false }
+        yield* super.coreStream(
+          messages,
+          modelId,
+          effectiveModelConfig,
+          temperature,
+          maxTokens,
+          mcpTools
+        )
+      } finally {
+        this.openai.chat.completions.create = originalCreate
+      }
+    } else {
+      yield* super.coreStream(messages, modelId, modelConfig, temperature, maxTokens, mcpTools)
+    }
   }
 
   protected async fetchOpenAIModels(options?: { timeout: number }): Promise<MODEL_META[]> {


### PR DESCRIPTION
add enable_thinking parameter support for siliconcloud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added four Silicon provider models: Hunyuan A13B Instruct, GLM‑4.5V (with vision), DeepSeek V3.1, and DeepSeek V3.1 Pro.
  - Expanded supported context lengths and token limits for these models.
  - Automatic activation of enhanced reasoning (“thinking”) mode for compatible SiliconCloud models when reasoning is enabled.
- Improvements
  - Better compatibility with function calling across newly added models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->