### PR TITLE
feat: implement thinking parameter support for doubao models

### DIFF
--- a/src/main/presenter/configPresenter/providerModelSettings.ts
+++ b/src/main/presenter/configPresenter/providerModelSettings.ts
@@ -92,7 +92,7 @@ export const providerModelSettings: Record<string, { models: ProviderModelSettin
         match: ['deepseek-v3-1-250821', 'deepseek-v3.1'],
         vision: false,
         functionCall: true,
-        reasoning: true
+        reasoning: false
       },
       {
         id: 'deepseek-r1-250120',


### PR DESCRIPTION
implement thinking parameter support for doubao models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enables “thinking” responses for select Doubao models during streaming.
  - Adds new Doubao models, including thinking and vision-capable variants.

- Changes
  - Updates model capabilities and defaults; reasoning is now disabled by default for certain models (e.g., DeepSeek V3.1 under Doubao).
  - Improves error feedback when the provider isn’t initialized or a model ID is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->