### PR TITLE
feat(dashscope): add qwen3-max-preview model

### DIFF
--- a/src/main/presenter/configPresenter/providerModelSettings.ts
+++ b/src/main/presenter/configPresenter/providerModelSettings.ts
@@ -2567,6 +2567,20 @@ export const providerModelSettings: Record<string, { models: ProviderModelSettin
       },
       // Qwen3系列模型
       {
+        id: 'qwen3-max-preview',
+        name: 'Qwen3 Max Preview',
+        temperature: 0.7,
+        maxTokens: 32768,
+        contextLength: 262144,
+        match: ['qwen3-max-preview'],
+        vision: false,
+        functionCall: true,
+        reasoning: false,
+        enableSearch: true,
+        forcedSearch: false,
+        searchStrategy: 'turbo'
+      },
+      {
         id: 'qwen3-235b-a22b-thinking-2507',
         name: 'Qwen3 235B A22B Thinking 2507',
         temperature: 0.6,

--- a/src/main/presenter/llmProviderPresenter/providers/dashscopeProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/dashscopeProvider.ts
@@ -44,7 +44,8 @@ export class DashscopeProvider extends OpenAICompatibleProvider {
     'qwen-turbo',
     'qwen-turbo-latest',
     'qwen-turbo-2025-07-15',
-    'qwq-plus'
+    'qwq-plus',
+    'qwen3-max-preview'
   ]
 
   constructor(provider: LLM_PROVIDER, configPresenter: IConfigPresenter) {


### PR DESCRIPTION
add qwen3-max-preview model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added the Qwen3 Max Preview model to the Qwen3 series, now selectable in the provider list.
  - Enables search-augmented conversations and tool/function calling with this model.
  - Supports a significantly larger context window for longer prompts and responses.
  - Note: Vision input is not supported; reasoning mode is not enabled for this model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->