### PR TITLE
fix: prevent @ symbol remaining when deleting mentions

### DIFF
--- a/src/renderer/src/components/ChatInput.vue
+++ b/src/renderer/src/components/ChatInput.vue
@@ -280,7 +280,8 @@ const editor = new Editor({
         class:
           'mention px-1.5 py-0.5 text-xs rounded-md bg-secondary text-foreground inline-block max-w-64 align-sub !truncate'
       },
-      suggestion
+      suggestion,
+      deleteTriggerWithBackspace: true
     }),
     Placeholder.configure({
       placeholder: () => {


### PR DESCRIPTION
prevent @ symbol remaining when deleting mentions

Original:

https://github.com/user-attachments/assets/9195fd54-3a18-432a-9181-0382cde196c0



Currently:

https://github.com/user-attachments/assets/122da582-7ce9-443d-a33b-5a35b336d389



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mentions behavior in the chat input: pressing Backspace now cleanly removes the mention trigger when editing, making it easier to correct or adjust mentions mid-typing.
  * Enhances text editing flow by preventing stray trigger characters and reducing friction when modifying mentions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->