### PR TITLE
fix: add missing qwen3-max search configuration in frontend

### DIFF
--- a/src/renderer/src/components/ChatConfig.vue
+++ b/src/renderer/src/components/ChatConfig.vue
@@ -120,6 +120,7 @@ const showSearchConfig = computed(() => {
 
   // 支持搜索的模型列表
   const enableSearchModels = [
+    'qwen3-max',
     'qwen-max',
     'qwen-plus',
     'qwen-plus-latest',

--- a/src/renderer/src/components/settings/ModelConfigDialog.vue
+++ b/src/renderer/src/components/settings/ModelConfigDialog.vue
@@ -748,7 +748,14 @@ const showDashScopeSearch = computed(() => {
   const isDashscope = props.providerId === 'dashscope'
   const modelId = props.modelId.toLowerCase()
   // DashScope 支持搜索的模型列表
-  const supportedModels = ['qwen-max', 'qwen-plus', 'qwen-flash', 'qwen-turbo', 'qwq-plus']
+  const supportedModels = [
+    'qwen3-max',
+    'qwen-max',
+    'qwen-plus',
+    'qwen-flash',
+    'qwen-turbo',
+    'qwq-plus'
+  ]
   const isSupported = supportedModels.some((supportedModel) => modelId.includes(supportedModel))
   return isDashscope && isSupported
 })


### PR DESCRIPTION
add missing qwen3-max search configuration in frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded search support to include the qwen3-max model, bringing it in line with existing DashScope-enabled models.
  * Users selecting qwen3-max will now see the search UI where applicable in chat and model configuration screens.
  * No changes to existing behavior for other models; overall experience remains consistent while broadening model compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->