### PR TITLE
fix: auto-scroll to view after pasting large content

### DIFF
--- a/src/renderer/src/components/ChatInput.vue
+++ b/src/renderer/src/components/ChatInput.vue
@@ -1079,7 +1079,11 @@ onMounted(() => {
             const to = sel.to
 
             // Replace current selection (or insert at cursor) with sanitized text
-            editor.commands.insertContentAt({ from, to }, clean, { updateSelection: true })
+            editor
+              .chain()
+              .insertContentAt({ from, to }, clean, { updateSelection: true })
+              .scrollIntoView()
+              .run()
             // keep the reactive inputText in sync
             inputText.value = editor.getText()
           }


### PR DESCRIPTION
auto-scroll to view after pasting large content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The chat editor now auto-scrolls after inserting text, keeping the cursor and newly added content in view.
- Bug Fixes
  - Improves visibility and continuity when pasting or inserting sanitized text in the chat input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->