### PR TITLE
fix: fork msg can not retry

### DIFF
--- a/src/main/presenter/sqlitePresenter/index.ts
+++ b/src/main/presenter/sqlitePresenter/index.ts
@@ -296,6 +296,11 @@ export class SQLitePresenter implements ISQLitePresenter {
     return this.messagesTable.update(messageId, data)
   }
 
+  // 更新消息父ID
+  public async updateMessageParentId(messageId: string, parentId: string): Promise<void> {
+    return this.messagesTable.updateParentId(messageId, parentId)
+  }
+
   // 删除消息
   public async deleteMessage(messageId: string): Promise<void> {
     return this.messagesTable.delete(messageId)

--- a/src/main/presenter/sqlitePresenter/tables/messages.ts
+++ b/src/main/presenter/sqlitePresenter/tables/messages.ts
@@ -138,6 +138,15 @@ export class MessagesTable extends BaseTable {
     }
   }
 
+  async updateParentId(messageId: string, parentId: string): Promise<void> {
+    const updateStmt = this.db.prepare(`
+      UPDATE messages
+      SET parent_id = ?
+      WHERE msg_id = ?
+    `)
+    updateStmt.run(parentId, messageId)
+  }
+
   async delete(messageId: string): Promise<void> {
     const deleteStmt = this.db.prepare('DELETE FROM messages WHERE msg_id = ?')
     deleteStmt.run(messageId)

--- a/src/shared/types/presenters/legacy.presenters.d.ts
+++ b/src/shared/types/presenters/legacy.presenters.d.ts
@@ -308,6 +308,7 @@ export interface ISQLitePresenter {
       tokenCount?: number
     }
   ): Promise<void>
+  updateMessageParentId(messageId: string, parentId: string): Promise<void>
   deleteMessage(messageId: string): Promise<void>
   getMaxOrderSeq(conversationId: string): Promise<number>
   addMessageAttachment(


### PR DESCRIPTION
- fix #901 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Forking a conversation now consistently preserves parent–child message relationships and correct message order, preventing broken or flattened threads in the new conversation.

* **Refactor**
  * Updated the underlying message duplication and linking process during conversation forks to improve stability and data integrity. No UI changes or user actions required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->