### PR TITLE
fix: add image capture for variants

### DIFF
--- a/src/renderer/src/components/message/MessageItemAssistant.vue
+++ b/src/renderer/src/components/message/MessageItemAssistant.vue
@@ -304,12 +304,14 @@ const handleAction = (action: HandleActionType) => {
 
     emit('scrollToBottom')
   } else if (action === 'copyImage') {
-    emit('copyImage', currentMessage.value.id, currentMessage.value.parentId, false, {
+    // 使用原始消息的ID，因为DOM中的data-message-id使用的是message.id
+    emit('copyImage', props.message.id, currentMessage.value.parentId, false, {
       model_name: currentMessage.value.model_name,
       model_provider: currentMessage.value.model_provider
     })
   } else if (action === 'copyImageFromTop') {
-    emit('copyImage', currentMessage.value.id, currentMessage.value.parentId, true, {
+    // 使用原始消息的ID，因为DOM中的data-message-id使用的是message.id
+    emit('copyImage', props.message.id, currentMessage.value.parentId, true, {
       model_name: currentMessage.value.model_name,
       model_provider: currentMessage.value.model_provider
     })

--- a/src/renderer/src/composables/usePageCapture.ts
+++ b/src/renderer/src/composables/usePageCapture.ts
@@ -337,7 +337,7 @@ export function usePageCapture() {
 
       return { success: true, imageData: finalImage }
     } catch (error) {
-      console.error('[CAPTURE_DEBUG] 截图过程中发生错误:', error)
+      console.error('截图过程中发生错误:', error)
       return {
         success: false,
         error: error instanceof Error ? error.message : '未知错误'
@@ -358,10 +358,12 @@ export function usePageCapture() {
    */
   const captureAndCopy = async (config: CaptureConfig): Promise<boolean> => {
     const result = await captureArea(config)
+
     if (result.success && result.imageData) {
       window.api.copyImage(result.imageData)
       return true
     }
+
     return false
   }
 


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.

When assistant messages have multiple variants, the screenshot function cannot locate and capture the correct message, which makes it difficult for users to save the intended information accurately.

### Describe the solution you'd like

This fix refines the screenshot positioning logic. Regardless of how many variants a message has, screenshots will now reliably target the selected message variant, ensuring accurate captures.

### UI/UX changes for Desktop Application

No new or changed UI/UX elements. The screenshot behavior remains consistent with previous versions, but now correctly handles multi-variant messages, improving user experience.

### Platform Compatibility Notes

This fix has been verified on Windows, macOS, and Linux. No additional platform-specific compatibility changes are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensured image copy actions use the correct raw message ID, aligning with DOM IDs to reliably copy the intended image (including from the top area).

- Style
  - Cleaned console error message by removing a debug prefix during page capture errors.
  - Minor formatting adjustments (added blank lines) in capture flow for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->