### PR TITLE
fix: css style override

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -87,6 +87,10 @@ export default defineConfig({
     ],
     build: {
       minify: 'esbuild',
+      // Ensure CSS order in build matches import order in dev
+      // This prevents extracted CSS from async chunks from reordering
+      // and breaking cascade precedence (e.g. markdown renderer vs app styles)
+      cssCodeSplit: false,
       rollupOptions: {
         input: {
           shell: resolve('src/renderer/shell/index.html'),

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "vitest": "^3.2.4",
     "vue": "^3.5.21",
     "vue-i18n": "^11.1.11",
-    "vue-renderer-markdown": "0.0.52-beta.3",
+    "vue-renderer-markdown": "0.0.53",
     "vue-router": "4",
     "vue-tsc": "^2.2.12",
     "vue-use-monaco": "^0.0.20",

--- a/src/renderer/src/assets/style.css
+++ b/src/renderer/src/assets/style.css
@@ -1,3 +1,4 @@
+@import 'vue-renderer-markdown/index.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -77,9 +78,12 @@
     --display-weight: 700;
     --text-weight: 400;
 
-    --usage-low: 142 71% 45%; /* 亮绿 */
-    --usage-mid: 48 96% 53%; /* 亮黄 */
-    --usage-high: 0 72% 51%; /* 亮红 */
+    --usage-low: 142 71% 45%;
+    /* 亮绿 */
+    --usage-mid: 48 96% 53%;
+    /* 亮黄 */
+    --usage-high: 0 72% 51%;
+    /* 亮红 */
   }
 
   .dark {
@@ -117,18 +121,24 @@
     --sidebar-border: var(--base-800);
     --sidebar-ring: var(--primary-600);
 
-    --usage-low: 142 40% 60%; /* 暗绿 */
-    --usage-mid: 48 80% 60%; /* 暗黄 */
-    --usage-high: 0 70% 65%; /* 暗红 */
+    --usage-low: 142 40% 60%;
+    /* 暗绿 */
+    --usage-mid: 48 80% 60%;
+    /* 暗黄 */
+    --usage-high: 0 70% 65%;
+    /* 暗红 */
   }
 }
+
 @layer base {
   * {
     @apply border-border;
   }
+
   body {
     @apply bg-transparent text-foreground font-text;
   }
+
   html {
     font-family:
       'Geist',
@@ -147,6 +157,7 @@
   .font-display {
     font-weight: var(--display-weight);
   }
+
   .font-text {
     font-weight: var(--text-weight);
   }

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -1,4 +1,3 @@
-import 'vue-renderer-markdown/index.css'
 import './assets/main.css'
 import { addCollection } from '@iconify/vue'
 import lucideIcons from '@iconify-json/lucide/icons.json'


### PR DESCRIPTION
fix css style after build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Consolidated markdown renderer styles into the main stylesheet.
  * Added a base typography layer (fonts, text weight, transparent body background).
  * Minor stylesheet comment formatting adjustments.

* **Chores**
  * Updated vue-renderer-markdown to 0.0.53.
  * Adjusted build configuration to disable CSS code splitting for the renderer.

* **Refactor**
  * Moved markdown CSS import from the app entry point into the central stylesheet for clearer style management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->