### PR TITLE
fix: Enter inserts newline in edit mode

### DIFF
--- a/src/renderer/src/components/message/MessageItemUser.vue
+++ b/src/renderer/src/components/message/MessageItemUser.vue
@@ -33,13 +33,17 @@
         </div>
         <div v-if="isEditMode" class="text-sm w-full min-w-[40vw] whitespace-pre-wrap break-all">
           <textarea
+            ref="editTextarea"
             v-model="editedText"
-            class="text-sm bg-[#EFF6FF] dark:bg-muted rounded-lg p-2 border flex flex-col gap-1.5 resize min-w-[40vw] w-full"
+            class="text-sm bg-[#EFF6FF] dark:bg-muted rounded-lg p-2 border flex flex-col gap-1.5 resize-none overflow-y-auto overscroll-contain min-w-[40vw] w-full"
             :style="{
-              height: originalContentHeight + 18 + 'px',
-              width: originalContentWidth + 20 + 'px'
+              width: originalContentWidth + 20 + 'px',
+              maxHeight: editMaxHeight ? editMaxHeight + 'px' : undefined
             }"
-            @keydown.enter.prevent="saveEdit"
+            rows="1"
+            @input="autoResize"
+            @keydown.meta.enter.prevent="saveEdit"
+            @keydown.ctrl.enter.prevent="saveEdit"
             @keydown.esc="cancelEdit"
           ></textarea>
         </div>
@@ -94,7 +98,7 @@ import MessageContent from './MessageContent.vue'
 import MessageTextContent from './MessageTextContent.vue'
 import { useChatStore } from '@/stores/chat'
 import { usePresenter } from '@/composables/usePresenter'
-import { ref, watch, onMounted } from 'vue'
+import { ref, watch, onMounted, nextTick, onBeforeUnmount } from 'vue'
 
 const chatStore = useChatStore()
 const windowPresenter = usePresenter('windowPresenter')
@@ -107,6 +111,8 @@ const props = defineProps<{
 const isEditMode = ref(false)
 const editedText = ref('')
 const originalContent = ref(null)
+const editTextarea = ref<HTMLTextAreaElement | null>(null)
+const editMaxHeight = ref(0)
 const originalContentHeight = ref(0)
 const originalContentWidth = ref(0)
 
@@ -125,6 +131,8 @@ watch(isEditMode, (newValue) => {
     originalContentHeight.value = (originalContent.value as any).offsetHeight
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     originalContentWidth.value = (originalContent.value as any).offsetWidth
+    computeEditMaxHeight()
+    nextTick(() => autoResize())
   }
 })
 
@@ -142,9 +150,11 @@ const startEdit = () => {
   if (props.message.content?.content && props.message.content.content.length > 0) {
     const textBlocks = props.message.content.content.filter((block) => block.type === 'text')
     editedText.value = textBlocks.map((block) => block.content).join('')
-    return
+  } else {
+    editedText.value = props.message.content.text || ''
   }
-  editedText.value = props.message.content.text || ''
+  computeEditMaxHeight()
+  nextTick(() => autoResize())
 }
 
 const saveEdit = async () => {
@@ -190,4 +200,42 @@ const handleMentionClick = (block: UserMessageMentionBlock) => {
   // 处理 mention 点击事件，可以根据需要实现具体逻辑
   console.log('Mention clicked:', block)
 }
+
+const autoResize = () => {
+  const el = editTextarea.value
+  if (!el) return
+  el.style.height = 'auto'
+  const computed = window.getComputedStyle(el)
+  const maxH = parseFloat(computed.maxHeight || '')
+  const scrollH = el.scrollHeight
+  const target = Number.isFinite(maxH) && maxH > 0 ? Math.min(scrollH, maxH) : scrollH
+  el.style.height = target + 'px'
+  if (scrollH > target) {
+    el.style.overflowY = 'auto'
+  } else {
+    el.style.overflowY = 'hidden'
+  }
+}
+
+watch(editedText, () => {
+  if (isEditMode.value) nextTick(() => autoResize())
+})
+
+const computeEditMaxHeight = () => {
+  const container = document.querySelector('.message-list-container') as HTMLElement | null
+  const base = container?.clientHeight || window.innerHeight
+  editMaxHeight.value = Math.max(120, Math.floor(base * 0.6))
+}
+
+const handleWindowResize = () => {
+  if (isEditMode.value) {
+    computeEditMaxHeight()
+    nextTick(() => autoResize())
+  }
+}
+
+window.addEventListener('resize', handleWindowResize)
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', handleWindowResize)
+})
 </script>


### PR DESCRIPTION
close #905 
Currently, both Enter and Shift+Enter create a new line, while Command+Enter or Ctrl+Enter saves and sends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editing a message now uses an auto-resizing text box that grows with content up to a sensible maximum and then scrolls.
  * Save shortcut updated to Ctrl/Cmd + Enter (Enter inserts a new line); Esc still cancels.
  * Edit area adapts to window size changes for better responsiveness.
  * Editing starts with correctly sized input across all message types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->