### PR TITLE
feat: add regenerate on user messages

### DIFF
--- a/src/renderer/src/components/message/MessageItemUser.vue
+++ b/src/renderer/src/components/message/MessageItemUser.vue
@@ -78,6 +78,7 @@
         :is-assistant="false"
         :is-edit-mode="isEditMode"
         :is-capturing-image="false"
+        @retry="emit('retry')"
         @delete="handleAction('delete')"
         @copy="handleAction('copy')"
         @edit="startEdit"

--- a/src/renderer/src/components/message/MessageList.vue
+++ b/src/renderer/src/components/message/MessageList.vue
@@ -380,19 +380,32 @@ const handleCancel = () => {
 }
 
 // Handle retry event from MessageItemUser
-const handleRetry = (index: number) => {
-  // Find the next assistant message after this user message
+const handleRetry = async (index: number) => {
+  let triggered = false
   for (let i = index + 1; i < props.messages.length; i++) {
     if (props.messages[i].role === 'assistant') {
       try {
         const assistantRef = assistantRefs[i]
         if (assistantRef && typeof assistantRef.handleAction === 'function') {
           assistantRef.handleAction('retry')
-          break
+          triggered = true
         }
       } catch (error) {
         console.error('Failed to trigger retry action:', error)
       }
+      break
+    }
+  }
+
+  if (!triggered) {
+    try {
+      const userMsg = props.messages[index]
+      if (userMsg && userMsg.role === 'user') {
+        await chatStore.regenerateFromUserMessage(userMsg.id)
+        scrollToBottom(true)
+      }
+    } catch (error) {
+      console.error('Failed to regenerate from user message:', error)
     }
   }
 }

--- a/src/renderer/src/components/message/MessageToolbar.vue
+++ b/src/renderer/src/components/message/MessageToolbar.vue
@@ -41,6 +41,20 @@
             <Tooltip :delayDuration="200">
               <TooltipTrigger as-child>
                 <Button
+                  v-show="!isAssistant && !isEditMode"
+                  variant="ghost"
+                  size="icon"
+                  class="w-4 h-4 text-muted-foreground hover:text-primary hover:bg-transparent"
+                  @click="emit('retry')"
+                >
+                  <Icon icon="lucide:refresh-cw" class="w-3 h-3" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{{ t('thread.toolbar.retry') }}</TooltipContent>
+            </Tooltip>
+            <Tooltip :delayDuration="200">
+              <TooltipTrigger as-child>
+                <Button
                   v-show="isAssistant && hasVariants"
                   :disabled="currentVariantIndex === 0"
                   variant="ghost"

--- a/src/renderer/src/stores/chat.ts
+++ b/src/renderer/src/stores/chat.ts
@@ -284,6 +284,29 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
+  const regenerateFromUserMessage = async (userMessageId: string) => {
+    if (!getActiveThreadId()) return
+    try {
+      generatingThreadIds.value.add(getActiveThreadId()!)
+      updateThreadWorkingStatus(getActiveThreadId()!, 'working')
+
+      const aiResponseMessage = await threadP.regenerateFromUserMessage(
+        getActiveThreadId()!,
+        userMessageId
+      )
+
+      getGeneratingMessagesCache().set(aiResponseMessage.id, {
+        message: aiResponseMessage,
+        threadId: getActiveThreadId()!
+      })
+
+      await loadMessages()
+    } catch (error) {
+      console.error('Failed to regenerate from user message:', error)
+      throw error
+    }
+  }
+
   // 创建会话分支（从指定消息开始fork一个新会话）
   const forkThread = async (messageId: string, forkTag: string = '(fork)') => {
     if (!getActiveThreadId()) return
@@ -1237,6 +1260,7 @@ export const useChatStore = defineStore('chat', () => {
     getMessages,
     getCurrentThreadMessages,
     exportThread,
-    showProviderSelector
+    showProviderSelector,
+    regenerateFromUserMessage
   }
 })

--- a/src/shared/types/presenters/legacy.presenters.d.ts
+++ b/src/shared/types/presenters/legacy.presenters.d.ts
@@ -770,6 +770,7 @@ export interface IThreadPresenter {
   ): Promise<{ total: number; list: MESSAGE[] }>
   sendMessage(conversationId: string, content: string, role: MESSAGE_ROLE): Promise<MESSAGE | null>
   startStreamCompletion(conversationId: string, queryMsgId?: string): Promise<void>
+  regenerateFromUserMessage(conversationId: string, userMessageId: string): Promise<MESSAGE>
   editMessage(messageId: string, content: string): Promise<MESSAGE>
   deleteMessage(messageId: string): Promise<void>
   retryMessage(messageId: string, modelId?: string): Promise<MESSAGE>


### PR DESCRIPTION
close #910 
add regenerate on user messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Retry/regenerate an assistant response starting from a specific user message.
  - Added a Retry button on user messages in the thread toolbar.
  - Retry action now bubbles up to trigger the nearest assistant message when available.
  - Falls back to generating a new assistant reply if no retryable assistant message exists.
  - More robust behavior with async handling, visible working state, and automatic scroll to the latest message after regeneration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->