### PR TITLE
fix: add fix for setting page with shortcut

### DIFF
--- a/src/main/presenter/shortcutPresenter.ts
+++ b/src/main/presenter/shortcutPresenter.ts
@@ -110,7 +110,7 @@ export class ShortcutPresenter implements IShortcutPresenter {
       globalShortcut.register(this.shortcutKeys.GoSettings, () => {
         const focusedWindow = presenter.windowPresenter.getFocusedWindow()
         if (focusedWindow?.isFocused()) {
-          presenter.windowPresenter.sendToActiveTab(focusedWindow.id, SHORTCUT_EVENTS.GO_SETTINGS)
+          eventBus.sendToMain(SHORTCUT_EVENTS.GO_SETTINGS, focusedWindow.id)
         }
       })
     }

--- a/src/renderer/shell/components/AppBar.vue
+++ b/src/renderer/shell/components/AppBar.vue
@@ -516,19 +516,9 @@ const closeWindow = () => {
 }
 
 const openSettings = () => {
-  // 检查是否已经存在设置标签页
-  const existingSettingsTab = tabStore.tabs.find((tab) => tab.url.includes('#/settings'))
-
-  if (existingSettingsTab) {
-    // 如果已经存在设置标签页，切换到该标签页
-    tabStore.setCurrentTabId(existingSettingsTab.id)
-  } else {
-    // 如果不存在设置标签页，创建新的
-    tabStore.addTab({
-      name: 'Settings',
-      icon: 'lucide:settings',
-      viewType: 'settings'
-    })
+  const windowId = window.api.getWindowId()
+  if (windowId != null) {
+    windowPresenter.openOrFocusSettingsTab(windowId)
   }
 }
 </script>

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -164,14 +164,7 @@ const handleCreateNewConversation = () => {
   }
 }
 
-// Handle going to settings page
-const handleGoSettings = () => {
-  const currentRoute = router.currentRoute.value
-  // Check if current route or its parent route is already settings
-  if (!currentRoute.path.startsWith('/settings')) {
-    router.push({ name: 'settings' })
-  }
-}
+// Removed GO_SETTINGS handler; now handled in main via tab logic
 
 // Handle ESC key - close floating chat window
 const handleEscKey = (event: KeyboardEvent) => {
@@ -219,9 +212,7 @@ onMounted(() => {
     handleCreateNewConversation()
   })
 
-  window.electron.ipcRenderer.on(SHORTCUT_EVENTS.GO_SETTINGS, () => {
-    handleGoSettings()
-  })
+  // GO_SETTINGS is now handled in main process (open/focus Settings tab)
 
   window.electron.ipcRenderer.on(NOTIFICATION_EVENTS.DATA_RESET_COMPLETE_DEV, () => {
     toast({
@@ -307,7 +298,7 @@ onBeforeUnmount(() => {
   window.electron.ipcRenderer.removeAllListeners(SHORTCUT_EVENTS.ZOOM_OUT)
   window.electron.ipcRenderer.removeAllListeners(SHORTCUT_EVENTS.ZOOM_RESUME)
   window.electron.ipcRenderer.removeAllListeners(SHORTCUT_EVENTS.CREATE_NEW_CONVERSATION)
-  window.electron.ipcRenderer.removeAllListeners(SHORTCUT_EVENTS.GO_SETTINGS)
+  // GO_SETTINGS listener removed; handled in main
   window.electron.ipcRenderer.removeAllListeners(NOTIFICATION_EVENTS.SYS_NOTIFY_CLICKED)
   window.electron.ipcRenderer.removeAllListeners(NOTIFICATION_EVENTS.DATA_RESET_COMPLETE_DEV)
 })

--- a/src/shared/types/presenters/legacy.presenters.d.ts
+++ b/src/shared/types/presenters/legacy.presenters.d.ts
@@ -190,6 +190,7 @@ export interface IWindowPresenter {
   sendToAllWindows(channel: string, ...args: unknown[]): void
   sendToWindow(windowId: number, channel: string, ...args: unknown[]): boolean
   sendToDefaultTab(channel: string, switchToTarget?: boolean, ...args: unknown[]): Promise<boolean>
+  openOrFocusSettingsTab(windowId: number): Promise<void>
   closeWindow(windowId: number, forceClose?: boolean): Promise<void>
   isApplicationQuitting(): boolean
   setApplicationQuitting(isQuitting: boolean): void


### PR DESCRIPTION
fix #918 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Opening Settings now focuses an existing tab or creates one if needed, ensuring consistent behavior from the AppBar and keyboard shortcut across windows.

- Bug Fixes
  - Prevents duplicate Settings tabs and improves reliability when switching or restoring focus to Settings.

- Refactor
  - Centralized Settings navigation logic to a single main-process pathway and unified it behind a window-scoped action for consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->