### PR TITLE
feat: add Qwen3-VL and Qwen3-Max 0924

### DIFF
--- a/src/main/presenter/configPresenter/providerModelSettings.ts
+++ b/src/main/presenter/configPresenter/providerModelSettings.ts
@@ -2730,10 +2730,24 @@ export const providerModelSettings: Record<string, { models: ProviderModelSettin
       },
       // Qwen3 series models
       {
+        id: 'qwen3-max-2025-09-23',
+        name: 'Qwen3 Max 20250923',
+        temperature: 0.7,
+        maxTokens: 65536,
+        contextLength: 262144,
+        match: ['qwen3-max-2025-09-23'],
+        vision: false,
+        functionCall: true,
+        reasoning: false,
+        enableSearch: true,
+        forcedSearch: false,
+        searchStrategy: 'turbo'
+      },
+      {
         id: 'qwen3-max-preview',
         name: 'Qwen3 Max Preview',
         temperature: 0.7,
-        maxTokens: 32768,
+        maxTokens: 65536,
         contextLength: 262144,
         match: ['qwen3-max-preview'],
         vision: false,
@@ -2862,6 +2876,18 @@ export const providerModelSettings: Record<string, { models: ProviderModelSettin
         functionCall: true,
         reasoning: true,
         thinkingBudget: 20000
+      },
+      {
+        id: 'qwen3-vl-plus',
+        name: 'Qwen3 VL Plus',
+        temperature: 0.6,
+        maxTokens: 32768,
+        contextLength: 262144,
+        match: ['qwen3-vl-plus', 'qwen3-vl-plus-2025-09-23'],
+        vision: true,
+        functionCall: false,
+        reasoning: true,
+        thinkingBudget: 81920
       },
       // QwQ series models
       {

--- a/src/main/presenter/llmProviderPresenter/providers/dashscopeProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/dashscopeProvider.ts
@@ -24,6 +24,7 @@ export class DashscopeProvider extends OpenAICompatibleProvider {
     'qwen3-1.7b',
     'qwen3-0.6b',
     // Commercial versions
+    'qwen3-vl-plus',
     'qwen-plus',
     'qwen-plus-latest',
     'qwen-plus-2025-04-28',
@@ -36,6 +37,7 @@ export class DashscopeProvider extends OpenAICompatibleProvider {
 
   // List of models that support enable_search parameter (internet search)
   private static readonly ENABLE_SEARCH_MODELS: string[] = [
+    'qwen3-max-2025-09-23',
     'qwen3-max-preview',
     'qwen-max',
     'qwen-plus',

--- a/src/renderer/src/components/ChatConfig.vue
+++ b/src/renderer/src/components/ChatConfig.vue
@@ -141,6 +141,7 @@ const showThinkingBudget = computed(() => {
     'qwen3-1.7b',
     'qwen3-0.6b',
     // Commercial versions
+    'qwen3-vl-plus',
     'qwen-plus',
     'qwen-flash',
     'qwen-turbo'
@@ -161,6 +162,7 @@ const showDashscopeSearchConfig = computed(() => {
   // Dashscope - ENABLE_SEARCH_MODELS
   const enableSearchModels = [
     'qwen3-max-preview',
+    'qwen3-max-2025-09-23',
     'qwen3-max',
     'qwen-max',
     'qwen-plus',
@@ -242,7 +244,11 @@ const getQwen3MaxBudget = (): number => {
   const modelId = props.modelId?.toLowerCase() || ''
 
   // 根据不同的 Qwen3 模型返回不同的最大值
-  if (modelId.includes('qwen3-235b-a22b') || modelId.includes('qwen3-30b-a3b')) {
+  if (
+    modelId.includes('qwen3-235b-a22b') ||
+    modelId.includes('qwen3-30b-a3b') ||
+    modelId.includes('qwen3-vl-plus')
+  ) {
     return 81920
   } else if (
     modelId.includes('qwen3-32b') ||
@@ -257,6 +263,11 @@ const getQwen3MaxBudget = (): number => {
 
   // 默认值
   return 81920
+}
+
+// 获取 Qwen3 模型的最小思考预算（统一为 1）
+const getQwen3MinBudget = (): number => {
+  return 1
 }
 
 // 获取 Gemini 模型的思考预算配置范围
@@ -351,11 +362,12 @@ const qwen3ThinkingBudgetError = computed(() => {
 
   const value = props.thinkingBudget
   const maxBudget = getQwen3MaxBudget()
+  const minBudget = getQwen3MinBudget()
 
   if (value === undefined || value === null) {
     return ''
   }
-  if (value < 1) {
+  if (value < minBudget) {
     return t('settings.model.modelConfig.thinkingBudget.qwen3.validation.minValue')
   }
   if (value > maxBudget) {
@@ -579,7 +591,7 @@ const qwen3ThinkingBudgetError = computed(() => {
             <Input
               v-model.number="displayThinkingBudget"
               type="number"
-              :min="1"
+              :min="getQwen3MinBudget()"
               :max="getQwen3MaxBudget()"
               :step="128"
               :placeholder="t('settings.model.modelConfig.thinkingBudget.qwen3.placeholder')"
@@ -594,7 +606,7 @@ const qwen3ThinkingBudgetError = computed(() => {
                   displayThinkingBudget === undefined
                     ? t('settings.model.modelConfig.currentUsingModelDefault')
                     : t('settings.model.modelConfig.thinkingBudget.range', {
-                        min: 1,
+                        min: getQwen3MinBudget(),
                         max: getQwen3MaxBudget()
                       })
                 }}

--- a/src/renderer/src/components/settings/ModelConfigDialog.vue
+++ b/src/renderer/src/components/settings/ModelConfigDialog.vue
@@ -706,6 +706,15 @@ const getThinkingBudgetConfig = (modelId: string) => {
     }
   }
 
+  if (modelId.includes('qwen3-vl-plus')) {
+    return {
+      min: 1,
+      max: 81920,
+      defaultValue: 81920,
+      canDisable: true
+    }
+  }
+
   if (
     modelId.includes('qwen3-32b') ||
     modelId.includes('qwen3-14b') ||
@@ -822,6 +831,7 @@ const showQwen3ThinkingBudget = computed(() => {
     'qwen3-1.7b',
     'qwen3-0.6b',
     // Commercial versions
+    'qwen3-vl-plus',
     'qwen-plus',
     'qwen-plus-latest',
     'qwen-plus-2025-04-28',
@@ -845,6 +855,7 @@ const showDashScopeSearch = computed(() => {
   const modelId = props.modelId.toLowerCase()
   // DashScope - ENABLE_SEARCH_MODELS
   const supportedSearchModels = [
+    'qwen3-max-2025-09-23',
     'qwen3-max-preview',
     'qwen3-max',
     'qwen-max',


### PR DESCRIPTION
add Qwen3-VL and Qwen3-Max

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for new Qwen3 models: qwen3-max-2025-09-23 and qwen3-vl-plus.
  * Enabled web search for qwen3-max-2025-09-23.
  * Enabled “thinking” mode for qwen3-vl-plus with a max thinking budget of 81,920.
  * Increased max tokens for Qwen3 Max Preview to 65,536.

* UI Improvements
  * Thinking budget controls now include qwen3-vl-plus and use a dynamic minimum (1).
  * Updated settings and chat configuration to reflect new models and search/thinking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->