### PR TITLE
fix: show all models in model check dialog instead of only enabled ones

### DIFF
--- a/src/renderer/src/components/settings/ModelCheckDialog.vue
+++ b/src/renderer/src/components/settings/ModelCheckDialog.vue
@@ -138,9 +138,9 @@ const isChecking = ref(false)
 const selectedModelId = ref<string>('')
 const result = ref<{ isOk: boolean; errorMsg: string | null } | null>(null)
 
-// 计算可用的模型列表
+// 计算可用的模型列表 - 显示所有模型
 const availableModels = computed(() => {
-  const providerModels = settingsStore.enabledModels.find((p) => p.providerId === props.providerId)
+  const providerModels = settingsStore.allProviderModels.find((p) => p.providerId === props.providerId)
   return providerModels?.models || []
 })
 

--- a/src/renderer/src/components/settings/ModelCheckDialog.vue
+++ b/src/renderer/src/components/settings/ModelCheckDialog.vue
@@ -140,7 +140,9 @@ const result = ref<{ isOk: boolean; errorMsg: string | null } | null>(null)
 
 // 计算可用的模型列表 - 显示所有模型
 const availableModels = computed(() => {
-  const providerModels = settingsStore.allProviderModels.find((p) => p.providerId === props.providerId)
+  const providerModels = settingsStore.allProviderModels.find(
+    (p) => p.providerId === props.providerId
+  )
   return providerModels?.models || []
 })
 


### PR DESCRIPTION
  ## Problem
  When validating API key in provider settings, the model check dialog shows "no available models"
  even though models were successfully fetched from the provider API.

  ## Root Cause
  The model check dialog was using `settingsStore.enabledModels` which only contains models that have
  been manually enabled by users. Newly fetched models have `enabled: false` by default.

  ## Solution
  Changed `ModelCheckDialog.vue` to use `settingsStore.allProviderModels` instead of `enabledModels`,
  so all fetched models (both enabled and disabled) are shown in the dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model selection dialog now shows all models available from the chosen provider (not limited to previously enabled models), enabling broader discovery.
  * Makes it easier to compare and validate model availability per provider without pre-enabling models, streamlining setup and evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->