### PR TITLE
chore: remove unused radix-vue dependency

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -47,7 +47,7 @@ DeepChat is an Electron application. This means it has:
 
 -   **Backend (Main Process)**: TypeScript
 -   **Frontend (Renderer Process)**: Vue.js (version 3), TypeScript, Pinia (for state management), Vue Router (for navigation).
--   **Styling**: Tailwind CSS and Shadcn/ui components are likely used given common project setups and `tailwind.config.js`, `components.json`.
+-   **Styling**: Tailwind CSS along with shadcn/ui components that consume primitives from `reka-ui`, replacing the earlier Radix Vue dependency.
 -   **Build Tool**: Electron Vite is used for a fast development server and optimized builds (`electron.vite.config.ts`).
 -   **Packaging**: Electron Builder (`electron-builder.yml`).
 

--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
     "picocolors": "^1.1.1",
     "pinia": "^3.0.3",
     "prettier": "^3.5.3",
-    "radix-vue": "^1.9.17",
     "reka-ui": "^2.5.0",
     "simple-git-hooks": "^2.13.1",
     "tailwind-merge": "^3.3.1",


### PR DESCRIPTION
## Summary
- remove the unused radix-vue dev dependency now that the shadcn components depend on reka-ui
- document the reka-ui dependency switch in the developer guide

## Testing
- pnpm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dff4d253a4832cb93a5c6b2ea1a386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated developer guide to reflect styling stack: Tailwind CSS with shadcn/ui components built on reka-ui primitives; notes replacement of the previous dependency.

- Chores
  - Removed an unused Radix Vue development dependency to streamline the toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->