### PR TITLE
fix global ignore of message variants in context

### DIFF
--- a/src/main/presenter/threadPresenter/index.ts
+++ b/src/main/presenter/threadPresenter/index.ts
@@ -1694,7 +1694,11 @@ export class ThreadPresenter implements IThreadPresenter {
     return results.map((result) => JSON.parse(result.content) as SearchResult) ?? []
   }
 
-  async startStreamCompletion(conversationId: string, queryMsgId?: string) {
+  async startStreamCompletion(
+    conversationId: string,
+    queryMsgId?: string,
+    selectedVariantsMap?: Record<string, string>
+  ) {
     const state = this.findGeneratingState(conversationId)
     if (!state) {
       console.warn('未找到状态，conversationId:', conversationId)
@@ -1707,7 +1711,8 @@ export class ThreadPresenter implements IThreadPresenter {
       // 1. 获取上下文信息
       const { conversation, userMessage, contextMessages } = await this.prepareConversationContext(
         conversationId,
-        queryMsgId
+        queryMsgId,
+        selectedVariantsMap
       )
 
       const { providerId, modelId } = conversation.settings
@@ -1823,7 +1828,11 @@ export class ThreadPresenter implements IThreadPresenter {
       throw error
     }
   }
-  async continueStreamCompletion(conversationId: string, queryMsgId: string) {
+  async continueStreamCompletion(
+    conversationId: string,
+    queryMsgId: string,
+    selectedVariantsMap?: Record<string, string>
+  ) {
     const state = this.findGeneratingState(conversationId)
     if (!state) {
       console.warn('未找到状态，conversationId:', conversationId)
@@ -1890,7 +1899,8 @@ export class ThreadPresenter implements IThreadPresenter {
       // 6. 获取上下文信息
       const { conversation, contextMessages, userMessage } = await this.prepareConversationContext(
         conversationId,
-        state.message.id
+        state.message.id,
+        selectedVariantsMap
       )
 
       // 检查是否已被取消
@@ -2020,7 +2030,8 @@ export class ThreadPresenter implements IThreadPresenter {
   // 准备会话上下文
   private async prepareConversationContext(
     conversationId: string,
-    queryMsgId?: string
+    queryMsgId?: string,
+    selectedVariantsMap?: Record<string, string>
   ): Promise<{
     conversation: CONVERSATION
     userMessage: Message
@@ -2066,6 +2077,34 @@ export class ThreadPresenter implements IThreadPresenter {
       }
       contextMessages = await this.getContextMessages(conversationId)
     }
+
+    // ================= 阶段三核心修改：开始 =================
+    // 在获取原始 contextMessages 列表之后，但在将其传递给 LLM 上下文筛选和格式化函数之前，
+    // 插入核心“变体内容和元数据替换”逻辑。
+    if (selectedVariantsMap && Object.keys(selectedVariantsMap).length > 0) {
+      contextMessages = contextMessages.map((msg) => {
+        if (msg.role === 'assistant' && selectedVariantsMap[msg.id] && msg.variants) {
+          const selectedVariantId = selectedVariantsMap[msg.id]
+          const selectedVariant = msg.variants.find((v) => v.id === selectedVariantId)
+
+          if (selectedVariant) {
+            // 创建一个新的 Message 对象副本，并用变体的内容和元数据替换
+            // 使用深拷贝以避免意外修改原始对象
+            const newMsg = JSON.parse(JSON.stringify(msg))
+            newMsg.content = selectedVariant.content
+            newMsg.usage = selectedVariant.usage
+            newMsg.model_id = selectedVariant.model_id
+            newMsg.model_provider = selectedVariant.model_provider
+            // 返回修改后的副本
+            return newMsg
+          }
+          // 防御性代码：如果找不到变体，则静默回退到使用原始主消息
+        }
+        // 对于非助手消息或没有选择变体的助手消息，返回原始消息
+        return msg
+      })
+    }
+    // ================= 阶段三核心修改：结束 =================
 
     // 处理 UserMessageMentionBlock
     if (userMessage.role === 'user') {
@@ -2677,7 +2716,8 @@ export class ThreadPresenter implements IThreadPresenter {
 
   async regenerateFromUserMessage(
     conversationId: string,
-    userMessageId: string
+    userMessageId: string,
+    selectedVariantsMap?: Record<string, string>
   ): Promise<AssistantMessage> {
     const userMessage = await this.messageManager.getMessage(userMessageId)
     if (!userMessage || userMessage.role !== 'user') {
@@ -2717,7 +2757,7 @@ export class ThreadPresenter implements IThreadPresenter {
       lastReasoningTime: null
     })
 
-    this.startStreamCompletion(conversationId, userMessageId).catch((e) => {
+    this.startStreamCompletion(conversationId, userMessageId, selectedVariantsMap).catch((e) => {
       console.error('Failed to start regeneration from user message:', e)
     })
 
@@ -2840,12 +2880,14 @@ export class ThreadPresenter implements IThreadPresenter {
         if (msg.role === 'user') {
           return {
             message: msg,
-            length:
-              `${(msg.content as UserMessageContent).text}${getFileContext((msg.content as UserMessageContent).files)}`
-                .length,
+            length: `${(msg.content as UserMessageContent).text}${getFileContext(
+              (msg.content as UserMessageContent).files
+            )}`.length,
             formattedMessage: {
               role: 'user' as const,
-              content: `${(msg.content as UserMessageContent).text}${getFileContext((msg.content as UserMessageContent).files)}`
+              content: `${(msg.content as UserMessageContent).text}${getFileContext(
+                (msg.content as UserMessageContent).files
+              )}`
             }
           }
         } else {
@@ -2918,13 +2960,15 @@ export class ThreadPresenter implements IThreadPresenter {
    * @param targetMessageId 目标消息ID（截止到该消息的所有消息将被复制）
    * @param newTitle 新会话标题
    * @param settings 新会话设置
+   * @param selectedVariantsMap 选定的变体映射表 (可选)
    * @returns 新创建的会话ID
    */
   async forkConversation(
     targetConversationId: string,
     targetMessageId: string,
     newTitle: string,
-    settings?: Partial<CONVERSATION_SETTINGS>
+    settings?: Partial<CONVERSATION_SETTINGS>,
+    selectedVariantsMap?: Record<string, string>
   ): Promise<string> {
     try {
       // 1. 获取源会话信息
@@ -2936,88 +2980,109 @@ export class ThreadPresenter implements IThreadPresenter {
       // 2. 创建新会话
       const newConversationId = await this.sqlitePresenter.createConversation(newTitle)
 
-      // 更新会话设置
-      if (settings || sourceConversation.settings) {
-        await this.updateConversationSettings(
-          newConversationId,
-          settings || sourceConversation.settings
-        )
-      }
+      const newSettings = { ...(settings || sourceConversation.settings) }
+      newSettings.selectedVariantsMap = {} // 确保新会话不继承变体选择
+      await this.updateConversationSettings(newConversationId, newSettings)
 
-      // 更新is_new标志
       await this.sqlitePresenter.updateConversation(newConversationId, { is_new: 0 })
 
-      // 3. 获取源会话中的消息历史
-      const message = await this.messageManager.getMessage(targetMessageId)
-      if (!message) {
+      // ================= 最终 BUG 修复：开始 =================
+      // 3.1. 获取完整的、未截断的会话历史（只包含主消息）
+      const { list: fullHistory } = await this.messageManager.getMessageThread(
+        targetConversationId,
+        1,
+        99999 // 使用一个足够大的数字确保获取全部历史
+      )
+
+      // 3.2. 获取用户点击的目标消息对象
+      const targetMessage = await this.messageManager.getMessage(targetMessageId)
+      if (!targetMessage) {
         throw new Error('目标消息不存在')
       }
 
-      // 获取目标消息之前的所有消息（包括目标消息）
-      const messageHistory = await this.getMessageHistory(targetMessageId, 100)
+      // 3.3. 确定目标消息所属的“主消息”ID
+      let mainTargetId: string | null = null
+      if (targetMessage.is_variant) {
+        // 如果是变体，则通过其 parentId（指向用户消息）找到其主消息
+        if (!targetMessage.parentId) {
+          throw new Error('变体消息缺少 parentId，无法定位主消息')
+        }
+        const mainMessage = await this.messageManager.getMainMessageByParentId(
+          targetConversationId,
+          targetMessage.parentId
+        )
+        mainTargetId = mainMessage ? mainMessage.id : null
+      } else {
+        // 如果本身就是主消息
+        mainTargetId = targetMessage.id
+      }
+
+      if (!mainTargetId) {
+        throw new Error('无法确定用于分叉的历史记录目标主消息ID')
+      }
+
+      // 3.4. 在完整历史中找到主消息的索引
+      const forkEndIndex = fullHistory.findIndex((msg) => msg.id === mainTargetId)
+      if (forkEndIndex === -1) {
+        throw new Error('目标主消息在会话历史中未找到，无法分叉。')
+      }
+
+      // 3.5. 截取从开始到目标主消息（包括）的正确历史记录
+      const messageHistory = fullHistory.slice(0, forkEndIndex + 1)
+      // ================= 最终 BUG 修复：结束 =================
 
       // 4. 创建消息ID映射表，用于维护父子关系
       const messageIdMap = new Map<string, string>() // 旧消息ID -> 新消息ID
-      const parentChildMap = new Map<string, string[]>() // 父消息ID -> 子消息ID列表
       const messagesToProcess: Array<{ msg: any; orderSeq: number }> = []
 
-      // 首先收集所有需要复制的消息，并建立父子关系映射
       for (const msg of messageHistory) {
-        // 只复制已发送成功的消息
         if (msg.status !== 'sent') {
           continue
         }
-
-        // 获取消息序号
         const orderSeq = (await this.sqlitePresenter.getMaxOrderSeq(newConversationId)) + 1
-
-        // 记录父子关系
-        if (msg.parentId && msg.parentId !== '') {
-          if (!parentChildMap.has(msg.parentId)) {
-            parentChildMap.set(msg.parentId, [])
-          }
-          parentChildMap.get(msg.parentId)!.push(msg.id)
-        }
-
         messagesToProcess.push({ msg, orderSeq })
       }
 
       // 5. 按顺序插入所有消息，先不设置父ID
       for (const { msg, orderSeq } of messagesToProcess) {
-        // 解析元数据
+        let finalMsg = msg
+        // 当循环到我们关心的主消息时，检查 selectedVariantsMap
+        if (msg.role === 'assistant' && selectedVariantsMap && selectedVariantsMap[msg.id]) {
+          const selectedVariantId = selectedVariantsMap[msg.id]
+          const variant = msg.variants?.find((v) => v.id === selectedVariantId)
+          if (variant) {
+            finalMsg = variant // 使用选定的变体对象进行复制
+          }
+        }
+
         const metadata: MESSAGE_METADATA = {
-          totalTokens: msg.usage?.total_tokens || 0,
+          totalTokens: finalMsg.usage?.total_tokens || 0,
           generationTime: 0,
           firstTokenTime: 0,
           tokensPerSecond: 0,
           contextUsage: 0,
-          inputTokens: msg.usage?.input_tokens || 0,
-          outputTokens: msg.usage?.output_tokens || 0,
-          ...(msg.model_id ? { model: msg.model_id } : {}),
-          ...(msg.model_provider ? { provider: msg.model_provider } : {})
+          inputTokens: finalMsg.usage?.input_tokens || 0,
+          outputTokens: finalMsg.usage?.output_tokens || 0,
+          ...(finalMsg.model_id ? { model: finalMsg.model_id } : {}),
+          ...(finalMsg.model_provider ? { provider: finalMsg.model_provider } : {})
         }
 
-        // 计算token数量
-        const tokenCount = msg.usage?.total_tokens || 0
+        const tokenCount = finalMsg.usage?.total_tokens || 0
+        const content =
+          typeof finalMsg.content === 'string' ? finalMsg.content : JSON.stringify(finalMsg.content)
 
-        // 内容处理（确保是字符串）
-        const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content)
-
-        // 插入消息记录，暂时不设置父ID
         const newMessageId = await this.sqlitePresenter.insertMessage(
-          newConversationId, // 新会话ID
-          content, // 内容
-          msg.role, // 角色
-          '', // 暂时无父消息ID，稍后更新
-          JSON.stringify(metadata), // 元数据
-          orderSeq, // 序号
-          tokenCount, // token数
-          'sent', // 状态固定为sent
-          0, // 不是上下文边界
-          0 // 不是变体
+          newConversationId,
+          content,
+          finalMsg.role,
+          '',
+          JSON.stringify(metadata),
+          orderSeq,
+          tokenCount,
+          'sent',
+          0,
+          0
         )
-
-        // 记录新旧消息ID的映射关系
         messageIdMap.set(msg.id, newMessageId)
       }
 
@@ -3026,7 +3091,6 @@ export class ThreadPresenter implements IThreadPresenter {
         if (msg.parentId && msg.parentId !== '') {
           const newMessageId = messageIdMap.get(msg.id)
           const newParentId = messageIdMap.get(msg.parentId)
-
           if (newMessageId && newParentId) {
             await this.sqlitePresenter.updateMessageParentId(newMessageId, newParentId)
           }

--- a/src/renderer/src/components/MessageNavigationSidebar.vue
+++ b/src/renderer/src/components/MessageNavigationSidebar.vue
@@ -161,12 +161,8 @@ const getFullMessageContent = (message: Message): string => {
     return userContent.text || ''
   } else if (message.role === 'assistant') {
     const assistantMessage = message as import('@shared/chat').AssistantMessage
-    let contentToDisplay =
+    const contentToDisplay =
       assistantMessage.content as import('@shared/chat').AssistantMessageBlock[]
-    if (assistantMessage.variants && assistantMessage.variants.length > 0) {
-      const latestVariant = assistantMessage.variants[assistantMessage.variants.length - 1]
-      contentToDisplay = latestVariant.content as import('@shared/chat').AssistantMessageBlock[]
-    }
     return contentToDisplay
       .filter((block: import('@shared/chat').AssistantMessageBlock) => block.type === 'content')
       .map((block: import('@shared/chat').AssistantMessageBlock) => block.content || '')

--- a/src/renderer/src/components/message/MessageItemAssistant.vue
+++ b/src/renderer/src/components/message/MessageItemAssistant.vue
@@ -157,7 +157,7 @@ const emit = defineEmits<{
     fromTop: boolean,
     modelInfo: { model_name: string; model_provider: string }
   ]
-  scrollToBottom: []
+  variantChanged: [messageId: string]
 }>()
 
 // 获取当前会话ID
@@ -337,7 +337,7 @@ const handleAction = (action: HandleActionType) => {
     // store 的更新会通过 computed 属性自动反馈到 UI
     chatStore.updateSelectedVariant(mainMessageId, selectedVariantId)
 
-    emit('scrollToBottom')
+    emit('variantChanged', props.message.id)
   } else if (action === 'copyImage') {
     // 使用原始消息的ID，因为DOM中的data-message-id使用的是message.id
     emit('copyImage', props.message.id, currentMessage.value.parentId, false, {

--- a/src/renderer/src/components/message/MessageItemAssistant.vue
+++ b/src/renderer/src/components/message/MessageItemAssistant.vue
@@ -231,7 +231,7 @@ watch(
     // 并且当前会话不是正在生成中的消息，避免在生成过程中频繁切换
     if (newLength > oldLength && !chatStore.generatingThreadIds.has(currentThreadId.value)) {
       const newVariantIndex = newLength // 新变体的索引
-      
+
       const mainMessageId = props.message.id
       // newVariantIndex 此时至少为 1
       const selectedVariant = allVariants.value[newVariantIndex - 1]
@@ -324,7 +324,7 @@ const handleAction = (action: HandleActionType) => {
         if (newIndex < totalVariants.value - 1) newIndex++
         break
     }
-    
+
     // 如果计算出的新索引与当前索引相同，则不执行任何操作
     if (newIndex === currentVariantIndex.value) return
 
@@ -332,7 +332,7 @@ const handleAction = (action: HandleActionType) => {
     // 如果 newIndex 是 0，则 selectedVariant 为 null，表示选择主消息
     const selectedVariant = newIndex > 0 ? allVariants.value[newIndex - 1] : null
     const selectedVariantId = selectedVariant ? selectedVariant.id : null
-    
+
     // 不再直接修改本地 state，而是调用 store 的 action 来更新全局状态
     // store 的更新会通过 computed 属性自动反馈到 UI
     chatStore.updateSelectedVariant(mainMessageId, selectedVariantId)

--- a/src/renderer/src/components/message/MessageItemAssistant.vue
+++ b/src/renderer/src/components/message/MessageItemAssistant.vue
@@ -111,7 +111,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { AssistantMessage, AssistantMessageBlock } from '@shared/chat'
 import MessageBlockContent from './MessageBlockContent.vue'
 import MessageBlockThink from './MessageBlockThink.vue'
@@ -147,7 +147,6 @@ const props = defineProps<{
 const themeStore = useThemeStore()
 const chatStore = useChatStore()
 const settingsStore = useSettingsStore()
-const currentVariantIndex = ref(0)
 const { t } = useI18n()
 
 // 定义事件
@@ -163,6 +162,28 @@ const emit = defineEmits<{
 
 // 获取当前会话ID
 const currentThreadId = computed(() => chatStore.getActiveThreadId() || '')
+
+// ============================= 核心修复：开始 =============================
+
+// 1. 将 currentVariantIndex 从 ref 改造为 computed 属性
+//    这确保了其值总是与 Pinia store 中的状态同步，从根本上消除了竞态条件。
+const currentVariantIndex = computed(() => {
+  const selectedVariantId = chatStore.selectedVariantsMap.get(props.message.id)
+
+  // 如果 store 中没有记录，则显示主消息 (索引 0)
+  if (!selectedVariantId) {
+    return 0
+  }
+
+  // 在所有变体中查找已选择的 ID
+  const variantIndex = allVariants.value.findIndex((v) => v.id === selectedVariantId)
+
+  // 如果找到了，返回其索引 + 1 (因为索引 0 是主消息)
+  // 如果没找到 (数据过时或已删除)，则安全地回退到主消息
+  return variantIndex !== -1 ? variantIndex + 1 : 0
+})
+
+// ============================= 核心修复：结束 =============================
 
 // 获取当前显示的消息（根据变体索引）
 const currentMessage = computed(() => {
@@ -202,18 +223,21 @@ const currentContent = computed(() => {
   return (variant?.content || props.message.content) as AssistantMessageBlock[]
 })
 
-// 监听变体变化
+// 监听 allVariants 长度变化，用于新变体生成时的自动切换和持久化
 watch(
   () => allVariants.value.length,
   (newLength, oldLength) => {
-    // 如果当前没有选中任何变体，或者当前选中的是最后一个变体
-    // 则自动跟随最新的变体
-    if (currentVariantIndex.value === 0 || newLength > oldLength) {
-      currentVariantIndex.value = newLength
-    }
-    // 如果当前选中的变体超出范围，调整到最后一个变体
-    else if (currentVariantIndex.value > newLength) {
-      currentVariantIndex.value = newLength
+    // 仅当新变体被添加时触发
+    // 并且当前会话不是正在生成中的消息，避免在生成过程中频繁切换
+    if (newLength > oldLength && !chatStore.generatingThreadIds.has(currentThreadId.value)) {
+      const newVariantIndex = newLength // 新变体的索引
+      
+      const mainMessageId = props.message.id
+      // newVariantIndex 此时至少为 1
+      const selectedVariant = allVariants.value[newVariantIndex - 1]
+
+      // 只有当 selectedVariant 存在时才调用 updateSelectedVariant，确保是有效的变体
+      chatStore.updateSelectedVariant(mainMessageId, selectedVariant ? selectedVariant.id : null)
     }
   }
 )
@@ -222,10 +246,6 @@ const isSearchResult = computed(() => {
   return Boolean(
     currentContent.value?.some((block) => block.type === 'search' && block.status === 'success')
   )
-})
-
-onMounted(async () => {
-  currentVariantIndex.value = allVariants.value.length
 })
 
 // 分支会话对话框
@@ -293,18 +313,29 @@ const handleAction = (action: HandleActionType) => {
         .trim()
     )
   } else if (action === 'prev' || action === 'next') {
+    // 修改 prev/next 逻辑以遵循单向数据流
+    let newIndex = currentVariantIndex.value // 获取当前计算出的索引
+
     switch (action) {
       case 'prev':
-        if (currentVariantIndex.value > 0) {
-          currentVariantIndex.value--
-        }
+        if (newIndex > 0) newIndex--
         break
       case 'next':
-        if (currentVariantIndex.value < totalVariants.value - 1) {
-          currentVariantIndex.value++
-        }
+        if (newIndex < totalVariants.value - 1) newIndex++
         break
     }
+    
+    // 如果计算出的新索引与当前索引相同，则不执行任何操作
+    if (newIndex === currentVariantIndex.value) return
+
+    const mainMessageId = props.message.id
+    // 如果 newIndex 是 0，则 selectedVariant 为 null，表示选择主消息
+    const selectedVariant = newIndex > 0 ? allVariants.value[newIndex - 1] : null
+    const selectedVariantId = selectedVariant ? selectedVariant.id : null
+    
+    // 不再直接修改本地 state，而是调用 store 的 action 来更新全局状态
+    // store 的更新会通过 computed 属性自动反馈到 UI
+    chatStore.updateSelectedVariant(mainMessageId, selectedVariantId)
 
     emit('scrollToBottom')
   } else if (action === 'copyImage') {

--- a/src/renderer/src/components/message/MessageList.vue
+++ b/src/renderer/src/components/message/MessageList.vue
@@ -17,7 +17,7 @@
             :message="msg as AssistantMessage"
             :is-capturing-image="isCapturingImage"
             @copy-image="handleCopyImage"
-            @scroll-to-bottom="scrollToBottom"
+            @variant-changed="scrollToMessage"
           />
           <MessageItemUser
             v-if="msg.role === 'user'"
@@ -297,7 +297,7 @@ const scrollToMessage = (messageId: string) => {
     const messageElement = document.querySelector(`[data-message-id="${messageId}"]`)
     if (messageElement) {
       messageElement.scrollIntoView({
-        behavior: 'smooth',
+        behavior: 'instant',
         block: 'start'
       })
 

--- a/src/renderer/src/stores/chat.ts
+++ b/src/renderer/src/stores/chat.ts
@@ -64,7 +64,8 @@ export const useChatStore = defineStore('chat', () => {
     forcedSearch: undefined,
     searchStrategy: undefined,
     reasoningEffort: undefined,
-    verbosity: undefined
+    verbosity: undefined,
+    selectedVariantsMap: {}
   })
 
   // Deeplink 消息缓存
@@ -75,6 +76,9 @@ export const useChatStore = defineStore('chat', () => {
     autoSend?: boolean
     mentions?: string[]
   } | null>(null)
+
+  // 新增：用于管理当前激活会话的 selectedVariantsMap
+  const selectedVariantsMap = ref<Map<string, string>>(new Map())
 
   // Getters
   const getTabId = () => window.api.getWebContentsId()
@@ -145,6 +149,7 @@ export const useChatStore = defineStore('chat', () => {
     if (!getActiveThreadId()) return
     await threadP.clearActiveThread(tabId)
     setActiveThreadId(null)
+    selectedVariantsMap.value.clear()
   }
 
   // 处理消息的 extra 信息
@@ -257,7 +262,11 @@ export const useChatStore = defineStore('chat', () => {
       })
 
       await loadMessages()
-      await threadP.startStreamCompletion(getActiveThreadId()!)
+      await threadP.startStreamCompletion(
+        getActiveThreadId()!,
+        undefined,
+        Object.fromEntries(selectedVariantsMap.value)
+      )
     } catch (error) {
       console.error('Failed to send message:', error)
       throw error
@@ -277,7 +286,11 @@ export const useChatStore = defineStore('chat', () => {
       generatingThreadIds.value.add(getActiveThreadId()!)
       // 设置当前会话的workingStatus为working
       updateThreadWorkingStatus(getActiveThreadId()!, 'working')
-      await threadP.startStreamCompletion(getActiveThreadId()!, messageId)
+      await threadP.startStreamCompletion(
+        getActiveThreadId()!,
+        messageId,
+        Object.fromEntries(selectedVariantsMap.value)
+      )
     } catch (error) {
       console.error('Failed to retry message:', error)
       throw error
@@ -292,7 +305,8 @@ export const useChatStore = defineStore('chat', () => {
 
       const aiResponseMessage = await threadP.regenerateFromUserMessage(
         getActiveThreadId()!,
-        userMessageId
+        userMessageId,
+        Object.fromEntries(selectedVariantsMap.value)
       )
 
       getGeneratingMessagesCache().set(aiResponseMessage.id, {
@@ -323,7 +337,8 @@ export const useChatStore = defineStore('chat', () => {
         getActiveThreadId()!,
         messageId,
         newThreadTitle,
-        currentThread.settings
+        currentThread.settings,
+        Object.fromEntries(selectedVariantsMap.value)
       )
 
       // 切换到新会话
@@ -765,6 +780,14 @@ export const useChatStore = defineStore('chat', () => {
       }
       if (conversation) {
         chatConfig.value = { ...conversation.settings }
+        // Populate the in-memory map from the loaded settings
+        if (conversation.settings.selectedVariantsMap) {
+          selectedVariantsMap.value = new Map(
+            Object.entries(conversation.settings.selectedVariantsMap)
+          )
+        } else {
+          selectedVariantsMap.value.clear()
+        }
       }
     } catch (error) {
       console.error('Failed to load conversation config:', error)
@@ -789,14 +812,47 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   const deleteMessage = async (messageId: string) => {
-    if (!getActiveThreadId()) return
+    const activeThreadId = getActiveThreadId()
+    if (!activeThreadId) return
+
     try {
+      const messages = getMessages()
+      let parentMessage: AssistantMessage | undefined
+      let parentIndex = -1
+      const mainMsgIndex = messages.findIndex((m) => m.id === messageId)
+      if (mainMsgIndex !== -1 && (messages[mainMsgIndex] as AssistantMessage).is_variant === 0) {
+        if (selectedVariantsMap.value.has(messageId)) {
+          selectedVariantsMap.value.delete(messageId)
+          await updateSelectedVariant(messageId, null)
+        }
+      } else {
+        for (let i = 0; i < messages.length; i++) {
+          const msg = messages[i] as AssistantMessage
+          if (msg.role === 'assistant' && msg.variants?.some((v) => v.id === messageId)) {
+            parentMessage = msg
+            parentIndex = i
+            break
+          }
+        }
+
+        if (parentMessage && parentIndex !== -1) {
+          const remainingVariants = parentMessage.variants?.filter((v) => v.id !== messageId) || []
+          parentMessage.variants = remainingVariants
+          messages[parentIndex] = { ...parentMessage }
+          const newSelectedVariantId =
+            remainingVariants.length > 0 ? remainingVariants[remainingVariants.length - 1].id : null
+          await updateSelectedVariant(parentMessage.id, newSelectedVariantId)
+        }
+      }
+
       await threadP.deleteMessage(messageId)
-      loadMessages()
+      await loadMessages()
     } catch (error) {
       console.error('Failed to delete message:', error)
+      await loadMessages()
     }
   }
+
   const clearAllMessages = async (threadId: string) => {
     if (!threadId) return
     try {
@@ -886,7 +942,11 @@ export const useChatStore = defineStore('chat', () => {
       })
 
       await loadMessages()
-      await threadP.continueStreamCompletion(conversationId, messageId)
+      await threadP.continueStreamCompletion(
+        conversationId,
+        messageId,
+        Object.fromEntries(selectedVariantsMap.value)
+      )
     } catch (error) {
       console.error('Failed to continue generation:', error)
       throw error
@@ -956,6 +1016,34 @@ export const useChatStore = defineStore('chat', () => {
           getMessages()[msgIndex] = enrichedMessage as AssistantMessage | UserMessage
         }
       }
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // 新增：更新和持久化变体选择
+  const updateSelectedVariant = async (mainMessageId: string, selectedVariantId: string | null) => {
+    const activeThreadId = getActiveThreadId()
+    if (!activeThreadId) return
+
+    // 更新内存中的 Map
+    if (selectedVariantId && selectedVariantId !== mainMessageId) {
+      selectedVariantsMap.value.set(mainMessageId, selectedVariantId)
+    } else {
+      selectedVariantsMap.value.delete(mainMessageId)
+    }
+
+    // 同步更新 chatConfig 内的 selectedVariantsMap
+    if (chatConfig.value) {
+      chatConfig.value.selectedVariantsMap = Object.fromEntries(selectedVariantsMap.value)
+    }
+
+    // 持久化到后端
+    try {
+      await threadP.updateConversationSettings(activeThreadId, {
+        selectedVariantsMap: Object.fromEntries(selectedVariantsMap.value)
+      })
+    } catch (error) {
+      console.error('Failed to update selected variant:', error)
     }
   }
 
@@ -1107,7 +1195,7 @@ export const useChatStore = defineStore('chat', () => {
     )
 
     // 监听：定向的会话激活事件
-    window.electron.ipcRenderer.on(CONVERSATION_EVENTS.ACTIVATED, (_, msg) => {
+    window.electron.ipcRenderer.on(CONVERSATION_EVENTS.ACTIVATED, async (_, msg) => {
       // 确保是发给当前Tab的事件
       if (msg.tabId !== getTabId()) {
         return
@@ -1124,8 +1212,9 @@ export const useChatStore = defineStore('chat', () => {
         }
       }
 
-      loadMessages()
-      loadChatConfig() // 加载对话配置
+      // 竞态？
+      await loadChatConfig() // 加载对话配置
+      await loadMessages()
 
       // 新增：在会话激活处理完成后，通过usePresenter发送确认信号
       tabP.onRendererTabActivated(msg.conversationId)
@@ -1228,6 +1317,7 @@ export const useChatStore = defineStore('chat', () => {
     threads,
     messagesMap,
     generatingThreadIds,
+    selectedVariantsMap,
     // Getters
     activeThread,
     // Actions
@@ -1261,6 +1351,7 @@ export const useChatStore = defineStore('chat', () => {
     getCurrentThreadMessages,
     exportThread,
     showProviderSelector,
-    regenerateFromUserMessage
+    regenerateFromUserMessage,
+    updateSelectedVariant
   }
 })

--- a/src/renderer/src/views/ChatTabView.vue
+++ b/src/renderer/src/views/ChatTabView.vue
@@ -56,7 +56,7 @@
       class="fixed right-0 top-0 w-80 max-w-80 h-full z-10 hidden lg:block"
     >
       <MessageNavigationSidebar
-        :messages="chatStore.getMessages()"
+        :messages="chatStore.variantAwareMessages"
         :is-open="chatStore.isMessageNavigationOpen"
         @close="chatStore.isMessageNavigationOpen = false"
         @scroll-to-message="handleScrollToMessage"
@@ -78,7 +78,7 @@
           <!-- 侧边栏 -->
           <div ref="messageNavigationRef" class="w-80 max-w-80">
             <MessageNavigationSidebar
-              :messages="chatStore.getMessages()"
+              :messages="chatStore.variantAwareMessages"
               :is-open="chatStore.isMessageNavigationOpen"
               @close="chatStore.isMessageNavigationOpen = false"
               @scroll-to-message="handleScrollToMessage"

--- a/src/shared/presenter.d.ts
+++ b/src/shared/presenter.d.ts
@@ -1,2 +1,22 @@
 // Compatibility stub: keep '@shared/presenter' import path stable during refactor
+
+// Re-declared based on usage in threadPresenter and chat.ts to add the new property
+export interface CONVERSATION_SETTINGS {
+  systemPrompt: string
+  temperature: number
+  contextLength: number
+  maxTokens: number
+  providerId: string
+  modelId: string
+  artifacts: 0 | 1
+  enabledMcpTools?: string[]
+  thinkingBudget?: number
+  enableSearch?: boolean
+  forcedSearch?: boolean
+  searchStrategy?: 'turbo' | 'max'
+  reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high'
+  verbosity?: 'low' | 'medium' | 'high'
+  selectedVariantsMap?: Record<string, string> // New property for variant selection
+}
+
 export * from './types/index'

--- a/src/shared/types/presenters/legacy.presenters.d.ts
+++ b/src/shared/types/presenters/legacy.presenters.d.ts
@@ -706,6 +706,7 @@ export interface ILlmProviderPresenter {
   ): Promise<string>
 }
 
+/*
 export type CONVERSATION_SETTINGS = {
   systemPrompt: string
   temperature: number
@@ -722,6 +723,7 @@ export type CONVERSATION_SETTINGS = {
   reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high'
   verbosity?: 'low' | 'medium' | 'high'
 }
+*/
 
 export type CONVERSATION = {
   id: string
@@ -758,7 +760,8 @@ export interface IThreadPresenter {
     targetConversationId: string,
     targetMessageId: string,
     newTitle: string,
-    settings?: Partial<CONVERSATION_SETTINGS>
+    settings?: Partial<CONVERSATION_SETTINGS>,
+    selectedVariantsMap?: Record<string, string>
   ): Promise<string>
 
   // Conversation list and activation status
@@ -782,8 +785,16 @@ export interface IThreadPresenter {
     pageSize: number
   ): Promise<{ total: number; list: MESSAGE[] }>
   sendMessage(conversationId: string, content: string, role: MESSAGE_ROLE): Promise<MESSAGE | null>
-  startStreamCompletion(conversationId: string, queryMsgId?: string): Promise<void>
-  regenerateFromUserMessage(conversationId: string, userMessageId: string): Promise<MESSAGE>
+  startStreamCompletion(
+    conversationId: string,
+    queryMsgId?: string,
+    selectedVariantsMap?: Record<string, string>
+  ): Promise<void>
+  regenerateFromUserMessage(
+    conversationId: string,
+    userMessageId: string,
+    selectedVariantsMap?: Record<string, string>
+  ): Promise<MESSAGE>
   editMessage(messageId: string, content: string): Promise<MESSAGE>
   deleteMessage(messageId: string): Promise<void>
   retryMessage(messageId: string, modelId?: string): Promise<MESSAGE>
@@ -813,7 +824,11 @@ export interface IThreadPresenter {
   setSearchAssistantModel(model: MODEL_META, providerId: string): void
   getMainMessageByParentId(conversationId: string, parentId: string): Promise<Message | null>
   destroy(): void
-  continueStreamCompletion(conversationId: string, queryMsgId: string): Promise<AssistantMessage>
+  continueStreamCompletion(
+    conversationId: string,
+    queryMsgId: string,
+    selectedVariantsMap?: Record<string, string>
+  ): Promise<AssistantMessage>
   toggleConversationPinned(conversationId: string, isPinned: boolean): Promise<void>
   findTabForConversation(conversationId: string): Promise<number | null>
 


### PR DESCRIPTION
fix: 系统性修复"历史上下文构建中对消息变体选择的全局性忽略"BUG
fix: 用户在UI界面中的会话变体消息选择实现永固化（后向兼容)
fix: prepareMsg/forkMsg/continueMsg/starStreaming等上下文构建全修正，以用户UI界面所选择的变体为准构建会话历史
fix: UI切换变体时修正视口滚动，同步切换消息导航内容
