### PR TITLE
fix: sync tool-call defaults for provider configs

### DIFF
--- a/src/main/presenter/configPresenter/modelConfig.ts
+++ b/src/main/presenter/configPresenter/modelConfig.ts
@@ -277,6 +277,17 @@ export class ModelConfigHelper {
     if (storedConfig && storedSource) {
       const finalStoredConfig = { ...storedConfig }
       finalStoredConfig.isUserDefined = false
+
+      if (storedSource !== 'user' && normProviderId && normModelId) {
+        const db = providerDbLoader.getDb()
+        const resolvedProviderId = this.resolveProviderId(normProviderId)
+        const provider = resolvedProviderId ? db?.providers?.[resolvedProviderId] : undefined
+        const model = provider?.models.find((m) => m.id === normModelId)
+        if (typeof model?.tool_call === 'boolean') {
+          finalStoredConfig.functionCall = model.tool_call
+        }
+      }
+
       return finalStoredConfig
     }
 


### PR DESCRIPTION
## Summary
- streamline the config presenter by removing provider DB tool-call sync listeners added in the previous attempt
- teach the model config helper to overlay Provider DB tool_call flags onto provider-managed configs while respecting user overrides
- extend the provider DB config tests with explicit tool_call scenarios and adjust fixture defaults to reflect the new expectations

## Testing
- pnpm vitest run providerDbModelConfig

------
https://chatgpt.com/codex/tasks/task_e_68ec879fde2c832c9bb060371eb7700c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Provider-managed function-calling settings are now correctly applied to non-user configurations and stay in sync with provider updates.
  - User-defined function-calling preferences reliably take precedence over provider defaults.

- Tests
  - Added coverage for precedence and sync behavior between provider and user settings.
  - Expanded test scenarios to validate default flags and overlay logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->