### PR TITLE
Fix appbar style on windows and linux

### DIFF
--- a/src/main/presenter/windowPresenter/index.ts
+++ b/src/main/presenter/windowPresenter/index.ts
@@ -654,6 +654,7 @@ export class WindowPresenter implements IWindowPresenter {
       titleBarStyle: 'hiddenInset', // macOS 风格标题栏
       transparent: process.platform === 'darwin', // macOS 标题栏透明
       vibrancy: process.platform === 'darwin' ? 'hud' : undefined, // macOS 磨砂效果
+      backgroundMaterial: process.platform === 'win32' ? 'mica' : undefined, // Windows 11 材质效果
       backgroundColor: '#00ffffff', // 透明背景色
       maximizable: true, // 允许最大化
       frame: process.platform === 'darwin', // macOS 无边框

--- a/src/renderer/shell/App.vue
+++ b/src/renderer/shell/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-screen h-screen">
+  <div class="w-screen h-screen" :class="isWinMacOS ? '' : 'bg-background'">
     <AppBar />
     <main class="content-container">
       <!-- WebContentsView will be rendered here by the main process -->
@@ -11,12 +11,12 @@
 import AppBar from './components/AppBar.vue'
 import { ref, onMounted } from 'vue'
 import { usePresenter } from '@/composables/usePresenter'
-const isMacOS = ref(false)
+const isWinMacOS = ref(false)
 const devicePresenter = usePresenter('devicePresenter')
 // Shell component setup
 onMounted(() => {
   devicePresenter.getDeviceInfo().then((deviceInfo) => {
-    isMacOS.value = deviceInfo.platform === 'darwin'
+    isWinMacOS.value = deviceInfo.platform === 'darwin' || deviceInfo.platform === 'win32'
   })
 })
 </script>

--- a/src/renderer/shell/components/AppBar.vue
+++ b/src/renderer/shell/components/AppBar.vue
@@ -3,7 +3,7 @@
     class="flex flex-row h-9 min-h-9 border border-b-0 border-window-inner-border box-border rounded-t-[10px] relative overflow-hidden"
     :class="[
       !isFullscreened && isMacOS ? '' : ' rounded-t-none',
-      isMacOS ? 'bg-window-background' : ''
+      isMacOS ? 'bg-window-background' : 'bg-window-background/10'
     ]"
     :dir="langStore.dir"
   >

--- a/src/renderer/shell/components/AppBar.vue
+++ b/src/renderer/shell/components/AppBar.vue
@@ -4,7 +4,7 @@
     :class="[!isFullscreened && isMacOS ? '' : ' rounded-t-none']"
     :dir="langStore.dir"
   >
-    <div class="absolute bottom-0 left-0 w-full h-[1px] bg-border"></div>
+    <div class="absolute bottom-0 left-0 w-full h-[1px] bg-border z-10"></div>
     <div
       class="h-full shrink-0 w-0 flex-1 flex select-none text-center text-sm font-medium flex-row items-center justify-start window-drag-region"
     >

--- a/src/renderer/shell/components/AppBar.vue
+++ b/src/renderer/shell/components/AppBar.vue
@@ -102,7 +102,7 @@
       </Button>
       <Button
         v-if="!isMacOS"
-        class="window-no-drag-region shrink-0 w-12 bg-transparent shadow-none rounded-none hover:bg-card/80 text-xs font-medium text-foreground flex items-center justify-center transition-all duration-200 group"
+        class="window-no-drag-region shrink-0 w-12 bg-transparent shadow-none rounded-none hover:bg-red-700/80 text-xs font-medium text-foreground flex items-center justify-center transition-all duration-200 group"
         @click="closeWindow"
       >
         <CloseIcon class="h-3! w-3!" />

--- a/src/renderer/shell/components/AppBar.vue
+++ b/src/renderer/shell/components/AppBar.vue
@@ -1,7 +1,10 @@
 <template>
   <div
-    class="flex flex-row h-9 min-h-9 bg-window-background border border-b-0 border-window-inner-border box-border rounded-t-[10px] relative overflow-hidden"
-    :class="[!isFullscreened && isMacOS ? '' : ' rounded-t-none']"
+    class="flex flex-row h-9 min-h-9 border border-b-0 border-window-inner-border box-border rounded-t-[10px] relative overflow-hidden"
+    :class="[
+      !isFullscreened && isMacOS ? '' : ' rounded-t-none',
+      isMacOS ? 'bg-window-background' : ''
+    ]"
     :dir="langStore.dir"
   >
     <div class="absolute bottom-0 left-0 w-full h-[1px] bg-border z-10"></div>
@@ -102,7 +105,7 @@
       </Button>
       <Button
         v-if="!isMacOS"
-        class="window-no-drag-region shrink-0 w-12 bg-transparent shadow-none rounded-none hover:bg-red-700/80 text-xs font-medium text-foreground flex items-center justify-center transition-all duration-200 group"
+        class="window-no-drag-region shrink-0 w-12 bg-transparent shadow-none rounded-none hover:bg-red-700/80 hover:text-white text-xs font-medium text-foreground flex items-center justify-center transition-all duration-200 group"
         @click="closeWindow"
       >
         <CloseIcon class="h-3! w-3!" />

--- a/src/renderer/src/assets/style.css
+++ b/src/renderer/src/assets/style.css
@@ -120,7 +120,7 @@
     /* light */
     /* color */
     --bg-accent: hsl(0 0 15% / 0.05);
-    --bg-window-background: hsl(0 0 100% / 0.1);
+    --bg-window-background: hsl(0 0 100% / 0.5);
     --bg-background-70: hsl(0 0 100% / 0.7);
     --bg-card: hsl(0 0 100%);
     --bg-primary: hsl(210 100% 43%);
@@ -178,7 +178,7 @@
     /* dark */
     /* color */
     --bg-accent: hsl(0 0 100% / 0.05);
-    --bg-window-background: hsl(0 0 0% / 1);
+    --bg-window-background: hsl(0 0 10% / 0.5);
     --bg-background-70: hsl(0 0 15% / 0.7);
 
     --bg-muted: hsl(0 0 100% / 0.03);
@@ -254,7 +254,7 @@
       --bg-primary: hsl(210 100% 43%);
       --bg-primary-70: hsl(210 100% 43% / 0.7);
       --bg-primary-700: hsl(210 100% 37%);
-      --bg-window-background: hsl(0 0 10% / 0.7);
+      --bg-window-background: hsl(0 0 10% / 0.5);
       --border-window-outside: hsl(0 0 0% / 0.4);
       --shadow-card: hsl(0 0 0% / 0.4);
       --syntax-bold: var(--color-blue-500);

--- a/src/renderer/src/components/NewThread.vue
+++ b/src/renderer/src/components/NewThread.vue
@@ -1,16 +1,5 @@
 <template>
   <div class="h-full w-full flex flex-col items-center justify-start">
-    <div class="w-full p-2 flex flex-row gap-2 items-center">
-      <Button
-        class="w-7 h-7 rounded-md"
-        size="icon"
-        variant="outline"
-        @click="onSidebarButtonClick"
-      >
-        <Icon v-if="chatStore.isSidebarOpen" icon="lucide:panel-left-close" class="w-4 h-4" />
-        <Icon v-else icon="lucide:panel-left-open" class="w-4 h-4" />
-      </Button>
-    </div>
     <div class="h-0 w-full grow flex flex-col items-center justify-center">
       <img src="@/assets/logo-dark.png" class="w-24 h-24" loading="lazy" />
       <h1 class="text-2xl font-bold px-8 pt-4">{{ t('newThread.greeting') }}</h1>
@@ -326,10 +315,6 @@ const handleMouseEnter = () => {
 
 const handleMouseLeave = () => {
   isHovering.value = false
-}
-
-const onSidebarButtonClick = () => {
-  chatStore.isSidebarOpen = !chatStore.isSidebarOpen
 }
 
 const handleModelUpdate = (model: MODEL_META, providerId: string) => {

--- a/src/renderer/src/components/mcpToolsList.vue
+++ b/src/renderer/src/components/mcpToolsList.vue
@@ -99,10 +99,8 @@ onMounted(async () => {
               id="mcp-btn"
               variant="outline"
               :class="[
-                'flex border border-input rounded-lg shadow-sm items-center gap-1.5 h-7 text-xs px-1.5 w-auto',
-                mcpEnabled
-                  ? 'dark:!bg-primary bg-primary border-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground'
-                  : ''
+                'flex text-accent-foreground rounded-lg shadow-sm items-center gap-1.5 h-7 text-xs px-1.5 w-auto',
+                mcpEnabled ? 'text-primary' : ''
               ]"
               size="icon"
             >
@@ -114,12 +112,9 @@ onMounted(async () => {
               />
               <Icon v-else icon="lucide:hammer" class="w-4 h-4" />
 
-              <span
-                v-if="hasTools && !isLoading && !isError"
-                :class="{ 'text-muted-foreground': !mcpEnabled, 'text-white': mcpEnabled }"
-                class="text-sm"
-                >{{ getTotalEnabledToolCount() }}</span
-              >
+              <span v-if="hasTools && !isLoading && !isError" class="text-sm">{{
+                getTotalEnabledToolCount()
+              }}</span>
             </Button>
           </TooltipTrigger>
           <TooltipContent>

--- a/src/renderer/src/components/message/MessageItemUser.vue
+++ b/src/renderer/src/components/message/MessageItemUser.vue
@@ -2,7 +2,7 @@
   <div
     v-show="!message.content.continue"
     :data-message-id="message.id"
-    class="flex flex-row-reverse group py-4 pl-11 gap-2 user-message-item"
+    class="flex flex-row-reverse group pl-11 gap-2 user-message-item"
   >
     <!-- 头像 -->
     <div class="w-5 h-5 bg-muted rounded-md overflow-hidden">
@@ -18,7 +18,7 @@
         :timestamp="message.timestamp"
       />
       <!-- 消息内容 -->
-      <div class="text-sm bg-[#EFF6FF] dark:bg-muted rounded-lg p-2 border flex flex-col gap-1.5">
+      <div class="text-sm bg-muted dark:bg-muted rounded-lg p-2 border flex flex-col gap-1.5">
         <div v-show="message.content.files.length > 0" class="flex flex-wrap gap-1.5">
           <FileItem
             v-for="file in message.content.files"
@@ -35,7 +35,7 @@
           <textarea
             ref="editTextarea"
             v-model="editedText"
-            class="text-sm bg-[#EFF6FF] dark:bg-muted rounded-lg p-2 border flex flex-col gap-1.5 resize-none overflow-y-auto overscroll-contain min-w-[40vw] w-full"
+            class="text-sm bg-muted dark:bg-muted rounded-lg p-2 border flex flex-col gap-1.5 resize-none overflow-y-auto overscroll-contain min-w-[40vw] w-full"
             :style="{
               width: originalContentWidth + 20 + 'px',
               maxHeight: editMaxHeight ? editMaxHeight + 'px' : undefined

--- a/src/renderer/src/components/message/MessageList.vue
+++ b/src/renderer/src/components/message/MessageList.vue
@@ -7,7 +7,7 @@
     >
       <div
         ref="messageList"
-        class="w-full break-all transition-opacity duration-300"
+        class="w-full break-all transition-opacity duration-300 pt-4"
         :class="{ 'opacity-0': !visible }"
       >
         <div

--- a/src/renderer/src/components/message/MessageToolbar.vue
+++ b/src/renderer/src/components/message/MessageToolbar.vue
@@ -2,7 +2,7 @@
   <template v-if="!isCapturingImage">
     <TooltipProvider>
       <div
-        class="w-full h-8 text-xs text-muted-foreground items-center justify-between flex flex-row opacity-0 group-hover:opacity-100 transition-opacity"
+        class="w-full h-7 text-xs text-muted-foreground items-center justify-between flex flex-row opacity-0 group-hover:opacity-100 transition-opacity"
         :class="[isAssistant ? '' : 'flex-row-reverse']"
       >
         <span v-show="!loading" class="flex flex-row gap-3">

--- a/src/renderer/src/components/prompt-input/ModelChooser.vue
+++ b/src/renderer/src/components/prompt-input/ModelChooser.vue
@@ -1,65 +1,68 @@
 <template>
-  <div
-    class="flex w-full flex-col gap-3 rounded-2xl border border-border/60 bg-card/95 p-4 shadow-[0_26px_60px_-32px_rgba(12,18,36,0.85)] backdrop-blur-lg dark:border-white/10 dark:bg-[#0b111b]/95"
+  <Card
+    class="w-full border-border/60 bg-card/95 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/80"
     :dir="langStore.dir"
   >
-    <Input
-      v-model="keyword"
-      :placeholder="t('model.search.placeholder')"
-      class="h-9 w-full rounded-lg border border-border/50 bg-white/60 px-3 text-xs font-medium text-foreground/80 placeholder:text-muted-foreground/70 focus-visible:border-primary focus-visible:bg-white focus-visible:ring-0 dark:border-white/10 dark:bg-white/[0.08] dark:text-white/80 dark:placeholder:text-white/50 dark:focus-visible:bg-white/[0.12]"
-    />
-    <ScrollArea class="h-72 pr-2">
-      <div class="flex flex-col gap-4">
-        <div v-for="provider in filteredProviders" :key="provider.id" class="flex flex-col gap-2">
-          <p
-            class="px-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70 dark:text-white/60"
-          >
-            {{ provider.name }}
-          </p>
-          <div class="flex flex-col gap-1.5" role="listbox" aria-orientation="vertical">
-            <button
-              v-for="model in provider.models"
-              :key="`${provider.id}-${model.id}`"
-              type="button"
-              class="relative flex w-full items-center gap-3 overflow-hidden rounded-xl border border-border/60 bg-white/70 px-4 py-2 text-left text-xs font-semibold text-foreground/80 shadow-[0_1px_0_rgba(9,13,24,0.08)] transition-all duration-200 hover:-translate-y-0.5 hover:border-border/80 hover:bg-white/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 dark:border-white/12 dark:bg-white/[0.06] dark:text-white/80 dark:shadow-[0_1px_0_rgba(12,18,36,0.4)] dark:hover:border-white/30 dark:hover:bg-white/12 before:absolute before:inset-y-2 before:left-1 before:w-px before:rounded-full before:bg-primary before:opacity-0 before:transition-opacity before:duration-200"
-              :class="[
-                isSelected(provider.id, model.id)
-                  ? 'border-primary/80 bg-primary/12 text-foreground shadow-[0_16px_34px_-22px_rgba(37,99,235,0.55)] ring-1 ring-primary/40 before:opacity-100 dark:border-[#3c82ff]/70 dark:bg-[#162237]/90 dark:text-white dark:ring-[#3c82ff]/45 dark:before:bg-[#3c82ff]'
-                  : 'dark:before:bg-white/20'
-              ]"
-              role="option"
-              :aria-selected="isSelected(provider.id, model.id)"
-              :data-selected="isSelected(provider.id, model.id)"
-              @click="handleModelSelect(provider.id, model)"
+    <CardContent class="flex flex-col gap-4 p-4">
+      <Input
+        v-model="keyword"
+        :placeholder="t('model.search.placeholder')"
+        class="h-9 w-full text-sm"
+      />
+      <ScrollArea class="h-72 pr-2">
+        <div class="flex flex-col gap-5">
+          <div v-for="provider in filteredProviders" :key="provider.id" class="flex flex-col gap-2">
+            <Badge
+              variant="outline"
+              class="w-fit uppercase tracking-[0.18em] text-[10px] font-semibold text-muted-foreground"
             >
-              <div
-                class="flex h-7 w-7 items-center justify-center rounded-lg border border-border/60 bg-white/80 text-[11px] font-semibold uppercase text-muted-foreground/80 transition-all duration-200 group-data-[selected=true]:border-transparent group-data-[selected=true]:bg-primary group-data-[selected=true]:text-white/90 dark:border-white/15 dark:bg-white/[0.08] dark:group-data-[selected=true]:bg-[#3c82ff]"
+              {{ provider.name }}
+            </Badge>
+            <div class="flex flex-col gap-1.5" role="listbox" aria-orientation="vertical">
+              <Button
+                v-for="model in provider.models"
+                :key="`${provider.id}-${model.id}`"
+                type="button"
+                variant="outline"
+                class="group w-full justify-start gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition data-[selected=true]:border-primary data-[selected=true]:bg-primary/10 data-[selected=true]:text-foreground/90 dark:data-[selected=true]:bg-primary/15"
+                role="option"
+                :aria-selected="isSelected(provider.id, model.id)"
+                :data-selected="isSelected(provider.id, model.id)"
+                @click="handleModelSelect(provider.id, model)"
               >
-                <ModelIcon
-                  class="h-4 w-4 shrink-0 opacity-70 transition duration-200 group-hover:opacity-100 group-data-[selected=true]:opacity-100"
-                  :model-id="provider.id"
-                  :is-dark="themeStore.isDark"
+                <div
+                  class="flex h-7 w-7 items-center justify-center rounded-md border border-border bg-muted/40 text-[11px] font-semibold uppercase text-muted-foreground transition group-data-[selected=true]:border-primary group-data-[selected=true]:bg-primary/20 group-data-[selected=true]:text-primary"
+                >
+                  <ModelIcon
+                    class="h-4 w-4 shrink-0 opacity-80 transition group-hover:opacity-100 group-data-[selected=true]:opacity-100"
+                    :model-id="provider.id"
+                    :is-dark="themeStore.isDark"
+                  />
+                </div>
+                <span class="flex-1 truncate">
+                  {{ model.name }}
+                </span>
+                <Icon
+                  v-if="isSelected(provider.id, model.id)"
+                  icon="lucide:check"
+                  class="h-4 w-4 shrink-0 text-primary dark:text-primary/80"
+                  aria-hidden="true"
                 />
-              </div>
-              <span class="flex-1 truncate text-[13px] font-medium">
-                {{ model.name }}
-              </span>
-              <Icon
-                icon="lucide:check"
-                class="h-3.5 w-3.5 shrink-0 text-primary opacity-0 transition-opacity duration-200 group-data-[selected=true]:opacity-100 dark:text-[#9db8ff]"
-                aria-hidden="true"
-              />
-            </button>
+              </Button>
+            </div>
           </div>
         </div>
-      </div>
-    </ScrollArea>
-  </div>
+      </ScrollArea>
+    </CardContent>
+  </Card>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, type PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { Badge } from '@shadcn/components/ui/badge'
+import { Button } from '@shadcn/components/ui/button'
+import { Card, CardContent } from '@shadcn/components/ui/card'
 import { Input } from '@shadcn/components/ui/input'
 import { ScrollArea } from '@shadcn/components/ui/scroll-area'
 import { useChatStore } from '@/stores/chat'

--- a/src/renderer/src/components/prompt-input/PromptInput.vue
+++ b/src/renderer/src/components/prompt-input/PromptInput.vue
@@ -47,7 +47,7 @@
                 <Button
                   variant="outline"
                   size="icon"
-                  class="w-7 h-7 text-xs rounded-lg dark:border-white/10 dark:bg-transparent dark:text-white/70 dark:hover:border-white/25 dark:hover:bg-white/10 dark:hover:text-white"
+                  class="w-7 h-7 text-xs rounded-lg text-accent-foreground"
                   @click="openFilePicker"
                 >
                   <Icon icon="lucide:paperclip" class="w-4 h-4" />
@@ -65,56 +65,18 @@
             </Tooltip>
             <Tooltip>
               <TooltipTrigger>
-                <span
-                  class="overflow-hidden border-white/10 flex items-center h-7 rounded-lg shadow-sm border transition-all duration-300"
-                  :class="{
-                    'border-primary': settings.webSearch
-                  }"
+                <Button
+                  variant="outline"
+                  :class="[
+                    'w-7 h-7  text-accent-foreground rounded-lg',
+                    settings.webSearch ? 'text-primary' : ''
+                  ]"
                   :dir="langStore.dir"
+                  size="icon"
+                  @click="onWebSearchClick"
                 >
-                  <Button
-                    variant="outline"
-                    :class="[
-                      'flex w-7 border-none rounded-none shadow-none items-center gap-1.5 px-2 h-full text-foreground ',
-                      settings.webSearch
-                        ? 'dark:!bg-primary hover:bg-primary/90 hover:text-primary-foreground'
-                        : 'dark:text-white/70'
-                    ]"
-                    :dir="langStore.dir"
-                    size="icon"
-                    @click="onWebSearchClick"
-                  >
-                    <Icon icon="lucide:globe" class="w-4 h-4" />
-                  </Button>
-                  <Select
-                    v-model="selectedSearchEngine"
-                    @update:model-value="onSearchEngineChange"
-                    @update:open="handleSelectOpen"
-                  >
-                    <SelectTrigger
-                      class="h-full rounded-none border-none shadow-none hover:bg-accent text-muted-foreground dark:text-white/60 dark:hover:bg-white/10 dark:hover:text-white transition-all duration-300"
-                      :class="{
-                        'w-0 opacity-0 p-0 overflow-hidden':
-                          !showSearchSettingsButton && !isSearchHovering && !isSelectOpen,
-                        'w-24 max-w-28 px-2 opacity-100':
-                          showSearchSettingsButton || isSearchHovering || isSelectOpen
-                      }"
-                    >
-                      <div class="flex items-center gap-1">
-                        <SelectValue class="text-xs font-bold truncate" />
-                      </div>
-                    </SelectTrigger>
-                    <SelectContent align="start" class="w-64">
-                      <SelectItem
-                        v-for="engine in searchEngines"
-                        :key="engine.id"
-                        :value="engine.id"
-                      >
-                        {{ engine.name }}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </span>
+                  <Icon icon="lucide:globe" class="w-4 h-4" />
+                </Button>
               </TooltipTrigger>
               <TooltipContent>{{ t('chat.features.webSearch') }}</TooltipContent>
             </Tooltip>
@@ -265,13 +227,6 @@ import {
   TooltipProvider,
   TooltipTrigger
 } from '@shadcn/components/ui/tooltip'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from '@shadcn/components/ui/select'
 import { Popover, PopoverContent, PopoverTrigger } from '@shadcn/components/ui/popover'
 import { Icon } from '@iconify/vue'
 import FileItem from '../FileItem.vue'
@@ -317,7 +272,6 @@ import { useToast } from '@/components/use-toast'
 import type { CategorizedData } from '../editor/mention/suggestion'
 import type { PromptListEntry } from '@shared/presenter'
 import { sanitizeText } from '@/lib/sanitizeText'
-import type { AcceptableValue } from 'reka-ui'
 import { ModelType } from '@shared/model'
 import { useThemeStore } from '@/stores/theme'
 
@@ -384,40 +338,6 @@ const editor = new Editor({
         class: 'line-break'
       }
     })
-    // CodeBlock.extend({
-    //   addStorage() {
-    //     return {
-    //       lastShiftEnterTime: 0
-    //     }
-    //   },
-    //   addKeyboardShortcuts() {
-    //     return {
-    //       'Shift-Enter': () => {
-    //         if (this.editor.isActive('codeBlock')) {
-    //           const now = Date.now()
-    //           const timeDiff = now - this.storage.lastShiftEnterTime
-
-    //           // If Shift+Enter was pressed within 800ms, exit the code block
-    //           if (timeDiff < 800) {
-    //             this.editor.commands.exitCode()
-    //             this.storage.lastShiftEnterTime = 0
-    //             return true
-    //           }
-
-    //           // Otherwise, insert a newline and record the time
-    //           this.editor.commands.insertContent('\n')
-    //           this.storage.lastShiftEnterTime = now
-    //           return true
-    //         }
-    //         return false
-    //       }
-    //     }
-    //   }
-    // }).configure({
-    //   HTMLAttributes: {
-    //     class: 'rounded-md bg-secondary dark:bg-zinc-800 p-2'
-    //   }
-    // })
   ],
   onUpdate: ({ editor }) => {
     inputText.value = editor.getText()
@@ -443,7 +363,7 @@ const settings = ref({
   webSearch: false
 })
 const selectedSearchEngine = ref('')
-const searchEngines = computed(() => settingsStore.searchEngines)
+
 const currentContextLength = computed(() => {
   return (
     approximateTokenSize(inputText.value) +
@@ -1165,10 +1085,6 @@ const onWebSearchClick = async () => {
 //   await configPresenter.setSetting('input_deepThinking', settings.value.deepThinking)
 // }
 
-const onSearchEngineChange = async (engineName: AcceptableValue) => {
-  await settingsStore.setSearchEngine(engineName as string)
-}
-
 const initSettings = async () => {
   settings.value.deepThinking = Boolean(await configPresenter.getSetting('input_deepThinking'))
   settings.value.webSearch = Boolean(await configPresenter.getSetting('input_webSearch'))
@@ -1251,14 +1167,7 @@ const handleDrop = async (e: DragEvent) => {
 }
 
 // Search engine selector variables
-const showSearchSettingsButton = ref(false)
 const isSearchHovering = ref(false)
-const isSelectOpen = ref(false)
-
-// Handle select open state
-const handleSelectOpen = (isOpen: boolean) => {
-  isSelectOpen.value = isOpen
-}
 
 // Mouse hover handlers for search engine selector
 const handleSearchMouseEnter = () => {


### PR DESCRIPTION
Fix appbar style on windows and linux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Windows: Shell window adopts Mica background for a native Windows 11 look.
  - Context length now includes tokens from selected files.

- Style
  - Refined window background opacity across light/dark themes.
  - OS-aware backgrounds for app shell and app bar; improved close-button hover on non‑macOS.
  - Updated message list spacing and user message backgrounds; toolbar height adjusted.
  - Simplified MCP tools toggle styling and count display.

- Refactor
  - Model chooser redesigned with card-based layout and clearer selection visuals.
  - Prompt input: streamlined web search toggle; removed select-based UI.
  - Removed sidebar toggle from New Thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->