### PR TITLE
fix: ensure switch scaling overrides apply

### DIFF
--- a/src/renderer/src/assets/style.css
+++ b/src/renderer/src/assets/style.css
@@ -16,6 +16,7 @@
   @import 'vue-renderer-markdown/index.css';
 
   :root {
+    --dc-font-scale: 1;
     --base-50: hsl(0 0% 100%);
     --base-100: hsl(0 0% 98.1%);
     --base-200: hsl(0 0% 93.4%);
@@ -145,6 +146,30 @@
     --text-secondary-foreground: hsl(0 0 15% / 0.5);
     --text-skeleton-primary: hsl(0 0 15% / 0.05);
     --window-inner-border: hsl(0 0 100% / 0.5);
+  }
+
+  html {
+    --dc-font-scale: 1;
+  }
+
+  html.text-sm {
+    --dc-font-scale: 0.875;
+  }
+
+  html.text-base {
+    --dc-font-scale: 1;
+  }
+
+  html.text-lg {
+    --dc-font-scale: 1.125;
+  }
+
+  html.text-xl {
+    --dc-font-scale: 1.25;
+  }
+
+  html.text-2xl {
+    --dc-font-scale: 1.5;
   }
 
   .dark,
@@ -824,6 +849,26 @@
   @font-face {
     font-family: 'Geist';
     src: url('./geist.ttf') format('truetype');
+  }
+}
+
+@layer utilities {
+  [data-slot='switch'] {
+    inline-size: calc(2rem / var(--dc-font-scale));
+    block-size: calc(1.15rem / var(--dc-font-scale));
+    min-inline-size: calc(2rem / var(--dc-font-scale));
+    min-block-size: calc(1.15rem / var(--dc-font-scale));
+    width: calc(2rem / var(--dc-font-scale));
+    height: calc(1.15rem / var(--dc-font-scale));
+    min-width: calc(2rem / var(--dc-font-scale));
+    min-height: calc(1.15rem / var(--dc-font-scale));
+  }
+
+  [data-slot='switch-thumb'] {
+    inline-size: calc(1rem / var(--dc-font-scale));
+    block-size: calc(1rem / var(--dc-font-scale));
+    width: calc(1rem / var(--dc-font-scale));
+    height: calc(1rem / var(--dc-font-scale));
   }
 }
 


### PR DESCRIPTION
## Summary
- add a global font scale variable that maps to the existing font size classes on the root element
- override the shadcn switch track and thumb dimensions so they stay visually consistent regardless of font scaling by defining the rules in the utilities layer so they win over Tailwind dimension classes

## Testing
- pnpm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68edbae39db4832cacbe0cde43c970e6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a global typography scale with size presets (sm, base, lg, xl, 2xl) to adjust overall font sizing.
  * Added utility styles so switch controls (including the thumb) scale proportionally with the selected typography size.
* **Style**
  * Centralized switch sizing under a utilities layer for more consistent layout across themes without changing colors or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->