### PR TITLE
fix: add fallback model lookup when provider missing

### DIFF
--- a/src/main/presenter/configPresenter/modelCapabilities.ts
+++ b/src/main/presenter/configPresenter/modelCapabilities.ts
@@ -53,24 +53,37 @@ export class ModelCapabilities {
     const mid = modelId?.toLowerCase()
     if (!mid) return undefined
 
-    const pid = providerId ? this.resolveProviderId(providerId.toLowerCase()) : undefined
+    const normalizedProviderId = providerId ? providerId.toLowerCase() : ''
+    const hasProviderId = normalizedProviderId.length > 0
+    const pid = hasProviderId ? this.resolveProviderId(normalizedProviderId) : undefined
+
     if (pid) {
       const providerModels = this.index.get(pid)
       if (providerModels) {
-        return providerModels.get(mid)
+        const providerMatch = providerModels.get(mid)
+        if (providerMatch) {
+          return providerMatch
+        }
+        return undefined
       }
 
-      for (const models of this.index.values()) {
-        if (!models) continue
-        if (models.has(mid)) {
-          const match = models.get(mid)
-          if (match) return match
-          break
-        }
-      }
+      return this.findModelAcrossProviders(mid)
+    }
+
+    if (!hasProviderId) {
       return undefined
     }
 
+    return this.findModelAcrossProviders(mid)
+  }
+
+  private findModelAcrossProviders(modelId: string): ProviderModel | undefined {
+    for (const models of this.index.values()) {
+      const fallbackModel = models.get(modelId)
+      if (fallbackModel) {
+        return fallbackModel
+      }
+    }
     return undefined
   }
 

--- a/src/main/presenter/configPresenter/modelConfig.ts
+++ b/src/main/presenter/configPresenter/modelConfig.ts
@@ -2,7 +2,7 @@ import { ModelType } from '@shared/model'
 import { IModelConfig, ModelConfig, ModelConfigSource } from '@shared/presenter'
 import ElectronStore from 'electron-store'
 import { providerDbLoader } from './providerDbLoader'
-import { isImageInputSupported } from '@shared/types/model-db'
+import { isImageInputSupported, ProviderModel } from '@shared/types/model-db'
 
 const SPECIAL_CONCAT_CHAR = '-_-'
 
@@ -49,6 +49,25 @@ export class ModelConfigHelper {
     if (!providerId) return undefined
     const alias = ModelConfigHelper.PROVIDER_ID_ALIASES[providerId]
     return alias || providerId
+  }
+
+  private buildConfigFromProviderModel(model: ProviderModel): ModelConfig {
+    return {
+      maxTokens: model.limit?.output ?? 4096,
+      contextLength: model.limit?.context ?? 8192,
+      temperature: 0.6,
+      vision: isImageInputSupported(model),
+      functionCall: model.tool_call ?? false,
+      reasoning: Boolean(model.reasoning?.default ?? false),
+      type: ModelType.Chat,
+      thinkingBudget: model.reasoning?.budget?.default ?? undefined,
+      enableSearch: Boolean(model.search?.default ?? false),
+      forcedSearch: Boolean(model.search?.forced_search),
+      searchStrategy: model.search?.search_strategy === 'max' ? 'max' : 'turbo',
+      reasoningEffort: undefined,
+      verbosity: undefined,
+      maxCompletionTokens: undefined
+    }
   }
 
   private initializeMetaFromLegacyStore(): void {
@@ -283,69 +302,40 @@ export class ModelConfigHelper {
     let finalConfig: ModelConfig | null = null
 
     // 严格匹配：仅当提供 providerId 时从 Provider DB 查找
-    if (normProviderId) {
-      const db = providerDbLoader.getDb()
-      const resolvedProviderId = this.resolveProviderId(normProviderId)
-      const providers = db?.providers
-      const provider = resolvedProviderId ? providers?.[resolvedProviderId] : undefined
+    const db = providerDbLoader.getDb()
+    const providers = db?.providers
+    const resolvedProviderId = normProviderId ? this.resolveProviderId(normProviderId) : undefined
+    const providerEntry = resolvedProviderId ? providers?.[resolvedProviderId] : undefined
+    const providerFound = Boolean(providerEntry)
 
-      if (provider && Array.isArray(provider.models)) {
-        for (let i = 0; i < provider.models.length; i += 1) {
-          const candidate = provider.models[i]
-          if (candidate && candidate.id === normModelId) {
-            finalConfig = {
-              maxTokens: candidate.limit?.output ?? 4096,
-              contextLength: candidate.limit?.context ?? 8192,
-              temperature: 0.6,
-              vision: isImageInputSupported(candidate),
-              functionCall: candidate.tool_call ?? false,
-              reasoning: Boolean(candidate.reasoning?.default ?? false),
-              type: ModelType.Chat,
-              thinkingBudget: candidate.reasoning?.budget?.default ?? undefined,
-              enableSearch: Boolean(candidate.search?.default ?? false),
-              forcedSearch: Boolean(candidate.search?.forced_search),
-              searchStrategy: candidate.search?.search_strategy === 'max' ? 'max' : 'turbo',
-              reasoningEffort: undefined,
-              verbosity: undefined,
-              maxCompletionTokens: undefined
-            }
+    if (normProviderId && providerEntry && Array.isArray(providerEntry.models)) {
+      for (let i = 0; i < providerEntry.models.length; i += 1) {
+        const candidate = providerEntry.models[i]
+        if (candidate && candidate.id === normModelId) {
+          finalConfig = this.buildConfigFromProviderModel(candidate)
+          break
+        }
+      }
+    }
+
+    if (!finalConfig && normProviderId && !providerFound && providers && normModelId) {
+      for (const key in providers) {
+        if (!Object.prototype.hasOwnProperty.call(providers, key)) continue
+        const candidateProvider = providers[key]
+        if (!candidateProvider || !Array.isArray(candidateProvider.models)) {
+          continue
+        }
+
+        for (let j = 0; j < candidateProvider.models.length; j += 1) {
+          const candidateModel = candidateProvider.models[j]
+          if (candidateModel && candidateModel.id === normModelId) {
+            finalConfig = this.buildConfigFromProviderModel(candidateModel)
             break
           }
         }
-      } else if (!provider && providers && normModelId) {
-        const providerKeys = Object.keys(providers)
-        for (let i = 0; i < providerKeys.length; i += 1) {
-          const candidateProvider = providers[providerKeys[i]]
-          if (!candidateProvider || !Array.isArray(candidateProvider.models)) {
-            continue
-          }
 
-          for (let j = 0; j < candidateProvider.models.length; j += 1) {
-            const candidateModel = candidateProvider.models[j]
-            if (candidateModel && candidateModel.id === normModelId) {
-              finalConfig = {
-                maxTokens: candidateModel.limit?.output ?? 4096,
-                contextLength: candidateModel.limit?.context ?? 8192,
-                temperature: 0.6,
-                vision: isImageInputSupported(candidateModel),
-                functionCall: candidateModel.tool_call ?? false,
-                reasoning: Boolean(candidateModel.reasoning?.default ?? false),
-                type: ModelType.Chat,
-                thinkingBudget: candidateModel.reasoning?.budget?.default ?? undefined,
-                enableSearch: Boolean(candidateModel.search?.default ?? false),
-                forcedSearch: Boolean(candidateModel.search?.forced_search),
-                searchStrategy: candidateModel.search?.search_strategy === 'max' ? 'max' : 'turbo',
-                reasoningEffort: undefined,
-                verbosity: undefined,
-                maxCompletionTokens: undefined
-              }
-              break
-            }
-          }
-
-          if (finalConfig) {
-            break
-          }
+        if (finalConfig) {
+          break
         }
       }
     }


### PR DESCRIPTION
## Summary
- add a sequential fallback lookup across providers when the requested provider id is not found
- preserve strict matching when a provider exists but does not include the requested model

## Testing
- pnpm run typecheck:node
- pnpm run typecheck:web

------
https://chatgpt.com/codex/tasks/task_e_68ee17af4b0c832ca75c23448af387fa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model lookup: if a model ID is provided without a matching provider, the app now searches across all providers to find and load the correct model and its configuration.
  * Better handling of optional or differently-cased provider IDs and a reliable fallback when a provider-specific match isn’t found, reducing “model not found” errors and improving loading of saved/shared settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->