### PR TITLE
fix: allow settings window links to open externally

### DIFF
--- a/src/main/presenter/windowPresenter/index.ts
+++ b/src/main/presenter/windowPresenter/index.ts
@@ -1291,7 +1291,20 @@ export class WindowPresenter implements IWindowPresenter {
 
     // Ensure links with target="_blank" open in the user's default browser
     settingsWindow.webContents.setWindowOpenHandler(({ url }) => {
-      shell.openExternal(url)
+      try {
+        // Validate URL protocol - only allow http/https
+        const parsedUrl = new URL(url)
+        if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+          console.log(`Opening external URL from settings window: ${url}`)
+          shell.openExternal(url).catch((error) => {
+            console.error(`Failed to open external URL: ${url}`, error)
+          })
+        } else {
+          console.warn(`Blocked attempt to open non-http(s) URL: ${url}`)
+        }
+      } catch (error) {
+        console.error(`Invalid URL format: ${url}`, error)
+      }
       return { action: 'deny' }
     })
 


### PR DESCRIPTION
## Summary
- ensure the standalone settings window routes target="_blank" links through the system browser

## Testing
- pnpm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f4c453d90c832cadb7174c0a16f280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External links in the settings window now open in your default browser instead of inside the app.
  * Non-http(s) external link attempts are blocked for safety; only http/https links are routed externally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->