### PR TITLE
fix: ensure renderer workers build as ES modules

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -83,6 +83,9 @@ export default defineConfig({
       svgLoader(),
       vueDevTools()
     ],
+    worker: {
+      format: 'es'
+    },
     build: {
       minify: 'esbuild',
       // Ensure CSS order in build matches import order in dev


### PR DESCRIPTION
## Summary
- set the renderer worker build format to ES modules to avoid Vite forcing IIFE output
- unblock bundling of the mermaid markdown worker during production builds

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68f7517c3ca8832ca2ffd331d530c7c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build configuration settings for improved build process optimization.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->