### PR TITLE
perf: remove unless renderMarkdown wrapper

### DIFF
--- a/src/renderer/settings/components/AboutUsSettings.vue
+++ b/src/renderer/settings/components/AboutUsSettings.vue
@@ -148,7 +148,10 @@
       <DialogHeader>
         <DialogTitle>{{ t('about.disclaimerTitle') }}</DialogTitle>
         <DialogDescription>
-          <div class="max-h-[300px] overflow-y-auto" v-html="disclaimerContent"></div>
+          <NodeRenderer
+            class="max-h-[300px] overflow-y-auto"
+            :content="t('searchDisclaimer')"
+          ></NodeRenderer>
         </DialogDescription>
       </DialogHeader>
       <DialogFooter>
@@ -160,7 +163,7 @@
 
 <script setup lang="ts">
 import { usePresenter } from '@/composables/usePresenter'
-import { computed, onMounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Button } from '@shadcn/components/ui/button'
 import { Icon } from '@iconify/vue'
@@ -179,7 +182,7 @@ import {
   SelectTrigger,
   SelectValue
 } from '@shadcn/components/ui/select'
-import { renderMarkdown, getCommonMarkdown } from 'vue-renderer-markdown'
+import NodeRenderer from 'vue-renderer-markdown'
 import { useUpgradeStore } from '@/stores/upgrade'
 import { useLanguageStore } from '@/stores/language'
 import type { AcceptableValue } from 'reka-ui'
@@ -236,9 +239,6 @@ const handleCheckUpdate = async () => {
 
   // 不再自动打开对话框，而是由下载完成后自动弹出
 }
-
-const md = getCommonMarkdown()
-const disclaimerContent = computed(() => renderMarkdown(md, t('searchDisclaimer')))
 
 const openExternalLink = (url: string) => {
   if (window.api?.openExternal) {

--- a/src/renderer/src/components/ui/UpdateDialog.vue
+++ b/src/renderer/src/components/ui/UpdateDialog.vue
@@ -9,9 +9,9 @@
               <p>{{ t('update.version') }}: {{ upgrade.updateInfo?.version }}</p>
               <p>{{ t('update.releaseDate') }}: {{ upgrade.updateInfo?.releaseDate }}</p>
               <p>{{ t('update.releaseNotes') }}:</p>
-              <p class="whitespace-pre-line"
-                v-html="renderMarkdown(getCommonMarkdown(), upgrade.updateInfo?.releaseNotes || '')" />
-
+              <p class="whitespace-pre-line">
+                <NodeRenderer :content="upgrade.updateInfo?.releaseNotes"></NodeRenderer>
+              </p>
               <!-- 显示下载进度 -->
               <div v-if="upgrade.isDownloading && upgrade.updateProgress" class="mt-4">
                 <p class="mb-2">
@@ -65,7 +65,7 @@ import {
   DialogTitle
 } from '@shadcn/components/ui/dialog'
 import { useUpgradeStore } from '@/stores/upgrade'
-import { renderMarkdown, getCommonMarkdown } from 'vue-renderer-markdown'
+import NodeRenderer from 'vue-renderer-markdown'
 
 const { t } = useI18n()
 const upgrade = useUpgradeStore()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * About settings disclaimer now uses the translated string and is rendered with the app's content renderer for consistent display within the dialog.
  * Update dialog release notes are now rendered through the app's content renderer, improving consistency of formatting and presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->