### PR TITLE
refactor: clean code and remove unless code

### DIFF
--- a/src/main/lib/svgSanitizer.ts
+++ b/src/main/lib/svgSanitizer.ts
@@ -304,7 +304,9 @@ export class SVGSanitizer {
 }
 
 // Export singleton instance for easy use
-export const svgSanitizer = new SVGSanitizer()
+export const svgSanitizer = new SVGSanitizer({
+  maxSize: 1024 * 1024
+})
 
 // Export factory function for custom options
 export const createSVGSanitizer = (options?: SanitizeOptions) => new SVGSanitizer(options)

--- a/src/main/presenter/devicePresenter/index.ts
+++ b/src/main/presenter/devicePresenter/index.ts
@@ -494,20 +494,6 @@ export class DevicePresenter implements IDevicePresenter {
   async sanitizeSvgContent(svgContent: string): Promise<string | null> {
     try {
       console.log('Sanitizing SVG content, length:', svgContent.length)
-
-      // 基本输入验证
-      if (!svgContent || typeof svgContent !== 'string') {
-        console.warn('Invalid SVG content provided')
-        return null
-      }
-
-      // 长度限制检查
-      if (svgContent.length > 1024 * 1024) {
-        // 1MB limit
-        console.warn('SVG content exceeds size limit')
-        return null
-      }
-
       // Debug: 显示SVG前100个字符
       console.log('SVG preview:', svgContent.substring(0, 100) + '...')
 

--- a/src/renderer/src/components/artifacts/ArtifactThinking.vue
+++ b/src/renderer/src/components/artifacts/ArtifactThinking.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-v-html -->
 <template>
   <div class="text-xs text-muted-foreground rounded-lg flex flex-row gap-2 px-2 py-2">
     <Icon icon="lucide:loader-2" class="w-4 h-4 animate-spin" />

--- a/src/renderer/src/components/markdown/MarkdownRenderer.vue
+++ b/src/renderer/src/components/markdown/MarkdownRenderer.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-v-html -->
 <template>
   <div class="prose prose-zinc prose-sm dark:prose-invert w-full max-w-none break-all">
     <NodeRenderer :content="debouncedContent" @copy="$emit('copy', $event)" />

--- a/src/renderer/src/components/message/SelectedTextContextMenu.vue
+++ b/src/renderer/src/components/message/SelectedTextContextMenu.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-v-html -->
 <template>
   <div></div>
 </template>

--- a/src/renderer/src/components/popup/TranslatePopup.vue
+++ b/src/renderer/src/components/popup/TranslatePopup.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-v-html -->
 <template>
   <div>
     <div

--- a/src/renderer/src/components/think-content/ThinkContent.vue
+++ b/src/renderer/src/components/think-content/ThinkContent.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-v-html -->
 <template>
   <div
     class="text-xs leading-4 text-[rgba(37,37,37,0.5)] dark:text-white/50 flex flex-col gap-[6px]"


### PR DESCRIPTION
remove redundant SVG content validation

remove eslint-disable comments from multiple Vue components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SVG processing now uses explicit size configuration with 1MB limit
  * Modified input validation workflow for improved content handling

* **Chores**
  * Removed linting directives from Vue components to improve code standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->