### PR TITLE
fix: fix first chat error loading timing

### DIFF
--- a/src/renderer/src/components/editor/mention/MentionList.vue
+++ b/src/renderer/src/components/editor/mention/MentionList.vue
@@ -87,10 +87,10 @@ const hasFiles = (item: CategorizedData): boolean => {
   // 类型保护：检查是否是 PromptListEntry 并且有 files 字段
   return Boolean(
     mcpEntry &&
-      'files' in mcpEntry &&
-      mcpEntry.files &&
-      Array.isArray(mcpEntry.files) &&
-      mcpEntry.files.length > 0
+    'files' in mcpEntry &&
+    mcpEntry.files &&
+    Array.isArray(mcpEntry.files) &&
+    mcpEntry.files.length > 0
   )
 }
 

--- a/src/renderer/src/composables/useIpcQuery.ts
+++ b/src/renderer/src/composables/useIpcQuery.ts
@@ -19,9 +19,9 @@ export interface UseIpcQueryOptions<
   TName extends PresenterName,
   TMethod extends PresenterMethod<TName>
 > extends Pick<
-    UseQueryOptions<Awaited<ReturnType<PresenterMethodFn<TName, TMethod>>>>,
-    QueryOptionKeys
-  > {
+  UseQueryOptions<Awaited<ReturnType<PresenterMethodFn<TName, TMethod>>>>,
+  QueryOptionKeys
+> {
   key: () => EntryKey
   presenter: TName
   method: TMethod

--- a/test/main/presenter/FileValidationService.test.ts
+++ b/test/main/presenter/FileValidationService.test.ts
@@ -346,9 +346,8 @@ describe('FileValidationService', () => {
       vi.clearAllMocks()
 
       // Import and use the real function directly
-      const { getMimeTypeAdapterMap: realGetMimeTypeAdapterMap } = await import(
-        '../../../src/main/presenter/filePresenter/mime'
-      )
+      const { getMimeTypeAdapterMap: realGetMimeTypeAdapterMap } =
+        await import('../../../src/main/presenter/filePresenter/mime')
 
       // Mock with real implementation
       vi.mocked(getMimeTypeAdapterMap).mockImplementation(realGetMimeTypeAdapterMap)


### PR DESCRIPTION
When I sent a message from the homepage chat box for the first time and an error was returned, the chat box was always loading and could not be sent again normally, but the list had been returned and the request reported an error.

before: 

https://github.com/user-attachments/assets/1fe93c8c-86a2-4744-8152-124435bd8180



after: 

https://github.com/user-attachments/assets/e15772db-9edd-4ad1-93a7-f4630271bfa7




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized chat streaming and event handling for more reliable thread state and consistent message streaming; event listeners now register/unregister in lifecycle hooks.
  * Reduced redundant lookups and ensured stable thread context during send/stream operations; stream lifecycle and error paths consistently clean up and update thread status.
* **Bug Fixes**
  * Improved reliability of auto-scrolling and focus restoration after streaming events.
* **New Features**
  * Clean chat history dialog now opens in response to the relevant event.
* **Style / Tests**
  * Minor formatting adjustments in editor and tests with no behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->