### PR TITLE
fix: fix monaco vertical scroll

### DIFF
--- a/src/renderer/src/components/trace/TraceDialog.vue
+++ b/src/renderer/src/components/trace/TraceDialog.vue
@@ -57,18 +57,18 @@
           </div>
         </div>
 
-        <div class="flex-1 min-h-0 flex flex-col border rounded-lg overflow-hidden">
-          <div class="flex items-center justify-between px-4 py-2 bg-muted border-b">
+        <div class="flex-1 min-h-0 flex flex-col border rounded-lg overflow-hidden min-h-[300px]">
+          <div class="flex-shrink-0 flex items-center justify-between px-4 py-2 bg-muted border-b">
             <span class="text-sm font-semibold">{{ t('traceDialog.body') }}</span>
             <Button variant="ghost" size="sm" @click="copyJson">
               <Icon icon="lucide:copy" class="w-4 h-4 mr-1" />
               {{ copySuccess ? t('traceDialog.copySuccess') : t('traceDialog.copyJson') }}
             </Button>
           </div>
-          <div class="flex-1 min-h-0 overflow-hidden bg-muted/30 relative">
+          <div class="flex-1 min-h-0 bg-muted/30 relative">
             <div
               ref="jsonEditor"
-              class="h-full w-full min-h-[200px]"
+              class="absolute inset-0"
               :class="{ 'opacity-0': !editorInitialized }"
             ></div>
             <!-- Fallback: show raw JSON while Monaco Editor is initializing -->
@@ -114,14 +114,20 @@ const threadPresenter = usePresenter('threadPresenter')
 const jsonEditor = ref<HTMLElement | null>(null)
 const { createEditor, updateCode, cleanupEditor } = useMonaco({
   readOnly: true,
-  wordWrap: 'on',
+  wordWrap: 'off',
   wrappingIndent: 'same',
   minimap: { enabled: false },
-  scrollBeyondLastLine: false,
+  scrollBeyondLastLine: true,
   fontSize: 12,
   lineNumbers: 'on',
   folding: true,
-  automaticLayout: true
+  automaticLayout: true,
+  scrollbar: {
+    horizontal: 'visible',
+    vertical: 'visible',
+    horizontalScrollbarSize: 10,
+    verticalScrollbarSize: 10
+  }
 })
 
 type PreviewData = {


### PR DESCRIPTION
修复因为 monaco 吸顶效果，导致的大片空白
<img width="522" height="588" alt="image" src="https://github.com/user-attachments/assets/49a16fe2-2f74-4fec-98ba-8eaa1dd3a408" />



修复内容展示不全

close #1142 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced trace dialog layout with improved container sizing constraints
  * Improved editor scrollbar visibility with configurable scroll behavior
  * Refined editor display configuration for better content navigation and visibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->