### PR TITLE
fix: font setting not work on settings page

### DIFF
--- a/src/renderer/settings/App.vue
+++ b/src/renderer/settings/App.vue
@@ -75,6 +75,7 @@ import { useSearchAssistantStore } from '@/stores/searchAssistantStore'
 import { useSearchEngineStore } from '@/stores/searchEngineStore'
 import { useMcpStore } from '@/stores/mcp'
 import { useMcpInstallDeeplinkHandler } from '../src/lib/storeInitializer'
+import { useFontManager } from '../src/composables/useFontManager'
 
 const devicePresenter = usePresenter('devicePresenter')
 const windowPresenter = usePresenter('windowPresenter')
@@ -82,6 +83,9 @@ const configPresenter = usePresenter('configPresenter')
 
 // Initialize stores
 const uiSettingsStore = useUiSettingsStore()
+const { setupFontListener } = useFontManager()
+setupFontListener()
+
 const languageStore = useLanguageStore()
 const modelCheckStore = useModelCheckStore()
 const { toast } = useToast()

--- a/src/renderer/settings/components/display/FontSettingsSection.vue
+++ b/src/renderer/settings/components/display/FontSettingsSection.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="flex flex-col gap-3 px-2 py-2 max-w-4xl">
+  <div class="flex flex-col gap-3 px-2 py-2">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <span
-        class="flex items-center gap-2 text-sm font-medium shrink-0 min-w-[200px]"
+        class="flex items-center gap-2 text-sm font-medium shrink-0 min-w-[220px]"
         :dir="languageStore.dir"
       >
         <Icon icon="lucide:type" class="w-4 h-4 text-muted-foreground" />
@@ -52,13 +52,14 @@
                 </Button>
               </PopoverTrigger>
               <PopoverContent class="w-[320px] p-0" align="start">
-                <div class="p-2">
+                <div class="p-2" :style="{ fontFamily: PREVIEW_FALLBACK }">
                   <div class="flex items-center gap-2 mb-2">
                     <Icon icon="lucide:search" class="h-4 w-4 text-muted-foreground" />
                     <Input
                       v-model="textQuery"
                       :placeholder="t('settings.display.fontSearchPlaceholder')"
                       class="h-8"
+                      :style="{ fontFamily: PREVIEW_FALLBACK }"
                     />
                   </div>
                   <ScrollArea class="h-64">
@@ -69,6 +70,7 @@
                         :class="{
                           'border border-primary/60 bg-primary/5': uiSettingsStore.fontFamily === ''
                         }"
+                        :style="{ fontFamily: PREVIEW_FALLBACK }"
                         @click="selectTextFont('')"
                       >
                         <span class="truncate">{{ defaultLabel }}</span>
@@ -87,7 +89,7 @@
                           'border border-primary/60 bg-primary/5':
                             uiSettingsStore.fontFamily === font
                         }"
-                        :style="{ fontFamily: buildFontPreview(font, textPreviewFont) }"
+                        :style="{ fontFamily: buildFontPreview(font) }"
                         @click="selectTextFont(font)"
                       >
                         <span class="truncate">{{ font }}</span>
@@ -138,13 +140,14 @@
                 </Button>
               </PopoverTrigger>
               <PopoverContent class="w-[320px] p-0" align="start">
-                <div class="p-2">
+                <div class="p-2" :style="{ fontFamily: PREVIEW_FALLBACK }">
                   <div class="flex items-center gap-2 mb-2">
                     <Icon icon="lucide:search" class="h-4 w-4 text-muted-foreground" />
                     <Input
                       v-model="codeQuery"
                       :placeholder="t('settings.display.fontSearchPlaceholder')"
                       class="h-8"
+                      :style="{ fontFamily: PREVIEW_FALLBACK }"
                     />
                   </div>
                   <ScrollArea class="h-64">
@@ -156,6 +159,7 @@
                           'border border-primary/60 bg-primary/5':
                             uiSettingsStore.codeFontFamily === ''
                         }"
+                        :style="{ fontFamily: PREVIEW_FALLBACK }"
                         @click="selectCodeFont('')"
                       >
                         <span class="truncate">{{ defaultLabel }}</span>
@@ -174,7 +178,7 @@
                           'border border-primary/60 bg-primary/5':
                             uiSettingsStore.codeFontFamily === font
                         }"
-                        :style="{ fontFamily: buildFontPreview(font, codePreviewFont) }"
+                        :style="{ fontFamily: buildFontPreview(font) }"
                         @click="selectCodeFont(font)"
                       >
                         <span class="truncate">{{ font }}</span>
@@ -274,12 +278,14 @@ const codeFontLabel = computed(() => uiSettingsStore.codeFontFamily || defaultLa
 const textPreviewFont = computed(() => uiSettingsStore.formattedFontFamily)
 const codePreviewFont = computed(() => uiSettingsStore.formattedCodeFontFamily)
 
-const buildFontPreview = (font: string, fallback: string) => {
+const PREVIEW_FALLBACK = 'ui-sans-serif, system-ui, sans-serif'
+
+const buildFontPreview = (font: string) => {
   const normalized = (font || '').trim()
-  if (!normalized) return fallback
+  if (!normalized) return PREVIEW_FALLBACK
   const wrapped =
     /\s/.test(normalized) && !normalized.includes(',') ? `"${normalized}"` : normalized
-  return `${wrapped}, ${fallback}`
+  return `${wrapped}, ${PREVIEW_FALLBACK}`
 }
 
 const selectTextFont = async (font: string) => {

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -21,6 +21,7 @@ import MessageDialog from './components/ui/MessageDialog.vue'
 import McpSamplingDialog from '@/components/mcp/McpSamplingDialog.vue'
 import { initAppStores, useMcpInstallDeeplinkHandler } from '@/lib/storeInitializer'
 import 'vue-sonner/style.css' // vue-sonner v2 requires this import
+import { useFontManager } from './composables/useFontManager'
 
 const route = useRoute()
 const configPresenter = usePresenter('configPresenter')
@@ -28,6 +29,9 @@ const artifactStore = useArtifactStore()
 const chatStore = useChatStore()
 const { toast } = useToast()
 const uiSettingsStore = useUiSettingsStore()
+const { setupFontListener } = useFontManager()
+setupFontListener()
+
 const themeStore = useThemeStore()
 const langStore = useLanguageStore()
 const modelCheckStore = useModelCheckStore()
@@ -62,19 +66,6 @@ watch(
     console.log('newTheme', newThemeName)
   },
   { immediate: false } // Initialization is handled in onMounted
-)
-
-const applyFontVariables = (textFont: string, codeFont: string) => {
-  document.documentElement.style.setProperty('--dc-font-family', textFont)
-  document.documentElement.style.setProperty('--dc-code-font-family', codeFont)
-}
-
-watch(
-  [() => uiSettingsStore.formattedFontFamily, () => uiSettingsStore.formattedCodeFontFamily],
-  ([textFont, codeFont]) => {
-    applyFontVariables(textFont, codeFont)
-  },
-  { immediate: true }
 )
 
 // Handle error notifications

--- a/src/renderer/src/composables/useFontManager.ts
+++ b/src/renderer/src/composables/useFontManager.ts
@@ -1,0 +1,25 @@
+import { watch } from 'vue'
+import { useUiSettingsStore } from '../stores/uiSettingsStore'
+
+export function useFontManager() {
+  const uiSettingsStore = useUiSettingsStore()
+
+  const applyFontVariables = (textFont: string, codeFont: string) => {
+    document.documentElement.style.setProperty('--dc-font-family', textFont)
+    document.documentElement.style.setProperty('--dc-code-font-family', codeFont)
+  }
+
+  const setupFontListener = () => {
+    watch(
+      [() => uiSettingsStore.formattedFontFamily, () => uiSettingsStore.formattedCodeFontFamily],
+      ([textFont, codeFont]) => {
+        applyFontVariables(textFont, codeFont)
+      },
+      { immediate: true }
+    )
+  }
+
+  return {
+    setupFontListener
+  }
+}


### PR DESCRIPTION
before: 
<img width="2214" height="1236" alt="c57e1310224a2caad2b39e7e8d298dbc" src="https://github.com/user-attachments/assets/e0ad62a5-8fa7-4fee-b094-03b4ff0de45e" />


after:

<img width="1419" height="932" alt="image" src="https://github.com/user-attachments/assets/b5e89f3e-8348-465f-bf08-f885f0084602" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved font preview consistency with fallback font styling across selection UI.
  * Enhanced font settings initialization during app startup.

* **UI**
  * Increased font settings panel width for better spacing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->