### PR TITLE
feat: custom clientId for github copilot

### DIFF
--- a/src/main/presenter/githubCopilotDeviceFlow.ts
+++ b/src/main/presenter/githubCopilotDeviceFlow.ts
@@ -591,13 +591,12 @@ export class GitHubCopilotDeviceFlow {
 }
 
 // GitHub Copilot Device Flow configuration
-export function createGitHubCopilotDeviceFlow(): GitHubCopilotDeviceFlow {
-  // Read GitHub OAuth configuration from environment variables
-  const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID
+export function createGitHubCopilotDeviceFlow(clientIdOverride?: string): GitHubCopilotDeviceFlow {
+  const clientId = clientIdOverride?.trim() || import.meta.env.VITE_GITHUB_CLIENT_ID
 
   if (!clientId) {
     throw new Error(
-      'VITE_GITHUB_CLIENT_ID environment variable is required. Please create a .env file with your GitHub OAuth Client ID.'
+      'GitHub Client ID is required. Please enter it in the Copilot settings input or set VITE_GITHUB_CLIENT_ID in .env.'
     )
   }
 
@@ -618,10 +617,18 @@ export function createGitHubCopilotDeviceFlow(): GitHubCopilotDeviceFlow {
  * 创建一个全局的 GitHub Copilot Device Flow 实例
  */
 let globalDeviceFlowInstance: GitHubCopilotDeviceFlow | null = null
+let globalDeviceFlowClientId: string | null = null
 
-export function getGlobalGitHubCopilotDeviceFlow(): GitHubCopilotDeviceFlow {
-  if (!globalDeviceFlowInstance) {
-    globalDeviceFlowInstance = createGitHubCopilotDeviceFlow()
+export function getGlobalGitHubCopilotDeviceFlow(
+  clientIdOverride?: string
+): GitHubCopilotDeviceFlow {
+  const effectiveClientId = clientIdOverride?.trim() || import.meta.env.VITE_GITHUB_CLIENT_ID
+
+  if (!globalDeviceFlowInstance || globalDeviceFlowClientId !== effectiveClientId) {
+    globalDeviceFlowInstance?.dispose()
+    globalDeviceFlowInstance = null
+    globalDeviceFlowInstance = createGitHubCopilotDeviceFlow(effectiveClientId)
+    globalDeviceFlowClientId = effectiveClientId || null
   }
   return globalDeviceFlowInstance
 }
@@ -631,4 +638,5 @@ export function disposeGlobalGitHubCopilotDeviceFlow(): void {
     globalDeviceFlowInstance.dispose()
     globalDeviceFlowInstance = null
   }
+  globalDeviceFlowClientId = null
 }

--- a/src/main/presenter/githubCopilotOAuth.ts
+++ b/src/main/presenter/githubCopilotOAuth.ts
@@ -221,15 +221,16 @@ export class GitHubCopilotOAuth {
 }
 
 // GitHub Copilot OAuth configuration
-export function createGitHubCopilotOAuth(): GitHubCopilotOAuth {
+export function createGitHubCopilotOAuth(clientIdOverride?: string): GitHubCopilotOAuth {
   // Read GitHub OAuth configuration from environment variables
-  const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID
+  const clientId = clientIdOverride?.trim() || import.meta.env.VITE_GITHUB_CLIENT_ID
   const clientSecret = import.meta.env.VITE_GITHUB_CLIENT_SECRET
   const redirectUri =
     import.meta.env.VITE_GITHUB_REDIRECT_URI || 'https://deepchatai.cn/auth/github/callback'
 
   console.log('GitHub OAuth Configuration:')
   console.log('- Client ID configured:', clientId ? '✅' : '❌')
+  console.log('- Client ID override provided:', clientIdOverride ? '✅' : '❌')
   console.log('- Client Secret configured:', clientSecret ? '✅' : '❌')
   console.log('- Redirect URI:', redirectUri)
   console.log('- Environment variables check:')
@@ -248,7 +249,7 @@ export function createGitHubCopilotOAuth(): GitHubCopilotOAuth {
 
   if (!clientId) {
     throw new Error(
-      'GITHUB_CLIENT_ID environment variable is required. Please create a .env file with your GitHub OAuth Client ID. You can use either GITHUB_CLIENT_ID or VITE_GITHUB_CLIENT_ID.'
+      'GitHub Client ID is required. Please enter it in the Copilot settings input or set GITHUB_CLIENT_ID / VITE_GITHUB_CLIENT_ID in .env.'
     )
   }
 

--- a/src/main/presenter/llmProviderPresenter/providers/githubCopilotProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/githubCopilotProvider.ts
@@ -43,7 +43,7 @@ export class GithubCopilotProvider extends BaseLLMProvider {
     if (this.provider.enable) {
       try {
         this.isInitialized = true
-        this.deviceFlow = getGlobalGitHubCopilotDeviceFlow()
+        this.deviceFlow = getGlobalGitHubCopilotDeviceFlow(this.provider.copilotClientId)
 
         // 检查现有认证状态
         if (this.provider.apiKey) {

--- a/src/main/presenter/oauthPresenter.ts
+++ b/src/main/presenter/oauthPresenter.ts
@@ -45,8 +45,8 @@ export class OAuthPresenter {
    */
   async startGitHubCopilotDeviceFlowLogin(providerId: string): Promise<boolean> {
     try {
-      const githubDeviceFlow = getGlobalGitHubCopilotDeviceFlow()
       const provider = presenter.configPresenter.getProviderById(providerId)
+      const githubDeviceFlow = getGlobalGitHubCopilotDeviceFlow(provider?.copilotClientId)
 
       // 首先检查现有认证状态
       if (provider && provider.apiKey) {
@@ -97,7 +97,8 @@ export class OAuthPresenter {
 
       // 使用专门的GitHub Copilot OAuth实现
       console.log('[GitHub Copilot][OAuth] Creating GitHub OAuth instance...')
-      const githubOAuth = createGitHubCopilotOAuth()
+      const provider = presenter.configPresenter.getProviderById(providerId)
+      const githubOAuth = createGitHubCopilotOAuth(provider?.copilotClientId)
 
       // 开始OAuth登录
       console.log('[GitHub Copilot][OAuth] Starting OAuth login flow...')
@@ -137,7 +138,6 @@ export class OAuthPresenter {
 
       // 保存访问令牌到provider配置
       console.log('[GitHub Copilot][OAuth] Saving access token to provider configuration...')
-      const provider = presenter.configPresenter.getProviderById(providerId)
       if (provider) {
         provider.apiKey = accessToken
         presenter.configPresenter.setProviderById(providerId, provider)

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -398,6 +398,8 @@
     "githubCopilotNotConnected": "GitHub Copilot ikke forbundet",
     "loginWithGitHub": "Log ind med GitHub",
     "loggingIn": "Logger ind...",
+    "githubCopilotClientId": "Custom Client ID",
+    "githubCopilotClientIdHint": "Optional. Leave empty to use the built-in default Client ID. Only affects GitHub Copilot auth.",
     "githubCopilotLoginTip": "Giv DeepChat adgang til dit GitHub Copilot-abonnement. Rettighederne 'read:user' og 'read:org' er nødvendige for Copilot API'et.",
     "loginSuccess": "Login lykkedes",
     "loginFailed": "Login mislykkedes",

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -410,6 +410,8 @@
     "githubCopilotNotConnected": "GitHub Copilot Not Connected",
     "loginWithGitHub": "Login with GitHub",
     "loggingIn": "Logging in...",
+    "githubCopilotClientId": "Custom Client ID",
+    "githubCopilotClientIdHint": "Optional. Leave empty to use the built-in default Client ID. Only affects GitHub Copilot auth.",
     "githubCopilotLoginTip": "Authorize DeepChat to access your GitHub Copilot subscription. 'read:user' and 'read:org' permissions are required to access the Copilot API.",
     "loginSuccess": "Login successful",
     "loginFailed": "Login failed",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -410,6 +410,8 @@
     "githubCopilotNotConnected": "گیت‌هاب کوپایلت پیوند داده نشده",
     "loginWithGitHub": "ورود با گیت‌هاب",
     "loggingIn": "در حال ورود...",
+    "githubCopilotClientId": "Custom Client ID",
+    "githubCopilotClientIdHint": "Optional. Leave empty to use the built-in default Client ID. Only affects GitHub Copilot auth.",
     "githubCopilotLoginTip": "دیپ‌چت را برای دسترسی به اشتراک گیت‌هاب کوپایلت خود مجاز کنید. دسترسی‌های 'read:user' و 'read:org' برای دسترسی به API کوپایلت لازم است.",
     "loginSuccess": "ورود موفق",
     "loginFailed": "ورود ناموفق",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -410,6 +410,8 @@
     "githubCopilotNotConnected": "GitHub Copilot non connecté",
     "loginWithGitHub": "Se connecter avec GitHub",
     "loggingIn": "Connexion en cours...",
+    "githubCopilotClientId": "Custom Client ID",
+    "githubCopilotClientIdHint": "Optional. Leave empty to use the built-in default Client ID. Only affects GitHub Copilot auth.",
     "githubCopilotLoginTip": "Autorisez DeepChat à accéder à votre abonnement GitHub Copilot. Les autorisations 'read:user' et 'read:org' sont requises pour accéder à l'API Copilot.",
     "loginSuccess": "Connexion réussie",
     "loginFailed": "Échec de la connexion",

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -410,6 +410,8 @@
     "githubCopilotNotConnected": "GitHub Copilot אינו מחובר",
     "loginWithGitHub": "התחבר עם GitHub",
     "loggingIn": "מתחבר...",
+    "githubCopilotClientId": "Custom Client ID",
+    "githubCopilotClientIdHint": "Optional. Leave empty to use the built-in default Client ID. Only affects GitHub Copilot auth.",
     "githubCopilotLoginTip": "אשר ל-DeepChat לגשת למנוי GitHub Copilot שלך. ההרשאות 'read:user' ו-'read:org' נדרשות כדי לגשת ל-API של Copilot.",
     "loginSuccess": "ההתחברות הצליחה",
     "loginFailed": "ההתחברות נכשלה",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -410,6 +410,8 @@
     "githubCopilotNotConnected": "GitHub Copilot未接続",
     "loginWithGitHub": "GitHubでログイン",
     "loggingIn": "ログイン中...",
+    "githubCopilotClientId": "Custom Client ID",
+    "githubCopilotClientIdHint": "Optional. Leave empty to use the built-in default Client ID. Only affects GitHub Copilot auth.",
     "githubCopilotLoginTip": "DeepChatがGitHub Copilotサブスクリプションにアクセスすることを許可します。Copilot APIにアクセスするには'read:user'と'read:org'の権限が必要です。",
     "loginSuccess": "ログイン成功",
     "loginFailed": "ログイン失敗",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -410,6 +410,8 @@
     "githubCopilotNotConnected": "GitHub Copilot 연결되지 않음",
     "loginWithGitHub": "GitHub로 로그인",
     "loggingIn": "로그인 중...",
+    "githubCopilotClientId": "Custom Client ID",
+    "githubCopilotClientIdHint": "Optional. Leave empty to use the built-in default Client ID. Only affects GitHub Copilot auth.",
     "githubCopilotLoginTip": "DeepChat이 GitHub Copilot 구독에 액세스하도록 허용하세요. Copilot API에 액세스하려면 'read:user' 및 'read:org' 권한이 필요합니다.",
     "loginSuccess": "로그인 성공",
     "loginFailed": "로그인 실패",

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -410,6 +410,8 @@
     "githubCopilotNotConnected": "GitHub Copilot Não Conectado",
     "loginWithGitHub": "Entrar com GitHub",
     "loggingIn": "Entrando...",
+    "githubCopilotClientId": "Custom Client ID",
+    "githubCopilotClientIdHint": "Optional. Leave empty to use the built-in default Client ID. Only affects GitHub Copilot auth.",
     "githubCopilotLoginTip": "Autorize o DeepChat a acessar sua assinatura do GitHub Copilot. As permissões 'read:user' e 'read:org' são necessárias para acessar a API do Copilot.",
     "loginSuccess": "Login bem-sucedido",
     "loginFailed": "Falha no login",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -410,6 +410,8 @@
     "githubCopilotNotConnected": "GitHub Copilot не подключен",
     "loginWithGitHub": "Войти через GitHub",
     "loggingIn": "Вход...",
+    "githubCopilotClientId": "Custom Client ID",
+    "githubCopilotClientIdHint": "Optional. Leave empty to use the built-in default Client ID. Only affects GitHub Copilot auth.",
     "githubCopilotLoginTip": "Разрешите DeepChat доступ к вашей подписке GitHub Copilot. Для доступа к API Copilot требуются разрешения 'read:user' и 'read:org'.",
     "loginSuccess": "Вход выполнен успешно",
     "loginFailed": "Ошибка входа",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -477,6 +477,8 @@
     "githubCopilotNotConnected": "GitHub Copilot 未连接",
     "loginWithGitHub": "使用 GitHub 登录",
     "loggingIn": "登录中...",
+    "githubCopilotClientId": "自定义 Client ID",
+    "githubCopilotClientIdHint": "可选，留空使用默认 Client ID，仅影响 GitHub Copilot 授权。",
     "githubCopilotLoginTip": "点击授权 DeepChat 访问您的 GitHub Copilot 订阅",
     "loginSuccess": "登录成功",
     "loginFailed": "登录失败",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -410,6 +410,8 @@
     "githubCopilotNotConnected": "GitHub Copilot 未連接",
     "loginWithGitHub": "用 GitHub 登入",
     "loggingIn": "登入中...",
+    "githubCopilotClientId": "自訂 Client ID",
+    "githubCopilotClientIdHint": "可選，留空會使用預設 Client ID，只影響 GitHub Copilot 授權。",
     "githubCopilotLoginTip": "請授權 DeepChat 存取你的 GitHub Copilot 訂閱。需要 'read:user' 及 'read:org' 權限才能正常使用 Copilot API。",
     "loginSuccess": "登入成功",
     "loginFailed": "登入失敗",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -410,6 +410,8 @@
     "githubCopilotNotConnected": "GitHub Copilot 未連接",
     "loginWithGitHub": "使用 GitHub 登入",
     "loggingIn": "登入中...",
+    "githubCopilotClientId": "自訂 Client ID",
+    "githubCopilotClientIdHint": "可選，留空會使用預設 Client ID，只影響 GitHub Copilot 授權。",
     "githubCopilotLoginTip": "請授權 DeepChat 訪問您的 GitHub Copilot 訂閱。需要 'read:user' 和 'read:org' 權限才能正常使用 Copilot API。",
     "loginSuccess": "登入成功",
     "loginFailed": "登入失敗",

--- a/src/shared/provider-operations.ts
+++ b/src/shared/provider-operations.ts
@@ -39,6 +39,7 @@ export interface ProviderChange {
 export const REBUILD_REQUIRED_FIELDS = [
   'enable',
   'apiKey',
+  'copilotClientId',
   'baseUrl',
   'authMode',
   'oauthToken',

--- a/src/shared/types/presenters/legacy.presenters.d.ts
+++ b/src/shared/types/presenters/legacy.presenters.d.ts
@@ -710,6 +710,7 @@ export type LLM_PROVIDER = {
   name: string
   apiType: string
   apiKey: string
+  copilotClientId?: string
   baseUrl: string
   enable: boolean
   custom?: boolean

--- a/src/shared/types/presenters/llmprovider.presenter.d.ts
+++ b/src/shared/types/presenters/llmprovider.presenter.d.ts
@@ -47,6 +47,7 @@ export type LLM_PROVIDER = {
   name: string
   apiType: string
   apiKey: string
+  copilotClientId?: string
   baseUrl: string
   models: MODEL_META[]
   customModels?: MODEL_META[]

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -843,6 +843,8 @@ declare module 'vue-i18n' {
       githubCopilotNotConnected: string
       loginWithGitHub: string
       loggingIn: string
+      githubCopilotClientId: string
+      githubCopilotClientIdHint: string
       githubCopilotLoginTip: string
       loginSuccess: string
       loginFailed: string


### PR DESCRIPTION
users can customize the GitHub Client Id to handle Copilot's authorization

link #1073 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom GitHub Copilot Client ID configuration in settings. Users can now optionally provide a client ID through the UI instead of relying solely on environment variables.
  * Extended localization support across 12 languages for the new Client ID settings field.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->