### PR TITLE
feat: add MCP tool annotations to all in-memory servers

### DIFF
--- a/src/main/presenter/mcpPresenter/inMemoryServers/appleServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/appleServer.ts
@@ -1212,7 +1212,7 @@ export class AppleServer {
           inputSchema: zodToJsonSchema(CalendarArgsSchema),
           annotations: {
             title: 'Apple Calendar',
-            destructiveHint: false,
+            destructiveHint: false
           }
         },
         {
@@ -1221,7 +1221,7 @@ export class AppleServer {
           inputSchema: zodToJsonSchema(ContactsArgsSchema),
           annotations: {
             title: 'Apple Contacts',
-            readOnlyHint: true,
+            readOnlyHint: true
           }
         },
         {
@@ -1232,7 +1232,7 @@ export class AppleServer {
           annotations: {
             title: 'Apple Mail',
             destructiveHint: false,
-            openWorldHint: true,
+            openWorldHint: true
           }
         },
         {
@@ -1242,7 +1242,7 @@ export class AppleServer {
           inputSchema: zodToJsonSchema(MapsArgsSchema),
           annotations: {
             title: 'Apple Maps',
-            destructiveHint: false,
+            destructiveHint: false
           }
         },
         {
@@ -1253,7 +1253,7 @@ export class AppleServer {
           annotations: {
             title: 'Apple Messages',
             destructiveHint: false,
-            openWorldHint: true,
+            openWorldHint: true
           }
         },
         {
@@ -1262,7 +1262,7 @@ export class AppleServer {
           inputSchema: zodToJsonSchema(NotesArgsSchema),
           annotations: {
             title: 'Apple Notes',
-            destructiveHint: false,
+            destructiveHint: false
           }
         },
         {
@@ -1271,7 +1271,7 @@ export class AppleServer {
           inputSchema: zodToJsonSchema(RemindersArgsSchema),
           annotations: {
             title: 'Apple Reminders',
-            destructiveHint: false,
+            destructiveHint: false
           }
         }
       ]

--- a/src/main/presenter/mcpPresenter/inMemoryServers/artifactsServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/artifactsServer.ts
@@ -583,7 +583,7 @@ export class ArtifactsServer {
             inputSchema: zodToJsonSchema(GetArtifactInstructionsArgsSchema),
             annotations: {
               title: 'Get Artifact Instructions',
-              readOnlyHint: true,
+              readOnlyHint: true
             }
           }
         ]

--- a/src/main/presenter/mcpPresenter/inMemoryServers/autoPromptingServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/autoPromptingServer.ts
@@ -114,7 +114,7 @@ export class AutoPromptingServer {
           inputSchema: zodToJsonSchema(z.object({})), // 无需参数
           annotations: {
             title: 'List Prompt Template Names',
-            readOnlyHint: true,
+            readOnlyHint: true
           }
         },
         {
@@ -123,7 +123,7 @@ export class AutoPromptingServer {
           inputSchema: GetTemplateParametersArgsJsonSchema,
           annotations: {
             title: 'Get Template Parameters',
-            readOnlyHint: true,
+            readOnlyHint: true
           }
         },
         {
@@ -132,7 +132,7 @@ export class AutoPromptingServer {
           inputSchema: FillTemplateArgsJsonSchema,
           annotations: {
             title: 'Fill Prompt Template',
-            readOnlyHint: true,
+            readOnlyHint: true
           }
         }
       ]

--- a/src/main/presenter/mcpPresenter/inMemoryServers/bochaSearchServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/bochaSearchServer.ts
@@ -135,7 +135,7 @@ export class BochaSearchServer {
             annotations: {
               title: 'Bocha Web Search',
               readOnlyHint: true,
-              openWorldHint: true,
+              openWorldHint: true
             }
           },
           {
@@ -146,7 +146,7 @@ export class BochaSearchServer {
             annotations: {
               title: 'Bocha AI Search',
               readOnlyHint: true,
-              openWorldHint: true,
+              openWorldHint: true
             }
           }
         ]

--- a/src/main/presenter/mcpPresenter/inMemoryServers/braveSearchServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/braveSearchServer.ts
@@ -316,7 +316,7 @@ export class BraveSearchServer {
             annotations: {
               title: 'Brave Web Search',
               readOnlyHint: true,
-              openWorldHint: true,
+              openWorldHint: true
             }
           },
           {
@@ -334,7 +334,7 @@ export class BraveSearchServer {
             annotations: {
               title: 'Brave Local Search',
               readOnlyHint: true,
-              openWorldHint: true,
+              openWorldHint: true
             }
           }
         ]

--- a/src/main/presenter/mcpPresenter/inMemoryServers/builtinKnowledgeServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/builtinKnowledgeServer.ts
@@ -60,7 +60,7 @@ export class BuiltinKnowledgeServer {
             inputSchema: zodToJsonSchema(BuiltinKnowledgeSearchArgsSchema),
             annotations: {
               title: 'Builtin Knowledge Search',
-              readOnlyHint: true,
+              readOnlyHint: true
             }
           }
         })

--- a/src/main/presenter/mcpPresenter/inMemoryServers/conversationSearchServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/conversationSearchServer.ts
@@ -485,7 +485,7 @@ export class ConversationSearchServer {
             inputSchema: zodToJsonSchema(SearchConversationsArgsSchema),
             annotations: {
               title: 'Search Conversations',
-              readOnlyHint: true,
+              readOnlyHint: true
             }
           },
           {
@@ -495,7 +495,7 @@ export class ConversationSearchServer {
             inputSchema: zodToJsonSchema(SearchMessagesArgsSchema),
             annotations: {
               title: 'Search Messages',
-              readOnlyHint: true,
+              readOnlyHint: true
             }
           },
           {
@@ -504,7 +504,7 @@ export class ConversationSearchServer {
             inputSchema: zodToJsonSchema(GetConversationHistoryArgsSchema),
             annotations: {
               title: 'Get Conversation History',
-              readOnlyHint: true,
+              readOnlyHint: true
             }
           },
           {
@@ -513,7 +513,7 @@ export class ConversationSearchServer {
             inputSchema: zodToJsonSchema(GetConversationStatsArgsSchema),
             annotations: {
               title: 'Get Conversation Stats',
-              readOnlyHint: true,
+              readOnlyHint: true
             }
           },
           {
@@ -523,7 +523,7 @@ export class ConversationSearchServer {
             inputSchema: zodToJsonSchema(CreateNewTabArgsSchema),
             annotations: {
               title: 'Create New Tab',
-              destructiveHint: false,
+              destructiveHint: false
             }
           }
         ]

--- a/src/main/presenter/mcpPresenter/inMemoryServers/deepResearchServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/deepResearchServer.ts
@@ -285,7 +285,7 @@ export class DeepResearchServer {
             inputSchema: zodToJsonSchema(StartDeepResearchArgsSchema),
             annotations: {
               title: 'Start Deep Research',
-              destructiveHint: false,
+              destructiveHint: false
             }
           },
           {
@@ -295,7 +295,7 @@ export class DeepResearchServer {
             annotations: {
               title: 'Execute Web Search',
               readOnlyHint: false,
-              openWorldHint: true,
+              openWorldHint: true
             }
           },
           {
@@ -304,7 +304,7 @@ export class DeepResearchServer {
             inputSchema: zodToJsonSchema(RequestResearchDataArgsSchema),
             annotations: {
               title: 'Request Research Data',
-              readOnlyHint: true,
+              readOnlyHint: true
             }
           },
           {
@@ -313,7 +313,7 @@ export class DeepResearchServer {
             inputSchema: zodToJsonSchema(SubmitReflectionResultsArgsSchema),
             annotations: {
               title: 'Submit Reflection Results',
-              destructiveHint: false,
+              destructiveHint: false
             }
           },
           {
@@ -322,7 +322,7 @@ export class DeepResearchServer {
             inputSchema: zodToJsonSchema(GenerateFinalAnswerArgsSchema),
             annotations: {
               title: 'Generate Final Answer',
-              destructiveHint: true,
+              destructiveHint: true
             }
           }
         ]

--- a/src/main/presenter/mcpPresenter/inMemoryServers/difyKnowledgeServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/difyKnowledgeServer.ts
@@ -136,7 +136,7 @@ export class DifyKnowledgeServer {
             annotations: {
               title: 'Dify Knowledge Search',
               readOnlyHint: true,
-              openWorldHint: true,
+              openWorldHint: true
             }
           }
         })

--- a/src/main/presenter/mcpPresenter/inMemoryServers/fastGptKnowledgeServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/fastGptKnowledgeServer.ts
@@ -125,7 +125,7 @@ export class FastGptKnowledgeServer {
             annotations: {
               title: 'FastGPT Knowledge Search',
               readOnlyHint: true,
-              openWorldHint: true,
+              openWorldHint: true
             }
           }
         })

--- a/src/main/presenter/mcpPresenter/inMemoryServers/imageServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/imageServer.ts
@@ -199,7 +199,7 @@ export class ImageServer {
             inputSchema: zodToJsonSchema(ReadImageBase64ArgsSchema),
             annotations: {
               title: 'Read Image Base64',
-              readOnlyHint: true,
+              readOnlyHint: true
             }
           },
           {
@@ -210,7 +210,7 @@ export class ImageServer {
             annotations: {
               title: 'Upload Image',
               destructiveHint: false,
-              openWorldHint: true,
+              openWorldHint: true
             }
           },
           {
@@ -220,7 +220,7 @@ export class ImageServer {
             inputSchema: zodToJsonSchema(ReadMultipleImagesBase64ArgsSchema),
             annotations: {
               title: 'Read Multiple Images Base64',
-              readOnlyHint: true,
+              readOnlyHint: true
             }
           },
           {
@@ -231,7 +231,7 @@ export class ImageServer {
             annotations: {
               title: 'Upload Multiple Images',
               destructiveHint: false,
-              openWorldHint: true,
+              openWorldHint: true
             }
           },
           {
@@ -242,7 +242,7 @@ export class ImageServer {
             annotations: {
               title: 'Describe Image',
               readOnlyHint: true,
-              openWorldHint: true,
+              openWorldHint: true
             }
           },
           {
@@ -253,7 +253,7 @@ export class ImageServer {
             annotations: {
               title: 'Query Image with Prompt',
               readOnlyHint: true,
-              openWorldHint: true,
+              openWorldHint: true
             }
           },
           {
@@ -264,7 +264,7 @@ export class ImageServer {
             annotations: {
               title: 'OCR Image',
               readOnlyHint: true,
-              openWorldHint: true,
+              openWorldHint: true
             }
           }
         ]

--- a/src/main/presenter/mcpPresenter/inMemoryServers/meetingServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/meetingServer.ts
@@ -162,7 +162,7 @@ export class MeetingServer {
           inputSchema: zodToJsonSchema(StartMeetingArgsSchema),
           annotations: {
             title: 'Start Meeting',
-            destructiveHint: false,
+            destructiveHint: false
           }
         }
       ]

--- a/src/main/presenter/mcpPresenter/inMemoryServers/powerpackServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/powerpackServer.ts
@@ -442,7 +442,7 @@ export class PowerpackServer {
           inputSchema: zodToJsonSchema(GetTimeArgsSchema),
           annotations: {
             title: 'Get Time',
-            readOnlyHint: true,
+            readOnlyHint: true
           }
         },
         {
@@ -455,7 +455,7 @@ export class PowerpackServer {
           annotations: {
             title: 'Get Web Info',
             readOnlyHint: true,
-            openWorldHint: true,
+            openWorldHint: true
           }
         },
         {
@@ -467,7 +467,7 @@ export class PowerpackServer {
           inputSchema: zodToJsonSchema(RunShellCommandArgsSchema),
           annotations: {
             title: 'Run Shell Command',
-            destructiveHint: true,
+            destructiveHint: true
           }
         }
       ]
@@ -486,7 +486,7 @@ export class PowerpackServer {
           annotations: {
             title: 'Run Code (E2B)',
             readOnlyHint: false,
-            openWorldHint: true,
+            openWorldHint: true
           }
         })
       } else {
@@ -508,7 +508,7 @@ export class PowerpackServer {
             inputSchema: zodToJsonSchema(RunNodeCodeArgsSchema),
             annotations: {
               title: 'Run Node.js Code',
-              destructiveHint: false,
+              destructiveHint: false
             }
           })
         }

--- a/src/main/presenter/mcpPresenter/inMemoryServers/ragflowKnowledgeServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/ragflowKnowledgeServer.ts
@@ -132,7 +132,7 @@ export class RagflowKnowledgeServer {
             annotations: {
               title: 'RAGFlow Knowledge Search',
               readOnlyHint: true,
-              openWorldHint: true,
+              openWorldHint: true
             }
           }
         })


### PR DESCRIPTION
## Summary

- Add MCP tool annotations (title, readOnlyHint, destructiveHint, openWorldHint) to all 14 in-memory MCP server files
- 42 tools annotated in total following the MCP specification
- Improves LLM understanding of tool behaviors and enables better tool selection and safety decisions

### Annotated Servers

| Server | Tools | Annotations |
|--------|-------|-------------|
| imageServer | 7 | read_image_base64, upload_image, read_multiple_images_base64, upload_multiple_images, describe_image, query_image_with_prompt, ocr_image |
| artifactsServer | 1 | get_artifact_instructions |
| autoPromptingServer | 3 | list_all_prompt_template_names, get_prompt_template_parameters, fill_prompt_template |
| bochaSearchServer | 2 | bocha_web_search, bocha_ai_search |
| braveSearchServer | 2 | brave_web_search, brave_local_search |
| builtinKnowledgeServer | 1 | builtin_knowledge_search |
| conversationSearchServer | 5 | search_conversations, search_messages, get_conversation_history, get_conversation_stats, create_new_tab |
| deepResearchServer | 5 | start_deep_research, execute_single_web_search, request_research_data, submit_reflection_results, generate_final_answer |
| difyKnowledgeServer | 1 | dify_knowledge_search |
| fastGptKnowledgeServer | 1 | fastgpt_knowledge_search |
| ragflowKnowledgeServer | 1 | ragflow_knowledge_search |
| meetingServer | 1 | start_meeting |
| powerpackServer | 5 | get_time, get_web_info, run_shell_command, run_code, run_node_code |
| appleServer | 7 | calendar, contacts, mail, maps, messages, notes, reminders |

### Annotation Criteria

- **readOnlyHint: true** - Tools that only read/search data without modifications
- **destructiveHint: false** - Tools that create/add content without deleting
- **destructiveHint: true** - Tools that can modify/delete data (e.g., shell commands)
- **openWorldHint: true** - Tools that interact with external services/APIs

## Test plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Annotations appear correctly in tools/list response
- [ ] LLM clients can read and utilize the annotation hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added human-readable titles and UI hints (e.g., readOnly, destructive, openWorld) to tool listings across the app (search, knowledge, calendar, contacts, mail, images, code, research, productivity, meetings, artifacts, power tools) to improve presentation and clarify expected behavior without changing tool functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->