### PR TITLE
fix: fix macos full window

### DIFF
--- a/src/main/presenter/windowPresenter/index.ts
+++ b/src/main/presenter/windowPresenter/index.ts
@@ -1116,7 +1116,6 @@ export class WindowPresenter implements IWindowPresenter {
       }
     })
 
-
     if (process.platform === 'darwin') {
       overlay.setHiddenInMissionControl(true)
       // Keep overlay off fullscreen spaces to avoid covering macOS traffic lights


### PR DESCRIPTION
close #1243 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS fullscreen: tooltip overlays are no longer created or shown while a window is fullscreen; overlays are destroyed on enter-fullscreen and recreated on exit.
  * Mission Control/workspaces: overlays remain hidden in Mission Control and fullscreen spaces but available on regular workspaces.
  * Robust lifecycle guards added to ensure overlays sync and clean up correctly during moves, resizes, loads, and window close.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->