### PR TITLE
fix(hooks): robust pnpm + commit msg resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,8 +183,8 @@
     "zod-to-json-schema": "^3.25.0"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm lint-staged && pnpm typecheck",
-    "commit-msg": "node scripts/verify-commit.js"
+    "pre-commit": "node scripts/pre-commit.mjs",
+    "commit-msg": "node scripts/verify-commit.js \"$1\""
   },
   "lint-staged": {
     "*.js": [

--- a/scripts/pre-commit.mjs
+++ b/scripts/pre-commit.mjs
@@ -1,0 +1,61 @@
+// @ts-check
+import { spawnSync } from 'node:child_process'
+
+const tryCommand = (cmd, args) => {
+  const result = spawnSync(cmd, args, { stdio: 'ignore' })
+  if (result.error) {
+    return false
+  }
+  return result.status === 0
+}
+
+const resolvePnpm = () => {
+  if (tryCommand('pnpm', ['--version'])) {
+    return { cmd: 'pnpm', argsPrefix: [], source: 'PATH' }
+  }
+  if (
+    tryCommand('mise', ['--version']) &&
+    tryCommand('mise', ['exec', '--', 'pnpm', '--version'])
+  ) {
+    return { cmd: 'mise', argsPrefix: ['exec', '--', 'pnpm'], source: 'mise' }
+  }
+  return null
+}
+
+const runner = resolvePnpm()
+if (!runner) {
+  console.error(
+    [
+      'ERROR: pnpm not found.',
+      'Expected to find pnpm on PATH or via "mise exec -- pnpm".',
+      'Fix one of:',
+      '- Ensure pnpm is on PATH for git hooks',
+      '- Or install/configure mise and run "mise install"',
+    ].join('\n'),
+  )
+  process.exit(1)
+}
+
+const runPnpm = (args) => {
+  const result = spawnSync(runner.cmd, [...runner.argsPrefix, ...args], {
+    stdio: 'inherit',
+  })
+  if (result.error) {
+    console.error(`ERROR: failed to run pnpm via ${runner.source}`)
+    process.exit(1)
+  }
+  if (typeof result.status === 'number' && result.status !== 0) {
+    process.exit(result.status)
+  }
+  if (result.signal) {
+    process.exit(1)
+  }
+}
+
+const args = process.argv.slice(2)
+if (args.length > 0) {
+  runPnpm(args)
+} else {
+  runPnpm(['lint-staged'])
+  runPnpm(['typecheck'])
+}

--- a/scripts/verify-commit.js
+++ b/scripts/verify-commit.js
@@ -1,9 +1,31 @@
 // @ts-check
 import pico from 'picocolors'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 
-const msgPath = path.resolve('.git/COMMIT_EDITMSG')
+const resolveMsgPath = () => {
+  const argPath = process.argv[2]
+  if (argPath && existsSync(argPath)) {
+    return argPath
+  }
+
+  const gitPath = path.resolve('.git')
+  if (existsSync(gitPath)) {
+    try {
+      const stat = readFileSync(gitPath, 'utf-8').trim()
+      if (stat.startsWith('gitdir:')) {
+        const gitDir = stat.replace('gitdir:', '').trim()
+        return path.resolve(gitDir, 'COMMIT_EDITMSG')
+      }
+    } catch {
+      // ignore and fall through
+    }
+  }
+
+  return path.resolve('.git/COMMIT_EDITMSG')
+}
+
+const msgPath = resolveMsgPath()
 const msg = readFileSync(msgPath, 'utf-8').trim()
 
 const commitRE =


### PR DESCRIPTION
## Summary
- add a pre-commit runner that locates pnpm via PATH or mise
- make commit-msg hook resolve COMMIT_EDITMSG from arg/GIT_DIR/worktree

## Testing
- not run (hook ran typecheck during commit)