### PR TITLE
fix: chat-input height fixed

### DIFF
--- a/src/renderer/src/components/chat-input/ChatInput.vue
+++ b/src/renderer/src/components/chat-input/ChatInput.vue
@@ -11,7 +11,13 @@
       <div
         ref="inputContainer"
         :dir="langStore.dir"
-        :style="inputHeight && variant === 'chat' ? { height: `${inputHeight}px` } : {}"
+        :style="
+          variant === 'chat'
+            ? inputHeight
+              ? { height: `${inputHeight}px` }
+              : { maxHeight: '50vh' }
+            : {}
+        "
         :class="[
           'flex flex-col gap-2 relative',
           variant === 'newThread'
@@ -521,8 +527,8 @@ const handleResize = (e: MouseEvent) => {
   if (!isResizing.value) return
   const deltaY = startY.value - e.clientY
   const newHeight = startHeight.value + deltaY
-  // Min height 100px, Max height 80% of window height
-  const maxHeight = window.innerHeight * 0.8
+  // Min height 100px, Max height 50% of window height
+  const maxHeight = window.innerHeight * 0.5
   if (newHeight > 100 && newHeight < maxHeight) {
     inputHeight.value = newHeight
   }
@@ -576,8 +582,7 @@ const history = useInputHistory(null as any, t)
 const editor = new Editor({
   editorProps: {
     attributes: {
-      class:
-        'outline-none focus:outline-none focus-within:outline-none min-h-12 h-full overflow-y-auto'
+      class: 'outline-none focus:outline-none focus-within:outline-none min-h-12'
     }
   },
   autofocus: true,


### PR DESCRIPTION
close #1256 

fix the problem of flex layout being stretched by sub-content 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chat input container sizing behavior with more constrained height limits
  * Reduced maximum resizable height from 80% to 50% of viewport
  * Simplified editor scroll behavior and layout constraints

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->