### PR TITLE
fix(ollama): handle showModelInfo errors to prevent empty model list

### DIFF
--- a/src/main/presenter/llmProviderPresenter/providers/ollamaProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/ollamaProvider.ts
@@ -323,21 +323,37 @@ export class OllamaProvider extends BaseLLMProvider {
   }
 
   private async attachModelInfo(model: OllamaModel): Promise<OllamaModel> {
-    const showResponse = await this.showModelInfo(model.name)
-    const info = showResponse.model_info
-    const family = model.details.family
-    const context_length = info?.[family + '.context_length'] ?? 4096
-    const embedding_length = info?.[family + '.embedding_length'] ?? 512
-    const capabilities = showResponse.capabilities ?? ['chat']
+    try {
+      const showResponse = await this.showModelInfo(model.name)
+      const info = showResponse.model_info
+      const family = model.details.family
+      const context_length = info?.[family + '.context_length'] ?? 4096
+      const embedding_length = info?.[family + '.embedding_length'] ?? 512
+      const capabilities = showResponse.capabilities ?? ['chat']
 
-    // Merge customConfig properties to model
-    return {
-      ...model,
-      model_info: {
-        context_length,
-        embedding_length
-      },
-      capabilities
+      // Merge customConfig properties to model
+      return {
+        ...model,
+        model_info: {
+          context_length,
+          embedding_length
+        },
+        capabilities
+      }
+    } catch (error) {
+      // If showModelInfo fails, return the model with default info
+      console.warn(
+        `Failed to get info for model ${model.name}, using defaults:`,
+        (error as Error).message
+      )
+      return {
+        ...model,
+        model_info: {
+          context_length: 4096,
+          embedding_length: 512
+        },
+        capabilities: ['chat']
+      }
     }
   }
 


### PR DESCRIPTION
If showModelInfo() fails for any model, the entire Promise.all would fail, returning an empty array. 
> Failed to show Ollama model info for gpt-oss:20b: template: :3: function "currentDate" not defined
09:38:19.378 › Failed to get info for model gpt-oss:20b, using defaults: template: :3: function "currentDate" not defined
<img width="3288" height="1818" alt="image" src="https://github.com/user-attachments/assets/446810d1-b883-4645-bbf4-dcc2f2e8eb90" />

Now it returns the model with default info on error.
<img width="1636" height="1380" alt="image" src="https://github.com/user-attachments/assets/0a60fa4b-d4b9-4bf5-b298-0f80afb349fe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling for Ollama model information retrieval with automatic fallback defaults, ensuring uninterrupted service when model details are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->