### PR TITLE
feat(mcp): implement real Apple Maps search using URL scheme

### DIFF
--- a/src/main/presenter/mcpPresenter/inMemoryServers/appleServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/appleServer.ts
@@ -1569,11 +1569,16 @@ export class AppleServer {
           if (!parsedArgs.query) {
             throw new Error('Query is required for search operation')
           }
+          await runAppleScript(`
+            open location "maps://?q=${encodeURIComponent(parsedArgs.query)}"
+            delay 0.3
+            tell application "Maps" to activate
+          `)
           return {
             content: [
               {
                 type: 'text' as const,
-                text: `Found locations for "${parsedArgs.query}":\n\n• Location 1: ${parsedArgs.query} Restaurant\n• Location 2: ${parsedArgs.query} Store\n• Location 3: ${parsedArgs.query} Center`
+                text: `Search for "${parsedArgs.query}" has been launched in Apple Maps app. Please check the Maps window for results.`
               }
             ]
           }


### PR DESCRIPTION
在此之前，apple-server 中的 maps.search 工具仅返回硬编码的模拟文本（Mock Data），且不会触发 macOS 系统产生任何实际反应。用户无法通过 AI 真正打开地图进行搜索。

主要变更
逻辑优化：移除了 handleMapsTool 中 search 操作的模拟数据。
系统集成：引入了真实的 AppleScript 调用，利用 maps:// URL Scheme 唤起系统原生的 Apple Maps 应用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apple Maps search integration now executes queries directly in the Maps application with automatic activation and confirmation messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->