### PR TITLE
feat: add tooltip for filling default API URL in settings

### DIFF
--- a/src/renderer/settings/components/AnthropicProviderSettingsDetail.vue
+++ b/src/renderer/settings/components/AnthropicProviderSettingsDetail.vue
@@ -54,11 +54,34 @@
           @keyup.enter="handleApiHostChange(apiHost)"
         />
         <div class="text-xs text-muted-foreground">
-          {{
-            t('settings.provider.urlFormat', {
-              defaultUrl: 'https://api.anthropic.com'
-            })
-          }}
+          <TooltipProvider v-if="hasDefaultBaseUrl" :delayDuration="200">
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <button
+                  type="button"
+                  class="text-xs text-muted-foreground underline decoration-dotted underline-offset-2 transition-colors hover:text-foreground"
+                  :aria-label="t('settings.provider.urlFormatFill')"
+                  @click="fillDefaultBaseUrl"
+                >
+                  {{
+                    t('settings.provider.urlFormat', {
+                      defaultUrl: defaultBaseUrl
+                    })
+                  }}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {{ t('settings.provider.urlFormatFill') }}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <span v-else>
+            {{
+              t('settings.provider.urlFormat', {
+                defaultUrl: defaultBaseUrl
+              })
+            }}
+          </span>
         </div>
 
         <Label :for="`${provider.id}-apikey`" class="flex-1 cursor-pointer">{{
@@ -340,6 +363,12 @@ import { onMounted, ref, watch, onUnmounted, computed } from 'vue'
 import { Label } from '@shadcn/components/ui/label'
 import { Input } from '@shadcn/components/ui/input'
 import { Button } from '@shadcn/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '@shadcn/components/ui/tooltip'
 import { Icon } from '@iconify/vue'
 import {
   Dialog,
@@ -396,6 +425,8 @@ const oauthCode = ref('')
 const codeValidationError = ref('')
 const isSubmittingCode = ref(false)
 const showDeleteProviderDialog = ref(false)
+const defaultBaseUrl = 'https://api.anthropic.com'
+const hasDefaultBaseUrl = defaultBaseUrl.length > 0
 
 // Computed
 const hasOAuthToken = ref(false)
@@ -608,6 +639,12 @@ const disconnectOAuth = async () => {
 // API URL 处理
 const handleApiHostChange = async (value: string) => {
   await providerStore.updateProviderApi(props.provider.id, undefined, value)
+}
+
+const fillDefaultBaseUrl = async () => {
+  if (!hasDefaultBaseUrl) return
+  apiHost.value = defaultBaseUrl
+  await handleApiHostChange(defaultBaseUrl)
 }
 
 // API Key 处理

--- a/src/renderer/settings/components/OllamaProviderSettingsDetail.vue
+++ b/src/renderer/settings/components/OllamaProviderSettingsDetail.vue
@@ -23,11 +23,34 @@
           @keyup.enter="handleApiHostChange(apiHost)"
         />
         <div class="text-xs text-muted-foreground">
-          {{
-            t('settings.provider.urlFormat', {
-              defaultUrl: 'http://127.0.0.1:11434'
-            })
-          }}
+          <TooltipProvider v-if="hasDefaultBaseUrl" :delayDuration="200">
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <button
+                  type="button"
+                  class="text-xs text-muted-foreground underline decoration-dotted underline-offset-2 transition-colors hover:text-foreground"
+                  :aria-label="t('settings.provider.urlFormatFill')"
+                  @click="fillDefaultBaseUrl"
+                >
+                  {{
+                    t('settings.provider.urlFormat', {
+                      defaultUrl: defaultBaseUrl
+                    })
+                  }}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {{ t('settings.provider.urlFormatFill') }}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <span v-else>
+            {{
+              t('settings.provider.urlFormat', {
+                defaultUrl: defaultBaseUrl
+              })
+            }}
+          </span>
         </div>
       </div>
 
@@ -276,6 +299,12 @@ import { Label } from '@shadcn/components/ui/label'
 import { Input } from '@shadcn/components/ui/input'
 import { Button } from '@shadcn/components/ui/button'
 import { Progress } from '@shadcn/components/ui/progress'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '@shadcn/components/ui/tooltip'
 import { Icon } from '@iconify/vue'
 import {
   Dialog,
@@ -310,6 +339,8 @@ const showPullModelDialog = ref(false)
 const showCheckModelDialog = ref(false)
 const checkResult = ref<boolean>(false)
 const showDeleteProviderDialog = ref(false)
+const defaultBaseUrl = 'http://127.0.0.1:11434'
+const hasDefaultBaseUrl = defaultBaseUrl.length > 0
 
 // 模型列表 - 从 settings store 获取
 const runningModels = computed(() => ollamaStore.getOllamaRunningModels(props.provider.id))
@@ -901,6 +932,12 @@ const isModelLocal = (modelName: string): boolean => {
 // API URL 处理
 const handleApiHostChange = async (value: string) => {
   await providerStore.updateProviderApi(props.provider.id, undefined, value)
+}
+
+const fillDefaultBaseUrl = async () => {
+  if (!hasDefaultBaseUrl) return
+  apiHost.value = defaultBaseUrl
+  await handleApiHostChange(defaultBaseUrl)
 }
 
 // API Key 处理

--- a/src/renderer/settings/components/ProviderApiConfig.vue
+++ b/src/renderer/settings/components/ProviderApiConfig.vue
@@ -23,11 +23,34 @@
         @update:model-value="apiHost = String($event)"
       />
       <div class="text-xs text-muted-foreground">
-        {{
-          t('settings.provider.urlFormat', {
-            defaultUrl: providerWebsites?.defaultBaseUrl || ''
-          })
-        }}
+        <TooltipProvider v-if="hasDefaultBaseUrl" :delayDuration="200">
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <button
+                type="button"
+                class="text-xs text-muted-foreground underline decoration-dotted underline-offset-2 transition-colors hover:text-foreground"
+                :aria-label="t('settings.provider.urlFormatFill')"
+                @click="fillDefaultBaseUrl"
+              >
+                {{
+                  t('settings.provider.urlFormat', {
+                    defaultUrl: defaultBaseUrl
+                  })
+                }}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {{ t('settings.provider.urlFormatFill') }}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <span v-else>
+          {{
+            t('settings.provider.urlFormat', {
+              defaultUrl: defaultBaseUrl
+            })
+          }}
+        </span>
       </div>
     </div>
 
@@ -127,11 +150,17 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Label } from '@shadcn/components/ui/label'
 import { Input } from '@shadcn/components/ui/input'
 import { Button } from '@shadcn/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '@shadcn/components/ui/tooltip'
 import { Icon } from '@iconify/vue'
 import GitHubCopilotOAuth from './GitHubCopilotOAuth.vue'
 import { usePresenter } from '@/composables/usePresenter'
@@ -169,6 +198,8 @@ const apiHost = ref(props.provider.baseUrl || '')
 const keyStatus = ref<KeyStatus | null>(null)
 const isRefreshing = ref(false)
 const showApiKey = ref(false)
+const defaultBaseUrl = computed(() => props.providerWebsites?.defaultBaseUrl?.trim() || '')
+const hasDefaultBaseUrl = computed(() => defaultBaseUrl.value.length > 0)
 
 watch(
   () => props.provider,
@@ -191,6 +222,12 @@ const handleApiKeyBlur = (event: FocusEvent) => {
 
 const handleApiHostChange = (value: string) => {
   emit('api-host-change', value)
+}
+
+const fillDefaultBaseUrl = () => {
+  if (!hasDefaultBaseUrl.value) return
+  apiHost.value = defaultBaseUrl.value
+  handleApiHostChange(defaultBaseUrl.value)
 }
 
 const handleApiHostBlur = (event: FocusEvent) => {

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -301,6 +301,7 @@
     "getKeyTip": "Besøg venligst",
     "getKeyTipEnd": "for at få API-nøglen",
     "urlFormat": "API-eksempel: {defaultUrl}",
+    "urlFormatFill": "Udfyld API-URL",
     "modelList": "Modelliste",
     "enableModels": "Aktivér modeller",
     "disableAllModels": "Deaktiver alle modeller",

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -313,6 +313,7 @@
     "getKeyTip": "Please visit",
     "getKeyTipEnd": "to get API Key",
     "urlFormat": "API Example: {defaultUrl}",
+    "urlFormatFill": "Fill into API URL",
     "modelList": "Model List",
     "enableModels": "Enable Models",
     "disableAllModels": "Disable All Models",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -313,6 +313,7 @@
     "getKeyTip": "لطفاً به",
     "getKeyTipEnd": "بروید تا کلید API را دریافت کنید",
     "urlFormat": "نمونه API: {defaultUrl}",
+    "urlFormatFill": "قرار دادن در URL API",
     "modelList": "فهرست مدل‌ها",
     "enableModels": "روشن کردن مدل‌ها",
     "disableAllModels": "خاموش کردن همه مدل‌ها",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -313,6 +313,7 @@
     "getKeyTip": "Veuillez visiter",
     "getKeyTipEnd": "pour obtenir la clé API",
     "urlFormat": "Exemple d'API : {defaultUrl}",
+    "urlFormatFill": "Renseigner l'URL de l'API",
     "modelList": "Liste des modèles",
     "enableModels": "Activer les modèles",
     "disableAllModels": "Désactiver tous les modèles",

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -313,6 +313,7 @@
     "getKeyTip": "אנא בקר ב",
     "getKeyTipEnd": "כדי לקבל מפתח API",
     "urlFormat": "דוגמת API: {defaultUrl}",
+    "urlFormatFill": "מילוי בכתובת ה-API",
     "modelList": "רשימת מודלים",
     "enableModels": "הפעל מודלים",
     "disableAllModels": "השבת את כל המודלים",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -313,6 +313,7 @@
     "getKeyTip": "以下へアクセスしてください",
     "getKeyTipEnd": "API Keyを取得する",
     "urlFormat": "API例：{defaultUrl}",
+    "urlFormatFill": "API URL に入力",
     "modelList": "モデル一覧",
     "enableModels": "モデルを有効にする",
     "disableAllModels": "すべてのモデルを無効にする",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -434,6 +434,7 @@
     "noLocalModels": "로컬 모델 없음",
     "localModels": "로컬 모델",
     "urlFormat": "API 샘플 : {defaultUrl}",
+    "urlFormatFill": "API URL에 입력",
     "azureApiVersion": "API 버전",
     "safety": {
       "title": "보안 설정",

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -313,6 +313,7 @@
     "getKeyTip": "Por favor, visite",
     "getKeyTipEnd": "para obter a Chave da API",
     "urlFormat": "Exemplo de API: {defaultUrl}",
+    "urlFormatFill": "Preencher na URL da API",
     "modelList": "Lista de Modelos",
     "enableModels": "Habilitar Modelos",
     "disableAllModels": "Desabilitar Todos os Modelos",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -434,6 +434,7 @@
     "noLocalModels": "Нет локальных моделей",
     "localModels": "Локальные модели",
     "urlFormat": "Образец API: {defaultUrl}",
+    "urlFormatFill": "Подставить в URL API",
     "azureApiVersion": "Версия API",
     "safety": {
       "title": "Настройки безопасности",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -314,6 +314,7 @@
     "getKeyTip": "请前往",
     "getKeyTipEnd": "获取API Key",
     "urlFormat": "API样例：{defaultUrl}",
+    "urlFormatFill": "填充到 API URL",
     "modelList": "模型列表",
     "enableModels": "启用模型",
     "disableAllModels": "禁用全部",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -313,6 +313,7 @@
     "getKeyTip": "請前往",
     "getKeyTipEnd": "獲取API Key",
     "urlFormat": "API範例：{defaultUrl}",
+    "urlFormatFill": "填入 API URL",
     "modelList": "模型列表",
     "enableModels": "模型已經啟用",
     "verifyLink": "驗證鏈接",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -313,6 +313,7 @@
     "getKeyTip": "請前往",
     "getKeyTipEnd": "取得 API 金鑰",
     "urlFormat": "API 範例：{defaultUrl}",
+    "urlFormatFill": "填入 API URL",
     "modelList": "模型清單",
     "enableModels": "啟用模型",
     "disableAllModels": "全部停用",


### PR DESCRIPTION

https://github.com/user-attachments/assets/db2a6b8f-598b-419e-bb61-1f5c71a93be5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick-fill buttons for API base URLs in provider settings (Anthropic, Ollama, and general provider configuration).
  * Users can now one-click populate API URL fields with default values when available.
  * Added tooltips to guide users through the new functionality.

* **Documentation**
  * Expanded translations for the new feature across 14 languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->