### PR TITLE
fix(preload): add URL protocol filter for openExternal

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -6,8 +6,6 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
     <key>com.apple.security.files.user-selected.read-only</key>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,17 @@ import {
 } from 'electron'
 import { exposeElectronAPI } from '@electron-toolkit/preload'
 
+const ALLOWED_PROTOCOLS = ['http:', 'https:', 'mailto:', 'tel:', 'deepchat:']
+
+const isValidExternalUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url)
+    return ALLOWED_PROTOCOLS.includes(parsed.protocol.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
 // Cache variables
 let cachedWindowId: number | undefined = undefined
 let cachedWebContentsId: number | undefined = undefined
@@ -44,6 +55,10 @@ const api = {
     return cachedWebContentsId
   },
   openExternal: (url: string) => {
+    if (!isValidExternalUrl(url)) {
+      console.warn('Preload: Blocked openExternal for disallowed URL:', url)
+      return Promise.reject(new Error('URL protocol not allowed'))
+    }
     return shell.openExternal(url)
   },
   toRelativePath: (filePath: string, baseDir?: string) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for external URLs, restricting supported protocols to http, https, mailto, tel, and deepchat.

* **Chores**
  * Updated macOS application entitlements configuration by removing an unused security setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->