### PR TITLE
fix(settings): disable auto-fallback in default model selection

### DIFF
--- a/src/renderer/settings/components/common/DefaultModelSettingsSection.vue
+++ b/src/renderer/settings/components/common/DefaultModelSettingsSection.vue
@@ -163,19 +163,6 @@ const selectBySetting = (
   return { providerId: setting.providerId, model: matchedModel }
 }
 
-const pickFirstEnabledModel = (
-  predicate?: (model: RENDERER_MODEL_META, providerId: string) => boolean
-): SelectedModel | null => {
-  for (const providerEntry of modelStore.enabledModels) {
-    for (const model of providerEntry.models) {
-      if (!predicate || predicate(model, providerEntry.providerId)) {
-        return { providerId: providerEntry.providerId, model }
-      }
-    }
-  }
-  return null
-}
-
 const persistModelSetting = async (
   key: 'assistantModel' | 'defaultModel' | 'defaultVisionModel',
   previous: { providerId: string; modelId: string } | undefined,
@@ -237,23 +224,14 @@ const syncModelSelections = async (): Promise<void> => {
       | undefined
 
     const chatSelection =
-      selectBySetting(defaultModelSetting, (_model, providerId) => providerId !== 'acp') ||
-      pickFirstEnabledModel((_model, providerId) => providerId !== 'acp')
+      selectBySetting(defaultModelSetting, (_model, providerId) => providerId !== 'acp')
 
     const assistantSelection =
-      selectBySetting(assistantModelSetting, (_model, providerId) => providerId !== 'acp') ||
-      chatSelection ||
-      pickFirstEnabledModel((_model, providerId) => providerId !== 'acp')
+      selectBySetting(assistantModelSetting, (_model, providerId) => providerId !== 'acp')
 
     const visionSelection =
       selectBySetting(
         defaultVisionModelSetting,
-        (model, providerId) =>
-          providerId !== 'acp' &&
-          Boolean(model.vision) &&
-          (model.type === ModelType.Chat || model.type === ModelType.ImageGeneration)
-      ) ||
-      pickFirstEnabledModel(
         (model, providerId) =>
           providerId !== 'acp' &&
           Boolean(model.vision) &&

--- a/src/renderer/settings/components/common/DefaultModelSettingsSection.vue
+++ b/src/renderer/settings/components/common/DefaultModelSettingsSection.vue
@@ -223,20 +223,23 @@ const syncModelSelections = async (): Promise<void> => {
       | { providerId: string; modelId: string }
       | undefined
 
-    const chatSelection =
-      selectBySetting(defaultModelSetting, (_model, providerId) => providerId !== 'acp')
+    const chatSelection = selectBySetting(
+      defaultModelSetting,
+      (_model, providerId) => providerId !== 'acp'
+    )
 
-    const assistantSelection =
-      selectBySetting(assistantModelSetting, (_model, providerId) => providerId !== 'acp')
+    const assistantSelection = selectBySetting(
+      assistantModelSetting,
+      (_model, providerId) => providerId !== 'acp'
+    )
 
-    const visionSelection =
-      selectBySetting(
-        defaultVisionModelSetting,
-        (model, providerId) =>
-          providerId !== 'acp' &&
-          Boolean(model.vision) &&
-          (model.type === ModelType.Chat || model.type === ModelType.ImageGeneration)
-      )
+    const visionSelection = selectBySetting(
+      defaultVisionModelSetting,
+      (model, providerId) =>
+        providerId !== 'acp' &&
+        Boolean(model.vision) &&
+        (model.type === ModelType.Chat || model.type === ModelType.ImageGeneration)
+    )
 
     selectedChatModel.value = chatSelection
     selectedAssistantModel.value = assistantSelection


### PR DESCRIPTION
Remove automatic model fallback in DefaultModelSettingsSection to prevent unintended model changes when providers load late. Models now only change on explicit user selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Default model selection now relies exclusively on explicit configuration (providerId + modelId) for chat, assistant, and vision; automatic fallbacks to other available models were removed.
  * Simplified selection flow by eliminating multi-step fallback behavior, ensuring selections reflect only the configured settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->