### PR TITLE
Use User-Agent header as well as HTTP-Referer/X-Title

### DIFF
--- a/src/main/presenter/devicePresenter/index.ts
+++ b/src/main/presenter/devicePresenter/index.ts
@@ -15,9 +15,11 @@ const execAsync = promisify(exec)
 
 export class DevicePresenter implements IDevicePresenter {
   static getDefaultHeaders(): Record<string, string> {
+    const version = app.getVersion()
     return {
       'HTTP-Referer': 'https://deepchatai.cn',
-      'X-Title': 'DeepChat'
+      'X-Title': 'DeepChat',
+      'User-Agent': `DeepChat/${version}`
     }
   }
   async getAppVersion(): Promise<string> {

--- a/test/main/presenter/devicePresenter.test.ts
+++ b/test/main/presenter/devicePresenter.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest'
+import { DevicePresenter } from '../../../src/main/presenter/devicePresenter/index'
+
+// Mock eventBus (imported by DevicePresenter via @/eventbus)
+vi.mock('@/eventbus', () => ({
+  eventBus: {
+    on: vi.fn(),
+    sendToRenderer: vi.fn(),
+    emit: vi.fn()
+  },
+  SendTarget: {
+    ALL_WINDOWS: 'ALL_WINDOWS'
+  }
+}))
+
+// Mock svgSanitizer (imported by DevicePresenter via @/lib/svgSanitizer)
+vi.mock('@/lib/svgSanitizer', () => ({
+  svgSanitizer: {
+    sanitize: vi.fn()
+  }
+}))
+
+describe('DevicePresenter', () => {
+  describe('getDefaultHeaders', () => {
+    it('should include User-Agent header with DeepChat/ prefix', () => {
+      const headers = DevicePresenter.getDefaultHeaders()
+
+      expect(headers).toHaveProperty('User-Agent')
+      expect(headers['User-Agent']).toMatch(/^DeepChat\//)
+    })
+
+    it('should include HTTP-Referer and X-Title headers', () => {
+      const headers = DevicePresenter.getDefaultHeaders()
+
+      expect(headers['HTTP-Referer']).toBe('https://deepchatai.cn')
+      expect(headers['X-Title']).toBe('DeepChat')
+    })
+  })
+})


### PR DESCRIPTION
Adds a standard User-Agent: DeepChat/{version} header for API identification, beyond just HTTP-Referer/X-Title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application identification in HTTP requests with dynamic version information in request headers.

* **Tests**
  * Added test coverage for request header validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->