### PR TITLE
fix(agent): guard large tool outputs

### DIFF
--- a/src/main/presenter/deepchatAgentPresenter/dispatch.ts
+++ b/src/main/presenter/deepchatAgentPresenter/dispatch.ts
@@ -574,6 +574,7 @@ export async function executeTools(
         }
       }
 
+      const isToolError = guardedResult.kind === 'tool_error' || toolRawData.isError === true
       const toolMessageContent =
         guardedResult.kind === 'tool_error' ? guardedResult.message : guardedResult.content
       conversation.push({
@@ -581,12 +582,7 @@ export async function executeTools(
         tool_call_id: tc.id,
         content: toolMessageContent
       })
-      updateToolCallBlock(
-        state.blocks,
-        tc.id,
-        toolMessageContent,
-        guardedResult.kind === 'tool_error'
-      )
+      updateToolCallBlock(state.blocks, tc.id, toolMessageContent, isToolError)
     } catch (err) {
       const errorText = err instanceof Error ? err.message : String(err)
       conversation.push({

--- a/src/main/presenter/deepchatAgentPresenter/dispatch.ts
+++ b/src/main/presenter/deepchatAgentPresenter/dispatch.ts
@@ -9,6 +9,7 @@ import { parseQuestionToolArgs, QUESTION_TOOL_NAME } from '../agentPresenter/too
 import type { IoParams, PendingToolInteraction, StreamState } from './types'
 import type { ChatMessage } from '@shared/types/core/chat-message'
 import { nanoid } from 'nanoid'
+import type { ToolOutputGuard } from './toolOutputGuard'
 
 type PermissionType = 'read' | 'write' | 'all' | 'command'
 
@@ -376,8 +377,15 @@ export async function executeTools(
   toolPresenter: IToolPresenter,
   modelId: string,
   io: IoParams,
-  permissionMode: PermissionMode
-): Promise<{ executed: number; pendingInteractions: PendingToolInteraction[] }> {
+  permissionMode: PermissionMode,
+  toolOutputGuard: ToolOutputGuard,
+  contextLength: number,
+  maxTokens: number
+): Promise<{
+  executed: number
+  pendingInteractions: PendingToolInteraction[]
+  terminalError?: string
+}> {
   for (const tc of state.completedToolCalls) {
     const toolDef = tools.find((t) => t.function.name === tc.name)
     if (!toolDef) continue
@@ -542,12 +550,43 @@ export async function executeTools(
       }
 
       const responseText = toolResponseToText(toolRawData.content)
+      const guardedResult = await toolOutputGuard.guardToolOutput({
+        sessionId: io.sessionId,
+        toolCallId: tc.id,
+        toolName: toolContext.name,
+        rawContent: responseText,
+        conversationMessages: conversation,
+        toolDefinitions: tools,
+        contextLength,
+        maxTokens
+      })
+
+      if (guardedResult.kind === 'terminal_error') {
+        updateToolCallBlock(state.blocks, tc.id, guardedResult.message, true)
+        state.dirty = true
+        executed += 1
+        flushBlocksToRenderer(io, state.blocks)
+        io.messageStore.updateAssistantContent(io.messageId, state.blocks)
+        return {
+          executed,
+          pendingInteractions,
+          terminalError: guardedResult.message
+        }
+      }
+
+      const toolMessageContent =
+        guardedResult.kind === 'tool_error' ? guardedResult.message : guardedResult.content
       conversation.push({
         role: 'tool',
         tool_call_id: tc.id,
-        content: responseText
+        content: toolMessageContent
       })
-      updateToolCallBlock(state.blocks, tc.id, responseText, false)
+      updateToolCallBlock(
+        state.blocks,
+        tc.id,
+        toolMessageContent,
+        guardedResult.kind === 'tool_error'
+      )
     } catch (err) {
       const errorText = err instanceof Error ? err.message : String(err)
       conversation.push({

--- a/src/main/presenter/deepchatAgentPresenter/index.ts
+++ b/src/main/presenter/deepchatAgentPresenter/index.ts
@@ -48,9 +48,16 @@ type PendingInteractionEntry = {
 type DeferredToolExecutionResult = {
   responseText: string
   isError: boolean
+  offloadPath?: string
   requiresPermission?: boolean
   permissionRequest?: PendingToolInteraction['permission']
   terminalError?: string
+}
+
+type ResumeBudgetToolCall = {
+  id: string
+  name: string
+  offloadPath?: string
 }
 
 type PersistedSessionGenerationRow = {
@@ -357,7 +364,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       }
 
       let waitingForUserMessage = false
-      let resumeBudgetToolCall: NonNullable<AssistantMessageBlock['tool_call']> | null = null
+      let resumeBudgetToolCall: ResumeBudgetToolCall | null = null
       const actionBlock = blocks[currentEntry.blockIndex]
       const toolCall = actionBlock.tool_call
       if (!toolCall?.id) {
@@ -414,7 +421,11 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
             execution.responseText,
             execution.isError
           )
-          resumeBudgetToolCall = toolCall
+          resumeBudgetToolCall = {
+            id: toolCall.id,
+            name: toolCall.name || '',
+            offloadPath: execution.offloadPath
+          }
 
           if (execution.requiresPermission && execution.permissionRequest) {
             actionBlock.status = 'pending'
@@ -849,7 +860,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
     sessionId: string,
     messageId: string,
     initialBlocks: AssistantMessageBlock[],
-    budgetToolCall?: NonNullable<AssistantMessageBlock['tool_call']> | null
+    budgetToolCall?: ResumeBudgetToolCall | null
   ): Promise<boolean> {
     if (this.resumingMessages.has(messageId)) {
       return false
@@ -907,6 +918,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
         })
 
         if (resumeBudget?.kind === 'tool_error') {
+          await this.toolOutputGuard.cleanupOffloadedOutput(budgetToolCall.offloadPath)
           this.updateToolCallResponse(initialBlocks, budgetToolCall.id, resumeBudget.message, true)
           this.messageStore.updateAssistantContent(messageId, initialBlocks)
           this.emitMessageRefresh(sessionId, messageId)
@@ -916,6 +928,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
             resumeBudget.message
           )
         } else if (resumeBudget?.kind === 'terminal_error') {
+          await this.toolOutputGuard.cleanupOffloadedOutput(budgetToolCall.offloadPath)
           this.updateToolCallResponse(initialBlocks, budgetToolCall.id, resumeBudget.message, true)
           this.messageStore.setMessageError(messageId, initialBlocks)
           this.emitMessageRefresh(sessionId, messageId)
@@ -1901,7 +1914,8 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       }
       return {
         responseText: prepared.content,
-        isError: Boolean(rawData.isError)
+        isError: Boolean(rawData.isError),
+        offloadPath: prepared.offloadPath
       }
     } catch (error) {
       const errorText = error instanceof Error ? error.message : String(error)

--- a/src/main/presenter/deepchatAgentPresenter/index.ts
+++ b/src/main/presenter/deepchatAgentPresenter/index.ts
@@ -14,7 +14,12 @@ import type {
 } from '@shared/types/agent-interface'
 import type { MCPToolCall, MCPToolResponse } from '@shared/types/core/mcp'
 import type { ChatMessage } from '@shared/types/core/chat-message'
-import type { IConfigPresenter, ILlmProviderPresenter, ModelConfig } from '@shared/presenter'
+import type {
+  IConfigPresenter,
+  ILlmProviderPresenter,
+  MCPToolDefinition,
+  ModelConfig
+} from '@shared/presenter'
 import type { IToolPresenter } from '@shared/types/presenters/tool.presenter'
 import { nanoid } from 'nanoid'
 import type { SQLitePresenter } from '../sqlitePresenter'
@@ -32,6 +37,7 @@ import { DeepChatMessageStore } from './messageStore'
 import { processStream } from './process'
 import { DeepChatSessionStore, type SessionSummaryState } from './sessionStore'
 import type { PendingToolInteraction, ProcessResult } from './types'
+import { ToolOutputGuard } from './toolOutputGuard'
 import type { ProviderRequestTracePayload } from '../llmProviderPresenter/requestTrace'
 
 type PendingInteractionEntry = {
@@ -44,6 +50,7 @@ type DeferredToolExecutionResult = {
   isError: boolean
   requiresPermission?: boolean
   permissionRequest?: PendingToolInteraction['permission']
+  terminalError?: string
 }
 
 type PersistedSessionGenerationRow = {
@@ -90,6 +97,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
   private readonly interactionLocks: Set<string> = new Set()
   private readonly resumingMessages: Set<string> = new Set()
   private readonly compactionService: CompactionService
+  private readonly toolOutputGuard: ToolOutputGuard
 
   constructor(
     llmProviderPresenter: ILlmProviderPresenter,
@@ -108,6 +116,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       this.llmProviderPresenter,
       this.configPresenter
     )
+    this.toolOutputGuard = new ToolOutputGuard()
 
     const recovered = this.messageStore.recoverPendingMessages()
     if (recovered > 0) {
@@ -348,6 +357,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       }
 
       let waitingForUserMessage = false
+      let resumeBudgetToolCall: NonNullable<AssistantMessageBlock['tool_call']> | null = null
       const actionBlock = blocks[currentEntry.blockIndex]
       const toolCall = actionBlock.tool_call
       if (!toolCall?.id) {
@@ -385,12 +395,26 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
           this.markPermissionResolved(actionBlock, true, permissionType)
           await this.grantPermissionForPayload(sessionId, permissionPayload, toolCall)
           const execution = await this.executeDeferredToolCall(sessionId, toolCall)
+          if (execution.terminalError) {
+            this.updateToolCallResponse(blocks, toolCall.id, execution.terminalError, true)
+            this.messageStore.setMessageError(messageId, blocks)
+            this.emitMessageRefresh(sessionId, messageId)
+            eventBus.sendToRenderer(STREAM_EVENTS.ERROR, SendTarget.ALL_WINDOWS, {
+              conversationId: sessionId,
+              eventId: messageId,
+              messageId,
+              error: execution.terminalError
+            })
+            this.setSessionStatus(sessionId, 'error')
+            return { resumed: false }
+          }
           this.updateToolCallResponse(
             blocks,
             toolCall.id,
             execution.responseText,
             execution.isError
           )
+          resumeBudgetToolCall = toolCall
 
           if (execution.requiresPermission && execution.permissionRequest) {
             actionBlock.status = 'pending'
@@ -426,8 +450,13 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
         return { resumed: false, waitingForUserMessage: true }
       }
 
-      await this.resumeAssistantMessage(sessionId, messageId, blocks)
-      return { resumed: true }
+      const resumed = await this.resumeAssistantMessage(
+        sessionId,
+        messageId,
+        blocks,
+        resumeBudgetToolCall
+      )
+      return { resumed }
     } finally {
       this.interactionLocks.delete(lockKey)
     }
@@ -698,9 +727,10 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
     messageId: string
     messages: ChatMessage[]
     projectDir: string | null
+    tools?: MCPToolDefinition[]
     initialBlocks?: AssistantMessageBlock[]
   }): Promise<ProcessResult> {
-    const { sessionId, messageId, messages, projectDir, initialBlocks } = args
+    const { sessionId, messageId, messages, projectDir, tools: providedTools, initialBlocks } = args
     const state = this.runtimeState.get(sessionId)
     if (!state) {
       throw new Error(`Session ${sessionId} not found`)
@@ -758,18 +788,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
     const temperature = generationSettings.temperature
     const maxTokens = generationSettings.maxTokens
 
-    let tools: import('@shared/presenter').MCPToolDefinition[] = []
-    if (this.toolPresenter) {
-      try {
-        tools = await this.toolPresenter.getAllToolDefinitions({
-          chatMode: 'agent',
-          conversationId: sessionId,
-          agentWorkspacePath: projectDir
-        })
-      } catch (error) {
-        console.error('[DeepChatAgent] failed to fetch tool definitions:', error)
-      }
-    }
+    const tools = providedTools ?? (await this.loadToolDefinitionsForSession(sessionId, projectDir))
 
     const abortController = new AbortController()
     this.abortControllers.set(sessionId, abortController)
@@ -786,6 +805,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
         temperature,
         maxTokens,
         permissionMode: state.permissionMode,
+        toolOutputGuard: this.toolOutputGuard,
         initialBlocks,
         io: {
           sessionId,
@@ -828,10 +848,11 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
   private async resumeAssistantMessage(
     sessionId: string,
     messageId: string,
-    initialBlocks: AssistantMessageBlock[]
-  ): Promise<void> {
+    initialBlocks: AssistantMessageBlock[],
+    budgetToolCall?: NonNullable<AssistantMessageBlock['tool_call']> | null
+  ): Promise<boolean> {
     if (this.resumingMessages.has(messageId)) {
-      return
+      return false
     }
     this.resumingMessages.add(messageId)
 
@@ -859,7 +880,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
         supportsVision: this.supportsVision(state.providerId, state.modelId)
       })
       const systemPrompt = appendSummarySection(baseSystemPrompt, summaryState.summaryText)
-      const resumeContext = buildResumeContext(
+      let resumeContext = buildResumeContext(
         sessionId,
         messageId,
         systemPrompt,
@@ -872,15 +893,53 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
           fallbackProtectedTurnCount: 1
         }
       )
+      const projectDir = this.resolveProjectDir(sessionId)
+      const tools = await this.loadToolDefinitionsForSession(sessionId, projectDir)
+
+      if (budgetToolCall?.id && budgetToolCall.name) {
+        const resumeBudget = this.fitResumeBudgetForToolCall({
+          resumeContext,
+          toolDefinitions: tools,
+          contextLength: generationSettings.contextLength,
+          maxTokens,
+          toolCallId: budgetToolCall.id,
+          toolName: budgetToolCall.name
+        })
+
+        if (resumeBudget?.kind === 'tool_error') {
+          this.updateToolCallResponse(initialBlocks, budgetToolCall.id, resumeBudget.message, true)
+          this.messageStore.updateAssistantContent(messageId, initialBlocks)
+          this.emitMessageRefresh(sessionId, messageId)
+          resumeContext = this.toolOutputGuard.replaceToolMessageContent(
+            resumeContext,
+            budgetToolCall.id,
+            resumeBudget.message
+          )
+        } else if (resumeBudget?.kind === 'terminal_error') {
+          this.updateToolCallResponse(initialBlocks, budgetToolCall.id, resumeBudget.message, true)
+          this.messageStore.setMessageError(messageId, initialBlocks)
+          this.emitMessageRefresh(sessionId, messageId)
+          eventBus.sendToRenderer(STREAM_EVENTS.ERROR, SendTarget.ALL_WINDOWS, {
+            conversationId: sessionId,
+            eventId: messageId,
+            messageId,
+            error: resumeBudget.message
+          })
+          this.setSessionStatus(sessionId, 'error')
+          return false
+        }
+      }
 
       const result = await this.runStreamForMessage({
         sessionId,
         messageId,
         messages: resumeContext,
-        projectDir: this.resolveProjectDir(sessionId),
+        projectDir,
+        tools,
         initialBlocks
       })
       this.applyProcessResultStatus(sessionId, result)
+      return true
     } catch (error) {
       console.error('[DeepChatAgent] resumeAssistantMessage error:', error)
       this.setSessionStatus(sessionId, 'error')
@@ -1793,19 +1852,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
     }
 
     const projectDir = this.resolveProjectDir(sessionId)
-    let toolDefinitions: import('@shared/presenter').MCPToolDefinition[] = []
-    try {
-      toolDefinitions = await this.toolPresenter.getAllToolDefinitions({
-        chatMode: 'agent',
-        conversationId: sessionId,
-        agentWorkspacePath: projectDir
-      })
-    } catch (error) {
-      console.error(
-        '[DeepChatAgent] Failed to load tool definitions for deferred execution:',
-        error
-      )
-    }
+    const toolDefinitions = await this.loadToolDefinitionsForSession(sessionId, projectDir)
 
     const toolDefinition = toolDefinitions.find((definition) => {
       if (definition.function.name !== toolName) {
@@ -1839,8 +1886,21 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
           permissionRequest: rawData.permissionRequest as PendingToolInteraction['permission']
         }
       }
+      const responseText = this.toolContentToText(rawData.content)
+      const prepared = await this.toolOutputGuard.prepareToolOutput({
+        sessionId,
+        toolCallId: toolCall.id || '',
+        toolName,
+        rawContent: responseText
+      })
+      if (prepared.kind === 'tool_error') {
+        return {
+          responseText: prepared.message,
+          isError: true
+        }
+      }
       return {
-        responseText: this.toolContentToText(rawData.content),
+        responseText: prepared.content,
         isError: Boolean(rawData.isError)
       }
     } catch (error) {
@@ -1850,6 +1910,60 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
         isError: true
       }
     }
+  }
+
+  private async loadToolDefinitionsForSession(
+    sessionId: string,
+    projectDir: string | null
+  ): Promise<MCPToolDefinition[]> {
+    if (!this.toolPresenter) {
+      return []
+    }
+
+    try {
+      return await this.toolPresenter.getAllToolDefinitions({
+        chatMode: 'agent',
+        conversationId: sessionId,
+        agentWorkspacePath: projectDir
+      })
+    } catch (error) {
+      console.error('[DeepChatAgent] failed to fetch tool definitions:', error)
+      return []
+    }
+  }
+
+  private fitResumeBudgetForToolCall(params: {
+    resumeContext: ChatMessage[]
+    toolDefinitions: MCPToolDefinition[]
+    contextLength: number
+    maxTokens: number
+    toolCallId: string
+    toolName: string
+  }) {
+    if (
+      this.toolOutputGuard.hasContextBudget({
+        conversationMessages: params.resumeContext,
+        toolDefinitions: params.toolDefinitions,
+        contextLength: params.contextLength,
+        maxTokens: params.maxTokens
+      })
+    ) {
+      return null
+    }
+
+    return this.toolOutputGuard.fitToolError({
+      conversationMessages: params.resumeContext,
+      toolDefinitions: params.toolDefinitions,
+      contextLength: params.contextLength,
+      maxTokens: params.maxTokens,
+      toolCallId: params.toolCallId,
+      toolName: params.toolName,
+      errorMessage: this.toolOutputGuard.buildContextOverflowMessage(
+        params.toolCallId,
+        params.toolName
+      ),
+      mode: 'replace'
+    })
   }
 
   private toolContentToText(content: MCPToolResponse['content']): string {

--- a/src/main/presenter/deepchatAgentPresenter/process.ts
+++ b/src/main/presenter/deepchatAgentPresenter/process.ts
@@ -1,4 +1,4 @@
-import type { ProcessParams, ProcessResult } from './types'
+import type { ProcessParams, ProcessResult, StreamState } from './types'
 import { createState } from './types'
 import { accumulate } from './accumulator'
 import { startEcho } from './echo'
@@ -7,6 +7,37 @@ import { eventBus, SendTarget } from '@/eventbus'
 import { STREAM_EVENTS } from '@/events'
 
 const MAX_TOOL_CALLS = 128
+const UNKNOWN_CONTEXT_LIMIT = Number.MAX_SAFE_INTEGER
+const CONTEXT_WINDOW_ERROR_PATTERNS = [
+  'context length',
+  'context window',
+  'too many tokens',
+  'prompt too long',
+  'maximum context length',
+  'reduce the length'
+]
+
+function isContextWindowErrorMessage(message: string): boolean {
+  const normalized = message.toLowerCase()
+  return CONTEXT_WINDOW_ERROR_PATTERNS.some((pattern) => normalized.includes(pattern))
+}
+
+function getLatestErrorMessage(state: StreamState): string | null {
+  for (let index = state.blocks.length - 1; index >= 0; index -= 1) {
+    const block = state.blocks[index]
+    if (block.type === 'error' && typeof block.content === 'string' && block.content.trim()) {
+      return block.content
+    }
+  }
+  return null
+}
+
+function stripTrailingErrorBlock(state: StreamState, message: string): void {
+  const lastBlock = state.blocks[state.blocks.length - 1]
+  if (lastBlock?.type === 'error' && lastBlock.content === message) {
+    state.blocks.pop()
+  }
+}
 
 /**
  * Unified stream processor. Handles both simple completions and multi-turn
@@ -112,10 +143,21 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
         toolPresenter!,
         modelId,
         io,
-        permissionMode
+        permissionMode,
+        params.toolOutputGuard,
+        modelConfig.contextLength > 0 ? modelConfig.contextLength : UNKNOWN_CONTEXT_LIMIT,
+        maxTokens
       )
       toolCallCount += executed.executed
       echo.flush()
+
+      if (executed.terminalError) {
+        finalizeError(state, io, executed.terminalError)
+        return {
+          status: 'error' as const,
+          terminalError: executed.terminalError
+        }
+      }
 
       if (executed.pendingInteractions.length > 0) {
         console.log(
@@ -133,6 +175,17 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
     }
 
     // Finalize
+    if (state.stopReason === 'error') {
+      const streamErrorMessage = getLatestErrorMessage(state)
+      if (streamErrorMessage && isContextWindowErrorMessage(streamErrorMessage)) {
+        stripTrailingErrorBlock(state, streamErrorMessage)
+        finalizeError(state, io, streamErrorMessage)
+        return {
+          status: 'error' as const,
+          terminalError: streamErrorMessage
+        }
+      }
+    }
     finalize(state, io)
     return {
       status: 'completed' as const

--- a/src/main/presenter/deepchatAgentPresenter/toolOutputGuard.ts
+++ b/src/main/presenter/deepchatAgentPresenter/toolOutputGuard.ts
@@ -17,6 +17,7 @@ export type PreparedToolOutputResult =
       kind: 'ok'
       content: string
       offloaded: boolean
+      offloadPath?: string
     }
   | {
       kind: 'tool_error'
@@ -28,6 +29,7 @@ export type ToolOutputGuardResult =
       kind: 'ok'
       content: string
       offloaded: boolean
+      offloadPath?: string
     }
   | {
       kind: 'tool_error'
@@ -74,7 +76,8 @@ export class ToolOutputGuard {
       return {
         kind: 'ok',
         content: rawContent,
-        offloaded: false
+        offloaded: false,
+        offloadPath: undefined
       }
     }
 
@@ -100,7 +103,8 @@ export class ToolOutputGuard {
     return {
       kind: 'ok',
       content: this.buildOffloadStub(rawContent, filePath),
-      offloaded: true
+      offloaded: true,
+      offloadPath: filePath
     }
   }
 
@@ -130,10 +134,12 @@ export class ToolOutputGuard {
       return prepared
     }
 
-    return this.fitToolError({
+    const overflowResult = this.fitToolError({
       ...params,
       errorMessage: this.buildContextOverflowMessage(params.toolCallId, params.toolName)
     })
+    await this.cleanupOffloadedOutput(prepared.offloadPath)
+    return overflowResult
   }
 
   hasContextBudget(params: ContextBudgetParams): boolean {
@@ -183,6 +189,18 @@ export class ToolOutputGuard {
     content: string
   ): ChatMessage[] {
     return this.withToolMessage(conversationMessages, toolCallId, content, 'replace')
+  }
+
+  async cleanupOffloadedOutput(offloadPath?: string): Promise<void> {
+    if (!offloadPath) {
+      return
+    }
+
+    try {
+      await fs.rm(offloadPath, { force: true })
+    } catch (error) {
+      console.warn('[ToolOutputGuard] Failed to delete offloaded tool output:', error)
+    }
   }
 
   buildContextOverflowMessage(toolCallId: string, toolName: string): string {
@@ -239,7 +257,7 @@ export class ToolOutputGuard {
     return [
       '[Tool output offloaded]',
       `Total characters: ${rawContent.length}`,
-      `Full output saved to: ${filePath}`,
+      `Offload file: ${path.basename(filePath)}`,
       `first ${preview.length} chars:`,
       preview
     ].join('\n')

--- a/src/main/presenter/deepchatAgentPresenter/toolOutputGuard.ts
+++ b/src/main/presenter/deepchatAgentPresenter/toolOutputGuard.ts
@@ -1,0 +1,255 @@
+import fs from 'fs/promises'
+import path from 'path'
+import { approximateTokenSize } from 'tokenx'
+import type { MCPToolDefinition } from '@shared/presenter'
+import type { ChatMessage } from '@shared/types/core/chat-message'
+import { estimateMessagesTokens } from './contextBuilder'
+import { resolveToolOffloadPath } from '../sessionPresenter/sessionPaths'
+
+const TOOL_OUTPUT_OFFLOAD_THRESHOLD = 5000
+const TOOL_OUTPUT_PREVIEW_LENGTH = 1024
+const TOOLS_REQUIRING_OFFLOAD = new Set(['exec', 'ls', 'find', 'grep'])
+
+type ToolMessageUpdateMode = 'append' | 'replace'
+
+export type PreparedToolOutputResult =
+  | {
+      kind: 'ok'
+      content: string
+      offloaded: boolean
+    }
+  | {
+      kind: 'tool_error'
+      message: string
+    }
+
+export type ToolOutputGuardResult =
+  | {
+      kind: 'ok'
+      content: string
+      offloaded: boolean
+    }
+  | {
+      kind: 'tool_error'
+      message: string
+    }
+  | {
+      kind: 'terminal_error'
+      message: string
+    }
+
+interface PrepareToolOutputParams {
+  sessionId: string
+  toolCallId: string
+  toolName: string
+  rawContent: string
+}
+
+interface GuardToolOutputParams extends PrepareToolOutputParams {
+  conversationMessages: ChatMessage[]
+  toolDefinitions: MCPToolDefinition[]
+  contextLength: number
+  maxTokens: number
+}
+
+interface ContextBudgetParams {
+  conversationMessages: ChatMessage[]
+  toolDefinitions: MCPToolDefinition[]
+  contextLength: number
+  maxTokens: number
+}
+
+interface FitToolErrorParams extends ContextBudgetParams {
+  toolCallId: string
+  toolName: string
+  errorMessage: string
+  mode?: ToolMessageUpdateMode
+}
+
+export class ToolOutputGuard {
+  async prepareToolOutput(params: PrepareToolOutputParams): Promise<PreparedToolOutputResult> {
+    const { sessionId, toolCallId, toolName, rawContent } = params
+
+    if (!this.requiresOffload(toolName) || rawContent.length <= TOOL_OUTPUT_OFFLOAD_THRESHOLD) {
+      return {
+        kind: 'ok',
+        content: rawContent,
+        offloaded: false
+      }
+    }
+
+    const filePath = resolveToolOffloadPath(sessionId, toolCallId)
+    if (!filePath) {
+      return {
+        kind: 'tool_error',
+        message: this.buildOffloadFailureMessage(toolCallId, toolName)
+      }
+    }
+
+    try {
+      await fs.mkdir(path.dirname(filePath), { recursive: true })
+      await fs.writeFile(filePath, rawContent, 'utf-8')
+    } catch (error) {
+      console.warn('[ToolOutputGuard] Failed to offload tool output:', error)
+      return {
+        kind: 'tool_error',
+        message: this.buildOffloadFailureMessage(toolCallId, toolName)
+      }
+    }
+
+    return {
+      kind: 'ok',
+      content: this.buildOffloadStub(rawContent, filePath),
+      offloaded: true
+    }
+  }
+
+  async guardToolOutput(params: GuardToolOutputParams): Promise<ToolOutputGuardResult> {
+    const prepared = await this.prepareToolOutput(params)
+    if (prepared.kind === 'tool_error') {
+      return this.fitToolError({
+        ...params,
+        errorMessage: prepared.message
+      })
+    }
+
+    const nextMessages = this.withToolMessage(
+      params.conversationMessages,
+      params.toolCallId,
+      prepared.content,
+      'append'
+    )
+    if (
+      this.hasContextBudget({
+        conversationMessages: nextMessages,
+        toolDefinitions: params.toolDefinitions,
+        contextLength: params.contextLength,
+        maxTokens: params.maxTokens
+      })
+    ) {
+      return prepared
+    }
+
+    return this.fitToolError({
+      ...params,
+      errorMessage: this.buildContextOverflowMessage(params.toolCallId, params.toolName)
+    })
+  }
+
+  hasContextBudget(params: ContextBudgetParams): boolean {
+    const { conversationMessages, toolDefinitions, contextLength, maxTokens } = params
+    const toolDefinitionTokens = toolDefinitions.reduce(
+      (total, tool) => total + approximateTokenSize(JSON.stringify(tool)),
+      0
+    )
+    return (
+      estimateMessagesTokens(conversationMessages) +
+        toolDefinitionTokens +
+        Math.max(0, Math.floor(maxTokens)) <=
+      contextLength
+    )
+  }
+
+  fitToolError(params: FitToolErrorParams): ToolOutputGuardResult {
+    const mode = params.mode ?? 'append'
+    const errorMessages = this.withToolMessage(
+      params.conversationMessages,
+      params.toolCallId,
+      params.errorMessage,
+      mode
+    )
+    if (
+      this.hasContextBudget({
+        conversationMessages: errorMessages,
+        toolDefinitions: params.toolDefinitions,
+        contextLength: params.contextLength,
+        maxTokens: params.maxTokens
+      })
+    ) {
+      return {
+        kind: 'tool_error',
+        message: params.errorMessage
+      }
+    }
+    return {
+      kind: 'terminal_error',
+      message: this.buildTerminalErrorMessage(params.toolCallId, params.toolName)
+    }
+  }
+
+  replaceToolMessageContent(
+    conversationMessages: ChatMessage[],
+    toolCallId: string,
+    content: string
+  ): ChatMessage[] {
+    return this.withToolMessage(conversationMessages, toolCallId, content, 'replace')
+  }
+
+  buildContextOverflowMessage(toolCallId: string, toolName: string): string {
+    return `The tool call with ID ${toolCallId} and name ${toolName} could not be injected into the conversation because the remaining context window is insufficient. Treat this tool call as failed and continue without its result.`
+  }
+
+  private requiresOffload(toolName: string): boolean {
+    return TOOLS_REQUIRING_OFFLOAD.has(toolName) || toolName.startsWith('yo_browser_')
+  }
+
+  private withToolMessage(
+    conversationMessages: ChatMessage[],
+    toolCallId: string,
+    content: string,
+    mode: ToolMessageUpdateMode
+  ): ChatMessage[] {
+    if (mode === 'replace') {
+      let replaced = false
+      const nextMessages = conversationMessages.map((message) => {
+        if (replaced || message.role !== 'tool' || message.tool_call_id !== toolCallId) {
+          return message
+        }
+        replaced = true
+        return {
+          ...message,
+          content
+        }
+      })
+      if (replaced) {
+        return nextMessages
+      }
+      return [
+        ...nextMessages,
+        {
+          role: 'tool',
+          tool_call_id: toolCallId,
+          content
+        }
+      ]
+    }
+
+    return [
+      ...conversationMessages,
+      {
+        role: 'tool',
+        tool_call_id: toolCallId,
+        content
+      }
+    ]
+  }
+
+  private buildOffloadStub(rawContent: string, filePath: string): string {
+    const preview = rawContent.slice(0, TOOL_OUTPUT_PREVIEW_LENGTH)
+    return [
+      '[Tool output offloaded]',
+      `Total characters: ${rawContent.length}`,
+      `Full output saved to: ${filePath}`,
+      `first ${preview.length} chars:`,
+      preview
+    ].join('\n')
+  }
+
+  private buildOffloadFailureMessage(toolCallId: string, toolName: string): string {
+    return `The tool call with ID ${toolCallId} and name ${toolName} produced a large result, but offloading that result to disk failed. Treat this tool call as failed and continue without its result.`
+  }
+
+  private buildTerminalErrorMessage(toolCallId: string, toolName: string): string {
+    return `The tool call with ID ${toolCallId} and name ${toolName} failed because the remaining context window is too small to continue this turn.`
+  }
+}

--- a/src/main/presenter/deepchatAgentPresenter/types.ts
+++ b/src/main/presenter/deepchatAgentPresenter/types.ts
@@ -9,6 +9,7 @@ import type { ChatMessage } from '@shared/types/core/chat-message'
 import type { MCPToolDefinition, ModelConfig } from '@shared/presenter'
 import type { IToolPresenter } from '@shared/types/presenters/tool.presenter'
 import type { DeepChatMessageStore } from './messageStore'
+import type { ToolOutputGuard } from './toolOutputGuard'
 
 export interface ToolCallResult {
   id: string
@@ -77,6 +78,7 @@ export interface PendingToolInteraction {
 export interface ProcessResult {
   status: 'completed' | 'paused' | 'aborted' | 'error'
   pendingInteractions?: PendingToolInteraction[]
+  terminalError?: string
 }
 
 export interface ProcessParams {
@@ -97,6 +99,7 @@ export interface ProcessParams {
   temperature: number
   maxTokens: number
   permissionMode: PermissionMode
+  toolOutputGuard: ToolOutputGuard
   initialBlocks?: AssistantMessageBlock[]
   io: IoParams
 }

--- a/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { app } from 'electron'
 import { DeepChatAgentPresenter } from '@/presenter/deepchatAgentPresenter/index'
 
 vi.mock('nanoid', () => ({ nanoid: vi.fn(() => 'mock-msg-id') }))
@@ -195,6 +199,8 @@ describe('DeepChatAgentPresenter', () => {
   let configPresenter: ReturnType<typeof createMockConfigPresenter>
   let toolPresenter: ReturnType<typeof createMockToolPresenter>
   let agent: DeepChatAgentPresenter
+  let tempHome: string | null = null
+  let getPathSpy: ReturnType<typeof vi.spyOn> | null = null
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -213,8 +219,14 @@ describe('DeepChatAgentPresenter', () => {
     agent = new DeepChatAgentPresenter(llmProvider, configPresenter, sqlitePresenter, toolPresenter)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers()
+    getPathSpy?.mockRestore()
+    getPathSpy = null
+    if (tempHome) {
+      await fs.rm(tempHome, { recursive: true, force: true })
+      tempHome = null
+    }
   })
 
   describe('constructor (crash recovery)', () => {
@@ -1560,6 +1572,78 @@ describe('DeepChatAgentPresenter', () => {
       expect(updatedBlocks[0].status).toBe('success')
       expect(updatedBlocks[1].status).toBe('granted')
       expect(updatedBlocks[1].extra.needsUserAction).toBe(false)
+    })
+
+    it('offloads deferred tool results before resume', async () => {
+      tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'deepchat-deferred-offload-'))
+      getPathSpy = vi.spyOn(app, 'getPath').mockReturnValue(tempHome)
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      makeAssistantRow({
+        blocks: [
+          {
+            type: 'tool_call',
+            status: 'pending',
+            timestamp: 1,
+            tool_call: {
+              id: 'tc1',
+              name: 'yo_browser_cdp_send',
+              params: '{"method":"Page.captureScreenshot"}',
+              response: ''
+            }
+          },
+          {
+            type: 'action',
+            action_type: 'tool_call_permission',
+            status: 'pending',
+            timestamp: 2,
+            content: 'Need permission',
+            tool_call: {
+              id: 'tc1',
+              name: 'yo_browser_cdp_send',
+              params: '{"method":"Page.captureScreenshot"}'
+            },
+            extra: {
+              needsUserAction: true,
+              permissionType: 'write',
+              permissionRequest: JSON.stringify({
+                permissionType: 'write',
+                description: 'Need permission',
+                toolName: 'yo_browser_cdp_send',
+                serverName: 'yo-browser'
+              })
+            }
+          }
+        ]
+      })
+      toolPresenter.getAllToolDefinitions.mockResolvedValueOnce([
+        {
+          type: 'function',
+          function: {
+            name: 'yo_browser_cdp_send',
+            description: 'CDP send',
+            parameters: { type: 'object', properties: {} }
+          },
+          server: { name: 'yo-browser', icons: '', description: '' }
+        }
+      ])
+      toolPresenter.callTool.mockResolvedValueOnce({
+        content: JSON.stringify({ data: 'x'.repeat(7000) }),
+        rawData: { content: JSON.stringify({ data: 'x'.repeat(7000) }), isError: false }
+      })
+
+      const result = await agent.respondToolInteraction('s1', 'm1', 'tc1', {
+        kind: 'permission',
+        granted: true
+      })
+
+      expect(result).toEqual({ resumed: true })
+      const updatedBlocks = JSON.parse(
+        sqlitePresenter.deepchatMessagesTable.updateContent.mock.calls[0][1]
+      )
+      expect(updatedBlocks[0].tool_call.response).toContain('[Tool output offloaded]')
+      expect(updatedBlocks[0].status).toBe('success')
+      expect(processStream).toHaveBeenCalledTimes(1)
     })
 
     it('handles permission deny and resumes with denial result', async () => {

--- a/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
@@ -1642,8 +1642,93 @@ describe('DeepChatAgentPresenter', () => {
         sqlitePresenter.deepchatMessagesTable.updateContent.mock.calls[0][1]
       )
       expect(updatedBlocks[0].tool_call.response).toContain('[Tool output offloaded]')
+      expect(updatedBlocks[0].tool_call.response).toContain('tool_tc1.offload')
+      expect(updatedBlocks[0].tool_call.response).not.toContain(tempHome!)
       expect(updatedBlocks[0].status).toBe('success')
       expect(processStream).toHaveBeenCalledTimes(1)
+    })
+
+    it('cleans deferred offload files when resume budget downgrades the tool result', async () => {
+      tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'deepchat-deferred-cleanup-'))
+      getPathSpy = vi.spyOn(app, 'getPath').mockReturnValue(tempHome)
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      makeAssistantRow({
+        blocks: [
+          {
+            type: 'tool_call',
+            status: 'pending',
+            timestamp: 1,
+            tool_call: {
+              id: 'tc1',
+              name: 'yo_browser_cdp_send',
+              params: '{"method":"Page.captureScreenshot"}',
+              response: ''
+            }
+          },
+          {
+            type: 'action',
+            action_type: 'tool_call_permission',
+            status: 'pending',
+            timestamp: 2,
+            content: 'Need permission',
+            tool_call: {
+              id: 'tc1',
+              name: 'yo_browser_cdp_send',
+              params: '{"method":"Page.captureScreenshot"}'
+            },
+            extra: {
+              needsUserAction: true,
+              permissionType: 'write',
+              permissionRequest: JSON.stringify({
+                permissionType: 'write',
+                description: 'Need permission',
+                toolName: 'yo_browser_cdp_send',
+                serverName: 'yo-browser'
+              })
+            }
+          }
+        ]
+      })
+      toolPresenter.getAllToolDefinitions.mockResolvedValueOnce([
+        {
+          type: 'function',
+          function: {
+            name: 'yo_browser_cdp_send',
+            description: 'CDP send',
+            parameters: { type: 'object', properties: {} }
+          },
+          server: { name: 'yo-browser', icons: '', description: '' }
+        }
+      ])
+      toolPresenter.callTool.mockResolvedValueOnce({
+        content: JSON.stringify({ data: 'x'.repeat(7000) }),
+        rawData: { content: JSON.stringify({ data: 'x'.repeat(7000) }), isError: false }
+      })
+
+      const hasContextBudgetSpy = vi.spyOn((agent as any).toolOutputGuard, 'hasContextBudget')
+      hasContextBudgetSpy.mockReturnValueOnce(false).mockReturnValueOnce(true)
+
+      try {
+        const result = await agent.respondToolInteraction('s1', 'm1', 'tc1', {
+          kind: 'permission',
+          granted: true
+        })
+
+        expect(result).toEqual({ resumed: true })
+        const updateCalls = sqlitePresenter.deepchatMessagesTable.updateContent.mock.calls
+        const updatedBlocks = JSON.parse(updateCalls[updateCalls.length - 1][1])
+        expect(updatedBlocks[0].tool_call.response).toContain(
+          'remaining context window is insufficient'
+        )
+        expect(updatedBlocks[0].tool_call.response).not.toContain('[Tool output offloaded]')
+        await expect(
+          fs.access(path.join(tempHome, '.deepchat', 'sessions', 's1', 'tool_tc1.offload'))
+        ).rejects.toThrow()
+        expect(processStream).toHaveBeenCalledTimes(1)
+      } finally {
+        hasContextBudgetSpy.mockRestore()
+      }
     })
 
     it('handles permission deny and resumes with denial result', async () => {

--- a/test/main/presenter/deepchatAgentPresenter/dispatch.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/dispatch.test.ts
@@ -310,6 +310,50 @@ describe('dispatch', () => {
       expect(block!.status).toBe('error')
     })
 
+    it('preserves raw tool error status when guard returns ok', async () => {
+      const tools = [makeTool('bad_tool')]
+      const toolPresenter = createMockToolPresenter()
+      ;(toolPresenter.callTool as ReturnType<typeof vi.fn>).mockResolvedValue({
+        content: 'Upstream failure',
+        rawData: {
+          toolCallId: 'tc1',
+          content: 'Upstream failure',
+          isError: true
+        }
+      })
+      const conversation: any[] = []
+
+      state.blocks.push({
+        type: 'tool_call',
+        content: '',
+        status: 'pending',
+        timestamp: Date.now(),
+        tool_call: { id: 'tc1', name: 'bad_tool', params: '{}', response: '' }
+      })
+      state.completedToolCalls = [{ id: 'tc1', name: 'bad_tool', arguments: '{}' }]
+
+      await executeTools(
+        state,
+        conversation,
+        0,
+        tools,
+        toolPresenter,
+        'gpt-4',
+        io,
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024
+      )
+
+      const toolMsg = conversation.find((message: any) => message.role === 'tool')
+      expect(toolMsg.content).toBe('Upstream failure')
+
+      const block = state.blocks.find((b) => b.type === 'tool_call')
+      expect(block!.tool_call!.response).toBe('Upstream failure')
+      expect(block!.status).toBe('error')
+    })
+
     it('stops on abort', async () => {
       const abortController = new AbortController()
       const abortIo = createIo({ abortSignal: abortController.signal })
@@ -446,6 +490,8 @@ describe('dispatch', () => {
       expect(executed.terminalError).toBeUndefined()
       const toolMessage = conversation.find((message: any) => message.role === 'tool')
       expect(toolMessage.content).toContain('[Tool output offloaded]')
+      expect(toolMessage.content).toContain('tool_tc1.offload')
+      expect(toolMessage.content).not.toContain(tempHome!)
       expect(state.blocks[0].tool_call?.response).toContain('[Tool output offloaded]')
       expect(state.blocks[0].status).toBe('success')
     })
@@ -502,6 +548,9 @@ describe('dispatch', () => {
     })
 
     it('marks the tool as error when offload succeeds but context budget cannot fit the stub', async () => {
+      tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'deepchat-dispatch-offload-clean-'))
+      getPathSpy = vi.spyOn(app, 'getPath').mockReturnValue(tempHome)
+
       const tools = [makeTool('yo_browser_cdp_send')]
       const longScreenshot = JSON.stringify({ data: 'x'.repeat(7000) })
       const toolPresenter = createMockToolPresenter({ yo_browser_cdp_send: longScreenshot })
@@ -544,9 +593,15 @@ describe('dispatch', () => {
       const toolMessage = conversation.find((message: any) => message.role === 'tool')
       expect(toolMessage.content).toContain('remaining context window is insufficient')
       expect(state.blocks[0].status).toBe('error')
+      await expect(
+        fs.access(path.join(tempHome, '.deepchat', 'sessions', 's1', 'tool_tc1.offload'))
+      ).rejects.toThrow()
     })
 
     it('returns terminalError when even the minimal tool failure stub cannot fit', async () => {
+      tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'deepchat-dispatch-terminal-clean-'))
+      getPathSpy = vi.spyOn(app, 'getPath').mockReturnValue(tempHome)
+
       const tools = [makeTool('yo_browser_cdp_send')]
       const longScreenshot = JSON.stringify({ data: 'x'.repeat(7000) })
       const toolPresenter = createMockToolPresenter({ yo_browser_cdp_send: longScreenshot })
@@ -589,6 +644,9 @@ describe('dispatch', () => {
       expect(executed.terminalError).toContain('remaining context window is too small')
       expect(conversation.find((message: any) => message.role === 'tool')).toBeUndefined()
       expect(state.blocks[0].status).toBe('error')
+      await expect(
+        fs.access(path.join(tempHome, '.deepchat', 'sessions', 's1', 'tool_tc1.offload'))
+      ).rejects.toThrow()
     })
   })
 

--- a/test/main/presenter/deepchatAgentPresenter/dispatch.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/dispatch.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { app } from 'electron'
 import type { StreamState, IoParams } from '@/presenter/deepchatAgentPresenter/types'
 import { createState } from '@/presenter/deepchatAgentPresenter/types'
 import type { MCPToolDefinition } from '@shared/presenter'
 import type { IToolPresenter } from '@shared/types/presenters/tool.presenter'
+import { ToolOutputGuard } from '@/presenter/deepchatAgentPresenter/toolOutputGuard'
 
 vi.mock('@/eventbus', () => ({
   eventBus: { sendToRenderer: vi.fn() },
@@ -82,11 +87,22 @@ function createMockToolPresenter(responses: Record<string, string> = {}): IToolP
 describe('dispatch', () => {
   let state: StreamState
   let io: IoParams
+  let tempHome: string | null = null
+  let getPathSpy: ReturnType<typeof vi.spyOn> | null = null
 
   beforeEach(() => {
     vi.clearAllMocks()
     state = createState()
     io = createIo()
+  })
+
+  afterEach(async () => {
+    getPathSpy?.mockRestore()
+    getPathSpy = null
+    if (tempHome) {
+      await fs.rm(tempHome, { recursive: true, force: true })
+      tempHome = null
+    }
   })
 
   describe('executeTools', () => {
@@ -119,7 +135,10 @@ describe('dispatch', () => {
         toolPresenter,
         'gpt-4',
         io,
-        'full_access'
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024
       )
 
       expect(executed.executed).toBe(1)
@@ -157,7 +176,19 @@ describe('dispatch', () => {
       })
       state.completedToolCalls = [{ id: 'tc1', name: 'get_weather', arguments: '{}' }]
 
-      await executeTools(state, [], 0, tools, toolPresenter, 'gpt-4', io, 'full_access')
+      await executeTools(
+        state,
+        [],
+        0,
+        tools,
+        toolPresenter,
+        'gpt-4',
+        io,
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024
+      )
 
       expect(state.blocks[0].tool_call!.server_name).toBe('test-server')
       expect(state.blocks[0].tool_call!.server_icons).toBe('icon')
@@ -192,7 +223,10 @@ describe('dispatch', () => {
         toolPresenter,
         'deepseek-reasoner',
         io,
-        'full_access'
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024
       )
 
       const assistantMsg = conversation.find((m: any) => m.role === 'assistant')
@@ -219,7 +253,19 @@ describe('dispatch', () => {
       })
       state.completedToolCalls = [{ id: 'tc1', name: 'search', arguments: '{}' }]
 
-      await executeTools(state, conversation, 0, tools, toolPresenter, 'gpt-4', io, 'full_access')
+      await executeTools(
+        state,
+        conversation,
+        0,
+        tools,
+        toolPresenter,
+        'gpt-4',
+        io,
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024
+      )
 
       const assistantMsg = conversation.find((m: any) => m.role === 'assistant')
       expect(assistantMsg.reasoning_content).toBeUndefined()
@@ -242,7 +288,19 @@ describe('dispatch', () => {
       })
       state.completedToolCalls = [{ id: 'tc1', name: 'bad_tool', arguments: '{}' }]
 
-      await executeTools(state, conversation, 0, tools, toolPresenter, 'gpt-4', io, 'full_access')
+      await executeTools(
+        state,
+        conversation,
+        0,
+        tools,
+        toolPresenter,
+        'gpt-4',
+        io,
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024
+      )
 
       const toolMsg = conversation.find((m: any) => m.role === 'tool')
       expect(toolMsg.content).toBe('Error: Tool failed')
@@ -291,7 +349,10 @@ describe('dispatch', () => {
         toolPresenter,
         'gpt-4',
         abortIo,
-        'full_access'
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024
       )
 
       // Only first tool should have been called
@@ -312,7 +373,19 @@ describe('dispatch', () => {
       })
       state.completedToolCalls = [{ id: 'tc1', name: 'tool_a', arguments: '{}' }]
 
-      await executeTools(state, [], 0, tools, toolPresenter, 'gpt-4', io, 'full_access')
+      await executeTools(
+        state,
+        [],
+        0,
+        tools,
+        toolPresenter,
+        'gpt-4',
+        io,
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024
+      )
 
       expect(eventBus.sendToRenderer).toHaveBeenCalledWith(
         'stream:response',
@@ -325,6 +398,197 @@ describe('dispatch', () => {
         })
       )
       expect(io.messageStore.updateAssistantContent).toHaveBeenCalled()
+    })
+
+    it('offloads large yo_browser responses into a stub', async () => {
+      tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'deepchat-dispatch-offload-'))
+      getPathSpy = vi.spyOn(app, 'getPath').mockReturnValue(tempHome)
+
+      const tools = [makeTool('yo_browser_cdp_send')]
+      const longScreenshot = JSON.stringify({ data: 'x'.repeat(7000) })
+      const toolPresenter = createMockToolPresenter({ yo_browser_cdp_send: longScreenshot })
+      const conversation: any[] = []
+
+      state.blocks.push({
+        type: 'tool_call',
+        content: '',
+        status: 'pending',
+        timestamp: Date.now(),
+        tool_call: {
+          id: 'tc1',
+          name: 'yo_browser_cdp_send',
+          params: '{"method":"Page.captureScreenshot"}',
+          response: ''
+        }
+      })
+      state.completedToolCalls = [
+        {
+          id: 'tc1',
+          name: 'yo_browser_cdp_send',
+          arguments: '{"method":"Page.captureScreenshot"}'
+        }
+      ]
+
+      const executed = await executeTools(
+        state,
+        conversation,
+        0,
+        tools,
+        toolPresenter,
+        'gpt-4',
+        io,
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024
+      )
+
+      expect(executed.terminalError).toBeUndefined()
+      const toolMessage = conversation.find((message: any) => message.role === 'tool')
+      expect(toolMessage.content).toContain('[Tool output offloaded]')
+      expect(state.blocks[0].tool_call?.response).toContain('[Tool output offloaded]')
+      expect(state.blocks[0].status).toBe('success')
+    })
+
+    it('turns offload write failures into tool errors instead of falling back to raw content', async () => {
+      tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'deepchat-dispatch-offload-fail-'))
+      getPathSpy = vi.spyOn(app, 'getPath').mockReturnValue(tempHome)
+      const writeFileSpy = vi.spyOn(fs, 'writeFile').mockRejectedValueOnce(new Error('disk full'))
+
+      const tools = [makeTool('yo_browser_cdp_send')]
+      const longScreenshot = JSON.stringify({ data: 'x'.repeat(7000) })
+      const toolPresenter = createMockToolPresenter({ yo_browser_cdp_send: longScreenshot })
+      const conversation: any[] = []
+
+      state.blocks.push({
+        type: 'tool_call',
+        content: '',
+        status: 'pending',
+        timestamp: Date.now(),
+        tool_call: {
+          id: 'tc1',
+          name: 'yo_browser_cdp_send',
+          params: '{"method":"Page.captureScreenshot"}',
+          response: ''
+        }
+      })
+      state.completedToolCalls = [
+        {
+          id: 'tc1',
+          name: 'yo_browser_cdp_send',
+          arguments: '{"method":"Page.captureScreenshot"}'
+        }
+      ]
+
+      await executeTools(
+        state,
+        conversation,
+        0,
+        tools,
+        toolPresenter,
+        'gpt-4',
+        io,
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024
+      )
+
+      writeFileSpy.mockRestore()
+      const toolMessage = conversation.find((message: any) => message.role === 'tool')
+      expect(toolMessage.content).toContain('offloading that result to disk failed')
+      expect(toolMessage.content).not.toContain(longScreenshot)
+      expect(state.blocks[0].status).toBe('error')
+    })
+
+    it('marks the tool as error when offload succeeds but context budget cannot fit the stub', async () => {
+      const tools = [makeTool('yo_browser_cdp_send')]
+      const longScreenshot = JSON.stringify({ data: 'x'.repeat(7000) })
+      const toolPresenter = createMockToolPresenter({ yo_browser_cdp_send: longScreenshot })
+      const conversation: any[] = []
+
+      state.blocks.push({
+        type: 'tool_call',
+        content: '',
+        status: 'pending',
+        timestamp: Date.now(),
+        tool_call: {
+          id: 'tc1',
+          name: 'yo_browser_cdp_send',
+          params: '{"method":"Page.captureScreenshot"}',
+          response: ''
+        }
+      })
+      state.completedToolCalls = [
+        {
+          id: 'tc1',
+          name: 'yo_browser_cdp_send',
+          arguments: '{"method":"Page.captureScreenshot"}'
+        }
+      ]
+
+      await executeTools(
+        state,
+        conversation,
+        0,
+        tools,
+        toolPresenter,
+        'gpt-4',
+        io,
+        'full_access',
+        new ToolOutputGuard(),
+        200,
+        32
+      )
+
+      const toolMessage = conversation.find((message: any) => message.role === 'tool')
+      expect(toolMessage.content).toContain('remaining context window is insufficient')
+      expect(state.blocks[0].status).toBe('error')
+    })
+
+    it('returns terminalError when even the minimal tool failure stub cannot fit', async () => {
+      const tools = [makeTool('yo_browser_cdp_send')]
+      const longScreenshot = JSON.stringify({ data: 'x'.repeat(7000) })
+      const toolPresenter = createMockToolPresenter({ yo_browser_cdp_send: longScreenshot })
+      const conversation: any[] = []
+
+      state.blocks.push({
+        type: 'tool_call',
+        content: '',
+        status: 'pending',
+        timestamp: Date.now(),
+        tool_call: {
+          id: 'tc1',
+          name: 'yo_browser_cdp_send',
+          params: '{"method":"Page.captureScreenshot"}',
+          response: ''
+        }
+      })
+      state.completedToolCalls = [
+        {
+          id: 'tc1',
+          name: 'yo_browser_cdp_send',
+          arguments: '{"method":"Page.captureScreenshot"}'
+        }
+      ]
+
+      const executed = await executeTools(
+        state,
+        conversation,
+        0,
+        tools,
+        toolPresenter,
+        'gpt-4',
+        io,
+        'full_access',
+        new ToolOutputGuard(),
+        1,
+        1
+      )
+
+      expect(executed.terminalError).toContain('remaining context window is too small')
+      expect(conversation.find((message: any) => message.role === 'tool')).toBeUndefined()
+      expect(state.blocks[0].status).toBe('error')
     })
   })
 

--- a/test/main/presenter/deepchatAgentPresenter/process.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/process.test.ts
@@ -249,6 +249,7 @@ describe('processStream', () => {
     const toolResultMsg = secondCallMessages.find((m: any) => m.role === 'tool')
     expect(toolResultMsg.content).toContain('[Tool output offloaded]')
     expect(toolResultMsg.content).toContain('tool_tc1.offload')
+    expect(toolResultMsg.content).not.toContain(tempHome!)
   })
 
   it('multiple tool calls in one turn', async () => {

--- a/test/main/presenter/deepchatAgentPresenter/process.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/process.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { app } from 'electron'
 import type { LLMCoreStreamEvent } from '@shared/types/core/llm-events'
 import type { MCPToolDefinition } from '@shared/presenter'
 import type { IToolPresenter } from '@shared/types/presenters/tool.presenter'
 import type { ProcessParams } from '@/presenter/deepchatAgentPresenter/types'
+import { ToolOutputGuard } from '@/presenter/deepchatAgentPresenter/toolOutputGuard'
 
 vi.mock('@/eventbus', () => ({
   eventBus: { sendToRenderer: vi.fn() },
@@ -75,6 +80,8 @@ function makeStreamEvents(...events: LLMCoreStreamEvent[]): LLMCoreStreamEvent[]
 
 describe('processStream', () => {
   let messageStore: ReturnType<typeof createMockMessageStore>
+  let tempHome: string | null = null
+  let getPathSpy: ReturnType<typeof vi.spyOn> | null = null
 
   beforeEach(() => {
     vi.useFakeTimers()
@@ -84,6 +91,13 @@ describe('processStream', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    getPathSpy?.mockRestore()
+    getPathSpy = null
+    if (tempHome) {
+      return fs.rm(tempHome, { recursive: true, force: true }).then(() => {
+        tempHome = null
+      })
+    }
   })
 
   function createParams(overrides: Partial<ProcessParams> = {}): ProcessParams {
@@ -108,6 +122,7 @@ describe('processStream', () => {
       temperature: 0.7,
       maxTokens: 4096,
       permissionMode: 'full_access',
+      toolOutputGuard: new ToolOutputGuard(),
       io: {
         sessionId: 's1',
         messageId: 'm1',
@@ -188,6 +203,52 @@ describe('processStream', () => {
     const toolResultMsg = secondCallMessages.find((m: any) => m.role === 'tool')
     expect(toolResultMsg).toBeDefined()
     expect(toolResultMsg.content).toBe('Sunny, 72F')
+  })
+
+  it('offloads large tool results before the next provider call', async () => {
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'deepchat-process-offload-'))
+    getPathSpy = vi.spyOn(app, 'getPath').mockReturnValue(tempHome)
+
+    let callCount = 0
+    const longScreenshot = JSON.stringify({ data: 'x'.repeat(7000) })
+    const coreStream = vi.fn(function () {
+      callCount++
+      if (callCount === 1) {
+        return (async function* () {
+          yield {
+            type: 'tool_call_start',
+            tool_call_id: 'tc1',
+            tool_call_name: 'yo_browser_cdp_send'
+          } as LLMCoreStreamEvent
+          yield {
+            type: 'tool_call_end',
+            tool_call_id: 'tc1',
+            tool_call_arguments_complete: '{"method":"Page.captureScreenshot"}'
+          } as LLMCoreStreamEvent
+          yield { type: 'stop', stop_reason: 'tool_use' } as LLMCoreStreamEvent
+        })()
+      }
+      return (async function* () {
+        yield { type: 'text', content: 'Done' } as LLMCoreStreamEvent
+        yield { type: 'stop', stop_reason: 'complete' } as LLMCoreStreamEvent
+      })()
+    }) as unknown as ProcessParams['coreStream']
+
+    const toolPresenter = createMockToolPresenter({ yo_browser_cdp_send: longScreenshot })
+    const params = createParams({
+      coreStream,
+      toolPresenter,
+      tools: [makeTool('yo_browser_cdp_send')]
+    })
+
+    const promise = processStream(params)
+    await vi.runAllTimersAsync()
+    await promise
+
+    const secondCallMessages = (coreStream as ReturnType<typeof vi.fn>).mock.calls[1][0]
+    const toolResultMsg = secondCallMessages.find((m: any) => m.role === 'tool')
+    expect(toolResultMsg.content).toContain('[Tool output offloaded]')
+    expect(toolResultMsg.content).toContain('tool_tc1.offload')
   })
 
   it('multiple tool calls in one turn', async () => {
@@ -445,6 +506,61 @@ describe('processStream', () => {
     // This matches the v2 behavior where error events from the stream
     // still lead to finalization (blocks contain the error block).
     expect(messageStore.finalizeAssistantMessage).toHaveBeenCalled()
+  })
+
+  it('context window error event is finalized as an error', async () => {
+    const coreStream = vi.fn(function* () {
+      yield {
+        type: 'error',
+        error_message: 'maximum context length exceeded'
+      } as LLMCoreStreamEvent
+    }) as unknown as ProcessParams['coreStream']
+
+    const params = createParams({ coreStream })
+
+    const promise = processStream(params)
+    await vi.runAllTimersAsync()
+    await promise
+
+    expect(messageStore.setMessageError).toHaveBeenCalled()
+    expect(messageStore.finalizeAssistantMessage).not.toHaveBeenCalled()
+  })
+
+  it('terminal tool output failure stops before the next provider call', async () => {
+    const coreStream = vi.fn(function () {
+      return (async function* () {
+        yield {
+          type: 'tool_call_start',
+          tool_call_id: 'tc1',
+          tool_call_name: 'yo_browser_cdp_send'
+        } as LLMCoreStreamEvent
+        yield {
+          type: 'tool_call_end',
+          tool_call_id: 'tc1',
+          tool_call_arguments_complete: '{"method":"Page.captureScreenshot"}'
+        } as LLMCoreStreamEvent
+        yield { type: 'stop', stop_reason: 'tool_use' } as LLMCoreStreamEvent
+      })()
+    }) as unknown as ProcessParams['coreStream']
+
+    const longScreenshot = JSON.stringify({ data: 'x'.repeat(7000) })
+    const toolPresenter = createMockToolPresenter({ yo_browser_cdp_send: longScreenshot })
+    const params = createParams({
+      coreStream,
+      toolPresenter,
+      tools: [makeTool('yo_browser_cdp_send')],
+      modelConfig: { contextLength: 1 } as any,
+      maxTokens: 1
+    })
+
+    const promise = processStream(params)
+    await vi.runAllTimersAsync()
+    const result = await promise
+
+    expect(result.status).toBe('error')
+    expect(result.terminalError).toContain('remaining context window is too small')
+    expect(coreStream).toHaveBeenCalledTimes(1)
+    expect(messageStore.setMessageError).toHaveBeenCalled()
   })
 
   it('stream exception → catch finalizeError', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Tool outputs are now guarded and can be offloaded to files when large; guarded content and context budgeting control how tool results are presented.

* **Bug Fixes**
  - Better handling and normalization of context-window errors and terminal tool errors.
  - Offload failures and oversized outputs now surface clear error messages and prevent broken states.

* **Tests**
  - Added tests covering offloading, budgeting/resume behavior, and terminal-error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->