### PR TITLE
fix(sqlite): avoid fresh install migration clash

### DIFF
--- a/src/main/presenter/sqlitePresenter/tables/baseTable.ts
+++ b/src/main/presenter/sqlitePresenter/tables/baseTable.ts
@@ -27,6 +27,22 @@ export abstract class BaseTable {
     return !!result
   }
 
+  protected getRecordedSchemaVersion(): number {
+    const versionTable = this.db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='schema_versions'`)
+      .get() as { name: string } | undefined
+
+    if (!versionTable) {
+      return 0
+    }
+
+    const result = this.db.prepare('SELECT MAX(version) as version FROM schema_versions').get() as
+      | { version: number | null }
+      | undefined
+
+    return result?.version ?? 0
+  }
+
   // 执行表创建
   public createTable(): void {
     if (!this.tableExists()) {

--- a/src/main/presenter/sqlitePresenter/tables/deepchatSessions.ts
+++ b/src/main/presenter/sqlitePresenter/tables/deepchatSessions.ts
@@ -42,12 +42,48 @@ export class DeepChatSessionsTable extends BaseTable {
   }
 
   getCreateTableSQL(): string {
+    return this.getCreateTableSQLForVersion(0)
+  }
+
+  override createTable(): void {
+    if (this.tableExists()) {
+      return
+    }
+
+    this.db.exec(this.getCreateTableSQLForVersion(this.getRecordedSchemaVersion()))
+  }
+
+  private getCreateTableSQLForVersion(version: number): string {
+    const columns = [
+      'id TEXT PRIMARY KEY',
+      'provider_id TEXT NOT NULL',
+      'model_id TEXT NOT NULL',
+      "permission_mode TEXT NOT NULL DEFAULT 'full_access'"
+    ]
+
+    if (version >= 12) {
+      columns.push(
+        'system_prompt TEXT',
+        'temperature REAL',
+        'context_length INTEGER',
+        'max_tokens INTEGER',
+        'thinking_budget INTEGER',
+        'reasoning_effort TEXT',
+        'verbosity TEXT'
+      )
+    }
+
+    if (version >= 14) {
+      columns.push(
+        'summary_text TEXT',
+        'summary_cursor_order_seq INTEGER NOT NULL DEFAULT 1',
+        'summary_updated_at INTEGER'
+      )
+    }
+
     return `
       CREATE TABLE IF NOT EXISTS deepchat_sessions (
-        id TEXT PRIMARY KEY,
-        provider_id TEXT NOT NULL,
-        model_id TEXT NOT NULL,
-        permission_mode TEXT NOT NULL DEFAULT 'full_access'
+        ${columns.join(',\n        ')}
       );
     `
   }

--- a/src/main/presenter/sqlitePresenter/tables/newSessions.ts
+++ b/src/main/presenter/sqlitePresenter/tables/newSessions.ts
@@ -20,15 +20,41 @@ export class NewSessionsTable extends BaseTable {
   }
 
   getCreateTableSQL(): string {
+    return this.getCreateTableSQLForVersion(0)
+  }
+
+  override createTable(): void {
+    if (this.tableExists()) {
+      return
+    }
+
+    this.db.exec(this.getCreateTableSQLForVersion(this.getRecordedSchemaVersion()))
+  }
+
+  private getCreateTableSQLForVersion(version: number): string {
+    const columns = [
+      'id TEXT PRIMARY KEY',
+      'agent_id TEXT NOT NULL',
+      'title TEXT NOT NULL',
+      'project_dir TEXT',
+      'is_pinned INTEGER DEFAULT 0'
+    ]
+
+    if (version >= 11) {
+      columns.push('is_draft INTEGER NOT NULL DEFAULT 0')
+    }
+    if (version >= 15) {
+      columns.push("active_skills TEXT NOT NULL DEFAULT '[]'")
+    }
+    if (version >= 16) {
+      columns.push("disabled_agent_tools TEXT NOT NULL DEFAULT '[]'")
+    }
+
+    columns.push('created_at INTEGER NOT NULL', 'updated_at INTEGER NOT NULL')
+
     return `
       CREATE TABLE IF NOT EXISTS new_sessions (
-        id TEXT PRIMARY KEY,
-        agent_id TEXT NOT NULL,
-        title TEXT NOT NULL,
-        project_dir TEXT,
-        is_pinned INTEGER DEFAULT 0,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
+        ${columns.join(',\n        ')}
       );
       CREATE INDEX IF NOT EXISTS idx_new_sessions_agent ON new_sessions(agent_id);
       CREATE INDEX IF NOT EXISTS idx_new_sessions_updated ON new_sessions(updated_at DESC);

--- a/test/main/presenter/sqlitePresenter.test.ts
+++ b/test/main/presenter/sqlitePresenter.test.ts
@@ -132,4 +132,102 @@ describe('SQLitePresenter legacy schema bootstrap', () => {
     expect(versions.map((row) => row.version)).toEqual(expect.arrayContaining([11, 15, 16]))
     checkDb.close()
   })
+
+  it('recreates new_sessions with applied columns when schema version is already 16', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-sqlite-presenter-'))
+    tempDirs.push(tempDir)
+
+    const dbPath = path.join(tempDir, 'agent.db')
+    const bootstrapDb = new Database(dbPath)
+    bootstrapDb.exec(`
+      CREATE TABLE IF NOT EXISTS schema_versions (
+        version INTEGER PRIMARY KEY,
+        applied_at INTEGER NOT NULL
+      );
+      INSERT INTO schema_versions (version, applied_at) VALUES (16, ${Date.now()});
+    `)
+    bootstrapDb.close()
+
+    const presenter = new SQLitePresenter(dbPath)
+    presenter.newSessionsTable.create('session-1', 'agent-1', 'Recovered session', null)
+    presenter.close()
+
+    const checkDb = new Database(dbPath)
+    const newSessionColumns = checkDb.prepare('PRAGMA table_info(new_sessions)').all() as Array<{
+      name: string
+    }>
+    const columnNames = new Set(newSessionColumns.map((column) => column.name))
+
+    expect(columnNames.has('is_draft')).toBe(true)
+    expect(columnNames.has('active_skills')).toBe(true)
+    expect(columnNames.has('disabled_agent_tools')).toBe(true)
+
+    const row = checkDb
+      .prepare(
+        'SELECT is_draft, active_skills, disabled_agent_tools FROM new_sessions WHERE id = ?'
+      )
+      .get('session-1') as
+      | {
+          is_draft: number
+          active_skills: string
+          disabled_agent_tools: string
+        }
+      | undefined
+
+    expect(row).toEqual({
+      is_draft: 0,
+      active_skills: '[]',
+      disabled_agent_tools: '[]'
+    })
+    checkDb.close()
+  })
+
+  it('recreates deepchat_sessions with applied columns when schema version is already 14', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-sqlite-presenter-'))
+    tempDirs.push(tempDir)
+
+    const dbPath = path.join(tempDir, 'agent.db')
+    const bootstrapDb = new Database(dbPath)
+    bootstrapDb.exec(`
+      CREATE TABLE IF NOT EXISTS schema_versions (
+        version INTEGER PRIMARY KEY,
+        applied_at INTEGER NOT NULL
+      );
+      INSERT INTO schema_versions (version, applied_at) VALUES (14, ${Date.now()});
+    `)
+    bootstrapDb.close()
+
+    const presenter = new SQLitePresenter(dbPath)
+    presenter.deepchatSessionsTable.create('session-1', 'openai', 'gpt-4o')
+    presenter.close()
+
+    const checkDb = new Database(dbPath)
+    const deepchatColumns = checkDb.prepare('PRAGMA table_info(deepchat_sessions)').all() as Array<{
+      name: string
+    }>
+    const columnNames = new Set(deepchatColumns.map((column) => column.name))
+
+    expect(columnNames.has('system_prompt')).toBe(true)
+    expect(columnNames.has('summary_text')).toBe(true)
+    expect(columnNames.has('summary_cursor_order_seq')).toBe(true)
+
+    const row = checkDb
+      .prepare(
+        'SELECT system_prompt, summary_text, summary_cursor_order_seq FROM deepchat_sessions WHERE id = ?'
+      )
+      .get('session-1') as
+      | {
+          system_prompt: string | null
+          summary_text: string | null
+          summary_cursor_order_seq: number
+        }
+      | undefined
+
+    expect(row).toEqual({
+      system_prompt: null,
+      summary_text: null,
+      summary_cursor_order_seq: 1
+    })
+    checkDb.close()
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Database schema now uses version-aware creation and migrations for session data, improving upgrade reliability and safely introducing new session fields (draft flag, skill lists, summary fields).

* **Tests**
  * Expanded tests to validate migration paths, schema versions, presence of new columns, and their default values across upgrade scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->