### PR TITLE
feat(renderer): edit SessionItem style

### DIFF
--- a/src/renderer/src/components/WindowSideBarSessionItem.vue
+++ b/src/renderer/src/components/WindowSideBarSessionItem.vue
@@ -1,64 +1,37 @@
 <template>
-  <ContextMenu>
-    <ContextMenuTrigger as-child>
-      <button
-        type="button"
-        class="no-drag flex items-center gap-2 w-full px-2 py-1.5 rounded-md text-left transition-all duration-150"
-        :class="
-          active ? 'bg-accent text-accent-foreground' : 'text-foreground/80 hover:bg-accent/50'
-        "
-        @click="$emit('select', session)"
-      >
-        <Icon
-          v-if="session.isPinned"
-          icon="lucide:pin"
-          class="w-3.5 h-3.5 text-yellow-500 shrink-0"
-        />
-        <span class="flex-1 text-sm truncate">{{ session.title }}</span>
-        <span v-if="session.status === 'working'" class="shrink-0">
-          <Icon icon="lucide:loader-2" class="w-3.5 h-3.5 text-primary animate-spin" />
-        </span>
-        <span v-else-if="session.status === 'completed'" class="shrink-0">
-          <Icon icon="lucide:check" class="w-3.5 h-3.5 text-green-500" />
-        </span>
-        <span v-else-if="session.status === 'error'" class="shrink-0">
-          <Icon icon="lucide:alert-circle" class="w-3.5 h-3.5 text-destructive" />
-        </span>
-      </button>
-    </ContextMenuTrigger>
-
-    <ContextMenuContent class="w-48">
-      <ContextMenuItem @select="$emit('toggle-pin', session)">
-        <Icon :icon="session.isPinned ? 'lucide:pin-off' : 'lucide:pin'" class="mr-2 h-4 w-4" />
-        <span>{{ session.isPinned ? t('thread.actions.unpin') : t('thread.actions.pin') }}</span>
-      </ContextMenuItem>
-      <ContextMenuItem @select="$emit('rename', session)">
-        <Icon icon="lucide:pencil" class="mr-2 h-4 w-4" />
-        <span>{{ t('thread.actions.rename') }}</span>
-      </ContextMenuItem>
-      <ContextMenuItem @select="$emit('clear', session)">
-        <Icon icon="lucide:eraser" class="mr-2 h-4 w-4" />
-        <span>{{ t('thread.actions.cleanMessages') }}</span>
-      </ContextMenuItem>
-      <ContextMenuSeparator />
-      <ContextMenuItem class="text-destructive" @select="$emit('delete', session)">
-        <Icon icon="lucide:trash-2" class="mr-2 h-4 w-4" />
-        <span>{{ t('thread.actions.delete') }}</span>
-      </ContextMenuItem>
-    </ContextMenuContent>
-  </ContextMenu>
+  <div
+    class="session-item no-drag flex items-center gap-2 w-full px-2 py-1.5 rounded-md text-left transition-all duration-150"
+    :class="active ? 'bg-accent text-accent-foreground' : 'text-foreground/80 hover:bg-accent/50'"
+    @click="$emit('select', session)"
+  >
+    <span class="flex-1 text-sm truncate">{{ session.title }}</span>
+    <span v-if="session.status === 'working'" class="shrink-0">
+      <Icon icon="lucide:loader-2" class="w-3.5 h-3.5 text-primary animate-spin" />
+    </span>
+    <span v-else-if="session.status === 'completed'" class="shrink-0">
+      <Icon icon="lucide:check" class="w-3.5 h-3.5 text-green-500" />
+    </span>
+    <span v-else-if="session.status === 'error'" class="shrink-0">
+      <Icon icon="lucide:alert-circle" class="w-3.5 h-3.5 text-destructive" />
+    </span>
+    <span class="right-button flex gap-2 items-center opacity-0 transition-all">
+      <Icon
+        @click.stop="$emit('delete', session)"
+        icon="lucide:trash-2"
+        class="h-4 w-4 cursor-pointer hover:text-primary"
+      />
+      <Icon
+        @click.stop="$emit('toggle-pin', session)"
+        :icon="session.isPinned ? 'lucide:pin-off' : 'lucide:pin'"
+        class="h-4 w-4 hover:text-primary cursor-pointer"
+      />
+    </span>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
-import { useI18n } from 'vue-i18n'
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuTrigger
-} from '@shadcn/components/ui/context-menu'
+
 import type { UISession } from '@/stores/ui/session'
 
 defineOptions({
@@ -77,12 +50,15 @@ defineEmits<{
   clear: [session: UISession]
   delete: [session: UISession]
 }>()
-
-const { t } = useI18n()
 </script>
 
 <style scoped>
 .no-drag {
   -webkit-app-region: no-drag;
+}
+
+.session-item:hover .right-button {
+  display: flex;
+  opacity: 1;
 }
 </style>


### PR DESCRIPTION
I replaced the right-click method with a hover and removed the clear and edit buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session item action icons (delete, toggle-pin) now appear on hover within the sidebar row.

* **UI/UX Changes**
  * Transitioned from context menu interactions to inline action buttons for session management.
  * Removed rename and clear action options from session controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->