### PR TITLE
fix: rate limit

### DIFF
--- a/src/main/presenter/deepchatAgentPresenter/compactionService.ts
+++ b/src/main/presenter/deepchatAgentPresenter/compactionService.ts
@@ -21,6 +21,25 @@ const SAFETY_MARGIN = 1.2
 const SUMMARIZATION_OVERHEAD_TOKENS = 4096
 const SUMMARY_OUTPUT_TOKENS_CAP = 2048
 
+const createAbortError = (): Error => {
+  if (typeof DOMException !== 'undefined') {
+    return new DOMException('Aborted', 'AbortError')
+  }
+
+  const error = new Error('Aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+const throwIfAbortRequested = (signal?: AbortSignal): void => {
+  if (signal?.aborted) {
+    throw createAbortError()
+  }
+}
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof Error && (error.name === 'AbortError' || error.name === 'CanceledError')
+
 export type ModelSpec = {
   providerId: string
   modelId: string
@@ -215,8 +234,11 @@ export class CompactionService {
     supportsVision: boolean
     preserveInterleavedReasoning: boolean
     newUserContent: string | SendMessageInput
+    signal?: AbortSignal
   }): Promise<CompactionIntent | null> {
+    throwIfAbortRequested(params.signal)
     const settings = await this.getCompactionSettings(params.sessionId)
+    throwIfAbortRequested(params.signal)
     if (!settings.enabled) {
       return null
     }
@@ -245,8 +267,11 @@ export class CompactionService {
     reserveTokens: number
     supportsVision: boolean
     preserveInterleavedReasoning: boolean
+    signal?: AbortSignal
   }): Promise<CompactionIntent | null> {
+    throwIfAbortRequested(params.signal)
     const settings = await this.getCompactionSettings(params.sessionId)
+    throwIfAbortRequested(params.signal)
     if (!settings.enabled) {
       return null
     }
@@ -279,14 +304,19 @@ export class CompactionService {
     })
   }
 
-  async applyCompaction(intent: CompactionIntent): Promise<CompactionExecutionResult> {
+  async applyCompaction(
+    intent: CompactionIntent,
+    signal?: AbortSignal
+  ): Promise<CompactionExecutionResult> {
     try {
+      throwIfAbortRequested(signal)
       const nextSummary = await this.generateRollingSummary({
         sessionId: intent.sessionId,
         previousSummary: intent.previousState.summaryText,
         summaryBlocks: intent.summaryBlocks,
         currentModel: intent.currentModel,
-        reserveTokens: intent.reserveTokens
+        reserveTokens: intent.reserveTokens,
+        signal
       })
 
       const updatedState: SessionSummaryState = {
@@ -313,6 +343,9 @@ export class CompactionService {
         summaryState: compareAndSet.currentState
       }
     } catch (error) {
+      if (signal?.aborted || isAbortError(error)) {
+        throw error
+      }
       console.warn(`[CompactionService] Failed to compact session ${intent.sessionId}:`, error)
       return {
         succeeded: false,
@@ -496,9 +529,12 @@ export class CompactionService {
     summaryBlocks: string[]
     currentModel: ModelSpec
     reserveTokens: number
+    signal?: AbortSignal
   }): Promise<string> {
+    throwIfAbortRequested(params.signal)
     const currentModel = params.currentModel
     const assistantModel = await this.getAssistantModelSpec(params.sessionId, currentModel)
+    throwIfAbortRequested(params.signal)
     const previousSummaryTokens = approximateTokenSize(params.previousSummary || '')
     const blockTokens = params.summaryBlocks.reduce(
       (total, block) => total + approximateTokenSize(block),
@@ -515,7 +551,8 @@ export class CompactionService {
     return await this.summarizeBlocks(params.summaryBlocks, {
       previousSummary: params.previousSummary,
       model: preferredModel,
-      reserveTokens: params.reserveTokens
+      reserveTokens: params.reserveTokens,
+      signal: params.signal
     })
   }
 
@@ -525,8 +562,10 @@ export class CompactionService {
       previousSummary: string | null
       model: ModelSpec
       reserveTokens: number
+      signal?: AbortSignal
     }
   ): Promise<string> {
+    throwIfAbortRequested(options.signal)
     const normalizedBlocks = blocks.map((block) => block.trim()).filter(Boolean)
     if (normalizedBlocks.length === 0) {
       const normalizedPrevious = options.previousSummary?.trim()
@@ -546,7 +585,8 @@ export class CompactionService {
         options.model,
         options.reserveTokens,
         options.previousSummary,
-        normalizedBlocks.join('\n\n')
+        normalizedBlocks.join('\n\n'),
+        options.signal
       )
     }
 
@@ -569,7 +609,8 @@ export class CompactionService {
             options.model,
             options.reserveTokens,
             options.previousSummary,
-            joinedSplitBlocks
+            joinedSplitBlocks,
+            options.signal
           )
         }
 
@@ -596,16 +637,20 @@ export class CompactionService {
       previousSummary: string | null
       model: ModelSpec
       reserveTokens: number
+      signal?: AbortSignal
     }
   ): Promise<string> {
+    throwIfAbortRequested(options.signal)
     const chunkSummaries: string[] = []
     for (const chunk of chunkGroups) {
+      throwIfAbortRequested(options.signal)
       chunkSummaries.push(
         await this.generateSummaryText(
           options.model,
           options.reserveTokens,
           null,
-          chunk.join('\n\n')
+          chunk.join('\n\n'),
+          options.signal
         )
       )
     }
@@ -701,10 +746,17 @@ export class CompactionService {
     model: ModelSpec,
     reserveTokens: number,
     previousSummary: string | null,
-    spanText: string
+    spanText: string,
+    signal?: AbortSignal
   ): Promise<string> {
+    throwIfAbortRequested(signal)
     const prompt = this.buildSummaryPrompt(previousSummary, spanText)
-    await this.llmProviderPresenter.executeWithRateLimit(model.providerId)
+    if (signal) {
+      await this.llmProviderPresenter.executeWithRateLimit(model.providerId, { signal })
+    } else {
+      await this.llmProviderPresenter.executeWithRateLimit(model.providerId)
+    }
+    throwIfAbortRequested(signal)
     const response = await this.llmProviderPresenter.generateText(
       model.providerId,
       prompt,

--- a/src/main/presenter/deepchatAgentPresenter/compactionService.ts
+++ b/src/main/presenter/deepchatAgentPresenter/compactionService.ts
@@ -704,6 +704,7 @@ export class CompactionService {
     spanText: string
   ): Promise<string> {
     const prompt = this.buildSummaryPrompt(previousSummary, spanText)
+    await this.llmProviderPresenter.executeWithRateLimit(model.providerId)
     const response = await this.llmProviderPresenter.generateText(
       model.providerId,
       prompt,

--- a/src/main/presenter/deepchatAgentPresenter/index.ts
+++ b/src/main/presenter/deepchatAgentPresenter/index.ts
@@ -15,7 +15,12 @@ import type {
 } from '@shared/types/agent-interface'
 import type { MCPToolCall, MCPToolResponse } from '@shared/types/core/mcp'
 import type { ChatMessage } from '@shared/types/core/chat-message'
-import type { IConfigPresenter, ILlmProviderPresenter, ModelConfig } from '@shared/presenter'
+import type {
+  IConfigPresenter,
+  ILlmProviderPresenter,
+  ModelConfig,
+  RateLimitQueueSnapshot
+} from '@shared/presenter'
 import type { MCPToolDefinition } from '@shared/types/core/mcp'
 import type { IToolPresenter } from '@shared/types/presenters/tool.presenter'
 import type { ReasoningPortrait } from '@shared/types/model-db'
@@ -113,6 +118,8 @@ const isReasoningEffort = (value: unknown): value is 'minimal' | 'low' | 'medium
 
 const isVerbosity = (value: unknown): value is 'low' | 'medium' | 'high' =>
   value === 'low' || value === 'medium' || value === 'high'
+
+const RATE_LIMIT_STREAM_MESSAGE_PREFIX = '__rate_limit__:'
 
 const createAbortError = (): Error => {
   if (typeof DOMException !== 'undefined') {
@@ -1342,6 +1349,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
     }
 
     const traceEnabled = this.configPresenter.getSetting<boolean>('traceDebugEnabled') === true
+    const llmProviderPresenter = this.llmProviderPresenter
     const pendingInputCoordinator = this.pendingInputCoordinator
     const injectSteerInputsIntoRequest = this.injectSteerInputsIntoRequest.bind(this)
     const persistMessageTrace = this.persistMessageTrace.bind(this)
@@ -1374,6 +1382,9 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
 
     const abortController = new AbortController()
     const activeGeneration = this.registerActiveGeneration(sessionId, messageId, abortController)
+    const rateLimitMessageId = this.buildRateLimitStreamMessageId(activeGeneration.runId)
+    const emitRateLimitWaitingMessage = this.emitRateLimitWaitingMessage.bind(this)
+    const clearRateLimitWaitingMessage = this.clearRateLimitWaitingMessage.bind(this)
 
     try {
       this.dispatchHook('SessionStart', {
@@ -1407,8 +1418,21 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
           )
 
           let didConsumeSteerBatch = false
+          let queuedForRateLimit = false
 
           try {
+            await llmProviderPresenter.executeWithRateLimit(state.providerId, {
+              signal: abortController.signal,
+              onQueued: (snapshot) => {
+                queuedForRateLimit = true
+                emitRateLimitWaitingMessage(sessionId, rateLimitMessageId, snapshot)
+              }
+            })
+            if (queuedForRateLimit) {
+              clearRateLimitWaitingMessage(sessionId, rateLimitMessageId)
+              queuedForRateLimit = false
+            }
+
             for await (const event of provider.coreStream(
               injectedMessages,
               requestModelId,
@@ -1428,6 +1452,9 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
               pendingInputCoordinator.consumeClaimedSteerBatch(sessionId)
             }
           } catch (error) {
+            if (queuedForRateLimit) {
+              clearRateLimitWaitingMessage(sessionId, rateLimitMessageId)
+            }
             if (!didConsumeSteerBatch && claimedSteerBatch.length > 0) {
               pendingInputCoordinator.releaseClaimedInputs(sessionId)
             }
@@ -1667,6 +1694,47 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
 
   private isActiveRun(sessionId: string, runId: string): boolean {
     return this.activeGenerations.get(sessionId)?.runId === runId
+  }
+
+  private buildRateLimitStreamMessageId(runId: string): string {
+    return `${RATE_LIMIT_STREAM_MESSAGE_PREFIX}${runId}`
+  }
+
+  private emitRateLimitWaitingMessage(
+    sessionId: string,
+    messageId: string,
+    snapshot: RateLimitQueueSnapshot
+  ): void {
+    const block: AssistantMessageBlock = {
+      type: 'action',
+      action_type: 'rate_limit',
+      content: '',
+      status: 'pending',
+      timestamp: Date.now(),
+      extra: {
+        providerId: snapshot.providerId,
+        qpsLimit: snapshot.qpsLimit,
+        currentQps: snapshot.currentQps,
+        queueLength: snapshot.queueLength,
+        estimatedWaitTime: snapshot.estimatedWaitTime
+      }
+    }
+
+    eventBus.sendToRenderer(STREAM_EVENTS.RESPONSE, SendTarget.ALL_WINDOWS, {
+      conversationId: sessionId,
+      eventId: messageId,
+      messageId,
+      blocks: [block]
+    })
+  }
+
+  private clearRateLimitWaitingMessage(sessionId: string, messageId: string): void {
+    eventBus.sendToRenderer(STREAM_EVENTS.RESPONSE, SendTarget.ALL_WINDOWS, {
+      conversationId: sessionId,
+      eventId: messageId,
+      messageId,
+      blocks: []
+    })
   }
 
   private applyProcessResultStatus(

--- a/src/main/presenter/deepchatAgentPresenter/index.ts
+++ b/src/main/presenter/deepchatAgentPresenter/index.ts
@@ -1492,6 +1492,9 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
               clearRateLimitWaitingMessage(sessionId, rateLimitMessageId)
               queuedForRateLimit = false
             }
+            if (abortController.signal.aborted) {
+              throw createAbortError()
+            }
 
             for await (const event of provider.coreStream(
               injectedMessages,
@@ -1839,6 +1842,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
     }
     this.resumingMessages.add(messageId)
     let preStreamAbortController: AbortController | null = null
+    let preStreamAbortSignal: AbortSignal | undefined
 
     try {
       const state = this.runtimeState.get(sessionId)
@@ -1848,7 +1852,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
 
       this.setSessionStatus(sessionId, 'generating')
       preStreamAbortController = this.ensureSessionAbortController(sessionId)
-      const preStreamAbortSignal = preStreamAbortController.signal
+      preStreamAbortSignal = preStreamAbortController.signal
       this.throwIfAbortRequested(preStreamAbortSignal)
       const generationSettings = await this.getEffectiveSessionGenerationSettings(sessionId)
       this.throwIfAbortRequested(preStreamAbortSignal)
@@ -1952,7 +1956,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       return true
     } catch (error) {
       console.error('[DeepChatAgent] resumeAssistantMessage error:', error)
-      if (this.isAbortError(error)) {
+      if (this.isAbortError(error) || preStreamAbortSignal?.aborted) {
         const blocks = buildTerminalErrorBlocks(
           initialBlocks,
           'common.error.userCanceledGeneration'
@@ -3609,7 +3613,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
     try {
       result = await this.compactionService.applyCompaction(intent, options?.signal)
     } catch (error) {
-      if (this.isAbortError(error)) {
+      if (this.isAbortError(error) || options?.signal?.aborted) {
         this.messageStore.deleteMessage(compactionMessageId)
         this.emitMessageRefresh(sessionId, compactionMessageId)
         this.emitCompactionState(

--- a/src/main/presenter/deepchatAgentPresenter/index.ts
+++ b/src/main/presenter/deepchatAgentPresenter/index.ts
@@ -3275,6 +3275,9 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
         visionModel.modelId,
         visionModel.providerId
       )
+      await this.llmProviderPresenter.executeWithRateLimit(visionModel.providerId, {
+        signal: abortSignal
+      })
       const response = await this.llmProviderPresenter.generateCompletionStandalone(
         visionModel.providerId,
         messages,

--- a/src/main/presenter/deepchatAgentPresenter/index.ts
+++ b/src/main/presenter/deepchatAgentPresenter/index.ts
@@ -389,12 +389,16 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
     )
 
     this.setSessionStatus(sessionId, 'generating')
+    const preStreamAbortController = this.ensureSessionAbortController(sessionId)
+    const preStreamAbortSignal = preStreamAbortController.signal
     let consumedPendingQueueItem = false
     let userMessageId: string | null = null
     let assistantMessageId: string | null = null
 
     try {
+      this.throwIfAbortRequested(preStreamAbortSignal)
       const generationSettings = await this.getEffectiveSessionGenerationSettings(sessionId)
+      this.throwIfAbortRequested(preStreamAbortSignal)
       const interleavedReasoning = this.resolveInterleavedReasoningConfig(
         state.providerId,
         state.modelId,
@@ -402,11 +406,13 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       )
       const maxTokens = generationSettings.maxTokens
       const tools = await this.loadToolDefinitionsForSession(sessionId, projectDir)
+      this.throwIfAbortRequested(preStreamAbortSignal)
       const baseSystemPrompt = await this.buildSystemPromptWithSkills(
         sessionId,
         generationSettings.systemPrompt,
         tools
       )
+      this.throwIfAbortRequested(preStreamAbortSignal)
       const historyRecords = this.messageStore
         .getMessages(sessionId)
         .filter((message) => message.status === 'sent')
@@ -427,7 +433,8 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
         reserveTokens: maxTokens,
         supportsVision,
         preserveInterleavedReasoning: interleavedReasoning.preserveReasoningContent,
-        newUserContent: normalizedInput
+        newUserContent: normalizedInput,
+        signal: preStreamAbortSignal
       })
       let summaryState: SessionSummaryState
 
@@ -450,7 +457,8 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
         })
         summaryState = await this.applyCompactionIntent(sessionId, compactionIntent, {
           compactionMessageId,
-          startedExternally: true
+          startedExternally: true,
+          signal: preStreamAbortSignal
         })
       } else {
         summaryState = this.sessionStore.getSummaryState(sessionId)
@@ -463,6 +471,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       if (!userMessageId) {
         throw new Error('Failed to create user message.')
       }
+      this.throwIfAbortRequested(preStreamAbortSignal)
       this.emitMessageRefresh(sessionId, userMessageId)
 
       this.dispatchHook('UserPromptSubmit', {
@@ -492,6 +501,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
 
       const assistantOrderSeq = this.messageStore.getNextOrderSeq(sessionId)
       assistantMessageId = this.messageStore.createAssistantMessage(sessionId, assistantOrderSeq)
+      this.throwIfAbortRequested(preStreamAbortSignal)
 
       if (context?.pendingQueueItemId) {
         this.pendingInputCoordinator.consumeQueuedInput(sessionId, context.pendingQueueItemId)
@@ -531,6 +541,27 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
           console.warn('[DeepChatAgent] failed to release claimed queue input:', releaseError)
         }
       }
+      if (this.isAbortError(err) || preStreamAbortSignal.aborted) {
+        if (userMessageId) {
+          this.emitMessageRefresh(sessionId, userMessageId)
+        }
+        if (assistantMessageId) {
+          const existingAssistant = this.messageStore.getMessage(assistantMessageId)
+          const blocks = buildTerminalErrorBlocks(
+            existingAssistant ? this.parseAssistantBlocks(existingAssistant.content) : [],
+            'common.error.userCanceledGeneration'
+          )
+          this.messageStore.setMessageError(assistantMessageId, blocks)
+          this.emitMessageRefresh(sessionId, assistantMessageId)
+        }
+        this.dispatchTerminalHooks(sessionId, state, {
+          status: 'aborted',
+          stopReason: 'user_stop',
+          errorMessage: 'common.error.userCanceledGeneration'
+        })
+        this.setSessionStatus(sessionId, 'idle')
+        return
+      }
       const errorMessage = err instanceof Error ? err.message : String(err)
       if (assistantMessageId) {
         const existingAssistant = this.messageStore.getMessage(assistantMessageId)
@@ -556,6 +587,8 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
         error: { message: errorMessage }
       })
       this.setSessionStatus(sessionId, 'error')
+    } finally {
+      this.clearSessionAbortController(sessionId, preStreamAbortController)
     }
   }
 
@@ -1043,6 +1076,33 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       this.activeGenerations.get(sessionId)?.abortController.signal ??
       this.abortControllers.get(sessionId)?.signal
     )
+  }
+
+  private ensureSessionAbortController(sessionId: string): AbortController {
+    const activeGeneration = this.activeGenerations.get(sessionId)
+    if (activeGeneration) {
+      return activeGeneration.abortController
+    }
+
+    const existing = this.abortControllers.get(sessionId)
+    if (existing) {
+      existing.abort()
+    }
+
+    const controller = new AbortController()
+    this.abortControllers.set(sessionId, controller)
+    return controller
+  }
+
+  private clearSessionAbortController(sessionId: string, controller?: AbortController): void {
+    const current = this.abortControllers.get(sessionId)
+    if (!current) {
+      return
+    }
+    if (controller && current !== controller) {
+      return
+    }
+    this.abortControllers.delete(sessionId)
   }
 
   private buildDeferredToolAbortKey(sessionId: string, toolCallId: string): string {
@@ -1778,6 +1838,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       return false
     }
     this.resumingMessages.add(messageId)
+    let preStreamAbortController: AbortController | null = null
 
     try {
       const state = this.runtimeState.get(sessionId)
@@ -1786,7 +1847,11 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       }
 
       this.setSessionStatus(sessionId, 'generating')
+      preStreamAbortController = this.ensureSessionAbortController(sessionId)
+      const preStreamAbortSignal = preStreamAbortController.signal
+      this.throwIfAbortRequested(preStreamAbortSignal)
       const generationSettings = await this.getEffectiveSessionGenerationSettings(sessionId)
+      this.throwIfAbortRequested(preStreamAbortSignal)
       const interleavedReasoning = this.resolveInterleavedReasoningConfig(
         state.providerId,
         state.modelId,
@@ -1795,11 +1860,13 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       const maxTokens = generationSettings.maxTokens
       const projectDir = this.resolveProjectDir(sessionId)
       const tools = await this.loadToolDefinitionsForSession(sessionId, projectDir)
+      this.throwIfAbortRequested(preStreamAbortSignal)
       const baseSystemPrompt = await this.buildSystemPromptWithSkills(
         sessionId,
         generationSettings.systemPrompt,
         tools
       )
+      this.throwIfAbortRequested(preStreamAbortSignal)
       const summaryState = await this.resolveCompactionStateForResumeTurn({
         sessionId,
         messageId,
@@ -1809,8 +1876,10 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
         contextLength: generationSettings.contextLength,
         reserveTokens: maxTokens,
         supportsVision: this.supportsVision(state.providerId, state.modelId),
-        preserveInterleavedReasoning: interleavedReasoning.preserveReasoningContent
+        preserveInterleavedReasoning: interleavedReasoning.preserveReasoningContent,
+        signal: preStreamAbortSignal
       })
+      this.throwIfAbortRequested(preStreamAbortSignal)
       const systemPrompt = appendSummarySection(baseSystemPrompt, summaryState.summaryText)
       let resumeContext = buildResumeContext(
         sessionId,
@@ -1862,6 +1931,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
         }
       }
 
+      this.throwIfAbortRequested(preStreamAbortSignal)
       const { runId, result } = await this.runStreamForMessage({
         sessionId,
         messageId,
@@ -1882,6 +1952,21 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       return true
     } catch (error) {
       console.error('[DeepChatAgent] resumeAssistantMessage error:', error)
+      if (this.isAbortError(error)) {
+        const blocks = buildTerminalErrorBlocks(
+          initialBlocks,
+          'common.error.userCanceledGeneration'
+        )
+        this.messageStore.setMessageError(messageId, blocks)
+        this.emitMessageRefresh(sessionId, messageId)
+        this.dispatchTerminalHooks(sessionId, this.runtimeState.get(sessionId), {
+          status: 'aborted',
+          stopReason: 'user_stop',
+          errorMessage: 'common.error.userCanceledGeneration'
+        })
+        this.setSessionStatus(sessionId, 'idle')
+        return false
+      }
       const errorMessage = error instanceof Error ? error.message : String(error)
       const blocks = buildTerminalErrorBlocks(initialBlocks, errorMessage)
       this.messageStore.setMessageError(messageId, blocks)
@@ -1889,6 +1974,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       this.setSessionStatus(sessionId, 'error')
       throw error
     } finally {
+      this.clearSessionAbortController(sessionId, preStreamAbortController ?? undefined)
       this.resumingMessages.delete(messageId)
     }
   }
@@ -3482,9 +3568,10 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
     reserveTokens: number
     supportsVision: boolean
     preserveInterleavedReasoning: boolean
+    signal?: AbortSignal
   }): Promise<SessionSummaryState> {
     const intent = await this.compactionService.prepareForResumeTurn(params)
-    return await this.applyCompactionIntent(params.sessionId, intent)
+    return await this.applyCompactionIntent(params.sessionId, intent, { signal: params.signal })
   }
 
   private async applyCompactionIntent(
@@ -3493,6 +3580,7 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
     options?: {
       compactionMessageId?: string
       startedExternally?: boolean
+      signal?: AbortSignal
     }
   ): Promise<SessionSummaryState> {
     if (!intent) {
@@ -3517,7 +3605,20 @@ export class DeepChatAgentPresenter implements IAgentImplementation {
       })
     }
 
-    const result = await this.compactionService.applyCompaction(intent)
+    let result: Awaited<ReturnType<CompactionService['applyCompaction']>>
+    try {
+      result = await this.compactionService.applyCompaction(intent, options?.signal)
+    } catch (error) {
+      if (this.isAbortError(error)) {
+        this.messageStore.deleteMessage(compactionMessageId)
+        this.emitMessageRefresh(sessionId, compactionMessageId)
+        this.emitCompactionState(
+          sessionId,
+          this.summaryStateToCompactionState(intent.previousState)
+        )
+      }
+      throw error
+    }
     if (result.succeeded) {
       this.messageStore.updateCompactionMessage(
         compactionMessageId,

--- a/src/main/presenter/deepchatAgentPresenter/process.ts
+++ b/src/main/presenter/deepchatAgentPresenter/process.ts
@@ -18,6 +18,10 @@ const CONTEXT_WINDOW_ERROR_PATTERNS = [
 const USER_CANCELED_GENERATION_ERROR = 'common.error.userCanceledGeneration'
 const NO_MODEL_RESPONSE_ERROR = 'common.error.noModelResponse'
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'CanceledError')
+}
+
 function isContextWindowErrorMessage(message: string): boolean {
   const normalized = message.toLowerCase()
   return CONTEXT_WINDOW_ERROR_PATTERNS.some((pattern) => normalized.includes(pattern))
@@ -268,6 +272,15 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
       usage: buildUsageSnapshot(state)
     }
   } catch (err) {
+    if (io.abortSignal.aborted || isAbortError(err)) {
+      console.log(`[ProcessStream] aborted via exception after ${eventCount} events`)
+      return {
+        status: 'aborted' as const,
+        stopReason: 'user_stop',
+        errorMessage: USER_CANCELED_GENERATION_ERROR,
+        usage: buildUsageSnapshot(state)
+      }
+    }
     console.error(`[ProcessStream] exception after ${eventCount} events:`, err)
     finalizeError(state, io, err)
     return {

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -337,6 +337,8 @@ export class Presenter implements IPresenter {
           this.filePresenter.prepareFileCompletely(absPath, typeInfo, contentType)
       }),
       getLlmProviderPresenter: () => ({
+        executeWithRateLimit: (providerId, options) =>
+          this.llmproviderPresenter.executeWithRateLimit(providerId, options),
         generateCompletionStandalone: (providerId, messages, modelId, temperature, maxTokens) =>
           this.llmproviderPresenter.generateCompletionStandalone(
             providerId,

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -339,13 +339,21 @@ export class Presenter implements IPresenter {
       getLlmProviderPresenter: () => ({
         executeWithRateLimit: (providerId, options) =>
           this.llmproviderPresenter.executeWithRateLimit(providerId, options),
-        generateCompletionStandalone: (providerId, messages, modelId, temperature, maxTokens) =>
+        generateCompletionStandalone: (
+          providerId,
+          messages,
+          modelId,
+          temperature,
+          maxTokens,
+          options
+        ) =>
           this.llmproviderPresenter.generateCompletionStandalone(
             providerId,
             messages,
             modelId,
             temperature,
-            maxTokens
+            maxTokens,
+            options
           )
       }),
       createSettingsWindow: () => this.windowPresenter.createSettingsWindow(),

--- a/src/main/presenter/llmProviderPresenter/index.ts
+++ b/src/main/presenter/llmProviderPresenter/index.ts
@@ -12,6 +12,7 @@ import {
   IConfigPresenter,
   ISQLitePresenter,
   AcpConfigState,
+  RateLimitQueueSnapshot,
   AcpWorkdirInfo,
   AcpDebugRequest,
   AcpDebugRunResult
@@ -201,6 +202,16 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
     }
   > {
     return this.rateLimitManager.getAllProviderRateLimitStatus()
+  }
+
+  async executeWithRateLimit(
+    providerId: string,
+    options?: {
+      signal?: AbortSignal
+      onQueued?: (snapshot: RateLimitQueueSnapshot) => void
+    }
+  ): Promise<void> {
+    await this.rateLimitManager.executeWithRateLimit(providerId, options)
   }
 
   isGenerating(eventId: string): boolean {

--- a/src/main/presenter/llmProviderPresenter/managers/rateLimitManager.ts
+++ b/src/main/presenter/llmProviderPresenter/managers/rateLimitManager.ts
@@ -1,7 +1,23 @@
 import { RATE_LIMIT_EVENTS } from '@/events'
 import { eventBus, SendTarget } from '@/eventbus'
 import { IConfigPresenter, LLM_PROVIDER } from '@shared/presenter'
-import { ProviderRateLimitState, QueueItem, RateLimitConfig } from '../types'
+import {
+  ExecuteWithRateLimitOptions,
+  ProviderRateLimitState,
+  QueueItem,
+  RateLimitConfig,
+  RateLimitQueueSnapshot
+} from '../types'
+
+const createAbortError = (): Error => {
+  if (typeof DOMException !== 'undefined') {
+    return new DOMException('Aborted', 'AbortError')
+  }
+
+  const error = new Error('Aborted')
+  error.name = 'AbortError'
+  return error
+}
 
 export class RateLimitManager {
   private readonly providerRateLimitStates: Map<string, ProviderRateLimitState> = new Map()
@@ -97,8 +113,14 @@ export class RateLimitManager {
     return status
   }
 
-  async executeWithRateLimit(providerId: string): Promise<void> {
+  async executeWithRateLimit(
+    providerId: string,
+    options?: ExecuteWithRateLimitOptions
+  ): Promise<void> {
     const state = this.getOrCreateRateLimitState(providerId)
+    if (options?.signal?.aborted) {
+      throw createAbortError()
+    }
     if (!state.config.enabled) {
       this.recordRequest(providerId)
       return Promise.resolve()
@@ -108,14 +130,27 @@ export class RateLimitManager {
       return Promise.resolve()
     }
     return new Promise<void>((resolve, reject) => {
+      let settled = false
+      let abortCleanup: (() => void) | null = null
+      const settle = (callback: () => void) => {
+        if (settled) {
+          return
+        }
+        settled = true
+        abortCleanup?.()
+        abortCleanup = null
+        callback()
+      }
+
       const queueItem: QueueItem = {
         id: `${providerId}-${Date.now()}-${Math.random()}`,
         timestamp: Date.now(),
-        resolve,
-        reject
+        resolve: () => settle(resolve),
+        reject: (error) => settle(() => reject(error))
       }
 
       state.queue.push(queueItem)
+      const snapshot = this.buildQueueSnapshot(providerId, state)
       console.log(
         `[RateLimitManager] Request queued for ${providerId}, queue length: ${state.queue.length}`
       )
@@ -124,6 +159,29 @@ export class RateLimitManager {
         queueLength: state.queue.length,
         requestId: queueItem.id
       })
+      try {
+        options?.onQueued?.(snapshot)
+      } catch (error) {
+        console.warn(`[RateLimitManager] onQueued callback failed for ${providerId}:`, error)
+      }
+
+      const signal = options?.signal
+      if (signal) {
+        const onAbort = () => {
+          const removed = this.removeQueueItem(providerId, queueItem.id)
+          if (removed) {
+            console.log(`[RateLimitManager] Request aborted while queued for ${providerId}`)
+          }
+          queueItem.reject(createAbortError())
+        }
+        signal.addEventListener('abort', onAbort, { once: true })
+        abortCleanup = () => signal.removeEventListener('abort', onAbort)
+        if (signal.aborted) {
+          onAbort()
+          return
+        }
+      }
+
       this.processRateLimitQueue(providerId)
     })
   }
@@ -279,6 +337,39 @@ export class RateLimitManager {
   getQueueLength(providerId: string): number {
     const state = this.providerRateLimitStates.get(providerId)
     return state?.queue.length || 0
+  }
+
+  private removeQueueItem(providerId: string, queueItemId: string): boolean {
+    const state = this.providerRateLimitStates.get(providerId)
+    if (!state) {
+      return false
+    }
+
+    const index = state.queue.findIndex((item) => item.id === queueItemId)
+    if (index === -1) {
+      return false
+    }
+
+    state.queue.splice(index, 1)
+    return true
+  }
+
+  private buildQueueSnapshot(
+    providerId: string,
+    state: ProviderRateLimitState
+  ): RateLimitQueueSnapshot {
+    const intervalMs = (1 / state.config.qpsLimit) * 1000
+    const nextAllowedTime = state.lastRequestTime + intervalMs
+    const baseWaitTime = Math.max(0, nextAllowedTime - Date.now())
+    const additionalQueuedIntervals = Math.max(0, state.queue.length - 1) * intervalMs
+
+    return {
+      providerId,
+      qpsLimit: state.config.qpsLimit,
+      currentQps: this.getCurrentQps(providerId),
+      queueLength: state.queue.length,
+      estimatedWaitTime: Math.max(0, baseWaitTime + additionalQueuedIntervals)
+    }
   }
 
   private getLastRequestTime(providerId: string): number {

--- a/src/main/presenter/llmProviderPresenter/types.ts
+++ b/src/main/presenter/llmProviderPresenter/types.ts
@@ -5,6 +5,19 @@ export interface RateLimitConfig {
   enabled: boolean
 }
 
+export interface RateLimitQueueSnapshot {
+  providerId: string
+  qpsLimit: number
+  currentQps: number
+  queueLength: number
+  estimatedWaitTime: number
+}
+
+export interface ExecuteWithRateLimitOptions {
+  signal?: AbortSignal
+  onQueued?: (snapshot: RateLimitQueueSnapshot) => void
+}
+
 export interface QueueItem {
   id: string
   timestamp: number

--- a/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
@@ -1231,7 +1231,7 @@ export class AgentToolManager {
     let visionTarget: Awaited<ReturnType<typeof this.resolveVisionTargetForConversation>>
 
     try {
-      visionTarget = await this.resolveVisionTargetForConversation(conversationId)
+      visionTarget = await this.resolveVisionTargetForConversation(conversationId, signal)
     } catch (error) {
       logger.warn('[AgentToolManager] Failed to resolve vision target for image read:', {
         conversationId,
@@ -1306,7 +1306,7 @@ export class AgentToolManager {
     }
   }
 
-  private async resolveVisionTargetForConversation(conversationId?: string) {
+  private async resolveVisionTargetForConversation(conversationId?: string, signal?: AbortSignal) {
     if (!conversationId) {
       return null
     }
@@ -1318,6 +1318,7 @@ export class AgentToolManager {
         modelId: sessionInfo?.modelId,
         agentId: sessionInfo?.agentId,
         configPresenter: this.configPresenter,
+        signal,
         logLabel: `read:${conversationId}`
       })
     } catch (error) {

--- a/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
@@ -72,6 +72,25 @@ interface AgentToolManagerOptions {
   runtimePort: AgentToolRuntimePort
 }
 
+const createAbortError = (): Error => {
+  if (typeof DOMException !== 'undefined') {
+    return new DOMException('Aborted', 'AbortError')
+  }
+
+  const error = new Error('Aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+const throwIfAbortRequested = (signal?: AbortSignal): void => {
+  if (signal?.aborted) {
+    throw createAbortError()
+  }
+}
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof Error && (error.name === 'AbortError' || error.name === 'CanceledError')
+
 export class AgentToolManager {
   private static readonly YO_BROWSER_TOOL_NAME_SET = new Set<string>(YO_BROWSER_TOOL_NAMES)
   private agentWorkspacePath: string | null
@@ -414,7 +433,7 @@ export class AgentToolManager {
       if (!this.fileSystemHandler) {
         throw new Error(`FileSystem handler not initialized for tool: ${toolName}`)
       }
-      return await this.callFileSystemTool(toolName, args, conversationId)
+      return await this.callFileSystemTool(toolName, args, conversationId, options)
     }
 
     // Route to Skill tools
@@ -691,7 +710,10 @@ export class AgentToolManager {
   private async callFileSystemTool(
     toolName: string,
     args: Record<string, unknown>,
-    conversationId?: string
+    conversationId?: string,
+    options?: {
+      signal?: AbortSignal
+    }
   ): Promise<AgentToolCallResult> {
     // Handle process tool separately
     if (this.isProcessTool(toolName)) {
@@ -798,7 +820,12 @@ export class AgentToolManager {
 
           if (this.isImageMimeType(mimeType)) {
             return {
-              content: await this.readImageWithVisionFallback(validPath, mimeType, conversationId)
+              content: await this.readImageWithVisionFallback(
+                validPath,
+                mimeType,
+                conversationId,
+                options?.signal
+              )
             }
           }
 
@@ -1194,9 +1221,12 @@ export class AgentToolManager {
   private async readImageWithVisionFallback(
     filePath: string,
     mimeType: string,
-    conversationId?: string
+    conversationId?: string,
+    signal?: AbortSignal
   ): Promise<string> {
+    throwIfAbortRequested(signal)
     const fileBuffer = await fs.promises.readFile(filePath)
+    throwIfAbortRequested(signal)
     const metadata = this.buildImageMetadataBlock(filePath, mimeType, fileBuffer.length)
     let visionTarget: Awaited<ReturnType<typeof this.resolveVisionTargetForConversation>>
 
@@ -1216,6 +1246,7 @@ export class AgentToolManager {
     }
 
     try {
+      throwIfAbortRequested(signal)
       const dataUrl = `data:${mimeType};base64,${fileBuffer.toString('base64')}`
       const messages: ChatMessage[] = [
         {
@@ -1237,14 +1268,29 @@ export class AgentToolManager {
         visionTarget.modelId,
         visionTarget.providerId
       )
-      await this.getLlmProviderPresenter().executeWithRateLimit(visionTarget.providerId)
-      const response = await this.getLlmProviderPresenter().generateCompletionStandalone(
-        visionTarget.providerId,
-        messages,
-        visionTarget.modelId,
-        modelConfig?.temperature ?? 0.2,
-        modelConfig?.maxTokens ?? 1200
-      )
+      const llmProviderPresenter = this.getLlmProviderPresenter()
+      if (signal) {
+        await llmProviderPresenter.executeWithRateLimit(visionTarget.providerId, { signal })
+      } else {
+        await llmProviderPresenter.executeWithRateLimit(visionTarget.providerId)
+      }
+      throwIfAbortRequested(signal)
+      const response = signal
+        ? await llmProviderPresenter.generateCompletionStandalone(
+            visionTarget.providerId,
+            messages,
+            visionTarget.modelId,
+            modelConfig?.temperature ?? 0.2,
+            modelConfig?.maxTokens ?? 1200,
+            { signal }
+          )
+        : await llmProviderPresenter.generateCompletionStandalone(
+            visionTarget.providerId,
+            messages,
+            visionTarget.modelId,
+            modelConfig?.temperature ?? 0.2,
+            modelConfig?.maxTokens ?? 1200
+          )
 
       const normalized = (response || '').trim()
       if (!normalized) {
@@ -1252,6 +1298,9 @@ export class AgentToolManager {
       }
       return normalized
     } catch (error) {
+      if (isAbortError(error)) {
+        throw error
+      }
       const message = error instanceof Error ? error.message : String(error)
       return `${metadata}\n\nVision analysis failed, downgraded to metadata.\nerror: ${message}`
     }

--- a/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
@@ -1237,6 +1237,7 @@ export class AgentToolManager {
         visionTarget.modelId,
         visionTarget.providerId
       )
+      await this.getLlmProviderPresenter().executeWithRateLimit(visionTarget.providerId)
       const response = await this.getLlmProviderPresenter().generateCompletionStandalone(
         visionTarget.providerId,
         messages,

--- a/src/main/presenter/toolPresenter/runtimePorts.ts
+++ b/src/main/presenter/toolPresenter/runtimePorts.ts
@@ -61,7 +61,10 @@ export interface AgentToolRuntimePort {
   getSkillPresenter(): ISkillPresenter
   getYoBrowserToolHandler(): IYoBrowserPresenter['toolHandler']
   getFilePresenter(): Pick<IFilePresenter, 'getMimeType' | 'prepareFileCompletely'>
-  getLlmProviderPresenter(): Pick<ILlmProviderPresenter, 'generateCompletionStandalone'>
+  getLlmProviderPresenter(): Pick<
+    ILlmProviderPresenter,
+    'executeWithRateLimit' | 'generateCompletionStandalone'
+  >
   createSettingsWindow(): ReturnType<IWindowPresenter['createSettingsWindow']>
   sendToWindow(
     windowId: number,

--- a/src/renderer/src/components/chat/MessageList.vue
+++ b/src/renderer/src/components/chat/MessageList.vue
@@ -43,6 +43,14 @@
           @copy-image="handleCopyImage"
         />
       </template>
+      <div v-if="ephemeralRateLimitBlock" data-rate-limit-indicator="true" class="pl-11 pr-11 pt-1">
+        <MessageBlockAction
+          :message-id="ephemeralRateLimitMessageId || '__rate_limit__'"
+          :conversation-id="conversationId"
+          :block="ephemeralRateLimitBlock"
+          :is-read-only="isReadOnly"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -51,10 +59,12 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import MessageItemAssistant from '@/components/message/MessageItemAssistant.vue'
+import MessageBlockAction from '@/components/message/MessageBlockAction.vue'
 import MessageItemUser from '@/components/message/MessageItemUser.vue'
 import { useMessageCapture } from '@/composables/message/useMessageCapture'
 import {
   type DisplayAssistantMessage,
+  type DisplayAssistantMessageBlock,
   isCompactionMessageItem,
   type DisplayUserMessage,
   type DisplayMessage,
@@ -64,11 +74,17 @@ import {
 const props = withDefaults(
   defineProps<{
     messages: MessageListItem[]
+    conversationId?: string
+    ephemeralRateLimitBlock?: DisplayAssistantMessageBlock | null
+    ephemeralRateLimitMessageId?: string | null
     isGenerating?: boolean
     traceMessageIds?: string[]
     isReadOnly?: boolean
   }>(),
   {
+    conversationId: '',
+    ephemeralRateLimitBlock: null,
+    ephemeralRateLimitMessageId: null,
     isGenerating: false,
     traceMessageIds: () => [],
     isReadOnly: false

--- a/src/renderer/src/components/message/MessageBlockAction.vue
+++ b/src/renderer/src/components/message/MessageBlockAction.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="flex flex-col w-[360px] break-all shadow-sm my-2 items-start p-2 gap-2 rounded-lg border bg-card text-card-foreground"
-  >
+  <div :class="containerClass">
     <div v-if="block.extra?.needContinue" class="flex flex-row items-center gap-2 w-full">
       <div class="flex flex-row gap-2 items-center cursor-pointer">
         <Icon icon="lucide:info" class="w-4 h-4 text-red-500/80" />
@@ -13,47 +11,18 @@
       </div>
     </div>
 
-    <div v-else-if="block.action_type === 'rate_limit'" class="flex flex-col gap-3 w-full">
-      <div class="flex flex-row items-center gap-2 w-full">
-        <Icon icon="lucide:clock" class="w-4 h-4 text-orange-500 animate-pulse" />
-        <div class="flex flex-col gap-1">
-          <div class="text-sm font-medium text-card-foreground">
-            {{ t('chat.messages.rateLimitTitle') }}
-          </div>
-          <div class="text-xs text-muted-foreground">
-            {{ getProviderName(block.extra?.providerId) }}
-          </div>
-        </div>
-      </div>
-
-      <div class="flex flex-col gap-2 text-xs">
-        <div class="flex justify-between">
-          <span class="text-muted-foreground">{{ t('chat.messages.rateLimitQueue') }}:</span>
-          <span class="font-mono">{{ block.extra?.queueLength || 0 }}</span>
-        </div>
-        <div class="flex justify-between">
-          <span class="text-muted-foreground">{{ t('chat.messages.rateLimitEstimated') }}:</span>
-          <span class="font-mono">{{ formatEstimatedTime(block.extra?.estimatedWaitTime) }}</span>
-        </div>
-      </div>
-
-      <div class="w-full bg-secondary rounded-full h-1.5">
-        <div
-          class="bg-orange-500 h-1.5 rounded-full transition-all duration-1000 animate-pulse"
-          :style="{ width: `${getProgressWidth()}%` }"
-        ></div>
-      </div>
-
-      <div v-if="!isReadOnly" class="flex flex-row gap-2">
-        <Button variant="outline" size="sm" class="h-7 text-xs" @click="handleQuickSettings">
-          <Icon icon="lucide:settings" class="w-3 h-3 mr-1" />
-          {{ t('chat.messages.rateLimitQuickSettings') }}
-        </Button>
-        <Button variant="outline" size="sm" class="h-7 text-xs" @click="handleSwitchProvider">
-          <Icon icon="lucide:shuffle" class="w-3 h-3 mr-1" />
-          {{ t('chat.messages.rateLimitSwitchProvider') }}
-        </Button>
-      </div>
+    <div
+      v-else-if="isRateLimitBlock"
+      data-rate-limit-block="true"
+      class="inline-flex items-center gap-[10px] text-xs leading-4 text-[rgba(37,37,37,0.5)] dark:text-white/50"
+    >
+      <span class="whitespace-nowrap">
+        {{ rateLimitStatusLabel }}
+      </span>
+      <Icon
+        icon="lucide:ellipsis"
+        class="w-[14px] h-[14px] text-[rgba(37,37,37,0.5)] dark:text-white/50 animate-[pulse_1s_ease-in-out_infinite]"
+      />
     </div>
 
     <Button
@@ -92,63 +61,40 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   continue: [conversationId: string, messageId: string]
-  switchProvider: []
 }>()
 
 const progressTimer = ref<number | null>(null)
 const currentTime = ref(Date.now())
 const isReadOnly = computed(() => props.isReadOnly === true)
-
-const getProviderName = (providerId?: string | number | boolean | object[]) => {
-  if (!providerId || typeof providerId !== 'string') return 'Unknown Provider'
-  return providerId.charAt(0).toUpperCase() + providerId.slice(1)
-}
-
-const formatEstimatedTime = (estimatedWaitTime?: string | number | boolean | object[]) => {
-  if (!estimatedWaitTime || typeof estimatedWaitTime !== 'number' || estimatedWaitTime <= 0) {
-    return t('chat.messages.rateLimitImmediately')
+const isRateLimitBlock = computed(() => props.block.action_type === 'rate_limit')
+const elapsedSeconds = computed(() => {
+  if (!isRateLimitBlock.value) {
+    return 0
   }
-
-  const seconds = Math.ceil(estimatedWaitTime / 1000)
-  if (seconds < 60) {
-    return `${seconds}${t('chat.messages.rateLimitSeconds')}`
-  }
-
-  const minutes = Math.ceil(seconds / 60)
-  return `${minutes}${t('chat.messages.rateLimitMinutes')}`
-}
-
-const getProgressWidth = () => {
-  const estimatedWaitTime = props.block.extra?.estimatedWaitTime
-  if (!estimatedWaitTime || typeof estimatedWaitTime !== 'number') return 100
 
   const elapsed = currentTime.value - props.block.timestamp
-  const total = estimatedWaitTime
-  const progress = Math.min(100, (elapsed / total) * 100)
-
-  return Math.max(10, progress)
-}
-
-const handleQuickSettings = () => {
-  window.electron.ipcRenderer.invoke('open-settings', {
-    tab: 'providers',
-    providerId: props.block.extra?.providerId
+  return Math.max(0, Math.floor(Math.max(0, elapsed) / 1000))
+})
+const rateLimitStatusLabel = computed(() =>
+  t('chat.messages.rateLimitCompactLoading', {
+    seconds: elapsedSeconds.value
   })
-}
-
-const handleSwitchProvider = () => {
-  emit('switchProvider')
-}
+)
+const containerClass = computed(() =>
+  isRateLimitBlock.value
+    ? 'my-2'
+    : 'flex flex-col w-[360px] break-all shadow-sm my-2 items-start p-2 gap-2 rounded-lg border bg-card text-card-foreground'
+)
 
 const handleClick = () => {
   emit('continue', props.conversationId, props.messageId)
 }
 
 onMounted(() => {
-  if (props.block.action_type === 'rate_limit') {
+  if (isRateLimitBlock.value) {
     progressTimer.value = window.setInterval(() => {
       currentTime.value = Date.now()
-    }, 100)
+    }, 1000)
   }
 })
 

--- a/src/renderer/src/i18n/da-DK/chat.json
+++ b/src/renderer/src/i18n/da-DK/chat.json
@@ -81,6 +81,7 @@
     "rateLimitSwitchProvider": "Skift tjenesteudbyder",
     "rateLimitTitle": "Anmodningsfrekvensbegrænsning",
     "rateLimitWaiting": "Anmodningsfrekvensbegrænsning, venter i kø...",
+    "rateLimitCompactLoading": "Hastighedsbegrænset ({seconds}s)",
     "thinking": "Tænker..."
   },
   "notify": {

--- a/src/renderer/src/i18n/en-US/chat.json
+++ b/src/renderer/src/i18n/en-US/chat.json
@@ -83,6 +83,7 @@
   "messages": {
     "thinking": "Thinking...",
     "rateLimitWaiting": "Rate limit reached, waiting in queue...",
+    "rateLimitCompactLoading": "Rate limited for {seconds}s...",
     "rateLimitTitle": "Rate Limit Active",
     "rateLimitQueue": "Queue Position",
     "rateLimitEstimated": "Estimated Wait",

--- a/src/renderer/src/i18n/fa-IR/chat.json
+++ b/src/renderer/src/i18n/fa-IR/chat.json
@@ -83,6 +83,7 @@
   "messages": {
     "thinking": "در حال تفکر...",
     "rateLimitWaiting": "محدودیت نرخ درخواست، در صف انتظار...",
+    "rateLimitCompactLoading": "در محدودیت نرخ ({seconds}ث)",
     "rateLimitTitle": "محدودیت نرخ درخواست",
     "rateLimitQueue": "موقعیت صف",
     "rateLimitEstimated": "زمان تخمینی انتظار",

--- a/src/renderer/src/i18n/fr-FR/chat.json
+++ b/src/renderer/src/i18n/fr-FR/chat.json
@@ -83,6 +83,7 @@
   "messages": {
     "thinking": "Pensée...",
     "rateLimitWaiting": "Limitation de débit, en attente dans la file...",
+    "rateLimitCompactLoading": "Limité par le débit ({seconds}s)",
     "rateLimitTitle": "Limitation de débit des requêtes",
     "rateLimitQueue": "Position dans la file",
     "rateLimitEstimated": "Temps d'attente estimé",

--- a/src/renderer/src/i18n/he-IL/chat.json
+++ b/src/renderer/src/i18n/he-IL/chat.json
@@ -83,6 +83,7 @@
   "messages": {
     "thinking": "חושב...",
     "rateLimitWaiting": "הגעת למגבלת הקצב, ממתין בתור...",
+    "rateLimitCompactLoading": "מוגבל קצב ({seconds}ש׳)",
     "rateLimitTitle": "מגבלת קצב פעילה",
     "rateLimitQueue": "מיקום בתור",
     "rateLimitEstimated": "המתנה משוערת",

--- a/src/renderer/src/i18n/ja-JP/chat.json
+++ b/src/renderer/src/i18n/ja-JP/chat.json
@@ -83,6 +83,7 @@
   "messages": {
     "thinking": "思考中...",
     "rateLimitWaiting": "レート制限により、キューで待機中...",
+    "rateLimitCompactLoading": "制限中（{seconds}秒）",
     "rateLimitTitle": "リクエストレート制限",
     "rateLimitQueue": "キューの位置",
     "rateLimitEstimated": "推定待機時間",

--- a/src/renderer/src/i18n/ko-KR/chat.json
+++ b/src/renderer/src/i18n/ko-KR/chat.json
@@ -83,6 +83,7 @@
   "messages": {
     "thinking": "생각...",
     "rateLimitWaiting": "속도 제한으로 대기열에서 대기 중...",
+    "rateLimitCompactLoading": "속도 제한 중 ({seconds}초)",
     "rateLimitTitle": "요청 속도 제한",
     "rateLimitQueue": "대기열 위치",
     "rateLimitEstimated": "예상 대기 시간",

--- a/src/renderer/src/i18n/pt-BR/chat.json
+++ b/src/renderer/src/i18n/pt-BR/chat.json
@@ -83,6 +83,7 @@
   "messages": {
     "thinking": "Pensando...",
     "rateLimitWaiting": "Limite de taxa atingido, aguardando na fila...",
+    "rateLimitCompactLoading": "Limitado por taxa ({seconds}s)",
     "rateLimitTitle": "Limite de Taxa Ativo",
     "rateLimitQueue": "Posição na Fila",
     "rateLimitEstimated": "Tempo Estimado",

--- a/src/renderer/src/i18n/ru-RU/chat.json
+++ b/src/renderer/src/i18n/ru-RU/chat.json
@@ -83,6 +83,7 @@
   "messages": {
     "thinking": "Думаю ...",
     "rateLimitWaiting": "Ограничение скорости, ожидание в очереди...",
+    "rateLimitCompactLoading": "Ограничение скорости ({seconds}с)",
     "rateLimitTitle": "Ограничение скорости запросов",
     "rateLimitQueue": "Позиция в очереди",
     "rateLimitEstimated": "Предполагаемое время ожидания",

--- a/src/renderer/src/i18n/zh-CN/chat.json
+++ b/src/renderer/src/i18n/zh-CN/chat.json
@@ -83,7 +83,7 @@
   "messages": {
     "thinking": "正在思考...",
     "rateLimitWaiting": "请求频率限制，正在排队等待...",
-    "rateLimitCompactLoading": "限速中（第 {seconds} 秒）",
+    "rateLimitCompactLoading": "限速中（{seconds} 秒）",
     "rateLimitTitle": "请求频率限制",
     "rateLimitQueue": "队列位置",
     "rateLimitEstimated": "预计等待",

--- a/src/renderer/src/i18n/zh-CN/chat.json
+++ b/src/renderer/src/i18n/zh-CN/chat.json
@@ -83,6 +83,7 @@
   "messages": {
     "thinking": "正在思考...",
     "rateLimitWaiting": "请求频率限制，正在排队等待...",
+    "rateLimitCompactLoading": "限速中（第 {seconds} 秒）",
     "rateLimitTitle": "请求频率限制",
     "rateLimitQueue": "队列位置",
     "rateLimitEstimated": "预计等待",

--- a/src/renderer/src/i18n/zh-HK/chat.json
+++ b/src/renderer/src/i18n/zh-HK/chat.json
@@ -83,6 +83,7 @@
   "messages": {
     "thinking": "正在思考...",
     "rateLimitWaiting": "速率限制，正在佇列等待...",
+    "rateLimitCompactLoading": "限速中（第 {seconds} 秒）",
     "rateLimitTitle": "請求速率限制",
     "rateLimitQueue": "佇列位置",
     "rateLimitEstimated": "預估等待時間",

--- a/src/renderer/src/i18n/zh-TW/chat.json
+++ b/src/renderer/src/i18n/zh-TW/chat.json
@@ -83,6 +83,7 @@
   "messages": {
     "thinking": "正在思考...",
     "rateLimitWaiting": "速率限制，正在佇列等待...",
+    "rateLimitCompactLoading": "限速中（第 {seconds} 秒）",
     "rateLimitTitle": "請求速率限制",
     "rateLimitQueue": "佇列位置",
     "rateLimitEstimated": "預估等待時間",

--- a/src/renderer/src/pages/ChatPage.vue
+++ b/src/renderer/src/pages/ChatPage.vue
@@ -14,6 +14,9 @@
       />
       <MessageList
         :messages="displayMessages"
+        :conversation-id="props.sessionId"
+        :ephemeral-rate-limit-block="ephemeralRateLimitBlock"
+        :ephemeral-rate-limit-message-id="ephemeralRateLimitMessageId"
         :is-generating="isGenerating"
         :trace-message-ids="traceMessageIds"
         :is-read-only="isReadOnlySession"
@@ -131,6 +134,7 @@ const isReadOnlySession = computed(() => sessionStore.activeSession?.sessionKind
 const isGenerating = computed(
   () => sessionStore.activeSession?.status === 'working' || messageStore.isStreaming
 )
+const RATE_LIMIT_STREAM_MESSAGE_PREFIX = '__rate_limit__:'
 const isAcpWorkdirMissing = computed(() => {
   const activeSession = sessionStore.activeSession
   if (!activeSession || activeSession.providerId !== 'acp') {
@@ -311,6 +315,36 @@ const hasInlineStreamingTarget = computed(() => {
   return messageStore.messages.some((msg) => msg.id === messageId)
 })
 
+const ephemeralRateLimitMessageId = computed(() => {
+  const messageId = messageStore.currentStreamMessageId
+  if (
+    !messageStore.isStreaming ||
+    !messageId ||
+    !messageId.startsWith(RATE_LIMIT_STREAM_MESSAGE_PREFIX)
+  ) {
+    return null
+  }
+
+  return messageId
+})
+
+const ephemeralRateLimitBlock = computed<DisplayAssistantMessageBlock | null>(() => {
+  if (!ephemeralRateLimitMessageId.value || messageStore.streamingBlocks.length === 0) {
+    return null
+  }
+
+  const [firstBlock] = messageStore.streamingBlocks as DisplayAssistantMessageBlock[]
+  if (
+    messageStore.streamingBlocks.length !== 1 ||
+    firstBlock?.type !== 'action' ||
+    firstBlock.action_type !== 'rate_limit'
+  ) {
+    return null
+  }
+
+  return firstBlock
+})
+
 const displayMessages = computed(() => {
   const msgs: DisplayMessage[] = messageStore.messages.map(toDisplayMessage)
 
@@ -319,7 +353,8 @@ const displayMessages = computed(() => {
   if (
     messageStore.isStreaming &&
     messageStore.streamingBlocks.length > 0 &&
-    !hasInlineStreamingTarget.value
+    !hasInlineStreamingTarget.value &&
+    !ephemeralRateLimitBlock.value
   ) {
     msgs.push(toStreamingMessage(messageStore.streamingBlocks, messageStore.currentStreamMessageId))
   }
@@ -335,7 +370,7 @@ const traceMessageIds = computed(() =>
 
 // Auto-scroll when displayMessages changes (new message added, streaming updates)
 watch(
-  displayMessages,
+  [displayMessages, ephemeralRateLimitBlock],
   () => {
     if (isNearBottom.value) {
       nextTick(scrollToBottom)

--- a/src/renderer/src/stores/ui/message.ts
+++ b/src/renderer/src/stores/ui/message.ts
@@ -9,6 +9,8 @@ import type {
 } from '@shared/types/agent-interface'
 import { useSessionStore } from './session'
 
+const EPHEMERAL_STREAM_MESSAGE_PREFIXES = ['__rate_limit__:']
+
 // --- Store ---
 
 export const useMessageStore = defineStore('message', () => {
@@ -124,6 +126,10 @@ export const useMessageStore = defineStore('message', () => {
     currentStreamMessageId.value = null
   }
 
+  function isEphemeralStreamMessageId(messageId: string): boolean {
+    return EPHEMERAL_STREAM_MESSAGE_PREFIXES.some((prefix) => messageId.startsWith(prefix))
+  }
+
   function applyStreamingBlocksToMessage(
     messageId: string,
     conversationId: string,
@@ -184,7 +190,7 @@ export const useMessageStore = defineStore('message', () => {
         currentStreamSessionId.value = msg.conversationId
         currentStreamMessageId.value = streamMessageId ?? null
         streamingBlocks.value = msg.blocks
-        if (streamMessageId) {
+        if (streamMessageId && !isEphemeralStreamMessageId(streamMessageId)) {
           applyStreamingBlocksToMessage(streamMessageId, msg.conversationId, msg.blocks)
         }
       }

--- a/src/shared/types/agent-interface.d.ts
+++ b/src/shared/types/agent-interface.d.ts
@@ -272,7 +272,7 @@ export interface AssistantMessageBlock {
   }
   tool_call?: ToolCallBlockData
   extra?: AssistantMessageExtra
-  action_type?: 'tool_call_permission' | 'question_request'
+  action_type?: 'tool_call_permission' | 'question_request' | 'rate_limit'
 }
 
 export interface MessageMetadata {

--- a/src/shared/types/presenters/index.d.ts
+++ b/src/shared/types/presenters/index.d.ts
@@ -12,6 +12,7 @@ export type {
   LLM_PROVIDER,
   LLM_PROVIDER_BASE,
   MODEL_META,
+  RateLimitQueueSnapshot,
   RENDERER_MODEL_META,
   LLM_EMBEDDING_ATTRS,
   KeyStatus,

--- a/src/shared/types/presenters/legacy.presenters.d.ts
+++ b/src/shared/types/presenters/legacy.presenters.d.ts
@@ -1157,6 +1157,19 @@ export interface ILlmProviderPresenter {
       lastRequestTime: number
     }
   >
+  executeWithRateLimit(
+    providerId: string,
+    options?: {
+      signal?: AbortSignal
+      onQueued?: (snapshot: {
+        providerId: string
+        qpsLimit: number
+        currentQps: number
+        queueLength: number
+        estimatedWaitTime: number
+      }) => void
+    }
+  ): Promise<void>
   syncModelScopeMcpServers(
     providerId: string,
     syncOptions?: ModelScopeMcpSyncOptions

--- a/src/shared/types/presenters/llmprovider.presenter.d.ts
+++ b/src/shared/types/presenters/llmprovider.presenter.d.ts
@@ -169,6 +169,14 @@ export interface ModelScopeMcpSyncResult {
   errors: string[]
 }
 
+export type RateLimitQueueSnapshot = {
+  providerId: string
+  qpsLimit: number
+  currentQps: number
+  queueLength: number
+  estimatedWaitTime: number
+}
+
 export type AcpConfigOptionValue = {
   value: string
   label: string
@@ -259,6 +267,13 @@ export interface ILlmProviderPresenter {
       lastRequestTime: number
     }
   >
+  executeWithRateLimit(
+    providerId: string,
+    options?: {
+      signal?: AbortSignal
+      onQueued?: (snapshot: RateLimitQueueSnapshot) => void
+    }
+  ): Promise<void>
   syncModelScopeMcpServers(
     providerId: string,
     syncOptions?: ModelScopeMcpSyncOptions

--- a/test/main/presenter/deepchatAgentPresenter/compactionService.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/compactionService.test.ts
@@ -140,6 +140,7 @@ function createService(options?: {
   } as any
 
   const llmProviderPresenter = {
+    executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
     generateText: vi.fn().mockResolvedValue({
       content: 'generated summary'
     })

--- a/test/main/presenter/deepchatAgentPresenter/compactionService.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/compactionService.test.ts
@@ -453,6 +453,62 @@ describe('CompactionService', () => {
     )
   })
 
+  it('passes abort signals into rate-limited compaction waits and rethrows cancellation', async () => {
+    const { service, llmProviderPresenter } = createService()
+    const abortController = new AbortController()
+    const abortError = new Error('Aborted')
+    abortError.name = 'AbortError'
+
+    llmProviderPresenter.executeWithRateLimit.mockImplementation(
+      (_providerId: string, options?: { signal?: AbortSignal }) =>
+        new Promise<void>((resolve, reject) => {
+          if (options?.signal?.aborted) {
+            reject(abortError)
+            return
+          }
+
+          options?.signal?.addEventListener(
+            'abort',
+            () => {
+              reject(abortError)
+            },
+            { once: true }
+          )
+
+          void resolve
+        })
+    )
+
+    const compactionPromise = service.applyCompaction(
+      {
+        sessionId: 's1',
+        previousState: {
+          summaryText: null,
+          summaryCursorOrderSeq: 1,
+          summaryUpdatedAt: null
+        },
+        targetCursorOrderSeq: 3,
+        summaryBlocks: ['span to summarize'],
+        currentModel: {
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          contextLength: 4096
+        },
+        reserveTokens: 512
+      },
+      abortController.signal
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    abortController.abort()
+
+    await expect(compactionPromise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(llmProviderPresenter.executeWithRateLimit).toHaveBeenCalledWith('openai', {
+      signal: abortController.signal
+    })
+    expect(llmProviderPresenter.generateText).not.toHaveBeenCalled()
+  })
+
   it('avoids direct oversized single-shot summarization when splitLargeBlock does not split', async () => {
     const { service } = createService()
     const generateSummaryTextSpy = vi

--- a/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
@@ -798,6 +798,7 @@ describe('DeepChatAgentPresenter', () => {
       await agent.processMessage('s1', 'new prompt')
 
       expect(llmProvider.generateText).toHaveBeenCalledTimes(1)
+      expect(llmProvider.executeWithRateLimit).toHaveBeenCalledWith('openai')
       expect(
         sqlitePresenter.deepchatSessionsTable.updateSummaryStateIfMatches
       ).toHaveBeenCalledWith(
@@ -3022,6 +3023,12 @@ describe('DeepChatAgentPresenter', () => {
         params: '{"method":"Page.captureScreenshot","params":{"format":"jpeg"}}'
       })
 
+      expect(llmProvider.executeWithRateLimit).toHaveBeenCalledWith(
+        'openai',
+        expect.objectContaining({
+          signal: expect.any(Object)
+        })
+      )
       expect(llmProvider.generateCompletionStandalone).toHaveBeenCalledWith(
         'openai',
         [
@@ -3348,6 +3355,12 @@ describe('DeepChatAgentPresenter', () => {
         'persisted-agent',
         'vision'
       )
+      expect(llmProvider.executeWithRateLimit).toHaveBeenCalledWith(
+        'google',
+        expect.objectContaining({
+          signal: undefined
+        })
+      )
       expect(llmProvider.generateCompletionStandalone).toHaveBeenCalledWith(
         'google',
         expect.any(Array),
@@ -3373,6 +3386,7 @@ describe('DeepChatAgentPresenter', () => {
         abortSignal: abortController.signal
       })
 
+      expect(llmProvider.executeWithRateLimit).not.toHaveBeenCalled()
       expect(llmProvider.generateCompletionStandalone).not.toHaveBeenCalled()
       expect(normalized).toBe('Screenshot captured, but automatic English analysis was canceled.')
     })

--- a/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
@@ -1065,6 +1065,91 @@ describe('DeepChatAgentPresenter', () => {
       expect((await agent.getSessionState('s1'))?.status).toBe('idle')
     })
 
+    it('does not call provider.coreStream when cancellation lands right after rate-limit wait', async () => {
+      llmProvider.executeWithRateLimit.mockImplementation(
+        async (
+          _providerId: string,
+          options?: { signal?: AbortSignal; onQueued?: (snapshot: any) => void }
+        ) => {
+          options?.onQueued?.({
+            providerId: 'openai',
+            qpsLimit: 1,
+            currentQps: 1,
+            queueLength: 1,
+            estimatedWaitTime: 1000
+          })
+          queueMicrotask(() => {
+            void agent.cancelGeneration('s1')
+          })
+        }
+      )
+      ;(processStream as ReturnType<typeof vi.fn>).mockImplementation(
+        async (params: {
+          coreStream: (
+            messages: any[],
+            modelId: string,
+            modelConfig: any,
+            temperature: number,
+            maxTokens: number,
+            tools: any[]
+          ) => AsyncGenerator<unknown>
+          messages: any[]
+          modelId: string
+          modelConfig: any
+          temperature: number
+          maxTokens: number
+          tools: any[]
+        }) => {
+          try {
+            for await (const _event of params.coreStream(
+              params.messages,
+              params.modelId,
+              params.modelConfig,
+              params.temperature,
+              params.maxTokens,
+              params.tools
+            )) {
+            }
+
+            return { status: 'completed' as const }
+          } catch (error) {
+            return {
+              status:
+                error instanceof Error && error.name === 'AbortError'
+                  ? ('aborted' as const)
+                  : ('error' as const),
+              stopReason:
+                error instanceof Error && error.name === 'AbortError' ? 'user_stop' : 'error',
+              errorMessage: error instanceof Error ? error.message : String(error)
+            }
+          }
+        }
+      )
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      await agent.processMessage('s1', 'Hello')
+
+      const providerCoreStream = llmProvider.getProviderInstance.mock.results[0]?.value.coreStream
+      expect(providerCoreStream).not.toHaveBeenCalled()
+
+      const streamResponseCalls = (eventBus.sendToRenderer as ReturnType<typeof vi.fn>).mock.calls
+        .filter(([eventName]) => eventName === 'stream:response')
+        .map(([, , payload]) => payload)
+        .filter((payload) => typeof payload?.messageId === 'string')
+      const rateLimitClear = streamResponseCalls.find(
+        (payload) =>
+          payload.messageId.startsWith('__rate_limit__:') &&
+          Array.isArray(payload.blocks) &&
+          payload.blocks.length === 0
+      )
+
+      expect(rateLimitClear).toMatchObject({
+        conversationId: 's1',
+        blocks: []
+      })
+      expect((await agent.getSessionState('s1'))?.status).toBe('idle')
+    })
+
     it('reuses cached system prompt within the same day', async () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-03-05T08:00:00.000Z'))
@@ -2380,6 +2465,49 @@ describe('DeepChatAgentPresenter', () => {
       expect(sqlitePresenter.deepchatMessagesTable.delete).toHaveBeenCalledWith('mock-msg-id')
     })
 
+    it('treats aborted compaction signals as cancellation even for non-abort errors', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      vi.mocked(eventBus.sendToRenderer).mockClear()
+      sqlitePresenter.deepchatMessagesTable.delete.mockClear()
+
+      const abortController = new AbortController()
+      abortController.abort()
+      vi.spyOn((agent as any).compactionService, 'applyCompaction').mockRejectedValueOnce(
+        new Error('late failure')
+      )
+
+      await expect(
+        (agent as any).applyCompactionIntent(
+          's1',
+          {
+            sessionId: 's1',
+            previousState: {
+              summaryText: null,
+              summaryCursorOrderSeq: 1,
+              summaryUpdatedAt: null
+            },
+            targetCursorOrderSeq: 3,
+            summaryBlocks: ['summarize this'],
+            currentModel: {
+              providerId: 'openai',
+              modelId: 'gpt-4',
+              contextLength: 128000
+            },
+            reserveTokens: 512
+          },
+          { signal: abortController.signal }
+        )
+      ).rejects.toThrow('late failure')
+
+      expect(sqlitePresenter.deepchatMessagesTable.delete).toHaveBeenCalledWith('mock-msg-id')
+      expect(eventBus.sendToRenderer).toHaveBeenCalledWith('session:compaction-updated', 'all', {
+        sessionId: 's1',
+        status: 'idle',
+        cursorOrderSeq: 1,
+        summaryUpdatedAt: null
+      })
+    })
+
     it('emits idle when clearMessages resets compaction state', async () => {
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
       sqlitePresenter.deepchatSessionsTable.updateSummaryState('s1', {
@@ -2526,6 +2654,37 @@ describe('DeepChatAgentPresenter', () => {
         })
       )
       expect(processStream).toHaveBeenCalledTimes(1)
+    })
+
+    it('treats an aborted resume signal as cancellation even for non-abort errors', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      makeAssistantRow({ blocks: [] })
+      vi.spyOn(agent as any, 'resolveCompactionStateForResumeTurn').mockResolvedValue({
+        summaryText: null,
+        summaryCursorOrderSeq: 1,
+        summaryUpdatedAt: null
+      })
+      vi.spyOn(agent as any, 'runStreamForMessage').mockImplementation(async () => {
+        ;(agent as any).abortControllers.get('s1')?.abort()
+        throw new Error('late failure')
+      })
+
+      const resumed = await (agent as any).resumeAssistantMessage('s1', 'm1', [])
+
+      expect(resumed).toBe(false)
+      const [messageId, contentJson, status] =
+        sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls.at(-1)
+      expect(messageId).toBe('m1')
+      expect(status).toBe('error')
+      expect(JSON.parse(contentJson)).toEqual([
+        {
+          type: 'error',
+          content: 'common.error.userCanceledGeneration',
+          status: 'error',
+          timestamp: expect.any(Number)
+        }
+      ])
+      expect((await agent.getSessionState('s1'))?.status).toBe('idle')
     })
 
     it('handles question_other and waits for user message without resume', async () => {

--- a/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
@@ -798,7 +798,12 @@ describe('DeepChatAgentPresenter', () => {
       await agent.processMessage('s1', 'new prompt')
 
       expect(llmProvider.generateText).toHaveBeenCalledTimes(1)
-      expect(llmProvider.executeWithRateLimit).toHaveBeenCalledWith('openai')
+      expect(llmProvider.executeWithRateLimit).toHaveBeenCalledWith(
+        'openai',
+        expect.objectContaining({
+          signal: expect.any(AbortSignal)
+        })
+      )
       expect(
         sqlitePresenter.deepchatSessionsTable.updateSummaryStateIfMatches
       ).toHaveBeenCalledWith(
@@ -964,7 +969,16 @@ describe('DeepChatAgentPresenter', () => {
     it('does not call provider.coreStream when a queued request is canceled', async () => {
       const abortError = new Error('Aborted')
       abortError.name = 'AbortError'
-      const queued = Promise.withResolvers<void>()
+      let queuedResolve!: (value?: void | PromiseLike<void>) => void
+      let queuedReject!: (reason?: unknown) => void
+      const queued = {
+        promise: new Promise<void>((resolve, reject) => {
+          queuedResolve = resolve
+          queuedReject = reject
+        }),
+        resolve: queuedResolve,
+        reject: queuedReject
+      }
       llmProvider.executeWithRateLimit.mockImplementation(
         (
           _providerId: string,
@@ -1428,9 +1442,47 @@ describe('DeepChatAgentPresenter', () => {
 
       expect(prepareForNextUserTurn).toHaveBeenCalledWith(
         expect.objectContaining({
-          preserveInterleavedReasoning: true
+          preserveInterleavedReasoning: true,
+          signal: expect.any(AbortSignal)
         })
       )
+    })
+
+    it('passes abort signals into next-turn compaction execution', async () => {
+      const compactionIntent = {
+        sessionId: 's1',
+        previousState: {
+          summaryText: null,
+          summaryCursorOrderSeq: 1,
+          summaryUpdatedAt: null
+        },
+        targetCursorOrderSeq: 3,
+        summaryBlocks: ['summarize this'],
+        currentModel: {
+          providerId: 'openai',
+          modelId: 'gpt-4',
+          contextLength: 128000
+        },
+        reserveTokens: 4096
+      }
+      vi.spyOn((agent as any).compactionService, 'prepareForNextUserTurn').mockResolvedValue(
+        compactionIntent
+      )
+      const applyCompaction = vi
+        .spyOn((agent as any).compactionService, 'applyCompaction')
+        .mockResolvedValue({
+          succeeded: true,
+          summaryState: {
+            summaryText: 'rolled summary',
+            summaryCursorOrderSeq: 3,
+            summaryUpdatedAt: 123
+          }
+        })
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      await agent.processMessage('s1', 'Hello')
+
+      expect(applyCompaction).toHaveBeenCalledWith(compactionIntent, expect.any(AbortSignal))
     })
 
     it('injects request trace context when trace debug is enabled', async () => {
@@ -2421,6 +2473,10 @@ describe('DeepChatAgentPresenter', () => {
     }
 
     it('handles question_option and resumes assistant message', async () => {
+      const prepareForResumeTurn = vi.spyOn(
+        (agent as any).compactionService,
+        'prepareForResumeTurn'
+      )
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
       makeAssistantRow({
         blocks: [
@@ -2464,6 +2520,11 @@ describe('DeepChatAgentPresenter', () => {
       expect(updatedBlocks[0].status).toBe('success')
       expect(updatedBlocks[1].status).toBe('success')
       expect(updatedBlocks[1].extra.answerText).toBe('A')
+      expect(prepareForResumeTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signal: expect.any(AbortSignal)
+        })
+      )
       expect(processStream).toHaveBeenCalledTimes(1)
     })
 

--- a/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/deepchatAgentPresenter.test.ts
@@ -171,10 +171,13 @@ function createMockCoreStream() {
 }
 
 function createMockLlmProviderPresenter() {
+  const providerInstance = {
+    coreStream: vi.fn().mockImplementation(() => createMockCoreStream()())
+  }
+
   return {
-    getProviderInstance: vi.fn().mockReturnValue({
-      coreStream: vi.fn().mockReturnValue(createMockCoreStream()())
-    }),
+    getProviderInstance: vi.fn().mockReturnValue(providerInstance),
+    executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
     generateCompletionStandalone: vi.fn().mockResolvedValue('English screenshot summary'),
     generateText: vi.fn().mockResolvedValue({
       content: ['## Current Goal', '- Continue the session safely'].join('\n')
@@ -854,6 +857,197 @@ describe('DeepChatAgentPresenter', () => {
       expect(callArgs.modelConfig.thinkingBudget).toBe(1024)
       expect(callArgs.modelConfig.reasoningEffort).toBe('low')
       expect(callArgs.modelConfig.verbosity).toBe('high')
+    })
+
+    it('passes every provider turn through executeWithRateLimit', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      await agent.processMessage('s1', 'Hello')
+
+      const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      for await (const _event of callArgs.coreStream(
+        callArgs.messages,
+        callArgs.modelId,
+        callArgs.modelConfig,
+        callArgs.temperature,
+        callArgs.maxTokens,
+        callArgs.tools
+      )) {
+      }
+      for await (const _event of callArgs.coreStream(
+        callArgs.messages,
+        callArgs.modelId,
+        callArgs.modelConfig,
+        callArgs.temperature,
+        callArgs.maxTokens,
+        callArgs.tools
+      )) {
+      }
+
+      expect(llmProvider.executeWithRateLimit).toHaveBeenCalledTimes(2)
+      expect(llmProvider.executeWithRateLimit).toHaveBeenNthCalledWith(
+        1,
+        'openai',
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+          onQueued: expect.any(Function)
+        })
+      )
+    })
+
+    it('emits and clears an ephemeral rate-limit message while waiting for the provider gate', async () => {
+      llmProvider.executeWithRateLimit.mockImplementation(
+        async (_providerId: string, options?: { onQueued?: (snapshot: any) => void }) => {
+          options?.onQueued?.({
+            providerId: 'openai',
+            qpsLimit: 1,
+            currentQps: 1,
+            queueLength: 2,
+            estimatedWaitTime: 4000
+          })
+        }
+      )
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      await agent.processMessage('s1', 'Hello')
+
+      const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      for await (const _event of callArgs.coreStream(
+        callArgs.messages,
+        callArgs.modelId,
+        callArgs.modelConfig,
+        callArgs.temperature,
+        callArgs.maxTokens,
+        callArgs.tools
+      )) {
+      }
+
+      const streamResponseCalls = (eventBus.sendToRenderer as ReturnType<typeof vi.fn>).mock.calls
+        .filter(([eventName]) => eventName === 'stream:response')
+        .map(([, , payload]) => payload)
+        .filter((payload) => typeof payload?.messageId === 'string')
+
+      const rateLimitShow = streamResponseCalls.find(
+        (payload) =>
+          payload.messageId.startsWith('__rate_limit__:') &&
+          Array.isArray(payload.blocks) &&
+          payload.blocks.length === 1
+      )
+      const rateLimitClear = streamResponseCalls.find(
+        (payload) =>
+          payload.messageId.startsWith('__rate_limit__:') &&
+          Array.isArray(payload.blocks) &&
+          payload.blocks.length === 0
+      )
+
+      expect(rateLimitShow).toMatchObject({
+        conversationId: 's1',
+        blocks: [
+          expect.objectContaining({
+            type: 'action',
+            action_type: 'rate_limit',
+            status: 'pending',
+            extra: expect.objectContaining({
+              providerId: 'openai',
+              queueLength: 2,
+              estimatedWaitTime: 4000
+            })
+          })
+        ]
+      })
+      expect(rateLimitClear).toMatchObject({
+        conversationId: 's1',
+        blocks: []
+      })
+    })
+
+    it('does not call provider.coreStream when a queued request is canceled', async () => {
+      const abortError = new Error('Aborted')
+      abortError.name = 'AbortError'
+      const queued = Promise.withResolvers<void>()
+      llmProvider.executeWithRateLimit.mockImplementation(
+        (
+          _providerId: string,
+          options?: { signal?: AbortSignal; onQueued?: (snapshot: any) => void }
+        ) =>
+          new Promise<void>((resolve, reject) => {
+            options?.onQueued?.({
+              providerId: 'openai',
+              qpsLimit: 1,
+              currentQps: 1,
+              queueLength: 1,
+              estimatedWaitTime: 1000
+            })
+            queued.resolve()
+
+            if (options?.signal?.aborted) {
+              reject(abortError)
+              return
+            }
+
+            options?.signal?.addEventListener(
+              'abort',
+              () => {
+                reject(abortError)
+              },
+              { once: true }
+            )
+
+            void resolve
+          })
+      )
+      ;(processStream as ReturnType<typeof vi.fn>).mockImplementation(
+        async (params: {
+          coreStream: (
+            messages: any[],
+            modelId: string,
+            modelConfig: any,
+            temperature: number,
+            maxTokens: number,
+            tools: any[]
+          ) => AsyncGenerator<unknown>
+          messages: any[]
+          modelId: string
+          modelConfig: any
+          temperature: number
+          maxTokens: number
+          tools: any[]
+        }) => {
+          try {
+            for await (const _event of params.coreStream(
+              params.messages,
+              params.modelId,
+              params.modelConfig,
+              params.temperature,
+              params.maxTokens,
+              params.tools
+            )) {
+            }
+
+            return { status: 'completed' as const }
+          } catch (error) {
+            return {
+              status:
+                error instanceof Error && error.name === 'AbortError'
+                  ? ('aborted' as const)
+                  : ('error' as const),
+              stopReason:
+                error instanceof Error && error.name === 'AbortError' ? 'user_stop' : 'error',
+              errorMessage: error instanceof Error ? error.message : String(error)
+            }
+          }
+        }
+      )
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+
+      const processing = agent.processMessage('s1', 'Hello')
+      await queued.promise
+      await agent.cancelGeneration('s1')
+      await processing
+
+      const providerCoreStream = llmProvider.getProviderInstance.mock.results[0]?.value.coreStream
+      expect(providerCoreStream).not.toHaveBeenCalled()
+      expect((await agent.getSessionState('s1'))?.status).toBe('idle')
     })
 
     it('reuses cached system prompt within the same day', async () => {

--- a/test/main/presenter/deepchatAgentPresenter/process.test.ts
+++ b/test/main/presenter/deepchatAgentPresenter/process.test.ts
@@ -168,6 +168,32 @@ describe('processStream', () => {
     )
   })
 
+  it('treats AbortError thrown before the first event as aborted without writing an error block', async () => {
+    const abortError = new Error('Aborted')
+    abortError.name = 'AbortError'
+    const coreStream = vi.fn(async function* () {
+      throw abortError
+    }) as unknown as ProcessParams['coreStream']
+
+    const params = createParams({ coreStream })
+    const promise = processStream(params)
+    await vi.runAllTimersAsync()
+    const result = await promise
+
+    expect(result).toMatchObject({
+      status: 'aborted',
+      stopReason: 'user_stop',
+      errorMessage: 'common.error.userCanceledGeneration'
+    })
+    expect(messageStore.setMessageError).not.toHaveBeenCalled()
+    expect(messageStore.finalizeAssistantMessage).not.toHaveBeenCalled()
+    expect(eventBus.sendToRenderer).not.toHaveBeenCalledWith(
+      'stream:error',
+      'all',
+      expect.anything()
+    )
+  })
+
   it('single tool call → loop once, finalize', async () => {
     let callCount = 0
     const coreStream = vi.fn(function () {

--- a/test/main/presenter/llmProviderPresenter/rateLimitManager.test.ts
+++ b/test/main/presenter/llmProviderPresenter/rateLimitManager.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/eventbus', () => ({
+  eventBus: {
+    send: vi.fn()
+  },
+  SendTarget: {
+    ALL_WINDOWS: 'all'
+  }
+}))
+
+vi.mock('@/events', () => ({
+  RATE_LIMIT_EVENTS: {
+    CONFIG_UPDATED: 'rate-limit:config-updated',
+    REQUEST_QUEUED: 'rate-limit:request-queued',
+    REQUEST_EXECUTED: 'rate-limit:request-executed',
+    LIMIT_EXCEEDED: 'rate-limit:limit-exceeded'
+  }
+}))
+
+import { eventBus } from '@/eventbus'
+import { RateLimitManager } from '@/presenter/llmProviderPresenter/managers/rateLimitManager'
+
+function createConfigPresenter(rateLimit?: { enabled: boolean; qpsLimit: number }) {
+  const provider = {
+    id: 'openai',
+    name: 'OpenAI',
+    rateLimit: rateLimit ?? { enabled: false, qpsLimit: 1 }
+  }
+
+  return {
+    provider,
+    presenter: {
+      getProviders: vi.fn(() => [provider]),
+      getProviderById: vi.fn(() => provider),
+      setProviderById: vi.fn((providerId: string, nextProvider: typeof provider) => {
+        if (providerId === provider.id) {
+          Object.assign(provider, nextProvider)
+        }
+      })
+    }
+  }
+}
+
+describe('RateLimitManager', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-01T00:00:00.000Z'))
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('executes immediately and records the request when the provider is not rate limited', async () => {
+    const { presenter } = createConfigPresenter({ enabled: false, qpsLimit: 1 })
+    const manager = new RateLimitManager(presenter as any)
+    manager.initializeProviderRateLimitConfigs()
+
+    await manager.executeWithRateLimit('openai')
+
+    expect(eventBus.send).toHaveBeenCalledWith(
+      'rate-limit:request-executed',
+      'all',
+      expect.objectContaining({
+        providerId: 'openai',
+        timestamp: Date.now()
+      })
+    )
+  })
+
+  it('queues a request, reports queue info, and executes it after the interval', async () => {
+    const { presenter } = createConfigPresenter({ enabled: true, qpsLimit: 1 })
+    const manager = new RateLimitManager(presenter as any)
+    manager.initializeProviderRateLimitConfigs()
+
+    await manager.executeWithRateLimit('openai')
+
+    const onQueued = vi.fn()
+    const queuedPromise = manager.executeWithRateLimit('openai', { onQueued })
+    await Promise.resolve()
+
+    expect(onQueued).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: 'openai',
+        qpsLimit: 1,
+        currentQps: 1,
+        queueLength: 1,
+        estimatedWaitTime: expect.any(Number)
+      })
+    )
+    expect(manager.getQueueLength('openai')).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await queuedPromise
+
+    expect(manager.getQueueLength('openai')).toBe(0)
+    expect(
+      (eventBus.send as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([eventName]) => eventName === 'rate-limit:request-queued'
+      )
+    ).toHaveLength(1)
+    expect(
+      (eventBus.send as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([eventName]) => eventName === 'rate-limit:request-executed'
+      )
+    ).toHaveLength(2)
+  })
+
+  it('removes an aborted queued request and never reaches the provider gate', async () => {
+    const { presenter } = createConfigPresenter({ enabled: true, qpsLimit: 1 })
+    const manager = new RateLimitManager(presenter as any)
+    manager.initializeProviderRateLimitConfigs()
+
+    await manager.executeWithRateLimit('openai')
+
+    const abortController = new AbortController()
+    const queuedPromise = manager.executeWithRateLimit('openai', {
+      signal: abortController.signal
+    })
+    await Promise.resolve()
+
+    abortController.abort()
+
+    await expect(queuedPromise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(manager.getQueueLength('openai')).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(
+      (eventBus.send as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([eventName]) => eventName === 'rate-limit:request-executed'
+      )
+    ).toHaveLength(1)
+  })
+})

--- a/test/main/presenter/mcpClient.test.ts
+++ b/test/main/presenter/mcpClient.test.ts
@@ -37,6 +37,7 @@ vi.mock('../../../src/main/eventbus', () => ({
 const presenterMocks = vi.hoisted(() => ({
   handleSamplingRequest: vi.fn(),
   cancelSamplingRequest: vi.fn(),
+  executeWithRateLimit: vi.fn(),
   generateCompletionStandalone: vi.fn(),
   getProviderModels: vi.fn(),
   getCustomModels: vi.fn()
@@ -54,6 +55,7 @@ vi.mock('../../../src/main/presenter', () => ({
       cancelSamplingRequest: presenterMocks.cancelSamplingRequest
     },
     llmproviderPresenter: {
+      executeWithRateLimit: presenterMocks.executeWithRateLimit,
       generateCompletionStandalone: presenterMocks.generateCompletionStandalone
     }
   }

--- a/test/main/presenter/toolPresenter/agentTools/agentToolManagerRead.test.ts
+++ b/test/main/presenter/toolPresenter/agentTools/agentToolManagerRead.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
 import { AgentToolManager } from '@/presenter/toolPresenter/agentTools/agentToolManager'
+import * as sessionVisionResolverModule from '@/presenter/vision/sessionVisionResolver'
 
 vi.mock('fs', async (importOriginal) => {
   const actual = (await importOriginal()) as typeof import('fs')
@@ -262,6 +263,39 @@ describe('AgentToolManager read routing', () => {
       })
     )
     expect(llmProviderPresenter.generateCompletionStandalone).not.toHaveBeenCalled()
+  })
+
+  it('passes abort signals into vision target resolution', async () => {
+    const filePath = path.join(workspaceDir, 'image-resolver-signal.png')
+    await fs.writeFile(filePath, Buffer.from([4, 5, 6, 7]))
+    filePresenter.getMimeType.mockResolvedValue('image/png')
+    resolveConversationSessionInfo.mockResolvedValue({
+      agentId: 'deepchat',
+      providerId: 'openai',
+      modelId: 'gpt-4o'
+    })
+    configPresenter.getModelConfig.mockImplementation((modelId: string, providerId?: string) => ({
+      temperature: 0.2,
+      maxTokens: 1200,
+      vision: providerId === 'openai' && modelId === 'gpt-4o'
+    }))
+    llmProviderPresenter.generateCompletionStandalone.mockResolvedValue('visible image description')
+    const resolveVisionTargetSpy = vi.spyOn(
+      sessionVisionResolverModule,
+      'resolveSessionVisionTarget'
+    )
+    const abortController = new AbortController()
+
+    await manager.callTool('read', { path: 'image-resolver-signal.png' }, 'conv1', {
+      signal: abortController.signal
+    })
+
+    expect(resolveVisionTargetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal: abortController.signal,
+        logLabel: 'read:conv1'
+      })
+    )
   })
 
   it('falls back to image metadata when neither the current model nor the agent can analyze images', async () => {

--- a/test/main/presenter/toolPresenter/agentTools/agentToolManagerRead.test.ts
+++ b/test/main/presenter/toolPresenter/agentTools/agentToolManagerRead.test.ts
@@ -205,6 +205,65 @@ describe('AgentToolManager read routing', () => {
     )
   })
 
+  it('propagates abort signals to queued image analysis waits', async () => {
+    const filePath = path.join(workspaceDir, 'image-abort.png')
+    await fs.writeFile(filePath, Buffer.from([4, 3, 2, 1]))
+    filePresenter.getMimeType.mockResolvedValue('image/png')
+    resolveConversationSessionInfo.mockResolvedValue({
+      agentId: 'deepchat',
+      providerId: 'openai',
+      modelId: 'gpt-4o'
+    })
+    configPresenter.getModelConfig.mockImplementation((modelId: string, providerId?: string) => ({
+      temperature: 0.2,
+      maxTokens: 1200,
+      vision: providerId === 'openai' && modelId === 'gpt-4o'
+    }))
+
+    const abortController = new AbortController()
+    const abortError = new Error('Aborted')
+    abortError.name = 'AbortError'
+    let queuedResolve!: () => void
+    const queued = new Promise<void>((resolve) => {
+      queuedResolve = resolve
+    })
+
+    llmProviderPresenter.executeWithRateLimit.mockImplementation(
+      async (_providerId: string, options?: { signal?: AbortSignal }) =>
+        await new Promise<void>((_resolve, reject) => {
+          queuedResolve()
+
+          if (options?.signal?.aborted) {
+            reject(abortError)
+            return
+          }
+
+          options?.signal?.addEventListener(
+            'abort',
+            () => {
+              reject(abortError)
+            },
+            { once: true }
+          )
+        })
+    )
+
+    const resultPromise = manager.callTool('read', { path: 'image-abort.png' }, 'conv1', {
+      signal: abortController.signal
+    })
+    await queued
+    abortController.abort()
+
+    await expect(resultPromise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(llmProviderPresenter.executeWithRateLimit).toHaveBeenCalledWith(
+      'openai',
+      expect.objectContaining({
+        signal: abortController.signal
+      })
+    )
+    expect(llmProviderPresenter.generateCompletionStandalone).not.toHaveBeenCalled()
+  })
+
   it('falls back to image metadata when neither the current model nor the agent can analyze images', async () => {
     const filePath = path.join(workspaceDir, 'image-no-vision.png')
     await fs.writeFile(filePath, Buffer.from([9, 8, 7, 6]))

--- a/test/main/presenter/toolPresenter/agentTools/agentToolManagerRead.test.ts
+++ b/test/main/presenter/toolPresenter/agentTools/agentToolManagerRead.test.ts
@@ -33,6 +33,7 @@ describe('AgentToolManager read routing', () => {
     prepareFileCompletely: ReturnType<typeof vi.fn>
   }
   let llmProviderPresenter: {
+    executeWithRateLimit: ReturnType<typeof vi.fn>
     generateCompletionStandalone: ReturnType<typeof vi.fn>
   }
   let resolveConversationWorkdir: ReturnType<typeof vi.fn>
@@ -46,6 +47,7 @@ describe('AgentToolManager read routing', () => {
       prepareFileCompletely: vi.fn()
     }
     llmProviderPresenter = {
+      executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
       generateCompletionStandalone: vi.fn()
     }
     resolveConversationWorkdir = vi.fn().mockResolvedValue(null)
@@ -155,6 +157,7 @@ describe('AgentToolManager read routing', () => {
     }
 
     expect(result.content).toContain('detailed image description')
+    expect(llmProviderPresenter.executeWithRateLimit).toHaveBeenCalledWith('openai')
     expect(llmProviderPresenter.generateCompletionStandalone).toHaveBeenCalled()
     expect(llmProviderPresenter.generateCompletionStandalone).toHaveBeenCalledWith(
       'openai',
@@ -192,6 +195,7 @@ describe('AgentToolManager read routing', () => {
 
     expect(result.content).toContain('fallback image description')
     expect(configPresenter.resolveDeepChatAgentConfig).toHaveBeenCalledWith('agent-vision')
+    expect(llmProviderPresenter.executeWithRateLimit).toHaveBeenCalledWith('anthropic')
     expect(llmProviderPresenter.generateCompletionStandalone).toHaveBeenCalledWith(
       'anthropic',
       expect.any(Array),
@@ -218,6 +222,7 @@ describe('AgentToolManager read routing', () => {
 
     expect(result.content).toContain('[Image Metadata]')
     expect(result.content).toContain('neither the current session model nor the agent vision model')
+    expect(llmProviderPresenter.executeWithRateLimit).not.toHaveBeenCalled()
   })
 
   it('falls back to image metadata when the conversation cannot be found', async () => {
@@ -236,6 +241,7 @@ describe('AgentToolManager read routing', () => {
 
     expect(result.content).toContain('[Image Metadata]')
     expect(result.content).toContain('neither the current session model nor the agent vision model')
+    expect(llmProviderPresenter.executeWithRateLimit).not.toHaveBeenCalled()
   })
 
   it('surfaces runtime errors while resolving the conversation vision target', async () => {

--- a/test/main/presenter/toolPresenter/agentTools/agentToolManagerSettings.test.ts
+++ b/test/main/presenter/toolPresenter/agentTools/agentToolManagerSettings.test.ts
@@ -47,6 +47,7 @@ describe('AgentToolManager DeepChat settings tool gating', () => {
           prepareFileCompletely: vi.fn()
         }),
         getLlmProviderPresenter: () => ({
+          executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
           generateCompletionStandalone: vi.fn()
         }),
         createSettingsWindow: vi.fn(),

--- a/test/main/presenter/toolPresenter/agentTools/agentToolManagerSkillAccess.test.ts
+++ b/test/main/presenter/toolPresenter/agentTools/agentToolManagerSkillAccess.test.ts
@@ -65,6 +65,7 @@ describe('AgentToolManager skill file access', () => {
         }),
         getFilePresenter: () => filePresenter,
         getLlmProviderPresenter: () => ({
+          executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
           generateCompletionStandalone: vi.fn()
         }),
         createSettingsWindow: vi.fn(),

--- a/test/main/presenter/toolPresenter/agentTools/subagentOrchestratorTool.test.ts
+++ b/test/main/presenter/toolPresenter/agentTools/subagentOrchestratorTool.test.ts
@@ -96,6 +96,7 @@ describe('SubagentOrchestratorTool', () => {
         prepareFileCompletely: vi.fn()
       })),
       getLlmProviderPresenter: vi.fn(() => ({
+        executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
         generateCompletionStandalone: vi.fn()
       })),
       createSettingsWindow: vi.fn(),

--- a/test/main/presenter/toolPresenter/toolPresenter.test.ts
+++ b/test/main/presenter/toolPresenter/toolPresenter.test.ts
@@ -70,6 +70,7 @@ describe('ToolPresenter', () => {
           prepareFileCompletely: vi.fn()
         }),
         getLlmProviderPresenter: () => ({
+          executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
           generateCompletionStandalone: vi.fn()
         }),
         createSettingsWindow: vi.fn(),
@@ -124,6 +125,7 @@ describe('ToolPresenter', () => {
         prepareFileCompletely: vi.fn()
       }),
       getLlmProviderPresenter: () => ({
+        executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
         generateCompletionStandalone: vi.fn()
       }),
       createSettingsWindow: vi.fn(),
@@ -159,7 +161,14 @@ describe('ToolPresenter', () => {
       conversationId: 'conv-1'
     })
 
-    expect(callToolSpy).toHaveBeenCalledWith('read', { path: 'foo' }, 'conv-1')
+    expect(callToolSpy).toHaveBeenCalledWith(
+      'read',
+      { path: 'foo' },
+      'conv-1',
+      expect.objectContaining({
+        toolCallId: 'tool-1'
+      })
+    )
   })
 
   it('filters disabled agent tools while preserving MCP tools', async () => {
@@ -197,6 +206,7 @@ describe('ToolPresenter', () => {
         prepareFileCompletely: vi.fn()
       }),
       getLlmProviderPresenter: () => ({
+        executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
         generateCompletionStandalone: vi.fn()
       }),
       createSettingsWindow: vi.fn(),
@@ -268,6 +278,7 @@ describe('ToolPresenter', () => {
           prepareFileCompletely: vi.fn()
         }),
         getLlmProviderPresenter: () => ({
+          executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
           generateCompletionStandalone: vi.fn()
         }),
         createSettingsWindow: vi.fn(),
@@ -354,6 +365,7 @@ describe('ToolPresenter', () => {
           prepareFileCompletely: vi.fn()
         }),
         getLlmProviderPresenter: () => ({
+          executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
           generateCompletionStandalone: vi.fn()
         }),
         createSettingsWindow: vi.fn(),
@@ -432,6 +444,7 @@ describe('ToolPresenter', () => {
         prepareFileCompletely: vi.fn()
       }),
       getLlmProviderPresenter: () => ({
+        executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
         generateCompletionStandalone: vi.fn()
       }),
       createSettingsWindow: vi.fn(),
@@ -529,6 +542,7 @@ describe('ToolPresenter', () => {
           prepareFileCompletely: vi.fn()
         }),
         getLlmProviderPresenter: () => ({
+          executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
           generateCompletionStandalone: vi.fn()
         }),
         createSettingsWindow: vi.fn(),

--- a/test/renderer/components/ChatPage.test.ts
+++ b/test/renderer/components/ChatPage.test.ts
@@ -29,6 +29,9 @@ const buildAssistantMessage = (content: unknown) => ({
 
 type SetupOptions = {
   messages?: Array<Record<string, unknown>>
+  isStreaming?: boolean
+  streamingBlocks?: unknown[]
+  currentStreamMessageId?: string | null
   pendingInputStorePatch?: Record<string, unknown>
   sessionKind?: 'regular' | 'subagent'
 }
@@ -62,9 +65,9 @@ const setup = async (options: SetupOptions = {}) => {
         }
       ])
     ],
-    isStreaming: false,
-    streamingBlocks: [],
-    currentStreamMessageId: null,
+    isStreaming: options.isStreaming ?? false,
+    streamingBlocks: options.streamingBlocks ?? [],
+    currentStreamMessageId: options.currentStreamMessageId ?? null,
     loadMessages: vi.fn().mockResolvedValue(undefined),
     clearStreamingState: vi.fn(),
     addOptimisticUserMessage: vi.fn()
@@ -148,6 +151,18 @@ const setup = async (options: SetupOptions = {}) => {
           type: Array,
           required: true
         },
+        conversationId: {
+          type: String,
+          default: ''
+        },
+        ephemeralRateLimitBlock: {
+          type: Object,
+          default: null
+        },
+        ephemeralRateLimitMessageId: {
+          type: String,
+          default: null
+        },
         isGenerating: {
           type: Boolean,
           default: false
@@ -161,7 +176,8 @@ const setup = async (options: SetupOptions = {}) => {
           default: false
         }
       },
-      template: '<div class="message-list-stub" :data-read-only="String(isReadOnly)" />'
+      template:
+        '<div class="message-list-stub" :data-read-only="String(isReadOnly)" :data-has-rate-limit="String(Boolean(ephemeralRateLimitBlock))" />'
     })
   }))
   vi.doMock('@/components/chat/ChatInputBox.vue', () => ({
@@ -255,6 +271,32 @@ describe('ChatPage', () => {
     expect(messages).toHaveLength(1)
     expect(messages[0].usage.reasoning_start_time).toBe(1_200)
     expect(messages[0].usage.reasoning_end_time).toBe(4_500)
+  })
+
+  it('extracts ephemeral rate-limit streaming blocks instead of creating a virtual assistant message', async () => {
+    const { wrapper } = await setup({
+      messages: [],
+      isStreaming: true,
+      currentStreamMessageId: '__rate_limit__:s1:1',
+      streamingBlocks: [
+        {
+          type: 'action',
+          action_type: 'rate_limit',
+          status: 'pending',
+          timestamp: 1
+        }
+      ]
+    })
+
+    const messageList = wrapper.findComponent({ name: 'MessageList' })
+    expect(messageList.props('messages')).toEqual([])
+    expect(messageList.props('ephemeralRateLimitMessageId')).toBe('__rate_limit__:s1:1')
+    expect(messageList.props('ephemeralRateLimitBlock')).toEqual(
+      expect.objectContaining({
+        action_type: 'rate_limit'
+      })
+    )
+    expect(wrapper.find('.message-list-stub').attributes('data-has-rate-limit')).toBe('true')
   })
 
   it('keeps pending lane visible below the tool interaction overlay', async () => {

--- a/test/renderer/components/MessageList.test.ts
+++ b/test/renderer/components/MessageList.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { mount } from '@vue/test-utils'
-import type { DisplayMessage } from '@/components/chat/messageListItems'
+import type {
+  DisplayAssistantMessageBlock,
+  DisplayMessage
+} from '@/components/chat/messageListItems'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
@@ -45,6 +48,19 @@ vi.mock('@/components/message/MessageItemAssistant.vue', () => ({
     },
     template:
       '<div class="assistant-item" :data-read-only="String(isReadOnly)">{{ message.id }}</div>'
+  })
+}))
+
+vi.mock('@/components/message/MessageBlockAction.vue', () => ({
+  default: defineComponent({
+    name: 'MessageBlockAction',
+    props: {
+      block: {
+        type: Object,
+        required: true
+      }
+    },
+    template: '<div class="rate-limit-block-stub">{{ block.action_type || "unknown" }}</div>'
   })
 }))
 
@@ -166,5 +182,25 @@ describe('MessageList', () => {
 
     expect(wrapper.find('.user-item').attributes('data-read-only')).toBe('true')
     expect(wrapper.find('.assistant-item').attributes('data-read-only')).toBe('true')
+  })
+
+  it('renders an ephemeral rate-limit block without creating an assistant item', () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [createMessage('u1', 'user', 1)],
+        conversationId: 's1',
+        ephemeralRateLimitMessageId: '__rate_limit__:s1:1',
+        ephemeralRateLimitBlock: {
+          type: 'action',
+          action_type: 'rate_limit',
+          status: 'pending',
+          timestamp: 1
+        } satisfies DisplayAssistantMessageBlock
+      }
+    })
+
+    expect(wrapper.find('[data-rate-limit-indicator="true"]').exists()).toBe(true)
+    expect(wrapper.find('.rate-limit-block-stub').text()).toBe('rate_limit')
+    expect(wrapper.findAll('.assistant-item')).toHaveLength(0)
   })
 })

--- a/test/renderer/components/message/MessageBlockBasics.test.ts
+++ b/test/renderer/components/message/MessageBlockBasics.test.ts
@@ -67,28 +67,21 @@ describe('MessageBlock basics', () => {
     expect(wrapper.emitted('continue')).toEqual([['s1', 'm1']])
   })
 
-  it('renders rate limit info and emits switchProvider', async () => {
+  it('renders a compact rate limit status block', () => {
     const wrapper = mount(MessageBlockAction, {
       props: {
         messageId: 'm1',
         conversationId: 's1',
         block: createBlock({
           action_type: 'rate_limit',
-          extra: {
-            providerId: 'openai',
-            queueLength: 3,
-            estimatedWaitTime: 5_000
-          }
+          timestamp: Date.now()
         })
       }
     })
 
-    const buttons = wrapper.findAll('button')
-    await buttons[1].trigger('click')
-
-    expect(wrapper.text()).toContain('chat.messages.rateLimitTitle')
-    expect(wrapper.text()).toContain('Openai')
-    expect(wrapper.emitted('switchProvider')).toEqual([[]])
+    expect(wrapper.find('[data-rate-limit-block="true"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('chat.messages.rateLimitCompactLoading')
+    expect(wrapper.findAll('button')).toHaveLength(0)
   })
 
   it('renders question request content and answer', () => {

--- a/test/renderer/stores/messageStore.test.ts
+++ b/test/renderer/stores/messageStore.test.ts
@@ -118,4 +118,55 @@ describe('messageStore', () => {
     expect(store.messages.value).toHaveLength(1)
     expect(store.messages.value[0]?.id).toBe('m2')
   })
+
+  it('keeps rate-limit stream messages ephemeral and skips message hydration', async () => {
+    const { store, newAgentPresenter } = await setupStore()
+    const responseHandler = (
+      (window as any).electron.ipcRenderer.on as ReturnType<typeof vi.fn>
+    ).mock.calls.find(([eventName]) => eventName === 'stream:response')?.[1]
+
+    expect(typeof responseHandler).toBe('function')
+
+    responseHandler(
+      {},
+      {
+        conversationId: 's1',
+        messageId: '__rate_limit__:s1:1',
+        blocks: [
+          {
+            type: 'action',
+            action_type: 'rate_limit',
+            status: 'pending',
+            timestamp: 1,
+            extra: {
+              providerId: 'openai',
+              qpsLimit: 1,
+              currentQps: 1,
+              queueLength: 2,
+              estimatedWaitTime: 4000
+            }
+          }
+        ]
+      }
+    )
+
+    expect(store.isStreaming.value).toBe(true)
+    expect(store.currentStreamMessageId.value).toBe('__rate_limit__:s1:1')
+    expect(store.streamingBlocks.value).toHaveLength(1)
+    expect(store.messages.value).toHaveLength(0)
+    expect(newAgentPresenter.getMessage).not.toHaveBeenCalled()
+
+    responseHandler(
+      {},
+      {
+        conversationId: 's1',
+        messageId: '__rate_limit__:s1:1',
+        blocks: []
+      }
+    )
+
+    expect(store.streamingBlocks.value).toEqual([])
+    expect(store.messages.value).toHaveLength(0)
+    expect(newAgentPresenter.getMessage).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
fixed #1418


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate-limit queuing with a compact ephemeral status indicator in chat; provider queue/wait events surfaced and cleared.
  * Abort/cancellation support for in-progress generation, queued requests, image analysis, and compaction flows (user stop handled gracefully).
  * Added multilingual compact rate-limit messages.

* **Bug Fixes**
  * Prevent duplicate/competing streaming render paths while rate-limit status is shown; ensure session state resets on cancellation.

* **Tests**
  * Added/updated tests for rate-limit queueing, abort behavior, and UI rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->