### PR TITLE
fix(acp): bridge terminal permission approval

### DIFF
--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -3186,7 +3186,6 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       } else {
         await this.llmProviderPresenter.resolveAgentPermission(input.requestId, input.granted)
         this.updatePersistedProviderPermissionState(
-          input.sessionId,
           input.messageId,
           input.toolCallId,
           input.requestId,
@@ -3200,7 +3199,6 @@ export class AgentRuntimePresenter implements IAgentImplementation {
   }
 
   private updatePersistedProviderPermissionState(
-    sessionId: string,
     messageId: string,
     toolCallId: string,
     requestId: string,

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -91,6 +91,16 @@ type ResumeBudgetToolCall = {
   offloadPath?: string
 }
 
+type ActiveProviderPermission = {
+  requestId: string
+  sessionId: string
+  messageId: string
+  toolCallId: string
+  providerId: string
+  permissionType: 'read' | 'write' | 'all' | 'command'
+  resolve: (granted: boolean) => Promise<void>
+}
+
 type PersistedSessionGenerationRow = {
   provider_id: string
   model_id: string
@@ -155,6 +165,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
   private readonly interactionLocks: Set<string> = new Set()
   private readonly resumingMessages: Set<string> = new Set()
   private readonly drainingPendingQueues: Set<string> = new Set()
+  private readonly activeProviderPermissions: Map<string, ActiveProviderPermission> = new Map()
   private readonly compactionService: CompactionService
   private readonly toolOutputGuard: ToolOutputGuard
   private readonly hooksBridge?: NewSessionHooksBridge
@@ -279,6 +290,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     }
     this.abortDeferredToolAbortControllers(sessionId)
     this.activeGenerations.delete(sessionId)
+    this.clearActiveProviderPermissionsForSession(sessionId)
 
     this.pendingInputCoordinator.deleteBySession(sessionId)
     this.messageStore.deleteBySession(sessionId)
@@ -708,6 +720,19 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         }
         const permissionPayload = this.parsePermissionPayload(actionBlock)
         const permissionType = permissionPayload?.permissionType ?? 'write'
+        const requestId = permissionPayload?.requestId?.trim()
+        const providerId = permissionPayload?.providerId?.trim()
+        if (providerId === 'acp' && requestId) {
+          await this.resolveProviderPermissionInteraction({
+            sessionId,
+            messageId,
+            toolCallId: toolCall.id,
+            requestId,
+            permissionType,
+            granted: response.granted
+          })
+          return { resumed: false }
+        }
         const state = this.runtimeState.get(sessionId)
         const projectDir = this.resolveProjectDir(sessionId)
         let shouldDispatchResolvedToolHook = false
@@ -994,6 +1019,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       }
     }
     this.abortDeferredToolAbortControllers(sessionId)
+    this.clearActiveProviderPermissionsForSession(sessionId)
     this.setSessionStatus(sessionId, 'idle')
   }
 
@@ -1626,6 +1652,15 @@ export class AgentRuntimePresenter implements IAgentImplementation {
               tool
             })
           },
+          onStreamingProviderPermission: (permission, tool, commitDecision) => {
+            this.registerActiveProviderPermission(
+              sessionId,
+              messageId,
+              permission,
+              tool,
+              commitDecision
+            )
+          },
           onInterleavedReasoningGap: (gap) => {
             console.warn(
               `[DeepChatAgent] Interleaved reasoning gap detected for ${gap.providerId}/${gap.modelId}. Update provider DB metadata at ${gap.providerDbSourceUrl}.`
@@ -1817,6 +1852,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       return
     }
     this.activeGenerations.delete(sessionId)
+    this.clearActiveProviderPermissionsForSession(sessionId)
     if (this.abortControllers.get(sessionId) === activeGeneration.abortController) {
       this.abortControllers.delete(sessionId)
     }
@@ -3100,6 +3136,104 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         typeof block.extra?.permissionRequestId === 'string'
           ? block.extra.permissionRequestId
           : undefined
+    }
+  }
+
+  private registerActiveProviderPermission(
+    sessionId: string,
+    messageId: string,
+    permission: NonNullable<PendingToolInteraction['permission']>,
+    tool: {
+      callId?: string
+      name?: string
+      params?: string
+    },
+    commitDecision: (granted: boolean) => void
+  ): void {
+    const requestId = permission.requestId?.trim()
+    const providerId = permission.providerId?.trim()
+    if (!requestId || providerId !== 'acp') {
+      return
+    }
+
+    this.activeProviderPermissions.set(requestId, {
+      requestId,
+      sessionId,
+      messageId,
+      toolCallId: tool.callId || '',
+      providerId,
+      permissionType: permission.permissionType,
+      resolve: async (granted: boolean) => {
+        await this.llmProviderPresenter.resolveAgentPermission(requestId, granted)
+        commitDecision(granted)
+      }
+    })
+  }
+
+  private async resolveProviderPermissionInteraction(input: {
+    sessionId: string
+    messageId: string
+    toolCallId: string
+    requestId: string
+    permissionType: 'read' | 'write' | 'all' | 'command'
+    granted: boolean
+  }): Promise<void> {
+    const active = this.activeProviderPermissions.get(input.requestId)
+
+    try {
+      if (active) {
+        await active.resolve(input.granted)
+      } else {
+        await this.llmProviderPresenter.resolveAgentPermission(input.requestId, input.granted)
+        this.updatePersistedProviderPermissionState(
+          input.sessionId,
+          input.messageId,
+          input.toolCallId,
+          input.requestId,
+          input.permissionType,
+          input.granted
+        )
+      }
+    } finally {
+      this.activeProviderPermissions.delete(input.requestId)
+    }
+  }
+
+  private updatePersistedProviderPermissionState(
+    sessionId: string,
+    messageId: string,
+    toolCallId: string,
+    requestId: string,
+    permissionType: 'read' | 'write' | 'all' | 'command',
+    granted: boolean
+  ): void {
+    const message = this.messageStore.getMessage(messageId)
+    if (!message || message.role !== 'assistant') {
+      return
+    }
+
+    const blocks = this.parseAssistantBlocks(message.content)
+    const actionBlock = blocks.find(
+      (block) =>
+        block.type === 'action' &&
+        block.action_type === 'tool_call_permission' &&
+        block.tool_call?.id === toolCallId &&
+        (block.extra?.permissionRequestId === requestId || requestId === '')
+    )
+
+    if (!actionBlock) {
+      return
+    }
+
+    this.markPermissionResolved(actionBlock, granted, permissionType)
+    this.messageStore.updateAssistantContent(messageId, blocks)
+  }
+
+  private clearActiveProviderPermissionsForSession(sessionId: string): void {
+    for (const [requestId, permission] of this.activeProviderPermissions.entries()) {
+      if (permission.sessionId === sessionId) {
+        this.activeProviderPermissions.delete(requestId)
+      }
     }
   }
 

--- a/src/main/presenter/agentRuntimePresenter/process.ts
+++ b/src/main/presenter/agentRuntimePresenter/process.ts
@@ -25,6 +25,7 @@ const CONTEXT_WINDOW_ERROR_PATTERNS = [
 const USER_CANCELED_GENERATION_ERROR = 'common.error.userCanceledGeneration'
 const NO_MODEL_RESPONSE_ERROR = 'common.error.noModelResponse'
 type PendingPermissionPayload = NonNullable<PendingToolInteraction['permission']>
+type PendingPermissionCommandInfo = NonNullable<PendingPermissionPayload['commandInfo']>
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && (error.name === 'AbortError' || error.name === 'CanceledError')
@@ -104,6 +105,50 @@ function normalizeProviderPermissionType(
     : 'write'
 }
 
+function parseStreamingPermissionPaths(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined
+  }
+
+  const paths = raw.filter(
+    (item): item is string => typeof item === 'string' && item.trim().length > 0
+  )
+  return paths.length > 0 ? paths : undefined
+}
+
+function parseStreamingPermissionCommandInfo(
+  raw: unknown
+): PendingPermissionCommandInfo | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return undefined
+  }
+
+  const value = raw as Record<string, unknown>
+  if (typeof value.command !== 'string' || !value.command.trim()) {
+    return undefined
+  }
+
+  const riskLevel =
+    value.riskLevel === 'low' ||
+    value.riskLevel === 'medium' ||
+    value.riskLevel === 'high' ||
+    value.riskLevel === 'critical'
+      ? value.riskLevel
+      : 'medium'
+
+  return {
+    command: value.command.trim(),
+    riskLevel,
+    suggestion: typeof value.suggestion === 'string' ? value.suggestion.trim() : '',
+    ...(typeof value.signature === 'string' && value.signature.trim()
+      ? { signature: value.signature.trim() }
+      : {}),
+    ...(typeof value.baseCommand === 'string' && value.baseCommand.trim()
+      ? { baseCommand: value.baseCommand.trim() }
+      : {})
+  }
+}
+
 function toStreamingProviderPermission(
   permission: PermissionRequestPayload
 ): PendingPermissionPayload {
@@ -127,6 +172,12 @@ function toStreamingProviderPermission(
     typeof permission.command === 'string' && permission.command.trim()
       ? permission.command.trim()
       : undefined
+  const commandSignature =
+    typeof permission.commandSignature === 'string' && permission.commandSignature.trim()
+      ? permission.commandSignature.trim()
+      : undefined
+  const paths = parseStreamingPermissionPaths(permission.paths)
+  const commandInfo = parseStreamingPermissionCommandInfo(permission.commandInfo)
   const metadata =
     permission.metadata &&
     typeof permission.metadata === 'object' &&
@@ -146,6 +197,9 @@ function toStreamingProviderPermission(
     ...(providerId ? { providerId } : {}),
     ...(requestId ? { requestId } : {}),
     ...(command ? { command } : {}),
+    ...(commandSignature ? { commandSignature } : {}),
+    ...(paths ? { paths } : {}),
+    ...(commandInfo ? { commandInfo } : {}),
     ...(metadata?.rememberable === false ? { rememberable: false } : {})
   }
 }

--- a/src/main/presenter/agentRuntimePresenter/process.ts
+++ b/src/main/presenter/agentRuntimePresenter/process.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessageBlock } from '@shared/types/agent-interface'
+import type { PermissionRequestPayload } from '@shared/types/core/llm-events'
 import type {
   IoParams,
   PendingToolInteraction,
@@ -23,6 +24,7 @@ const CONTEXT_WINDOW_ERROR_PATTERNS = [
 ]
 const USER_CANCELED_GENERATION_ERROR = 'common.error.userCanceledGeneration'
 const NO_MODEL_RESPONSE_ERROR = 'common.error.noModelResponse'
+type PendingPermissionPayload = NonNullable<PendingToolInteraction['permission']>
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && (error.name === 'AbortError' || error.name === 'CanceledError')
@@ -103,8 +105,8 @@ function normalizeProviderPermissionType(
 }
 
 function toStreamingProviderPermission(
-  permission: Record<string, unknown>
-): NonNullable<PendingToolInteraction['permission']> {
+  permission: PermissionRequestPayload
+): PendingPermissionPayload {
   const toolName =
     typeof permission.tool_call_name === 'string' && permission.tool_call_name.trim()
       ? permission.tool_call_name.trim()
@@ -131,9 +133,7 @@ function toStreamingProviderPermission(
     !Array.isArray(permission.metadata)
       ? (permission.metadata as Record<string, unknown>)
       : undefined
-  const permissionType = normalizeProviderPermissionType(
-    permission.permissionType as PendingToolInteraction['permission']['permissionType']
-  )
+  const permissionType = normalizeProviderPermissionType(permission.permissionType)
 
   return {
     permissionType,
@@ -152,10 +152,10 @@ function toStreamingProviderPermission(
 
 function appendStreamingProviderPermissionBlock(
   state: StreamState,
-  permissionPayload: Record<string, unknown>
+  permissionPayload: PermissionRequestPayload
 ): {
   actionBlock: AssistantMessageBlock
-  permission: NonNullable<PendingToolInteraction['permission']>
+  permission: PendingPermissionPayload
   tool: {
     callId?: string
     name?: string
@@ -301,7 +301,7 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
         if (event.type === 'permission') {
           const { actionBlock, permission, tool } = appendStreamingProviderPermissionBlock(
             state,
-            event.permission as Record<string, unknown>
+            event.permission
           )
           hooks?.onPermissionRequest?.(permission, tool)
           hooks?.onStreamingProviderPermission?.(permission, tool, (granted) => {

--- a/src/main/presenter/agentRuntimePresenter/process.ts
+++ b/src/main/presenter/agentRuntimePresenter/process.ts
@@ -1,7 +1,13 @@
 import type { AssistantMessageBlock } from '@shared/types/agent-interface'
-import type { IoParams, ProcessParams, ProcessResult, StreamState } from './types'
+import type {
+  IoParams,
+  PendingToolInteraction,
+  ProcessParams,
+  ProcessResult,
+  StreamState
+} from './types'
 import { createState } from './types'
-import { accumulate } from './accumulator'
+import { accumulate, finalizeTrailingPendingNarrativeBlocks } from './accumulator'
 import { startEcho } from './echo'
 import { executeTools, finalize, finalizeError, finalizePaused } from './dispatch'
 
@@ -85,6 +91,146 @@ function finalizeUserCanceledErrorIfNeeded(state: StreamState, io: IoParams): vo
   finalizeError(state, io, USER_CANCELED_GENERATION_ERROR)
 }
 
+function normalizeProviderPermissionType(
+  permissionType: unknown
+): 'read' | 'write' | 'all' | 'command' {
+  return permissionType === 'read' ||
+    permissionType === 'write' ||
+    permissionType === 'all' ||
+    permissionType === 'command'
+    ? permissionType
+    : 'write'
+}
+
+function toStreamingProviderPermission(
+  permission: Record<string, unknown>
+): NonNullable<PendingToolInteraction['permission']> {
+  const toolName =
+    typeof permission.tool_call_name === 'string' && permission.tool_call_name.trim()
+      ? permission.tool_call_name.trim()
+      : undefined
+  const serverName =
+    typeof permission.server_name === 'string' && permission.server_name.trim()
+      ? permission.server_name.trim()
+      : undefined
+  const providerId =
+    typeof permission.providerId === 'string' && permission.providerId.trim()
+      ? permission.providerId.trim()
+      : undefined
+  const requestId =
+    typeof permission.requestId === 'string' && permission.requestId.trim()
+      ? permission.requestId.trim()
+      : undefined
+  const command =
+    typeof permission.command === 'string' && permission.command.trim()
+      ? permission.command.trim()
+      : undefined
+  const metadata =
+    permission.metadata &&
+    typeof permission.metadata === 'object' &&
+    !Array.isArray(permission.metadata)
+      ? (permission.metadata as Record<string, unknown>)
+      : undefined
+  const permissionType = normalizeProviderPermissionType(
+    permission.permissionType as PendingToolInteraction['permission']['permissionType']
+  )
+
+  return {
+    permissionType,
+    description:
+      typeof permission.description === 'string' && permission.description.trim()
+        ? permission.description
+        : `components.messageBlockPermissionRequest.description.${permissionType}`,
+    ...(toolName ? { toolName } : {}),
+    ...(serverName ? { serverName } : {}),
+    ...(providerId ? { providerId } : {}),
+    ...(requestId ? { requestId } : {}),
+    ...(command ? { command } : {}),
+    ...(metadata?.rememberable === false ? { rememberable: false } : {})
+  }
+}
+
+function appendStreamingProviderPermissionBlock(
+  state: StreamState,
+  permissionPayload: Record<string, unknown>
+): {
+  actionBlock: AssistantMessageBlock
+  permission: NonNullable<PendingToolInteraction['permission']>
+  tool: {
+    callId?: string
+    name?: string
+    params?: string
+  }
+} {
+  const permission = toStreamingProviderPermission(permissionPayload)
+  const toolCallId =
+    typeof permissionPayload.tool_call_id === 'string' && permissionPayload.tool_call_id.trim()
+      ? permissionPayload.tool_call_id.trim()
+      : permission.requestId || 'acp-permission'
+  const toolArgs =
+    typeof permissionPayload.tool_call_params === 'string' ? permissionPayload.tool_call_params : ''
+  const toolName = permission.toolName || toolCallId
+  finalizeTrailingPendingNarrativeBlocks(state.blocks)
+  const actionBlock: AssistantMessageBlock = {
+    type: 'action',
+    content: permission.description,
+    status: 'pending',
+    timestamp: Date.now(),
+    action_type: 'tool_call_permission',
+    tool_call: {
+      id: toolCallId,
+      name: toolName,
+      params: toolArgs,
+      ...(permission.serverName ? { server_name: permission.serverName } : {}),
+      ...(typeof permissionPayload.server_description === 'string'
+        ? { server_description: permissionPayload.server_description }
+        : {}),
+      ...(typeof permissionPayload.server_icons === 'string'
+        ? { server_icons: permissionPayload.server_icons }
+        : {})
+    },
+    extra: {
+      needsUserAction: true,
+      permissionType: permission.permissionType,
+      ...(permission.toolName ? { toolName: permission.toolName } : {}),
+      ...(permission.serverName ? { serverName: permission.serverName } : {}),
+      ...(permission.providerId ? { providerId: permission.providerId } : {}),
+      ...(permission.requestId ? { permissionRequestId: permission.requestId } : {}),
+      permissionRequest: JSON.stringify(permission),
+      ...(permission.rememberable === false ? { rememberable: false } : {})
+    }
+  }
+
+  state.blocks.push(actionBlock)
+  state.dirty = true
+
+  return {
+    actionBlock,
+    permission,
+    tool: {
+      callId: toolCallId,
+      name: toolName,
+      params: toolArgs
+    }
+  }
+}
+
+function markStreamingProviderPermissionResolved(
+  block: AssistantMessageBlock,
+  granted: boolean,
+  permissionType: 'read' | 'write' | 'all' | 'command'
+): void {
+  block.status = granted ? 'granted' : 'denied'
+  block.extra = {
+    ...block.extra,
+    needsUserAction: false,
+    ...(granted ? { grantedPermissions: permissionType } : {})
+  }
+  if (!granted) {
+    block.content = 'User denied the request.'
+  }
+}
+
 /**
  * Unified stream processor. Handles both simple completions and multi-turn
  * tool-calling loops in a single code path.
@@ -151,6 +297,22 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
             usage: buildUsageSnapshot(state)
           }
         }
+
+        if (event.type === 'permission') {
+          const { actionBlock, permission, tool } = appendStreamingProviderPermissionBlock(
+            state,
+            event.permission as Record<string, unknown>
+          )
+          hooks?.onPermissionRequest?.(permission, tool)
+          hooks?.onStreamingProviderPermission?.(permission, tool, (granted) => {
+            markStreamingProviderPermissionResolved(actionBlock, granted, permission.permissionType)
+            state.dirty = true
+            echo.flush()
+          })
+          echo.flush()
+          continue
+        }
+
         accumulate(state, event)
       }
 

--- a/src/main/presenter/agentRuntimePresenter/types.ts
+++ b/src/main/presenter/agentRuntimePresenter/types.ts
@@ -88,6 +88,15 @@ export interface ProcessHooks {
   autoGrantPermission?: (
     permission: NonNullable<PendingToolInteraction['permission']>
   ) => Promise<void>
+  onStreamingProviderPermission?: (
+    permission: NonNullable<PendingToolInteraction['permission']>,
+    tool: {
+      callId?: string
+      name?: string
+      params?: string
+    },
+    commitDecision: (granted: boolean) => void
+  ) => void
   normalizeToolResult?: (tool: {
     sessionId: string
     toolCallId: string

--- a/src/main/presenter/llmProviderPresenter/providers/acpProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/acpProvider.ts
@@ -1071,6 +1071,7 @@ export class AcpProvider extends BaseLLMProvider {
   ): PermissionRequestPayload {
     const permissionType = this.mapPermissionType(params.toolCall.kind)
     const toolName = params.toolCall.title?.trim() || params.toolCall.toolCallId
+    const command = this.extractCommand(params.toolCall)
     const options: PermissionRequestOption[] = params.options.map((option) => ({
       optionId: option.optionId,
       kind: option.kind,
@@ -1092,6 +1093,7 @@ export class AcpProvider extends BaseLLMProvider {
       permissionType,
       server_name: context.agent.name,
       server_description: context.agent.command,
+      ...(command ? { command } : {}),
       options,
       metadata: { rememberable: false }
     }
@@ -1112,7 +1114,23 @@ export class AcpProvider extends BaseLLMProvider {
     return toolCall.toolCallId
   }
 
-  private mapPermissionType(kind?: schema.ToolKind | null): 'read' | 'write' | 'all' {
+  private extractCommand(
+    toolCall: schema.RequestPermissionRequest['toolCall']
+  ): string | undefined {
+    const rawInput = toolCall.rawInput
+    if (!rawInput || typeof rawInput !== 'object') {
+      return undefined
+    }
+
+    const command = (rawInput as Record<string, unknown>).command
+    if (typeof command !== 'string' || !command.trim()) {
+      return undefined
+    }
+
+    return command.trim()
+  }
+
+  private mapPermissionType(kind?: schema.ToolKind | null): 'read' | 'write' | 'all' | 'command' {
     switch (kind) {
       case 'read':
       case 'fetch':
@@ -1121,8 +1139,9 @@ export class AcpProvider extends BaseLLMProvider {
       case 'edit':
       case 'delete':
       case 'move':
-      case 'execute':
         return 'write'
+      case 'execute':
+        return 'command'
       default:
         return 'all'
     }

--- a/src/shared/types/core/llm-events.ts
+++ b/src/shared/types/core/llm-events.ts
@@ -222,6 +222,7 @@ export interface PermissionRequestPayload {
   server_name?: string
   server_description?: string
   server_icons?: string
+  command?: string
   options?: PermissionRequestOption[]
   metadata?: Record<string, unknown>
 }

--- a/src/shared/types/core/llm-events.ts
+++ b/src/shared/types/core/llm-events.ts
@@ -223,6 +223,15 @@ export interface PermissionRequestPayload {
   server_description?: string
   server_icons?: string
   command?: string
+  commandSignature?: string
+  paths?: string[]
+  commandInfo?: {
+    command: string
+    riskLevel: 'low' | 'medium' | 'high' | 'critical'
+    suggestion: string
+    signature?: string
+    baseCommand?: string
+  }
   options?: PermissionRequestOption[]
   metadata?: Record<string, unknown>
 }

--- a/test/main/presenter/acpProvider.test.ts
+++ b/test/main/presenter/acpProvider.test.ts
@@ -119,6 +119,37 @@ describe('AcpProvider runDebugAction error handling', () => {
     expect(commands).toEqual([{ name: 'review', description: 'run review', input: null }])
   })
 
+  it('maps execute permissions to command and includes the raw command', () => {
+    const provider = Object.create(AcpProvider.prototype) as any
+    provider.provider = { id: 'acp', name: 'ACP' }
+
+    const payload = provider.buildPermissionPayload(
+      {
+        sessionId: 'session-1',
+        toolCall: {
+          toolCallId: 'tc-terminal',
+          title: 'Terminal',
+          kind: 'execute',
+          rawInput: { command: 'dir' }
+        },
+        options: []
+      },
+      {
+        conversationId: 'conv-1',
+        agent: {
+          id: 'agent1',
+          name: 'Claude Agent',
+          command: 'claude'
+        }
+      },
+      'req-1'
+    )
+
+    expect(payload.permissionType).toBe('command')
+    expect(payload.command).toBe('dir')
+    expect(payload.description).toBe('components.messageBlockPermissionRequest.description.command')
+  })
+
   it('prepares ACP session without prompt and emits ready events', async () => {
     const configState = createConfigState()
     const provider = Object.create(AcpProvider.prototype) as any

--- a/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
@@ -185,6 +185,7 @@ function createMockLlmProviderPresenter() {
 
   return {
     getProviderInstance: vi.fn().mockReturnValue(providerInstance),
+    resolveAgentPermission: vi.fn().mockResolvedValue(undefined),
     executeWithRateLimit: vi.fn().mockResolvedValue(undefined),
     generateCompletionStandalone: vi.fn().mockResolvedValue('English screenshot summary'),
     generateText: vi.fn().mockResolvedValue({
@@ -3179,6 +3180,161 @@ describe('AgentRuntimePresenter', () => {
         })
       )
       expect(processStream).toHaveBeenCalledTimes(1)
+    })
+
+    it('handles ACP permission grant through live provider resolver without deferred tool resume', async () => {
+      await agent.initSession('s1', { providerId: 'acp', modelId: 'claude-code-acp' })
+      makeAssistantRow({
+        blocks: [
+          {
+            type: 'tool_call',
+            status: 'pending',
+            timestamp: 1,
+            tool_call: { id: 'tc1', name: 'Terminal', params: '{"command":"dir"}', response: '' }
+          },
+          {
+            type: 'action',
+            action_type: 'tool_call_permission',
+            status: 'pending',
+            timestamp: 2,
+            content: 'components.messageBlockPermissionRequest.description.command',
+            tool_call: { id: 'tc1', name: 'Terminal', params: '{"command":"dir"}' },
+            extra: {
+              needsUserAction: true,
+              permissionType: 'command',
+              providerId: 'acp',
+              permissionRequestId: 'acp-req-1',
+              permissionRequest: JSON.stringify({
+                permissionType: 'command',
+                description: 'components.messageBlockPermissionRequest.description.command',
+                toolName: 'Terminal',
+                providerId: 'acp',
+                requestId: 'acp-req-1',
+                command: 'dir'
+              })
+            }
+          }
+        ]
+      })
+
+      ;(agent as any).activeProviderPermissions.set('acp-req-1', {
+        requestId: 'acp-req-1',
+        sessionId: 's1',
+        messageId: 'm1',
+        toolCallId: 'tc1',
+        providerId: 'acp',
+        permissionType: 'command',
+        resolve: async (granted: boolean) => {
+          await llmProvider.resolveAgentPermission('acp-req-1', granted)
+          sqlitePresenter.deepchatMessagesTable.updateContent(
+            'm1',
+            JSON.stringify([
+              {
+                type: 'tool_call',
+                status: 'pending',
+                timestamp: 1,
+                tool_call: {
+                  id: 'tc1',
+                  name: 'Terminal',
+                  params: '{"command":"dir"}',
+                  response: ''
+                }
+              },
+              {
+                type: 'action',
+                action_type: 'tool_call_permission',
+                status: 'granted',
+                timestamp: 2,
+                content: 'components.messageBlockPermissionRequest.description.command',
+                tool_call: { id: 'tc1', name: 'Terminal', params: '{"command":"dir"}' },
+                extra: {
+                  needsUserAction: false,
+                  permissionType: 'command',
+                  grantedPermissions: 'command',
+                  providerId: 'acp',
+                  permissionRequestId: 'acp-req-1',
+                  permissionRequest: JSON.stringify({
+                    permissionType: 'command',
+                    description: 'components.messageBlockPermissionRequest.description.command',
+                    toolName: 'Terminal',
+                    providerId: 'acp',
+                    requestId: 'acp-req-1',
+                    command: 'dir'
+                  })
+                }
+              }
+            ])
+          )
+        }
+      })
+
+      const result = await agent.respondToolInteraction('s1', 'm1', 'tc1', {
+        kind: 'permission',
+        granted: true
+      })
+
+      expect(result).toEqual({ resumed: false })
+      expect(llmProvider.resolveAgentPermission).toHaveBeenCalledWith('acp-req-1', true)
+      expect(toolPresenter.callTool).not.toHaveBeenCalled()
+      expect(processStream).not.toHaveBeenCalled()
+      const updatedBlocks = JSON.parse(
+        sqlitePresenter.deepchatMessagesTable.updateContent.mock.calls[0][1]
+      )
+      expect(updatedBlocks[1].status).toBe('granted')
+      expect(updatedBlocks[1].extra.needsUserAction).toBe(false)
+      expect((agent as any).activeProviderPermissions.has('acp-req-1')).toBe(false)
+    })
+
+    it('falls back to direct ACP permission resolve when live resolver is missing', async () => {
+      await agent.initSession('s1', { providerId: 'acp', modelId: 'claude-code-acp' })
+      makeAssistantRow({
+        blocks: [
+          {
+            type: 'tool_call',
+            status: 'pending',
+            timestamp: 1,
+            tool_call: { id: 'tc1', name: 'Terminal', params: '{"command":"dir"}', response: '' }
+          },
+          {
+            type: 'action',
+            action_type: 'tool_call_permission',
+            status: 'pending',
+            timestamp: 2,
+            content: 'components.messageBlockPermissionRequest.description.command',
+            tool_call: { id: 'tc1', name: 'Terminal', params: '{"command":"dir"}' },
+            extra: {
+              needsUserAction: true,
+              permissionType: 'command',
+              providerId: 'acp',
+              permissionRequestId: 'acp-req-2',
+              permissionRequest: JSON.stringify({
+                permissionType: 'command',
+                description: 'components.messageBlockPermissionRequest.description.command',
+                toolName: 'Terminal',
+                providerId: 'acp',
+                requestId: 'acp-req-2',
+                command: 'dir'
+              })
+            }
+          }
+        ]
+      })
+
+      const result = await agent.respondToolInteraction('s1', 'm1', 'tc1', {
+        kind: 'permission',
+        granted: false
+      })
+
+      expect(result).toEqual({ resumed: false })
+      expect(llmProvider.resolveAgentPermission).toHaveBeenCalledWith('acp-req-2', false)
+      expect(toolPresenter.callTool).not.toHaveBeenCalled()
+      expect(processStream).not.toHaveBeenCalled()
+      const updatedBlocks = JSON.parse(
+        sqlitePresenter.deepchatMessagesTable.updateContent.mock.calls[0][1]
+      )
+      expect(updatedBlocks[1].status).toBe('denied')
+      expect(updatedBlocks[1].content).toBe('User denied the request.')
+      expect(updatedBlocks[1].extra.needsUserAction).toBe(false)
     })
   })
 

--- a/test/main/presenter/agentRuntimePresenter/process.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/process.test.ts
@@ -168,6 +168,101 @@ describe('processStream', () => {
     )
   })
 
+  it('flushes ACP provider permission blocks immediately and keeps live permission updates mutable', async () => {
+    let releaseStream: (() => void) | null = null
+    let commitDecision: ((granted: boolean) => void) | null = null
+    const coreStream = vi.fn(async function* () {
+      yield {
+        type: 'tool_call_start',
+        tool_call_id: 'tc1',
+        tool_call_name: 'Terminal'
+      } as LLMCoreStreamEvent
+      yield {
+        type: 'tool_call_chunk',
+        tool_call_id: 'tc1',
+        tool_call_arguments_chunk: '{"command":"dir"}'
+      } as LLMCoreStreamEvent
+      yield {
+        type: 'permission',
+        permission: {
+          providerId: 'acp',
+          requestId: 'req-acp-1',
+          tool_call_id: 'tc1',
+          tool_call_name: 'Terminal',
+          tool_call_params: '{"command":"dir"}',
+          description: 'components.messageBlockPermissionRequest.description.command',
+          permissionType: 'command',
+          server_name: 'Claude Agent',
+          command: 'dir',
+          metadata: { rememberable: false }
+        }
+      } as LLMCoreStreamEvent
+      await new Promise<void>((resolve) => {
+        releaseStream = resolve
+      })
+      yield { type: 'stop', stop_reason: 'complete' } as LLMCoreStreamEvent
+    }) as unknown as ProcessParams['coreStream']
+
+    const onStreamingProviderPermission = vi.fn(
+      (_permission, _tool, resolvePermission: (granted: boolean) => void) => {
+        commitDecision = resolvePermission
+      }
+    )
+    const params = createParams({
+      providerId: 'acp',
+      modelId: 'claude-code-acp',
+      coreStream,
+      hooks: { onStreamingProviderPermission }
+    })
+
+    const promise = processStream(params)
+    await vi.advanceTimersByTimeAsync(1)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(onStreamingProviderPermission).toHaveBeenCalledTimes(1)
+    expect(messageStore.updateAssistantContent).toHaveBeenCalled()
+
+    const pendingBlocks = (messageStore.updateAssistantContent as ReturnType<typeof vi.fn>).mock
+      .calls[0][1]
+    expect(pendingBlocks[0].type).toBe('tool_call')
+    expect(pendingBlocks[1]).toEqual(
+      expect.objectContaining({
+        type: 'action',
+        action_type: 'tool_call_permission',
+        status: 'pending',
+        extra: expect.objectContaining({
+          providerId: 'acp',
+          permissionRequestId: 'req-acp-1',
+          permissionType: 'command',
+          needsUserAction: true,
+          rememberable: false
+        })
+      })
+    )
+    expect(JSON.parse(pendingBlocks[1].extra.permissionRequest)).toEqual(
+      expect.objectContaining({
+        providerId: 'acp',
+        requestId: 'req-acp-1',
+        permissionType: 'command',
+        command: 'dir'
+      })
+    )
+
+    expect(commitDecision).not.toBeNull()
+    commitDecision?.(true)
+
+    const grantedBlocks = (messageStore.updateAssistantContent as ReturnType<typeof vi.fn>).mock
+      .calls[1][1]
+    expect(grantedBlocks[1].status).toBe('granted')
+    expect(grantedBlocks[1].extra.needsUserAction).toBe(false)
+    expect(grantedBlocks[1].extra.grantedPermissions).toBe('command')
+
+    releaseStream?.()
+    await vi.runAllTimersAsync()
+    await promise
+  })
+
   it('treats AbortError thrown before the first event as aborted without writing an error block', async () => {
     const abortError = new Error('Aborted')
     abortError.name = 'AbortError'

--- a/test/main/presenter/agentRuntimePresenter/process.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/process.test.ts
@@ -194,6 +194,15 @@ describe('processStream', () => {
           permissionType: 'command',
           server_name: 'Claude Agent',
           command: 'dir',
+          commandSignature: 'dir',
+          paths: ['C:/tmp/a.txt', '', 123 as unknown as string],
+          commandInfo: {
+            command: 'dir',
+            riskLevel: 'medium',
+            suggestion: 'Review before running.',
+            signature: 'dir',
+            baseCommand: 'dir'
+          },
           metadata: { rememberable: false }
         }
       } as LLMCoreStreamEvent
@@ -245,7 +254,16 @@ describe('processStream', () => {
         providerId: 'acp',
         requestId: 'req-acp-1',
         permissionType: 'command',
-        command: 'dir'
+        command: 'dir',
+        commandSignature: 'dir',
+        paths: ['C:/tmp/a.txt'],
+        commandInfo: {
+          command: 'dir',
+          riskLevel: 'medium',
+          suggestion: 'Review before running.',
+          signature: 'dir',
+          baseCommand: 'dir'
+        }
       })
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time permission handling during generation with streaming grant/deny flow and a session-scoped in‑flight registry.
  * Streaming permission hook to register and commit provider decisions; pending permission action blocks are created and updated when resolved.
  * Added "command" permission type and support for including command/paths/commandInfo in permission requests.
* **Tests**
  * New unit and integration tests covering streaming permission creation, grant/deny resolution, fallback paths, and lifecycle cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->