### PR TITLE
perf: Reduce renderer reflow and popup overhead during streaming

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -9,6 +9,7 @@ import tailwindcss from '@tailwindcss/vite'
 
 const isCustomElement = (tag: string) =>
   tag === 'voice-agent-widget' || tag.startsWith('ui-resource-renderer')
+const isVueDevToolsOverlayEnabled = process.env.DEEPCHAT_VUE_DEVTOOLS_OVERLAY !== '0'
 
 export default defineConfig({
   main: {
@@ -85,12 +86,14 @@ export default defineConfig({
         }
       }),
       svgLoader(),
-      vueDevTools(
-        {
-          appendTo:'src/renderer/src/main.ts'
-          // appendTo:'src/renderer/browser/main.ts'
-        }
-      )
+      ...(isVueDevToolsOverlayEnabled
+        ? [
+            vueDevTools({
+              appendTo: 'src/renderer/src/main.ts'
+              // appendTo:'src/renderer/browser/main.ts'
+            })
+          ]
+        : [])
     ],
     worker: {
       format: 'es'

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "typecheck": "pnpm run typecheck:node && pnpm run typecheck:web",
     "start": "electron-vite preview",
     "dev": "electron-vite dev --watch",
+    "dev:trace": "cross-env DEEPCHAT_VUE_DEVTOOLS_OVERLAY=0 electron-vite dev --watch",
     "dev:inspect": "electron-vite dev --watch --inspect=9229",
     "dev:linux": "electron-vite dev --watch --noSandbox",
     "build": "pnpm run typecheck && electron-vite build",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "katex": "^0.16.27",
     "lint-staged": "^16.4.0",
     "lucide-vue-next": "^0.544.0",
-    "markstream-vue": "0.0.12-beta.1",
+    "markstream-vue": "0.0.13-beta.0",
     "mermaid": "^11.13.0",
     "minimatch": "^10.2.4",
     "monaco-editor": "^0.52.2",

--- a/src/main/presenter/agentRuntimePresenter/dispatch.ts
+++ b/src/main/presenter/agentRuntimePresenter/dispatch.ts
@@ -24,6 +24,8 @@ import { nanoid } from 'nanoid'
 import type { ToolBatchOutputFitItem, ToolOutputGuard } from './toolOutputGuard'
 import { buildTerminalErrorBlocks } from './messageStore'
 import { finalizeTrailingPendingNarrativeBlocks } from './accumulator'
+import type { EchoHandle } from './echo'
+import { cloneBlocksForRenderer } from './echo'
 import {
   buildAssistantPreviewMarkdown,
   buildAssistantResponseMarkdown,
@@ -68,6 +70,8 @@ type PermissionRequestLike = {
   rememberable?: boolean
   paths?: string[]
 }
+
+type RendererFlushHandle = Pick<EchoHandle, 'flush' | 'schedule'>
 
 function extractTextFromBlocks(blocks: AssistantMessageBlock[]): string {
   return blocks
@@ -337,14 +341,27 @@ function shouldRefreshToolsAfterCall(toolName: string, rawData: MCPToolResponse)
   return toolResult?.activationApplied === true
 }
 
-function persistToolExecutionState(io: IoParams, state: StreamState): void {
+function scheduleRendererFlush(
+  state: StreamState,
+  rendererFlushHandle?: Pick<RendererFlushHandle, 'schedule'>
+): void {
   if (!state.dirty) {
     return
   }
 
-  flushBlocksToRenderer(io, state.blocks)
-  io.messageStore.updateAssistantContent(io.messageId, state.blocks)
-  state.dirty = false
+  rendererFlushHandle?.schedule()
+}
+
+function persistToolExecutionState(
+  _io: IoParams,
+  state: StreamState,
+  rendererFlushHandle?: Pick<RendererFlushHandle, 'schedule'>
+): void {
+  if (!state.dirty) {
+    return
+  }
+
+  scheduleRendererFlush(state, rendererFlushHandle)
 }
 
 function finalizePendingNarrativeBeforeToolExecution(state: StreamState): void {
@@ -596,7 +613,7 @@ function flushBlocksToRenderer(io: IoParams, blocks: AssistantMessageBlock[]): v
     conversationId: io.sessionId,
     eventId: io.messageId,
     messageId: io.messageId,
-    blocks: JSON.parse(JSON.stringify(blocks))
+    blocks: cloneBlocksForRenderer(blocks)
   })
 
   emitDeepChatInternalSessionUpdate({
@@ -623,6 +640,7 @@ export async function executeTools(
   toolOutputGuard: ToolOutputGuard,
   contextLength: number,
   maxTokens: number,
+  rendererFlushHandle: RendererFlushHandle,
   hooks?: ProcessHooks,
   providerId?: string
 ): Promise<{
@@ -632,7 +650,7 @@ export async function executeTools(
   terminalError?: string
 }> {
   finalizePendingNarrativeBeforeToolExecution(state)
-  persistToolExecutionState(io, state)
+  persistToolExecutionState(io, state, rendererFlushHandle)
 
   for (const tc of state.completedToolCalls) {
     const toolDef = tools.find((t) => t.function.name === tc.name)
@@ -726,7 +744,7 @@ export async function executeTools(
           updateToolCallBlock(state.blocks, tc.id, errorText, true)
           state.dirty = true
           executed += 1
-          persistToolExecutionState(io, state)
+          persistToolExecutionState(io, state, rendererFlushHandle)
           continue
         }
 
@@ -792,8 +810,8 @@ export async function executeTools(
           update.responseMarkdown,
           update.progressJson
         )
-        flushBlocksToRenderer(io, state.blocks)
-        io.messageStore.updateAssistantContent(io.messageId, state.blocks)
+        state.dirty = true
+        scheduleRendererFlush(state, rendererFlushHandle)
       }
 
       const toolCallResult = await toolPresenter.callTool(toolCall, {
@@ -940,7 +958,7 @@ export async function executeTools(
       hooks,
       appendToConversation: fittedResults.kind === 'ok'
     })
-    persistToolExecutionState(io, state)
+    persistToolExecutionState(io, state, rendererFlushHandle)
 
     if (fittedResults.kind === 'terminal_error') {
       return {
@@ -952,7 +970,7 @@ export async function executeTools(
     }
   }
 
-  persistToolExecutionState(io, state)
+  persistToolExecutionState(io, state, rendererFlushHandle)
   return { executed, pendingInteractions, toolsChanged }
 }
 

--- a/src/main/presenter/agentRuntimePresenter/dispatch.ts
+++ b/src/main/presenter/agentRuntimePresenter/dispatch.ts
@@ -71,7 +71,7 @@ type PermissionRequestLike = {
   paths?: string[]
 }
 
-type RendererFlushHandle = Pick<EchoHandle, 'flush' | 'schedule'>
+type RendererFlushHandle = Pick<EchoHandle, 'flush' | 'schedule' | 'rescheduleRenderer'>
 
 function extractTextFromBlocks(blocks: AssistantMessageBlock[]): string {
   return blocks
@@ -346,6 +346,22 @@ function scheduleRendererFlush(
   rendererFlushHandle?: Pick<RendererFlushHandle, 'schedule'>
 ): void {
   if (!state.dirty) {
+    return
+  }
+
+  rendererFlushHandle?.schedule()
+}
+
+function rescheduleRendererFlush(
+  state: StreamState,
+  rendererFlushHandle?: Pick<RendererFlushHandle, 'schedule' | 'rescheduleRenderer'>
+): void {
+  if (!state.dirty) {
+    return
+  }
+
+  if (rendererFlushHandle?.rescheduleRenderer) {
+    rendererFlushHandle.rescheduleRenderer()
     return
   }
 
@@ -757,6 +773,7 @@ export async function executeTools(
         })
         pendingInteractions.push(interaction)
         updateToolCallBlock(state.blocks, tc.id, '', false)
+        rescheduleRendererFlush(state, rendererFlushHandle)
         continue
       }
 
@@ -789,6 +806,7 @@ export async function executeTools(
           )
           pendingInteractions.push(interaction)
           updateToolCallBlock(state.blocks, tc.id, '', false)
+          rescheduleRendererFlush(state, rendererFlushHandle)
           continue
         }
       }
@@ -852,6 +870,7 @@ export async function executeTools(
             )
             pendingInteractions.push(interaction)
             updateToolCallBlock(state.blocks, tc.id, '', false)
+            rescheduleRendererFlush(state, rendererFlushHandle)
             continue
           }
         }

--- a/src/main/presenter/agentRuntimePresenter/echo.ts
+++ b/src/main/presenter/agentRuntimePresenter/echo.ts
@@ -1,3 +1,4 @@
+import type { AssistantMessageBlock } from '@shared/types/agent-interface'
 import type { StreamState, IoParams } from './types'
 import { createThrottle } from '@shared/utils/throttle'
 import { eventBus, SendTarget } from '@/eventbus'
@@ -7,8 +8,23 @@ const RENDERER_FLUSH_INTERVAL = 120
 const DB_FLUSH_INTERVAL = 600
 
 export interface EchoHandle {
+  schedule(): void
   flush(): void
   stop(): void
+}
+
+export function cloneBlocksForRenderer(blocks: AssistantMessageBlock[]): AssistantMessageBlock[] {
+  const clone = (
+    globalThis as typeof globalThis & {
+      structuredClone?: <T>(value: T) => T
+    }
+  ).structuredClone
+
+  if (typeof clone === 'function') {
+    return clone(blocks)
+  }
+
+  return JSON.parse(JSON.stringify(blocks)) as AssistantMessageBlock[]
 }
 
 export function startEcho(state: StreamState, io: IoParams): EchoHandle {
@@ -17,7 +33,7 @@ export function startEcho(state: StreamState, io: IoParams): EchoHandle {
       conversationId: io.sessionId,
       eventId: io.messageId,
       messageId: io.messageId,
-      blocks: JSON.parse(JSON.stringify(state.blocks))
+      blocks: cloneBlocksForRenderer(state.blocks)
     })
   }
 
@@ -41,18 +57,21 @@ export function startEcho(state: StreamState, io: IoParams): EchoHandle {
     }
   }, DB_FLUSH_INTERVAL)
 
-  const rendererTimer = setInterval(rendererThrottle, RENDERER_FLUSH_INTERVAL)
-  const dbTimer = setInterval(dbThrottle, DB_FLUSH_INTERVAL)
-
   return {
+    schedule(): void {
+      if (!state.dirty) {
+        return
+      }
+
+      rendererThrottle()
+      dbThrottle()
+    },
     flush(): void {
       flushToRenderer()
       flushToDb()
       state.dirty = false
     },
     stop(): void {
-      clearInterval(rendererTimer)
-      clearInterval(dbTimer)
       rendererThrottle.cancel()
       dbThrottle.cancel()
     }

--- a/src/main/presenter/agentRuntimePresenter/echo.ts
+++ b/src/main/presenter/agentRuntimePresenter/echo.ts
@@ -9,6 +9,7 @@ const DB_FLUSH_INTERVAL = 600
 
 export interface EchoHandle {
   schedule(): void
+  rescheduleRenderer(): void
   flush(): void
   stop(): void
 }
@@ -64,6 +65,14 @@ export function startEcho(state: StreamState, io: IoParams): EchoHandle {
       }
 
       rendererThrottle()
+      dbThrottle()
+    },
+    rescheduleRenderer(): void {
+      if (!state.dirty) {
+        return
+      }
+
+      rendererThrottle.reschedule()
       dbThrottle()
     },
     flush(): void {

--- a/src/main/presenter/agentRuntimePresenter/process.ts
+++ b/src/main/presenter/agentRuntimePresenter/process.ts
@@ -368,6 +368,7 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
         }
 
         accumulate(state, event)
+        echo.schedule()
       }
 
       console.log(
@@ -411,6 +412,7 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
         params.toolOutputGuard,
         modelConfig.contextLength > 0 ? modelConfig.contextLength : UNKNOWN_CONTEXT_LIMIT,
         maxTokens,
+        echo,
         hooks,
         providerId
       )

--- a/src/renderer/src/components/message/MessageBlockToolCall.vue
+++ b/src/renderer/src/components/message/MessageBlockToolCall.vue
@@ -19,12 +19,8 @@
         <span
           v-if="summaryText"
           data-testid="tool-call-summary"
-          ref="summaryElement"
-          :class="[
-            'tool-call-summary text-[11px]',
-            { 'tool-call-summary--overflowing': isSummaryOverflowing }
-          ]"
-          :title="isSummaryOverflowing ? summaryText : undefined"
+          class="tool-call-summary text-[11px]"
+          :title="summaryText"
         >
           {{ summaryText }}
         </span>
@@ -180,7 +176,7 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { CodeBlockNode } from 'markstream-vue'
 import { summarizeToolCallPreview } from '@shared/lib/toolCallSummary'
 import { useThemeStore } from '@/stores/theme'
@@ -218,9 +214,6 @@ const coerceNumericParam = (value: unknown): number | null => {
 const isExpanded = ref(false)
 const expansionSource = ref<ExpansionSource>(null)
 const autoExpandDismissed = ref(false)
-const summaryElement = ref<HTMLElement | null>(null)
-const isSummaryOverflowing = ref(false)
-let summaryResizeObserver: ResizeObserver | null = null
 
 const statusVariant = computed(() => {
   if (props.block.status === 'error') return 'error'
@@ -380,16 +373,6 @@ const subagentTasks = computed<SubagentProgressTask[]>(() => {
     }
   })
 })
-
-const updateSummaryOverflow = () => {
-  const element = summaryElement.value
-  if (!element || !summaryText.value) {
-    isSummaryOverflowing.value = false
-    return
-  }
-
-  isSummaryOverflowing.value = element.scrollWidth - element.clientWidth > 1
-}
 
 const isExecTool = computed(() => {
   const toolName = rawToolName.value
@@ -566,20 +549,6 @@ watch(toolCallIdentity, (nextIdentity, previousIdentity) => {
   }
 })
 
-watch(summaryElement, (nextElement, previousElement) => {
-  if (summaryResizeObserver && previousElement) {
-    summaryResizeObserver.unobserve(previousElement)
-  }
-  if (summaryResizeObserver && nextElement) {
-    summaryResizeObserver.observe(nextElement)
-  }
-  void nextTick(updateSummaryOverflow)
-})
-
-watch(summaryText, () => {
-  void nextTick(updateSummaryOverflow)
-})
-
 watch(
   [() => props.block.status, shouldAutoExpand],
   ([status, autoExpandable], previousValue) => {
@@ -587,25 +556,6 @@ watch(
   },
   { immediate: true }
 )
-
-onMounted(() => {
-  if (typeof ResizeObserver !== 'undefined') {
-    summaryResizeObserver = new ResizeObserver(() => {
-      updateSummaryOverflow()
-    })
-
-    if (summaryElement.value) {
-      summaryResizeObserver.observe(summaryElement.value)
-    }
-  }
-
-  void nextTick(updateSummaryOverflow)
-})
-
-onBeforeUnmount(() => {
-  summaryResizeObserver?.disconnect()
-  summaryResizeObserver = null
-})
 
 const paramsCopyText = ref(t('common.copy'))
 const responseCopyText = ref(t('common.copy'))
@@ -712,16 +662,12 @@ function getSubagentStatusLabel(status: string): string {
   min-width: 0;
   display: block;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
   line-height: 1.2;
   padding-block: 1px;
   color: hsl(var(--muted-foreground) / 0.9);
   font-weight: 400;
-}
-
-.tool-call-summary--overflowing {
-  mask-image: linear-gradient(to right, #000 calc(100% - 1.5rem), transparent);
-  -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 1.5rem), transparent);
 }
 
 .tool-call-status-ring {

--- a/src/renderer/src/components/message/MessageItemUser.vue
+++ b/src/renderer/src/components/message/MessageItemUser.vue
@@ -34,11 +34,7 @@
           <textarea
             ref="editTextarea"
             v-model="editedText"
-            class="text-sm bg-muted dark:bg-muted rounded-lg p-2 border flex flex-col gap-1.5 resize-none overflow-y-auto overscroll-contain min-w-[40vw] w-full"
-            :style="{
-              width: originalContentWidth + 20 + 'px',
-              maxHeight: editMaxHeight ? editMaxHeight + 'px' : undefined
-            }"
+            class="text-sm bg-muted dark:bg-muted rounded-lg p-2 border flex flex-col gap-1.5 resize-none overflow-y-auto overscroll-contain min-w-[40vw] w-full max-h-[60vh]"
             rows="1"
             @input="autoResize"
             @keydown.meta.enter.prevent="saveEdit"
@@ -46,20 +42,16 @@
             @keydown.esc="cancelEdit"
           ></textarea>
         </div>
-        <div v-else ref="originalContent" class="flex w-full min-w-0 flex-col items-end gap-1.5">
+        <div v-else class="flex w-full min-w-0 flex-col items-end gap-1.5">
           <div
-            ref="contentBody"
             data-user-message-content-body="true"
             :data-user-message-collapsible="String(isCollapsible)"
             :data-user-message-expanded="String(isExpanded)"
             class="relative w-full min-w-0"
-            :class="{ 'overflow-hidden': shouldClampContent }"
-            :style="contentBodyStyle"
           >
             <div
-              ref="contentMeasure"
-              data-user-message-content-measure="true"
               class="w-full min-w-0"
+              :class="{ 'user-message-content--clamped': shouldClampContent }"
             >
               <MessageContent
                 v-if="message.content.content && message.content.content.length > 0"
@@ -119,11 +111,10 @@ import MessageToolbar from './MessageToolbar.vue'
 import MessageContent from './MessageContent.vue'
 import MessageTextContent from './MessageTextContent.vue'
 import { usePresenter } from '@/composables/usePresenter'
-import { computed, ref, watch, onMounted, nextTick, onBeforeUnmount } from 'vue'
+import { computed, ref, watch, nextTick } from 'vue'
 
 const COLLAPSE_CHAR_THRESHOLD = 600
 const COLLAPSE_EXPLICIT_LINE_THRESHOLD = 8
-const COLLAPSE_PREVIEW_LINE_COUNT = 12
 
 type DisplayUserMessageRichBlock =
   | DisplayUserMessageTextBlock
@@ -165,127 +156,20 @@ const props = defineProps<{
 
 const isEditMode = ref(false)
 const editedText = ref('')
-const originalContent = ref<HTMLDivElement | null>(null)
-const contentBody = ref<HTMLDivElement | null>(null)
-const contentMeasure = ref<HTMLDivElement | null>(null)
 const editTextarea = ref<HTMLTextAreaElement | null>(null)
-const editMaxHeight = ref(0)
-const originalContentWidth = ref(0)
-const isCollapsible = ref(false)
 const isExpanded = ref(true)
-const collapsedContentHeight = ref(0)
 const hasManualCollapsePreference = ref(false)
 const visibleMessageText = computed(() => getVisibleMessageText(props.message))
+const explicitLineCount = computed(() =>
+  visibleMessageText.value ? visibleMessageText.value.split(/\r\n|\r|\n/).length : 0
+)
+const isCollapsible = computed(
+  () =>
+    visibleMessageText.value.length >= COLLAPSE_CHAR_THRESHOLD ||
+    explicitLineCount.value >= COLLAPSE_EXPLICIT_LINE_THRESHOLD
+)
 const shouldClampContent = computed(() => isCollapsible.value && !isExpanded.value)
 const showFadeMask = computed(() => shouldClampContent.value)
-const contentBodyStyle = computed(() => {
-  if (!shouldClampContent.value || collapsedContentHeight.value <= 0) {
-    return undefined
-  }
-  return {
-    maxHeight: `${collapsedContentHeight.value}px`
-  }
-})
-
-let contentResizeObserver: ResizeObserver | null = null
-
-const getEffectiveLineHeight = (element: HTMLElement) => {
-  const styles = window.getComputedStyle(element)
-  const explicitLineHeight = Number.parseFloat(styles.lineHeight || '')
-  if (Number.isFinite(explicitLineHeight)) {
-    return explicitLineHeight
-  }
-
-  const fontSize = Number.parseFloat(styles.fontSize || '')
-  if (Number.isFinite(fontSize)) {
-    return fontSize * 1.5
-  }
-
-  return 24
-}
-
-const syncOriginalContentMetrics = () => {
-  const widthSource = contentBody.value ?? originalContent.value
-  if (!widthSource) return
-  originalContentWidth.value = widthSource.offsetWidth
-}
-
-const evaluateContentLayout = () => {
-  const measureTarget = contentMeasure.value
-  if (!measureTarget || isEditMode.value) {
-    return
-  }
-
-  const previewHeight = Math.ceil(
-    getEffectiveLineHeight(measureTarget) * COLLAPSE_PREVIEW_LINE_COUNT
-  )
-  const actualHeight = Math.max(measureTarget.scrollHeight, measureTarget.offsetHeight)
-  const explicitLineCount = visibleMessageText.value
-    ? visibleMessageText.value.split(/\r\n|\r|\n/).length
-    : 0
-  const exceedsTextThreshold =
-    visibleMessageText.value.length >= COLLAPSE_CHAR_THRESHOLD ||
-    explicitLineCount >= COLLAPSE_EXPLICIT_LINE_THRESHOLD
-  const shouldCollapse = exceedsTextThreshold && actualHeight > previewHeight + 1
-  const wasCollapsible = isCollapsible.value
-
-  collapsedContentHeight.value = previewHeight
-  isCollapsible.value = shouldCollapse
-
-  if (!shouldCollapse) {
-    isExpanded.value = true
-    hasManualCollapsePreference.value = false
-    return
-  }
-
-  if (!wasCollapsible || !hasManualCollapsePreference.value) {
-    isExpanded.value = false
-  }
-}
-
-const scheduleContentLayoutEvaluation = () => {
-  if (isEditMode.value) {
-    return
-  }
-
-  nextTick(() => {
-    syncOriginalContentMetrics()
-    evaluateContentLayout()
-  })
-}
-
-onMounted(() => {
-  syncOriginalContentMetrics()
-  scheduleContentLayoutEvaluation()
-
-  if (typeof ResizeObserver !== 'undefined') {
-    contentResizeObserver = new ResizeObserver(() => {
-      if (isEditMode.value) {
-        return
-      }
-      syncOriginalContentMetrics()
-      evaluateContentLayout()
-    })
-
-    if (originalContent.value) {
-      contentResizeObserver.observe(originalContent.value)
-    }
-    if (contentMeasure.value) {
-      contentResizeObserver.observe(contentMeasure.value)
-    }
-  }
-})
-
-watch(isEditMode, (newValue) => {
-  if (newValue) {
-    syncOriginalContentMetrics()
-    computeEditMaxHeight()
-    nextTick(() => autoResize())
-    return
-  }
-
-  scheduleContentLayoutEvaluation()
-})
 
 const emit = defineEmits<{
   fileClick: [fileName: string]
@@ -319,7 +203,6 @@ const startEdit = () => {
   } else {
     editedText.value = props.message.content.text || ''
   }
-  computeEditMaxHeight()
   nextTick(() => autoResize())
 }
 
@@ -389,10 +272,9 @@ const autoResize = () => {
   const el = editTextarea.value
   if (!el) return
   el.style.height = 'auto'
-  const computed = window.getComputedStyle(el)
-  const maxH = parseFloat(computed.maxHeight || '')
+  const maxH = Math.max(120, Math.floor(window.innerHeight * 0.6))
   const scrollH = el.scrollHeight
-  const target = Number.isFinite(maxH) && maxH > 0 ? Math.min(scrollH, maxH) : scrollH
+  const target = Math.min(scrollH, maxH)
   el.style.height = target + 'px'
   if (scrollH > target) {
     el.style.overflowY = 'auto'
@@ -406,56 +288,31 @@ watch(editedText, () => {
 })
 
 watch(
-  () => [props.message.id, visibleMessageText.value] as const,
-  () => {
-    scheduleContentLayoutEvaluation()
-  }
+  () => [props.message.id, visibleMessageText.value, isCollapsible.value] as const,
+  ([messageId, visibleText, collapsible], previousValue) => {
+    if (!collapsible) {
+      isExpanded.value = true
+      hasManualCollapsePreference.value = false
+      return
+    }
+
+    if (
+      previousValue?.[0] !== messageId ||
+      previousValue?.[1] !== visibleText ||
+      !hasManualCollapsePreference.value
+    ) {
+      isExpanded.value = false
+    }
+  },
+  { immediate: true }
 )
-
-watch(originalContent, (nextElement, previousElement) => {
-  if (!contentResizeObserver) {
-    return
-  }
-  if (previousElement) {
-    contentResizeObserver.unobserve(previousElement)
-  }
-  if (nextElement) {
-    contentResizeObserver.observe(nextElement)
-  }
-})
-
-watch(contentMeasure, (nextElement, previousElement) => {
-  if (!contentResizeObserver) {
-    return
-  }
-  if (previousElement) {
-    contentResizeObserver.unobserve(previousElement)
-  }
-  if (nextElement) {
-    contentResizeObserver.observe(nextElement)
-  }
-})
-
-const computeEditMaxHeight = () => {
-  const container = document.querySelector('.message-list-container') as HTMLElement | null
-  const base = container?.clientHeight || window.innerHeight
-  editMaxHeight.value = Math.max(120, Math.floor(base * 0.6))
-}
-
-const handleWindowResize = () => {
-  if (isEditMode.value) {
-    computeEditMaxHeight()
-    nextTick(() => autoResize())
-    return
-  }
-
-  scheduleContentLayoutEvaluation()
-}
-
-window.addEventListener('resize', handleWindowResize)
-onBeforeUnmount(() => {
-  contentResizeObserver?.disconnect()
-  contentResizeObserver = null
-  window.removeEventListener('resize', handleWindowResize)
-})
 </script>
+
+<style scoped>
+.user-message-content--clamped {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 12;
+}
+</style>

--- a/src/renderer/src/components/popup/TranslatePopup.vue
+++ b/src/renderer/src/components/popup/TranslatePopup.vue
@@ -3,12 +3,14 @@
     <div
       v-if="isOpen"
       ref="popupRef"
-      class="fixed z-50 w-[500px] bg-background border rounded-lg shadow-lg"
-      :style="{ top: position.y + 'px', left: position.x + 'px' }"
+      class="translate-popup fixed left-0 top-0 z-50 w-[500px] rounded-lg border bg-background shadow-lg"
+      :style="popupStyle"
+      data-translate-popup="true"
     >
       <div
-        class="flex items-center justify-between p-4 border-b cursor-move"
-        @mousedown="startDrag"
+        class="translate-popup__header flex cursor-move items-center justify-between border-b p-4"
+        data-translate-popup-header="true"
+        @pointerdown="startDrag"
       >
         <h3 class="text-lg font-semibold">{{ t('contextMenu.translate.title') }}</h3>
         <Button variant="ghost" size="icon" @click="close">
@@ -36,7 +38,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { usePresenter } from '@/composables/usePresenter'
 import { useAgentStore } from '@/stores/ui/agent'
@@ -47,84 +49,172 @@ const { t, locale } = useI18n()
 const agentSessionPresenter = usePresenter('agentSessionPresenter')
 const agentStore = useAgentStore()
 
-// 状态
 const isOpen = ref(false)
 const text = ref('')
 const translatedText = ref('')
 const isTranslating = ref(false)
 const popupRef = ref<HTMLElement | null>(null)
 
-// 窗口位置状态
 const position = ref({ x: 100, y: 100 })
 
-// 拖动相关状态
 const isDragging = ref(false)
 const dragStart = ref({ x: 0, y: 0 })
+const dragBounds = {
+  minX: 0,
+  maxX: 0,
+  minY: 0,
+  maxY: 0
+}
+let dragFrameId: number | null = null
+let pendingDragPosition: { x: number; y: number } | null = null
 
 const POPUP_WIDTH = 500
 const POPUP_HEIGHT = 220
-const VISIBLE_EDGE = 40 // 保证至少40px可见
+const VISIBLE_EDGE = 40
+const DRAG_EXCLUDED_SELECTOR = 'button, a, input, textarea, select, [role="button"]'
 
-// 开始拖动
-const startDrag = (event: MouseEvent) => {
+const popupStyle = computed(() => ({
+  transform: `translate3d(${position.value.x}px, ${position.value.y}px, 0)`
+}))
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
+
+const getPopupRect = () => popupRef.value?.getBoundingClientRect()
+
+const getBounds = () => {
+  const rect = getPopupRect()
+  const width = rect?.width || POPUP_WIDTH
+  const height = rect?.height || POPUP_HEIGHT
+
+  return {
+    minX: -(width - VISIBLE_EDGE),
+    maxX: window.innerWidth - VISIBLE_EDGE,
+    minY: -(height - VISIBLE_EDGE),
+    maxY: window.innerHeight - VISIBLE_EDGE
+  }
+}
+
+const applyPosition = (x: number, y: number, bounds = getBounds()) => {
+  position.value = {
+    x: clamp(x, bounds.minX, bounds.maxX),
+    y: clamp(y, bounds.minY, bounds.maxY)
+  }
+}
+
+const flushPendingDragPosition = () => {
+  dragFrameId = null
+
+  if (!pendingDragPosition) {
+    return
+  }
+
+  const nextPosition = pendingDragPosition
+  pendingDragPosition = null
+  position.value = nextPosition
+}
+
+const scheduleDragPosition = (x: number, y: number) => {
+  pendingDragPosition = { x, y }
+
+  if (dragFrameId !== null) {
+    return
+  }
+
+  dragFrameId = window.requestAnimationFrame(flushPendingDragPosition)
+}
+
+const removeDragListeners = () => {
+  window.removeEventListener('pointermove', handleDrag)
+  window.removeEventListener('pointerup', stopDrag)
+  window.removeEventListener('pointercancel', stopDrag)
+}
+
+const addDragListeners = () => {
+  window.addEventListener('pointermove', handleDrag, { passive: true })
+  window.addEventListener('pointerup', stopDrag)
+  window.addEventListener('pointercancel', stopDrag)
+}
+
+const startDrag = (event: PointerEvent) => {
+  if (event.button !== 0) {
+    return
+  }
+
+  const target = event.target as HTMLElement | null
+  if (target?.closest(DRAG_EXCLUDED_SELECTOR)) {
+    return
+  }
+
+  event.preventDefault()
+  const bounds = getBounds()
+
+  dragBounds.minX = bounds.minX
+  dragBounds.maxX = bounds.maxX
+  dragBounds.minY = bounds.minY
+  dragBounds.maxY = bounds.maxY
+
   isDragging.value = true
   dragStart.value = {
     x: event.clientX - position.value.x,
     y: event.clientY - position.value.y
   }
+  addDragListeners()
 }
-
-// 处理拖动
-const getMaxX = () => window.innerWidth - VISIBLE_EDGE
-const getMinX = () => -(POPUP_WIDTH - VISIBLE_EDGE)
-const getMaxY = () => window.innerHeight - VISIBLE_EDGE
-const getMinY = (ref: HTMLElement | null) => -((ref?.offsetHeight || POPUP_HEIGHT) - VISIBLE_EDGE)
 
 const handleDrag = (event: MouseEvent) => {
   if (!isDragging.value) return
 
-  let newX = event.clientX - dragStart.value.x
-  let newY = event.clientY - dragStart.value.y
-
-  newX = Math.max(getMinX(), Math.min(newX, getMaxX()))
-  newY = Math.max(getMinY(popupRef.value), Math.min(newY, getMaxY()))
-  position.value = { x: newX, y: newY }
+  const newX = clamp(event.clientX - dragStart.value.x, dragBounds.minX, dragBounds.maxX)
+  const newY = clamp(event.clientY - dragStart.value.y, dragBounds.minY, dragBounds.maxY)
+  scheduleDragPosition(newX, newY)
 }
 
-// 结束拖动
 const stopDrag = () => {
+  if (!isDragging.value && dragFrameId === null && !pendingDragPosition) {
+    return
+  }
+
   isDragging.value = false
+  removeDragListeners()
+
+  if (dragFrameId !== null) {
+    window.cancelAnimationFrame(dragFrameId)
+    dragFrameId = null
+  }
+
+  if (pendingDragPosition) {
+    position.value = pendingDragPosition
+    pendingDragPosition = null
+  }
 }
 
-// 关闭弹窗
 const close = () => {
+  stopDrag()
   isOpen.value = false
   text.value = ''
   translatedText.value = ''
   isTranslating.value = false
 }
 
-// 处理翻译请求
+const clampPopupToViewport = async (nextX = position.value.x, nextY = position.value.y) => {
+  await nextTick()
+  applyPosition(nextX, nextY)
+}
+
 const handleTranslateRequest = async (event: Event) => {
   const customEvent = event as CustomEvent<{ text: string; x?: number; y?: number }>
   const { text: newText, x, y } = customEvent.detail
 
+  stopDrag()
   text.value = newText
-  if (typeof x === 'number' && typeof y === 'number') {
-    const posX = x
-    const posY = y
-    position.value = {
-      x: Math.max(0, posX),
-      y: Math.max(0, posY)
-    }
-    if (posX + POPUP_WIDTH > getMaxX()) {
-      position.value.x = getMaxX() - POPUP_WIDTH
-    }
-  }
-
   isOpen.value = true
   isTranslating.value = true
   translatedText.value = ''
+
+  await clampPopupToViewport(
+    typeof x === 'number' ? x : position.value.x,
+    typeof y === 'number' ? y : position.value.y
+  )
 
   try {
     const result = await agentSessionPresenter.translateText(
@@ -137,24 +227,32 @@ const handleTranslateRequest = async (event: Event) => {
     translatedText.value = t('contextMenu.translate.error')
   } finally {
     isTranslating.value = false
+    await clampPopupToViewport()
   }
 }
 
 onMounted(() => {
   window.addEventListener('context-menu-translate-text', handleTranslateRequest)
-  document.addEventListener('mousemove', handleDrag)
-  document.addEventListener('mouseup', stopDrag)
 })
 
 onUnmounted(() => {
+  stopDrag()
   window.removeEventListener('context-menu-translate-text', handleTranslateRequest)
-  document.removeEventListener('mousemove', handleDrag)
-  document.removeEventListener('mouseup', stopDrag)
 })
 </script>
 
 <style scoped>
-.cursor-move {
+.translate-popup {
+  contain: layout paint;
+  will-change: transform;
+}
+
+.translate-popup__header {
+  touch-action: none;
+}
+
+.cursor-move,
+.translate-popup__header {
   cursor: move;
 }
 </style>

--- a/src/renderer/src/components/sidepanel/WorkspacePanel.vue
+++ b/src/renderer/src/components/sidepanel/WorkspacePanel.vue
@@ -135,8 +135,6 @@ import { useArtifactStore } from '@/stores/artifact'
 import { useMessageStore } from '@/stores/ui/message'
 import { useSidepanelStore, type WorkspaceArtifactContext } from '@/stores/ui/sidepanel'
 import type { WorkspaceGitFileChange } from '@shared/presenter'
-import type { ChatMessageRecord } from '@shared/types/agent-interface'
-import type { DisplayAssistantMessageBlock } from '@/components/chat/messageListItems'
 
 const props = defineProps<{
   sessionId: string
@@ -179,16 +177,6 @@ const {
   sidepanelStore
 })
 
-const parseAssistantBlocks = (record: ChatMessageRecord) => {
-  try {
-    return JSON.parse(record.content) as Array<
-      Pick<DisplayAssistantMessageBlock, 'content' | 'status'>
-    >
-  } catch {
-    return []
-  }
-}
-
 const artifactItems = computed<ArtifactItem[]>(() => {
   const items: ArtifactItem[] = []
 
@@ -197,7 +185,7 @@ const artifactItems = computed<ArtifactItem[]>(() => {
       continue
     }
 
-    for (const block of parseAssistantBlocks(message)) {
+    for (const block of messageStore.getAssistantMessageBlocks(message)) {
       for (const artifact of extractArtifactsFromContent(block.content ?? '', block.status)) {
         items.push({
           key: `${message.id}:${artifact.identifier}`,

--- a/src/renderer/src/pages/ChatPage.vue
+++ b/src/renderer/src/pages/ChatPage.vue
@@ -180,6 +180,8 @@ const displayMessageCache = new Map<
   string,
   {
     updatedAt: number
+    content: ChatMessageRecord['content']
+    metadata: ChatMessageRecord['metadata']
     modelId: string
     providerId: string
     status: DisplayMessage['status']
@@ -345,6 +347,8 @@ function toDisplayMessage(record: ChatMessageRecord): DisplayMessage {
   if (
     cached &&
     cached.updatedAt === record.updatedAt &&
+    cached.content === record.content &&
+    cached.metadata === record.metadata &&
     cached.modelId === modelId &&
     cached.providerId === providerId &&
     cached.status === record.status
@@ -387,6 +391,8 @@ function toDisplayMessage(record: ChatMessageRecord): DisplayMessage {
 
   displayMessageCache.set(record.id, {
     updatedAt: record.updatedAt,
+    content: record.content,
+    metadata: record.metadata,
     modelId,
     providerId,
     status: record.status,
@@ -492,6 +498,7 @@ watch(
     () => messageStore.messageIds.length,
     () => messageStore.currentStreamMessageId,
     () => messageStore.streamRevision,
+    () => messageStore.lastPersistedRevision,
     () => ephemeralRateLimitMessageId.value
   ],
   () => {

--- a/src/renderer/src/pages/ChatPage.vue
+++ b/src/renderer/src/pages/ChatPage.vue
@@ -112,8 +112,7 @@ import MessageList from '@/components/chat/MessageList.vue'
 import type {
   DisplayAssistantMessageBlock,
   DisplayMessage,
-  DisplayMessageUsage,
-  DisplayUserMessageContent
+  DisplayMessageUsage
 } from '@/components/chat/messageListItems'
 import ChatInputBox from '@/components/chat/ChatInputBox.vue'
 import ChatInputToolbar from '@/components/chat/ChatInputToolbar.vue'
@@ -177,6 +176,16 @@ const NEAR_BOTTOM_THRESHOLD = 80 // px
 const MESSAGE_JUMP_RETRY_INTERVAL = 80
 const MESSAGE_HIGHLIGHT_DURATION = 2000
 const MAX_MESSAGE_JUMP_RETRIES = 8
+const displayMessageCache = new Map<
+  string,
+  {
+    updatedAt: number
+    modelId: string
+    providerId: string
+    status: DisplayMessage['status']
+    message: DisplayMessage
+  }
+>()
 const traceMessageId = ref<string | null>(null)
 const isChatSearchOpen = ref(false)
 const chatSearchQuery = ref('')
@@ -187,18 +196,59 @@ const chatSearchBarRef = ref<{
   selectInput: () => void
 } | null>(null)
 let spotlightJumpTimer: number | null = null
+let scrollReadFrame: number | null = null
+let scrollWriteFrame: number | null = null
+let pendingForcedScroll = false
+let lastObservedScrollHeight = 0
 
-function scrollToBottom() {
+function syncScrollPosition() {
   const el = scrollContainer.value
   if (!el) return
-  el.scrollTop = el.scrollHeight
+  lastObservedScrollHeight = el.scrollHeight
+  const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+  isNearBottom.value = distanceFromBottom <= NEAR_BOTTOM_THRESHOLD
+}
+
+function scheduleScrollMetricsRead() {
+  if (scrollReadFrame !== null) {
+    return
+  }
+
+  scrollReadFrame = window.requestAnimationFrame(() => {
+    scrollReadFrame = null
+    syncScrollPosition()
+  })
+}
+
+function scrollToBottom(force = false) {
+  pendingForcedScroll = pendingForcedScroll || force
+  if (scrollWriteFrame !== null) {
+    return
+  }
+
+  scrollWriteFrame = window.requestAnimationFrame(() => {
+    scrollWriteFrame = null
+
+    const el = scrollContainer.value
+    if (!el) {
+      pendingForcedScroll = false
+      return
+    }
+
+    const shouldForce = pendingForcedScroll
+    pendingForcedScroll = false
+    const nextScrollHeight = el.scrollHeight
+
+    if (shouldForce || nextScrollHeight > lastObservedScrollHeight) {
+      el.scrollTop = nextScrollHeight
+    }
+
+    syncScrollPosition()
+  })
 }
 
 function onScroll() {
-  const el = scrollContainer.value
-  if (!el) return
-  const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-  isNearBottom.value = distanceFromBottom <= NEAR_BOTTOM_THRESHOLD
+  scheduleScrollMetricsRead()
 }
 
 async function focusPendingSpotlightMessageJump(attempt = 0): Promise<void> {
@@ -248,65 +298,22 @@ watch(
   () => props.sessionId,
   async (id) => {
     clearChatSearchState()
+    displayMessageCache.clear()
     if (id) {
       await Promise.all([messageStore.loadMessages(id), pendingInputStore.loadPendingInputs(id)])
       await nextTick()
+      syncScrollPosition()
       if (spotlightStore.pendingMessageJump?.sessionId === id) {
         void focusPendingSpotlightMessageJump()
         return
       }
-      scrollToBottom()
+      scrollToBottom(true)
       return
     }
     pendingInputStore.clear()
   },
   { immediate: true }
 )
-
-function parseUserMessageContent(record: ChatMessageRecord): DisplayUserMessageContent {
-  try {
-    const parsed = JSON.parse(record.content) as DisplayUserMessageContent
-    if (parsed && typeof parsed === 'object') {
-      return {
-        text: parsed.text ?? '',
-        files: parsed.files ?? [],
-        links: parsed.links ?? [],
-        search: parsed.search ?? false,
-        think: parsed.think ?? false,
-        continue: parsed.continue,
-        resources: parsed.resources,
-        prompts: parsed.prompts,
-        content: parsed.content
-      }
-    }
-  } catch {}
-
-  return {
-    text: '',
-    files: [],
-    links: [],
-    search: false,
-    think: false
-  }
-}
-
-function parseAssistantMessageContent(record: ChatMessageRecord): DisplayAssistantMessageBlock[] {
-  try {
-    const parsed = JSON.parse(record.content) as DisplayAssistantMessageBlock[]
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-function parseMessageMetadata(record: ChatMessageRecord): MessageMetadata {
-  try {
-    const parsed = JSON.parse(record.metadata) as MessageMetadata
-    return parsed && typeof parsed === 'object' ? parsed : {}
-  } catch {
-    return {}
-  }
-}
 
 function resolveAssistantModelName(modelId: string): string {
   if (!modelId) {
@@ -331,9 +338,20 @@ function buildUsage(metadata: MessageMetadata): DisplayMessageUsage {
 }
 
 function toDisplayMessage(record: ChatMessageRecord): DisplayMessage {
-  const metadata = parseMessageMetadata(record)
+  const metadata = messageStore.getMessageMetadata(record)
   const modelId = metadata.model || sessionStore.activeSession?.modelId || ''
   const providerId = metadata.provider || sessionStore.activeSession?.providerId || ''
+  const cached = displayMessageCache.get(record.id)
+  if (
+    cached &&
+    cached.updatedAt === record.updatedAt &&
+    cached.modelId === modelId &&
+    cached.providerId === providerId &&
+    cached.status === record.status
+  ) {
+    return cached.message
+  }
+
   const modelName = record.role === 'assistant' ? resolveAssistantModelName(modelId) : ''
   const baseMessage = {
     id: record.id,
@@ -354,19 +372,28 @@ function toDisplayMessage(record: ChatMessageRecord): DisplayMessage {
     summaryUpdatedAt: metadata.summaryUpdatedAt ?? null
   } as const
 
-  if (record.role === 'assistant') {
-    return {
-      ...baseMessage,
-      role: 'assistant',
-      content: parseAssistantMessageContent(record)
-    }
-  }
+  const nextMessage =
+    record.role === 'assistant'
+      ? ({
+          ...baseMessage,
+          role: 'assistant',
+          content: messageStore.getAssistantMessageBlocks(record)
+        } as DisplayMessage)
+      : ({
+          ...baseMessage,
+          role: 'user',
+          content: messageStore.getUserMessageContent(record)
+        } as DisplayMessage)
 
-  return {
-    ...baseMessage,
-    role: 'user',
-    content: parseUserMessageContent(record)
-  }
+  displayMessageCache.set(record.id, {
+    updatedAt: record.updatedAt,
+    modelId,
+    providerId,
+    status: record.status,
+    message: nextMessage
+  })
+
+  return nextMessage
 }
 
 // Build a streaming assistant message from live blocks
@@ -397,7 +424,7 @@ function toStreamingMessage(
 const hasInlineStreamingTarget = computed(() => {
   const messageId = messageStore.currentStreamMessageId
   if (!messageId) return false
-  return messageStore.messages.some((msg) => msg.id === messageId)
+  return messageStore.messageCache.has(messageId)
 })
 
 const ephemeralRateLimitMessageId = computed(() => {
@@ -431,7 +458,13 @@ const ephemeralRateLimitBlock = computed<DisplayAssistantMessageBlock | null>(()
 })
 
 const displayMessages = computed(() => {
-  const msgs: DisplayMessage[] = messageStore.messages.map(toDisplayMessage)
+  const msgs = messageStore.messages.map(toDisplayMessage)
+  const activeMessageIds = new Set(messageStore.messages.map((message) => message.id))
+  for (const cachedId of displayMessageCache.keys()) {
+    if (!activeMessageIds.has(cachedId)) {
+      displayMessageCache.delete(cachedId)
+    }
+  }
 
   // Fallback to a virtual streaming message only when target assistant message
   // is not yet available in messageStore.
@@ -455,7 +488,12 @@ const traceMessageIds = computed(() =>
 
 // Auto-scroll when displayMessages changes (new message added, streaming updates)
 watch(
-  [displayMessages, ephemeralRateLimitBlock],
+  [
+    () => messageStore.messageIds.length,
+    () => messageStore.currentStreamMessageId,
+    () => messageStore.streamRevision,
+    () => ephemeralRateLimitMessageId.value
+  ],
   () => {
     if (spotlightStore.pendingMessageJump?.sessionId === props.sessionId) {
       void focusPendingSpotlightMessageJump()
@@ -463,10 +501,10 @@ watch(
     }
 
     if (isNearBottom.value) {
-      nextTick(scrollToBottom)
+      scrollToBottom()
     }
   },
-  { deep: true }
+  { flush: 'post' }
 )
 
 async function refreshChatSearchHighlights() {
@@ -586,7 +624,7 @@ watch(
 
     void refreshChatSearchHighlights()
   },
-  { deep: true }
+  { flush: 'post' }
 )
 
 const message = ref('')
@@ -629,15 +667,6 @@ type SubagentProgressPayload = {
   }>
 }
 
-function parseAssistantBlocks(content: string): AssistantMessageBlock[] {
-  try {
-    const parsed = JSON.parse(content) as AssistantMessageBlock[]
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
 function parseSubagentProgress(value: unknown): SubagentProgressPayload | null {
   if (typeof value !== 'string' || !value.trim()) {
     return null
@@ -656,7 +685,7 @@ const pendingInteractions = computed<PendingInteractionView[]>(() => {
 
   for (const message of messageStore.messages) {
     if (message.role !== 'assistant') continue
-    const blocks = parseAssistantBlocks(message.content)
+    const blocks = messageStore.getAssistantMessageBlocks(message)
 
     for (const block of blocks) {
       if (
@@ -732,15 +761,17 @@ const isAwaitingToolQuestionFollowUp = computed(() => {
       return false
     }
 
-    return parseAssistantBlocks(message.content).some(
-      (block) =>
-        block.type === 'action' &&
-        block.action_type === 'question_request' &&
-        block.status === 'success' &&
-        block.extra?.needsUserAction === false &&
-        block.extra?.questionResolution === 'replied' &&
-        typeof block.extra?.answerText !== 'string'
-    )
+    return messageStore
+      .getAssistantMessageBlocks(message)
+      .some(
+        (block) =>
+          block.type === 'action' &&
+          block.action_type === 'question_request' &&
+          block.status === 'success' &&
+          block.extra?.needsUserAction === false &&
+          block.extra?.questionResolution === 'replied' &&
+          typeof block.extra?.answerText !== 'string'
+      )
   })
 })
 const hasInputText = computed(() => Boolean(message.value.trim()))
@@ -941,6 +972,7 @@ async function onResumePendingQueue() {
 onMounted(() => {
   window.addEventListener('context-menu-ask-ai', handleContextMenuAskAI)
   window.addEventListener('keydown', handleWindowKeydown)
+  syncScrollPosition()
 })
 
 onUnmounted(() => {
@@ -950,6 +982,14 @@ onUnmounted(() => {
   if (spotlightJumpTimer) {
     window.clearTimeout(spotlightJumpTimer)
     spotlightJumpTimer = null
+  }
+  if (scrollReadFrame !== null) {
+    window.cancelAnimationFrame(scrollReadFrame)
+    scrollReadFrame = null
+  }
+  if (scrollWriteFrame !== null) {
+    window.cancelAnimationFrame(scrollWriteFrame)
+    scrollWriteFrame = null
   }
   pendingInputStore.clear()
 })

--- a/src/renderer/src/stores/ui/message.ts
+++ b/src/renderer/src/stores/ui/message.ts
@@ -35,6 +35,7 @@ export const useMessageStore = defineStore('message', () => {
   // --- State ---
   const messageIds = ref<string[]>([])
   const messageCache = ref<Map<string, ChatMessageRecord>>(new Map())
+  const lastPersistedRevision = ref(0)
   const parsedMessageCache = new Map<string, ParsedMessageCacheEntry>()
   const hydratingStreamMessageIds = new Set<string>()
   let latestLoadRequestId = 0
@@ -168,6 +169,7 @@ export const useMessageStore = defineStore('message', () => {
         messageCache.value.set(msg.id, msg)
         messageIds.value.push(msg.id)
       }
+      lastPersistedRevision.value += 1
     } catch (e) {
       console.error('Failed to load messages:', e)
     }
@@ -297,6 +299,7 @@ export const useMessageStore = defineStore('message', () => {
     streamingBlocks: streamStateStore.streamingBlocks,
     currentStreamMessageId: streamStateStore.currentStreamMessageId,
     streamRevision: streamStateStore.streamRevision,
+    lastPersistedRevision,
     messages,
     getAssistantMessageBlocks,
     getUserMessageContent,

--- a/src/renderer/src/stores/ui/message.ts
+++ b/src/renderer/src/stores/ui/message.ts
@@ -2,15 +2,29 @@ import { defineStore } from 'pinia'
 import { ref, computed, onScopeDispose, getCurrentScope } from 'vue'
 import { usePresenter } from '@/composables/usePresenter'
 import type {
+  DisplayAssistantMessageBlock,
+  DisplayUserMessageContent
+} from '@/components/chat/messageListItems'
+import type {
   ChatMessageRecord,
   AssistantMessageBlock,
-  MessageFile
+  MessageFile,
+  MessageMetadata
 } from '@shared/types/agent-interface'
 import { useSessionStore } from './session'
 import { useStreamStateStore } from './stream'
 import { bindMessageStoreIpc } from './messageIpc'
 
 const EPHEMERAL_STREAM_MESSAGE_PREFIXES = ['__rate_limit__:']
+
+type ParsedMessageCacheEntry = {
+  updatedAt: number
+  content: string
+  metadata: string
+  assistantBlocks?: DisplayAssistantMessageBlock[]
+  userContent?: DisplayUserMessageContent
+  parsedMetadata?: MessageMetadata
+}
 
 // --- Store ---
 
@@ -21,6 +35,7 @@ export const useMessageStore = defineStore('message', () => {
   // --- State ---
   const messageIds = ref<string[]>([])
   const messageCache = ref<Map<string, ChatMessageRecord>>(new Map())
+  const parsedMessageCache = new Map<string, ParsedMessageCacheEntry>()
   const hydratingStreamMessageIds = new Set<string>()
   let latestLoadRequestId = 0
 
@@ -45,6 +60,99 @@ export const useMessageStore = defineStore('message', () => {
     }
   }
 
+  function getParsedEntry(record: ChatMessageRecord) {
+    const cached = parsedMessageCache.get(record.id)
+    if (cached) {
+      if (cached.content !== record.content) {
+        cached.content = record.content
+        delete cached.assistantBlocks
+        delete cached.userContent
+      }
+
+      if (cached.metadata !== record.metadata) {
+        cached.metadata = record.metadata
+        delete cached.parsedMetadata
+      }
+
+      cached.updatedAt = record.updatedAt
+      return cached
+    }
+
+    const nextEntry: ParsedMessageCacheEntry = {
+      updatedAt: record.updatedAt,
+      content: record.content,
+      metadata: record.metadata
+    }
+    parsedMessageCache.set(record.id, nextEntry)
+    return nextEntry
+  }
+
+  function getAssistantMessageBlocks(record: ChatMessageRecord): DisplayAssistantMessageBlock[] {
+    const entry = getParsedEntry(record)
+    if (entry.assistantBlocks) {
+      return entry.assistantBlocks
+    }
+
+    try {
+      const parsed = JSON.parse(record.content) as DisplayAssistantMessageBlock[]
+      entry.assistantBlocks = Array.isArray(parsed) ? parsed : []
+    } catch {
+      entry.assistantBlocks = []
+    }
+
+    return entry.assistantBlocks
+  }
+
+  function getUserMessageContent(record: ChatMessageRecord): DisplayUserMessageContent {
+    const entry = getParsedEntry(record)
+    if (entry.userContent) {
+      return entry.userContent
+    }
+
+    try {
+      const parsed = JSON.parse(record.content) as DisplayUserMessageContent
+      if (parsed && typeof parsed === 'object') {
+        entry.userContent = {
+          text: parsed.text ?? '',
+          files: parsed.files ?? [],
+          links: parsed.links ?? [],
+          search: parsed.search ?? false,
+          think: parsed.think ?? false,
+          continue: parsed.continue,
+          resources: parsed.resources,
+          prompts: parsed.prompts,
+          content: parsed.content
+        }
+        return entry.userContent
+      }
+    } catch {}
+
+    entry.userContent = {
+      text: '',
+      files: [],
+      links: [],
+      search: false,
+      think: false
+    }
+    return entry.userContent
+  }
+
+  function getMessageMetadata(record: ChatMessageRecord): MessageMetadata {
+    const entry = getParsedEntry(record)
+    if (entry.parsedMetadata) {
+      return entry.parsedMetadata
+    }
+
+    try {
+      const parsed = JSON.parse(record.metadata) as MessageMetadata
+      entry.parsedMetadata = parsed && typeof parsed === 'object' ? parsed : {}
+    } catch {
+      entry.parsedMetadata = {}
+    }
+
+    return entry.parsedMetadata
+  }
+
   async function loadMessages(sessionId: string): Promise<void> {
     const requestId = ++latestLoadRequestId
     try {
@@ -54,6 +162,7 @@ export const useMessageStore = defineStore('message', () => {
       }
 
       messageCache.value.clear()
+      parsedMessageCache.clear()
       messageIds.value = []
       for (const msg of result) {
         messageCache.value.set(msg.id, msg)
@@ -113,6 +222,7 @@ export const useMessageStore = defineStore('message', () => {
     latestLoadRequestId += 1
     messageIds.value = []
     messageCache.value.clear()
+    parsedMessageCache.clear()
     clearStreamingState()
     hydratingStreamMessageIds.clear()
   }
@@ -134,6 +244,9 @@ export const useMessageStore = defineStore('message', () => {
     const existing = messageCache.value.get(messageId)
     if (existing) {
       if (existing.sessionId !== conversationId) return
+      if (existing.content === serializedBlocks && existing.status === 'pending') {
+        return
+      }
       upsertMessageRecord({
         ...existing,
         content: serializedBlocks,
@@ -183,7 +296,11 @@ export const useMessageStore = defineStore('message', () => {
     isStreaming: streamStateStore.isStreaming,
     streamingBlocks: streamStateStore.streamingBlocks,
     currentStreamMessageId: streamStateStore.currentStreamMessageId,
+    streamRevision: streamStateStore.streamRevision,
     messages,
+    getAssistantMessageBlocks,
+    getUserMessageContent,
+    getMessageMetadata,
     loadMessages,
     getMessage,
     addOptimisticUserMessage,

--- a/src/renderer/src/stores/ui/stream.ts
+++ b/src/renderer/src/stores/ui/stream.ts
@@ -7,12 +7,14 @@ export const useStreamStateStore = defineStore('streamState', () => {
   const streamingBlocks = ref<AssistantMessageBlock[]>([])
   const currentStreamSessionId = ref<string | null>(null)
   const currentStreamMessageId = ref<string | null>(null)
+  const streamRevision = ref(0)
 
   function setStream(sessionId: string, blocks: AssistantMessageBlock[], messageId?: string): void {
     isStreaming.value = true
     currentStreamSessionId.value = sessionId
     currentStreamMessageId.value = messageId ?? null
     streamingBlocks.value = blocks
+    streamRevision.value += 1
   }
 
   function clearStreamingState(): void {
@@ -20,6 +22,7 @@ export const useStreamStateStore = defineStore('streamState', () => {
     streamingBlocks.value = []
     currentStreamSessionId.value = null
     currentStreamMessageId.value = null
+    streamRevision.value += 1
   }
 
   return {
@@ -27,6 +30,7 @@ export const useStreamStateStore = defineStore('streamState', () => {
     streamingBlocks,
     currentStreamSessionId,
     currentStreamMessageId,
+    streamRevision,
     setStream,
     clearStreamingState
   }

--- a/src/shared/utils/throttle.ts
+++ b/src/shared/utils/throttle.ts
@@ -9,6 +9,7 @@ export interface ThrottleHandle {
   (): void
   flush(): void
   cancel(): void
+  reschedule(): void
 }
 
 export function createThrottle(fn: () => void, interval: number): ThrottleHandle {
@@ -40,6 +41,14 @@ export function createThrottle(fn: () => void, interval: number): ThrottleHandle
       clearTimeout(timer)
       timer = null
     }
+  }
+
+  invoke.reschedule = (): void => {
+    if (timer) {
+      clearTimeout(timer)
+    }
+
+    timer = setTimeout(run, interval)
   }
 
   return invoke

--- a/test/main/presenter/agentRuntimePresenter/dispatch.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/dispatch.test.ts
@@ -447,8 +447,9 @@ describe('dispatch', () => {
       expect(hooks.onPreToolUse).not.toHaveBeenCalled()
       expect(toolPresenter.callTool).not.toHaveBeenCalled()
       expect(rendererFlushHandle.rescheduleRenderer).toHaveBeenCalledTimes(1)
+      expect(rendererFlushHandle.schedule).toHaveBeenCalled()
       expect(rendererFlushHandle.rescheduleRenderer.mock.invocationCallOrder[0]).toBeLessThan(
-        rendererFlushHandle.schedule.mock.invocationCallOrder.at(-1) ?? Number.POSITIVE_INFINITY
+        rendererFlushHandle.schedule.mock.invocationCallOrder.at(-1)!
       )
     })
 
@@ -505,8 +506,9 @@ describe('dispatch', () => {
       expect(hooks.onPermissionRequest).toHaveBeenCalledTimes(1)
       expect(toolPresenter.callTool).not.toHaveBeenCalled()
       expect(rendererFlushHandle.rescheduleRenderer).toHaveBeenCalledTimes(1)
+      expect(rendererFlushHandle.schedule).toHaveBeenCalled()
       expect(rendererFlushHandle.rescheduleRenderer.mock.invocationCallOrder[0]).toBeLessThan(
-        rendererFlushHandle.schedule.mock.invocationCallOrder.at(-1) ?? Number.POSITIVE_INFINITY
+        rendererFlushHandle.schedule.mock.invocationCallOrder.at(-1)!
       )
     })
 

--- a/test/main/presenter/agentRuntimePresenter/dispatch.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/dispatch.test.ts
@@ -48,6 +48,7 @@ import {
   finalize,
   finalizeError
 } from '@/presenter/agentRuntimePresenter/dispatch'
+import type { EchoHandle } from '@/presenter/agentRuntimePresenter/echo'
 import { accumulate } from '@/presenter/agentRuntimePresenter/accumulator'
 import { eventBus } from '@/eventbus'
 
@@ -117,10 +118,43 @@ async function executeTools(
   toolOutputGuard: ToolOutputGuard,
   contextLength: number,
   maxTokens: number,
-  hooks?: Parameters<typeof executeToolsInternal>[12],
+  hooks?: Parameters<typeof executeToolsInternal>[13],
   providerId?: string,
-  interleavedReasoning: InterleavedReasoningConfig = DEFAULT_INTERLEAVED_REASONING
+  interleavedReasoning: InterleavedReasoningConfig = DEFAULT_INTERLEAVED_REASONING,
+  rendererFlushHandle?: Pick<EchoHandle, 'flush' | 'schedule' | 'rescheduleRenderer'>
 ) {
+  const flushHandle =
+    rendererFlushHandle ??
+    ({
+      flush: vi.fn(() => {
+        eventBus.sendToRenderer('stream:response', 'all', {
+          conversationId: io.sessionId,
+          eventId: io.messageId,
+          messageId: io.messageId,
+          blocks: state.blocks
+        })
+        io.messageStore.updateAssistantContent(io.messageId, state.blocks)
+      }),
+      schedule: vi.fn(() => {
+        eventBus.sendToRenderer('stream:response', 'all', {
+          conversationId: io.sessionId,
+          eventId: io.messageId,
+          messageId: io.messageId,
+          blocks: state.blocks
+        })
+        io.messageStore.updateAssistantContent(io.messageId, state.blocks)
+      }),
+      rescheduleRenderer: vi.fn(() => {
+        eventBus.sendToRenderer('stream:response', 'all', {
+          conversationId: io.sessionId,
+          eventId: io.messageId,
+          messageId: io.messageId,
+          blocks: state.blocks
+        })
+        io.messageStore.updateAssistantContent(io.messageId, state.blocks)
+      })
+    } satisfies Pick<EchoHandle, 'flush' | 'schedule' | 'rescheduleRenderer'>)
+
   return executeToolsInternal(
     state,
     conversation,
@@ -134,6 +168,7 @@ async function executeTools(
     toolOutputGuard,
     contextLength,
     maxTokens,
+    flushHandle,
     hooks,
     providerId
   )
@@ -366,6 +401,11 @@ describe('dispatch', () => {
         onPostToolUseFailure: vi.fn()
       }
       const toolPresenter = createMockToolPresenter()
+      const rendererFlushHandle = {
+        flush: vi.fn(),
+        schedule: vi.fn(),
+        rescheduleRenderer: vi.fn()
+      }
 
       state.blocks.push({
         type: 'tool_call',
@@ -397,12 +437,19 @@ describe('dispatch', () => {
         new ToolOutputGuard(),
         32000,
         1024,
-        hooks
+        hooks,
+        undefined,
+        DEFAULT_INTERLEAVED_REASONING,
+        rendererFlushHandle
       )
 
       expect(result.pendingInteractions).toHaveLength(1)
       expect(hooks.onPreToolUse).not.toHaveBeenCalled()
       expect(toolPresenter.callTool).not.toHaveBeenCalled()
+      expect(rendererFlushHandle.rescheduleRenderer).toHaveBeenCalledTimes(1)
+      expect(rendererFlushHandle.rescheduleRenderer.mock.invocationCallOrder[0]).toBeLessThan(
+        rendererFlushHandle.schedule.mock.invocationCallOrder.at(-1) ?? Number.POSITIVE_INFINITY
+      )
     })
 
     it('does not emit PreToolUse before a pre-checked permission pause', async () => {
@@ -414,6 +461,11 @@ describe('dispatch', () => {
       }
       const toolPresenter = createMockToolPresenter() as IToolPresenter & {
         preCheckToolPermission: ReturnType<typeof vi.fn>
+      }
+      const rendererFlushHandle = {
+        flush: vi.fn(),
+        schedule: vi.fn(),
+        rescheduleRenderer: vi.fn()
       }
       toolPresenter.preCheckToolPermission = vi.fn().mockResolvedValue({
         needsPermission: true,
@@ -442,13 +494,20 @@ describe('dispatch', () => {
         new ToolOutputGuard(),
         32000,
         1024,
-        hooks
+        hooks,
+        undefined,
+        DEFAULT_INTERLEAVED_REASONING,
+        rendererFlushHandle
       )
 
       expect(result.pendingInteractions).toHaveLength(1)
       expect(hooks.onPreToolUse).not.toHaveBeenCalled()
       expect(hooks.onPermissionRequest).toHaveBeenCalledTimes(1)
       expect(toolPresenter.callTool).not.toHaveBeenCalled()
+      expect(rendererFlushHandle.rescheduleRenderer).toHaveBeenCalledTimes(1)
+      expect(rendererFlushHandle.rescheduleRenderer.mock.invocationCallOrder[0]).toBeLessThan(
+        rendererFlushHandle.schedule.mock.invocationCallOrder.at(-1) ?? Number.POSITIVE_INFINITY
+      )
     })
 
     it('enriches tool_call blocks with server info', async () => {

--- a/test/main/presenter/agentRuntimePresenter/echo.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/echo.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/events', () => ({
   }
 }))
 
-import { startEcho } from '@/presenter/agentRuntimePresenter/echo'
+import { cloneBlocksForRenderer, startEcho } from '@/presenter/agentRuntimePresenter/echo'
 import { eventBus } from '@/eventbus'
 
 function createIo(): IoParams {
@@ -35,6 +35,7 @@ describe('echo', () => {
 
   beforeEach(() => {
     vi.useFakeTimers()
+    vi.setSystemTime(new Date(0))
     vi.clearAllMocks()
     state = createState()
     io = createIo()
@@ -44,12 +45,12 @@ describe('echo', () => {
     vi.useRealTimers()
   })
 
-  it('flushes to renderer on interval when dirty', () => {
+  it('flushes to renderer through schedule when dirty', () => {
     const echo = startEcho(state, io)
 
-    // Mark dirty
     state.dirty = true
     state.blocks.push({ type: 'content', content: 'hi', status: 'pending', timestamp: Date.now() })
+    echo.schedule()
 
     vi.advanceTimersByTime(130)
 
@@ -67,11 +68,12 @@ describe('echo', () => {
     echo.stop()
   })
 
-  it('flushes to DB on interval when dirty', () => {
+  it('flushes to DB through schedule when dirty', () => {
     const echo = startEcho(state, io)
 
     state.dirty = true
     state.blocks.push({ type: 'content', content: 'hi', status: 'pending', timestamp: Date.now() })
+    echo.schedule()
 
     vi.advanceTimersByTime(610)
 
@@ -83,6 +85,7 @@ describe('echo', () => {
   it('does not flush when not dirty', () => {
     const echo = startEcho(state, io)
 
+    echo.schedule()
     vi.advanceTimersByTime(1000)
 
     expect(eventBus.sendToRenderer).not.toHaveBeenCalled()
@@ -115,18 +118,55 @@ describe('echo', () => {
     echo.stop()
   })
 
-  it('stop() clears intervals', () => {
+  it('stop() cancels pending throttled work', () => {
     const echo = startEcho(state, io)
-
-    echo.stop()
 
     state.dirty = true
     state.blocks.push({ type: 'content', content: 'hi', status: 'pending', timestamp: Date.now() })
+    echo.schedule()
+    echo.stop()
 
     vi.advanceTimersByTime(1000)
 
     // Nothing should have been flushed after stop
     expect(eventBus.sendToRenderer).not.toHaveBeenCalled()
     expect(io.messageStore.updateAssistantContent).not.toHaveBeenCalled()
+  })
+
+  it('coalesces repeated schedule calls into one renderer flush per interval window', () => {
+    const echo = startEcho(state, io)
+
+    state.dirty = true
+    state.blocks.push({ type: 'content', content: 'hi', status: 'pending', timestamp: Date.now() })
+
+    echo.schedule()
+    echo.schedule()
+    echo.schedule()
+
+    vi.advanceTimersByTime(130)
+
+    expect(eventBus.sendToRenderer).toHaveBeenCalledTimes(1)
+    echo.stop()
+  })
+
+  it('clones renderer blocks with structuredClone semantics', () => {
+    const blocks = [
+      {
+        type: 'content' as const,
+        content: 'hi',
+        status: 'pending' as const,
+        timestamp: 1,
+        extra: {
+          nested: [{ value: 1 }]
+        }
+      }
+    ]
+
+    const cloned = cloneBlocksForRenderer(blocks)
+
+    expect(cloned).toEqual(blocks)
+    expect(cloned).not.toBe(blocks)
+    expect(cloned[0]).not.toBe(blocks[0])
+    expect(cloned[0]?.extra).not.toBe(blocks[0]?.extra)
   })
 })

--- a/test/main/presenter/agentRuntimePresenter/echo.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/echo.test.ts
@@ -190,5 +190,7 @@ describe('echo', () => {
     expect(cloned).not.toBe(blocks)
     expect(cloned[0]).not.toBe(blocks[0])
     expect(cloned[0]?.extra).not.toBe(blocks[0]?.extra)
+    expect(cloned[0]?.extra?.nested).not.toBe(blocks[0]?.extra?.nested)
+    expect(cloned[0]?.extra?.nested[0]).not.toBe(blocks[0]?.extra?.nested[0])
   })
 })

--- a/test/main/presenter/agentRuntimePresenter/echo.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/echo.test.ts
@@ -149,6 +149,28 @@ describe('echo', () => {
     echo.stop()
   })
 
+  it('rescheduleRenderer() resets the renderer flush window from the latest interaction', () => {
+    const echo = startEcho(state, io)
+
+    state.dirty = true
+    state.blocks.push({ type: 'content', content: 'hi', status: 'pending', timestamp: Date.now() })
+
+    echo.schedule()
+    vi.advanceTimersByTime(130)
+    expect(eventBus.sendToRenderer).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(40)
+    echo.rescheduleRenderer()
+
+    vi.advanceTimersByTime(119)
+    expect(eventBus.sendToRenderer).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1)
+    expect(eventBus.sendToRenderer).toHaveBeenCalledTimes(2)
+
+    echo.stop()
+  })
+
   it('clones renderer blocks with structuredClone semantics', () => {
     const blocks = [
       {

--- a/test/renderer/components/ChatPage.test.ts
+++ b/test/renderer/components/ChatPage.test.ts
@@ -69,6 +69,36 @@ const setup = async (options: SetupOptions = {}) => {
     isStreaming: options.isStreaming ?? false,
     streamingBlocks: options.streamingBlocks ?? [],
     currentStreamMessageId: options.currentStreamMessageId ?? null,
+    streamRevision: 0,
+    messageIds: (
+      options.messages ?? [
+        buildAssistantMessage([
+          {
+            type: 'reasoning_content',
+            content: 'thinking',
+            status: 'success',
+            timestamp: 1
+          }
+        ])
+      ]
+    ).map((message) => String(message.id)),
+    messageCache: new Map(
+      (
+        options.messages ?? [
+          buildAssistantMessage([
+            {
+              type: 'reasoning_content',
+              content: 'thinking',
+              status: 'success',
+              timestamp: 1
+            }
+          ])
+        ]
+      ).map((message) => [String(message.id), message])
+    ),
+    getAssistantMessageBlocks: vi.fn((message: { content: string }) => JSON.parse(message.content)),
+    getUserMessageContent: vi.fn((message: { content: string }) => JSON.parse(message.content)),
+    getMessageMetadata: vi.fn((message: { metadata: string }) => JSON.parse(message.metadata)),
     loadMessages: vi.fn().mockResolvedValue(undefined),
     clearStreamingState: vi.fn(),
     addOptimisticUserMessage: vi.fn()

--- a/test/renderer/components/ChatPage.test.ts
+++ b/test/renderer/components/ChatPage.test.ts
@@ -70,6 +70,7 @@ const setup = async (options: SetupOptions = {}) => {
     streamingBlocks: options.streamingBlocks ?? [],
     currentStreamMessageId: options.currentStreamMessageId ?? null,
     streamRevision: 0,
+    lastPersistedRevision: 0,
     messageIds: (
       options.messages ?? [
         buildAssistantMessage([
@@ -341,6 +342,57 @@ describe('ChatPage', () => {
     expect(messages).toHaveLength(1)
     expect(messages[0].usage.reasoning_start_time).toBe(1_200)
     expect(messages[0].usage.reasoning_end_time).toBe(4_500)
+  })
+
+  it('rebuilds cached display messages when raw content or metadata change without updatedAt changing', async () => {
+    const initialMessage = buildAssistantMessage([
+      {
+        type: 'content',
+        content: 'first',
+        status: 'success',
+        timestamp: 1
+      }
+    ])
+    const { wrapper, messageStore } = await setup({
+      messages: [initialMessage]
+    })
+
+    const messageList = wrapper.findComponent({ name: 'MessageList' })
+    const before = messageList.props('messages') as Array<{
+      content: Array<{ content?: string }>
+      usage: { total_tokens: number }
+    }>
+
+    expect(before[0].content[0]?.content).toBe('first')
+    expect(before[0].usage.total_tokens).toBe(0)
+
+    messageStore.messages[0] = {
+      ...messageStore.messages[0],
+      content: JSON.stringify([
+        {
+          type: 'content',
+          content: 'second',
+          status: 'success',
+          timestamp: 1
+        }
+      ]),
+      metadata: JSON.stringify({
+        model: 'dimcode-acp',
+        provider: 'acp',
+        totalTokens: 42
+      }),
+      updatedAt: initialMessage.updatedAt
+    }
+
+    await flushPromises()
+
+    const after = messageList.props('messages') as Array<{
+      content: Array<{ content?: string }>
+      usage: { total_tokens: number }
+    }>
+
+    expect(after[0].content[0]?.content).toBe('second')
+    expect(after[0].usage.total_tokens).toBe(42)
   })
 
   it('extracts ephemeral rate-limit streaming blocks instead of creating a virtual assistant message', async () => {

--- a/test/renderer/components/TranslatePopup.test.ts
+++ b/test/renderer/components/TranslatePopup.test.ts
@@ -1,0 +1,173 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import TranslatePopup from '@/components/popup/TranslatePopup.vue'
+
+const translateText = vi.fn()
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      if (key === 'contextMenu.translate.title') return 'Translate'
+      if (key === 'contextMenu.translate.error') return 'Translate failed'
+      if (key === 'common.loading') return 'Loading'
+      return key
+    },
+    locale: {
+      value: 'en-US'
+    }
+  })
+}))
+
+vi.mock('@/composables/usePresenter', () => ({
+  usePresenter: () => ({
+    translateText
+  })
+}))
+
+vi.mock('@/stores/ui/agent', () => ({
+  useAgentStore: () => ({
+    selectedAgentId: null
+  })
+}))
+
+vi.mock('@shadcn/components/ui/button', () => ({
+  Button: defineComponent({
+    name: 'Button',
+    template: '<button type="button"><slot /></button>'
+  })
+}))
+
+vi.mock('@iconify/vue', () => ({
+  Icon: defineComponent({
+    name: 'Icon',
+    template: '<span class="icon-stub" />'
+  })
+}))
+
+describe('TranslatePopup', () => {
+  let originalInnerWidth: number
+  let originalInnerHeight: number
+
+  beforeEach(() => {
+    translateText.mockReset()
+    translateText.mockResolvedValue('Bonjour')
+    originalInnerWidth = window.innerWidth
+    originalInnerHeight = window.innerHeight
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 800
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 600
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: originalInnerWidth
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: originalInnerHeight
+    })
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('opens the popup, clamps it to the viewport, and requests translation', async () => {
+    const wrapper = mount(TranslatePopup, {
+      attachTo: document.body
+    })
+
+    window.dispatchEvent(
+      new CustomEvent('context-menu-translate-text', {
+        detail: {
+          text: 'hello',
+          x: 900,
+          y: 700
+        }
+      })
+    )
+
+    await flushPromises()
+
+    const popup = wrapper.get('[data-translate-popup="true"]')
+
+    expect(translateText).toHaveBeenCalledWith('hello', 'en-US', 'deepchat')
+    expect(popup.attributes('style')).toContain('translate3d(760px, 560px, 0)')
+    expect(wrapper.text()).toContain('Bonjour')
+  })
+
+  it('attaches drag listeners only during dragging and coalesces pointer moves in rAF', async () => {
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+    const rafCallbacks: FrameRequestCallback[] = []
+
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
+      (callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback)
+        return rafCallbacks.length
+      }
+    )
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+
+    const wrapper = mount(TranslatePopup, {
+      attachTo: document.body
+    })
+
+    expect(addEventListenerSpy.mock.calls.some(([type]) => type === 'pointermove')).toBe(false)
+
+    window.dispatchEvent(
+      new CustomEvent('context-menu-translate-text', {
+        detail: {
+          text: 'drag me',
+          x: 10,
+          y: 20
+        }
+      })
+    )
+
+    await flushPromises()
+
+    const popup = wrapper.get('[data-translate-popup="true"]')
+    const header = wrapper.get('[data-translate-popup-header="true"]')
+
+    header.element.dispatchEvent(
+      new MouseEvent('pointerdown', {
+        bubbles: true,
+        button: 0,
+        clientX: 30,
+        clientY: 50
+      })
+    )
+
+    expect(addEventListenerSpy.mock.calls.some(([type]) => type === 'pointermove')).toBe(true)
+    expect(addEventListenerSpy.mock.calls.some(([type]) => type === 'pointerup')).toBe(true)
+    expect(addEventListenerSpy.mock.calls.some(([type]) => type === 'pointercancel')).toBe(true)
+
+    window.dispatchEvent(
+      new MouseEvent('pointermove', { bubbles: true, clientX: 100, clientY: 120 })
+    )
+    window.dispatchEvent(
+      new MouseEvent('pointermove', { bubbles: true, clientX: 140, clientY: 160 })
+    )
+
+    expect(popup.attributes('style')).toContain('translate3d(10px, 20px, 0)')
+    expect(rafCallbacks).toHaveLength(1)
+
+    rafCallbacks[0](performance.now())
+    await flushPromises()
+
+    expect(popup.attributes('style')).toContain('translate3d(120px, 130px, 0)')
+
+    window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }))
+
+    expect(removeEventListenerSpy.mock.calls.some(([type]) => type === 'pointermove')).toBe(true)
+    expect(removeEventListenerSpy.mock.calls.some(([type]) => type === 'pointerup')).toBe(true)
+    expect(removeEventListenerSpy.mock.calls.some(([type]) => type === 'pointercancel')).toBe(true)
+  })
+})

--- a/test/renderer/components/WorkspacePanel.test.ts
+++ b/test/renderer/components/WorkspacePanel.test.ts
@@ -100,7 +100,8 @@ const messageStore = {
       createdAt: 10,
       updatedAt: 10
     }
-  ]
+  ],
+  getAssistantMessageBlocks: (message: { content: string }) => JSON.parse(message.content)
 }
 
 type IpcHandler = (_event: unknown, payload: unknown) => void

--- a/test/renderer/components/message/MessageBlockToolCall.test.ts
+++ b/test/renderer/components/message/MessageBlockToolCall.test.ts
@@ -4,23 +4,9 @@ import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
 import MessageBlockToolCall from '@/components/message/MessageBlockToolCall.vue'
 import type { DisplayAssistantMessageBlock } from '@/components/chat/messageListItems'
 
-const originalResizeObserver = globalThis.ResizeObserver
-let resizeObserverCallback: ResizeObserverCallback | null = null
 const { selectSessionMock } = vi.hoisted(() => ({
   selectSessionMock: vi.fn()
 }))
-
-class MockResizeObserver {
-  constructor(callback: ResizeObserverCallback) {
-    resizeObserverCallback = callback
-  }
-
-  observe() {}
-
-  unobserve() {}
-
-  disconnect() {}
-}
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
@@ -108,19 +94,11 @@ const createBlock = (
 })
 
 beforeEach(() => {
-  resizeObserverCallback = null
   selectSessionMock.mockReset()
-  globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
 })
 
 afterEach(() => {
-  if (originalResizeObserver) {
-    globalThis.ResizeObserver = originalResizeObserver
-    return
-  }
-
-  delete (globalThis as typeof globalThis & { ResizeObserver?: typeof ResizeObserver })
-    .ResizeObserver
+  selectSessionMock.mockReset()
 })
 
 describe('MessageBlockToolCall', () => {
@@ -234,7 +212,7 @@ describe('MessageBlockToolCall', () => {
     )
   })
 
-  it('only adds the summary fade when the text actually overflows', async () => {
+  it('always exposes the full summary in the title attribute', () => {
     const summaryValue = 'C:/workspace/' + 'nested/'.repeat(8) + 'MessageBlockToolCall.vue'
     const wrapper = mount(MessageBlockToolCall, {
       props: {
@@ -251,21 +229,6 @@ describe('MessageBlockToolCall', () => {
 
     const summary = wrapper.get('[data-testid="tool-call-summary"]')
 
-    expect(summary.classes()).not.toContain('tool-call-summary--overflowing')
-
-    Object.defineProperty(summary.element, 'clientWidth', {
-      configurable: true,
-      value: 80
-    })
-    Object.defineProperty(summary.element, 'scrollWidth', {
-      configurable: true,
-      value: 160
-    })
-
-    resizeObserverCallback?.([] as ResizeObserverEntry[], {} as ResizeObserver)
-    await nextTick()
-
-    expect(summary.classes()).toContain('tool-call-summary--overflowing')
     expect(summary.attributes('title')).toBe(summaryValue)
   })
 

--- a/test/renderer/components/message/MessageItemUser.test.ts
+++ b/test/renderer/components/message/MessageItemUser.test.ts
@@ -8,21 +8,7 @@ import type {
 import type { MessageFile } from '@shared/types/agent-interface'
 import MessageItemUser from '@/components/message/MessageItemUser.vue'
 
-const originalResizeObserver = globalThis.ResizeObserver
 const originalApi = window.api
-let resizeObserverCallback: ResizeObserverCallback | null = null
-
-class MockResizeObserver {
-  constructor(callback: ResizeObserverCallback) {
-    resizeObserverCallback = callback
-  }
-
-  observe() {}
-
-  unobserve() {}
-
-  disconnect() {}
-}
 
 const getVisibleMentionLabel = (block: DisplayUserMessageMentionBlock) => {
   if (block.category === 'prompts') {
@@ -181,85 +167,14 @@ const globalMountOptions = {
   attachTo: document.body
 }
 
-const setContentMeasurement = async (
-  wrapper: ReturnType<typeof mount>,
-  options: {
-    scrollHeight: number
-    offsetWidth?: number
-    lineHeight?: string
-    fontSize?: string
-  }
-) => {
-  const contentBody = wrapper.get('[data-user-message-content-body="true"]').element as HTMLElement
-  const contentMeasure = wrapper.get('[data-user-message-content-measure="true"]')
-    .element as HTMLElement
-
-  contentMeasure.dataset.lineHeight = options.lineHeight ?? '20px'
-  contentMeasure.dataset.fontSize = options.fontSize ?? '14px'
-
-  Object.defineProperty(contentBody, 'offsetWidth', {
-    configurable: true,
-    value: options.offsetWidth ?? 320
-  })
-  Object.defineProperty(contentMeasure, 'scrollHeight', {
-    configurable: true,
-    value: options.scrollHeight
-  })
-  Object.defineProperty(contentMeasure, 'offsetHeight', {
-    configurable: true,
-    value: options.scrollHeight
-  })
-
-  resizeObserverCallback?.([] as ResizeObserverEntry[], {} as ResizeObserver)
-  await nextTick()
-}
-
 describe('MessageItemUser', () => {
-  let getComputedStyleSpy: ReturnType<typeof vi.spyOn>
-
   beforeEach(() => {
-    resizeObserverCallback = null
-    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
     window.api = {
       copyText: vi.fn()
     } as typeof window.api
-
-    getComputedStyleSpy = vi.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
-      if (element instanceof HTMLElement && element.dataset.userMessageContentMeasure === 'true') {
-        return {
-          lineHeight: element.dataset.lineHeight ?? '20px',
-          fontSize: element.dataset.fontSize ?? '14px',
-          maxHeight: ''
-        } as CSSStyleDeclaration
-      }
-
-      if (element instanceof HTMLTextAreaElement) {
-        return {
-          lineHeight: '20px',
-          fontSize: '14px',
-          maxHeight: element.style.maxHeight || ''
-        } as CSSStyleDeclaration
-      }
-
-      return {
-        lineHeight: '20px',
-        fontSize: '14px',
-        maxHeight: ''
-      } as CSSStyleDeclaration
-    })
   })
 
   afterEach(() => {
-    getComputedStyleSpy.mockRestore()
-    resizeObserverCallback = null
-
-    if (originalResizeObserver) {
-      globalThis.ResizeObserver = originalResizeObserver
-    } else {
-      delete (globalThis as typeof globalThis & { ResizeObserver?: typeof ResizeObserver })
-        .ResizeObserver
-    }
-
     window.api = originalApi
     document.body.innerHTML = ''
   })
@@ -271,8 +186,6 @@ describe('MessageItemUser', () => {
       },
       ...globalMountOptions
     })
-
-    await setContentMeasurement(wrapper, { scrollHeight: 80 })
 
     const body = wrapper.get('[data-user-message-content-body="true"]')
     expect(body.attributes('data-user-message-collapsible')).toBe('false')
@@ -288,14 +201,12 @@ describe('MessageItemUser', () => {
       ...globalMountOptions
     })
 
-    await setContentMeasurement(wrapper, { scrollHeight: 320 })
-
     const body = wrapper.get('[data-user-message-content-body="true"]')
     const toggle = wrapper.get('[data-user-message-toggle="true"]')
 
     expect(body.attributes('data-user-message-collapsible')).toBe('true')
     expect(body.attributes('data-user-message-expanded')).toBe('false')
-    expect(body.attributes('style')).toContain('max-height: 240px;')
+    expect(wrapper.find('.user-message-content--clamped').exists()).toBe(true)
     expect(wrapper.find('[data-user-message-fade="true"]').exists()).toBe(true)
     expect(toggle.text()).toBe('展开')
 
@@ -340,8 +251,6 @@ describe('MessageItemUser', () => {
       ...globalMountOptions
     })
 
-    await setContentMeasurement(wrapper, { scrollHeight: 340 })
-
     expect(wrapper.find('[data-user-message-toggle="true"]').exists()).toBe(true)
     expect(wrapper.text()).toContain('prompt-name')
     expect(wrapper.text()).toContain('const answer = 42;')
@@ -355,8 +264,6 @@ describe('MessageItemUser', () => {
       ...globalMountOptions
     })
 
-    await setContentMeasurement(wrapper, { scrollHeight: 320 })
-
     expect(wrapper.findAll('.attachment-stub')).toHaveLength(1)
     expect(wrapper.find('[data-user-message-toggle="true"]').exists()).toBe(true)
   })
@@ -369,7 +276,6 @@ describe('MessageItemUser', () => {
       ...globalMountOptions
     })
 
-    await setContentMeasurement(wrapper, { scrollHeight: 320 })
     await wrapper.get('[data-action="edit"]').trigger('click')
     await nextTick()
 
@@ -378,7 +284,7 @@ describe('MessageItemUser', () => {
     expect((wrapper.get('textarea').element as HTMLTextAreaElement).value).toBe('c'.repeat(700))
   })
 
-  it('re-evaluates collapse state when content height shrinks below the preview limit', async () => {
+  it('re-evaluates collapse state when content length drops below the collapse threshold', async () => {
     const wrapper = mount(MessageItemUser, {
       props: {
         message: createMessage({}, { text: 'd'.repeat(700) })
@@ -386,10 +292,12 @@ describe('MessageItemUser', () => {
       ...globalMountOptions
     })
 
-    await setContentMeasurement(wrapper, { scrollHeight: 320 })
     expect(wrapper.find('[data-user-message-toggle="true"]').exists()).toBe(true)
 
-    await setContentMeasurement(wrapper, { scrollHeight: 180 })
+    await wrapper.setProps({
+      message: createMessage({}, { text: 'short again' })
+    })
+    await nextTick()
 
     const body = wrapper.get('[data-user-message-content-body="true"]')
     expect(body.attributes('data-user-message-collapsible')).toBe('false')

--- a/test/renderer/stores/messageStore.test.ts
+++ b/test/renderer/stores/messageStore.test.ts
@@ -173,4 +173,57 @@ describe('messageStore', () => {
     expect(store.messages.value).toHaveLength(0)
     expect(agentSessionPresenter.getMessage).not.toHaveBeenCalled()
   })
+
+  it('reuses parsed assistant content and metadata until the record changes', async () => {
+    const { store, agentSessionPresenter } = await setupStore()
+    agentSessionPresenter.getMessages.mockResolvedValueOnce([
+      {
+        id: 'm1',
+        sessionId: 's1',
+        orderSeq: 1,
+        role: 'assistant',
+        content: '[{"type":"content","content":"hello","status":"success","timestamp":1}]',
+        status: 'sent',
+        isContextEdge: 0,
+        metadata: '{"totalTokens":42}',
+        traceCount: 0,
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+
+    await store.loadMessages('s1')
+
+    const firstRecord = store.messages.value[0]!
+    const firstBlocks = store.getAssistantMessageBlocks(firstRecord)
+    const firstMetadata = store.getMessageMetadata(firstRecord)
+
+    expect(store.getAssistantMessageBlocks(firstRecord)).toBe(firstBlocks)
+    expect(store.getMessageMetadata(firstRecord)).toBe(firstMetadata)
+
+    const responseHandler = (
+      (window as any).electron.ipcRenderer.on as ReturnType<typeof vi.fn>
+    ).mock.calls.find(([eventName]) => eventName === 'stream:response')?.[1]
+
+    responseHandler(
+      {},
+      {
+        conversationId: 's1',
+        messageId: 'm1',
+        blocks: [
+          {
+            type: 'content',
+            content: 'updated',
+            status: 'pending',
+            timestamp: 2
+          }
+        ]
+      }
+    )
+
+    const updatedRecord = store.messages.value[0]!
+    expect(store.streamRevision.value).toBeGreaterThan(0)
+    expect(store.getAssistantMessageBlocks(updatedRecord)).not.toBe(firstBlocks)
+    expect(store.getMessageMetadata(updatedRecord)).toBe(firstMetadata)
+  })
 })

--- a/test/renderer/stores/messageStore.test.ts
+++ b/test/renderer/stores/messageStore.test.ts
@@ -123,6 +123,45 @@ describe('messageStore', () => {
     expect(store.messages.value[0]?.id).toBe('m2')
   })
 
+  it('increments lastPersistedRevision for same-length persisted reloads', async () => {
+    const { store, agentSessionPresenter } = await setupStore()
+    const firstPayload = [
+      {
+        id: 'm1',
+        sessionId: 's1',
+        orderSeq: 1,
+        role: 'assistant',
+        content: '[{"type":"content","content":"first","status":"success","timestamp":1}]',
+        status: 'sent',
+        isContextEdge: 0,
+        metadata: '{"totalTokens":1}',
+        traceCount: 0,
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
+    const secondPayload = [
+      {
+        ...firstPayload[0],
+        content: '[{"type":"content","content":"second","status":"success","timestamp":1}]',
+        metadata: '{"totalTokens":2}'
+      }
+    ]
+
+    agentSessionPresenter.getMessages
+      .mockResolvedValueOnce(firstPayload)
+      .mockResolvedValueOnce(secondPayload)
+
+    await store.loadMessages('s1')
+    const firstRevision = store.lastPersistedRevision.value
+
+    await store.loadMessages('s1')
+
+    expect(store.messages.value).toHaveLength(1)
+    expect(store.messages.value[0]?.content).toContain('second')
+    expect(store.lastPersistedRevision.value).toBe(firstRevision + 1)
+  })
+
   it('keeps rate-limit stream messages ephemeral and skips message hydration', async () => {
     const { store, agentSessionPresenter } = await setupStore()
     const responseHandler = (

--- a/test/shared/utils/throttle.test.ts
+++ b/test/shared/utils/throttle.test.ts
@@ -95,11 +95,18 @@ describe('createThrottle', () => {
     const throttled = createThrottle(fn, 100)
 
     throttled() // immediate
+    throttled() // schedule original trailing timer at +100ms
 
     vi.advanceTimersByTime(40)
     throttled.reschedule()
 
-    vi.advanceTimersByTime(99)
+    vi.advanceTimersByTime(59)
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(39)
     expect(fn).toHaveBeenCalledTimes(1)
 
     vi.advanceTimersByTime(1)

--- a/test/shared/utils/throttle.test.ts
+++ b/test/shared/utils/throttle.test.ts
@@ -89,4 +89,20 @@ describe('createThrottle', () => {
 
     expect(fn).toHaveBeenCalledTimes(1)
   })
+
+  it('reschedule() resets the trailing timer from now', () => {
+    const fn = vi.fn()
+    const throttled = createThrottle(fn, 100)
+
+    throttled() // immediate
+
+    vi.advanceTimersByTime(40)
+    throttled.reschedule()
+
+    vi.advanceTimersByTime(99)
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
## Summary
- Reduce renderer-side layout thrash during streaming by caching parsed message data, stabilizing display message references, and throttling renderer flushes for text/tool progress updates.
- Replace synchronous overflow and resize measurement in message UI with CSS-driven truncation/clamping for tool-call summaries and long user messages.
- Rework chat auto-scroll to use lightweight stream signals plus `requestAnimationFrame`, which keeps follow-bottom behavior while cutting scroll-triggered layout work.
- Trim translate popup interaction overhead by attaching drag listeners only while dragging, coalescing pointer updates per frame, and adding a `dev:trace` path that disables the Vue devtools overlay for cleaner profiling.
- Implementation approach: follow the trace hotspots first, remove sync layout reads on the renderer path, then narrow event frequency and flush cadence so streaming updates stay incremental instead of repeatedly recomputing the whole chat surface.

## Testing
- `pnpm vitest run test/renderer/components/message/MessageBlockToolCall.test.ts test/renderer/components/message/MessageItemUser.test.ts test/renderer/stores/messageStore.test.ts test/renderer/components/ChatPage.test.ts test/renderer/components/WorkspacePanel.test.ts test/main/presenter/agentRuntimePresenter/echo.test.ts`
- `pnpm vitest run test/renderer/components/TranslatePopup.test.ts test/renderer/components/App.startup.test.ts`
- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & UI Improvements**
  * CSS-only message truncation and simpler collapse behavior for more consistent rendering
  * Fixed edit textarea sizing with a capped max height for improved editing UX
  * Translate popup: smoother pointer-driven drag, viewport clamping, transform-based positioning, and better performance hints
  * Faster, less-janky message rendering via parsing cache and refined auto-scroll scheduling
  * More efficient background flushing for tool execution to reduce UI stutter

* **New Features**
  * Dev-time toggle to disable the Vue DevTools overlay

* **Tests**
  * Expanded unit/integration tests covering scheduling, cloning, parsing cache, and popup behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->