### PR TITLE
fix(model): cap derived max tokens

### DIFF
--- a/src/main/presenter/configPresenter/index.ts
+++ b/src/main/presenter/configPresenter/index.ts
@@ -29,9 +29,9 @@ import {
 } from '@shared/model'
 import {
   DEFAULT_MODEL_CAPABILITY_FALLBACKS,
+  resolveDerivedModelMaxTokens,
   resolveModelContextLength,
   resolveModelFunctionCall,
-  resolveModelMaxTokens,
   resolveModelVision
 } from '@shared/modelConfigDefaults'
 import ElectronStore from 'electron-store'
@@ -1090,7 +1090,7 @@ export class ConfigPresenter implements IConfigPresenter {
       id: m.id,
       name: m.display_name || m.name || m.id,
       contextLength: resolveModelContextLength(m.limit?.context),
-      maxTokens: resolveModelMaxTokens(m.limit?.output),
+      maxTokens: resolveDerivedModelMaxTokens(m.limit?.output),
       provider: providerId,
       providerId,
       group: 'default',

--- a/src/main/presenter/configPresenter/modelConfig.ts
+++ b/src/main/presenter/configPresenter/modelConfig.ts
@@ -2,9 +2,9 @@ import { ApiEndpointType, ModelType, isNewApiEndpointType } from '@shared/model'
 import { IModelConfig, ModelConfig, ModelConfigSource } from '@shared/presenter'
 import {
   DEFAULT_MODEL_CAPABILITY_FALLBACKS,
+  resolveDerivedModelMaxTokens,
   resolveModelContextLength,
-  resolveModelFunctionCall,
-  resolveModelMaxTokens
+  resolveModelFunctionCall
 } from '@shared/modelConfigDefaults'
 import ElectronStore from 'electron-store'
 import { providerDbLoader } from './providerDbLoader'
@@ -130,7 +130,7 @@ export class ModelConfigHelper {
     )
 
     return {
-      maxTokens: resolveModelMaxTokens(model.limit?.output),
+      maxTokens: resolveDerivedModelMaxTokens(model.limit?.output),
       contextLength: resolveModelContextLength(model.limit?.context),
       temperature: 0.6,
       vision: isImageInputSupported(model),
@@ -441,7 +441,10 @@ export class ModelConfigHelper {
     if (storedConfig && storedSource && storedSource !== 'user') {
       finalConfig = {
         ...finalConfig,
-        maxTokens: storedConfig.maxTokens ?? finalConfig.maxTokens,
+        maxTokens:
+          storedConfig.maxTokens !== undefined
+            ? resolveDerivedModelMaxTokens(storedConfig.maxTokens)
+            : finalConfig.maxTokens,
         contextLength: storedConfig.contextLength ?? finalConfig.contextLength,
         temperature: storedConfig.temperature ?? finalConfig.temperature,
         vision: storedConfig.vision ?? finalConfig.vision,
@@ -482,8 +485,13 @@ export class ModelConfigHelper {
   ): ModelConfig {
     const cacheKey = this.generateCacheKey(providerId, modelId)
     const source: ModelConfigSource = options?.source ?? 'user'
+    const normalizedMaxTokens =
+      source === 'provider'
+        ? resolveDerivedModelMaxTokens(config.maxTokens)
+        : (config.maxTokens ?? undefined)
     const storedConfig: ModelConfig = {
       ...config,
+      ...(normalizedMaxTokens !== undefined ? { maxTokens: normalizedMaxTokens } : {}),
       isUserDefined: source === 'user'
     }
     const configData: IModelConfig = {

--- a/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
@@ -9,9 +9,9 @@ import {
 import {
   DEFAULT_MODEL_CONTEXT_LENGTH,
   DEFAULT_MODEL_MAX_TOKENS,
+  resolveDerivedModelMaxTokens,
   resolveModelContextLength,
-  resolveModelFunctionCall,
-  resolveModelMaxTokens
+  resolveModelFunctionCall
 } from '@shared/modelConfigDefaults'
 import {
   AWS_BEDROCK_PROVIDER,
@@ -832,7 +832,7 @@ export class AiSdkProvider extends BaseLLMProvider {
         providerId: this.provider.id,
         isCustom: false,
         contextLength: resolveModelContextLength(model.limit?.context),
-        maxTokens: resolveModelMaxTokens(model.limit?.output),
+        maxTokens: resolveDerivedModelMaxTokens(model.limit?.output),
         vision: hasImageInput,
         functionCall: resolveModelFunctionCall(model.tool_call),
         reasoning: Boolean(model.reasoning?.supported),

--- a/src/renderer/src/stores/modelStore.ts
+++ b/src/renderer/src/stores/modelStore.ts
@@ -5,6 +5,7 @@ import { useThrottleFn } from '@vueuse/core'
 import type { MODEL_META, RENDERER_MODEL_META, ModelConfig } from '@shared/presenter'
 import { ModelType } from '@shared/model'
 import {
+  resolveDerivedModelMaxTokens,
   resolveModelContextLength,
   resolveModelFunctionCall,
   resolveModelMaxTokens,
@@ -95,6 +96,27 @@ export const useModelStore = defineStore('model', () => {
     name: model.name || model.id,
     contextLength: resolveModelContextLength(model.contextLength),
     maxTokens: resolveModelMaxTokens(model.maxTokens),
+    group: model.group || 'default',
+    providerId,
+    enabled: (model as RENDERER_MODEL_META).enabled ?? false,
+    isCustom: model.isCustom ?? false,
+    vision: resolveModelVision(model.vision),
+    functionCall: resolveModelFunctionCall(model.functionCall),
+    reasoning: model.reasoning ?? false,
+    enableSearch: (model as RENDERER_MODEL_META).enableSearch ?? false,
+    type: (model.type ?? ModelType.Chat) as ModelType,
+    supportedEndpointTypes: model.supportedEndpointTypes,
+    endpointType: model.endpointType
+  })
+
+  const normalizeDerivedRendererModel = (
+    model: MODEL_META,
+    providerId: string
+  ): RENDERER_MODEL_META => ({
+    id: model.id,
+    name: model.name || model.id,
+    contextLength: resolveModelContextLength(model.contextLength),
+    maxTokens: resolveDerivedModelMaxTokens(model.maxTokens),
     group: model.group || 'default',
     providerId,
     enabled: (model as RENDERER_MODEL_META).enabled ?? false,
@@ -325,7 +347,7 @@ export const useModelStore = defineStore('model', () => {
             contextLength: resolveModelContextLength(
               model.contextLength ?? fallback?.contextLength
             ),
-            maxTokens: resolveModelMaxTokens(model.maxTokens ?? fallback?.maxTokens),
+            maxTokens: resolveDerivedModelMaxTokens(model.maxTokens ?? fallback?.maxTokens),
             vision: resolveModelVision(model.vision ?? fallback?.vision),
             functionCall: resolveModelFunctionCall(model.functionCall ?? fallback?.functionCall),
             // Standard models should keep DB-backed reasoning capability metadata.
@@ -352,7 +374,7 @@ export const useModelStore = defineStore('model', () => {
         // If models array is empty, use storedModels directly
         if (models.length === 0) {
           for (const model of storedModelMap.values()) {
-            mergedModels.push(model)
+            mergedModels.push(normalizeDerivedRendererModel(model, providerId))
           }
         } else {
           // Otherwise, merge db models with stored models
@@ -360,15 +382,17 @@ export const useModelStore = defineStore('model', () => {
             const override = storedModelMap.get(model.id)
             if (override) {
               storedModelMap.delete(model.id)
-              mergedModels.push({ ...model, ...override, providerId })
+              mergedModels.push(
+                normalizeDerivedRendererModel({ ...model, ...override, providerId }, providerId)
+              )
             } else {
-              mergedModels.push({ ...model, providerId })
+              mergedModels.push(normalizeDerivedRendererModel({ ...model, providerId }, providerId))
             }
           }
 
           // Add remaining stored models that are not in db
           for (const model of storedModelMap.values()) {
-            mergedModels.push(model)
+            mergedModels.push(normalizeDerivedRendererModel(model, providerId))
           }
         }
 
@@ -410,7 +434,7 @@ export const useModelStore = defineStore('model', () => {
       const modelsWithStatus = await Promise.all(
         models.map(async (model) => {
           const base: RENDERER_MODEL_META = {
-            ...normalizeRendererModel(model, providerId),
+            ...normalizeDerivedRendererModel(model, providerId),
             enabled: modelStatusMap[model.id] ?? true,
             isCustom: model.isCustom || false
           }

--- a/src/renderer/src/utils/maxOutputTokens.ts
+++ b/src/renderer/src/utils/maxOutputTokens.ts
@@ -1,4 +1,6 @@
-const GLOBAL_OUTPUT_TOKEN_MAX = 32000
+import { DERIVED_MODEL_MAX_TOKENS_CAP } from '@shared/modelConfigDefaults'
+
+const GLOBAL_OUTPUT_TOKEN_MAX = DERIVED_MODEL_MAX_TOKENS_CAP
 
 interface CalculateSafeDefaultOptions {
   modelMaxTokens: number

--- a/src/shared/modelConfigDefaults.ts
+++ b/src/shared/modelConfigDefaults.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_MODEL_CONTEXT_LENGTH = 16000
 export const DEFAULT_MODEL_MAX_TOKENS = 4096
+export const DERIVED_MODEL_MAX_TOKENS_CAP = 32000
 export const DEFAULT_MODEL_VISION = false
 export const DEFAULT_MODEL_FUNCTION_CALL = true
 export const DEFAULT_MODEL_REASONING = false
@@ -17,6 +18,9 @@ export const resolveModelContextLength = (value: number | undefined | null): num
 
 export const resolveModelMaxTokens = (value: number | undefined | null): number =>
   value ?? DEFAULT_MODEL_MAX_TOKENS
+
+export const resolveDerivedModelMaxTokens = (value: number | undefined | null): number =>
+  Math.min(resolveModelMaxTokens(value), DERIVED_MODEL_MAX_TOKENS_CAP)
 
 export const resolveModelVision = (value: boolean | undefined | null): boolean =>
   value ?? DEFAULT_MODEL_VISION

--- a/src/shared/modelConfigDefaults.ts
+++ b/src/shared/modelConfigDefaults.ts
@@ -19,8 +19,12 @@ export const resolveModelContextLength = (value: number | undefined | null): num
 export const resolveModelMaxTokens = (value: number | undefined | null): number =>
   value ?? DEFAULT_MODEL_MAX_TOKENS
 
-export const resolveDerivedModelMaxTokens = (value: number | undefined | null): number =>
-  Math.min(resolveModelMaxTokens(value), DERIVED_MODEL_MAX_TOKENS_CAP)
+export const resolveDerivedModelMaxTokens = (value: number | undefined | null): number => {
+  const resolvedValue = resolveModelMaxTokens(value)
+  const sanePositiveValue = Number.isFinite(resolvedValue) && resolvedValue > 0 ? resolvedValue : 1
+
+  return Math.min(sanePositiveValue, DERIVED_MODEL_MAX_TOKENS_CAP)
+}
 
 export const resolveModelVision = (value: boolean | undefined | null): boolean =>
   value ?? DEFAULT_MODEL_VISION

--- a/test/main/presenter/modelConfig.test.ts
+++ b/test/main/presenter/modelConfig.test.ts
@@ -355,8 +355,8 @@ describe('Model Configuration Tests', () => {
 
     it('marks provider-managed configs as non-user entries', () => {
       const providerConfig: ModelConfig = {
-        maxTokens: 5555,
-        contextLength: 9999,
+        maxTokens: 64000,
+        contextLength: 128000,
         temperature: 0.4,
         vision: false,
         functionCall: true,
@@ -372,7 +372,7 @@ describe('Model Configuration Tests', () => {
 
       const storedConfig = modelConfigHelper.getModelConfig(providerManagedModelId, providerId)
       expect(storedConfig.isUserDefined).toBe(false)
-      expect(storedConfig.maxTokens).toBe(providerConfig.maxTokens)
+      expect(storedConfig.maxTokens).toBe(32000)
     })
 
     it('keeps user configs but drops provider configs when defaults change', () => {

--- a/test/main/presenter/providerDbModelConfig.test.ts
+++ b/test/main/presenter/providerDbModelConfig.test.ts
@@ -83,6 +83,11 @@ describe('Provider DB strict matching + user overrides', () => {
               modalities: { input: ['text'] }
             },
             {
+              id: 'large-output',
+              limit: { context: 200000, output: 64000 },
+              modalities: { input: ['text'] }
+            },
+            {
               id: 'no-limit' // both missing -> fallback 16000/4096
             },
             {
@@ -176,6 +181,14 @@ describe('Provider DB strict matching + user overrides', () => {
     expect(cfg2.searchStrategy).toBe('turbo')
   })
 
+  it('caps provider-derived maxTokens defaults at 32000', () => {
+    const helper = new ModelConfigHelper('1.0.0')
+    const cfg = helper.getModelConfig('large-output', 'test-provider')
+
+    expect(cfg.contextLength).toBe(200000)
+    expect(cfg.maxTokens).toBe(32000)
+  })
+
   it('preserves explicit tool_call=false from provider DB', () => {
     const helper = new ModelConfigHelper('1.0.0')
     const cfg = helper.getModelConfig('tool-call-disabled', 'test-provider')
@@ -196,8 +209,8 @@ describe('Provider DB strict matching + user overrides', () => {
   it('prefers user config over provider DB and persists across restart', () => {
     const helper1 = new ModelConfigHelper('1.0.0')
     const userCfg = {
-      maxTokens: 8888,
-      contextLength: 7777,
+      maxTokens: 64000,
+      contextLength: 128000,
       temperature: 0.5,
       vision: false,
       functionCall: false,
@@ -217,6 +230,55 @@ describe('Provider DB strict matching + user overrides', () => {
     const helper3 = new ModelConfigHelper('2.0.0')
     const read3 = helper3.getModelConfig('test-model', 'test-provider')
     expect(read3).toMatchObject({ ...userCfg, isUserDefined: true })
+  })
+
+  it('caps legacy provider-managed cache values on read while preserving user values', () => {
+    const helper = new ModelConfigHelper('1.0.0')
+    const helperAny = helper as any
+    const providerCacheKey = helperAny.generateCacheKey('test-provider', 'large-output')
+
+    helper.importConfigs(
+      {
+        [providerCacheKey]: {
+          id: 'large-output',
+          providerId: 'test-provider',
+          source: 'provider',
+          config: {
+            maxTokens: 64000,
+            contextLength: 200000,
+            temperature: 0.4,
+            vision: false,
+            functionCall: true,
+            reasoning: false,
+            type: ModelType.Chat,
+            isUserDefined: false
+          }
+        }
+      },
+      false
+    )
+
+    const providerRead = helper.getModelConfig('large-output', 'test-provider')
+    expect(providerRead.maxTokens).toBe(32000)
+
+    helper.setModelConfig(
+      'large-output',
+      'test-provider',
+      {
+        maxTokens: 64000,
+        contextLength: 128000,
+        temperature: 0.6,
+        vision: false,
+        functionCall: true,
+        reasoning: false,
+        type: ModelType.Chat
+      },
+      { source: 'user' }
+    )
+
+    const userRead = helper.getModelConfig('large-output', 'test-provider')
+    expect(userRead.maxTokens).toBe(64000)
+    expect(userRead.isUserDefined).toBe(true)
   })
 
   it('matches DB with case-insensitive provider/model IDs for provider data (strictly lowercase in DB)', () => {

--- a/test/main/shared/modelConfigDefaults.test.ts
+++ b/test/main/shared/modelConfigDefaults.test.ts
@@ -22,6 +22,18 @@ describe('resolveDerivedModelMaxTokens', () => {
   it('falls back to the default when metadata is missing', () => {
     expect(resolveDerivedModelMaxTokens(undefined)).toBe(DEFAULT_MODEL_MAX_TOKENS)
   })
+
+  it('clamps zero to a sane positive minimum', () => {
+    expect(resolveDerivedModelMaxTokens(0)).toBe(1)
+  })
+
+  it('clamps negative values to a sane positive minimum', () => {
+    expect(resolveDerivedModelMaxTokens(-1024)).toBe(1)
+  })
+
+  it('clamps NaN to a sane positive minimum', () => {
+    expect(resolveDerivedModelMaxTokens(Number.NaN)).toBe(1)
+  })
 })
 
 describe('resolveModelMaxTokens', () => {

--- a/test/main/shared/modelConfigDefaults.test.ts
+++ b/test/main/shared/modelConfigDefaults.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DERIVED_MODEL_MAX_TOKENS_CAP,
+  DEFAULT_MODEL_MAX_TOKENS,
+  resolveDerivedModelMaxTokens,
+  resolveModelMaxTokens
+} from '../../../src/shared/modelConfigDefaults'
+
+describe('resolveDerivedModelMaxTokens', () => {
+  it('caps large derived values at 32000', () => {
+    expect(resolveDerivedModelMaxTokens(64000)).toBe(32000)
+  })
+
+  it('keeps exact cap values', () => {
+    expect(resolveDerivedModelMaxTokens(32000)).toBe(32000)
+  })
+
+  it('keeps values below the cap', () => {
+    expect(resolveDerivedModelMaxTokens(8192)).toBe(8192)
+  })
+
+  it('falls back to the default when metadata is missing', () => {
+    expect(resolveDerivedModelMaxTokens(undefined)).toBe(DEFAULT_MODEL_MAX_TOKENS)
+  })
+})
+
+describe('resolveModelMaxTokens', () => {
+  it('preserves user-sized values above the derived cap', () => {
+    expect(resolveModelMaxTokens(64000)).toBe(64000)
+  })
+
+  it('exports the shared derived cap constant', () => {
+    expect(DERIVED_MODEL_MAX_TOKENS_CAP).toBe(32000)
+  })
+})

--- a/test/renderer/components/ChatStatusBar.test.ts
+++ b/test/renderer/components/ChatStatusBar.test.ts
@@ -912,6 +912,20 @@ describe('ChatStatusBar model and session panels', () => {
     expect((wrapper.vm as any).localSettings.thinkingBudget).toBe(512)
   })
 
+  it('uses the derived default maxTokens value from model config', async () => {
+    const { wrapper } = await setup({
+      agentId: 'deepchat',
+      hasActiveSession: false,
+      modelConfig: {
+        contextLength: 128000,
+        maxTokens: 32000
+      }
+    })
+
+    expect((wrapper.vm as any).localSettings.contextLength).toBe(128000)
+    expect((wrapper.vm as any).localSettings.maxTokens).toBe(32000)
+  })
+
   it('awaits async model config values for draft model settings', async () => {
     const { wrapper } = await setup({
       agentId: 'deepchat',
@@ -931,6 +945,24 @@ describe('ChatStatusBar model and session panels', () => {
     expect((wrapper.vm as any).localSettings.contextLength).toBe(8192)
     expect((wrapper.vm as any).localSettings.maxTokens).toBe(2048)
     expect((wrapper.vm as any).localSettings.forceInterleavedThinkingCompat).toBe(true)
+  })
+
+  it('preserves user-entered maxTokens values above the default cap', async () => {
+    const { wrapper, draftStore } = await setup({
+      agentId: 'deepchat',
+      hasActiveSession: false,
+      modelConfig: {
+        contextLength: 128000,
+        maxTokens: 32000
+      }
+    })
+    await (wrapper.vm as any).openModelSettings('openai', 'gpt-4')
+    await flushPromises()
+
+    await commitNumericInput(wrapper, 'maxTokens', '64000')
+
+    expect((wrapper.vm as any).localSettings.maxTokens).toBe(64000)
+    expect(draftStore.maxTokens).toBe(64000)
   })
 
   it('hides temperature controls when the selected model disables temperature', async () => {

--- a/test/renderer/stores/modelStore.test.ts
+++ b/test/renderer/stores/modelStore.test.ts
@@ -221,6 +221,51 @@ describe('modelStore.refreshProviderModels', () => {
     ])
   })
 
+  it('caps derived maxTokens for merged standard models', async () => {
+    const dbModel = {
+      id: 'gpt-5.4',
+      name: 'GPT-5.4',
+      providerId: 'openai',
+      reasoning: true,
+      functionCall: true,
+      vision: false,
+      contextLength: 400000,
+      maxTokens: 128000,
+      isCustom: false
+    }
+    const storedModel = {
+      id: 'gpt-5.4',
+      name: 'GPT-5.4',
+      providerId: 'openai',
+      functionCall: true,
+      vision: false,
+      contextLength: 400000,
+      maxTokens: 64000,
+      isCustom: false
+    }
+    const { store } = await setupStore({
+      configPresenter: {
+        getDbProviderModels: vi.fn(async () => [dbModel]),
+        getProviderModels: vi.fn(async () => [storedModel]),
+        getBatchModelStatus: vi.fn(async () => ({ 'gpt-5.4': true }))
+      }
+    })
+
+    await store.refreshProviderModels('openai')
+
+    expect(store.allProviderModels.value).toEqual([
+      {
+        providerId: 'openai',
+        models: [
+          expect.objectContaining({
+            id: 'gpt-5.4',
+            maxTokens: 32000
+          })
+        ]
+      }
+    ])
+  })
+
   it('uses stored reasoning metadata when no db capability fallback exists', async () => {
     const storedModel = {
       id: 'custom-chat',
@@ -248,6 +293,41 @@ describe('modelStore.refreshProviderModels', () => {
           expect.objectContaining({
             id: 'custom-chat',
             reasoning: true
+          })
+        ]
+      }
+    ])
+  })
+
+  it('caps derived maxTokens for stored-only standard models', async () => {
+    const storedModel = {
+      id: 'custom-chat',
+      name: 'Custom Chat',
+      providerId: 'openai',
+      reasoning: true,
+      functionCall: false,
+      vision: false,
+      contextLength: 200000,
+      maxTokens: 128000,
+      isCustom: false
+    }
+    const { store } = await setupStore({
+      configPresenter: {
+        getDbProviderModels: vi.fn(async () => []),
+        getProviderModels: vi.fn(async () => [storedModel]),
+        getBatchModelStatus: vi.fn(async () => ({ 'custom-chat': true }))
+      }
+    })
+
+    await store.refreshProviderModels('openai')
+
+    expect(store.allProviderModels.value).toEqual([
+      {
+        providerId: 'openai',
+        models: [
+          expect.objectContaining({
+            id: 'custom-chat',
+            maxTokens: 32000
           })
         ]
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a derived max-token cap (32,000) applied to provider-derived model defaults and renderer defaults.

* **Improvements**
  * Normalized and tightened token-limit calculations across model settings and persistence paths.
  * Renderer and settings UI now reflect capped derived defaults while still allowing user-saved values above the cap.

* **Tests**
  * Added/updated tests covering large-output models, capping behavior, and user override persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->