### PR TITLE
feat(project): add ability to clear selected project in NewThreadPage

### DIFF
--- a/src/main/presenter/devicePresenter/index.ts
+++ b/src/main/presenter/devicePresenter/index.ts
@@ -190,7 +190,12 @@ export class DevicePresenter implements IDevicePresenter {
       })
 
       // 获取内容类型并确定文件扩展名
-      const contentType = response.headers['content-type'] || 'image/jpeg'
+      const rawContentType = response.headers['content-type']
+      const contentType = Array.isArray(rawContentType)
+        ? rawContentType.join(';')
+        : typeof rawContentType === 'string'
+          ? rawContentType
+          : 'image/jpeg'
       let extension = 'jpg'
 
       if (contentType.includes('png')) {

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -19,6 +19,7 @@
             <Button
               variant="ghost"
               size="sm"
+              data-testid="new-thread-project-trigger"
               class="h-7 px-2.5 gap-1.5 text-xs text-muted-foreground hover:text-foreground mb-6"
             >
               <Icon icon="lucide:folder" class="w-3.5 h-3.5" />
@@ -28,6 +29,16 @@
           </DropdownMenuTrigger>
           <DropdownMenuContent align="center" class="min-w-[200px]">
             <DropdownMenuLabel class="text-xs">{{ t('common.project.recent') }}</DropdownMenuLabel>
+            <DropdownMenuItem
+              data-testid="new-thread-clear-project"
+              class="gap-2 text-xs py-1.5 px-2"
+              :disabled="!canClearProjectSelection"
+              @click="clearSelectedProject"
+            >
+              <Icon icon="lucide:folder-x" class="w-3.5 h-3.5 text-muted-foreground" />
+              <span>{{ t('common.project.none') }}</span>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
             <DropdownMenuItem
               v-for="project in projectStore.projects"
               :key="project.path"
@@ -40,7 +51,6 @@
                 <span class="text-[10px] text-muted-foreground truncate">{{ project.path }}</span>
               </div>
             </DropdownMenuItem>
-            <DropdownMenuSeparator />
             <DropdownMenuItem
               class="gap-2 text-xs py-1.5 px-2"
               @click="projectStore.openFolderPicker()"
@@ -168,9 +178,16 @@ const normalizeProjectPath = (value: string | null | undefined) => {
   const normalized = value?.trim()
   return normalized ? normalized : null
 }
-const selectedProjectName = computed(
-  () => projectStore.selectedProject?.name ?? t('common.project.select')
+const hasExplicitNoProjectSelection = computed(
+  () => projectStore.selectionSource === 'manual' && !projectStore.selectedProject?.path?.trim()
 )
+const selectedProjectName = computed(() => {
+  if (projectStore.selectedProject?.name) {
+    return projectStore.selectedProject.name
+  }
+  return hasExplicitNoProjectSelection.value ? t('common.project.none') : t('common.project.select')
+})
+const canClearProjectSelection = computed(() => Boolean(projectStore.selectedProject?.path?.trim()))
 const isAcpWorkdirMissing = computed(() => {
   if (!isAcpSelectedAgent.value) {
     return false
@@ -452,6 +469,10 @@ function onFilesChange(files: MessageFile[]) {
 
 function onPendingSkillsChange(skills: string[]) {
   pendingSkills.value = [...skills]
+}
+
+function clearSelectedProject() {
+  projectStore.selectProject(null, 'manual')
 }
 
 const ensureAcpDraftSession = async (agentId: string, projectPath: string) => {

--- a/src/renderer/src/stores/ui/project.ts
+++ b/src/renderer/src/stores/ui/project.ts
@@ -153,7 +153,7 @@ export const useProjectStore = defineStore('project', () => {
     source: ProjectSelectionSource = normalizePath(path) ? 'manual' : 'none'
   ): void {
     selectedProjectPath.value = normalizePath(path)
-    selectionSource.value = selectedProjectPath.value ? source : 'none'
+    selectionSource.value = selectedProjectPath.value || source === 'manual' ? source : 'none'
     projects.value = reconcileProjects(projects.value)
   }
 
@@ -209,6 +209,7 @@ export const useProjectStore = defineStore('project', () => {
     environments,
     selectedProjectPath,
     defaultProjectPath,
+    selectionSource,
     error,
     selectedProject,
     fetchProjects,

--- a/test/renderer/pages/NewThreadPage.test.ts
+++ b/test/renderer/pages/NewThreadPage.test.ts
@@ -37,10 +37,21 @@ const setup = async (pendingModelId: string) => {
     selectedProject: {
       name: 'demo',
       path: '/workspace/demo'
-    },
+    } as { name: string; path: string } | null,
     defaultProjectPath: null as string | null,
-    projects: [] as Array<{ name: string; path: string }>,
-    selectProject: vi.fn(),
+    selectionSource: 'manual' as 'none' | 'manual' | 'default',
+    projects: [{ name: 'demo', path: '/workspace/demo' }] as Array<{ name: string; path: string }>,
+    selectProject: vi.fn((path: string | null, source?: 'none' | 'manual' | 'default') => {
+      const normalizedPath = path?.trim() || null
+      projectStore.selectedProject = normalizedPath
+        ? {
+            name: normalizedPath.split('/').pop() ?? normalizedPath,
+            path: normalizedPath
+          }
+        : null
+      projectStore.selectionSource =
+        normalizedPath || source === 'manual' ? (source ?? 'manual') : 'none'
+    }),
     openFolderPicker: vi.fn()
   })
   const sessionStore = {
@@ -123,19 +134,33 @@ const setup = async (pendingModelId: string) => {
         TooltipProvider: {
           template: '<div><slot /></div>'
         },
-        DropdownMenu: true,
-        DropdownMenuTrigger: true,
-        DropdownMenuContent: true,
-        DropdownMenuLabel: true,
-        DropdownMenuItem: true,
-        DropdownMenuSeparator: true,
-        Button: true,
+        DropdownMenu: {
+          template: '<div><slot /></div>'
+        },
+        DropdownMenuTrigger: {
+          template: '<div><slot /></div>'
+        },
+        DropdownMenuContent: {
+          template: '<div><slot /></div>'
+        },
+        DropdownMenuLabel: {
+          template: '<div><slot /></div>'
+        },
+        DropdownMenuItem: {
+          template: '<button type="button" v-bind="$attrs"><slot /></button>'
+        },
+        DropdownMenuSeparator: {
+          template: '<div />'
+        },
+        Button: {
+          template: '<button type="button" v-bind="$attrs"><slot /></button>'
+        },
         ChatInputToolbar: true,
         ChatStatusBar: true,
         ChatInputBox: {
           name: 'ChatInputBox',
           props: ['modelValue'],
-          template: '<div data-testid="chat-input">{{ modelValue }}</div>'
+          template: '<div data-testid="chat-input">{{ modelValue }}<slot name="toolbar" /></div>'
         }
       }
     }
@@ -145,7 +170,8 @@ const setup = async (pendingModelId: string) => {
 
   return {
     wrapper,
-    draftStore
+    draftStore,
+    projectStore
   }
 }
 
@@ -160,12 +186,24 @@ describe('NewThreadPage start deeplink prefill', () => {
     expect(draftStore.providerId).toBe('openai')
     expect(draftStore.modelId).toBe('deepseek-chat')
     expect(draftStore.clearPendingStartDeeplink).toHaveBeenCalledTimes(1)
-  })
+  }, 20000)
 
   it('falls back to fuzzy model matching when no exact match exists', async () => {
     const { draftStore } = await setup('seek-chat')
 
     expect(draftStore.providerId).toBe('openai')
     expect(draftStore.modelId).toBe('deepseek-chat')
-  })
+  }, 20000)
+
+  it('allows clearing the selected project from the new thread dropdown', async () => {
+    const { wrapper, projectStore } = await setup('deepseek-chat')
+
+    await wrapper.get('[data-testid="new-thread-clear-project"]').trigger('click')
+    await flushPromises()
+
+    expect(projectStore.selectProject).toHaveBeenCalledWith(null, 'manual')
+    expect(wrapper.get('[data-testid="new-thread-project-trigger"]').text()).toContain(
+      'common.project.none'
+    )
+  }, 20000)
 })

--- a/test/renderer/stores/projectStore.test.ts
+++ b/test/renderer/stores/projectStore.test.ts
@@ -119,4 +119,25 @@ describe('projectStore default project handling', () => {
 
     expect(store.selectedProject.value?.path).toBe('/work/changed-default')
   })
+
+  it('keeps an explicit clear selection instead of reapplying the default directory', async () => {
+    const { store, emitIpc, CONFIG_EVENTS } = await setupStore({
+      recentProjects: [{ path: '/work/recent', name: 'recent', icon: null }],
+      defaultProjectPath: '/work/default'
+    })
+
+    await store.fetchProjects()
+    store.selectProject(null, 'manual')
+
+    expect(store.selectedProjectPath.value).toBeNull()
+    expect(store.selectedProject.value).toBeUndefined()
+
+    emitIpc(CONFIG_EVENTS.DEFAULT_PROJECT_PATH_CHANGED, {
+      path: '/work/changed-default'
+    })
+
+    expect(store.defaultProjectPath.value).toBe('/work/changed-default')
+    expect(store.selectedProjectPath.value).toBeNull()
+    expect(store.selectedProject.value).toBeUndefined()
+  })
 })


### PR DESCRIPTION
<img width="710" height="591" alt="image" src="https://github.com/user-attachments/assets/d7486348-7350-4ac5-bc78-faf8950fbb04" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "clear project" option in the project dropdown to manually remove the selected project.

* **Improvements**
  * Refined project selection behavior so manual clears persist and default projects are not re-applied unintentionally.
  * Dropdown UI now more clearly indicates explicit "no project" vs. "select project" states.

* **Bug Fixes / Reliability**
  * More robust handling of content-type when caching remote images.

* **Tests**
  * Added/updated tests to cover manual clear behavior and dropdown interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->