### PR TITLE
fix(timeout): preserve timeout in route contracts

### DIFF
--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -420,6 +420,7 @@ const applyDraftDefaultsForSelectedAgent = async (): Promise<void> => {
   draftStore.temperature = undefined
   draftStore.contextLength = undefined
   draftStore.maxTokens = undefined
+  draftStore.timeout = undefined
   draftStore.thinkingBudget = undefined
   draftStore.reasoningEffort = undefined
   draftStore.reasoningVisibility = undefined

--- a/src/shared/contracts/common.ts
+++ b/src/shared/contracts/common.ts
@@ -54,6 +54,7 @@ export const SessionGenerationSettingsSchema = z.object({
   temperature: z.number(),
   contextLength: z.number().int(),
   maxTokens: z.number().int(),
+  timeout: z.number().int(),
   thinkingBudget: z.number().int().optional(),
   reasoningEffort: ReasoningEffortSchema.optional(),
   reasoningVisibility: ReasoningVisibilitySchema.optional(),

--- a/test/main/routes/contracts.test.ts
+++ b/test/main/routes/contracts.test.ts
@@ -14,6 +14,7 @@ import {
   providersListModelsRoute,
   providersTestConnectionRoute,
   sessionsActivateRoute,
+  sessionsGetGenerationSettingsRoute,
   settingsGetSnapshotRoute,
   settingsListSystemFontsRoute,
   settingsUpdateRoute,
@@ -22,8 +23,10 @@ import {
   sessionsGetActiveRoute,
   sessionsListRoute,
   sessionsRestoreRoute,
+  sessionsUpdateGenerationSettingsRoute,
   systemOpenSettingsRoute
 } from '@shared/contracts/routes'
+import { SessionGenerationSettingsPatchSchema } from '@shared/contracts/common'
 
 describe('main kernel contracts', () => {
   it('registers typed route catalog entries through phase4', () => {
@@ -137,6 +140,62 @@ describe('main kernel contracts', () => {
       })
     ).toEqual({
       fonts: ['Inter', 'JetBrains Mono']
+    })
+  })
+
+  it('preserves timeout in session generation settings contracts', () => {
+    expect(SessionGenerationSettingsPatchSchema.parse({ timeout: 5000 })).toEqual({
+      timeout: 5000
+    })
+
+    expect(
+      sessionsUpdateGenerationSettingsRoute.input.parse({
+        sessionId: 'session-1',
+        settings: {
+          timeout: 5000
+        }
+      })
+    ).toEqual({
+      sessionId: 'session-1',
+      settings: {
+        timeout: 5000
+      }
+    })
+
+    expect(
+      sessionsGetGenerationSettingsRoute.output.parse({
+        settings: {
+          systemPrompt: '',
+          temperature: 0.7,
+          contextLength: 32000,
+          maxTokens: 4096,
+          timeout: 5000
+        }
+      })
+    ).toEqual({
+      settings: {
+        systemPrompt: '',
+        temperature: 0.7,
+        contextLength: 32000,
+        maxTokens: 4096,
+        timeout: 5000
+      }
+    })
+
+    expect(
+      sessionsCreateRoute.input.parse({
+        agentId: 'deepchat',
+        message: 'hello',
+        generationSettings: {
+          timeout: 5000
+        }
+      })
+    ).toEqual({
+      agentId: 'deepchat',
+      message: 'hello',
+      generationSettings: {
+        timeout: 5000
+      }
     })
   })
 

--- a/test/main/routes/dispatcher.test.ts
+++ b/test/main/routes/dispatcher.test.ts
@@ -248,6 +248,22 @@ function createRuntime() {
     getActiveSession: vi.fn().mockResolvedValue(null),
     activateSession: vi.fn().mockResolvedValue(undefined),
     deactivateSession: vi.fn().mockResolvedValue(undefined),
+    getSessionGenerationSettings: vi.fn().mockResolvedValue({
+      systemPrompt: '',
+      temperature: 0.7,
+      contextLength: 32000,
+      maxTokens: 4096,
+      timeout: 5000
+    }),
+    updateSessionGenerationSettings: vi
+      .fn()
+      .mockImplementation(async (_sessionId: string, settings: { timeout?: number }) => ({
+        systemPrompt: '',
+        temperature: 0.7,
+        contextLength: 32000,
+        maxTokens: 4096,
+        timeout: settings.timeout ?? 5000
+      })),
     sendMessage: vi.fn().mockResolvedValue(undefined),
     cancelGeneration: vi.fn().mockResolvedValue(undefined),
     getMessage: vi.fn().mockResolvedValue({
@@ -588,6 +604,63 @@ describe('dispatchDeepchatRoute', () => {
     )
 
     expect(agentSessionPresenter.sendMessage).toHaveBeenCalledWith('session-1', 'follow up')
+  })
+
+  it('dispatches session generation settings routes without dropping timeout', async () => {
+    const { runtime, agentSessionPresenter } = createRuntime()
+
+    const updateResult = await dispatchDeepchatRoute(
+      runtime,
+      'sessions.updateGenerationSettings',
+      {
+        sessionId: 'session-1',
+        settings: {
+          timeout: 5000
+        }
+      },
+      {
+        webContentsId: 88,
+        windowId: 3
+      }
+    )
+
+    const getResult = await dispatchDeepchatRoute(
+      runtime,
+      'sessions.getGenerationSettings',
+      {
+        sessionId: 'session-1'
+      },
+      {
+        webContentsId: 88,
+        windowId: 3
+      }
+    )
+
+    expect(agentSessionPresenter.updateSessionGenerationSettings).toHaveBeenCalledWith(
+      'session-1',
+      {
+        timeout: 5000
+      }
+    )
+    expect(updateResult).toEqual({
+      settings: {
+        systemPrompt: '',
+        temperature: 0.7,
+        contextLength: 32000,
+        maxTokens: 4096,
+        timeout: 5000
+      }
+    })
+    expect(agentSessionPresenter.getSessionGenerationSettings).toHaveBeenCalledWith('session-1')
+    expect(getResult).toEqual({
+      settings: {
+        systemPrompt: '',
+        temperature: 0.7,
+        contextLength: 32000,
+        maxTokens: 4096,
+        timeout: 5000
+      }
+    })
   })
 
   it('dispatches provider query and tool interaction routes through typed services', async () => {


### PR DESCRIPTION
fix(timeout): preserve timeout in route contracts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeout configuration to session generation settings, allowing control over timeout duration for sessions and draft defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->