### PR TITLE
refactor: replace client instantiation with factory functions

### DIFF
--- a/src/renderer/api/BrowserClient.ts
+++ b/src/renderer/api/BrowserClient.ts
@@ -15,10 +15,8 @@ import type { YoBrowserStatus } from '@shared/types/browser'
 import { getDeepchatBridge } from './core'
 import { getRuntimeWindowId, openRuntimeExternal } from './runtime'
 
-export class BrowserClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  private toSerializableBounds(bounds: { x: number; y: number; width: number; height: number }) {
+export function createBrowserClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  function toSerializableBounds(bounds: { x: number; y: number; width: number; height: number }) {
     return {
       x: Number(bounds.x),
       y: Number(bounds.y),
@@ -27,13 +25,13 @@ export class BrowserClient {
     }
   }
 
-  async getStatus(sessionId: string) {
-    const result = await this.bridge.invoke(browserGetStatusRoute.name, { sessionId })
+  async function getStatus(sessionId: string) {
+    const result = await bridge.invoke(browserGetStatusRoute.name, { sessionId })
     return result.status
   }
 
-  async loadUrl(sessionId: string, url: string, timeoutMs?: number) {
-    const result = await this.bridge.invoke(browserLoadUrlRoute.name, {
+  async function loadUrl(sessionId: string, url: string, timeoutMs?: number) {
+    const result = await bridge.invoke(browserLoadUrlRoute.name, {
       sessionId,
       url,
       timeoutMs
@@ -41,12 +39,12 @@ export class BrowserClient {
     return result.status
   }
 
-  async attachCurrentWindow(sessionId: string) {
-    const result = await this.bridge.invoke(browserAttachCurrentWindowRoute.name, { sessionId })
+  async function attachCurrentWindow(sessionId: string) {
+    const result = await bridge.invoke(browserAttachCurrentWindowRoute.name, { sessionId })
     return result.attached
   }
 
-  async updateCurrentWindowBounds(
+  async function updateCurrentWindowBounds(
     sessionId: string,
     bounds: {
       x: number
@@ -56,44 +54,44 @@ export class BrowserClient {
     },
     visible: boolean
   ) {
-    const result = await this.bridge.invoke(browserUpdateCurrentWindowBoundsRoute.name, {
+    const result = await bridge.invoke(browserUpdateCurrentWindowBoundsRoute.name, {
       sessionId,
-      bounds: this.toSerializableBounds(bounds),
+      bounds: toSerializableBounds(bounds),
       visible
     })
     return result.updated
   }
 
-  async detach(sessionId: string) {
-    const result = await this.bridge.invoke(browserDetachRoute.name, { sessionId })
+  async function detach(sessionId: string) {
+    const result = await bridge.invoke(browserDetachRoute.name, { sessionId })
     return result.detached
   }
 
-  async destroy(sessionId: string) {
-    const result = await this.bridge.invoke(browserDestroyRoute.name, { sessionId })
+  async function destroy(sessionId: string) {
+    const result = await bridge.invoke(browserDestroyRoute.name, { sessionId })
     return result.destroyed
   }
 
-  async goBack(sessionId: string) {
-    const result = await this.bridge.invoke(browserGoBackRoute.name, { sessionId })
+  async function goBack(sessionId: string) {
+    const result = await bridge.invoke(browserGoBackRoute.name, { sessionId })
     return result.status
   }
 
-  async goForward(sessionId: string) {
-    const result = await this.bridge.invoke(browserGoForwardRoute.name, { sessionId })
+  async function goForward(sessionId: string) {
+    const result = await bridge.invoke(browserGoForwardRoute.name, { sessionId })
     return result.status
   }
 
-  async reload(sessionId: string) {
-    const result = await this.bridge.invoke(browserReloadRoute.name, { sessionId })
+  async function reload(sessionId: string) {
+    const result = await bridge.invoke(browserReloadRoute.name, { sessionId })
     return result.status
   }
 
-  async openExternal(url: string) {
+  async function openExternal(url: string) {
     await openRuntimeExternal(url)
   }
 
-  onOpenRequested(
+  function onOpenRequested(
     listener: (payload: {
       sessionId: string
       windowId: number
@@ -101,10 +99,10 @@ export class BrowserClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(browserOpenRequestedEvent.name, listener)
+    return bridge.on(browserOpenRequestedEvent.name, listener)
   }
 
-  onOpenRequestedForCurrentWindow(
+  function onOpenRequestedForCurrentWindow(
     listener: (payload: {
       sessionId: string
       windowId: number
@@ -114,7 +112,7 @@ export class BrowserClient {
   ) {
     const currentWindowId = getRuntimeWindowId()
 
-    return this.onOpenRequested((payload) => {
+    return onOpenRequested((payload) => {
       if (currentWindowId != null && payload.windowId !== currentWindowId) {
         return
       }
@@ -123,7 +121,7 @@ export class BrowserClient {
     })
   }
 
-  onStatusChanged(
+  function onStatusChanged(
     listener: (payload: {
       sessionId: string
       reason: 'created' | 'updated' | 'closed' | 'focused' | 'visibility'
@@ -133,6 +131,24 @@ export class BrowserClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(browserStatusChangedEvent.name, listener)
+    return bridge.on(browserStatusChangedEvent.name, listener)
+  }
+
+  return {
+    getStatus,
+    loadUrl,
+    attachCurrentWindow,
+    updateCurrentWindowBounds,
+    detach,
+    destroy,
+    goBack,
+    goForward,
+    reload,
+    openExternal,
+    onOpenRequested,
+    onOpenRequestedForCurrentWindow,
+    onStatusChanged
   }
 }
+
+export type BrowserClient = ReturnType<typeof createBrowserClient>

--- a/src/renderer/api/ChatClient.ts
+++ b/src/renderer/api/ChatClient.ts
@@ -14,43 +14,56 @@ import {
 import type { SendMessageInput, ToolInteractionResponse } from '@shared/types/agent-interface'
 import { getDeepchatBridge } from './core'
 
-export class ChatClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async sendMessage(sessionId: string, content: string | SendMessageInput) {
+export function createChatClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function sendMessage(sessionId: string, content: string | SendMessageInput) {
     const input = {
       sessionId,
       content
     } as DeepchatRouteInput<typeof chatSendMessageRoute.name>
 
-    return await this.bridge.invoke(chatSendMessageRoute.name, input)
+    return await bridge.invoke(chatSendMessageRoute.name, input)
   }
 
-  async stopStream(input: { sessionId?: string; requestId?: string }) {
-    return await this.bridge.invoke(chatStopStreamRoute.name, input)
+  async function stopStream(input: { sessionId?: string; requestId?: string }) {
+    return await bridge.invoke(chatStopStreamRoute.name, input)
   }
 
-  async respondToolInteraction(input: {
+  async function respondToolInteraction(input: {
     sessionId: string
     messageId: string
     toolCallId: string
     response: ToolInteractionResponse
   }) {
-    return await this.bridge.invoke(
+    return await bridge.invoke(
       chatRespondToolInteractionRoute.name,
       input as DeepchatRouteInput<typeof chatRespondToolInteractionRoute.name>
     )
   }
 
-  onStreamUpdated(listener: (payload: DeepchatEventPayload<'chat.stream.updated'>) => void) {
-    return this.bridge.on(chatStreamUpdatedEvent.name, listener)
+  function onStreamUpdated(
+    listener: (payload: DeepchatEventPayload<'chat.stream.updated'>) => void
+  ) {
+    return bridge.on(chatStreamUpdatedEvent.name, listener)
   }
 
-  onStreamCompleted(listener: (payload: DeepchatEventPayload<'chat.stream.completed'>) => void) {
-    return this.bridge.on(chatStreamCompletedEvent.name, listener)
+  function onStreamCompleted(
+    listener: (payload: DeepchatEventPayload<'chat.stream.completed'>) => void
+  ) {
+    return bridge.on(chatStreamCompletedEvent.name, listener)
   }
 
-  onStreamFailed(listener: (payload: DeepchatEventPayload<'chat.stream.failed'>) => void) {
-    return this.bridge.on(chatStreamFailedEvent.name, listener)
+  function onStreamFailed(listener: (payload: DeepchatEventPayload<'chat.stream.failed'>) => void) {
+    return bridge.on(chatStreamFailedEvent.name, listener)
+  }
+
+  return {
+    sendMessage,
+    stopStream,
+    respondToolInteraction,
+    onStreamUpdated,
+    onStreamCompleted,
+    onStreamFailed
   }
 }
+
+export type ChatClient = ReturnType<typeof createChatClient>

--- a/src/renderer/api/ConfigClient.ts
+++ b/src/renderer/api/ConfigClient.ts
@@ -59,8 +59,8 @@ import {
   type ConfigEntryValues
 } from '@shared/contracts/routes'
 import type { Prompt, ShortcutKeySetting, SystemPrompt } from '@shared/presenter'
-import { SettingsClient } from './SettingsClient'
 import { getDeepchatBridge } from './core'
+import { createSettingsClient } from './SettingsClient'
 
 type VoiceAIConfig = {
   audioFormat: string
@@ -78,279 +78,281 @@ type GeminiSafetyValue =
   | 'BLOCK_LOW_AND_ABOVE'
   | 'HARM_BLOCK_THRESHOLD_UNSPECIFIED'
 
-export class ConfigClient extends SettingsClient {
-  constructor(bridge: DeepchatBridge = getDeepchatBridge()) {
-    super(bridge)
+export function createConfigClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  const settingsClient = createSettingsClient(bridge)
+
+  async function getSetting<K extends ConfigEntryKey>(
+    key: K
+  ): Promise<ConfigEntryValues[K] | undefined> {
+    return await settingsClient.getConfigEntry(key)
   }
 
-  async getSetting<K extends ConfigEntryKey>(key: K): Promise<ConfigEntryValues[K] | undefined> {
-    return await this.getConfigEntry(key)
+  async function setSetting<K extends ConfigEntryKey>(key: K, value: ConfigEntryValues[K]) {
+    return await settingsClient.setConfigEntry(key, value)
   }
 
-  async setSetting<K extends ConfigEntryKey>(key: K, value: ConfigEntryValues[K]) {
-    return await this.setConfigEntry(key, value)
-  }
-
-  async getLanguage() {
-    const result = await this.bridge.invoke(configGetLanguageRoute.name, {})
+  async function getLanguage() {
+    const result = await bridge.invoke(configGetLanguageRoute.name, {})
     return result.locale
   }
 
-  async getRequestedLanguage() {
-    const result = await this.bridge.invoke(configGetLanguageRoute.name, {})
+  async function getRequestedLanguage() {
+    const result = await bridge.invoke(configGetLanguageRoute.name, {})
     return result.requestedLanguage
   }
 
-  async getLanguageState() {
-    return await this.bridge.invoke(configGetLanguageRoute.name, {})
+  async function getLanguageState() {
+    return await bridge.invoke(configGetLanguageRoute.name, {})
   }
 
-  async setLanguage(language: string) {
-    return await this.bridge.invoke(configSetLanguageRoute.name, { language })
+  async function setLanguage(language: string) {
+    return await bridge.invoke(configSetLanguageRoute.name, { language })
   }
 
-  async getTheme() {
-    const result = await this.bridge.invoke(configGetThemeRoute.name, {})
+  async function getTheme() {
+    const result = await bridge.invoke(configGetThemeRoute.name, {})
     return result.theme
   }
 
-  async getCurrentThemeIsDark() {
-    const result = await this.bridge.invoke(configGetThemeRoute.name, {})
+  async function getCurrentThemeIsDark() {
+    const result = await bridge.invoke(configGetThemeRoute.name, {})
     return result.isDark
   }
 
-  async getThemeState() {
-    return await this.bridge.invoke(configGetThemeRoute.name, {})
+  async function getThemeState() {
+    return await bridge.invoke(configGetThemeRoute.name, {})
   }
 
-  async setTheme(theme: 'dark' | 'light' | 'system') {
-    const result = await this.bridge.invoke(configSetThemeRoute.name, { theme })
+  async function setTheme(theme: 'dark' | 'light' | 'system') {
+    const result = await bridge.invoke(configSetThemeRoute.name, { theme })
     return result.isDark
   }
 
-  async getFloatingButtonEnabled() {
-    const result = await this.bridge.invoke(configGetFloatingButtonRoute.name, {})
+  async function getFloatingButtonEnabled() {
+    const result = await bridge.invoke(configGetFloatingButtonRoute.name, {})
     return result.enabled
   }
 
-  async setFloatingButtonEnabled(enabled: boolean) {
-    return await this.bridge.invoke(configSetFloatingButtonRoute.name, { enabled })
+  async function setFloatingButtonEnabled(enabled: boolean) {
+    return await bridge.invoke(configSetFloatingButtonRoute.name, { enabled })
   }
 
-  async getSyncEnabled() {
-    const result = await this.bridge.invoke(configGetSyncSettingsRoute.name, {})
+  async function getSyncEnabled() {
+    const result = await bridge.invoke(configGetSyncSettingsRoute.name, {})
     return result.enabled
   }
 
-  async setSyncEnabled(enabled: boolean) {
-    return await this.bridge.invoke(configUpdateSyncSettingsRoute.name, { enabled })
+  async function setSyncEnabled(enabled: boolean) {
+    return await bridge.invoke(configUpdateSyncSettingsRoute.name, { enabled })
   }
 
-  async getSyncFolderPath() {
-    const result = await this.bridge.invoke(configGetSyncSettingsRoute.name, {})
+  async function getSyncFolderPath() {
+    const result = await bridge.invoke(configGetSyncSettingsRoute.name, {})
     return result.folderPath
   }
 
-  async setSyncFolderPath(folderPath: string) {
-    return await this.bridge.invoke(configUpdateSyncSettingsRoute.name, { folderPath })
+  async function setSyncFolderPath(folderPath: string) {
+    return await bridge.invoke(configUpdateSyncSettingsRoute.name, { folderPath })
   }
 
-  async getDefaultProjectPath() {
-    const result = await this.bridge.invoke(configGetDefaultProjectPathRoute.name, {})
+  async function getDefaultProjectPath() {
+    const result = await bridge.invoke(configGetDefaultProjectPathRoute.name, {})
     return result.path
   }
 
-  async setDefaultProjectPath(path: string | null) {
-    return await this.bridge.invoke(configSetDefaultProjectPathRoute.name, { path })
+  async function setDefaultProjectPath(path: string | null) {
+    return await bridge.invoke(configSetDefaultProjectPathRoute.name, { path })
   }
 
-  async getShortcutKey(): Promise<ShortcutKeySetting> {
-    const result = await this.bridge.invoke(configGetShortcutKeysRoute.name, {})
+  async function getShortcutKey(): Promise<ShortcutKeySetting> {
+    const result = await bridge.invoke(configGetShortcutKeysRoute.name, {})
     return result.shortcuts
   }
 
-  async setShortcutKey(shortcuts: ShortcutKeySetting) {
-    return await this.bridge.invoke(configSetShortcutKeysRoute.name, { shortcuts })
+  async function setShortcutKey(shortcuts: ShortcutKeySetting) {
+    return await bridge.invoke(configSetShortcutKeysRoute.name, { shortcuts })
   }
 
-  async resetShortcutKeys() {
-    return await this.bridge.invoke(configResetShortcutKeysRoute.name, {})
+  async function resetShortcutKeys() {
+    return await bridge.invoke(configResetShortcutKeysRoute.name, {})
   }
 
-  async getCustomPrompts(): Promise<Prompt[]> {
-    const result = await this.bridge.invoke(configListCustomPromptsRoute.name, {})
+  async function getCustomPrompts(): Promise<Prompt[]> {
+    const result = await bridge.invoke(configListCustomPromptsRoute.name, {})
     return result.prompts as unknown as Prompt[]
   }
 
-  async setCustomPrompts(prompts: Prompt[]) {
-    return await this.bridge.invoke(configSetCustomPromptsRoute.name, {
+  async function setCustomPrompts(prompts: Prompt[]) {
+    return await bridge.invoke(configSetCustomPromptsRoute.name, {
       prompts: prompts as any
     })
   }
 
-  async addCustomPrompt(prompt: Prompt) {
-    return await this.bridge.invoke(configAddCustomPromptRoute.name, {
+  async function addCustomPrompt(prompt: Prompt) {
+    return await bridge.invoke(configAddCustomPromptRoute.name, {
       prompt: prompt as any
     })
   }
 
-  async updateCustomPrompt(promptId: string, updates: Partial<Prompt>) {
-    return await this.bridge.invoke(configUpdateCustomPromptRoute.name, {
+  async function updateCustomPrompt(promptId: string, updates: Partial<Prompt>) {
+    return await bridge.invoke(configUpdateCustomPromptRoute.name, {
       promptId,
       updates: updates as any
     })
   }
 
-  async deleteCustomPrompt(promptId: string) {
-    return await this.bridge.invoke(configDeleteCustomPromptRoute.name, { promptId })
+  async function deleteCustomPrompt(promptId: string) {
+    return await bridge.invoke(configDeleteCustomPromptRoute.name, { promptId })
   }
 
-  async getSystemPrompts(): Promise<SystemPrompt[]> {
-    const result = await this.bridge.invoke(configGetSystemPromptsRoute.name, {})
+  async function getSystemPrompts(): Promise<SystemPrompt[]> {
+    const result = await bridge.invoke(configGetSystemPromptsRoute.name, {})
     return result.prompts as unknown as SystemPrompt[]
   }
 
-  async getDefaultSystemPromptId() {
-    const result = await this.bridge.invoke(configGetDefaultSystemPromptRoute.name, {})
+  async function getDefaultSystemPromptId() {
+    const result = await bridge.invoke(configGetDefaultSystemPromptRoute.name, {})
     return result.defaultPromptId
   }
 
-  async getDefaultSystemPrompt() {
-    const result = await this.bridge.invoke(configGetDefaultSystemPromptRoute.name, {})
+  async function getDefaultSystemPrompt() {
+    const result = await bridge.invoke(configGetDefaultSystemPromptRoute.name, {})
     return result.prompt
   }
 
-  async setDefaultSystemPrompt(prompt: string) {
-    return await this.bridge.invoke(configSetDefaultSystemPromptRoute.name, { prompt })
+  async function setDefaultSystemPrompt(prompt: string) {
+    return await bridge.invoke(configSetDefaultSystemPromptRoute.name, { prompt })
   }
 
-  async resetToDefaultPrompt() {
-    return await this.bridge.invoke(configResetDefaultSystemPromptRoute.name, {})
+  async function resetToDefaultPrompt() {
+    return await bridge.invoke(configResetDefaultSystemPromptRoute.name, {})
   }
 
-  async clearSystemPrompt() {
-    return await this.bridge.invoke(configClearDefaultSystemPromptRoute.name, {})
+  async function clearSystemPrompt() {
+    return await bridge.invoke(configClearDefaultSystemPromptRoute.name, {})
   }
 
-  async setSystemPrompts(prompts: SystemPrompt[]) {
-    return await this.bridge.invoke(configSetSystemPromptsRoute.name, {
+  async function setSystemPrompts(prompts: SystemPrompt[]) {
+    return await bridge.invoke(configSetSystemPromptsRoute.name, {
       prompts: prompts as any
     })
   }
 
-  async addSystemPrompt(prompt: SystemPrompt) {
-    return await this.bridge.invoke(configAddSystemPromptRoute.name, {
+  async function addSystemPrompt(prompt: SystemPrompt) {
+    return await bridge.invoke(configAddSystemPromptRoute.name, {
       prompt: prompt as any
     })
   }
 
-  async updateSystemPrompt(promptId: string, updates: Partial<SystemPrompt>) {
-    return await this.bridge.invoke(configUpdateSystemPromptRoute.name, {
+  async function updateSystemPrompt(promptId: string, updates: Partial<SystemPrompt>) {
+    return await bridge.invoke(configUpdateSystemPromptRoute.name, {
       promptId,
       updates: updates as any
     })
   }
 
-  async deleteSystemPrompt(promptId: string) {
-    return await this.bridge.invoke(configDeleteSystemPromptRoute.name, { promptId })
+  async function deleteSystemPrompt(promptId: string) {
+    return await bridge.invoke(configDeleteSystemPromptRoute.name, { promptId })
   }
 
-  async setDefaultSystemPromptId(promptId: string) {
-    return await this.bridge.invoke(configSetDefaultSystemPromptIdRoute.name, { promptId })
+  async function setDefaultSystemPromptId(promptId: string) {
+    return await bridge.invoke(configSetDefaultSystemPromptIdRoute.name, { promptId })
   }
 
-  async getAcpEnabled() {
-    const result = await this.bridge.invoke(configGetAcpStateRoute.name, {})
+  async function getAcpEnabled() {
+    const result = await bridge.invoke(configGetAcpStateRoute.name, {})
     return result.enabled
   }
 
-  async getAcpAgents() {
-    const result = await this.bridge.invoke(configGetAcpStateRoute.name, {})
+  async function getAcpAgents() {
+    const result = await bridge.invoke(configGetAcpStateRoute.name, {})
     return result.agents
   }
 
-  async resolveDeepChatAgentConfig(agentId: string) {
-    const result = await this.bridge.invoke(configResolveDeepChatAgentConfigRoute.name, {
+  type AcpAgents = Awaited<ReturnType<typeof getAcpAgents>>
+
+  async function resolveDeepChatAgentConfig(agentId: string) {
+    const result = await bridge.invoke(configResolveDeepChatAgentConfigRoute.name, {
       agentId
     })
     return result.config
   }
 
-  async getAgentMcpSelections(agentId: string) {
-    const result = await this.bridge.invoke(configGetAgentMcpSelectionsRoute.name, {
+  async function getAgentMcpSelections(agentId: string) {
+    const result = await bridge.invoke(configGetAgentMcpSelectionsRoute.name, {
       agentId
     })
     return result.selections
   }
 
-  async getAcpSharedMcpSelections() {
-    const result = await this.bridge.invoke(configGetAcpSharedMcpSelectionsRoute.name, {})
+  async function getAcpSharedMcpSelections() {
+    const result = await bridge.invoke(configGetAcpSharedMcpSelectionsRoute.name, {})
     return result.selections
   }
 
-  async setAcpSharedMcpSelections(selections: string[]) {
-    return await this.bridge.invoke(configSetAcpSharedMcpSelectionsRoute.name, {
+  async function setAcpSharedMcpSelections(selections: string[]) {
+    return await bridge.invoke(configSetAcpSharedMcpSelectionsRoute.name, {
       selections
     })
   }
 
-  async getMcpServers() {
-    const result = await this.bridge.invoke(configGetMcpServersRoute.name, {})
+  async function getMcpServers() {
+    const result = await bridge.invoke(configGetMcpServersRoute.name, {})
     return result.servers
   }
 
-  async getAcpRegistryIconMarkup(agentId: string, iconUrl: string) {
-    const result = await this.bridge.invoke(configGetAcpRegistryIconMarkupRoute.name, {
+  async function getAcpRegistryIconMarkup(agentId: string, iconUrl: string) {
+    const result = await bridge.invoke(configGetAcpRegistryIconMarkupRoute.name, {
       agentId,
       iconUrl
     })
     return result.markup
   }
 
-  async getVoiceAIConfig(): Promise<VoiceAIConfig> {
-    const result = await this.bridge.invoke(configGetVoiceAiConfigRoute.name, {})
+  async function getVoiceAIConfig(): Promise<VoiceAIConfig> {
+    const result = await bridge.invoke(configGetVoiceAiConfigRoute.name, {})
     return result.config
   }
 
-  async updateVoiceAIConfig(updates: Partial<VoiceAIConfig>) {
-    const result = await this.bridge.invoke(configUpdateVoiceAiConfigRoute.name, {
+  async function updateVoiceAIConfig(updates: Partial<VoiceAIConfig>) {
+    const result = await bridge.invoke(configUpdateVoiceAiConfigRoute.name, {
       updates
     })
     return result.config
   }
 
-  async getAzureApiVersion() {
-    const result = await this.bridge.invoke(configGetAzureApiVersionRoute.name, {})
+  async function getAzureApiVersion() {
+    const result = await bridge.invoke(configGetAzureApiVersionRoute.name, {})
     return result.version
   }
 
-  async setAzureApiVersion(version: string) {
-    return await this.bridge.invoke(configSetAzureApiVersionRoute.name, { version })
+  async function setAzureApiVersion(version: string) {
+    return await bridge.invoke(configSetAzureApiVersionRoute.name, { version })
   }
 
-  async getGeminiSafety(key: string) {
-    const result = await this.bridge.invoke(configGetGeminiSafetyRoute.name, { key })
+  async function getGeminiSafety(key: string) {
+    const result = await bridge.invoke(configGetGeminiSafetyRoute.name, { key })
     return result.value
   }
 
-  async setGeminiSafety(key: string, value: GeminiSafetyValue) {
-    const result = await this.bridge.invoke(configSetGeminiSafetyRoute.name, { key, value })
+  async function setGeminiSafety(key: string, value: GeminiSafetyValue) {
+    const result = await bridge.invoke(configSetGeminiSafetyRoute.name, { key, value })
     return result.value
   }
 
-  async getAwsBedrockCredential() {
-    const result = await this.bridge.invoke(configGetAwsBedrockCredentialRoute.name, {})
+  async function getAwsBedrockCredential() {
+    const result = await bridge.invoke(configGetAwsBedrockCredentialRoute.name, {})
     return result.value
   }
 
-  async setAwsBedrockCredential(credential: any) {
-    const result = await this.bridge.invoke(configSetAwsBedrockCredentialRoute.name, {
+  async function setAwsBedrockCredential(credential: any) {
+    const result = await bridge.invoke(configSetAwsBedrockCredentialRoute.name, {
       credential
     })
     return result.value
   }
 
-  onLanguageChanged(
+  function onLanguageChanged(
     listener: (payload: {
       requestedLanguage: string
       locale: string
@@ -358,56 +360,54 @@ export class ConfigClient extends SettingsClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(configLanguageChangedEvent.name, listener)
+    return bridge.on(configLanguageChangedEvent.name, listener)
   }
 
-  onThemeChanged(
+  function onThemeChanged(
     listener: (payload: {
       theme: 'dark' | 'light' | 'system'
       isDark: boolean
       version: number
     }) => void
   ) {
-    return this.bridge.on(configThemeChangedEvent.name, listener)
+    return bridge.on(configThemeChangedEvent.name, listener)
   }
 
-  onSystemThemeChanged(listener: (payload: { isDark: boolean; version: number }) => void) {
-    return this.bridge.on(configSystemThemeChangedEvent.name, listener)
+  function onSystemThemeChanged(listener: (payload: { isDark: boolean; version: number }) => void) {
+    return bridge.on(configSystemThemeChangedEvent.name, listener)
   }
 
-  onFloatingButtonChanged(listener: (payload: { enabled: boolean; version: number }) => void) {
-    return this.bridge.on(configFloatingButtonChangedEvent.name, listener)
+  function onFloatingButtonChanged(
+    listener: (payload: { enabled: boolean; version: number }) => void
+  ) {
+    return bridge.on(configFloatingButtonChangedEvent.name, listener)
   }
 
-  onSyncSettingsChanged(
+  function onSyncSettingsChanged(
     listener: (payload: { enabled: boolean; folderPath: string; version: number }) => void
   ) {
-    return this.bridge.on(configSyncSettingsChangedEvent.name, listener)
+    return bridge.on(configSyncSettingsChangedEvent.name, listener)
   }
 
-  onDefaultProjectPathChanged(
+  function onDefaultProjectPathChanged(
     listener: (payload: { path: string | null; version: number }) => void
   ) {
-    return this.bridge.on(configDefaultProjectPathChangedEvent.name, listener)
+    return bridge.on(configDefaultProjectPathChangedEvent.name, listener)
   }
 
-  onAgentsChanged(
-    listener: (payload: {
-      enabled: boolean
-      agents: Awaited<ReturnType<ConfigClient['getAcpAgents']>>
-      version: number
-    }) => void
+  function onAgentsChanged(
+    listener: (payload: { enabled: boolean; agents: AcpAgents; version: number }) => void
   ) {
-    return this.bridge.on(configAgentsChangedEvent.name, listener)
+    return bridge.on(configAgentsChangedEvent.name, listener)
   }
 
-  onShortcutKeysChanged(
+  function onShortcutKeysChanged(
     listener: (payload: { shortcuts: ShortcutKeySetting; version: number }) => void
   ) {
-    return this.bridge.on(configShortcutKeysChangedEvent.name, listener)
+    return bridge.on(configShortcutKeysChangedEvent.name, listener)
   }
 
-  onSystemPromptsChanged(
+  function onSystemPromptsChanged(
     listener: (payload: {
       prompts: SystemPrompt[]
       defaultPromptId: string
@@ -415,15 +415,86 @@ export class ConfigClient extends SettingsClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(configSystemPromptsChangedEvent.name, listener)
+    return bridge.on(configSystemPromptsChangedEvent.name, listener)
   }
 
-  onCustomPromptsChanged(listener: (payload: { prompts: Prompt[]; version: number }) => void) {
-    return this.bridge.on(configCustomPromptsChangedEvent.name, (payload) => {
+  function onCustomPromptsChanged(
+    listener: (payload: { prompts: Prompt[]; version: number }) => void
+  ) {
+    return bridge.on(configCustomPromptsChangedEvent.name, (payload) => {
       listener({
         ...payload,
         prompts: payload.prompts as unknown as Prompt[]
       })
     })
   }
+
+  return {
+    ...settingsClient,
+    getSetting,
+    setSetting,
+    getLanguage,
+    getRequestedLanguage,
+    getLanguageState,
+    setLanguage,
+    getTheme,
+    getCurrentThemeIsDark,
+    getThemeState,
+    setTheme,
+    getFloatingButtonEnabled,
+    setFloatingButtonEnabled,
+    getSyncEnabled,
+    setSyncEnabled,
+    getSyncFolderPath,
+    setSyncFolderPath,
+    getDefaultProjectPath,
+    setDefaultProjectPath,
+    getShortcutKey,
+    setShortcutKey,
+    resetShortcutKeys,
+    getCustomPrompts,
+    setCustomPrompts,
+    addCustomPrompt,
+    updateCustomPrompt,
+    deleteCustomPrompt,
+    getSystemPrompts,
+    getDefaultSystemPromptId,
+    getDefaultSystemPrompt,
+    setDefaultSystemPrompt,
+    resetToDefaultPrompt,
+    clearSystemPrompt,
+    setSystemPrompts,
+    addSystemPrompt,
+    updateSystemPrompt,
+    deleteSystemPrompt,
+    setDefaultSystemPromptId,
+    getAcpEnabled,
+    getAcpAgents,
+    resolveDeepChatAgentConfig,
+    getAgentMcpSelections,
+    getAcpSharedMcpSelections,
+    setAcpSharedMcpSelections,
+    getMcpServers,
+    getAcpRegistryIconMarkup,
+    getVoiceAIConfig,
+    updateVoiceAIConfig,
+    getAzureApiVersion,
+    setAzureApiVersion,
+    getGeminiSafety,
+    setGeminiSafety,
+    getAwsBedrockCredential,
+    setAwsBedrockCredential,
+    onLanguageChanged,
+    onThemeChanged,
+    onSystemThemeChanged,
+    onFloatingButtonChanged,
+    onSyncSettingsChanged,
+    onDefaultProjectPathChanged,
+    onAgentsChanged,
+    onShortcutKeysChanged,
+    onSystemPromptsChanged,
+    onCustomPromptsChanged
+  }
 }
+
+export type ConfigClient = ReturnType<typeof createConfigClient>

--- a/src/renderer/api/DeviceClient.ts
+++ b/src/renderer/api/DeviceClient.ts
@@ -9,41 +9,52 @@ import {
 import { getDeepchatBridge } from './core'
 import { copyRuntimeImage, copyRuntimeText, readRuntimeClipboardText } from './runtime'
 
-export class DeviceClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async getAppVersion() {
-    const result = await this.bridge.invoke(deviceGetAppVersionRoute.name, {})
+export function createDeviceClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function getAppVersion() {
+    const result = await bridge.invoke(deviceGetAppVersionRoute.name, {})
     return result.version
   }
 
-  async getDeviceInfo() {
-    const result = await this.bridge.invoke(deviceGetInfoRoute.name, {})
+  async function getDeviceInfo() {
+    const result = await bridge.invoke(deviceGetInfoRoute.name, {})
     return result.info
   }
 
-  async selectDirectory() {
-    return await this.bridge.invoke(deviceSelectDirectoryRoute.name, {})
+  async function selectDirectory() {
+    return await bridge.invoke(deviceSelectDirectoryRoute.name, {})
   }
 
-  async restartApp() {
-    return await this.bridge.invoke(deviceRestartAppRoute.name, {})
+  async function restartApp() {
+    return await bridge.invoke(deviceRestartAppRoute.name, {})
   }
 
-  async sanitizeSvgContent(svgContent: string) {
-    const result = await this.bridge.invoke(deviceSanitizeSvgRoute.name, { svgContent })
+  async function sanitizeSvgContent(svgContent: string) {
+    const result = await bridge.invoke(deviceSanitizeSvgRoute.name, { svgContent })
     return result.content
   }
 
-  copyText(text: string): void {
+  function copyText(text: string): void {
     copyRuntimeText(text)
   }
 
-  copyImage(image: string): void {
+  function copyImage(image: string): void {
     copyRuntimeImage(image)
   }
 
-  readClipboardText(): string {
+  function readClipboardText(): string {
     return readRuntimeClipboardText()
   }
+
+  return {
+    getAppVersion,
+    getDeviceInfo,
+    selectDirectory,
+    restartApp,
+    sanitizeSvgContent,
+    copyText,
+    copyImage,
+    readClipboardText
+  }
 }
+
+export type DeviceClient = ReturnType<typeof createDeviceClient>

--- a/src/renderer/api/DialogClient.ts
+++ b/src/renderer/api/DialogClient.ts
@@ -4,18 +4,16 @@ import { dialogErrorRoute, dialogRespondRoute } from '@shared/contracts/routes'
 import type { DialogResponse } from '@shared/presenter'
 import { getDeepchatBridge } from './core'
 
-export class DialogClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async handleDialogResponse(response: DialogResponse) {
-    await this.bridge.invoke(dialogRespondRoute.name, response)
+export function createDialogClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function handleDialogResponse(response: DialogResponse) {
+    await bridge.invoke(dialogRespondRoute.name, response)
   }
 
-  async handleDialogError(id: string) {
-    await this.bridge.invoke(dialogErrorRoute.name, { id })
+  async function handleDialogError(id: string) {
+    await bridge.invoke(dialogErrorRoute.name, { id })
   }
 
-  onRequested(
+  function onRequested(
     listener: (payload: {
       id: string
       title: string
@@ -27,6 +25,14 @@ export class DialogClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(dialogRequestedEvent.name, listener)
+    return bridge.on(dialogRequestedEvent.name, listener)
+  }
+
+  return {
+    handleDialogResponse,
+    handleDialogError,
+    onRequested
   }
 }
+
+export type DialogClient = ReturnType<typeof createDialogClient>

--- a/src/renderer/api/FileClient.ts
+++ b/src/renderer/api/FileClient.ts
@@ -10,48 +10,60 @@ import {
 import { getDeepchatBridge } from './core'
 import { formatRuntimePathForInput, getRuntimePathForFile, toRuntimeRelativePath } from './runtime'
 
-export class FileClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async getMimeType(path: string) {
-    const result = await this.bridge.invoke(fileGetMimeTypeRoute.name, { path })
+export function createFileClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function getMimeType(path: string) {
+    const result = await bridge.invoke(fileGetMimeTypeRoute.name, { path })
     return result.mimeType
   }
 
-  async prepareFile(path: string, mimeType?: string) {
-    const result = await this.bridge.invoke(filePrepareFileRoute.name, { path, mimeType })
+  async function prepareFile(path: string, mimeType?: string) {
+    const result = await bridge.invoke(filePrepareFileRoute.name, { path, mimeType })
     return result.file
   }
 
-  async prepareDirectory(path: string) {
-    const result = await this.bridge.invoke(filePrepareDirectoryRoute.name, { path })
+  async function prepareDirectory(path: string) {
+    const result = await bridge.invoke(filePrepareDirectoryRoute.name, { path })
     return result.file
   }
 
-  async readFile(path: string) {
-    const result = await this.bridge.invoke(fileReadFileRoute.name, { path })
+  async function readFile(path: string) {
+    const result = await bridge.invoke(fileReadFileRoute.name, { path })
     return result.content
   }
 
-  async isDirectory(path: string) {
-    const result = await this.bridge.invoke(fileIsDirectoryRoute.name, { path })
+  async function isDirectory(path: string) {
+    const result = await bridge.invoke(fileIsDirectoryRoute.name, { path })
     return result.isDirectory
   }
 
-  async writeImageBase64(file: { name: string; content: string }) {
-    const result = await this.bridge.invoke(fileWriteImageBase64Route.name, file)
+  async function writeImageBase64(file: { name: string; content: string }) {
+    const result = await bridge.invoke(fileWriteImageBase64Route.name, file)
     return result.path
   }
 
-  getPathForFile(file: File): string {
+  function getPathForFile(file: File): string {
     return getRuntimePathForFile(file)
   }
 
-  toRelativePath(filePath: string, baseDir?: string): string {
+  function toRelativePath(filePath: string, baseDir?: string): string {
     return toRuntimeRelativePath(filePath, baseDir)
   }
 
-  formatPathForInput(filePath: string): string {
+  function formatPathForInput(filePath: string): string {
     return formatRuntimePathForInput(filePath)
   }
+
+  return {
+    getMimeType,
+    prepareFile,
+    prepareDirectory,
+    readFile,
+    isDirectory,
+    writeImageBase64,
+    getPathForFile,
+    toRelativePath,
+    formatPathForInput
+  }
 }
+
+export type FileClient = ReturnType<typeof createFileClient>

--- a/src/renderer/api/McpClient.ts
+++ b/src/renderer/api/McpClient.ts
@@ -44,173 +44,208 @@ import type {
 } from '@shared/presenter'
 import { getDeepchatBridge } from './core'
 
-export class McpClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async getMcpServers() {
-    const result = await this.bridge.invoke(mcpGetServersRoute.name, {})
+export function createMcpClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function getMcpServers() {
+    const result = await bridge.invoke(mcpGetServersRoute.name, {})
     return result.servers
   }
 
-  async getMcpEnabled() {
-    const result = await this.bridge.invoke(mcpGetEnabledRoute.name, {})
+  async function getMcpEnabled() {
+    const result = await bridge.invoke(mcpGetEnabledRoute.name, {})
     return result.enabled
   }
 
-  async getMcpClients() {
-    const result = await this.bridge.invoke(mcpGetClientsRoute.name, {})
+  async function getMcpClients() {
+    const result = await bridge.invoke(mcpGetClientsRoute.name, {})
     return result.clients
   }
 
-  async getAllToolDefinitions(enabledMcpTools?: string[]) {
-    const result = await this.bridge.invoke(mcpListToolDefinitionsRoute.name, {
+  async function getAllToolDefinitions(enabledMcpTools?: string[]) {
+    const result = await bridge.invoke(mcpListToolDefinitionsRoute.name, {
       enabledMcpTools
     })
     return result.tools
   }
 
-  async getAllPrompts() {
-    const result = await this.bridge.invoke(mcpListPromptsRoute.name, {})
+  async function getAllPrompts() {
+    const result = await bridge.invoke(mcpListPromptsRoute.name, {})
     return result.prompts
   }
 
-  async getAllResources() {
-    const result = await this.bridge.invoke(mcpListResourcesRoute.name, {})
+  async function getAllResources() {
+    const result = await bridge.invoke(mcpListResourcesRoute.name, {})
     return result.resources
   }
 
-  async callTool(request: MCPToolCall) {
-    return await this.bridge.invoke(mcpCallToolRoute.name, { request })
+  async function callTool(request: MCPToolCall) {
+    return await bridge.invoke(mcpCallToolRoute.name, { request })
   }
 
-  async addMcpServer(serverName: string, config: MCPServerConfig) {
-    const result = await this.bridge.invoke(mcpAddServerRoute.name, { serverName, config })
+  async function addMcpServer(serverName: string, config: MCPServerConfig) {
+    const result = await bridge.invoke(mcpAddServerRoute.name, { serverName, config })
     return result.success
   }
 
-  async updateMcpServer(serverName: string, config: Partial<MCPServerConfig>) {
-    await this.bridge.invoke(mcpUpdateServerRoute.name, { serverName, config })
+  async function updateMcpServer(serverName: string, config: Partial<MCPServerConfig>) {
+    await bridge.invoke(mcpUpdateServerRoute.name, { serverName, config })
   }
 
-  async removeMcpServer(serverName: string) {
-    await this.bridge.invoke(mcpRemoveServerRoute.name, { serverName })
+  async function removeMcpServer(serverName: string) {
+    await bridge.invoke(mcpRemoveServerRoute.name, { serverName })
   }
 
-  async setMcpServerEnabled(serverName: string, enabled: boolean) {
-    const result = await this.bridge.invoke(mcpSetServerEnabledRoute.name, {
+  async function setMcpServerEnabled(serverName: string, enabled: boolean) {
+    const result = await bridge.invoke(mcpSetServerEnabledRoute.name, {
       serverName,
       enabled
     })
     return result.enabled
   }
 
-  async setMcpEnabled(enabled: boolean) {
-    const result = await this.bridge.invoke(mcpSetEnabledRoute.name, { enabled })
+  async function setMcpEnabled(enabled: boolean) {
+    const result = await bridge.invoke(mcpSetEnabledRoute.name, { enabled })
     return result.enabled
   }
 
-  async isServerRunning(serverName: string) {
-    const result = await this.bridge.invoke(mcpIsServerRunningRoute.name, { serverName })
+  async function isServerRunning(serverName: string) {
+    const result = await bridge.invoke(mcpIsServerRunningRoute.name, { serverName })
     return result.running
   }
 
-  async startServer(serverName: string) {
-    await this.bridge.invoke(mcpStartServerRoute.name, { serverName })
+  async function startServer(serverName: string) {
+    await bridge.invoke(mcpStartServerRoute.name, { serverName })
   }
 
-  async stopServer(serverName: string) {
-    await this.bridge.invoke(mcpStopServerRoute.name, { serverName })
+  async function stopServer(serverName: string) {
+    await bridge.invoke(mcpStopServerRoute.name, { serverName })
   }
 
-  async getPrompt(prompt: PromptListEntry, args?: Record<string, unknown>) {
-    const result = await this.bridge.invoke(mcpGetPromptRoute.name, { prompt, args })
+  async function getPrompt(prompt: PromptListEntry, args?: Record<string, unknown>) {
+    const result = await bridge.invoke(mcpGetPromptRoute.name, { prompt, args })
     return result.result
   }
 
-  async readResource(resource: ResourceListEntry) {
-    const result = await this.bridge.invoke(mcpReadResourceRoute.name, { resource })
+  async function readResource(resource: ResourceListEntry) {
+    const result = await bridge.invoke(mcpReadResourceRoute.name, { resource })
     return result.resource
   }
 
-  async submitSamplingDecision(decision: McpSamplingDecision) {
-    await this.bridge.invoke(mcpSubmitSamplingDecisionRoute.name, { decision })
+  async function submitSamplingDecision(decision: McpSamplingDecision) {
+    await bridge.invoke(mcpSubmitSamplingDecisionRoute.name, { decision })
   }
 
-  async cancelSamplingRequest(requestId: string, reason?: string) {
-    await this.bridge.invoke(mcpCancelSamplingRequestRoute.name, { requestId, reason })
+  async function cancelSamplingRequest(requestId: string, reason?: string) {
+    await bridge.invoke(mcpCancelSamplingRequestRoute.name, { requestId, reason })
   }
 
-  async getNpmRegistryStatus() {
-    const result = await this.bridge.invoke(mcpGetNpmRegistryStatusRoute.name, {})
+  async function getNpmRegistryStatus() {
+    const result = await bridge.invoke(mcpGetNpmRegistryStatusRoute.name, {})
     return result.status
   }
 
-  async refreshNpmRegistry() {
-    const result = await this.bridge.invoke(mcpRefreshNpmRegistryRoute.name, {})
+  async function refreshNpmRegistry() {
+    const result = await bridge.invoke(mcpRefreshNpmRegistryRoute.name, {})
     return result.registry
   }
 
-  async setCustomNpmRegistry(registry: string | undefined) {
-    await this.bridge.invoke(mcpSetCustomNpmRegistryRoute.name, { registry })
+  async function setCustomNpmRegistry(registry: string | undefined) {
+    await bridge.invoke(mcpSetCustomNpmRegistryRoute.name, { registry })
   }
 
-  async setAutoDetectNpmRegistry(enabled: boolean) {
-    await this.bridge.invoke(mcpSetAutoDetectNpmRegistryRoute.name, { enabled })
+  async function setAutoDetectNpmRegistry(enabled: boolean) {
+    await bridge.invoke(mcpSetAutoDetectNpmRegistryRoute.name, { enabled })
   }
 
-  async clearNpmRegistryCache() {
-    await this.bridge.invoke(mcpClearNpmRegistryCacheRoute.name, {})
+  async function clearNpmRegistryCache() {
+    await bridge.invoke(mcpClearNpmRegistryCacheRoute.name, {})
   }
 
-  onServerStarted(listener: (payload: { serverName: string; version: number }) => void) {
-    return this.bridge.on(mcpServerStartedEvent.name, listener)
+  function onServerStarted(listener: (payload: { serverName: string; version: number }) => void) {
+    return bridge.on(mcpServerStartedEvent.name, listener)
   }
 
-  onServerStopped(listener: (payload: { serverName: string; version: number }) => void) {
-    return this.bridge.on(mcpServerStoppedEvent.name, listener)
+  function onServerStopped(listener: (payload: { serverName: string; version: number }) => void) {
+    return bridge.on(mcpServerStoppedEvent.name, listener)
   }
 
-  onConfigChanged(
+  function onConfigChanged(
     listener: (payload: {
       mcpServers: Record<string, MCPServerConfig>
       mcpEnabled: boolean
       version: number
     }) => void
   ) {
-    return this.bridge.on(mcpConfigChangedEvent.name, listener)
+    return bridge.on(mcpConfigChangedEvent.name, listener)
   }
 
-  onServerStatusChanged(
+  function onServerStatusChanged(
     listener: (payload: { serverName: string; isRunning: boolean; version: number }) => void
   ) {
-    return this.bridge.on(mcpServerStatusChangedEvent.name, listener)
+    return bridge.on(mcpServerStatusChangedEvent.name, listener)
   }
 
-  onToolCallResult(
+  function onToolCallResult(
     listener: (payload: {
       functionName?: string
       content: string | { type: string; text: string }[]
       version: number
     }) => void
   ) {
-    return this.bridge.on(mcpToolCallResultEvent.name, listener)
+    return bridge.on(mcpToolCallResultEvent.name, listener)
   }
 
-  onSamplingRequest(listener: (payload: { request: unknown; version: number }) => void) {
-    return this.bridge.on(mcpSamplingRequestEvent.name, (payload) => {
+  function onSamplingRequest(listener: (payload: { request: unknown; version: number }) => void) {
+    return bridge.on(mcpSamplingRequestEvent.name, (payload) => {
       listener(payload as { request: unknown; version: number })
     })
   }
 
-  onSamplingDecision(listener: (payload: { decision: unknown; version: number }) => void) {
-    return this.bridge.on(mcpSamplingDecisionEvent.name, (payload) => {
+  function onSamplingDecision(listener: (payload: { decision: unknown; version: number }) => void) {
+    return bridge.on(mcpSamplingDecisionEvent.name, (payload) => {
       listener(payload as { decision: unknown; version: number })
     })
   }
 
-  onSamplingCancelled(
+  function onSamplingCancelled(
     listener: (payload: { requestId: string; reason?: string; version: number }) => void
   ) {
-    return this.bridge.on(mcpSamplingCancelledEvent.name, listener)
+    return bridge.on(mcpSamplingCancelledEvent.name, listener)
+  }
+
+  return {
+    getMcpServers,
+    getMcpEnabled,
+    getMcpClients,
+    getAllToolDefinitions,
+    getAllPrompts,
+    getAllResources,
+    callTool,
+    addMcpServer,
+    updateMcpServer,
+    removeMcpServer,
+    setMcpServerEnabled,
+    setMcpEnabled,
+    isServerRunning,
+    startServer,
+    stopServer,
+    getPrompt,
+    readResource,
+    submitSamplingDecision,
+    cancelSamplingRequest,
+    getNpmRegistryStatus,
+    refreshNpmRegistry,
+    setCustomNpmRegistry,
+    setAutoDetectNpmRegistry,
+    clearNpmRegistryCache,
+    onServerStarted,
+    onServerStopped,
+    onConfigChanged,
+    onServerStatusChanged,
+    onToolCallResult,
+    onSamplingRequest,
+    onSamplingDecision,
+    onSamplingCancelled
   }
 }
+
+export type McpClient = ReturnType<typeof createMcpClient>

--- a/src/renderer/api/ModelClient.ts
+++ b/src/renderer/api/ModelClient.ts
@@ -23,65 +23,69 @@ import {
 import type { IModelConfig, ModelConfig, RENDERER_MODEL_META } from '@shared/presenter'
 import { getDeepchatBridge } from './core'
 
-type ProviderCatalogCacheEntry = {
-  expiresAt: number
-  promise: Promise<Awaited<ReturnType<ModelClient['fetchProviderCatalog']>>>
-}
-
-export class ModelClient {
-  private readonly catalogCache = new Map<string, ProviderCatalogCacheEntry>()
-  private readonly capabilitiesCache = new Map<
-    string,
-    Promise<Awaited<ReturnType<ModelClient['getCapabilities']>>>
-  >()
-
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  private async fetchProviderCatalog(providerId: string) {
-    const result = await this.bridge.invoke(modelsGetProviderCatalogRoute.name, { providerId })
+export function createModelClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function fetchProviderCatalog(providerId: string) {
+    const result = await bridge.invoke(modelsGetProviderCatalogRoute.name, { providerId })
     return result.catalog
   }
 
-  clearProviderCatalogCache(providerId?: string) {
-    if (providerId) {
-      this.catalogCache.delete(providerId)
-      return
-    }
-    this.catalogCache.clear()
+  async function fetchCapabilities(providerId: string, modelId: string) {
+    return await bridge.invoke(modelsGetCapabilitiesRoute.name, {
+      providerId,
+      modelId
+    })
   }
 
-  private async getProviderCatalog(providerId: string) {
-    const cached = this.catalogCache.get(providerId)
+  type ProviderCatalog = Awaited<ReturnType<typeof fetchProviderCatalog>>
+  type ProviderCatalogCacheEntry = {
+    expiresAt: number
+    promise: Promise<ProviderCatalog>
+  }
+
+  const catalogCache = new Map<string, ProviderCatalogCacheEntry>()
+  const capabilitiesCache = new Map<string, ReturnType<typeof fetchCapabilities>>()
+
+  function clearProviderCatalogCache(providerId?: string) {
+    if (providerId) {
+      catalogCache.delete(providerId)
+      return
+    }
+
+    catalogCache.clear()
+  }
+
+  async function getProviderCatalog(providerId: string) {
+    const cached = catalogCache.get(providerId)
     const now = Date.now()
     if (cached && cached.expiresAt > now) {
       return await cached.promise
     }
 
-    const promise = this.fetchProviderCatalog(providerId)
-    this.catalogCache.set(providerId, {
+    const promise = fetchProviderCatalog(providerId)
+    catalogCache.set(providerId, {
       expiresAt: now + 200,
       promise
     })
     return await promise
   }
 
-  async getProviderModels(providerId: string) {
-    const catalog = await this.getProviderCatalog(providerId)
+  async function getProviderModels(providerId: string) {
+    const catalog = await getProviderCatalog(providerId)
     return catalog.providerModels
   }
 
-  async getCustomModels(providerId: string) {
-    const catalog = await this.getProviderCatalog(providerId)
+  async function getCustomModels(providerId: string) {
+    const catalog = await getProviderCatalog(providerId)
     return catalog.customModels
   }
 
-  async getDbProviderModels(providerId: string) {
-    const catalog = await this.getProviderCatalog(providerId)
+  async function getDbProviderModels(providerId: string) {
+    const catalog = await getProviderCatalog(providerId)
     return catalog.dbProviderModels
   }
 
-  async getBatchModelStatus(providerId: string, modelIds: string[]) {
-    const catalog = await this.getProviderCatalog(providerId)
+  async function getBatchModelStatus(providerId: string, modelIds: string[]) {
+    const catalog = await getProviderCatalog(providerId)
     const result: Record<string, boolean> = {}
     for (const modelId of modelIds) {
       result[modelId] = catalog.modelStatusMap[modelId] ?? false
@@ -89,149 +93,146 @@ export class ModelClient {
     return result
   }
 
-  async getModelList(providerId: string) {
-    const result = await this.bridge.invoke(modelsListRuntimeRoute.name, { providerId })
-    this.clearProviderCatalogCache(providerId)
+  async function getModelList(providerId: string) {
+    const result = await bridge.invoke(modelsListRuntimeRoute.name, { providerId })
+    clearProviderCatalogCache(providerId)
     return result.models
   }
 
-  async updateModelStatus(providerId: string, modelId: string, enabled: boolean) {
-    const result = await this.bridge.invoke(modelsSetStatusRoute.name, {
+  async function updateModelStatus(providerId: string, modelId: string, enabled: boolean) {
+    const result = await bridge.invoke(modelsSetStatusRoute.name, {
       providerId,
       modelId,
       enabled
     })
-    this.clearProviderCatalogCache(providerId)
+    clearProviderCatalogCache(providerId)
     return result
   }
 
-  async addCustomModel(
+  async function addCustomModel(
     providerId: string,
     model: Omit<RENDERER_MODEL_META, 'providerId' | 'isCustom' | 'group'>
   ) {
-    const result = await this.bridge.invoke(modelsAddCustomRoute.name, { providerId, model })
-    this.clearProviderCatalogCache(providerId)
+    const result = await bridge.invoke(modelsAddCustomRoute.name, { providerId, model })
+    clearProviderCatalogCache(providerId)
     return result.model
   }
 
-  async removeCustomModel(providerId: string, modelId: string) {
-    const result = await this.bridge.invoke(modelsRemoveCustomRoute.name, { providerId, modelId })
-    this.clearProviderCatalogCache(providerId)
+  async function removeCustomModel(providerId: string, modelId: string) {
+    const result = await bridge.invoke(modelsRemoveCustomRoute.name, { providerId, modelId })
+    clearProviderCatalogCache(providerId)
     return result.removed
   }
 
-  async updateCustomModel(
+  async function updateCustomModel(
     providerId: string,
     modelId: string,
     updates: Partial<RENDERER_MODEL_META> & { enabled?: boolean }
   ) {
-    const result = await this.bridge.invoke(modelsUpdateCustomRoute.name, {
+    const result = await bridge.invoke(modelsUpdateCustomRoute.name, {
       providerId,
       modelId,
       updates
     })
-    this.clearProviderCatalogCache(providerId)
+    clearProviderCatalogCache(providerId)
     return result.updated
   }
 
-  async getModelConfig(modelId: string, providerId?: string) {
-    const result = await this.bridge.invoke(modelsGetConfigRoute.name, { modelId, providerId })
+  async function getModelConfig(modelId: string, providerId?: string) {
+    const result = await bridge.invoke(modelsGetConfigRoute.name, { modelId, providerId })
     return result.config
   }
 
-  async setModelConfig(modelId: string, providerId: string, config: ModelConfig) {
-    const result = await this.bridge.invoke(modelsSetConfigRoute.name, {
+  async function setModelConfig(modelId: string, providerId: string, config: ModelConfig) {
+    const result = await bridge.invoke(modelsSetConfigRoute.name, {
       modelId,
       providerId,
       config: config as any
     })
-    this.clearProviderCatalogCache(providerId)
+    clearProviderCatalogCache(providerId)
     return result.config
   }
 
-  async resetModelConfig(modelId: string, providerId: string) {
-    const result = await this.bridge.invoke(modelsResetConfigRoute.name, {
+  async function resetModelConfig(modelId: string, providerId: string) {
+    const result = await bridge.invoke(modelsResetConfigRoute.name, {
       modelId,
       providerId
     })
-    this.clearProviderCatalogCache(providerId)
+    clearProviderCatalogCache(providerId)
     return result.reset
   }
 
-  async getProviderModelConfigs(providerId: string) {
-    const result = await this.bridge.invoke(modelsGetProviderConfigsRoute.name, { providerId })
+  async function getProviderModelConfigs(providerId: string) {
+    const result = await bridge.invoke(modelsGetProviderConfigsRoute.name, { providerId })
     return result.configs
   }
 
-  async hasUserModelConfig(modelId: string, providerId: string) {
-    const result = await this.bridge.invoke(modelsHasUserConfigRoute.name, {
+  async function hasUserModelConfig(modelId: string, providerId: string) {
+    const result = await bridge.invoke(modelsHasUserConfigRoute.name, {
       modelId,
       providerId
     })
     return result.hasConfig
   }
 
-  async exportModelConfigs() {
-    const result = await this.bridge.invoke(modelsExportConfigsRoute.name, {})
+  async function exportModelConfigs() {
+    const result = await bridge.invoke(modelsExportConfigsRoute.name, {})
     return result.configs
   }
 
-  async importModelConfigs(configs: Record<string, IModelConfig>, overwrite = false) {
-    return await this.bridge.invoke(modelsImportConfigsRoute.name, {
+  async function importModelConfigs(configs: Record<string, IModelConfig>, overwrite = false) {
+    return await bridge.invoke(modelsImportConfigsRoute.name, {
       configs: configs as any,
       overwrite
     })
   }
 
-  async getCapabilities(providerId: string, modelId: string) {
+  async function getCapabilities(providerId: string, modelId: string) {
     const cacheKey = `${providerId}:${modelId}`
-    const cached = this.capabilitiesCache.get(cacheKey)
+    const cached = capabilitiesCache.get(cacheKey)
     if (cached) {
       return (await cached).capabilities
     }
 
-    const promise = this.bridge.invoke(modelsGetCapabilitiesRoute.name, {
-      providerId,
-      modelId
-    })
-    this.capabilitiesCache.set(cacheKey, promise)
+    const promise = fetchCapabilities(providerId, modelId)
+    capabilitiesCache.set(cacheKey, promise)
 
     try {
       return (await promise).capabilities
     } finally {
-      this.capabilitiesCache.delete(cacheKey)
+      capabilitiesCache.delete(cacheKey)
     }
   }
 
-  async supportsReasoningCapability(providerId: string, modelId: string) {
-    return (await this.getCapabilities(providerId, modelId)).supportsReasoning
+  async function supportsReasoningCapability(providerId: string, modelId: string) {
+    return (await getCapabilities(providerId, modelId)).supportsReasoning
   }
 
-  async getReasoningPortrait(providerId: string, modelId: string) {
-    return (await this.getCapabilities(providerId, modelId)).reasoningPortrait
+  async function getReasoningPortrait(providerId: string, modelId: string) {
+    return (await getCapabilities(providerId, modelId)).reasoningPortrait
   }
 
-  async getThinkingBudgetRange(providerId: string, modelId: string) {
-    return (await this.getCapabilities(providerId, modelId)).thinkingBudgetRange
+  async function getThinkingBudgetRange(providerId: string, modelId: string) {
+    return (await getCapabilities(providerId, modelId)).thinkingBudgetRange
   }
 
-  async supportsSearchCapability(providerId: string, modelId: string) {
-    return (await this.getCapabilities(providerId, modelId)).supportsSearch
+  async function supportsSearchCapability(providerId: string, modelId: string) {
+    return (await getCapabilities(providerId, modelId)).supportsSearch
   }
 
-  async getSearchDefaults(providerId: string, modelId: string) {
-    return (await this.getCapabilities(providerId, modelId)).searchDefaults
+  async function getSearchDefaults(providerId: string, modelId: string) {
+    return (await getCapabilities(providerId, modelId)).searchDefaults
   }
 
-  async supportsTemperatureControl(providerId: string, modelId: string) {
-    return (await this.getCapabilities(providerId, modelId)).supportsTemperatureControl
+  async function supportsTemperatureControl(providerId: string, modelId: string) {
+    return (await getCapabilities(providerId, modelId)).supportsTemperatureControl
   }
 
-  async getTemperatureCapability(providerId: string, modelId: string) {
-    return (await this.getCapabilities(providerId, modelId)).temperatureCapability
+  async function getTemperatureCapability(providerId: string, modelId: string) {
+    return (await getCapabilities(providerId, modelId)).temperatureCapability
   }
 
-  onModelsChanged(
+  function onModelsChanged(
     listener: (payload: {
       reason:
         | 'provider-models'
@@ -244,10 +245,10 @@ export class ModelClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(modelsChangedEvent.name, listener)
+    return bridge.on(modelsChangedEvent.name, listener)
   }
 
-  onModelStatusChanged(
+  function onModelStatusChanged(
     listener: (payload: {
       providerId: string
       modelId: string
@@ -255,10 +256,10 @@ export class ModelClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(modelsStatusChangedEvent.name, listener)
+    return bridge.on(modelsStatusChangedEvent.name, listener)
   }
 
-  onModelConfigChanged(
+  function onModelConfigChanged(
     listener: (payload: {
       changeType: 'updated' | 'reset' | 'imported'
       providerId?: string
@@ -268,6 +269,39 @@ export class ModelClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(modelsConfigChangedEvent.name, listener)
+    return bridge.on(modelsConfigChangedEvent.name, listener)
+  }
+
+  return {
+    clearProviderCatalogCache,
+    getProviderModels,
+    getCustomModels,
+    getDbProviderModels,
+    getBatchModelStatus,
+    getModelList,
+    updateModelStatus,
+    addCustomModel,
+    removeCustomModel,
+    updateCustomModel,
+    getModelConfig,
+    setModelConfig,
+    resetModelConfig,
+    getProviderModelConfigs,
+    hasUserModelConfig,
+    exportModelConfigs,
+    importModelConfigs,
+    getCapabilities,
+    supportsReasoningCapability,
+    getReasoningPortrait,
+    getThinkingBudgetRange,
+    supportsSearchCapability,
+    getSearchDefaults,
+    supportsTemperatureControl,
+    getTemperatureCapability,
+    onModelsChanged,
+    onModelStatusChanged,
+    onModelConfigChanged
   }
 }
+
+export type ModelClient = ReturnType<typeof createModelClient>

--- a/src/renderer/api/ProjectClient.ts
+++ b/src/renderer/api/ProjectClient.ts
@@ -7,25 +7,32 @@ import {
 } from '@shared/contracts/routes'
 import { getDeepchatBridge } from './core'
 
-export class ProjectClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async listRecent(limit: number = 20) {
-    const result = await this.bridge.invoke(projectListRecentRoute.name, { limit })
+export function createProjectClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function listRecent(limit: number = 20) {
+    const result = await bridge.invoke(projectListRecentRoute.name, { limit })
     return result.projects
   }
 
-  async listEnvironments() {
-    const result = await this.bridge.invoke(projectListEnvironmentsRoute.name, {})
+  async function listEnvironments() {
+    const result = await bridge.invoke(projectListEnvironmentsRoute.name, {})
     return result.environments
   }
 
-  async openDirectory(path: string) {
-    return await this.bridge.invoke(projectOpenDirectoryRoute.name, { path })
+  async function openDirectory(path: string) {
+    return await bridge.invoke(projectOpenDirectoryRoute.name, { path })
   }
 
-  async selectDirectory() {
-    const result = await this.bridge.invoke(projectSelectDirectoryRoute.name, {})
+  async function selectDirectory() {
+    const result = await bridge.invoke(projectSelectDirectoryRoute.name, {})
     return result.path
   }
+
+  return {
+    listRecent,
+    listEnvironments,
+    openDirectory,
+    selectDirectory
+  }
 }
+
+export type ProjectClient = ReturnType<typeof createProjectClient>

--- a/src/renderer/api/ProviderClient.ts
+++ b/src/renderer/api/ProviderClient.ts
@@ -21,103 +21,101 @@ import {
 import type { LLM_PROVIDER } from '@shared/presenter'
 import { getDeepchatBridge } from './core'
 
-export class ProviderClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async getProviders() {
-    const result = await this.bridge.invoke(providersListRoute.name, {})
+export function createProviderClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function getProviders() {
+    const result = await bridge.invoke(providersListRoute.name, {})
     return result.providers
   }
 
-  async getDefaultProviders() {
-    const result = await this.bridge.invoke(providersListDefaultsRoute.name, {})
+  async function getDefaultProviders() {
+    const result = await bridge.invoke(providersListDefaultsRoute.name, {})
     return result.providers
   }
 
-  async setProviderById(providerId: string, provider: LLM_PROVIDER) {
-    const result = await this.bridge.invoke(providersSetByIdRoute.name, {
+  async function setProviderById(providerId: string, provider: LLM_PROVIDER) {
+    const result = await bridge.invoke(providersSetByIdRoute.name, {
       providerId,
       provider
     })
     return result.provider
   }
 
-  async updateProviderAtomic(providerId: string, updates: Partial<LLM_PROVIDER>) {
-    const result = await this.bridge.invoke(providersUpdateRoute.name, {
+  async function updateProviderAtomic(providerId: string, updates: Partial<LLM_PROVIDER>) {
+    const result = await bridge.invoke(providersUpdateRoute.name, {
       providerId,
       updates
     })
     return result.requiresRebuild
   }
 
-  async addProviderAtomic(provider: LLM_PROVIDER) {
-    const result = await this.bridge.invoke(providersAddRoute.name, { provider })
+  async function addProviderAtomic(provider: LLM_PROVIDER) {
+    const result = await bridge.invoke(providersAddRoute.name, { provider })
     return result.provider
   }
 
-  async removeProviderAtomic(providerId: string) {
-    const result = await this.bridge.invoke(providersRemoveRoute.name, { providerId })
+  async function removeProviderAtomic(providerId: string) {
+    const result = await bridge.invoke(providersRemoveRoute.name, { providerId })
     return result.removed
   }
 
-  async reorderProvidersAtomic(providers: LLM_PROVIDER[]) {
-    const result = await this.bridge.invoke(providersReorderRoute.name, { providers })
+  async function reorderProvidersAtomic(providers: LLM_PROVIDER[]) {
+    const result = await bridge.invoke(providersReorderRoute.name, { providers })
     return result.providers
   }
 
-  async listModels(providerId: string) {
-    return await this.bridge.invoke(providersListModelsRoute.name, { providerId })
+  async function listModels(providerId: string) {
+    return await bridge.invoke(providersListModelsRoute.name, { providerId })
   }
 
-  async testConnection(input: { providerId: string; modelId?: string }) {
-    return await this.bridge.invoke(providersTestConnectionRoute.name, input)
+  async function testConnection(input: { providerId: string; modelId?: string }) {
+    return await bridge.invoke(providersTestConnectionRoute.name, input)
   }
 
-  async getProviderRateLimitStatus(providerId: string) {
-    const result = await this.bridge.invoke(providersGetRateLimitStatusRoute.name, { providerId })
+  async function getProviderRateLimitStatus(providerId: string) {
+    const result = await bridge.invoke(providersGetRateLimitStatusRoute.name, { providerId })
     return result.status
   }
 
-  async refreshModels(providerId: string) {
-    return await this.bridge.invoke(providersRefreshModelsRoute.name, { providerId })
+  async function refreshModels(providerId: string) {
+    return await bridge.invoke(providersRefreshModelsRoute.name, { providerId })
   }
 
-  async listOllamaModels(providerId: string) {
-    const result = await this.bridge.invoke(providersListOllamaModelsRoute.name, { providerId })
+  async function listOllamaModels(providerId: string) {
+    const result = await bridge.invoke(providersListOllamaModelsRoute.name, { providerId })
     return result.models
   }
 
-  async listOllamaRunningModels(providerId: string) {
-    const result = await this.bridge.invoke(providersListOllamaRunningModelsRoute.name, {
+  async function listOllamaRunningModels(providerId: string) {
+    const result = await bridge.invoke(providersListOllamaRunningModelsRoute.name, {
       providerId
     })
     return result.models
   }
 
-  async pullOllamaModels(providerId: string, modelName: string) {
-    const result = await this.bridge.invoke(providersPullOllamaModelRoute.name, {
+  async function pullOllamaModels(providerId: string, modelName: string) {
+    const result = await bridge.invoke(providersPullOllamaModelRoute.name, {
       providerId,
       modelName
     })
     return result.success
   }
 
-  async warmupAcpProcess(agentId: string, workdir?: string) {
-    return await this.bridge.invoke(providersWarmupAcpProcessRoute.name, {
+  async function warmupAcpProcess(agentId: string, workdir?: string) {
+    return await bridge.invoke(providersWarmupAcpProcessRoute.name, {
       agentId,
       workdir
     })
   }
 
-  async getAcpProcessConfigOptions(agentId: string, workdir?: string) {
-    const result = await this.bridge.invoke(providersGetAcpProcessConfigOptionsRoute.name, {
+  async function getAcpProcessConfigOptions(agentId: string, workdir?: string) {
+    const result = await bridge.invoke(providersGetAcpProcessConfigOptionsRoute.name, {
       agentId,
       workdir
     })
     return result.state
   }
 
-  onProvidersChanged(
+  function onProvidersChanged(
     listener: (payload: {
       reason:
         | 'providers'
@@ -129,10 +127,10 @@ export class ProviderClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(providersChangedEvent.name, listener)
+    return bridge.on(providersChangedEvent.name, listener)
   }
 
-  onOllamaPullProgress(
+  function onOllamaPullProgress(
     listener: (payload: {
       eventId: string
       providerId: string
@@ -143,6 +141,29 @@ export class ProviderClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(providersOllamaPullProgressEvent.name, listener)
+    return bridge.on(providersOllamaPullProgressEvent.name, listener)
+  }
+
+  return {
+    getProviders,
+    getDefaultProviders,
+    setProviderById,
+    updateProviderAtomic,
+    addProviderAtomic,
+    removeProviderAtomic,
+    reorderProvidersAtomic,
+    listModels,
+    testConnection,
+    getProviderRateLimitStatus,
+    refreshModels,
+    listOllamaModels,
+    listOllamaRunningModels,
+    pullOllamaModels,
+    warmupAcpProcess,
+    getAcpProcessConfigOptions,
+    onProvidersChanged,
+    onOllamaPullProgress
   }
 }
+
+export type ProviderClient = ReturnType<typeof createProviderClient>

--- a/src/renderer/api/RemoteControlRuntime.ts
+++ b/src/renderer/api/RemoteControlRuntime.ts
@@ -14,24 +14,31 @@ type RemoteControlPresenterCompat = IRemoteControlPresenter & {
 const defaultRemoteControlPresenter =
   useLegacyRemoteControlPresenter() as RemoteControlPresenterCompat
 
-export class RemoteControlRuntime {
-  constructor(
-    private readonly presenter: RemoteControlPresenterCompat = defaultRemoteControlPresenter
-  ) {}
-
-  async listRemoteChannels(): Promise<RemoteChannelDescriptor[] | null> {
-    return this.presenter.listRemoteChannels ? await this.presenter.listRemoteChannels() : null
+export function createRemoteControlRuntime(
+  presenter: RemoteControlPresenterCompat = defaultRemoteControlPresenter
+) {
+  async function listRemoteChannels(): Promise<RemoteChannelDescriptor[] | null> {
+    return presenter.listRemoteChannels ? await presenter.listRemoteChannels() : null
   }
 
-  async getChannelStatus(channel: RemoteChannel): Promise<RemoteChannelStatus | null> {
-    return this.presenter.getChannelStatus ? await this.presenter.getChannelStatus(channel) : null
+  async function getChannelStatus(channel: RemoteChannel): Promise<RemoteChannelStatus | null> {
+    return presenter.getChannelStatus ? await presenter.getChannelStatus(channel) : null
   }
 
-  async getTelegramStatus() {
-    return await this.presenter.getTelegramStatus()
+  async function getTelegramStatus() {
+    return await presenter.getTelegramStatus()
   }
 
-  async getWeixinIlinkStatus() {
-    return await this.presenter.getWeixinIlinkStatus()
+  async function getWeixinIlinkStatus() {
+    return await presenter.getWeixinIlinkStatus()
+  }
+
+  return {
+    listRemoteChannels,
+    getChannelStatus,
+    getTelegramStatus,
+    getWeixinIlinkStatus
   }
 }
+
+export type RemoteControlRuntime = ReturnType<typeof createRemoteControlRuntime>

--- a/src/renderer/api/SessionClient.ts
+++ b/src/renderer/api/SessionClient.ts
@@ -54,65 +54,67 @@ import {
 import type { CreateSessionInput, SendMessageInput } from '@shared/types/agent-interface'
 import { getDeepchatBridge } from './core'
 
-export class SessionClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async create(input: CreateSessionInput) {
-    return await this.bridge.invoke(
+export function createSessionClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function create(input: CreateSessionInput) {
+    return await bridge.invoke(
       sessionsCreateRoute.name,
       input as DeepchatRouteInput<typeof sessionsCreateRoute.name>
     )
   }
 
-  async restore(sessionId: string) {
-    return await this.bridge.invoke(sessionsRestoreRoute.name, { sessionId })
+  async function restore(sessionId: string) {
+    return await bridge.invoke(sessionsRestoreRoute.name, { sessionId })
   }
 
-  async activate(sessionId: string) {
-    return await this.bridge.invoke(sessionsActivateRoute.name, { sessionId })
+  async function activate(sessionId: string) {
+    return await bridge.invoke(sessionsActivateRoute.name, { sessionId })
   }
 
-  async deactivate() {
-    return await this.bridge.invoke(sessionsDeactivateRoute.name, {})
+  async function deactivate() {
+    return await bridge.invoke(sessionsDeactivateRoute.name, {})
   }
 
-  async getActive() {
-    return await this.bridge.invoke(sessionsGetActiveRoute.name, {})
+  async function getActive() {
+    return await bridge.invoke(sessionsGetActiveRoute.name, {})
   }
 
-  async list(filters?: {
+  async function list(filters?: {
     agentId?: string
     projectDir?: string
     includeSubagents?: boolean
     parentSessionId?: string
   }) {
-    return await this.bridge.invoke(sessionsListRoute.name, filters ?? {})
+    return await bridge.invoke(sessionsListRoute.name, filters ?? {})
   }
 
-  async ensureAcpDraftSession(input: {
+  async function ensureAcpDraftSession(input: {
     agentId: string
     projectDir: string
     permissionMode?: 'default' | 'full_access'
   }) {
-    const result = await this.bridge.invoke(sessionsEnsureAcpDraftRoute.name, input)
+    const result = await bridge.invoke(sessionsEnsureAcpDraftRoute.name, input)
     return result.session
   }
 
-  async listPendingInputs(sessionId: string) {
-    const result = await this.bridge.invoke(sessionsListPendingInputsRoute.name, { sessionId })
+  async function listPendingInputs(sessionId: string) {
+    const result = await bridge.invoke(sessionsListPendingInputsRoute.name, { sessionId })
     return result.items
   }
 
-  async queuePendingInput(sessionId: string, content: string | SendMessageInput) {
-    const result = await this.bridge.invoke(sessionsQueuePendingInputRoute.name, {
+  async function queuePendingInput(sessionId: string, content: string | SendMessageInput) {
+    const result = await bridge.invoke(sessionsQueuePendingInputRoute.name, {
       sessionId,
       content
     })
     return result.item
   }
 
-  async updateQueuedInput(sessionId: string, itemId: string, content: string | SendMessageInput) {
-    const result = await this.bridge.invoke(sessionsUpdateQueuedInputRoute.name, {
+  async function updateQueuedInput(
+    sessionId: string,
+    itemId: string,
+    content: string | SendMessageInput
+  ) {
+    const result = await bridge.invoke(sessionsUpdateQueuedInputRoute.name, {
       sessionId,
       itemId,
       content
@@ -120,8 +122,8 @@ export class SessionClient {
     return result.item
   }
 
-  async moveQueuedInput(sessionId: string, itemId: string, toIndex: number) {
-    const result = await this.bridge.invoke(sessionsMoveQueuedInputRoute.name, {
+  async function moveQueuedInput(sessionId: string, itemId: string, toIndex: number) {
+    const result = await bridge.invoke(sessionsMoveQueuedInputRoute.name, {
       sessionId,
       itemId,
       toIndex
@@ -129,35 +131,35 @@ export class SessionClient {
     return result.items
   }
 
-  async convertPendingInputToSteer(sessionId: string, itemId: string) {
-    const result = await this.bridge.invoke(sessionsConvertPendingInputToSteerRoute.name, {
+  async function convertPendingInputToSteer(sessionId: string, itemId: string) {
+    const result = await bridge.invoke(sessionsConvertPendingInputToSteerRoute.name, {
       sessionId,
       itemId
     })
     return result.item
   }
 
-  async deletePendingInput(sessionId: string, itemId: string) {
-    await this.bridge.invoke(sessionsDeletePendingInputRoute.name, {
+  async function deletePendingInput(sessionId: string, itemId: string) {
+    await bridge.invoke(sessionsDeletePendingInputRoute.name, {
       sessionId,
       itemId
     })
   }
 
-  async resumePendingQueue(sessionId: string) {
-    await this.bridge.invoke(sessionsResumePendingQueueRoute.name, { sessionId })
+  async function resumePendingQueue(sessionId: string) {
+    await bridge.invoke(sessionsResumePendingQueueRoute.name, { sessionId })
   }
 
-  async retryMessage(sessionId: string, messageId: string) {
-    await this.bridge.invoke(sessionsRetryMessageRoute.name, { sessionId, messageId })
+  async function retryMessage(sessionId: string, messageId: string) {
+    await bridge.invoke(sessionsRetryMessageRoute.name, { sessionId, messageId })
   }
 
-  async deleteMessage(sessionId: string, messageId: string) {
-    await this.bridge.invoke(sessionsDeleteMessageRoute.name, { sessionId, messageId })
+  async function deleteMessage(sessionId: string, messageId: string) {
+    await bridge.invoke(sessionsDeleteMessageRoute.name, { sessionId, messageId })
   }
 
-  async editUserMessage(sessionId: string, messageId: string, text: string) {
-    const result = await this.bridge.invoke(sessionsEditUserMessageRoute.name, {
+  async function editUserMessage(sessionId: string, messageId: string, text: string) {
+    const result = await bridge.invoke(sessionsEditUserMessageRoute.name, {
       sessionId,
       messageId,
       text
@@ -165,8 +167,8 @@ export class SessionClient {
     return result.message
   }
 
-  async forkSession(sourceSessionId: string, targetMessageId: string, newTitle?: string) {
-    const result = await this.bridge.invoke(sessionsForkRoute.name, {
+  async function forkSession(sourceSessionId: string, targetMessageId: string, newTitle?: string) {
+    const result = await bridge.invoke(sessionsForkRoute.name, {
       sourceSessionId,
       targetMessageId,
       newTitle
@@ -174,29 +176,29 @@ export class SessionClient {
     return result.session
   }
 
-  async searchHistory(query: string, options?: { limit?: number }) {
-    const result = await this.bridge.invoke(sessionsSearchHistoryRoute.name, {
+  async function searchHistory(query: string, options?: { limit?: number }) {
+    const result = await bridge.invoke(sessionsSearchHistoryRoute.name, {
       query,
       options
     })
     return result.hits
   }
 
-  async getSearchResults(messageId: string, searchId?: string) {
-    const result = await this.bridge.invoke(sessionsGetSearchResultsRoute.name, {
+  async function getSearchResults(messageId: string, searchId?: string) {
+    const result = await bridge.invoke(sessionsGetSearchResultsRoute.name, {
       messageId,
       searchId
     })
     return result.results
   }
 
-  async listMessageTraces(messageId: string) {
-    const result = await this.bridge.invoke(sessionsListMessageTracesRoute.name, { messageId })
+  async function listMessageTraces(messageId: string) {
+    const result = await bridge.invoke(sessionsListMessageTracesRoute.name, { messageId })
     return result.traces
   }
 
-  async translateText(text: string, locale?: string, agentId?: string) {
-    const result = await this.bridge.invoke(sessionsTranslateTextRoute.name, {
+  async function translateText(text: string, locale?: string, agentId?: string) {
+    const result = await bridge.invoke(sessionsTranslateTextRoute.name, {
       text,
       locale,
       agentId
@@ -204,48 +206,55 @@ export class SessionClient {
     return result.text
   }
 
-  async getAgents() {
-    const result = await this.bridge.invoke(sessionsGetAgentsRoute.name, {})
+  async function getAgents() {
+    const result = await bridge.invoke(sessionsGetAgentsRoute.name, {})
     return result.agents
   }
 
-  async renameSession(sessionId: string, title: string) {
-    await this.bridge.invoke(sessionsRenameRoute.name, { sessionId, title })
+  async function renameSession(sessionId: string, title: string) {
+    await bridge.invoke(sessionsRenameRoute.name, { sessionId, title })
   }
 
-  async toggleSessionPinned(sessionId: string, pinned: boolean) {
-    await this.bridge.invoke(sessionsTogglePinnedRoute.name, { sessionId, pinned })
+  async function toggleSessionPinned(sessionId: string, pinned: boolean) {
+    await bridge.invoke(sessionsTogglePinnedRoute.name, { sessionId, pinned })
   }
 
-  async clearSessionMessages(sessionId: string) {
-    await this.bridge.invoke(sessionsClearMessagesRoute.name, { sessionId })
+  async function clearSessionMessages(sessionId: string) {
+    await bridge.invoke(sessionsClearMessagesRoute.name, { sessionId })
   }
 
-  async exportSession(sessionId: string, format: 'markdown' | 'html' | 'txt' | 'nowledge-mem') {
-    return await this.bridge.invoke(sessionsExportRoute.name, {
+  async function exportSession(
+    sessionId: string,
+    format: 'markdown' | 'html' | 'txt' | 'nowledge-mem'
+  ) {
+    return await bridge.invoke(sessionsExportRoute.name, {
       sessionId,
       format
     })
   }
 
-  async deleteSession(sessionId: string) {
-    await this.bridge.invoke(sessionsDeleteRoute.name, { sessionId })
+  async function deleteSession(sessionId: string) {
+    await bridge.invoke(sessionsDeleteRoute.name, { sessionId })
   }
 
-  async getAcpSessionCommands(sessionId: string) {
-    const result = await this.bridge.invoke(sessionsGetAcpSessionCommandsRoute.name, { sessionId })
+  async function getAcpSessionCommands(sessionId: string) {
+    const result = await bridge.invoke(sessionsGetAcpSessionCommandsRoute.name, { sessionId })
     return result.commands
   }
 
-  async getAcpSessionConfigOptions(sessionId: string) {
-    const result = await this.bridge.invoke(sessionsGetAcpSessionConfigOptionsRoute.name, {
+  async function getAcpSessionConfigOptions(sessionId: string) {
+    const result = await bridge.invoke(sessionsGetAcpSessionConfigOptionsRoute.name, {
       sessionId
     })
     return result.state
   }
 
-  async setAcpSessionConfigOption(sessionId: string, configId: string, value: string | boolean) {
-    const result = await this.bridge.invoke(sessionsSetAcpSessionConfigOptionRoute.name, {
+  async function setAcpSessionConfigOption(
+    sessionId: string,
+    configId: string,
+    value: string | boolean
+  ) {
+    const result = await bridge.invoke(sessionsSetAcpSessionConfigOptionRoute.name, {
       sessionId,
       configId,
       value
@@ -253,25 +262,25 @@ export class SessionClient {
     return result.state
   }
 
-  async getPermissionMode(sessionId: string) {
-    const result = await this.bridge.invoke(sessionsGetPermissionModeRoute.name, { sessionId })
+  async function getPermissionMode(sessionId: string) {
+    const result = await bridge.invoke(sessionsGetPermissionModeRoute.name, { sessionId })
     return result.mode
   }
 
-  async setPermissionMode(sessionId: string, mode: 'default' | 'full_access') {
-    await this.bridge.invoke(sessionsSetPermissionModeRoute.name, { sessionId, mode })
+  async function setPermissionMode(sessionId: string, mode: 'default' | 'full_access') {
+    await bridge.invoke(sessionsSetPermissionModeRoute.name, { sessionId, mode })
   }
 
-  async setSessionSubagentEnabled(sessionId: string, enabled: boolean) {
-    const result = await this.bridge.invoke(sessionsSetSubagentEnabledRoute.name, {
+  async function setSessionSubagentEnabled(sessionId: string, enabled: boolean) {
+    const result = await bridge.invoke(sessionsSetSubagentEnabledRoute.name, {
       sessionId,
       enabled
     })
     return result.session
   }
 
-  async setSessionModel(sessionId: string, providerId: string, modelId: string) {
-    const result = await this.bridge.invoke(sessionsSetModelRoute.name, {
+  async function setSessionModel(sessionId: string, providerId: string, modelId: string) {
+    const result = await bridge.invoke(sessionsSetModelRoute.name, {
       sessionId,
       providerId,
       modelId
@@ -279,44 +288,44 @@ export class SessionClient {
     return result.session
   }
 
-  async setSessionProjectDir(sessionId: string, projectDir: string | null) {
-    const result = await this.bridge.invoke(sessionsSetProjectDirRoute.name, {
+  async function setSessionProjectDir(sessionId: string, projectDir: string | null) {
+    const result = await bridge.invoke(sessionsSetProjectDirRoute.name, {
       sessionId,
       projectDir
     })
     return result.session
   }
 
-  async getSessionGenerationSettings(sessionId: string) {
-    const result = await this.bridge.invoke(sessionsGetGenerationSettingsRoute.name, { sessionId })
+  async function getSessionGenerationSettings(sessionId: string) {
+    const result = await bridge.invoke(sessionsGetGenerationSettingsRoute.name, { sessionId })
     return result.settings
   }
 
-  async getSessionDisabledAgentTools(sessionId: string) {
-    const result = await this.bridge.invoke(sessionsGetDisabledAgentToolsRoute.name, { sessionId })
+  async function getSessionDisabledAgentTools(sessionId: string) {
+    const result = await bridge.invoke(sessionsGetDisabledAgentToolsRoute.name, { sessionId })
     return result.disabledAgentTools
   }
 
-  async updateSessionDisabledAgentTools(sessionId: string, disabledAgentTools: string[]) {
-    const result = await this.bridge.invoke(sessionsUpdateDisabledAgentToolsRoute.name, {
+  async function updateSessionDisabledAgentTools(sessionId: string, disabledAgentTools: string[]) {
+    const result = await bridge.invoke(sessionsUpdateDisabledAgentToolsRoute.name, {
       sessionId,
       disabledAgentTools
     })
     return result.disabledAgentTools
   }
 
-  async updateSessionGenerationSettings(
+  async function updateSessionGenerationSettings(
     sessionId: string,
     settings: DeepchatRouteInput<typeof sessionsUpdateGenerationSettingsRoute.name>['settings']
   ) {
-    const result = await this.bridge.invoke(sessionsUpdateGenerationSettingsRoute.name, {
+    const result = await bridge.invoke(sessionsUpdateGenerationSettingsRoute.name, {
       sessionId,
       settings
     })
     return result.settings
   }
 
-  onUpdated(
+  function onUpdated(
     listener: (payload: {
       sessionIds: string[]
       reason: 'created' | 'activated' | 'deactivated' | 'list-refreshed' | 'updated' | 'deleted'
@@ -324,24 +333,26 @@ export class SessionClient {
       webContentsId?: number
     }) => void
   ) {
-    return this.bridge.on(sessionsUpdatedEvent.name, listener)
+    return bridge.on(sessionsUpdatedEvent.name, listener)
   }
 
-  onStatusChanged(
+  function onStatusChanged(
     listener: (payload: {
       sessionId: string
       status: 'idle' | 'generating' | 'error'
       version: number
     }) => void
   ) {
-    return this.bridge.on(sessionsStatusChangedEvent.name, listener)
+    return bridge.on(sessionsStatusChangedEvent.name, listener)
   }
 
-  onPendingInputsChanged(listener: (payload: { sessionId: string; version: number }) => void) {
-    return this.bridge.on(sessionsPendingInputsChangedEvent.name, listener)
+  function onPendingInputsChanged(
+    listener: (payload: { sessionId: string; version: number }) => void
+  ) {
+    return bridge.on(sessionsPendingInputsChangedEvent.name, listener)
   }
 
-  onAcpCommandsReady(
+  function onAcpCommandsReady(
     listener: (payload: {
       conversationId: string
       agentId: string
@@ -353,10 +364,10 @@ export class SessionClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(sessionsAcpCommandsReadyEvent.name, listener)
+    return bridge.on(sessionsAcpCommandsReadyEvent.name, listener)
   }
 
-  onAcpConfigOptionsReady(
+  function onAcpConfigOptionsReady(
     listener: (payload: {
       conversationId?: string
       agentId: string
@@ -382,6 +393,56 @@ export class SessionClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(sessionsAcpConfigOptionsReadyEvent.name, listener)
+    return bridge.on(sessionsAcpConfigOptionsReadyEvent.name, listener)
+  }
+
+  return {
+    create,
+    restore,
+    activate,
+    deactivate,
+    getActive,
+    list,
+    ensureAcpDraftSession,
+    listPendingInputs,
+    queuePendingInput,
+    updateQueuedInput,
+    moveQueuedInput,
+    convertPendingInputToSteer,
+    deletePendingInput,
+    resumePendingQueue,
+    retryMessage,
+    deleteMessage,
+    editUserMessage,
+    forkSession,
+    searchHistory,
+    getSearchResults,
+    listMessageTraces,
+    translateText,
+    getAgents,
+    renameSession,
+    toggleSessionPinned,
+    clearSessionMessages,
+    exportSession,
+    deleteSession,
+    getAcpSessionCommands,
+    getAcpSessionConfigOptions,
+    setAcpSessionConfigOption,
+    getPermissionMode,
+    setPermissionMode,
+    setSessionSubagentEnabled,
+    setSessionModel,
+    setSessionProjectDir,
+    getSessionGenerationSettings,
+    getSessionDisabledAgentTools,
+    updateSessionDisabledAgentTools,
+    updateSessionGenerationSettings,
+    onUpdated,
+    onStatusChanged,
+    onPendingInputsChanged,
+    onAcpCommandsReady,
+    onAcpConfigOptionsReady
   }
 }
+
+export type SessionClient = ReturnType<typeof createSessionClient>

--- a/src/renderer/api/SettingsClient.ts
+++ b/src/renderer/api/SettingsClient.ts
@@ -1,6 +1,6 @@
-import type { SettingsNavigationPayload } from '@shared/settingsNavigation'
 import type { DeepchatBridge } from '@shared/contracts/bridge'
 import { settingsChangedEvent } from '@shared/contracts/events'
+import type { SettingsNavigationPayload } from '@shared/settingsNavigation'
 import {
   configGetEntriesRoute,
   configUpdateEntriesRoute,
@@ -17,55 +17,67 @@ import {
 } from '@shared/contracts/routes'
 import { getDeepchatBridge } from './core'
 
-export class SettingsClient {
-  constructor(protected readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async getSnapshot(keys?: SettingsKey[]): Promise<Partial<SettingsSnapshotValues>> {
-    const result = await this.bridge.invoke(settingsGetSnapshotRoute.name, { keys })
+export function createSettingsClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function getSnapshot(keys?: SettingsKey[]): Promise<Partial<SettingsSnapshotValues>> {
+    const result = await bridge.invoke(settingsGetSnapshotRoute.name, { keys })
     return result.values
   }
 
-  async getSystemFonts(): Promise<string[]> {
-    const result = await this.bridge.invoke(settingsListSystemFontsRoute.name, {})
+  async function getSystemFonts(): Promise<string[]> {
+    const result = await bridge.invoke(settingsListSystemFontsRoute.name, {})
     return result.fonts
   }
 
-  async getConfigEntries(keys?: ConfigEntryKey[]): Promise<Partial<ConfigEntryValues>> {
-    const result = await this.bridge.invoke(configGetEntriesRoute.name, { keys })
+  async function getConfigEntries(keys?: ConfigEntryKey[]): Promise<Partial<ConfigEntryValues>> {
+    const result = await bridge.invoke(configGetEntriesRoute.name, { keys })
     return result.values
   }
 
-  async updateConfigEntries(changes: ConfigEntryChange[]) {
-    return await this.bridge.invoke(configUpdateEntriesRoute.name, { changes })
+  async function updateConfigEntries(changes: ConfigEntryChange[]) {
+    return await bridge.invoke(configUpdateEntriesRoute.name, { changes })
   }
 
-  async getConfigEntry<K extends ConfigEntryKey>(
+  async function getConfigEntry<K extends ConfigEntryKey>(
     key: K
   ): Promise<ConfigEntryValues[K] | undefined> {
-    const values = await this.getConfigEntries([key])
+    const values = await getConfigEntries([key])
     return values[key] as ConfigEntryValues[K] | undefined
   }
 
-  async setConfigEntry<K extends ConfigEntryKey>(key: K, value: ConfigEntryValues[K]) {
-    const result = await this.updateConfigEntries([{ key, value } as ConfigEntryChange])
+  async function setConfigEntry<K extends ConfigEntryKey>(key: K, value: ConfigEntryValues[K]) {
+    const result = await updateConfigEntries([{ key, value } as ConfigEntryChange])
     return result.values[key] as ConfigEntryValues[K] | undefined
   }
 
-  async update(changes: SettingsChange[]) {
-    return await this.bridge.invoke(settingsUpdateRoute.name, { changes })
+  async function update(changes: SettingsChange[]) {
+    return await bridge.invoke(settingsUpdateRoute.name, { changes })
   }
 
-  async openSettings(navigation?: SettingsNavigationPayload) {
-    return await this.bridge.invoke(systemOpenSettingsRoute.name, navigation ?? {})
+  async function openSettings(navigation?: SettingsNavigationPayload) {
+    return await bridge.invoke(systemOpenSettingsRoute.name, navigation ?? {})
   }
 
-  onChanged(
+  function onChanged(
     listener: (payload: {
       changedKeys: SettingsKey[]
       version: number
       values: Partial<SettingsSnapshotValues>
     }) => void
   ) {
-    return this.bridge.on(settingsChangedEvent.name, listener)
+    return bridge.on(settingsChangedEvent.name, listener)
+  }
+
+  return {
+    getSnapshot,
+    getSystemFonts,
+    getConfigEntries,
+    updateConfigEntries,
+    getConfigEntry,
+    setConfigEntry,
+    update,
+    openSettings,
+    onChanged
   }
 }
+
+export type SettingsClient = ReturnType<typeof createSettingsClient>

--- a/src/renderer/api/ShortcutRuntime.ts
+++ b/src/renderer/api/ShortcutRuntime.ts
@@ -3,14 +3,19 @@ import { useLegacyShortcutPresenter } from './legacy/presenters'
 
 const defaultShortcutPresenter = useLegacyShortcutPresenter()
 
-export class ShortcutRuntime {
-  constructor(private readonly presenter: IShortcutPresenter = defaultShortcutPresenter) {}
-
-  registerShortcuts() {
-    this.presenter.registerShortcuts()
+export function createShortcutRuntime(presenter: IShortcutPresenter = defaultShortcutPresenter) {
+  function registerShortcuts() {
+    presenter.registerShortcuts()
   }
 
-  destroy() {
-    this.presenter.destroy()
+  function destroy() {
+    presenter.destroy()
+  }
+
+  return {
+    registerShortcuts,
+    destroy
   }
 }
+
+export type ShortcutRuntime = ReturnType<typeof createShortcutRuntime>

--- a/src/renderer/api/SkillClient.ts
+++ b/src/renderer/api/SkillClient.ts
@@ -20,55 +20,57 @@ import {
 import type { SkillExtensionConfig, SkillInstallOptions } from '@shared/types/skill'
 import { getDeepchatBridge } from './core'
 
-export class SkillClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async getMetadataList() {
-    const result = await this.bridge.invoke(skillsListMetadataRoute.name, {})
+export function createSkillClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function getMetadataList() {
+    const result = await bridge.invoke(skillsListMetadataRoute.name, {})
     return result.skills
   }
 
-  async getSkillsDir() {
-    const result = await this.bridge.invoke(skillsGetDirectoryRoute.name, {})
+  async function getSkillsDir() {
+    const result = await bridge.invoke(skillsGetDirectoryRoute.name, {})
     return result.path
   }
 
-  async installFromFolder(folderPath: string, options?: SkillInstallOptions) {
-    const result = await this.bridge.invoke(skillsInstallFromFolderRoute.name, {
+  async function installFromFolder(folderPath: string, options?: SkillInstallOptions) {
+    const result = await bridge.invoke(skillsInstallFromFolderRoute.name, {
       folderPath,
       options
     })
     return result.result
   }
 
-  async installFromZip(zipPath: string, options?: SkillInstallOptions) {
-    const result = await this.bridge.invoke(skillsInstallFromZipRoute.name, {
+  async function installFromZip(zipPath: string, options?: SkillInstallOptions) {
+    const result = await bridge.invoke(skillsInstallFromZipRoute.name, {
       zipPath,
       options
     })
     return result.result
   }
 
-  async installFromUrl(url: string, options?: SkillInstallOptions) {
-    const result = await this.bridge.invoke(skillsInstallFromUrlRoute.name, {
+  async function installFromUrl(url: string, options?: SkillInstallOptions) {
+    const result = await bridge.invoke(skillsInstallFromUrlRoute.name, {
       url,
       options
     })
     return result.result
   }
 
-  async uninstallSkill(name: string) {
-    const result = await this.bridge.invoke(skillsUninstallRoute.name, { name })
+  async function uninstallSkill(name: string) {
+    const result = await bridge.invoke(skillsUninstallRoute.name, { name })
     return result.result
   }
 
-  async updateSkillFile(name: string, content: string) {
-    const result = await this.bridge.invoke(skillsUpdateFileRoute.name, { name, content })
+  async function updateSkillFile(name: string, content: string) {
+    const result = await bridge.invoke(skillsUpdateFileRoute.name, { name, content })
     return result.result
   }
 
-  async saveSkillWithExtension(name: string, content: string, config: SkillExtensionConfig) {
-    const result = await this.bridge.invoke(skillsSaveWithExtensionRoute.name, {
+  async function saveSkillWithExtension(
+    name: string,
+    content: string,
+    config: SkillExtensionConfig
+  ) {
+    const result = await bridge.invoke(skillsSaveWithExtensionRoute.name, {
       name,
       content,
       config
@@ -76,53 +78,53 @@ export class SkillClient {
     return result.result
   }
 
-  async getSkillFolderTree(name: string) {
-    const result = await this.bridge.invoke(skillsGetFolderTreeRoute.name, { name })
+  async function getSkillFolderTree(name: string) {
+    const result = await bridge.invoke(skillsGetFolderTreeRoute.name, { name })
     return result.nodes
   }
 
-  async openSkillsFolder() {
-    await this.bridge.invoke(skillsOpenFolderRoute.name, {})
+  async function openSkillsFolder() {
+    await bridge.invoke(skillsOpenFolderRoute.name, {})
   }
 
-  async getSkillExtension(name: string) {
-    const result = await this.bridge.invoke(skillsGetExtensionRoute.name, { name })
+  async function getSkillExtension(name: string) {
+    const result = await bridge.invoke(skillsGetExtensionRoute.name, { name })
     return result.config
   }
 
-  async saveSkillExtension(name: string, config: SkillExtensionConfig) {
-    await this.bridge.invoke(skillsSaveExtensionRoute.name, { name, config })
+  async function saveSkillExtension(name: string, config: SkillExtensionConfig) {
+    await bridge.invoke(skillsSaveExtensionRoute.name, { name, config })
   }
 
-  async listSkillScripts(name: string) {
-    const result = await this.bridge.invoke(skillsListScriptsRoute.name, { name })
+  async function listSkillScripts(name: string) {
+    const result = await bridge.invoke(skillsListScriptsRoute.name, { name })
     return result.scripts
   }
 
-  async getActiveSkills(conversationId: string) {
-    const result = await this.bridge.invoke(skillsGetActiveRoute.name, { conversationId })
+  async function getActiveSkills(conversationId: string) {
+    const result = await bridge.invoke(skillsGetActiveRoute.name, { conversationId })
     return result.skills
   }
 
-  async setActiveSkills(conversationId: string, skills: string[]) {
-    const result = await this.bridge.invoke(skillsSetActiveRoute.name, {
+  async function setActiveSkills(conversationId: string, skills: string[]) {
+    const result = await bridge.invoke(skillsSetActiveRoute.name, {
       conversationId,
       skills
     })
     return result.skills
   }
 
-  onCatalogChanged(
+  function onCatalogChanged(
     listener: (payload: {
       reason: 'discovered' | 'installed' | 'uninstalled' | 'metadata-updated'
       name?: string
       version: number
     }) => void
   ) {
-    return this.bridge.on(skillsCatalogChangedEvent.name, listener)
+    return bridge.on(skillsCatalogChangedEvent.name, listener)
   }
 
-  onSessionChanged(
+  function onSessionChanged(
     listener: (payload: {
       conversationId: string
       skills: string[]
@@ -130,6 +132,28 @@ export class SkillClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(skillsSessionChangedEvent.name, listener)
+    return bridge.on(skillsSessionChangedEvent.name, listener)
+  }
+
+  return {
+    getMetadataList,
+    getSkillsDir,
+    installFromFolder,
+    installFromZip,
+    installFromUrl,
+    uninstallSkill,
+    updateSkillFile,
+    saveSkillWithExtension,
+    getSkillFolderTree,
+    openSkillsFolder,
+    getSkillExtension,
+    saveSkillExtension,
+    listSkillScripts,
+    getActiveSkills,
+    setActiveSkills,
+    onCatalogChanged,
+    onSessionChanged
   }
 }
+
+export type SkillClient = ReturnType<typeof createSkillClient>

--- a/src/renderer/api/SyncClient.ts
+++ b/src/renderer/api/SyncClient.ts
@@ -17,49 +17,47 @@ import {
 } from '@shared/contracts/routes'
 import { getDeepchatBridge } from './core'
 
-export class SyncClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async getBackupStatus() {
-    const result = await this.bridge.invoke(syncGetBackupStatusRoute.name, {})
+export function createSyncClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function getBackupStatus() {
+    const result = await bridge.invoke(syncGetBackupStatusRoute.name, {})
     return result.status
   }
 
-  async listBackups() {
-    const result = await this.bridge.invoke(syncListBackupsRoute.name, {})
+  async function listBackups() {
+    const result = await bridge.invoke(syncListBackupsRoute.name, {})
     return result.backups
   }
 
-  async startBackup() {
-    const result = await this.bridge.invoke(syncStartBackupRoute.name, {})
+  async function startBackup() {
+    const result = await bridge.invoke(syncStartBackupRoute.name, {})
     return result.backup
   }
 
-  async importFromSync(backupFile: string, mode?: 'increment' | 'overwrite') {
-    const result = await this.bridge.invoke(syncImportRoute.name, {
+  async function importFromSync(backupFile: string, mode?: 'increment' | 'overwrite') {
+    const result = await bridge.invoke(syncImportRoute.name, {
       backupFile,
       mode
     })
     return result.result
   }
 
-  async openSyncFolder() {
-    await this.bridge.invoke(syncOpenFolderRoute.name, {})
+  async function openSyncFolder() {
+    await bridge.invoke(syncOpenFolderRoute.name, {})
   }
 
-  onBackupStarted(listener: (payload: { version: number }) => void) {
-    return this.bridge.on(syncBackupStartedEvent.name, listener)
+  function onBackupStarted(listener: (payload: { version: number }) => void) {
+    return bridge.on(syncBackupStartedEvent.name, listener)
   }
 
-  onBackupCompleted(listener: (payload: { timestamp: number; version: number }) => void) {
-    return this.bridge.on(syncBackupCompletedEvent.name, listener)
+  function onBackupCompleted(listener: (payload: { timestamp: number; version: number }) => void) {
+    return bridge.on(syncBackupCompletedEvent.name, listener)
   }
 
-  onBackupError(listener: (payload: { error?: string; version: number }) => void) {
-    return this.bridge.on(syncBackupErrorEvent.name, listener)
+  function onBackupError(listener: (payload: { error?: string; version: number }) => void) {
+    return bridge.on(syncBackupErrorEvent.name, listener)
   }
 
-  onBackupStatusChanged(
+  function onBackupStatusChanged(
     listener: (payload: {
       status: string
       previousStatus?: string
@@ -69,18 +67,35 @@ export class SyncClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(syncBackupStatusChangedEvent.name, listener)
+    return bridge.on(syncBackupStatusChangedEvent.name, listener)
   }
 
-  onImportStarted(listener: (payload: { version: number }) => void) {
-    return this.bridge.on(syncImportStartedEvent.name, listener)
+  function onImportStarted(listener: (payload: { version: number }) => void) {
+    return bridge.on(syncImportStartedEvent.name, listener)
   }
 
-  onImportCompleted(listener: (payload: { version: number }) => void) {
-    return this.bridge.on(syncImportCompletedEvent.name, listener)
+  function onImportCompleted(listener: (payload: { version: number }) => void) {
+    return bridge.on(syncImportCompletedEvent.name, listener)
   }
 
-  onImportError(listener: (payload: { error?: string; version: number }) => void) {
-    return this.bridge.on(syncImportErrorEvent.name, listener)
+  function onImportError(listener: (payload: { error?: string; version: number }) => void) {
+    return bridge.on(syncImportErrorEvent.name, listener)
+  }
+
+  return {
+    getBackupStatus,
+    listBackups,
+    startBackup,
+    importFromSync,
+    openSyncFolder,
+    onBackupStarted,
+    onBackupCompleted,
+    onBackupError,
+    onBackupStatusChanged,
+    onImportStarted,
+    onImportCompleted,
+    onImportError
   }
 }
+
+export type SyncClient = ReturnType<typeof createSyncClient>

--- a/src/renderer/api/TabClient.ts
+++ b/src/renderer/api/TabClient.ts
@@ -7,23 +7,21 @@ import {
 } from '@shared/contracts/routes'
 import { getDeepchatBridge } from './core'
 
-export class TabClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async notifyRendererReady() {
-    return await this.bridge.invoke(tabNotifyRendererReadyRoute.name, {})
+export function createTabClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function notifyRendererReady() {
+    return await bridge.invoke(tabNotifyRendererReadyRoute.name, {})
   }
 
-  async notifyRendererActivated(sessionId: string) {
-    return await this.bridge.invoke(tabNotifyRendererActivatedRoute.name, { sessionId })
+  async function notifyRendererActivated(sessionId: string) {
+    return await bridge.invoke(tabNotifyRendererActivatedRoute.name, { sessionId })
   }
 
-  async captureCurrentArea(rect: { x: number; y: number; width: number; height: number }) {
-    const result = await this.bridge.invoke(tabCaptureCurrentAreaRoute.name, { rect })
+  async function captureCurrentArea(rect: { x: number; y: number; width: number; height: number }) {
+    const result = await bridge.invoke(tabCaptureCurrentAreaRoute.name, { rect })
     return result.imageData
   }
 
-  async stitchImagesWithWatermark(
+  async function stitchImagesWithWatermark(
     images: string[],
     watermark?: {
       isDark?: boolean
@@ -37,10 +35,19 @@ export class TabClient {
       }
     }
   ) {
-    const result = await this.bridge.invoke(tabStitchImagesWithWatermarkRoute.name, {
+    const result = await bridge.invoke(tabStitchImagesWithWatermarkRoute.name, {
       images,
       watermark
     })
     return result.imageData
   }
+
+  return {
+    notifyRendererReady,
+    notifyRendererActivated,
+    captureCurrentArea,
+    stitchImagesWithWatermark
+  }
 }
+
+export type TabClient = ReturnType<typeof createTabClient>

--- a/src/renderer/api/ToolClient.ts
+++ b/src/renderer/api/ToolClient.ts
@@ -2,10 +2,8 @@ import type { DeepchatBridge } from '@shared/contracts/bridge'
 import { toolsListDefinitionsRoute } from '@shared/contracts/routes'
 import { getDeepchatBridge } from './core'
 
-export class ToolClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async getAllToolDefinitions(context: {
+export function createToolClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function getAllToolDefinitions(context: {
     enabledMcpTools?: string[]
     disabledAgentTools?: string[]
     chatMode?: 'agent' | 'acp agent'
@@ -13,7 +11,13 @@ export class ToolClient {
     agentWorkspacePath?: string | null
     conversationId?: string
   }) {
-    const result = await this.bridge.invoke(toolsListDefinitionsRoute.name, context)
+    const result = await bridge.invoke(toolsListDefinitionsRoute.name, context)
     return result.tools
   }
+
+  return {
+    getAllToolDefinitions
+  }
 }
+
+export type ToolClient = ReturnType<typeof createToolClient>

--- a/src/renderer/api/UpgradeClient.ts
+++ b/src/renderer/api/UpgradeClient.ts
@@ -16,43 +16,41 @@ import {
 } from '@shared/contracts/routes'
 import { getDeepchatBridge } from './core'
 
-export class UpgradeClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async getUpdateStatus() {
-    const result = await this.bridge.invoke(upgradeGetStatusRoute.name, {})
+export function createUpgradeClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function getUpdateStatus() {
+    const result = await bridge.invoke(upgradeGetStatusRoute.name, {})
     return result.snapshot
   }
 
-  async checkUpdate(type?: string) {
-    await this.bridge.invoke(upgradeCheckRoute.name, { type })
+  async function checkUpdate(type?: string) {
+    await bridge.invoke(upgradeCheckRoute.name, { type })
   }
 
-  async goDownloadUpgrade(type: 'github' | 'official') {
-    await this.bridge.invoke(upgradeOpenDownloadRoute.name, { type })
+  async function goDownloadUpgrade(type: 'github' | 'official') {
+    await bridge.invoke(upgradeOpenDownloadRoute.name, { type })
   }
 
-  async startDownloadUpdate() {
-    const result = await this.bridge.invoke(upgradeStartDownloadRoute.name, {})
+  async function startDownloadUpdate() {
+    const result = await bridge.invoke(upgradeStartDownloadRoute.name, {})
     return result.started
   }
 
-  async mockDownloadedUpdate() {
-    const result = await this.bridge.invoke(upgradeMockDownloadedRoute.name, {})
+  async function mockDownloadedUpdate() {
+    const result = await bridge.invoke(upgradeMockDownloadedRoute.name, {})
     return result.updated
   }
 
-  async clearMockUpdate() {
-    const result = await this.bridge.invoke(upgradeClearMockRoute.name, {})
+  async function clearMockUpdate() {
+    const result = await bridge.invoke(upgradeClearMockRoute.name, {})
     return result.updated
   }
 
-  async restartToUpdate() {
-    const result = await this.bridge.invoke(upgradeRestartToUpdateRoute.name, {})
+  async function restartToUpdate() {
+    const result = await bridge.invoke(upgradeRestartToUpdateRoute.name, {})
     return result.restarted
   }
 
-  onStatusChanged(
+  function onStatusChanged(
     listener: (payload: {
       status:
         | 'checking'
@@ -75,10 +73,10 @@ export class UpgradeClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(upgradeStatusChangedEvent.name, listener)
+    return bridge.on(upgradeStatusChangedEvent.name, listener)
   }
 
-  onProgress(
+  function onProgress(
     listener: (payload: {
       bytesPerSecond: number
       percent: number
@@ -87,14 +85,30 @@ export class UpgradeClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(upgradeProgressEvent.name, listener)
+    return bridge.on(upgradeProgressEvent.name, listener)
   }
 
-  onWillRestart(listener: (payload: { version: number }) => void) {
-    return this.bridge.on(upgradeWillRestartEvent.name, listener)
+  function onWillRestart(listener: (payload: { version: number }) => void) {
+    return bridge.on(upgradeWillRestartEvent.name, listener)
   }
 
-  onError(listener: (payload: { error: string; version: number }) => void) {
-    return this.bridge.on(upgradeErrorEvent.name, listener)
+  function onError(listener: (payload: { error: string; version: number }) => void) {
+    return bridge.on(upgradeErrorEvent.name, listener)
+  }
+
+  return {
+    getUpdateStatus,
+    checkUpdate,
+    goDownloadUpgrade,
+    startDownloadUpdate,
+    mockDownloadedUpdate,
+    clearMockUpdate,
+    restartToUpdate,
+    onStatusChanged,
+    onProgress,
+    onWillRestart,
+    onError
   }
 }
+
+export type UpgradeClient = ReturnType<typeof createUpgradeClient>

--- a/src/renderer/api/WindowClient.ts
+++ b/src/renderer/api/WindowClient.ts
@@ -11,37 +11,35 @@ import {
 import { getDeepchatBridge } from './core'
 import { getRuntimeWindowId } from './runtime'
 
-export class WindowClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async getCurrentState() {
-    const result = await this.bridge.invoke(windowGetCurrentStateRoute.name, {})
+export function createWindowClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function getCurrentState() {
+    const result = await bridge.invoke(windowGetCurrentStateRoute.name, {})
     return result.state
   }
 
-  async minimizeCurrent() {
-    const result = await this.bridge.invoke(windowMinimizeCurrentRoute.name, {})
+  async function minimizeCurrent() {
+    const result = await bridge.invoke(windowMinimizeCurrentRoute.name, {})
     return result.state
   }
 
-  async toggleMaximizeCurrent() {
-    const result = await this.bridge.invoke(windowToggleMaximizeCurrentRoute.name, {})
+  async function toggleMaximizeCurrent() {
+    const result = await bridge.invoke(windowToggleMaximizeCurrentRoute.name, {})
     return result.state
   }
 
-  async closeCurrent() {
-    return await this.bridge.invoke(windowCloseCurrentRoute.name, {})
+  async function closeCurrent() {
+    return await bridge.invoke(windowCloseCurrentRoute.name, {})
   }
 
-  async closeFloatingCurrent() {
-    return await this.bridge.invoke(windowCloseFloatingCurrentRoute.name, {})
+  async function closeFloatingCurrent() {
+    return await bridge.invoke(windowCloseFloatingCurrentRoute.name, {})
   }
 
-  async previewFile(filePath: string) {
-    return await this.bridge.invoke(windowPreviewFileRoute.name, { filePath })
+  async function previewFile(filePath: string) {
+    return await bridge.invoke(windowPreviewFileRoute.name, { filePath })
   }
 
-  onStateChanged(
+  function onStateChanged(
     listener: (payload: {
       windowId: number | null
       exists: boolean
@@ -51,10 +49,10 @@ export class WindowClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(windowStateChangedEvent.name, listener)
+    return bridge.on(windowStateChangedEvent.name, listener)
   }
 
-  onCurrentStateChanged(
+  function onCurrentStateChanged(
     listener: (payload: {
       windowId: number | null
       exists: boolean
@@ -66,7 +64,7 @@ export class WindowClient {
   ) {
     const currentWindowId = getRuntimeWindowId()
 
-    return this.onStateChanged((payload) => {
+    return onStateChanged((payload) => {
       if (currentWindowId != null && payload.windowId !== currentWindowId) {
         return
       }
@@ -74,4 +72,17 @@ export class WindowClient {
       listener(payload)
     })
   }
+
+  return {
+    getCurrentState,
+    minimizeCurrent,
+    toggleMaximizeCurrent,
+    closeCurrent,
+    closeFloatingCurrent,
+    previewFile,
+    onStateChanged,
+    onCurrentStateChanged
+  }
 }
+
+export type WindowClient = ReturnType<typeof createWindowClient>

--- a/src/renderer/api/WorkspaceClient.ts
+++ b/src/renderer/api/WorkspaceClient.ts
@@ -19,79 +19,83 @@ import { getDeepchatBridge } from './core'
 
 type WorkspaceRegistrationMode = 'workspace' | 'workdir'
 
-export class WorkspaceClient {
-  constructor(private readonly bridge: DeepchatBridge = getDeepchatBridge()) {}
-
-  async registerWorkspace(workspacePath: string, mode: WorkspaceRegistrationMode = 'workspace') {
-    return await this.bridge.invoke(workspaceRegisterRoute.name, { workspacePath, mode })
+export function createWorkspaceClient(bridge: DeepchatBridge = getDeepchatBridge()) {
+  async function registerWorkspace(
+    workspacePath: string,
+    mode: WorkspaceRegistrationMode = 'workspace'
+  ) {
+    return await bridge.invoke(workspaceRegisterRoute.name, { workspacePath, mode })
   }
 
-  async unregisterWorkspace(workspacePath: string, mode: WorkspaceRegistrationMode = 'workspace') {
-    return await this.bridge.invoke(workspaceUnregisterRoute.name, { workspacePath, mode })
+  async function unregisterWorkspace(
+    workspacePath: string,
+    mode: WorkspaceRegistrationMode = 'workspace'
+  ) {
+    return await bridge.invoke(workspaceUnregisterRoute.name, { workspacePath, mode })
   }
 
-  async watchWorkspace(workspacePath: string) {
-    return await this.bridge.invoke(workspaceWatchRoute.name, { workspacePath })
+  async function watchWorkspace(workspacePath: string) {
+    return await bridge.invoke(workspaceWatchRoute.name, { workspacePath })
   }
 
-  async unwatchWorkspace(workspacePath: string) {
-    return await this.bridge.invoke(workspaceUnwatchRoute.name, { workspacePath })
+  async function unwatchWorkspace(workspacePath: string) {
+    return await bridge.invoke(workspaceUnwatchRoute.name, { workspacePath })
   }
 
-  async readDirectory(path: string) {
-    const result = await this.bridge.invoke(workspaceReadDirectoryRoute.name, { path })
+  async function readDirectory(path: string) {
+    const result = await bridge.invoke(workspaceReadDirectoryRoute.name, { path })
     return result.nodes
   }
 
-  async expandDirectory(path: string) {
-    const result = await this.bridge.invoke(workspaceExpandDirectoryRoute.name, { path })
+  async function expandDirectory(path: string) {
+    const result = await bridge.invoke(workspaceExpandDirectoryRoute.name, { path })
     return result.nodes
   }
 
-  async revealFileInFolder(path: string) {
-    return await this.bridge.invoke(workspaceRevealFileInFolderRoute.name, { path })
+  async function revealFileInFolder(path: string) {
+    return await bridge.invoke(workspaceRevealFileInFolderRoute.name, { path })
   }
 
-  async openFile(path: string) {
-    return await this.bridge.invoke(workspaceOpenFileRoute.name, { path })
+  async function openFile(path: string) {
+    return await bridge.invoke(workspaceOpenFileRoute.name, { path })
   }
 
-  async readFilePreview(path: string) {
-    const result = await this.bridge.invoke(workspaceReadFilePreviewRoute.name, { path })
+  async function readFilePreview(path: string) {
+    const result = await bridge.invoke(workspaceReadFilePreviewRoute.name, { path })
     return result.preview
   }
 
-  async resolveMarkdownLinkedFile(input: {
+  async function resolveMarkdownLinkedFile(input: {
     workspacePath: string | null
     href: string
     sourceFilePath?: string | null
   }) {
-    const result = await this.bridge.invoke(workspaceResolveMarkdownLinkedFileRoute.name, input)
+    const result = await bridge.invoke(workspaceResolveMarkdownLinkedFileRoute.name, input)
     return result.resolution
   }
 
-  async getGitStatus(workspacePath: string) {
-    const result = await this.bridge.invoke(workspaceGetGitStatusRoute.name, { workspacePath })
+  async function getGitStatus(workspacePath: string) {
+    const result = await bridge.invoke(workspaceGetGitStatusRoute.name, { workspacePath })
     return result.state
   }
 
-  async getGitDiff(workspacePath: string, filePath?: string) {
-    const result = await this.bridge.invoke(workspaceGetGitDiffRoute.name, {
+  async function getGitDiff(workspacePath: string, filePath?: string) {
+    const result = await bridge.invoke(workspaceGetGitDiffRoute.name, {
       workspacePath,
       filePath
     })
     return result.diff
   }
 
-  async searchFiles(workspacePath: string, query: string) {
-    const result = await this.bridge.invoke(workspaceSearchFilesRoute.name, {
+  async function searchFiles(workspacePath: string, query: string) {
+    const result = await bridge.invoke(workspaceSearchFilesRoute.name, {
       workspacePath,
       query
     })
     return result.nodes
   }
 
-  onInvalidated(
+  function onInvalidated(
     listener: (payload: {
       workspacePath: string
       kind: 'fs' | 'git' | 'full'
@@ -99,6 +103,25 @@ export class WorkspaceClient {
       version: number
     }) => void
   ) {
-    return this.bridge.on(workspaceInvalidatedEvent.name, listener)
+    return bridge.on(workspaceInvalidatedEvent.name, listener)
+  }
+
+  return {
+    registerWorkspace,
+    unregisterWorkspace,
+    watchWorkspace,
+    unwatchWorkspace,
+    readDirectory,
+    expandDirectory,
+    revealFileInFolder,
+    openFile,
+    readFilePreview,
+    resolveMarkdownLinkedFile,
+    getGitStatus,
+    getGitDiff,
+    searchFiles,
+    onInvalidated
   }
 }
+
+export type WorkspaceClient = ReturnType<typeof createWorkspaceClient>

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onMounted, ref, watch, onBeforeUnmount, computed } from 'vue'
 import { RouterView, useRoute, useRouter } from 'vue-router'
-import { ConfigClient } from '@api/ConfigClient'
+import { createConfigClient } from '@api/ConfigClient'
 import SelectedTextContextMenu from './components/message/SelectedTextContextMenu.vue'
 import { useArtifactStore } from './stores/artifact'
 import { useSessionStore } from '@/stores/ui/session'
@@ -31,13 +31,13 @@ import { useSidepanelStore } from '@/stores/ui/sidepanel'
 import { useSidebarStore } from '@/stores/ui/sidebar'
 import { useAppIpcRuntime } from '@/composables/useAppIpcRuntime'
 import type { DatabaseRepairSuggestedPayload } from '@shared/presenter'
-import { WindowClient } from '@api/WindowClient'
+import { createWindowClient } from '@api/WindowClient'
 
 const DEV_WELCOME_OVERRIDE_KEY = '__deepchat_dev_force_welcome'
 
 const route = useRoute()
-const configClient = new ConfigClient()
-const windowClient = new WindowClient()
+const configClient = createConfigClient()
+const windowClient = createWindowClient()
 const artifactStore = useArtifactStore()
 const sessionStore = useSessionStore()
 const agentStore = useAgentStore()

--- a/src/renderer/src/components/AppBar.vue
+++ b/src/renderer/src/components/AppBar.vue
@@ -56,8 +56,8 @@ import MaximizeIcon from './icons/MaximizeIcon.vue'
 import RestoreIcon from './icons/RestoreIcon.vue'
 import CloseIcon from './icons/CloseIcon.vue'
 import MinimizeIcon from './icons/MinimizeIcon.vue'
-import { DeviceClient } from '@api/DeviceClient'
-import { WindowClient } from '@api/WindowClient'
+import { createDeviceClient } from '@api/DeviceClient'
+import { createWindowClient } from '@api/WindowClient'
 import { Button } from '@shadcn/components/ui/button'
 import { useLanguageStore } from '@/stores/language'
 import { useI18n } from 'vue-i18n'
@@ -65,8 +65,8 @@ import { useUpgradeStore } from '@/stores/upgrade'
 import { useRoute } from 'vue-router'
 
 const langStore = useLanguageStore()
-const windowClient = new WindowClient()
-const deviceClient = new DeviceClient()
+const windowClient = createWindowClient()
+const deviceClient = createDeviceClient()
 const upgrade = useUpgradeStore()
 const route = useRoute()
 

--- a/src/renderer/src/components/WindowSideBar.vue
+++ b/src/renderer/src/components/WindowSideBar.vue
@@ -334,8 +334,8 @@ import {
   DialogHeader,
   DialogTitle
 } from '@shadcn/components/ui/dialog'
-import { SettingsClient } from '@api/SettingsClient'
-import { RemoteControlRuntime } from '@api/RemoteControlRuntime'
+import { createSettingsClient } from '@api/SettingsClient'
+import { createRemoteControlRuntime } from '@api/RemoteControlRuntime'
 import { useAgentStore } from '@/stores/ui/agent'
 import { useSessionStore, type SessionGroup, type UISession } from '@/stores/ui/session'
 import { useSpotlightStore } from '@/stores/ui/spotlight'
@@ -360,8 +360,8 @@ const PIN_FLIGHT_DURATION_MS = 500
 const getPinFeedbackMode = (nextPinned: boolean): PinFeedbackMode =>
   nextPinned ? 'pinning' : 'unpinning'
 
-const settingsClient = new SettingsClient()
-const remoteControlRuntime = new RemoteControlRuntime()
+const settingsClient = createSettingsClient()
+const remoteControlRuntime = createRemoteControlRuntime()
 const { t } = useI18n()
 const agentStore = useAgentStore()
 const sessionStore = useSessionStore()

--- a/src/renderer/src/components/artifacts/ArtifactBlock.vue
+++ b/src/renderer/src/components/artifacts/ArtifactBlock.vue
@@ -25,7 +25,7 @@
 import { computed } from 'vue'
 import { Button } from '@shadcn/components/ui/button'
 import { Icon } from '@iconify/vue'
-import { DeviceClient } from '@api/DeviceClient'
+import { createDeviceClient } from '@api/DeviceClient'
 import CodeArtifact from './CodeArtifact.vue'
 import MarkdownArtifact from './MarkdownArtifact.vue'
 import HTMLArtifact from './HTMLArtifact.vue'
@@ -42,7 +42,7 @@ const props = defineProps<{
     content: string
   }
 }>()
-const deviceClient = new DeviceClient()
+const deviceClient = createDeviceClient()
 
 const artifactComponent = computed(() => {
   if (!props.block.artifact) return null

--- a/src/renderer/src/components/artifacts/ArtifactThinking.vue
+++ b/src/renderer/src/components/artifacts/ArtifactThinking.vue
@@ -9,10 +9,10 @@
 // import { useI18n } from 'vue-i18n'
 import { Icon } from '@iconify/vue'
 import { onMounted, ref, watch } from 'vue'
-import { ConfigClient } from '@api/ConfigClient'
+import { createConfigClient } from '@api/ConfigClient'
 
 // const { t } = useI18n()
-const configClient = new ConfigClient()
+const configClient = createConfigClient()
 const collapse = ref(false)
 
 watch(

--- a/src/renderer/src/components/artifacts/CodeArtifact.vue
+++ b/src/renderer/src/components/artifacts/CodeArtifact.vue
@@ -43,7 +43,7 @@ import { useI18n } from 'vue-i18n'
 import { useThrottleFn } from '@vueuse/core'
 import { Icon } from '@iconify/vue'
 import { MermaidBlockNode } from 'markstream-vue'
-import { DeviceClient } from '@api/DeviceClient'
+import { createDeviceClient } from '@api/DeviceClient'
 import { useArtifactStore } from '@/stores/artifact'
 import { useUiSettingsStore } from '@/stores/uiSettingsStore'
 import { getLanguageIcon } from 'markstream-vue'
@@ -65,7 +65,7 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
-const deviceClient = new DeviceClient()
+const deviceClient = createDeviceClient()
 const uiSettingsStore = useUiSettingsStore()
 const { createEditor, updateCode, getEditorView } = useMonaco({
   wordWrap: 'on',

--- a/src/renderer/src/components/artifacts/SvgArtifact.vue
+++ b/src/renderer/src/components/artifacts/SvgArtifact.vue
@@ -42,12 +42,12 @@
 
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue'
-import { DeviceClient } from '@api/DeviceClient'
+import { createDeviceClient } from '@api/DeviceClient'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
-const deviceClient = new DeviceClient()
+const deviceClient = createDeviceClient()
 
 const props = defineProps<{
   block: {

--- a/src/renderer/src/components/chat-input/McpIndicator.vue
+++ b/src/renderer/src/components/chat-input/McpIndicator.vue
@@ -218,10 +218,10 @@ import {
   SelectValue
 } from '@shadcn/components/ui/select'
 import { Switch } from '@shadcn/components/ui/switch'
-import { SettingsClient } from '@api/SettingsClient'
-import { SessionClient } from '@api/SessionClient'
-import { SkillClient } from '@api/SkillClient'
-import { ToolClient } from '@api/ToolClient'
+import { createSettingsClient } from '@api/SettingsClient'
+import { createSessionClient } from '@api/SessionClient'
+import { createSkillClient } from '@api/SkillClient'
+import { createToolClient } from '@api/ToolClient'
 import type { MCPToolDefinition } from '@shared/presenter'
 import { useMcpStore } from '@/stores/mcp'
 import { useSessionStore } from '@/stores/ui/session'
@@ -295,10 +295,10 @@ const sessionStore = useSessionStore()
 const draftStore = useDraftStore()
 const agentStore = useAgentStore()
 const projectStore = useProjectStore()
-const settingsClient = new SettingsClient()
-const toolClient = new ToolClient()
-const sessionClient = new SessionClient()
-const skillClient = new SkillClient()
+const settingsClient = createSettingsClient()
+const toolClient = createToolClient()
+const sessionClient = createSessionClient()
+const skillClient = createSkillClient()
 
 const panelOpen = ref(false)
 const toolsLoading = ref(false)

--- a/src/renderer/src/components/chat-input/SkillsIndicator.vue
+++ b/src/renderer/src/components/chat-input/SkillsIndicator.vue
@@ -51,7 +51,7 @@ import {
 } from '@shadcn/components/ui/tooltip'
 import { Popover, PopoverContent, PopoverTrigger } from '@shadcn/components/ui/popover'
 import { Button } from '@shadcn/components/ui/button'
-import { SettingsClient } from '@api/SettingsClient'
+import { createSettingsClient } from '@api/SettingsClient'
 import { useSkillsData } from './composables/useSkillsData'
 import SkillsPanel from './SkillsPanel.vue'
 
@@ -60,7 +60,7 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
-const settingsClient = new SettingsClient()
+const settingsClient = createSettingsClient()
 
 // Panel open state
 const panelOpen = ref(false)

--- a/src/renderer/src/components/chat-input/composables/useAgentMcpData.ts
+++ b/src/renderer/src/components/chat-input/composables/useAgentMcpData.ts
@@ -1,14 +1,14 @@
 import { computed, ref, watch } from 'vue'
 import { useMcpStore } from '@/stores/mcp'
 import { useSessionStore } from '@/stores/ui/session'
-import { ConfigClient } from '@api/ConfigClient'
+import { createConfigClient } from '@api/ConfigClient'
 
 const CUSTOM_PROMPTS_CLIENT = 'deepchat/custom-prompts-server'
 
 export function useAgentMcpData() {
   const sessionStore = useSessionStore()
   const mcpStore = useMcpStore()
-  const configClient = new ConfigClient()
+  const configClient = createConfigClient()
   const activeSelections = ref<string[] | null>(null)
   let requestSeq = 0
 

--- a/src/renderer/src/components/chat-input/composables/useChatMode.ts
+++ b/src/renderer/src/components/chat-input/composables/useChatMode.ts
@@ -3,8 +3,8 @@ import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 // === Composables ===
-import { ConfigClient } from '@api/ConfigClient'
-import { ModelClient } from '@api/ModelClient'
+import { createConfigClient } from '@api/ConfigClient'
+import { createModelClient } from '@api/ModelClient'
 
 export type ChatMode = 'agent' | 'acp agent'
 
@@ -20,8 +20,8 @@ let hasLoaded = false
 let loadPromise: Promise<void> | null = null
 let modeUpdateVersion = 0
 let hasAcpListener = false
-const configClient = new ConfigClient()
-const modelClient = new ModelClient()
+const configClient = createConfigClient()
+const modelClient = createModelClient()
 
 /**
  * Manages chat mode selection (agent, acp agent)

--- a/src/renderer/src/components/chat-input/composables/useInputSettings.ts
+++ b/src/renderer/src/components/chat-input/composables/useInputSettings.ts
@@ -2,14 +2,14 @@
 import { ref, onMounted } from 'vue'
 
 // === Composables ===
-import { ConfigClient } from '@api/ConfigClient'
+import { createConfigClient } from '@api/ConfigClient'
 
 /**
  * Manages input-specific settings (deep thinking)
  */
 export function useInputSettings() {
   // === Clients ===
-  const configClient = new ConfigClient()
+  const configClient = createConfigClient()
 
   // === Local State ===
   const settings = ref({

--- a/src/renderer/src/components/chat-input/composables/useRateLimitStatus.ts
+++ b/src/renderer/src/components/chat-input/composables/useRateLimitStatus.ts
@@ -5,7 +5,7 @@ import { ref, computed, onMounted, onUnmounted, watch, type Ref } from 'vue'
 import type { CONVERSATION_SETTINGS } from '@shared/presenter'
 
 // === Composables ===
-import { ProviderClient } from '@api/ProviderClient'
+import { createProviderClient } from '@api/ProviderClient'
 
 // === Stores ===
 import { useProviderStore } from '@/stores/providerStore'
@@ -32,7 +32,7 @@ export function useRateLimitStatus(
   t: (key: string, params?: any) => string
 ) {
   // === Clients ===
-  const providerClient = new ProviderClient()
+  const providerClient = createProviderClient()
 
   // === Stores ===
   const providerStore = useProviderStore()

--- a/src/renderer/src/components/chat-input/composables/useSkillsData.ts
+++ b/src/renderer/src/components/chat-input/composables/useSkillsData.ts
@@ -5,7 +5,7 @@ import { ref, computed, watch, onMounted, onUnmounted, type Ref, type ComputedRe
 import type { SkillMetadata } from '@shared/types/skill'
 
 // === Composables ===
-import { SkillClient } from '@api/SkillClient'
+import { createSkillClient } from '@api/SkillClient'
 
 // === Stores ===
 import { useSkillsStore } from '@/stores/skillsStore'
@@ -21,7 +21,7 @@ import { useSkillsStore } from '@/stores/skillsStore'
  * - Event listeners for real-time updates
  */
 export function useSkillsData(conversationId: Ref<string | null> | ComputedRef<string | null>) {
-  const skillClient = new SkillClient()
+  const skillClient = createSkillClient()
   const skillsStore = useSkillsStore()
   let unsubscribeSkillSessionChanged: (() => void) | null = null
 

--- a/src/renderer/src/components/chat/ChatStatusBar.vue
+++ b/src/renderer/src/components/chat/ChatStatusBar.vue
@@ -866,10 +866,10 @@ import {
 import { DEFAULT_MODEL_TIMEOUT } from '@shared/modelConfigDefaults'
 import McpIndicator from '@/components/chat-input/McpIndicator.vue'
 import ModelIcon from '@/components/icons/ModelIcon.vue'
-import { ConfigClient } from '@api/ConfigClient'
-import { ModelClient } from '@api/ModelClient'
-import { ProviderClient } from '@api/ProviderClient'
-import { SessionClient } from '@api/SessionClient'
+import { createConfigClient } from '@api/ConfigClient'
+import { createModelClient } from '@api/ModelClient'
+import { createProviderClient } from '@api/ProviderClient'
+import { createSessionClient } from '@api/SessionClient'
 import { useModelStore } from '@/stores/modelStore'
 import { useProviderStore } from '@/stores/providerStore'
 import { useThemeStore } from '@/stores/theme'
@@ -928,10 +928,10 @@ const agentStore = useAgentStore()
 const sessionStore = useSessionStore()
 const draftStore = useDraftStore()
 const projectStore = useProjectStore()
-const configClient = new ConfigClient()
-const modelClient = new ModelClient()
-const providerClient = new ProviderClient()
-const sessionClient = new SessionClient()
+const configClient = createConfigClient()
+const modelClient = createModelClient()
+const providerClient = createProviderClient()
+const sessionClient = createSessionClient()
 const { t } = useI18n()
 
 const draftModelSelection = ref<ModelSelection | null>(null)

--- a/src/renderer/src/components/chat/composables/useChatInputFiles.ts
+++ b/src/renderer/src/components/chat/composables/useChatInputFiles.ts
@@ -1,6 +1,6 @@
 import { ref, type Ref } from 'vue'
 import type { MessageFile } from '@shared/types/agent-interface'
-import { FileClient } from '@api/FileClient'
+import { createFileClient } from '@api/FileClient'
 import { useToast } from '@/components/use-toast'
 import { calculateImageTokens, getClipboardImageInfo, imageFileToBase64 } from '@/lib/image'
 import { approximateTokenSize } from 'tokenx'
@@ -21,7 +21,7 @@ export function useChatInputFiles(
   emit: (event: 'file-upload', files: MessageFile[]) => void,
   t: (key: string, params?: any) => string
 ) {
-  const fileClient = new FileClient()
+  const fileClient = createFileClient()
   const { toast } = useToast()
   const selectedFiles = ref<MessageFile[]>([])
 

--- a/src/renderer/src/components/chat/composables/useChatInputMentions.ts
+++ b/src/renderer/src/components/chat/composables/useChatInputMentions.ts
@@ -2,9 +2,9 @@ import { computed, onMounted, onUnmounted, ref, watch, type Ref } from 'vue'
 import { VueRenderer } from '@tiptap/vue-3'
 import type { Editor, Range } from '@tiptap/core'
 import tippy from 'tippy.js'
-import { SessionClient } from '@api/SessionClient'
-import { SkillClient } from '@api/SkillClient'
-import { WorkspaceClient } from '@api/WorkspaceClient'
+import { createSessionClient } from '@api/SessionClient'
+import { createSkillClient } from '@api/SkillClient'
+import { createWorkspaceClient } from '@api/WorkspaceClient'
 import type { PromptListEntry, WorkspaceFileNode } from '@shared/presenter'
 import { useMcpStore } from '@/stores/mcp'
 import { useSkillsStore } from '@/stores/skillsStore'
@@ -85,9 +85,9 @@ const normalizeAcpCommands = (commands: unknown): AcpSessionCommand[] => {
 }
 
 export function useChatInputMentions(options: UseChatInputMentionsOptions) {
-  const workspaceClient = new WorkspaceClient()
-  const sessionClient = new SessionClient()
-  const skillClient = new SkillClient()
+  const workspaceClient = createWorkspaceClient()
+  const sessionClient = createSessionClient()
+  const skillClient = createSkillClient()
   const mcpStore = useMcpStore()
   const skillsStore = useSkillsStore()
 

--- a/src/renderer/src/components/icons/AcpAgentIcon.vue
+++ b/src/renderer/src/components/icons/AcpAgentIcon.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { ConfigClient } from '@api/ConfigClient'
+import { createConfigClient } from '@api/ConfigClient'
 
 const ACP_REGISTRY_ICON_PREFIX = 'https://cdn.agentclientprotocol.com/registry/'
 
@@ -28,7 +28,7 @@ const props = withDefaults(
 const svgMarkup = ref('')
 const imageLoadFailed = ref(false)
 const requestSeq = ref(0)
-const configClient = new ConfigClient()
+const configClient = createConfigClient()
 
 const isThemeableRegistryIcon = computed(() => {
   const icon = props.icon.trim()

--- a/src/renderer/src/components/markdown/MarkdownRenderer.vue
+++ b/src/renderer/src/components/markdown/MarkdownRenderer.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup lang="ts">
-import { SessionClient } from '@api/SessionClient'
+import { createSessionClient } from '@api/SessionClient'
 import { useArtifactStore } from '@/stores/artifact'
 import { useReferenceStore } from '@/stores/reference'
 import { nanoid } from 'nanoid'
@@ -47,7 +47,7 @@ const artifactStore = useArtifactStore()
 const fallbackMessageId = `artifact-msg-${nanoid()}`
 const fallbackThreadId = `artifact-thread-${nanoid()}`
 const referenceStore = useReferenceStore()
-const sessionClient = new SessionClient()
+const sessionClient = createSessionClient()
 const referenceNode = ref<HTMLElement | null>(null)
 const debouncedContent = ref(props.content)
 const effectiveMessageId = computed(() => props.messageId ?? fallbackMessageId)

--- a/src/renderer/src/components/markdown/useMarkdownLinkNavigation.ts
+++ b/src/renderer/src/components/markdown/useMarkdownLinkNavigation.ts
@@ -1,6 +1,6 @@
 import { toValue, type MaybeRefOrGetter } from 'vue'
-import { BrowserClient } from '@api/BrowserClient'
-import { WorkspaceClient } from '@api/WorkspaceClient'
+import { createBrowserClient } from '@api/BrowserClient'
+import { createWorkspaceClient } from '@api/WorkspaceClient'
 import { useSessionStore } from '@/stores/ui/session'
 import { useSidepanelStore } from '@/stores/ui/sidepanel'
 import { classifyMarkdownLink, type MarkdownLinkContext } from './linkTypes'
@@ -22,8 +22,8 @@ function buildSafeAttributeSelector(value: string): string {
 export function useMarkdownLinkNavigation(options: UseMarkdownLinkNavigationOptions = {}) {
   const sessionStore = useSessionStore()
   const sidepanelStore = useSidepanelStore()
-  const browserClient = new BrowserClient()
-  const workspaceClient = new WorkspaceClient()
+  const browserClient = createBrowserClient()
+  const workspaceClient = createWorkspaceClient()
 
   const getSessionContext = (): SessionContext => {
     const linkContext = toValue(options.linkContext)

--- a/src/renderer/src/components/mcp-config/AgentMcpSelector.vue
+++ b/src/renderer/src/components/mcp-config/AgentMcpSelector.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { ConfigClient } from '@api/ConfigClient'
+import { createConfigClient } from '@api/ConfigClient'
 import { Checkbox } from '@shadcn/components/ui/checkbox'
 import { useToast } from '@/components/use-toast'
 
@@ -11,7 +11,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { toast } = useToast()
-const configClient = new ConfigClient()
+const configClient = createConfigClient()
 
 const loading = ref(false)
 const saving = ref(false)

--- a/src/renderer/src/components/mcp-config/mcpServerForm.vue
+++ b/src/renderer/src/components/mcp-config/mcpServerForm.vue
@@ -18,12 +18,12 @@ import { EmojiPicker } from '@/components/emoji-picker'
 import { useToast } from '@/components/use-toast'
 import { Icon } from '@iconify/vue'
 import { X } from 'lucide-vue-next'
-import { DeviceClient } from '@api/DeviceClient'
+import { createDeviceClient } from '@api/DeviceClient'
 import { nanoid } from 'nanoid'
 
 const { t } = useI18n()
 const { toast } = useToast()
-const deviceClient = new DeviceClient()
+const deviceClient = createDeviceClient()
 const props = defineProps<{
   serverName?: string
   initialConfig?: MCPServerConfig

--- a/src/renderer/src/components/message/MessageBlockThink.vue
+++ b/src/renderer/src/components/message/MessageBlockThink.vue
@@ -12,7 +12,7 @@
 import { useI18n } from 'vue-i18n'
 import { ThinkContent } from '@/components/think-content'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { ConfigClient } from '@api/ConfigClient'
+import { createConfigClient } from '@api/ConfigClient'
 import type { DisplayAssistantMessageBlock } from '@/components/chat/messageListItems'
 import { useThrottleFn } from '@vueuse/core'
 const props = defineProps<{
@@ -28,7 +28,7 @@ const emit = defineEmits<{
 }>()
 const { t } = useI18n()
 
-const configClient = new ConfigClient()
+const configClient = createConfigClient()
 
 // kept for potential future scroll anchoring; currently unused
 

--- a/src/renderer/src/components/message/MessageBlockToolCall.vue
+++ b/src/renderer/src/components/message/MessageBlockToolCall.vue
@@ -183,13 +183,13 @@ import { useThemeStore } from '@/stores/theme'
 import { useSessionStore } from '@/stores/ui/session'
 import { getLanguageFromFilename } from '@shared/utils/codeLanguage'
 import type { DisplayAssistantMessageBlock } from '@/components/chat/messageListItems'
-import { DeviceClient } from '@api/DeviceClient'
+import { createDeviceClient } from '@api/DeviceClient'
 
 const { t } = useI18n()
 
 const themeStore = useThemeStore()
 const sessionStore = useSessionStore()
-const deviceClient = new DeviceClient()
+const deviceClient = createDeviceClient()
 
 const props = defineProps<{
   block: DisplayAssistantMessageBlock

--- a/src/renderer/src/components/message/MessageItemAssistant.vue
+++ b/src/renderer/src/components/message/MessageItemAssistant.vue
@@ -202,7 +202,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger
 } from '@shadcn/components/ui/context-menu'
-import { DeviceClient } from '@api/DeviceClient'
+import { createDeviceClient } from '@api/DeviceClient'
 import { useThemeStore } from '@/stores/theme'
 const props = defineProps<{
   message: DisplayAssistantMessage
@@ -214,7 +214,7 @@ const props = defineProps<{
 }>()
 
 const themeStore = useThemeStore()
-const deviceClient = new DeviceClient()
+const deviceClient = createDeviceClient()
 const uiSettingsStore = useUiSettingsStore()
 const { t } = useI18n()
 

--- a/src/renderer/src/components/message/MessageItemUser.vue
+++ b/src/renderer/src/components/message/MessageItemUser.vue
@@ -110,8 +110,8 @@ import ChatAttachmentItem from '../chat/ChatAttachmentItem.vue'
 import MessageToolbar from './MessageToolbar.vue'
 import MessageContent from './MessageContent.vue'
 import MessageTextContent from './MessageTextContent.vue'
-import { DeviceClient } from '@api/DeviceClient'
-import { WindowClient } from '@api/WindowClient'
+import { createDeviceClient } from '@api/DeviceClient'
+import { createWindowClient } from '@api/WindowClient'
 import { computed, ref, watch, nextTick } from 'vue'
 
 const COLLAPSE_CHAR_THRESHOLD = 600
@@ -147,8 +147,8 @@ const getVisibleMessageText = (message: DisplayUserMessage) => {
   return message.content.text || ''
 }
 
-const deviceClient = new DeviceClient()
-const windowClient = new WindowClient()
+const deviceClient = createDeviceClient()
+const windowClient = createWindowClient()
 const { t } = useI18n()
 
 const props = defineProps<{

--- a/src/renderer/src/components/popup/TranslatePopup.vue
+++ b/src/renderer/src/components/popup/TranslatePopup.vue
@@ -40,13 +40,13 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { SessionClient } from '@api/SessionClient'
+import { createSessionClient } from '@api/SessionClient'
 import { useAgentStore } from '@/stores/ui/agent'
 import { Button } from '@shadcn/components/ui/button'
 import { Icon } from '@iconify/vue'
 
 const { t, locale } = useI18n()
-const sessionClient = new SessionClient()
+const sessionClient = createSessionClient()
 const agentStore = useAgentStore()
 
 const isOpen = ref(false)

--- a/src/renderer/src/components/settings/ModelConfigDialog.vue
+++ b/src/renderer/src/components/settings/ModelConfigDialog.vue
@@ -491,7 +491,7 @@ import {
 import { useModelConfigStore } from '@/stores/modelConfigStore'
 import { useModelStore } from '@/stores/modelStore'
 import { useProviderStore } from '@/stores/providerStore'
-import { ModelClient } from '@api/ModelClient'
+import { createModelClient } from '@api/ModelClient'
 import {
   Dialog,
   DialogContent,
@@ -545,7 +545,7 @@ const modelConfigStore = useModelConfigStore()
 const modelStore = useModelStore()
 const providerStore = useProviderStore()
 const { customModels, allProviderModels } = storeToRefs(modelStore)
-const modelClient = new ModelClient()
+const modelClient = createModelClient()
 const providerIdLower = computed(() => props.providerId?.toLowerCase() || '')
 const capabilityProviderId = ref(props.providerId)
 const currentProvider = computed(() =>

--- a/src/renderer/src/components/sidepanel/BrowserPanel.vue
+++ b/src/renderer/src/components/sidepanel/BrowserPanel.vue
@@ -57,7 +57,7 @@ import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
 import { Button } from '@shadcn/components/ui/button'
 import { Input } from '@shadcn/components/ui/input'
-import { BrowserClient } from '@api/BrowserClient'
+import { createBrowserClient } from '@api/BrowserClient'
 import BrowserPlaceholder from './BrowserPlaceholder.vue'
 import type { YoBrowserStatus } from '@shared/types/browser'
 import { useSidepanelStore } from '@/stores/ui/sidepanel'
@@ -70,7 +70,7 @@ const props = defineProps<{
 const { t } = useI18n()
 const sidepanelStore = useSidepanelStore()
 const sessionStore = useSessionStore()
-const browserClient = new BrowserClient()
+const browserClient = createBrowserClient()
 
 const containerRef = ref<HTMLElement | null>(null)
 const browserStatus = ref<YoBrowserStatus>({

--- a/src/renderer/src/components/sidepanel/ChatSidePanel.vue
+++ b/src/renderer/src/components/sidepanel/ChatSidePanel.vue
@@ -67,7 +67,7 @@ import { computed, onBeforeUnmount, onMounted } from 'vue'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
 import { Button } from '@shadcn/components/ui/button'
-import { BrowserClient } from '@api/BrowserClient'
+import { createBrowserClient } from '@api/BrowserClient'
 import BrowserPanel from './BrowserPanel.vue'
 import WorkspacePanel from './WorkspacePanel.vue'
 import { useSidepanelStore } from '@/stores/ui/sidepanel'
@@ -79,7 +79,7 @@ const props = defineProps<{
 
 const { t } = useI18n()
 const sidepanelStore = useSidepanelStore()
-const browserClient = new BrowserClient()
+const browserClient = createBrowserClient()
 let stopBrowserOpenRequestedListener: (() => void) | null = null
 
 const shouldShow = computed(() => sidepanelStore.open && Boolean(props.sessionId))

--- a/src/renderer/src/components/sidepanel/WorkspacePanel.vue
+++ b/src/renderer/src/components/sidepanel/WorkspacePanel.vue
@@ -145,9 +145,9 @@ import { computed, ref, toRef, watch } from 'vue'
 import { Icon } from '@iconify/vue'
 import { Button } from '@shadcn/components/ui/button'
 import { useI18n } from 'vue-i18n'
-import { FileClient } from '@api/FileClient'
-import { ProjectClient } from '@api/ProjectClient'
-import { WorkspaceClient } from '@api/WorkspaceClient'
+import { createFileClient } from '@api/FileClient'
+import { createProjectClient } from '@api/ProjectClient'
+import { createWorkspaceClient } from '@api/WorkspaceClient'
 import { extractArtifactsFromContent } from '@/composables/useArtifacts'
 import WorkspaceFileNode from '@/components/workspace/WorkspaceFileNode.vue'
 import WorkspaceViewer from './WorkspaceViewer.vue'
@@ -183,9 +183,9 @@ const artifactStore = useArtifactStore()
 const messageStore = useMessageStore()
 const sidepanelStore = useSidepanelStore()
 const sessionStore = useSessionStore()
-const workspaceClient = new WorkspaceClient()
-const projectClient = new ProjectClient()
-const fileClient = new FileClient()
+const workspaceClient = createWorkspaceClient()
+const projectClient = createProjectClient()
+const fileClient = createFileClient()
 
 const sessionState = computed(() => sidepanelStore.getSessionState(props.sessionId))
 const {

--- a/src/renderer/src/components/sidepanel/WorkspaceViewer.vue
+++ b/src/renderer/src/components/sidepanel/WorkspaceViewer.vue
@@ -133,7 +133,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Button } from '@shadcn/components/ui/button'
-import { WorkspaceClient } from '@api/WorkspaceClient'
+import { createWorkspaceClient } from '@api/WorkspaceClient'
 import { useSidepanelStore } from '@/stores/ui/sidepanel'
 import type { ArtifactState } from '@/stores/artifact'
 import type { WorkspaceFilePreview, WorkspaceGitDiff } from '@shared/presenter'
@@ -153,7 +153,7 @@ const props = defineProps<{
 
 const { t } = useI18n()
 const sidepanelStore = useSidepanelStore()
-const workspaceClient = new WorkspaceClient()
+const workspaceClient = createWorkspaceClient()
 
 const sessionState = computed(() => sidepanelStore.getSessionState(props.sessionId))
 const { activeSource, effectiveViewMode, paneKind, previewKind, shouldShowTabs } =

--- a/src/renderer/src/components/sidepanel/composables/useWorkspaceSync.ts
+++ b/src/renderer/src/components/sidepanel/composables/useWorkspaceSync.ts
@@ -1,5 +1,5 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch, type ComputedRef, type Ref } from 'vue'
-import { WorkspaceClient } from '@api/WorkspaceClient'
+import { createWorkspaceClient } from '@api/WorkspaceClient'
 import type {
   WorkspaceFileNode,
   WorkspaceFilePreview,
@@ -15,7 +15,7 @@ interface UseWorkspaceSyncOptions {
   active: ComputedRef<boolean>
   sessionState: ComputedRef<WorkspaceSessionState>
   workspaceClient: Pick<
-    WorkspaceClient,
+    ReturnType<typeof createWorkspaceClient>,
     | 'registerWorkspace'
     | 'watchWorkspace'
     | 'unwatchWorkspace'

--- a/src/renderer/src/components/trace/TraceDialog.vue
+++ b/src/renderer/src/components/trace/TraceDialog.vue
@@ -94,15 +94,15 @@ import { Button } from '@shadcn/components/ui/button'
 import { Spinner } from '@shadcn/components/ui/spinner'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
-import { DeviceClient } from '@api/DeviceClient'
-import { SessionClient } from '@api/SessionClient'
+import { createDeviceClient } from '@api/DeviceClient'
+import { createSessionClient } from '@api/SessionClient'
 import { useMonaco } from 'stream-monaco'
 import { useUiSettingsStore } from '@/stores/uiSettingsStore'
 import type { MessageTraceRecord } from '@shared/types/agent-interface'
 
 const { t } = useI18n()
-const deviceClient = new DeviceClient()
-const sessionClient = new SessionClient()
+const deviceClient = createDeviceClient()
+const sessionClient = createSessionClient()
 const uiSettingsStore = useUiSettingsStore()
 
 const jsonEditor = ref<HTMLElement | null>(null)

--- a/src/renderer/src/components/workspace/WorkspaceFileNode.vue
+++ b/src/renderer/src/components/workspace/WorkspaceFileNode.vue
@@ -63,7 +63,7 @@
 import { computed } from 'vue'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
-import { WorkspaceClient } from '@api/WorkspaceClient'
+import { createWorkspaceClient } from '@api/WorkspaceClient'
 import { setChatInputWorkspaceItemDragData } from '@/lib/chatInputWorkspaceReference'
 import {
   ContextMenu,
@@ -85,7 +85,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const workspaceClient = new WorkspaceClient()
+const workspaceClient = createWorkspaceClient()
 
 const extensionIconMap: Record<string, string> = {
   pdf: 'lucide:file-text',

--- a/src/renderer/src/composables/message/useMessageCapture.ts
+++ b/src/renderer/src/composables/message/useMessageCapture.ts
@@ -1,5 +1,5 @@
 import { ref, onUnmounted, nextTick } from 'vue'
-import { DeviceClient } from '@api/DeviceClient'
+import { createDeviceClient } from '@api/DeviceClient'
 import { usePageCapture } from '@/composables/usePageCapture'
 import { useThemeStore } from '@/stores/theme'
 import { useI18n } from 'vue-i18n'
@@ -8,7 +8,7 @@ import type { CaptureOptions } from './types'
 export function useMessageCapture() {
   const { t } = useI18n()
   const themeStore = useThemeStore()
-  const deviceClient = new DeviceClient()
+  const deviceClient = createDeviceClient()
   const { isCapturing, captureAndCopy } = usePageCapture()
 
   const appVersion = ref('')

--- a/src/renderer/src/composables/useDeviceVersion.ts
+++ b/src/renderer/src/composables/useDeviceVersion.ts
@@ -2,7 +2,7 @@
 import { ref, onMounted } from 'vue'
 
 // === Composables ===
-import { DeviceClient } from '@api/DeviceClient'
+import { createDeviceClient } from '@api/DeviceClient'
 
 /**
  * Composable for detecting device platform and OS version
@@ -31,7 +31,7 @@ export function useDeviceVersion() {
   // === Local State ===
   const isWinMacOS = ref(false)
   const isMacOS = ref(false)
-  const deviceClient = new DeviceClient()
+  const deviceClient = createDeviceClient()
 
   // === Lifecycle Hooks ===
   onMounted(() => {

--- a/src/renderer/src/composables/useModelCapabilities.ts
+++ b/src/renderer/src/composables/useModelCapabilities.ts
@@ -1,7 +1,7 @@
 // === Vue Core ===
 import { ref, watch, type Ref } from 'vue'
 
-import { ModelClient } from '@api/ModelClient'
+import { createModelClient } from '@api/ModelClient'
 
 // === Interfaces ===
 export interface ModelCapabilities {
@@ -30,7 +30,7 @@ export interface UseModelCapabilitiesOptions {
  */
 export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
   const { providerId, modelId } = options
-  const modelClient = new ModelClient()
+  const modelClient = createModelClient()
 
   // === Local State ===
   const capabilitySupportsReasoning = ref<boolean | null>(null)

--- a/src/renderer/src/composables/usePageCapture.example.ts
+++ b/src/renderer/src/composables/usePageCapture.example.ts
@@ -1,6 +1,6 @@
 // usePageCapture 使用示例
 
-import { DeviceClient } from '@api/DeviceClient'
+import { createDeviceClient } from '@api/DeviceClient'
 import { usePageCapture, createCapturePresets } from '@/composables/usePageCapture'
 import { useI18n } from 'vue-i18n'
 import { ref } from 'vue'
@@ -9,7 +9,7 @@ import { ref } from 'vue'
 export function useMessageCapture() {
   const { t } = useI18n()
   const { isCapturing, captureAndCopy } = usePageCapture()
-  const deviceClient = new DeviceClient()
+  const deviceClient = createDeviceClient()
   const appVersion = ref('')
 
   // 初始化应用版本

--- a/src/renderer/src/composables/usePageCapture.ts
+++ b/src/renderer/src/composables/usePageCapture.ts
@@ -1,6 +1,6 @@
 import { ref } from 'vue'
-import { DeviceClient } from '@api/DeviceClient'
-import { TabClient } from '@api/TabClient'
+import { createDeviceClient } from '@api/DeviceClient'
+import { createTabClient } from '@api/TabClient'
 
 export interface CaptureRect {
   x: number
@@ -73,8 +73,8 @@ export interface CaptureResult {
 
 export function usePageCapture() {
   const isCapturing = ref(false)
-  const tabClient = new TabClient()
-  const deviceClient = new DeviceClient()
+  const tabClient = createTabClient()
+  const deviceClient = createDeviceClient()
 
   /**
    * 获取滚动容器元素

--- a/src/renderer/src/lib/chatInputWorkspaceReference.ts
+++ b/src/renderer/src/lib/chatInputWorkspaceReference.ts
@@ -1,4 +1,4 @@
-import { FileClient } from '@api/FileClient'
+import { createFileClient } from '@api/FileClient'
 
 export const CHAT_INPUT_WORKSPACE_ITEM_MIME = 'application/x-deepchat-workspace-item'
 
@@ -7,7 +7,7 @@ export interface ChatInputWorkspaceItemDragPayload {
   isDirectory: boolean
 }
 
-const fileClient = new FileClient()
+const fileClient = createFileClient()
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null

--- a/src/renderer/src/pages/AgentWelcomePage.vue
+++ b/src/renderer/src/pages/AgentWelcomePage.vue
@@ -49,12 +49,12 @@
 import { computed } from 'vue'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
-import { SettingsClient } from '@api/SettingsClient'
+import { createSettingsClient } from '@api/SettingsClient'
 import { useAgentStore } from '@/stores/ui/agent'
 import AgentAvatar from '@/components/icons/AgentAvatar.vue'
 
 const { t } = useI18n()
-const settingsClient = new SettingsClient()
+const settingsClient = createSettingsClient()
 const agentStore = useAgentStore()
 const displayedAgents = computed(() => agentStore.enabledAgents.slice(0, 9))
 

--- a/src/renderer/src/pages/ChatPage.vue
+++ b/src/renderer/src/pages/ChatPage.vue
@@ -120,13 +120,13 @@ import PendingInputLane from '@/components/chat/PendingInputLane.vue'
 import ChatStatusBar from '@/components/chat/ChatStatusBar.vue'
 import ChatToolInteractionOverlay from '@/components/chat/ChatToolInteractionOverlay.vue'
 import TraceDialog from '@/components/trace/TraceDialog.vue'
-import { ChatClient } from '../../api/ChatClient'
+import { createChatClient } from '../../api/ChatClient'
 import { useSessionStore } from '@/stores/ui/session'
 import { useMessageStore } from '@/stores/ui/message'
 import { usePendingInputStore } from '@/stores/ui/pendingInput'
 import { useSpotlightStore } from '@/stores/ui/spotlight'
 import { useModelStore } from '@/stores/modelStore'
-import { SessionClient } from '@api/SessionClient'
+import { createSessionClient } from '@api/SessionClient'
 import {
   applyChatSearchHighlights,
   clearChatSearchHighlights,
@@ -150,8 +150,8 @@ const messageStore = useMessageStore()
 const pendingInputStore = usePendingInputStore()
 const spotlightStore = useSpotlightStore()
 const modelStore = useModelStore()
-const chatClient = new ChatClient()
-const sessionClient = new SessionClient()
+const chatClient = createChatClient()
+const sessionClient = createSessionClient()
 const { t } = useI18n()
 
 const sessionTitle = computed(() => sessionStore.activeSession?.title ?? t('common.newChat'))

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -113,8 +113,8 @@ import { useSessionStore } from '@/stores/ui/session'
 import { useAgentStore } from '@/stores/ui/agent'
 import { useModelStore } from '@/stores/modelStore'
 import { useDraftStore, type StartDeeplinkPayload } from '@/stores/ui/draft'
-import { ConfigClient } from '@api/ConfigClient'
-import { SessionClient } from '@api/SessionClient'
+import { createConfigClient } from '@api/ConfigClient'
+import { createSessionClient } from '@api/SessionClient'
 import type {
   DeepChatAgentConfig,
   MessageFile,
@@ -128,8 +128,8 @@ const sessionStore = useSessionStore()
 const agentStore = useAgentStore()
 const modelStore = useModelStore()
 const draftStore = useDraftStore()
-const configClient = new ConfigClient()
-const sessionClient = new SessionClient()
+const configClient = createConfigClient()
+const sessionClient = createSessionClient()
 const { t } = useI18n()
 
 const message = ref('')

--- a/src/renderer/src/pages/WelcomePage.vue
+++ b/src/renderer/src/pages/WelcomePage.vue
@@ -64,7 +64,7 @@
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
-import { ConfigClient } from '@api/ConfigClient'
+import { createConfigClient } from '@api/ConfigClient'
 import { useThemeStore } from '@/stores/theme'
 import { usePageRouterStore } from '@/stores/ui/pageRouter'
 import ModelIcon from '@/components/icons/ModelIcon.vue'
@@ -72,7 +72,7 @@ import ModelIcon from '@/components/icons/ModelIcon.vue'
 const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
-const configClient = new ConfigClient()
+const configClient = createConfigClient()
 const themeStore = useThemeStore()
 const pageRouter = usePageRouterStore()
 

--- a/src/renderer/src/stores/agentModelStore.ts
+++ b/src/renderer/src/stores/agentModelStore.ts
@@ -7,7 +7,7 @@ import type {
   RENDERER_MODEL_META
 } from '@shared/presenter'
 import { ModelType } from '@shared/model'
-import { ConfigClient } from '../../api/ConfigClient'
+import { createConfigClient } from '../../api/ConfigClient'
 
 export interface AgentModelRefreshResult {
   rendererModels: RENDERER_MODEL_META[]
@@ -20,7 +20,7 @@ const buildProcessKey = (providerId: string, agentId: string) =>
   `${providerId}${PROCESS_KEY_SEPARATOR}${agentId}`
 
 export const useAgentModelStore = defineStore('agent-model', () => {
-  const configClient = new ConfigClient()
+  const configClient = createConfigClient()
 
   const agentModels = ref<Record<string, RENDERER_MODEL_META[]>>({})
   const sessionStatus = ref<Record<string, AgentSessionState>>({})

--- a/src/renderer/src/stores/dialog.ts
+++ b/src/renderer/src/stores/dialog.ts
@@ -1,10 +1,10 @@
-import { DialogClient } from '@api/DialogClient'
+import { createDialogClient } from '@api/DialogClient'
 import { DialogRequest, DialogResponse } from '@shared/presenter'
 import { defineStore } from 'pinia'
 import { onMounted, onUnmounted, ref } from 'vue'
 
 export const useDialogStore = defineStore('dialog', () => {
-  const dialogClient = new DialogClient()
+  const dialogClient = createDialogClient()
   const dialogRequest = ref<DialogRequest | null>(null)
   const showDialog = ref(false)
   const timeoutMilliseconds = ref(0)

--- a/src/renderer/src/stores/floatingButton.ts
+++ b/src/renderer/src/stores/floatingButton.ts
@@ -1,9 +1,9 @@
 import { defineStore } from 'pinia'
 import { ref, onMounted } from 'vue'
-import { ConfigClient } from '../../api/ConfigClient'
+import { createConfigClient } from '../../api/ConfigClient'
 
 export const useFloatingButtonStore = defineStore('floatingButton', () => {
-  const configClient = new ConfigClient()
+  const configClient = createConfigClient()
 
   // 悬浮按钮是否启用的状态
   const enabled = ref<boolean>(false)

--- a/src/renderer/src/stores/language.ts
+++ b/src/renderer/src/stores/language.ts
@@ -2,14 +2,14 @@ import { defineStore } from 'pinia'
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { ConfigClient } from '../../api/ConfigClient'
+import { createConfigClient } from '../../api/ConfigClient'
 
 const RTL_LIST = ['fa-IR', 'he-IL']
 let languageListenerRegistered = false
 export const useLanguageStore = defineStore('language', () => {
   const { locale } = useI18n({ useScope: 'global' })
   const language = ref<string>('system')
-  const configClient = new ConfigClient()
+  const configClient = createConfigClient()
   const dir = ref('auto' as 'auto' | 'rtl' | 'ltr')
   // 初始化设置
   const initLanguage = async () => {

--- a/src/renderer/src/stores/mcp.ts
+++ b/src/renderer/src/stores/mcp.ts
@@ -1,7 +1,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { defineStore } from 'pinia'
-import { McpClient } from '@api/McpClient'
-import { ConfigClient } from '../../api/ConfigClient'
+import { createMcpClient } from '@api/McpClient'
+import { createConfigClient } from '../../api/ConfigClient'
 import { useIpcQuery } from '@/composables/useIpcQuery'
 import { useIpcMutation } from '@/composables/useIpcMutation'
 import { useI18n } from 'vue-i18n'
@@ -22,9 +22,9 @@ const ENABLED_MCP_TOOLS_KEY = 'input_enabledMcpTools'
 export const useMcpStore = defineStore('mcp', () => {
   const { t } = useI18n()
   // 获取MCP相关的presenter
-  const mcpClient = new McpClient()
+  const mcpClient = createMcpClient()
   // 获取配置相关的client
-  const configClient = new ConfigClient()
+  const configClient = createConfigClient()
 
   // ==================== 状态定义 ====================
   // MCP配置

--- a/src/renderer/src/stores/mcpSampling.ts
+++ b/src/renderer/src/stores/mcpSampling.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import { McpClient } from '@api/McpClient'
+import { createMcpClient } from '@api/McpClient'
 import type {
   McpSamplingDecision,
   McpSamplingRequestPayload,
@@ -98,7 +98,7 @@ export const resolveSamplingDefaultModel = (input: {
 }
 
 export const useMcpSamplingStore = defineStore('mcpSampling', () => {
-  const mcpClient = new McpClient()
+  const mcpClient = createMcpClient()
   const modelStore = useModelStore()
   const providerStore = useProviderStore()
   const sessionStore = useSessionStore()

--- a/src/renderer/src/stores/modelConfigStore.ts
+++ b/src/renderer/src/stores/modelConfigStore.ts
@@ -1,10 +1,10 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import type { ModelConfig, IModelConfig } from '@shared/presenter'
-import { ModelClient } from '../../api/ModelClient'
+import { createModelClient } from '../../api/ModelClient'
 
 export const useModelConfigStore = defineStore('modelConfig', () => {
-  const modelClient = new ModelClient()
+  const modelClient = createModelClient()
 
   const cache = ref<Record<string, ModelConfig>>({})
 

--- a/src/renderer/src/stores/modelStore.ts
+++ b/src/renderer/src/stores/modelStore.ts
@@ -15,7 +15,7 @@ import { useIpcMutation } from '@/composables/useIpcMutation'
 import { useAgentModelStore } from '@/stores/agentModelStore'
 import { useModelConfigStore } from '@/stores/modelConfigStore'
 import { useProviderStore } from '@/stores/providerStore'
-import { ModelClient } from '../../api/ModelClient'
+import { createModelClient } from '../../api/ModelClient'
 
 const PROVIDER_MODELS_KEY = (providerId: string) => ['model-store', 'provider-models', providerId]
 const CUSTOM_MODELS_KEY = (providerId: string) => ['model-store', 'custom-models', providerId]
@@ -29,7 +29,7 @@ type ModelQueryHandle<TData> = {
 }
 
 export const useModelStore = defineStore('model', () => {
-  const modelClient = new ModelClient()
+  const modelClient = createModelClient()
   const providerStore = useProviderStore()
   const modelConfigStore = useModelConfigStore()
   const agentModelStore = useAgentModelStore()

--- a/src/renderer/src/stores/ollamaStore.ts
+++ b/src/renderer/src/stores/ollamaStore.ts
@@ -1,12 +1,12 @@
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { defineStore } from 'pinia'
-import { ProviderClient } from '../../api/ProviderClient'
+import { createProviderClient } from '../../api/ProviderClient'
 import type { OllamaModel } from '@shared/presenter'
 import { useModelStore } from '@/stores/modelStore'
 import { useProviderStore } from '@/stores/providerStore'
 
 export const useOllamaStore = defineStore('ollama', () => {
-  const providerClient = new ProviderClient()
+  const providerClient = createProviderClient()
   const modelStore = useModelStore()
   const providerStore = useProviderStore()
   let unsubscribeOllamaPullProgress: (() => void) | null = null

--- a/src/renderer/src/stores/prompts.ts
+++ b/src/renderer/src/stores/prompts.ts
@@ -4,10 +4,10 @@ import { useIpcQuery } from '@/composables/useIpcQuery'
 import { useIpcMutation } from '@/composables/useIpcMutation'
 import { type EntryKey, type UseQueryReturn } from '@pinia/colada'
 import type { Prompt } from '@shared/presenter'
-import { ConfigClient } from '../../api/ConfigClient'
+import { createConfigClient } from '../../api/ConfigClient'
 
 export const usePromptsStore = defineStore('prompts', () => {
-  const configClient = new ConfigClient()
+  const configClient = createConfigClient()
   const customPromptsKey: EntryKey = ['config', 'customPrompts'] as const
 
   const promptsQuery = useIpcQuery({

--- a/src/renderer/src/stores/providerStore.ts
+++ b/src/renderer/src/stores/providerStore.ts
@@ -1,7 +1,7 @@
 import { computed, ref, watch } from 'vue'
 import { defineStore } from 'pinia'
-import { ProviderClient } from '../../api/ProviderClient'
-import { ConfigClient } from '../../api/ConfigClient'
+import { createProviderClient } from '../../api/ProviderClient'
+import { createConfigClient } from '../../api/ConfigClient'
 import { useIpcQuery } from '@/composables/useIpcQuery'
 import type { AWS_BEDROCK_PROVIDER, LLM_PROVIDER, VERTEX_PROVIDER } from '@shared/presenter'
 
@@ -18,8 +18,8 @@ const PROVIDER_ORDER_KEY = 'providerOrder'
 const PROVIDER_TIMESTAMP_KEY = 'providerTimestamps'
 
 export const useProviderStore = defineStore('provider', () => {
-  const configClient = new ConfigClient()
-  const providerClient = new ProviderClient()
+  const configClient = createConfigClient()
+  const providerClient = createProviderClient()
 
   const providersQuery = useIpcQuery({
     key: () => ['providers'],

--- a/src/renderer/src/stores/shortcutKey.ts
+++ b/src/renderer/src/stores/shortcutKey.ts
@@ -1,12 +1,12 @@
 import { defineStore } from 'pinia'
 import { onMounted, ref } from 'vue'
 import type { ShortcutKeySetting } from '@shared/presenter'
-import { ShortcutRuntime } from '@api/ShortcutRuntime'
-import { ConfigClient } from '../../api/ConfigClient'
+import { createShortcutRuntime } from '@api/ShortcutRuntime'
+import { createConfigClient } from '../../api/ConfigClient'
 
 export const useShortcutKeyStore = defineStore('shortcutKey', () => {
-  const configClient = new ConfigClient()
-  const shortcutRuntime = new ShortcutRuntime()
+  const configClient = createConfigClient()
+  const shortcutRuntime = createShortcutRuntime()
   const shortcutKeys = ref<ShortcutKeySetting>()
 
   const loadShortcutKeys = async () => {

--- a/src/renderer/src/stores/skillsStore.ts
+++ b/src/renderer/src/stores/skillsStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { SkillClient } from '@api/SkillClient'
+import { createSkillClient } from '@api/SkillClient'
 import type {
   SkillMetadata,
   SkillInstallResult,
@@ -21,7 +21,7 @@ function createDefaultSkillExtension(): SkillExtensionConfig {
 }
 
 export const useSkillsStore = defineStore('skills', () => {
-  const skillClient = new SkillClient()
+  const skillClient = createSkillClient()
   let catalogListenerRegistered = false
 
   const skills = ref<SkillMetadata[]>([])

--- a/src/renderer/src/stores/sync.ts
+++ b/src/renderer/src/stores/sync.ts
@@ -1,8 +1,8 @@
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
-import { DeviceClient } from '@api/DeviceClient'
-import { SyncClient } from '@api/SyncClient'
-import { ConfigClient } from '../../api/ConfigClient'
+import { createDeviceClient } from '@api/DeviceClient'
+import { createSyncClient } from '@api/SyncClient'
+import { createConfigClient } from '../../api/ConfigClient'
 import { useIpcQuery } from '@/composables/useIpcQuery'
 import { useIpcMutation } from '@/composables/useIpcMutation'
 import type { EntryKey, UseQueryReturn } from '@pinia/colada'
@@ -22,9 +22,9 @@ export const useSyncStore = defineStore('sync', () => {
     importedSessions?: number
   } | null>(null)
 
-  const configClient = new ConfigClient()
-  const syncClient = new SyncClient()
-  const deviceClient = new DeviceClient()
+  const configClient = createConfigClient()
+  const syncClient = createSyncClient()
+  const deviceClient = createDeviceClient()
   let syncEventsRegistered = false
   let syncSettingsListenerRegistered = false
 

--- a/src/renderer/src/stores/systemPromptStore.ts
+++ b/src/renderer/src/stores/systemPromptStore.ts
@@ -1,10 +1,10 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import type { SystemPrompt } from '@shared/presenter'
-import { ConfigClient } from '../../api/ConfigClient'
+import { createConfigClient } from '../../api/ConfigClient'
 
 export const useSystemPromptStore = defineStore('systemPrompt', () => {
-  const configClient = new ConfigClient()
+  const configClient = createConfigClient()
 
   const prompts = ref<SystemPrompt[]>([])
   const defaultPromptId = ref<string>('default')

--- a/src/renderer/src/stores/theme.ts
+++ b/src/renderer/src/stores/theme.ts
@@ -1,14 +1,14 @@
 import { useDark, useToggle } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { ConfigClient } from '../../api/ConfigClient'
+import { createConfigClient } from '../../api/ConfigClient'
 
 export type ThemeMode = 'dark' | 'light' | 'system'
 
 export const useThemeStore = defineStore('theme', () => {
   const isDark = useDark()
   const toggleDark = useToggle(isDark)
-  const configClient = new ConfigClient()
+  const configClient = createConfigClient()
   let listenersRegistered = false
 
   // 存储当前主题模式

--- a/src/renderer/src/stores/ui/agent.ts
+++ b/src/renderer/src/stores/ui/agent.ts
@@ -1,8 +1,8 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { ConfigClient } from '../../../api/ConfigClient'
-import { ModelClient } from '../../../api/ModelClient'
-import { SessionClient } from '../../../api/SessionClient'
+import { createConfigClient } from '../../../api/ConfigClient'
+import { createModelClient } from '../../../api/ModelClient'
+import { createSessionClient } from '../../../api/SessionClient'
 import type { Agent } from '@shared/types/agent-interface'
 
 // --- Type Definitions ---
@@ -25,9 +25,9 @@ export interface UIAgent {
 // --- Store ---
 
 export const useAgentStore = defineStore('agent', () => {
-  const sessionClient = new SessionClient()
-  const configClient = new ConfigClient()
-  const modelClient = new ModelClient()
+  const sessionClient = createSessionClient()
+  const configClient = createConfigClient()
+  const modelClient = createModelClient()
   let listenersRegistered = false
 
   // --- State ---

--- a/src/renderer/src/stores/ui/message.ts
+++ b/src/renderer/src/stores/ui/message.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed, onScopeDispose, getCurrentScope, isRef, toRef, type Ref } from 'vue'
-import { SessionClient } from '../../../api/SessionClient'
+import { createSessionClient } from '../../../api/SessionClient'
 import type {
   DisplayAssistantMessageBlock,
   DisplayUserMessageContent
@@ -33,7 +33,7 @@ type ParsedMessageCacheEntry = {
 // --- Store ---
 
 export const useMessageStore = defineStore('message', () => {
-  const sessionClient = new SessionClient()
+  const sessionClient = createSessionClient()
   const streamStateStore = useStreamStateStore()
   const isStreaming = toStoreStateRef(streamStateStore, 'isStreaming')
   const streamingBlocks = toStoreStateRef(streamStateStore, 'streamingBlocks')

--- a/src/renderer/src/stores/ui/messageIpc.ts
+++ b/src/renderer/src/stores/ui/messageIpc.ts
@@ -1,4 +1,4 @@
-import { ChatClient } from '../../../api/ChatClient'
+import { createChatClient } from '../../../api/ChatClient'
 import { onLegacyIpcChannel } from '@api/legacy/runtime'
 import { STREAM_EVENTS } from '@/events'
 import type { AssistantMessageBlock } from '@shared/types/agent-interface'
@@ -21,7 +21,7 @@ interface BindMessageStoreIpcOptions {
 }
 
 export function bindMessageStoreIpc(options: BindMessageStoreIpcOptions): () => void {
-  const chatClient = new ChatClient()
+  const chatClient = createChatClient()
   const reloadPersistedMessages = (sessionId: string) => {
     options.clearStreamingState()
     void options.loadMessages(sessionId)

--- a/src/renderer/src/stores/ui/pageRouter.ts
+++ b/src/renderer/src/stores/ui/pageRouter.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { SessionClient } from '../../../api/SessionClient'
+import { createSessionClient } from '../../../api/SessionClient'
 
 export type PageRoute = { name: 'newThread' } | { name: 'chat'; sessionId: string }
 type GoToNewThreadOptions = {
@@ -8,7 +8,7 @@ type GoToNewThreadOptions = {
 }
 
 export const usePageRouterStore = defineStore('pageRouter', () => {
-  const sessionClient = new SessionClient()
+  const sessionClient = createSessionClient()
 
   // --- State ---
   const route = ref<PageRoute>({ name: 'newThread' })

--- a/src/renderer/src/stores/ui/pendingInput.ts
+++ b/src/renderer/src/stores/ui/pendingInput.ts
@@ -1,12 +1,12 @@
 import { computed, onScopeDispose, ref } from 'vue'
 import { defineStore } from 'pinia'
-import { SessionClient } from '@api/SessionClient'
+import { createSessionClient } from '@api/SessionClient'
 import type { PendingSessionInputRecord, SendMessageInput } from '@shared/types/agent-interface'
 
 const MAX_PENDING_INPUTS = 5
 
 export const usePendingInputStore = defineStore('pendingInput', () => {
-  const sessionClient = new SessionClient()
+  const sessionClient = createSessionClient()
 
   const currentSessionId = ref<string | null>(null)
   const items = ref<PendingSessionInputRecord[]>([])

--- a/src/renderer/src/stores/ui/project.ts
+++ b/src/renderer/src/stores/ui/project.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { ConfigClient } from '../../../api/ConfigClient'
-import { ProjectClient } from '@api/ProjectClient'
+import { createConfigClient } from '../../../api/ConfigClient'
+import { createProjectClient } from '@api/ProjectClient'
 import type { EnvironmentSummary, Project } from '@shared/types/agent-interface'
 
 // --- Type Definitions ---
@@ -18,8 +18,8 @@ type ProjectSelectionSource = 'none' | 'manual' | 'default'
 // --- Store ---
 
 export const useProjectStore = defineStore('project', () => {
-  const configClient = new ConfigClient()
-  const projectClient = new ProjectClient()
+  const configClient = createConfigClient()
+  const projectClient = createProjectClient()
 
   // --- State ---
   const projects = ref<UIProject[]>([])

--- a/src/renderer/src/stores/ui/session.ts
+++ b/src/renderer/src/stores/ui/session.ts
@@ -1,9 +1,9 @@
 import { defineStore } from 'pinia'
 import { ref, computed, onScopeDispose, getCurrentScope } from 'vue'
-import { ChatClient } from '../../../api/ChatClient'
-import { ConfigClient } from '../../../api/ConfigClient'
-import { SessionClient } from '../../../api/SessionClient'
-import { TabClient } from '@api/TabClient'
+import { createChatClient } from '../../../api/ChatClient'
+import { createConfigClient } from '../../../api/ConfigClient'
+import { createSessionClient } from '../../../api/SessionClient'
+import { createTabClient } from '@api/TabClient'
 import { getRuntimeWebContentsId } from '@api/runtime'
 import type { ComputedRef } from 'vue'
 import type {
@@ -190,10 +190,10 @@ function getContentType(format: 'markdown' | 'html' | 'txt' | 'nowledge-mem'): s
 // --- Store ---
 
 export const useSessionStore = defineStore('session', () => {
-  const sessionClient = new SessionClient()
-  const chatClient = new ChatClient()
-  const configClient = new ConfigClient()
-  const tabClient = new TabClient()
+  const sessionClient = createSessionClient()
+  const chatClient = createChatClient()
+  const configClient = createConfigClient()
+  const tabClient = createTabClient()
   const agentStore = useAgentStore()
   const pageRouter = usePageRouterStore()
   const messageStore = useMessageStore()

--- a/src/renderer/src/stores/ui/sessionIpc.ts
+++ b/src/renderer/src/stores/ui/sessionIpc.ts
@@ -1,4 +1,4 @@
-import { SessionClient } from '../../../api/SessionClient'
+import { createSessionClient } from '../../../api/SessionClient'
 
 interface BindSessionStoreIpcOptions {
   webContentsId: number | null
@@ -9,7 +9,7 @@ interface BindSessionStoreIpcOptions {
 }
 
 export function bindSessionStoreIpc(options: BindSessionStoreIpcOptions): () => void {
-  const sessionClient = new SessionClient()
+  const sessionClient = createSessionClient()
   const cleanups = [
     sessionClient.onUpdated((payload) => {
       if (

--- a/src/renderer/src/stores/ui/spotlight.ts
+++ b/src/renderer/src/stores/ui/spotlight.ts
@@ -1,8 +1,8 @@
 import { computed, ref, watch } from 'vue'
 import { defineStore } from 'pinia'
 import { useDebounceFn } from '@vueuse/core'
-import { SettingsClient } from '@api/SettingsClient'
-import { SessionClient } from '@api/SessionClient'
+import { createSettingsClient } from '@api/SettingsClient'
+import { createSessionClient } from '@api/SessionClient'
 import { useProviderStore } from '@/stores/providerStore'
 import { useAgentStore } from './agent'
 import { usePageRouterStore } from './pageRouter'
@@ -127,8 +127,8 @@ const actionItems: Array<{
 ]
 
 export const useSpotlightStore = defineStore('spotlight', () => {
-  const sessionClient = new SessionClient()
-  const settingsClient = new SettingsClient()
+  const sessionClient = createSessionClient()
+  const settingsClient = createSettingsClient()
   const providerStore = useProviderStore()
   const sessionStore = useSessionStore()
   const agentStore = useAgentStore()

--- a/src/renderer/src/stores/uiSettingsStore.ts
+++ b/src/renderer/src/stores/uiSettingsStore.ts
@@ -2,7 +2,7 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { defineStore } from 'pinia'
 import type { SettingsChange, SettingsSnapshotValues } from '@shared/contracts/routes'
 import { buildFontStack, DEFAULT_CODE_FONT_STACK, DEFAULT_TEXT_FONT_STACK } from '@/lib/fontStack'
-import { SettingsClient } from '../../api/SettingsClient'
+import { createSettingsClient } from '../../api/SettingsClient'
 
 const FONT_SIZE_CLASSES = ['text-sm', 'text-base', 'text-lg', 'text-xl', 'text-2xl']
 const DEFAULT_FONT_SIZE_LEVEL = 1
@@ -18,7 +18,7 @@ const clampFontSizeLevel = (level: number) =>
   Math.max(0, Math.min(level, FONT_SIZE_CLASSES.length - 1))
 
 export const useUiSettingsStore = defineStore('uiSettings', () => {
-  const settingsClient = new SettingsClient()
+  const settingsClient = createSettingsClient()
 
   const fontSizeLevel = ref(DEFAULT_FONT_SIZE_LEVEL)
   const fontFamily = ref('')

--- a/src/renderer/src/stores/upgrade.ts
+++ b/src/renderer/src/stores/upgrade.ts
@@ -1,5 +1,5 @@
-import { DeviceClient } from '@api/DeviceClient'
-import { UpgradeClient } from '@api/UpgradeClient'
+import { createDeviceClient } from '@api/DeviceClient'
+import { createUpgradeClient } from '@api/UpgradeClient'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
@@ -64,8 +64,8 @@ const toProgressInfo = (progress: ProgressInfo | null | undefined): ProgressInfo
 }
 
 export const useUpgradeStore = defineStore('upgrade', () => {
-  const upgradeClient = new UpgradeClient()
-  const deviceClient = new DeviceClient()
+  const upgradeClient = createUpgradeClient()
+  const deviceClient = createDeviceClient()
 
   const rawStatus = ref<PresenterUpdateStatus>(null)
   const updateInfo = ref<UpdateInfo | null>(null)

--- a/test/renderer/api/clients.test.ts
+++ b/test/renderer/api/clients.test.ts
@@ -1,11 +1,11 @@
 import type { DeepchatBridge } from '@shared/contracts/bridge'
-import { BrowserClient } from '../../../src/renderer/api/BrowserClient'
-import { ChatClient } from '../../../src/renderer/api/ChatClient'
-import { ConfigClient } from '../../../src/renderer/api/ConfigClient'
-import { ModelClient } from '../../../src/renderer/api/ModelClient'
-import { ProviderClient } from '../../../src/renderer/api/ProviderClient'
-import { SessionClient } from '../../../src/renderer/api/SessionClient'
-import { SettingsClient } from '../../../src/renderer/api/SettingsClient'
+import { createBrowserClient } from '../../../src/renderer/api/BrowserClient'
+import { createChatClient } from '../../../src/renderer/api/ChatClient'
+import { createConfigClient } from '../../../src/renderer/api/ConfigClient'
+import { createModelClient } from '../../../src/renderer/api/ModelClient'
+import { createProviderClient } from '../../../src/renderer/api/ProviderClient'
+import { createSessionClient } from '../../../src/renderer/api/SessionClient'
+import { createSettingsClient } from '../../../src/renderer/api/SettingsClient'
 
 describe('renderer api clients', () => {
   function createBridge(): DeepchatBridge {
@@ -87,7 +87,7 @@ describe('renderer api clients', () => {
 
   it('routes settings calls through the shared registry names', async () => {
     const bridge = createBridge()
-    const client = new SettingsClient(bridge)
+    const client = createSettingsClient(bridge)
 
     await client.getSnapshot(['fontSizeLevel'])
     await client.getSystemFonts()
@@ -111,9 +111,9 @@ describe('renderer api clients', () => {
 
   it('routes session and chat calls through the shared registry names', async () => {
     const bridge = createBridge()
-    const sessionClient = new SessionClient(bridge)
-    const chatClient = new ChatClient(bridge)
-    const providerClient = new ProviderClient(bridge)
+    const sessionClient = createSessionClient(bridge)
+    const chatClient = createChatClient(bridge)
+    const providerClient = createProviderClient(bridge)
 
     await sessionClient.create({
       agentId: 'deepchat',
@@ -191,9 +191,9 @@ describe('renderer api clients', () => {
 
   it('routes phase2 config, provider, and model calls through the shared registry names', async () => {
     const bridge = createBridge()
-    const configClient = new ConfigClient(bridge)
-    const providerClient = new ProviderClient(bridge)
-    const modelClient = new ModelClient(bridge)
+    const configClient = createConfigClient(bridge)
+    const providerClient = createProviderClient(bridge)
+    const modelClient = createModelClient(bridge)
 
     await configClient.getSetting('input_chatMode')
     await configClient.setSetting('preferredModel', {
@@ -283,7 +283,7 @@ describe('renderer api clients', () => {
 
   it('serializes browser bounds updates before invoking the bridge', async () => {
     const bridge = createBridge()
-    const browserClient = new BrowserClient(bridge)
+    const browserClient = createBrowserClient(bridge)
     const reactiveBounds = new Proxy(
       {
         x: 12,

--- a/test/renderer/components/AcpAgentIcon.test.ts
+++ b/test/renderer/components/AcpAgentIcon.test.ts
@@ -8,7 +8,7 @@ const pendingRegistryIconUrl =
 const retryRegistryIconUrl = 'https://cdn.agentclientprotocol.com/registry/v1/latest/dimcode.svg'
 
 vi.mock('@api/ConfigClient', () => ({
-  ConfigClient: vi.fn(() => ({
+  createConfigClient: vi.fn(() => ({
     getAcpRegistryIconMarkup
   }))
 }))

--- a/test/renderer/components/AgentWelcomePage.test.ts
+++ b/test/renderer/components/AgentWelcomePage.test.ts
@@ -25,7 +25,7 @@ describe('AgentWelcomePage', () => {
     }
 
     vi.doMock('@api/SettingsClient', () => ({
-      SettingsClient: vi.fn(() => settingsClient)
+      createSettingsClient: vi.fn(() => settingsClient)
     }))
     vi.doMock('@/stores/ui/agent', () => ({
       useAgentStore: () => agentStore

--- a/test/renderer/components/App.startup.test.ts
+++ b/test/renderer/components/App.startup.test.ts
@@ -166,7 +166,7 @@ const mountApp = async (options?: {
   }))
 
   vi.doMock('@api/ConfigClient', () => ({
-    ConfigClient: vi.fn(() => configPresenter)
+    createConfigClient: vi.fn(() => configPresenter)
   }))
   vi.doMock('@/stores/artifact', () => ({
     useArtifactStore: () => ({

--- a/test/renderer/components/BrowserPanel.test.ts
+++ b/test/renderer/components/BrowserPanel.test.ts
@@ -61,16 +61,28 @@ describe('BrowserPanel', () => {
       sessions: options?.sessions ?? [{ id: options?.sessionId ?? 'session-a', status: 'none' }]
     }
 
-    const yoBrowserPresenter = {
-      getBrowserStatus: vi.fn().mockResolvedValue(options?.browserStatus ?? defaultBrowserStatus),
-      attachSessionBrowser: vi.fn().mockResolvedValue(true),
-      updateSessionBrowserBounds: vi.fn().mockResolvedValue(undefined),
+    const browserClient = {
+      getStatus: vi.fn().mockResolvedValue(options?.browserStatus ?? defaultBrowserStatus),
+      attachCurrentWindow: vi.fn().mockResolvedValue(true),
+      updateCurrentWindowBounds: vi.fn().mockResolvedValue(true),
       loadUrl: vi.fn().mockResolvedValue(options?.browserStatus ?? defaultBrowserStatus),
-      goBack: vi.fn().mockResolvedValue(undefined),
-      goForward: vi.fn().mockResolvedValue(undefined),
-      reload: vi.fn().mockResolvedValue(undefined),
-      detachSessionBrowser: vi.fn().mockResolvedValue(undefined),
-      destroySessionBrowser: vi.fn().mockResolvedValue(undefined)
+      goBack: vi.fn().mockResolvedValue(options?.browserStatus ?? defaultBrowserStatus),
+      goForward: vi.fn().mockResolvedValue(options?.browserStatus ?? defaultBrowserStatus),
+      reload: vi.fn().mockResolvedValue(options?.browserStatus ?? defaultBrowserStatus),
+      detach: vi.fn().mockResolvedValue(true),
+      destroy: vi.fn().mockResolvedValue(true),
+      onOpenRequestedForCurrentWindow: vi.fn((listener: IpcHandler) => {
+        handlers.set('yo-browser:open-requested', listener)
+        return () => {
+          handlers.delete('yo-browser:open-requested')
+        }
+      }),
+      onStatusChanged: vi.fn((listener: IpcHandler) => {
+        handlers.set('yo-browser:status-changed', listener)
+        return () => {
+          handlers.delete('yo-browser:status-changed')
+        }
+      })
     }
 
     vi.doMock('vue-i18n', () => ({
@@ -91,23 +103,9 @@ describe('BrowserPanel', () => {
       useSessionStore: () => sessionStore
     }))
 
-    vi.doMock('@api/legacy/presenters', () => ({
-      useLegacyPresenter: () => yoBrowserPresenter
+    vi.doMock('@api/BrowserClient', () => ({
+      createBrowserClient: () => browserClient
     }))
-    ;(window as any).api = {
-      ...(window as any).api,
-      getWindowId: vi.fn(() => 1)
-    }
-    ;(window as any).electron = {
-      ipcRenderer: {
-        on: vi.fn((channel: string, handler: IpcHandler) => {
-          handlers.set(channel, handler)
-        }),
-        removeListener: vi.fn((channel: string) => {
-          handlers.delete(channel)
-        })
-      }
-    }
 
     const BrowserPanel = (await import('@/components/sidepanel/BrowserPanel.vue')).default
     const wrapper = mount(BrowserPanel, {
@@ -140,7 +138,7 @@ describe('BrowserPanel', () => {
     })
 
     await flushPromises()
-    return { wrapper, yoBrowserPresenter, handlers }
+    return { wrapper, browserClient, handlers }
   }
 
   it('adds accessible labels to browser toolbar controls', async () => {
@@ -160,17 +158,16 @@ describe('BrowserPanel', () => {
       return rects.shift() ?? makeRect(24, 48, 320, 480)
     })
 
-    const { yoBrowserPresenter } = await setup()
+    const { browserClient } = await setup()
 
-    expect(yoBrowserPresenter.attachSessionBrowser).not.toHaveBeenCalled()
+    expect(browserClient.attachCurrentWindow).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(160)
     await flushPromises()
 
-    expect(yoBrowserPresenter.attachSessionBrowser).toHaveBeenCalledWith('session-a', 1)
-    expect(yoBrowserPresenter.updateSessionBrowserBounds).toHaveBeenCalledWith(
+    expect(browserClient.attachCurrentWindow).toHaveBeenCalledWith('session-a')
+    expect(browserClient.updateCurrentWindowBounds).toHaveBeenCalledWith(
       'session-a',
-      1,
       expect.objectContaining({
         x: 24,
         y: 48,
@@ -186,9 +183,9 @@ describe('BrowserPanel', () => {
       makeRect(10, 10, 300, 400)
     )
 
-    const { yoBrowserPresenter, handlers } = await setup()
-    yoBrowserPresenter.attachSessionBrowser.mockClear()
-    yoBrowserPresenter.updateSessionBrowserBounds.mockClear()
+    const { browserClient, handlers } = await setup()
+    browserClient.attachCurrentWindow.mockClear()
+    browserClient.updateCurrentWindowBounds.mockClear()
 
     const openRequestedHandler = handlers.get('yo-browser:open-requested')
     expect(openRequestedHandler).toBeTypeOf('function')
@@ -197,7 +194,7 @@ describe('BrowserPanel', () => {
     await openRequestedHandler?.({}, { sessionId: 'session-a', windowId: 2 })
     await flushPromises()
 
-    expect(yoBrowserPresenter.attachSessionBrowser).not.toHaveBeenCalled()
-    expect(yoBrowserPresenter.updateSessionBrowserBounds).not.toHaveBeenCalled()
+    expect(browserClient.attachCurrentWindow).not.toHaveBeenCalled()
+    expect(browserClient.updateCurrentWindowBounds).not.toHaveBeenCalled()
   })
 })

--- a/test/renderer/components/ChatPage.test.ts
+++ b/test/renderer/components/ChatPage.test.ts
@@ -166,7 +166,7 @@ const setup = async (options: SetupOptions = {}) => {
     useLegacyPresenter: () => agentSessionPresenter
   }))
   vi.doMock('../../../src/renderer/api/ChatClient', () => ({
-    ChatClient: vi.fn(() => chatClient)
+    createChatClient: vi.fn(() => chatClient)
   }))
   vi.doMock('@/stores/ui/spotlight', () => ({
     useSpotlightStore: () => spotlightStore

--- a/test/renderer/components/ChatStatusBar.test.ts
+++ b/test/renderer/components/ChatStatusBar.test.ts
@@ -520,16 +520,16 @@ const setup = async (options: SetupOptions = {}) => {
     useProjectStore: () => projectStore
   }))
   vi.doMock('@api/ConfigClient', () => ({
-    ConfigClient: vi.fn(() => configPresenter)
+    createConfigClient: vi.fn(() => configPresenter)
   }))
   vi.doMock('@api/ModelClient', () => ({
-    ModelClient: vi.fn(() => modelClient)
+    createModelClient: vi.fn(() => modelClient)
   }))
   vi.doMock('@api/ProviderClient', () => ({
-    ProviderClient: vi.fn(() => llmproviderPresenter)
+    createProviderClient: vi.fn(() => llmproviderPresenter)
   }))
   vi.doMock('@api/SessionClient', () => ({
-    SessionClient: vi.fn(() => agentSessionPresenter)
+    createSessionClient: vi.fn(() => agentSessionPresenter)
   }))
   vi.doMock('vue-i18n', () => ({
     useI18n: () => ({

--- a/test/renderer/components/MarkdownRenderer.test.ts
+++ b/test/renderer/components/MarkdownRenderer.test.ts
@@ -54,7 +54,7 @@ const setup = async (props: Record<string, unknown> = {}) => {
   }))
 
   vi.doMock('@api/SessionClient', () => ({
-    SessionClient: vi.fn(() => ({
+    createSessionClient: vi.fn(() => ({
       getSearchResults: getSearchResultsMock
     }))
   }))

--- a/test/renderer/components/McpIndicator.test.ts
+++ b/test/renderer/components/McpIndicator.test.ts
@@ -160,18 +160,18 @@ const setup = async (options?: {
     useProjectStore: () => projectStore
   }))
   vi.doMock('@api/ToolClient', () => ({
-    ToolClient: vi.fn(() => ({
+    createToolClient: vi.fn(() => ({
       getAllToolDefinitions: toolPresenter.getAllToolDefinitions
     }))
   }))
   vi.doMock('@api/SessionClient', () => ({
-    SessionClient: vi.fn(() => ({
+    createSessionClient: vi.fn(() => ({
       getSessionDisabledAgentTools: agentSessionPresenter.getSessionDisabledAgentTools,
       updateSessionDisabledAgentTools: agentSessionPresenter.updateSessionDisabledAgentTools
     }))
   }))
   vi.doMock('@api/SkillClient', () => ({
-    SkillClient: vi.fn(() => ({
+    createSkillClient: vi.fn(() => ({
       onSessionChanged: vi.fn(
         (
           listener: (payload: {
@@ -191,7 +191,7 @@ const setup = async (options?: {
     }))
   }))
   vi.doMock('@api/SettingsClient', () => ({
-    SettingsClient: vi.fn(() => ({
+    createSettingsClient: vi.fn(() => ({
       openSettings: windowPresenter.createSettingsWindow
     }))
   }))

--- a/test/renderer/components/ModelConfigDialog.test.ts
+++ b/test/renderer/components/ModelConfigDialog.test.ts
@@ -100,7 +100,7 @@ const setup = async (options: SetupOptions) => {
     useProviderStore: () => providerStore
   }))
   vi.doMock('@api/ModelClient', () => ({
-    ModelClient: vi.fn(() => modelClient)
+    createModelClient: vi.fn(() => modelClient)
   }))
   vi.doMock('vue-i18n', () => ({
     useI18n: () => ({

--- a/test/renderer/components/NewThreadPage.test.ts
+++ b/test/renderer/components/NewThreadPage.test.ts
@@ -152,10 +152,10 @@ const setup = async (options?: {
     useDraftStore: () => draftStore
   }))
   vi.doMock('@api/ConfigClient', () => ({
-    ConfigClient: vi.fn(() => configClient)
+    createConfigClient: vi.fn(() => configClient)
   }))
   vi.doMock('@api/SessionClient', () => ({
-    SessionClient: vi.fn(() => sessionClient)
+    createSessionClient: vi.fn(() => sessionClient)
   }))
   vi.doMock('vue-i18n', () => ({
     useI18n: () => ({

--- a/test/renderer/components/SvgArtifact.test.ts
+++ b/test/renderer/components/SvgArtifact.test.ts
@@ -9,7 +9,7 @@ vi.mock('vue-i18n', () => ({
 }))
 
 vi.mock('@api/DeviceClient', () => ({
-  DeviceClient: vi.fn(() => ({
+  createDeviceClient: vi.fn(() => ({
     sanitizeSvgContent: vi.fn(async (content: string) => content)
   }))
 }))

--- a/test/renderer/components/TranslatePopup.test.ts
+++ b/test/renderer/components/TranslatePopup.test.ts
@@ -20,7 +20,7 @@ vi.mock('vue-i18n', () => ({
 }))
 
 vi.mock('@api/SessionClient', () => ({
-  SessionClient: vi.fn(() => ({
+  createSessionClient: vi.fn(() => ({
     translateText
   }))
 }))

--- a/test/renderer/components/WelcomePage.test.ts
+++ b/test/renderer/components/WelcomePage.test.ts
@@ -22,7 +22,7 @@ describe('WelcomePage', () => {
     }
     const openSettings = vi.fn().mockResolvedValue(undefined)
     vi.doMock('@api/ConfigClient', () => ({
-      ConfigClient: vi.fn(() => ({
+      createConfigClient: vi.fn(() => ({
         setSetting: configPresenter.setSetting,
         openSettings
       }))
@@ -103,7 +103,7 @@ describe('WelcomePage', () => {
     }
     const openSettings = vi.fn().mockResolvedValue(undefined)
     vi.doMock('@api/ConfigClient', () => ({
-      ConfigClient: vi.fn(() => ({
+      createConfigClient: vi.fn(() => ({
         setSetting: configPresenter.setSetting,
         openSettings
       }))
@@ -184,7 +184,7 @@ describe('WelcomePage', () => {
     const openSettings = vi.fn().mockResolvedValue(undefined)
 
     vi.doMock('@api/ConfigClient', () => ({
-      ConfigClient: vi.fn(() => ({
+      createConfigClient: vi.fn(() => ({
         setSetting: configPresenter.setSetting,
         openSettings
       }))

--- a/test/renderer/components/WindowSideBar.test.ts
+++ b/test/renderer/components/WindowSideBar.test.ts
@@ -197,10 +197,10 @@ const setup = async (options: SetupOptions = {}) => {
     useSpotlightStore: () => spotlightStore
   }))
   vi.doMock('@api/SettingsClient', () => ({
-    SettingsClient: vi.fn(() => settingsClient)
+    createSettingsClient: vi.fn(() => settingsClient)
   }))
   vi.doMock('@api/RemoteControlRuntime', () => ({
-    RemoteControlRuntime: vi.fn(() => remoteControlRuntime)
+    createRemoteControlRuntime: vi.fn(() => remoteControlRuntime)
   }))
   vi.doMock('vue-i18n', () => ({
     useI18n: () => ({

--- a/test/renderer/components/WorkspacePanel.test.ts
+++ b/test/renderer/components/WorkspacePanel.test.ts
@@ -179,7 +179,7 @@ vi.mock('@/stores/ui/sidepanel', () => ({
 }))
 
 vi.mock('@api/WorkspaceClient', () => ({
-  WorkspaceClient: vi.fn(() => ({
+  createWorkspaceClient: vi.fn(() => ({
     registerWorkspace: registerWorkspaceMock,
     watchWorkspace: watchWorkspaceMock,
     unwatchWorkspace: unwatchWorkspaceMock,
@@ -197,13 +197,13 @@ vi.mock('@api/WorkspaceClient', () => ({
 }))
 
 vi.mock('@api/ProjectClient', () => ({
-  ProjectClient: vi.fn(() => ({
+  createProjectClient: vi.fn(() => ({
     selectDirectory: selectDirectoryMock
   }))
 }))
 
 vi.mock('@api/FileClient', () => ({
-  FileClient: vi.fn(() => ({
+  createFileClient: vi.fn(() => ({
     isDirectory: isDirectoryMock,
     getPathForFile: getPathForFileMock
   }))

--- a/test/renderer/components/message/MessageBlockThink.test.ts
+++ b/test/renderer/components/message/MessageBlockThink.test.ts
@@ -18,7 +18,7 @@ const configClient = {
 }
 
 vi.mock('@api/ConfigClient', () => ({
-  ConfigClient: vi.fn(() => configClient)
+  createConfigClient: vi.fn(() => configClient)
 }))
 
 vi.mock('@/components/think-content', () => ({

--- a/test/renderer/components/trace/TraceDialog.test.ts
+++ b/test/renderer/components/trace/TraceDialog.test.ts
@@ -6,13 +6,13 @@ const { listMessageTracesMock } = vi.hoisted(() => ({
 }))
 
 vi.mock('@api/SessionClient', () => ({
-  SessionClient: vi.fn(() => ({
+  createSessionClient: vi.fn(() => ({
     listMessageTraces: listMessageTracesMock
   }))
 }))
 
 vi.mock('@api/DeviceClient', () => ({
-  DeviceClient: vi.fn(() => ({
+  createDeviceClient: vi.fn(() => ({
     copyText: vi.fn()
   }))
 }))

--- a/test/renderer/composables/useModelCapabilities.test.ts
+++ b/test/renderer/composables/useModelCapabilities.test.ts
@@ -8,7 +8,7 @@ const modelClient = vi.hoisted(() => ({
 }))
 
 vi.mock('@api/ModelClient', () => ({
-  ModelClient: vi.fn(() => modelClient)
+  createModelClient: vi.fn(() => modelClient)
 }))
 
 import { useModelCapabilities } from '@/composables/useModelCapabilities'

--- a/test/renderer/composables/usePageCapture.test.ts
+++ b/test/renderer/composables/usePageCapture.test.ts
@@ -7,14 +7,14 @@ const { captureCurrentAreaMock, stitchImagesWithWatermarkMock, copyImageMock } =
 }))
 
 vi.mock('@api/TabClient', () => ({
-  TabClient: vi.fn(() => ({
+  createTabClient: vi.fn(() => ({
     captureCurrentArea: captureCurrentAreaMock,
     stitchImagesWithWatermark: stitchImagesWithWatermarkMock
   }))
 }))
 
 vi.mock('@api/DeviceClient', () => ({
-  DeviceClient: vi.fn(() => ({
+  createDeviceClient: vi.fn(() => ({
     copyImage: copyImageMock
   }))
 }))

--- a/test/renderer/pages/NewThreadPage.test.ts
+++ b/test/renderer/pages/NewThreadPage.test.ts
@@ -108,10 +108,10 @@ const setup = async (pendingModelId: string) => {
     useDraftStore: () => draftStore
   }))
   vi.doMock('@api/ConfigClient', () => ({
-    ConfigClient: vi.fn(() => configClient)
+    createConfigClient: vi.fn(() => configClient)
   }))
   vi.doMock('@api/SessionClient', () => ({
-    SessionClient: vi.fn(() => sessionClient)
+    createSessionClient: vi.fn(() => sessionClient)
   }))
   vi.doMock('vue-i18n', () => ({
     useI18n: () => ({

--- a/test/renderer/stores/mcpStore.test.ts
+++ b/test/renderer/stores/mcpStore.test.ts
@@ -40,11 +40,11 @@ vi.mock('vue', async () => {
 })
 
 vi.mock('@api/McpClient', () => ({
-  McpClient: vi.fn(() => mcpClientMock)
+  createMcpClient: vi.fn(() => mcpClientMock)
 }))
 
 vi.mock('../../../src/renderer/api/ConfigClient', () => ({
-  ConfigClient: vi.fn(() => configPresenterMock)
+  createConfigClient: vi.fn(() => configPresenterMock)
 }))
 
 vi.mock('@/composables/useIpcMutation', () => ({

--- a/test/renderer/stores/messageStore.reactivity.test.ts
+++ b/test/renderer/stores/messageStore.reactivity.test.ts
@@ -38,10 +38,10 @@ describe('messageStore reactivity', () => {
     }
 
     vi.doMock('../../../src/renderer/api/SessionClient', () => ({
-      SessionClient: vi.fn(() => sessionClient)
+      createSessionClient: vi.fn(() => sessionClient)
     }))
     vi.doMock('../../../src/renderer/api/ChatClient', () => ({
-      ChatClient: vi.fn(() => chatClient)
+      createChatClient: vi.fn(() => chatClient)
     }))
 
     ;(window as any).electron = {

--- a/test/renderer/stores/messageStore.test.ts
+++ b/test/renderer/stores/messageStore.test.ts
@@ -51,10 +51,10 @@ const setupStore = async () => {
   })
 
   vi.doMock('../../../src/renderer/api/SessionClient', () => ({
-    SessionClient: vi.fn(() => sessionClient)
+    createSessionClient: vi.fn(() => sessionClient)
   }))
   vi.doMock('../../../src/renderer/api/ChatClient', () => ({
-    ChatClient: vi.fn(() => chatClient)
+    createChatClient: vi.fn(() => chatClient)
   }))
 
   ;(window as any).electron = {

--- a/test/renderer/stores/modelStore.test.ts
+++ b/test/renderer/stores/modelStore.test.ts
@@ -79,7 +79,7 @@ const setupStore = async (overrides?: {
   }))
 
   vi.doMock('../../../src/renderer/api/ModelClient', () => ({
-    ModelClient: vi.fn(() => modelClient)
+    createModelClient: vi.fn(() => modelClient)
   }))
 
   vi.doMock('@/composables/useIpcMutation', () => ({

--- a/test/renderer/stores/ollamaStore.test.ts
+++ b/test/renderer/stores/ollamaStore.test.ts
@@ -55,7 +55,7 @@ const setupStore = async () => {
   })
 
   vi.doMock('../../../src/renderer/api/ProviderClient', () => ({
-    ProviderClient: vi.fn(() => providerClient)
+    createProviderClient: vi.fn(() => providerClient)
   }))
 
   vi.doMock('@api/legacy/runtime', () => ({

--- a/test/renderer/stores/pageRouter.test.ts
+++ b/test/renderer/stores/pageRouter.test.ts
@@ -17,7 +17,7 @@ const setupStore = async (options?: { activeAgentSession?: { id: string } | null
   })
 
   vi.doMock('../../../src/renderer/api/SessionClient', () => ({
-    SessionClient: vi.fn(() => sessionClient)
+    createSessionClient: vi.fn(() => sessionClient)
   }))
 
   const { usePageRouterStore } = await import('@/stores/ui/pageRouter')
@@ -91,7 +91,7 @@ describe('pageRouter.initialize', () => {
     })
 
     vi.doMock('../../../src/renderer/api/SessionClient', () => ({
-      SessionClient: vi.fn(() => sessionClient)
+      createSessionClient: vi.fn(() => sessionClient)
     }))
 
     const { usePageRouterStore } = await import('@/stores/ui/pageRouter')

--- a/test/renderer/stores/pendingInputStore.test.ts
+++ b/test/renderer/stores/pendingInputStore.test.ts
@@ -45,7 +45,7 @@ const setupStore = async () => {
   }
 
   vi.doMock('../../../src/renderer/api/SessionClient', () => ({
-    SessionClient: vi.fn(() => sessionClient)
+    createSessionClient: vi.fn(() => sessionClient)
   }))
 
   const { usePendingInputStore } = await import('@/stores/ui/pendingInput')

--- a/test/renderer/stores/projectStore.test.ts
+++ b/test/renderer/stores/projectStore.test.ts
@@ -38,7 +38,7 @@ const setupStore = async (overrides?: {
     }
   })
   vi.doMock('../../../src/renderer/api/ProjectClient', () => ({
-    ProjectClient: vi.fn(() => ({
+    createProjectClient: vi.fn(() => ({
       listRecent: projectPresenter.getRecentProjects,
       listEnvironments: projectPresenter.getEnvironments,
       openDirectory: projectPresenter.openDirectory,
@@ -46,7 +46,7 @@ const setupStore = async (overrides?: {
     }))
   }))
   vi.doMock('../../../src/renderer/api/ConfigClient', () => ({
-    ConfigClient: vi.fn(() => configClient)
+    createConfigClient: vi.fn(() => configClient)
   }))
 
   const { useProjectStore } = await import('@/stores/ui/project')

--- a/test/renderer/stores/sessionStore.test.ts
+++ b/test/renderer/stores/sessionStore.test.ts
@@ -104,16 +104,16 @@ const setupStore = async (options: SetupStoreOptions = {}) => {
   })
 
   vi.doMock('../../../src/renderer/api/ConfigClient', () => ({
-    ConfigClient: vi.fn(() => configClient)
+    createConfigClient: vi.fn(() => configClient)
   }))
   vi.doMock('../../../src/renderer/api/SessionClient', () => ({
-    SessionClient: vi.fn(() => sessionClient)
+    createSessionClient: vi.fn(() => sessionClient)
   }))
   vi.doMock('../../../src/renderer/api/ChatClient', () => ({
-    ChatClient: vi.fn(() => chatClient)
+    createChatClient: vi.fn(() => chatClient)
   }))
   vi.doMock('@api/TabClient', () => ({
-    TabClient: vi.fn(() => tabClient)
+    createTabClient: vi.fn(() => tabClient)
   }))
 
   vi.doMock('@/stores/ui/pageRouter', () => ({

--- a/test/renderer/stores/spotlight.test.ts
+++ b/test/renderer/stores/spotlight.test.ts
@@ -58,10 +58,10 @@ const setupStore = async (options?: {
   }))
 
   vi.doMock('@api/SessionClient', () => ({
-    SessionClient: vi.fn(() => sessionClient)
+    createSessionClient: vi.fn(() => sessionClient)
   }))
   vi.doMock('@api/SettingsClient', () => ({
-    SettingsClient: vi.fn(() => settingsClient)
+    createSettingsClient: vi.fn(() => settingsClient)
   }))
 
   vi.doMock('@/stores/ui/session', () => ({

--- a/test/renderer/stores/upgradeStore.test.ts
+++ b/test/renderer/stores/upgradeStore.test.ts
@@ -36,7 +36,7 @@ vi.mock('vue', async () => {
 })
 
 vi.mock('@api/UpgradeClient', () => ({
-  UpgradeClient: vi.fn(() => ({
+  createUpgradeClient: vi.fn(() => ({
     checkUpdate: upgradePresenterMock.checkUpdate,
     getUpdateStatus: upgradePresenterMock.getUpdateStatus,
     goDownloadUpgrade: upgradePresenterMock.goDownloadUpgrade,
@@ -64,7 +64,7 @@ vi.mock('@api/UpgradeClient', () => ({
 }))
 
 vi.mock('@api/DeviceClient', () => ({
-  DeviceClient: vi.fn(() => ({
+  createDeviceClient: vi.fn(() => ({
     getDeviceInfo: devicePresenterMock.getDeviceInfo
   }))
 }))


### PR DESCRIPTION
- Updated various stores to use factory functions for client creation instead of direct instantiation. This change improves consistency and potentially enhances testability across the application.
- Modified imports in `messageIpc.ts`, `pageRouter.ts`, `pendingInput.ts`, `project.ts`, `session.ts`, `sessionIpc.ts`, `spotlight.ts`, `uiSettingsStore.ts`, `upgrade.ts`, and other related files to reflect the new client creation methods.
- Adjusted corresponding tests to mock the new factory functions instead of the previous client constructors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal API clients were converted to factory-based creation for improved maintainability; behavior and user-facing functionality remain unchanged.
* **Tests**
  * Test mocks and suites updated to match the new factory-style clients; no change to tested behaviors or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->