### PR TITLE
feat(kimi): support fixed temperature by thinking

### DIFF
--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -42,6 +42,7 @@ import {
   toValidNonNegativeInteger,
   validateGenerationNumericField
 } from '@shared/utils/generationSettingsValidation'
+import { resolveMoonshotKimiTemperaturePolicy } from '@shared/moonshotKimiPolicy'
 import { DEFAULT_MODEL_TIMEOUT } from '@shared/modelConfigDefaults'
 import { nanoid } from 'nanoid'
 import type { SQLitePresenter } from '../sqlitePresenter'
@@ -2723,6 +2724,11 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     modelId: string
   ): Promise<SessionGenerationSettings> {
     const modelConfig = this.configPresenter.getModelConfig(modelId, providerId)
+    const fixedTemperatureKimi = resolveMoonshotKimiTemperaturePolicy(
+      providerId,
+      modelId,
+      modelConfig.reasoning
+    )
     const portrait = this.getReasoningPortrait(providerId, modelId)
     const capabilityProviderId = this.resolveCapabilityProviderId(providerId, modelId)
     const anthropicReasoningToggle = hasAnthropicReasoningToggle(capabilityProviderId, portrait)
@@ -2740,7 +2746,10 @@ export class AgentRuntimePresenter implements IAgentImplementation {
 
     const defaults: SessionGenerationSettings = {
       systemPrompt: defaultSystemPrompt ?? '',
-      temperature: parseFiniteNumericValue(modelConfig.temperature) ?? 0.7,
+      temperature:
+        fixedTemperatureKimi?.temperature ??
+        parseFiniteNumericValue(modelConfig.temperature) ??
+        0.7,
       contextLength: contextLengthDefault,
       timeout:
         timeoutDefault >= SESSION_TIMEOUT_MIN_MS && timeoutDefault <= SESSION_TIMEOUT_MAX_MS
@@ -2819,6 +2828,11 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     baseSettings?: SessionGenerationSettings
   ): Promise<SessionGenerationSettings> {
     const modelConfig = this.configPresenter.getModelConfig(modelId, providerId)
+    const fixedTemperatureKimi = resolveMoonshotKimiTemperaturePolicy(
+      providerId,
+      modelId,
+      modelConfig.reasoning
+    )
     const portrait = this.getReasoningPortrait(providerId, modelId)
     const capabilityProviderId = this.resolveCapabilityProviderId(providerId, modelId)
     const anthropicReasoningToggle = hasAnthropicReasoningToggle(capabilityProviderId, portrait)
@@ -2970,6 +2984,10 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       }
     } else if (typeof base.forceInterleavedThinkingCompat !== 'boolean') {
       delete next.forceInterleavedThinkingCompat
+    }
+
+    if (fixedTemperatureKimi) {
+      next.temperature = fixedTemperatureKimi.temperature
     }
 
     return next

--- a/src/main/presenter/configPresenter/modelConfig.ts
+++ b/src/main/presenter/configPresenter/modelConfig.ts
@@ -12,6 +12,7 @@ import {
   resolveModelContextLength,
   resolveModelFunctionCall
 } from '@shared/modelConfigDefaults'
+import { applyMoonshotKimiReasoningTemperaturePolicy } from '@shared/moonshotKimiPolicy'
 import ElectronStore from 'electron-store'
 import { providerDbLoader } from './providerDbLoader'
 import {
@@ -122,6 +123,18 @@ export class ModelConfigHelper {
     return ModelType.Chat
   }
 
+  private applyProviderSpecificPolicies(
+    providerId: string | undefined,
+    modelId: string,
+    config: ModelConfig
+  ): ModelConfig {
+    if (!providerId) {
+      return config
+    }
+
+    return applyMoonshotKimiReasoningTemperaturePolicy(providerId, modelId, config)
+  }
+
   private buildConfigFromProviderModel(model: ProviderModel, providerId: string): ModelConfig {
     const portrait = modelCapabilities.getReasoningPortrait(providerId, model.id)
     const capabilityProviderId = resolveProviderCapabilityProviderId(providerId, null, model.id)
@@ -143,7 +156,7 @@ export class ModelConfigHelper {
       portrait?.verbosity ?? model.reasoning?.verbosity
     )
 
-    return {
+    return this.applyProviderSpecificPolicies(providerId, model.id, {
       maxTokens: resolveDerivedModelMaxTokens(model.limit?.output),
       contextLength: resolveModelContextLength(model.limit?.context),
       timeout: DEFAULT_MODEL_TIMEOUT,
@@ -164,7 +177,7 @@ export class ModelConfigHelper {
         | 'balanced'
         | 'precise',
       maxCompletionTokens: undefined
-    }
+    })
   }
 
   private initializeMetaFromLegacyStore(): void {
@@ -385,7 +398,9 @@ export class ModelConfigHelper {
     const isUserConfig = storedSource === 'user'
 
     if (storedConfig && isUserConfig) {
-      const finalUserConfig = { ...storedConfig }
+      const finalUserConfig = this.applyProviderSpecificPolicies(providerId, modelId, {
+        ...storedConfig
+      })
       finalUserConfig.isUserDefined = true
       return finalUserConfig
     }
@@ -485,8 +500,12 @@ export class ModelConfigHelper {
       }
     }
 
-    finalConfig!.isUserDefined = false
-    return finalConfig!
+    const normalizedFinalConfig = this.applyProviderSpecificPolicies(providerId, modelId, {
+      ...finalConfig!,
+      isUserDefined: false
+    })
+    normalizedFinalConfig.isUserDefined = false
+    return normalizedFinalConfig
   }
 
   /**
@@ -511,12 +530,12 @@ export class ModelConfigHelper {
       typeof config.timeout === 'number' && Number.isFinite(config.timeout) && config.timeout > 0
         ? Math.round(config.timeout)
         : undefined
-    const storedConfig: ModelConfig = {
+    const storedConfig: ModelConfig = this.applyProviderSpecificPolicies(providerId, modelId, {
       ...config,
       ...(normalizedMaxTokens !== undefined ? { maxTokens: normalizedMaxTokens } : {}),
       ...(normalizedTimeout !== undefined ? { timeout: normalizedTimeout } : {}),
       isUserDefined: source === 'user'
-    }
+    })
     const configData: IModelConfig = {
       id: modelId,
       providerId: providerId,

--- a/src/main/presenter/llmProviderPresenter/aiSdk/providerOptionsMapper.ts
+++ b/src/main/presenter/llmProviderPresenter/aiSdk/providerOptionsMapper.ts
@@ -1,5 +1,6 @@
 import type { MCPToolDefinition, ModelConfig } from '@shared/presenter'
 import type { ModelMessage } from 'ai'
+import { resolveMoonshotKimiTemperaturePolicy } from '@shared/moonshotKimiPolicy'
 import {
   getReasoningEffectiveEnabledForProvider,
   hasAnthropicReasoningToggle,
@@ -127,14 +128,17 @@ export function buildProviderOptions(
     params.capabilityProviderId,
     params.modelId
   )
-  const reasoningEnabled = getReasoningEffectiveEnabledForProvider(
-    params.capabilityProviderId,
-    reasoningPortrait,
-    {
+  const fixedTemperatureKimi = resolveMoonshotKimiTemperaturePolicy(
+    params.providerId,
+    params.modelId,
+    params.modelConfig.reasoning
+  )
+  const reasoningEnabled =
+    fixedTemperatureKimi?.reasoningEnabled ??
+    getReasoningEffectiveEnabledForProvider(params.capabilityProviderId, reasoningPortrait, {
       reasoning: params.modelConfig.reasoning,
       reasoningEffort: params.modelConfig.reasoningEffort
-    }
-  )
+    })
   const hasThinkingConfig =
     params.modelConfig.thinkingBudget !== undefined || Boolean(params.modelConfig.reasoningEffort)
   const shouldSendThinkingConfig =
@@ -169,6 +173,11 @@ export function buildProviderOptions(
       }
       if (promptCachePlan.cacheKey) {
         config.promptCacheKey = promptCachePlan.cacheKey
+      }
+      if (fixedTemperatureKimi) {
+        config.thinking = {
+          type: fixedTemperatureKimi.thinkingType
+        }
       }
       if (supportsDoubaoThinking(params.providerId, params.modelId) && reasoningEnabled) {
         config.thinking = {

--- a/src/main/presenter/llmProviderPresenter/aiSdk/runtime.ts
+++ b/src/main/presenter/llmProviderPresenter/aiSdk/runtime.ts
@@ -9,6 +9,10 @@ import type {
   ModelConfig
 } from '@shared/presenter'
 import { ApiEndpointType } from '@shared/model'
+import {
+  applyMoonshotKimiReasoningTemperaturePolicy,
+  resolveMoonshotKimiTemperaturePolicy
+} from '@shared/moonshotKimiPolicy'
 import { presenter } from '@/presenter'
 import { EMBEDDING_TEST_KEY, isNormalized } from '@/utils/vector'
 import type { LLMCoreStreamEvent } from '@shared/types/core/llm-events'
@@ -150,6 +154,39 @@ function resolveRequestTimeout(modelConfig: ModelConfig): number | undefined {
   return Math.round(timeout)
 }
 
+function normalizeRuntimeModelConfig(
+  context: AiSdkRuntimeContext,
+  modelId: string,
+  modelConfig: ModelConfig
+): ModelConfig {
+  return applyMoonshotKimiReasoningTemperaturePolicy(context.provider.id, modelId, modelConfig)
+}
+
+function resolveRuntimeTemperature(
+  context: AiSdkRuntimeContext,
+  modelId: string,
+  modelConfig: ModelConfig,
+  requestedTemperature: number | undefined
+): { shouldSendTemperature: boolean; temperature: number | undefined } {
+  const fixedTemperatureKimi = resolveMoonshotKimiTemperaturePolicy(
+    context.provider.id,
+    modelId,
+    modelConfig.reasoning
+  )
+  if (fixedTemperatureKimi) {
+    return {
+      shouldSendTemperature: true,
+      temperature: fixedTemperatureKimi.temperature
+    }
+  }
+
+  return {
+    shouldSendTemperature:
+      supportsTemperatureControlRuntime(context, modelId) && requestedTemperature !== undefined,
+    temperature: requestedTemperature
+  }
+}
+
 async function buildPromptRuntime(
   context: AiSdkRuntimeContext,
   messages: ChatMessage[],
@@ -222,16 +259,24 @@ export async function runAiSdkGenerateText(
   temperature?: number,
   maxTokens?: number
 ): Promise<LLMResponse> {
-  const runtime = await buildPromptRuntime(context, messages, modelId, modelConfig, [])
-  const supportsTemperature = supportsTemperatureControlRuntime(context, modelId)
-  const timeout = resolveRequestTimeout(modelConfig)
+  const normalizedModelConfig = normalizeRuntimeModelConfig(context, modelId, modelConfig)
+  const runtime = await buildPromptRuntime(context, messages, modelId, normalizedModelConfig, [])
+  const { shouldSendTemperature, temperature: resolvedTemperature } = resolveRuntimeTemperature(
+    context,
+    modelId,
+    normalizedModelConfig,
+    temperature
+  )
+  const timeout = resolveRequestTimeout(normalizedModelConfig)
   const requestBody = {
     model: runtime.providerContext.resolvedModelId ?? modelId,
     maxOutputTokens: maxTokens,
-    ...(supportsTemperature && temperature !== undefined ? { temperature } : {})
+    ...(shouldSendTemperature && resolvedTemperature !== undefined
+      ? { temperature: resolvedTemperature }
+      : {})
   }
 
-  await context.emitRequestTrace?.(modelConfig, {
+  await context.emitRequestTrace?.(normalizedModelConfig, {
     endpoint: runtime.providerContext.endpoint,
     headers: context.buildTraceHeaders?.() ?? context.defaultHeaders,
     body: requestBody
@@ -242,7 +287,9 @@ export async function runAiSdkGenerateText(
     messages: runtime.messages,
     providerOptions: runtime.providerOptions as any,
     ...(timeout ? { abortSignal: AbortSignal.timeout(timeout) } : {}),
-    ...(supportsTemperature && temperature !== undefined ? { temperature } : {}),
+    ...(shouldSendTemperature && resolvedTemperature !== undefined
+      ? { temperature: resolvedTemperature }
+      : {}),
     maxOutputTokens: maxTokens
   })
 
@@ -262,9 +309,10 @@ export async function* runAiSdkCoreStream(
   maxTokens: number,
   tools: MCPToolDefinition[]
 ): AsyncGenerator<LLMCoreStreamEvent> {
-  const timeout = resolveRequestTimeout(modelConfig)
+  const normalizedModelConfig = normalizeRuntimeModelConfig(context, modelId, modelConfig)
+  const timeout = resolveRequestTimeout(normalizedModelConfig)
 
-  if (shouldUseImageGenerationRuntime(context, modelId, modelConfig)) {
+  if (shouldUseImageGenerationRuntime(context, modelId, normalizedModelConfig)) {
     const prompt = extractImagePrompt(messages)
 
     const providerContext = createAiSdkProviderContext({
@@ -314,16 +362,23 @@ export async function* runAiSdkCoreStream(
     return
   }
 
-  const runtime = await buildPromptRuntime(context, messages, modelId, modelConfig, tools)
-  const supportsTemperature = supportsTemperatureControlRuntime(context, modelId)
+  const runtime = await buildPromptRuntime(context, messages, modelId, normalizedModelConfig, tools)
+  const { shouldSendTemperature, temperature: resolvedTemperature } = resolveRuntimeTemperature(
+    context,
+    modelId,
+    normalizedModelConfig,
+    temperature
+  )
   const requestBody = {
     model: runtime.providerContext.resolvedModelId ?? modelId,
     maxOutputTokens: maxTokens,
-    ...(supportsTemperature ? { temperature } : {}),
+    ...(shouldSendTemperature && resolvedTemperature !== undefined
+      ? { temperature: resolvedTemperature }
+      : {}),
     tools: tools.map((tool) => tool.function.name)
   }
 
-  await context.emitRequestTrace?.(modelConfig, {
+  await context.emitRequestTrace?.(normalizedModelConfig, {
     endpoint: runtime.providerContext.endpoint,
     headers: context.buildTraceHeaders?.() ?? context.defaultHeaders,
     body: requestBody
@@ -335,7 +390,9 @@ export async function* runAiSdkCoreStream(
     tools: runtime.tools,
     providerOptions: runtime.providerOptions as any,
     ...(timeout ? { abortSignal: AbortSignal.timeout(timeout) } : {}),
-    ...(supportsTemperature ? { temperature } : {}),
+    ...(shouldSendTemperature && resolvedTemperature !== undefined
+      ? { temperature: resolvedTemperature }
+      : {}),
     maxOutputTokens: maxTokens
   })
 

--- a/src/renderer/src/components/chat/ChatStatusBar.vue
+++ b/src/renderer/src/components/chat/ChatStatusBar.vue
@@ -273,7 +273,9 @@
                               label: t('chat.advancedSettings.temperature')
                             })
                           "
-                          :disabled="hasNumericInputError('temperature')"
+                          :disabled="
+                            isMoonshotKimiTemperatureLocked || hasNumericInputError('temperature')
+                          "
                           @click="stepTemperature(-1)"
                         >
                           <Icon icon="lucide:minus" class="h-3 w-3" />
@@ -286,6 +288,7 @@
                           data-setting-control="temperature"
                           type="number"
                           :step="TEMPERATURE_STEP"
+                          :disabled="isMoonshotKimiTemperatureLocked"
                           :aria-invalid="hasNumericInputError('temperature')"
                           :model-value="temperatureInputValue"
                           @focus="startNumericInputEdit('temperature')"
@@ -304,12 +307,20 @@
                               label: t('chat.advancedSettings.temperature')
                             })
                           "
-                          :disabled="hasNumericInputError('temperature')"
+                          :disabled="
+                            isMoonshotKimiTemperatureLocked || hasNumericInputError('temperature')
+                          "
                           @click="stepTemperature(1)"
                         >
                           <Icon icon="lucide:plus" class="h-3 w-3" />
                         </Button>
                       </div>
+                      <p
+                        v-if="moonshotKimiTemperatureHint"
+                        class="text-[11px] text-muted-foreground"
+                      >
+                        {{ moonshotKimiTemperatureHint }}
+                      </p>
                       <p
                         v-if="getNumericInputErrorMessage('temperature')"
                         class="text-[11px] text-destructive"
@@ -882,6 +893,12 @@ import {
   resolveProviderCapabilityProviderId
 } from '@shared/model'
 import {
+  MOONSHOT_KIMI_THINKING_DISABLED_TEMPERATURE,
+  MOONSHOT_KIMI_THINKING_ENABLED_TEMPERATURE,
+  getMoonshotKimiTemperaturePolicy,
+  resolveMoonshotKimiTemperaturePolicy
+} from '@shared/moonshotKimiPolicy'
+import {
   ANTHROPIC_REASONING_VISIBILITY_VALUES,
   DEFAULT_REASONING_EFFORT_OPTIONS as FALLBACK_REASONING_EFFORT_OPTIONS,
   getReasoningEffectiveEnabledForProvider,
@@ -1133,6 +1150,24 @@ const effectiveModelSelection = computed<ModelSelection | null>(() => {
   }
   return draftModelSelection.value
 })
+
+const moonshotKimiTemperaturePolicy = computed(() =>
+  getMoonshotKimiTemperaturePolicy(
+    effectiveModelSelection.value?.providerId,
+    effectiveModelSelection.value?.modelId
+  )
+)
+const isMoonshotKimiTemperatureLocked = computed(
+  () => moonshotKimiTemperaturePolicy.value?.lockTemperatureControl === true
+)
+const moonshotKimiTemperatureHint = computed(() =>
+  isMoonshotKimiTemperatureLocked.value
+    ? t('chat.advancedSettings.temperatureFixedMoonshotKimi', {
+        enabled: MOONSHOT_KIMI_THINKING_ENABLED_TEMPERATURE.toFixed(1),
+        disabled: MOONSHOT_KIMI_THINKING_DISABLED_TEMPERATURE.toFixed(1)
+      })
+    : ''
+)
 
 const canSelectPermissionMode = computed(() => !isAcpAgent.value)
 const showSubagentToggle = computed(() => {
@@ -1795,7 +1830,9 @@ const showThinkingBudget = computed(() => {
 })
 
 const showTemperatureControl = computed(
-  () => capabilitySupportsTemperature.value !== false && Boolean(localSettings.value)
+  () =>
+    (capabilitySupportsTemperature.value !== false || isMoonshotKimiTemperatureLocked.value) &&
+    Boolean(localSettings.value)
 )
 
 const showVerbosity = computed(
@@ -2082,6 +2119,11 @@ const resolveDefaultGenerationSettings = async (
     modelId,
     modelConfig.endpointType
   )
+  const fixedTemperatureKimi = resolveMoonshotKimiTemperaturePolicy(
+    providerId,
+    modelId,
+    modelConfig.reasoning
+  )
   const portrait = capabilities.reasoningPortrait ?? null
   const contextLengthDefault = toValidNonNegativeInteger(modelConfig.contextLength) ?? 32000
   const maxTokensDefault =
@@ -2090,7 +2132,8 @@ const resolveDefaultGenerationSettings = async (
 
   const defaults: SessionGenerationSettings = {
     systemPrompt: agentConfig.systemPrompt ?? '',
-    temperature: parseFiniteNumericValue(modelConfig.temperature) ?? 0.7,
+    temperature:
+      fixedTemperatureKimi?.temperature ?? parseFiniteNumericValue(modelConfig.temperature) ?? 0.7,
     contextLength: contextLengthDefault,
     timeout:
       timeoutDefault >= TIMEOUT_MIN && timeoutDefault <= TIMEOUT_MAX
@@ -2243,42 +2286,47 @@ const updateLocalGenerationSettings = (patch: Partial<SessionGenerationSettings>
   generationSyncToken += 1
   generationLocalRevision += 1
 
+  const nextPatch = { ...patch }
+  if (isMoonshotKimiTemperatureLocked.value) {
+    delete nextPatch.temperature
+  }
+
   const next: SessionGenerationSettings = {
     ...localSettings.value,
-    ...patch
+    ...nextPatch
   }
 
   localSettings.value = next
 
   const normalizedPatch: Partial<SessionGenerationSettings> = {}
-  if (Object.prototype.hasOwnProperty.call(patch, 'systemPrompt')) {
+  if (Object.prototype.hasOwnProperty.call(nextPatch, 'systemPrompt')) {
     normalizedPatch.systemPrompt = next.systemPrompt
   }
-  if (Object.prototype.hasOwnProperty.call(patch, 'temperature')) {
+  if (Object.prototype.hasOwnProperty.call(nextPatch, 'temperature')) {
     normalizedPatch.temperature = next.temperature
   }
-  if (Object.prototype.hasOwnProperty.call(patch, 'contextLength')) {
+  if (Object.prototype.hasOwnProperty.call(nextPatch, 'contextLength')) {
     normalizedPatch.contextLength = next.contextLength
   }
-  if (Object.prototype.hasOwnProperty.call(patch, 'maxTokens')) {
+  if (Object.prototype.hasOwnProperty.call(nextPatch, 'maxTokens')) {
     normalizedPatch.maxTokens = next.maxTokens
   }
-  if (Object.prototype.hasOwnProperty.call(patch, 'timeout')) {
+  if (Object.prototype.hasOwnProperty.call(nextPatch, 'timeout')) {
     normalizedPatch.timeout = next.timeout
   }
-  if (Object.prototype.hasOwnProperty.call(patch, 'thinkingBudget')) {
+  if (Object.prototype.hasOwnProperty.call(nextPatch, 'thinkingBudget')) {
     normalizedPatch.thinkingBudget = next.thinkingBudget
   }
-  if (Object.prototype.hasOwnProperty.call(patch, 'reasoningEffort')) {
+  if (Object.prototype.hasOwnProperty.call(nextPatch, 'reasoningEffort')) {
     normalizedPatch.reasoningEffort = next.reasoningEffort
   }
-  if (Object.prototype.hasOwnProperty.call(patch, 'reasoningVisibility')) {
+  if (Object.prototype.hasOwnProperty.call(nextPatch, 'reasoningVisibility')) {
     normalizedPatch.reasoningVisibility = next.reasoningVisibility
   }
-  if (Object.prototype.hasOwnProperty.call(patch, 'verbosity')) {
+  if (Object.prototype.hasOwnProperty.call(nextPatch, 'verbosity')) {
     normalizedPatch.verbosity = next.verbosity
   }
-  if (Object.prototype.hasOwnProperty.call(patch, 'forceInterleavedThinkingCompat')) {
+  if (Object.prototype.hasOwnProperty.call(nextPatch, 'forceInterleavedThinkingCompat')) {
     normalizedPatch.forceInterleavedThinkingCompat = next.forceInterleavedThinkingCompat
   }
 
@@ -2855,6 +2903,9 @@ function stepTemperature(direction: -1 | 1) {
   if (!localSettings.value) {
     return
   }
+  if (isMoonshotKimiTemperatureLocked.value) {
+    return
+  }
   if (hasNumericInputError('temperature')) {
     return
   }
@@ -2866,10 +2917,17 @@ function stepTemperature(direction: -1 | 1) {
 }
 
 function onTemperatureInput(value: string | number) {
+  if (isMoonshotKimiTemperatureLocked.value) {
+    return
+  }
   setNumericInputDraft('temperature', value)
 }
 
 function commitTemperatureInput() {
+  if (isMoonshotKimiTemperatureLocked.value) {
+    resetNumericInputFieldState('temperature')
+    return
+  }
   const next = commitNumericField('temperature', numericInputDrafts.value.temperature)
   if (next === undefined) {
     return

--- a/src/renderer/src/components/settings/ModelConfigDialog.vue
+++ b/src/renderer/src/components/settings/ModelConfigDialog.vue
@@ -130,9 +130,13 @@
               :max="2"
               :placeholder="t('settings.model.modelConfig.temperature.label')"
               :class="{ 'border-destructive': errors.temperature }"
+              :disabled="isMoonshotKimiTemperatureLocked"
             />
             <p class="text-xs text-muted-foreground">
               {{ t('settings.model.modelConfig.temperature.description') }}
+            </p>
+            <p v-if="moonshotKimiTemperatureHint" class="text-xs text-muted-foreground">
+              {{ moonshotKimiTemperatureHint }}
             </p>
             <p v-if="errors.temperature" class="text-xs text-destructive">
               {{ errors.temperature }}
@@ -465,6 +469,12 @@ import {
   resolveProviderCapabilityProviderId,
   type NewApiEndpointType
 } from '@shared/model'
+import {
+  MOONSHOT_KIMI_THINKING_DISABLED_TEMPERATURE,
+  MOONSHOT_KIMI_THINKING_ENABLED_TEMPERATURE,
+  getMoonshotKimiTemperaturePolicy,
+  resolveMoonshotKimiTemperaturePolicy
+} from '@shared/moonshotKimiPolicy'
 import type { ModelConfig } from '@shared/presenter'
 import {
   ANTHROPIC_REASONING_VISIBILITY_VALUES,
@@ -841,6 +851,28 @@ const currentModelLookupId = computed(() =>
   (isCreateMode.value ? modelIdField.value : props.modelId || modelIdField.value).trim()
 )
 
+const moonshotKimiTemperaturePolicy = computed(() =>
+  getMoonshotKimiTemperaturePolicy(props.providerId, currentModelLookupId.value)
+)
+const resolvedMoonshotKimiTemperaturePolicy = computed(() =>
+  resolveMoonshotKimiTemperaturePolicy(
+    props.providerId,
+    currentModelLookupId.value,
+    config.value.reasoning
+  )
+)
+const isMoonshotKimiTemperatureLocked = computed(
+  () => moonshotKimiTemperaturePolicy.value?.lockTemperatureControl === true
+)
+const moonshotKimiTemperatureHint = computed(() =>
+  isMoonshotKimiTemperatureLocked.value
+    ? t('settings.model.modelConfig.temperature.fixedMoonshotKimi', {
+        enabled: MOONSHOT_KIMI_THINKING_ENABLED_TEMPERATURE.toFixed(1),
+        disabled: MOONSHOT_KIMI_THINKING_DISABLED_TEMPERATURE.toFixed(1)
+      })
+    : ''
+)
+
 const providerModelMeta = computed(() => {
   const targetModelId = currentModelLookupId.value
   if (!targetModelId) return null
@@ -898,18 +930,26 @@ const hasModelIdConflict = (modelId: string, excludeId?: string) => {
   })
 }
 
-const buildCustomModelPayload = (id: string, name: string, enabled?: boolean) => ({
-  id,
-  name,
-  enabled: enabled ?? true,
-  contextLength: config.value.contextLength ?? DEFAULT_MODEL_CONTEXT_LENGTH,
-  maxTokens: config.value.maxTokens ?? DEFAULT_MODEL_MAX_TOKENS,
-  vision: config.value.vision ?? DEFAULT_MODEL_VISION,
-  functionCall: config.value.functionCall ?? DEFAULT_MODEL_FUNCTION_CALL,
-  reasoning: config.value.reasoning ?? false,
-  type: config.value.type ?? ModelType.Chat,
-  endpointType: config.value.endpointType
-})
+const buildCustomModelPayload = (id: string, name: string, enabled?: boolean) => {
+  const fixedTemperatureKimi = resolveMoonshotKimiTemperaturePolicy(
+    props.providerId,
+    id,
+    config.value.reasoning
+  )
+
+  return {
+    id,
+    name,
+    enabled: enabled ?? true,
+    contextLength: config.value.contextLength ?? DEFAULT_MODEL_CONTEXT_LENGTH,
+    maxTokens: config.value.maxTokens ?? DEFAULT_MODEL_MAX_TOKENS,
+    vision: config.value.vision ?? DEFAULT_MODEL_VISION,
+    functionCall: config.value.functionCall ?? DEFAULT_MODEL_FUNCTION_CALL,
+    reasoning: fixedTemperatureKimi?.reasoningEnabled ?? config.value.reasoning ?? false,
+    type: config.value.type ?? ModelType.Chat,
+    endpointType: config.value.endpointType
+  }
+}
 
 const syncNewApiDerivedFields = () => {
   if (!showEndpointTypeSelector.value) {
@@ -1252,9 +1292,15 @@ const showReasoningVisibility = computed(
 )
 const supportsTemperatureControl = computed(() => capabilitySupportsTemperature.value !== false)
 const showTemperatureControl = computed(
-  () => supportsTemperatureControl.value && !supportsReasoningEffort.value
+  () =>
+    (supportsTemperatureControl.value || isMoonshotKimiTemperatureLocked.value) &&
+    !supportsReasoningEffort.value
 )
 const reasoningToggleMode = computed(() => {
+  if (moonshotKimiTemperaturePolicy.value?.isThinkingVariant) {
+    return 'indicator' as const
+  }
+
   if (isCreateMode.value || props.isCustomModel) {
     return 'toggle' as const
   }
@@ -1272,9 +1318,11 @@ const reasoningToggleMode = computed(() => {
 })
 const reasoningToggleDisabled = computed(() => reasoningToggleMode.value === 'indicator')
 const reasoningToggleValue = computed(() =>
-  reasoningToggleDisabled.value
-    ? supportsReasoningCapability(capabilityReasoningPortrait.value)
-    : Boolean(config.value.reasoning)
+  moonshotKimiTemperaturePolicy.value?.isThinkingVariant
+    ? true
+    : reasoningToggleDisabled.value
+      ? supportsReasoningCapability(capabilityReasoningPortrait.value)
+      : Boolean(config.value.reasoning)
 )
 const reasoningToggleLabelKey = computed(() =>
   reasoningToggleDisabled.value
@@ -1348,6 +1396,25 @@ watch(
   () => [props.providerId, currentModelLookupId.value, providerModelMeta.value?.id],
   () => {
     syncCapabilityProviderId()
+  },
+  { immediate: true }
+)
+
+watch(
+  () => [props.providerId, currentModelLookupId.value, config.value.reasoning],
+  () => {
+    const fixedTemperatureKimi = resolvedMoonshotKimiTemperaturePolicy.value
+    if (!fixedTemperatureKimi) {
+      return
+    }
+
+    if (config.value.reasoning !== fixedTemperatureKimi.reasoningEnabled) {
+      config.value.reasoning = fixedTemperatureKimi.reasoningEnabled
+    }
+
+    if (config.value.temperature !== fixedTemperatureKimi.temperature) {
+      config.value.temperature = fixedTemperatureKimi.temperature
+    }
   },
   { immediate: true }
 )

--- a/src/renderer/src/i18n/da-DK/chat.json
+++ b/src/renderer/src/i18n/da-DK/chat.json
@@ -147,7 +147,7 @@
     "systemPrompt": "Systemprompt",
     "systemPromptPlaceholder": "Vælg en forudindstilling",
     "temperature": "Temperatur",
-    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 låser temperaturen til {enabled}, når tænkning er aktiveret, og til {disabled}, når den er deaktiveret.",
     "contextLength": "Kontekstlængde",
     "maxTokens": "Maks. tokens",
     "thinkingBudget": "Tænkebudget",

--- a/src/renderer/src/i18n/da-DK/chat.json
+++ b/src/renderer/src/i18n/da-DK/chat.json
@@ -147,6 +147,7 @@
     "systemPrompt": "Systemprompt",
     "systemPromptPlaceholder": "Vælg en forudindstilling",
     "temperature": "Temperatur",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
     "contextLength": "Kontekstlængde",
     "maxTokens": "Maks. tokens",
     "thinkingBudget": "Tænkebudget",

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -411,7 +411,7 @@
       "currentUsingModelDefault": "Bruger i øjeblikket modellens standardkonfiguration",
       "temperature": {
         "description": "Styrer tilfældigheden i output. De fleste modeller bruger 0-1, nogle understøtter 0-2. Højere værdi øger tilfældigheden.",
-        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 låser temperaturen til {enabled}, når tænkning er aktiveret, og til {disabled}, når den er deaktiveret.",
         "label": "Temperatur"
       },
       "title": "Brugerdefinerede modelparametre",

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -411,6 +411,7 @@
       "currentUsingModelDefault": "Bruger i øjeblikket modellens standardkonfiguration",
       "temperature": {
         "description": "Styrer tilfældigheden i output. De fleste modeller bruger 0-1, nogle understøtter 0-2. Højere værdi øger tilfældigheden.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
         "label": "Temperatur"
       },
       "title": "Brugerdefinerede modelparametre",

--- a/src/renderer/src/i18n/en-US/chat.json
+++ b/src/renderer/src/i18n/en-US/chat.json
@@ -154,6 +154,7 @@
     "systemPrompt": "System Prompt",
     "systemPromptPlaceholder": "Select a preset",
     "temperature": "Temperature",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
     "contextLength": "Context Length",
     "maxTokens": "Max Tokens",
     "thinkingBudget": "Thinking Budget",

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -540,6 +540,7 @@
       "currentUsingModelDefault": "Currently using model default configuration",
       "temperature": {
         "description": "Control the randomness of the output. Most models are 0-1, and some support between 0-2. Higher values increase randomness.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
         "label": "Temperature"
       },
       "title": "Custom model parameters",

--- a/src/renderer/src/i18n/fa-IR/chat.json
+++ b/src/renderer/src/i18n/fa-IR/chat.json
@@ -147,7 +147,7 @@
     "systemPrompt": "پرامپت سیستم",
     "systemPromptPlaceholder": "یک پیش‌تنظیم را انتخاب کنید",
     "temperature": "دما",
-    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 وقتی تفکر فعال باشد دما را روی {enabled} و وقتی غیرفعال باشد روی {disabled} ثابت نگه می‌دارد.",
     "contextLength": "طول زمینه",
     "maxTokens": "حداکثر توکن",
     "thinkingBudget": "بودجه تفکر",

--- a/src/renderer/src/i18n/fa-IR/chat.json
+++ b/src/renderer/src/i18n/fa-IR/chat.json
@@ -147,6 +147,7 @@
     "systemPrompt": "پرامپت سیستم",
     "systemPromptPlaceholder": "یک پیش‌تنظیم را انتخاب کنید",
     "temperature": "دما",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
     "contextLength": "طول زمینه",
     "maxTokens": "حداکثر توکن",
     "thinkingBudget": "بودجه تفکر",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -478,7 +478,7 @@
       "currentUsingModelDefault": "در حال حاضر از پیکربندی پیش‌فرض مدل استفاده می‌کند",
       "temperature": {
         "description": "تصادفی بودن خروجی را کنترل کنید. بیشتر مدل ها 0-1 و برخی از پشتیبانی بین 0-2 هستند. هرچه تصادفی بالاتر باشد.",
-        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 وقتی تفکر فعال باشد دما را روی {enabled} و وقتی غیرفعال باشد روی {disabled} ثابت نگه می‌دارد.",
         "label": "درجه حرارت"
       },
       "title": "پارامترهای مدل سفارشی",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -478,6 +478,7 @@
       "currentUsingModelDefault": "در حال حاضر از پیکربندی پیش‌فرض مدل استفاده می‌کند",
       "temperature": {
         "description": "تصادفی بودن خروجی را کنترل کنید. بیشتر مدل ها 0-1 و برخی از پشتیبانی بین 0-2 هستند. هرچه تصادفی بالاتر باشد.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
         "label": "درجه حرارت"
       },
       "title": "پارامترهای مدل سفارشی",

--- a/src/renderer/src/i18n/fr-FR/chat.json
+++ b/src/renderer/src/i18n/fr-FR/chat.json
@@ -147,6 +147,7 @@
     "systemPrompt": "Prompt système",
     "systemPromptPlaceholder": "Sélectionner un préréglage",
     "temperature": "Température",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
     "contextLength": "Longueur du contexte",
     "maxTokens": "Jetons max",
     "thinkingBudget": "Budget de réflexion",

--- a/src/renderer/src/i18n/fr-FR/chat.json
+++ b/src/renderer/src/i18n/fr-FR/chat.json
@@ -147,7 +147,7 @@
     "systemPrompt": "Prompt système",
     "systemPromptPlaceholder": "Sélectionner un préréglage",
     "temperature": "Température",
-    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixe la température à {enabled} lorsque la réflexion est activée et à {disabled} lorsqu’elle est désactivée.",
     "contextLength": "Longueur du contexte",
     "maxTokens": "Jetons max",
     "thinkingBudget": "Budget de réflexion",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -478,7 +478,7 @@
       "currentUsingModelDefault": "Utilise actuellement la configuration par défaut du modèle",
       "temperature": {
         "description": "Contrôle l’aléatoire de la sortie. Valeur plus élevée = plus aléatoire.",
-        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixe la température à {enabled} lorsque la réflexion est activée et à {disabled} lorsqu’elle est désactivée.",
         "label": "Température"
       },
       "title": "Paramètres du modèle personnalisé",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -478,6 +478,7 @@
       "currentUsingModelDefault": "Utilise actuellement la configuration par défaut du modèle",
       "temperature": {
         "description": "Contrôle l’aléatoire de la sortie. Valeur plus élevée = plus aléatoire.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
         "label": "Température"
       },
       "title": "Paramètres du modèle personnalisé",

--- a/src/renderer/src/i18n/he-IL/chat.json
+++ b/src/renderer/src/i18n/he-IL/chat.json
@@ -147,7 +147,7 @@
     "systemPrompt": "הנחיית מערכת",
     "systemPromptPlaceholder": "בחר תבנית",
     "temperature": "טמפרטורה",
-    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 מקבע את הטמפרטורה ל-{enabled} כשהחשיבה מופעלת ול-{disabled} כשהיא כבויה.",
     "contextLength": "אורך הקשר",
     "maxTokens": "מקסימום טוקנים",
     "thinkingBudget": "תקציב חשיבה",

--- a/src/renderer/src/i18n/he-IL/chat.json
+++ b/src/renderer/src/i18n/he-IL/chat.json
@@ -147,6 +147,7 @@
     "systemPrompt": "הנחיית מערכת",
     "systemPromptPlaceholder": "בחר תבנית",
     "temperature": "טמפרטורה",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
     "contextLength": "אורך הקשר",
     "maxTokens": "מקסימום טוקנים",
     "thinkingBudget": "תקציב חשיבה",

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -478,7 +478,7 @@
       "currentUsingModelDefault": "משתמש כעת בתצורת ברירת המחדל של המודל",
       "temperature": {
         "description": "שלוט באקראיות הפלט. רוב המודלים הם 0-1, וחלקם תומכים בין 0-2. ערכים גבוהים יותר מגבירים את האקראיות.",
-        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 מקבע את הטמפרטורה ל-{enabled} כשהחשיבה מופעלת ול-{disabled} כשהיא כבויה.",
         "label": "טמפרטורה"
       },
       "title": "פרמטרים מותאמים למודל",

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -478,6 +478,7 @@
       "currentUsingModelDefault": "משתמש כעת בתצורת ברירת המחדל של המודל",
       "temperature": {
         "description": "שלוט באקראיות הפלט. רוב המודלים הם 0-1, וחלקם תומכים בין 0-2. ערכים גבוהים יותר מגבירים את האקראיות.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
         "label": "טמפרטורה"
       },
       "title": "פרמטרים מותאמים למודל",

--- a/src/renderer/src/i18n/ja-JP/chat.json
+++ b/src/renderer/src/i18n/ja-JP/chat.json
@@ -147,7 +147,7 @@
     "systemPrompt": "システムプロンプト",
     "systemPromptPlaceholder": "プリセットを選択",
     "temperature": "温度",
-    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 は、思考を有効にすると温度が {enabled} に固定され、無効にすると {disabled} に固定されます。",
     "contextLength": "コンテキスト長",
     "maxTokens": "最大トークン",
     "thinkingBudget": "思考予算",

--- a/src/renderer/src/i18n/ja-JP/chat.json
+++ b/src/renderer/src/i18n/ja-JP/chat.json
@@ -147,6 +147,7 @@
     "systemPrompt": "システムプロンプト",
     "systemPromptPlaceholder": "プリセットを選択",
     "temperature": "温度",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
     "contextLength": "コンテキスト長",
     "maxTokens": "最大トークン",
     "thinkingBudget": "思考予算",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -478,7 +478,7 @@
       "currentUsingModelDefault": "現在モデルのデフォルト設定を使用中",
       "temperature": {
         "description": "出力のランダム性を制御します。値が高いほどランダム性が増します。",
-        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 は、思考を有効にすると温度が {enabled} に固定され、無効にすると {disabled} に固定されます。",
         "label": "温度"
       },
       "title": "カスタムモデルパラメーター",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -478,6 +478,7 @@
       "currentUsingModelDefault": "現在モデルのデフォルト設定を使用中",
       "temperature": {
         "description": "出力のランダム性を制御します。値が高いほどランダム性が増します。",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
         "label": "温度"
       },
       "title": "カスタムモデルパラメーター",

--- a/src/renderer/src/i18n/ko-KR/chat.json
+++ b/src/renderer/src/i18n/ko-KR/chat.json
@@ -147,7 +147,7 @@
     "systemPrompt": "시스템 프롬프트",
     "systemPromptPlaceholder": "프리셋 선택",
     "temperature": "온도",
-    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6은 생각이 활성화되면 온도를 {enabled}로, 비활성화되면 {disabled}로 고정합니다.",
     "contextLength": "컨텍스트 길이",
     "maxTokens": "최대 토큰",
     "thinkingBudget": "사고 예산",

--- a/src/renderer/src/i18n/ko-KR/chat.json
+++ b/src/renderer/src/i18n/ko-KR/chat.json
@@ -147,6 +147,7 @@
     "systemPrompt": "시스템 프롬프트",
     "systemPromptPlaceholder": "프리셋 선택",
     "temperature": "온도",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
     "contextLength": "컨텍스트 길이",
     "maxTokens": "최대 토큰",
     "thinkingBudget": "사고 예산",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -478,6 +478,7 @@
       "currentUsingModelDefault": "현재 모델 기본 설정 사용 중",
       "temperature": {
         "description": "출력의 무작위성을 제어하십시오. 대부분의 모델은 0-1이며 일부는 0-2 사이의 지원입니다. 무작위성이 높아집니다.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
         "label": "온도"
       },
       "title": "사용자 정의 모델 매개 변수",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -478,7 +478,7 @@
       "currentUsingModelDefault": "현재 모델 기본 설정 사용 중",
       "temperature": {
         "description": "출력의 무작위성을 제어하십시오. 대부분의 모델은 0-1이며 일부는 0-2 사이의 지원입니다. 무작위성이 높아집니다.",
-        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6은 생각이 활성화되면 온도를 {enabled}로, 비활성화되면 {disabled}로 고정합니다.",
         "label": "온도"
       },
       "title": "사용자 정의 모델 매개 변수",

--- a/src/renderer/src/i18n/pt-BR/chat.json
+++ b/src/renderer/src/i18n/pt-BR/chat.json
@@ -147,6 +147,7 @@
     "systemPrompt": "Prompt do sistema",
     "systemPromptPlaceholder": "Selecione um preset",
     "temperature": "Temperatura",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
     "contextLength": "Tamanho do contexto",
     "maxTokens": "Máx. de tokens",
     "thinkingBudget": "Orçamento de raciocínio",

--- a/src/renderer/src/i18n/pt-BR/chat.json
+++ b/src/renderer/src/i18n/pt-BR/chat.json
@@ -147,7 +147,7 @@
     "systemPrompt": "Prompt do sistema",
     "systemPromptPlaceholder": "Selecione um preset",
     "temperature": "Temperatura",
-    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixa a temperatura em {enabled} quando o modo de pensamento está ativado e em {disabled} quando está desativado.",
     "contextLength": "Tamanho do contexto",
     "maxTokens": "Máx. de tokens",
     "thinkingBudget": "Orçamento de raciocínio",

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -478,7 +478,7 @@
       "currentUsingModelDefault": "Usando a configuração padrão do modelo atualmente",
       "temperature": {
         "description": "Controla a aleatoriedade da saída. A maioria dos modelos é de 0 a 1, e alguns suportam entre 0 e 2. Valores mais altos aumentam a aleatoriedade.",
-        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixa a temperatura em {enabled} quando o modo de pensamento está ativado e em {disabled} quando está desativado.",
         "label": "Temperatura"
       },
       "title": "Parâmetros personalizados do modelo",

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -478,6 +478,7 @@
       "currentUsingModelDefault": "Usando a configuração padrão do modelo atualmente",
       "temperature": {
         "description": "Controla a aleatoriedade da saída. A maioria dos modelos é de 0 a 1, e alguns suportam entre 0 e 2. Valores mais altos aumentam a aleatoriedade.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
         "label": "Temperatura"
       },
       "title": "Parâmetros personalizados do modelo",

--- a/src/renderer/src/i18n/ru-RU/chat.json
+++ b/src/renderer/src/i18n/ru-RU/chat.json
@@ -147,7 +147,7 @@
     "systemPrompt": "Системный промпт",
     "systemPromptPlaceholder": "Выберите пресет",
     "temperature": "Температура",
-    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 фиксирует температуру на уровне {enabled}, когда мышление включено, и на уровне {disabled}, когда оно отключено.",
     "contextLength": "Длина контекста",
     "maxTokens": "Макс. токенов",
     "thinkingBudget": "Бюджет размышления",

--- a/src/renderer/src/i18n/ru-RU/chat.json
+++ b/src/renderer/src/i18n/ru-RU/chat.json
@@ -147,6 +147,7 @@
     "systemPrompt": "Системный промпт",
     "systemPromptPlaceholder": "Выберите пресет",
     "temperature": "Температура",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
     "contextLength": "Длина контекста",
     "maxTokens": "Макс. токенов",
     "thinkingBudget": "Бюджет размышления",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -478,6 +478,7 @@
       "currentUsingModelDefault": "В настоящее время используются настройки модели по умолчанию",
       "temperature": {
         "description": "Управляйте случайностью выхода. Большинство моделей 0-1, а некоторая поддержка между 0-2. Чем выше, тем выше случайность.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
         "label": "температура"
       },
       "title": "Пользовательские параметры модели",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -478,7 +478,7 @@
       "currentUsingModelDefault": "В настоящее время используются настройки модели по умолчанию",
       "temperature": {
         "description": "Управляйте случайностью выхода. Большинство моделей 0-1, а некоторая поддержка между 0-2. Чем выше, тем выше случайность.",
-        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 fixes temperature to {enabled} when thinking is enabled and {disabled} when it is disabled.",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 фиксирует температуру на уровне {enabled}, когда мышление включено, и на уровне {disabled}, когда оно отключено.",
         "label": "температура"
       },
       "title": "Пользовательские параметры модели",

--- a/src/renderer/src/i18n/zh-CN/chat.json
+++ b/src/renderer/src/i18n/zh-CN/chat.json
@@ -154,6 +154,7 @@
     "systemPrompt": "系统提示词",
     "systemPromptPlaceholder": "选择预设",
     "temperature": "温度",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 在开启思考时固定为 {enabled}，关闭思考时固定为 {disabled}。",
     "contextLength": "上下文长度",
     "maxTokens": "最大输出",
     "thinkingBudget": "思考预算",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -480,7 +480,8 @@
       },
       "temperature": {
         "label": "温度",
-        "description": "控制输出的随机性，大部分模型0-1，部分支持0-2之间，越高越随机"
+        "description": "控制输出的随机性，大部分模型0-1，部分支持0-2之间，越高越随机",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 在开启思考时固定为 {enabled}，关闭思考时固定为 {disabled}。"
       },
       "vision": {
         "label": "视觉能力",

--- a/src/renderer/src/i18n/zh-HK/chat.json
+++ b/src/renderer/src/i18n/zh-HK/chat.json
@@ -151,6 +151,7 @@
     "systemPrompt": "系統提示詞",
     "systemPromptPlaceholder": "選擇預設",
     "temperature": "溫度",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 在開啟思考時固定為 {enabled}，關閉思考時固定為 {disabled}。",
     "contextLength": "上下文長度",
     "maxTokens": "最大輸出",
     "thinkingBudget": "思考預算",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -478,6 +478,7 @@
       "currentUsingModelDefault": "目前使用模型預設配置",
       "temperature": {
         "description": "控制輸出的隨機性，大部分模型0-1，部分支持0-2之間，越高越隨機",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 在開啟思考時固定為 {enabled}，關閉思考時固定為 {disabled}。",
         "label": "溫度"
       },
       "title": "自定義模型參數",

--- a/src/renderer/src/i18n/zh-TW/chat.json
+++ b/src/renderer/src/i18n/zh-TW/chat.json
@@ -151,6 +151,7 @@
     "systemPrompt": "系統提示詞",
     "systemPromptPlaceholder": "選擇預設",
     "temperature": "溫度",
+    "temperatureFixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 在開啟思考時固定為 {enabled}，關閉思考時固定為 {disabled}。",
     "contextLength": "上下文長度",
     "maxTokens": "最大輸出",
     "thinkingBudget": "思考預算",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -478,6 +478,7 @@
       "currentUsingModelDefault": "目前使用模型預設配置",
       "temperature": {
         "description": "控制輸出的隨機性，大部分模型0-1，部分支持0-2之間，越高越隨機",
+        "fixedMoonshotKimi": "Moonshot Kimi K2.5/K2.6 在開啟思考時固定為 {enabled}，關閉思考時固定為 {disabled}。",
         "label": "溫度"
       },
       "title": "自定義模型參數",

--- a/src/shared/moonshotKimiPolicy.ts
+++ b/src/shared/moonshotKimiPolicy.ts
@@ -1,0 +1,103 @@
+const THINKING_SUFFIX = ':thinking'
+const FIXED_TEMPERATURE_MODELS = new Set([
+  'kimi-k2.5',
+  'kimi-k2.6',
+  'moonshotai/kimi-k2.5',
+  'moonshotai/kimi-k2.6'
+])
+
+export const MOONSHOT_KIMI_THINKING_ENABLED_TEMPERATURE = 1.0
+export const MOONSHOT_KIMI_THINKING_DISABLED_TEMPERATURE = 0.6
+
+export interface MoonshotKimiTemperaturePolicy {
+  modelId: string
+  baseModelId: string
+  isThinkingVariant: boolean
+  lockTemperatureControl: true
+  thinkingEnabledTemperature: typeof MOONSHOT_KIMI_THINKING_ENABLED_TEMPERATURE
+  thinkingDisabledTemperature: typeof MOONSHOT_KIMI_THINKING_DISABLED_TEMPERATURE
+}
+
+export interface ResolvedMoonshotKimiTemperaturePolicy extends MoonshotKimiTemperaturePolicy {
+  reasoningEnabled: boolean
+  temperature: number
+  thinkingType: 'enabled' | 'disabled'
+}
+
+const normalizeModelId = (modelId: string | null | undefined): string =>
+  modelId
+    ?.trim()
+    .toLowerCase()
+    .replace(/^models\//, '') ?? ''
+
+export const getMoonshotKimiTemperaturePolicy = (
+  _providerId: string | null | undefined,
+  modelId: string | null | undefined
+): MoonshotKimiTemperaturePolicy | null => {
+  const normalizedModelId = normalizeModelId(modelId)
+  if (!normalizedModelId) {
+    return null
+  }
+
+  const isThinkingVariant = normalizedModelId.endsWith(THINKING_SUFFIX)
+  const baseModelId = isThinkingVariant
+    ? normalizedModelId.slice(0, -THINKING_SUFFIX.length)
+    : normalizedModelId
+
+  if (!FIXED_TEMPERATURE_MODELS.has(baseModelId)) {
+    return null
+  }
+
+  return {
+    modelId: normalizedModelId,
+    baseModelId,
+    isThinkingVariant,
+    lockTemperatureControl: true,
+    thinkingEnabledTemperature: MOONSHOT_KIMI_THINKING_ENABLED_TEMPERATURE,
+    thinkingDisabledTemperature: MOONSHOT_KIMI_THINKING_DISABLED_TEMPERATURE
+  }
+}
+
+export const resolveMoonshotKimiTemperaturePolicy = (
+  providerId: string | null | undefined,
+  modelId: string | null | undefined,
+  reasoning: boolean | null | undefined
+): ResolvedMoonshotKimiTemperaturePolicy | null => {
+  const policy = getMoonshotKimiTemperaturePolicy(providerId, modelId)
+  if (!policy) {
+    return null
+  }
+
+  const reasoningEnabled = policy.isThinkingVariant ? true : reasoning === true
+
+  return {
+    ...policy,
+    reasoningEnabled,
+    temperature: reasoningEnabled
+      ? policy.thinkingEnabledTemperature
+      : policy.thinkingDisabledTemperature,
+    thinkingType: reasoningEnabled ? 'enabled' : 'disabled'
+  }
+}
+
+export const applyMoonshotKimiReasoningTemperaturePolicy = <
+  T extends {
+    reasoning?: boolean
+    temperature?: number
+  }
+>(
+  providerId: string | null | undefined,
+  modelId: string | null | undefined,
+  value: T
+): T => {
+  const resolved = resolveMoonshotKimiTemperaturePolicy(providerId, modelId, value.reasoning)
+  if (!resolved) {
+    return value
+  }
+
+  return {
+    ...value,
+    reasoning: resolved.reasoningEnabled,
+    temperature: resolved.temperature
+  }
+}

--- a/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
@@ -1936,6 +1936,70 @@ describe('AgentRuntimePresenter', () => {
       )
     })
 
+    it('normalizes Moonshot Kimi generation temperatures from model reasoning defaults', async () => {
+      configPresenter.getModelConfig.mockImplementation((modelId: string, providerId: string) => {
+        if (providerId === 'moonshot' && modelId === 'moonshotai/kimi-k2.6') {
+          return {
+            temperature: 0.6,
+            maxTokens: 4096,
+            contextLength: 128000,
+            reasoning: true,
+            thinkingBudget: 512,
+            vision: false
+          }
+        }
+
+        return {
+          temperature: 0.7,
+          maxTokens: 4096,
+          contextLength: 128000,
+          thinkingBudget: 512,
+          reasoningEffort: 'medium',
+          verbosity: 'medium',
+          vision: false
+        }
+      })
+      configPresenter.getReasoningPortrait.mockImplementation(
+        (providerId: string, modelId: string) => {
+          if (providerId === 'moonshot' && modelId === 'moonshotai/kimi-k2.6') {
+            return {
+              supported: true,
+              defaultEnabled: true,
+              mode: 'budget',
+              budget: { min: 0, max: 32768, default: 8192 }
+            }
+          }
+          return {
+            supported: true,
+            defaultEnabled: true,
+            mode: 'effort',
+            budget: { min: 0, max: 8192, default: 512 },
+            effort: 'medium',
+            effortOptions: ['minimal', 'low', 'medium', 'high'],
+            verbosity: 'medium',
+            verbosityOptions: ['low', 'medium', 'high']
+          }
+        }
+      )
+
+      await agent.initSession('s1', { providerId: 'moonshot', modelId: 'moonshotai/kimi-k2.6' })
+
+      const defaults = await agent.getGenerationSettings('s1')
+      expect(defaults?.temperature).toBe(1)
+
+      const updated = await agent.updateGenerationSettings('s1', {
+        temperature: 0.2
+      })
+
+      expect(updated.temperature).toBe(1)
+      expect(sqlitePresenter.deepchatSessionsTable.updateGenerationSettings).toHaveBeenCalledWith(
+        's1',
+        expect.objectContaining({
+          temperature: 1
+        })
+      )
+    })
+
     it('inherits interleaved thinking defaults and allows explicit session disable', async () => {
       configPresenter.getModelConfig.mockReturnValue({
         temperature: 0.7,

--- a/test/main/presenter/llmProviderPresenter/aiSdkProviderOptionsMapper.test.ts
+++ b/test/main/presenter/llmProviderPresenter/aiSdkProviderOptionsMapper.test.ts
@@ -43,6 +43,70 @@ describe('AI SDK provider options', () => {
     mockSupportsReasoning.mockReturnValue(false)
   })
 
+  it('maps Moonshot Kimi thinking state through providerOptions even when temperature is fixed', () => {
+    const enabled = buildProviderOptions({
+      providerId: 'moonshot',
+      capabilityProviderId: 'moonshot',
+      providerOptionsKey: 'openai',
+      apiType: 'openai_chat',
+      modelId: 'moonshotai/kimi-k2.6',
+      modelConfig: {
+        reasoning: true,
+        temperature: 0.6
+      } as any,
+      tools: [],
+      messages: []
+    })
+
+    expect(enabled.providerOptions?.openai).toMatchObject({
+      thinking: {
+        type: 'enabled'
+      }
+    })
+
+    const disabled = buildProviderOptions({
+      providerId: 'moonshot',
+      capabilityProviderId: 'moonshot',
+      providerOptionsKey: 'openai',
+      apiType: 'openai_chat',
+      modelId: 'moonshotai/kimi-k2.6',
+      modelConfig: {
+        reasoning: false,
+        temperature: 1
+      } as any,
+      tools: [],
+      messages: []
+    })
+
+    expect(disabled.providerOptions?.openai).toMatchObject({
+      thinking: {
+        type: 'disabled'
+      }
+    })
+  })
+
+  it('maps Kimi thinking state for transport-compatible proxy providers as well', () => {
+    const result = buildProviderOptions({
+      providerId: 'new-api',
+      capabilityProviderId: 'new-api',
+      providerOptionsKey: 'openai',
+      apiType: 'openai_chat',
+      modelId: 'kimi-k2.6',
+      modelConfig: {
+        reasoning: true,
+        temperature: 1.4
+      } as any,
+      tools: [],
+      messages: []
+    })
+
+    expect(result.providerOptions?.openai).toMatchObject({
+      thinking: {
+        type: 'enabled'
+      }
+    })
+  })
+
   it('maps official anthropic adaptive reasoning controls when enabled', () => {
     mockGetReasoningPortrait.mockReturnValue({
       supported: true,

--- a/test/main/presenter/llmProviderPresenter/aiSdkRuntime.test.ts
+++ b/test/main/presenter/llmProviderPresenter/aiSdkRuntime.test.ts
@@ -254,6 +254,76 @@ describe('AI SDK runtime', () => {
     expect(tracePayloads[0]?.body).toHaveProperty('temperature', 0.6)
   })
 
+  it('forces Moonshot Kimi temperature to 1.0 when reasoning is enabled', async () => {
+    const tracePayloads: Array<{ body?: Record<string, unknown> }> = []
+    const context = {
+      providerKind: 'openai-compatible',
+      provider: {
+        id: 'moonshot',
+        apiType: 'openai-compatible'
+      },
+      configPresenter: {},
+      defaultHeaders: {},
+      emitRequestTrace: vi.fn(async (_modelConfig, payload) => {
+        tracePayloads.push(payload)
+      })
+    } as any
+
+    await runAiSdkGenerateText(
+      context,
+      [],
+      'moonshotai/kimi-k2.6',
+      {
+        apiEndpoint: 'chat',
+        reasoning: true
+      } as any,
+      0.6,
+      1024
+    )
+
+    const request = mockGenerateText.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(request).toHaveProperty('temperature', 1)
+    expect(tracePayloads[0]?.body).toHaveProperty('temperature', 1)
+  })
+
+  it('forces Moonshot Kimi temperature to 0.6 when reasoning is disabled', async () => {
+    const tracePayloads: Array<{ body?: Record<string, unknown> }> = []
+    const context = {
+      providerKind: 'openai-compatible',
+      provider: {
+        id: 'moonshot',
+        apiType: 'openai-compatible'
+      },
+      configPresenter: {},
+      defaultHeaders: {},
+      emitRequestTrace: vi.fn(async (_modelConfig, payload) => {
+        tracePayloads.push(payload)
+      })
+    } as any
+
+    const events = []
+    for await (const event of runAiSdkCoreStream(
+      context,
+      [],
+      'moonshotai/kimi-k2.6',
+      {
+        apiEndpoint: 'chat',
+        reasoning: false,
+        functionCall: false
+      } as any,
+      1,
+      2048,
+      []
+    )) {
+      events.push(event)
+    }
+
+    const request = mockStreamText.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(request).toHaveProperty('temperature', 0.6)
+    expect(tracePayloads[0]?.body).toHaveProperty('temperature', 0.6)
+    expect(events).toEqual([])
+  })
+
   it('passes anthropic adaptive reasoning options through runtime context for zenmux routes', async () => {
     mockCreateAiSdkProviderContext.mockReturnValue({
       providerOptionsKey: 'anthropic',

--- a/test/main/presenter/providerDbModelConfig.test.ts
+++ b/test/main/presenter/providerDbModelConfig.test.ts
@@ -139,6 +139,42 @@ describe('Provider DB strict matching + user overrides', () => {
               }
             }
           ]
+        },
+        moonshot: {
+          id: 'moonshot',
+          name: 'Moonshot',
+          models: [
+            {
+              id: 'moonshotai/kimi-k2.6',
+              reasoning: {
+                supported: true,
+                default: true
+              },
+              extra_capabilities: {
+                reasoning: {
+                  supported: true,
+                  default_enabled: true,
+                  mode: 'budget',
+                  budget: { min: 0, max: 32768, default: 8192 }
+                }
+              }
+            },
+            {
+              id: 'moonshotai/kimi-k2.6:thinking',
+              reasoning: {
+                supported: true,
+                default: false
+              },
+              extra_capabilities: {
+                reasoning: {
+                  supported: true,
+                  default_enabled: false,
+                  mode: 'budget',
+                  budget: { min: 0, max: 32768, default: 8192 }
+                }
+              }
+            }
+          ]
         }
       }
     }
@@ -316,6 +352,24 @@ describe('Provider DB strict matching + user overrides', () => {
     expect(cfg.reasoning).toBe(false)
     expect(cfg.reasoningEffort).toBe('none')
     expect(cfg.verbosity).toBe('medium')
+  })
+
+  it('forces Moonshot Kimi defaults to the thinking-enabled temperature when reasoning defaults on', () => {
+    const helper = new ModelConfigHelper('1.0.0')
+
+    const cfg = helper.getModelConfig('moonshotai/kimi-k2.6', 'moonshot')
+
+    expect(cfg.reasoning).toBe(true)
+    expect(cfg.temperature).toBe(1)
+  })
+
+  it('forces Moonshot Kimi :thinking variants to keep reasoning on and temperature at 1.0', () => {
+    const helper = new ModelConfigHelper('1.0.0')
+
+    const cfg = helper.getModelConfig('moonshotai/kimi-k2.6:thinking', 'moonshot')
+
+    expect(cfg.reasoning).toBe(true)
+    expect(cfg.temperature).toBe(1)
   })
 
   it('recomputes reasoning-related fields for provider cached configs', () => {

--- a/test/renderer/components/ChatStatusBar.test.ts
+++ b/test/renderer/components/ChatStatusBar.test.ts
@@ -10,6 +10,7 @@ type TestGenerationSettings = {
   temperature: number
   contextLength: number
   maxTokens: number
+  reasoning?: boolean
   thinkingBudget?: number
   forceInterleavedThinkingCompat?: boolean
   reasoningEffort?: ReasoningEffort
@@ -1419,6 +1420,42 @@ describe('ChatStatusBar model and session panels', () => {
 
     expect((wrapper.vm as any).localSettings.forceInterleavedThinkingCompat).toBe(true)
     expect(findInterleavedThinkingToggle(wrapper).attributes('data-model-value')).toBe('true')
+  })
+
+  it('locks Moonshot Kimi temperatures in chat advanced settings and keeps the fixed value', async () => {
+    const { wrapper } = await setup({
+      agentId: 'deepchat',
+      hasActiveSession: false,
+      extraModelGroups: [
+        {
+          providerId: 'moonshot',
+          providerName: 'Moonshot',
+          models: [{ id: 'moonshotai/kimi-k2.6', name: 'Kimi K2.6' }]
+        }
+      ],
+      modelConfig: {
+        temperature: 0.6,
+        reasoning: true
+      },
+      reasoningPortrait: {
+        supported: true,
+        defaultEnabled: true,
+        mode: 'budget',
+        budget: { min: 0, max: 32768, default: 8192 }
+      }
+    })
+
+    await (wrapper.vm as any).openModelSettings('moonshot', 'moonshotai/kimi-k2.6')
+    await flushPromises()
+
+    expect((wrapper.vm as any).localSettings.temperature).toBe(1)
+    expect((wrapper.vm as any).isMoonshotKimiTemperatureLocked).toBe(true)
+    expect(wrapper.text()).toContain('chat.advancedSettings.temperatureFixedMoonshotKimi')
+    expect(findNumericButton(wrapper, 'temperature', 'increment').attributes('disabled')).toBe('')
+    expect(findNumericInput(wrapper, 'temperature').attributes('disabled')).toBe('')
+
+    await findNumericButton(wrapper, 'temperature', 'increment').trigger('click')
+    expect((wrapper.vm as any).localSettings.temperature).toBe(1)
   })
 
   it('ignores existing draft generation overrides when loading draft model defaults', async () => {

--- a/test/renderer/components/ModelConfigDialog.test.ts
+++ b/test/renderer/components/ModelConfigDialog.test.ts
@@ -518,6 +518,55 @@ describe('ModelConfigDialog reasoning portraits', () => {
 
     expect(wrapper.text()).not.toContain('settings.model.modelConfig.temperature.label')
   })
+
+  it('locks Moonshot Kimi temperatures and treats :thinking variants as indicator-only reasoning', async () => {
+    const { wrapper } = await setup({
+      providerId: 'moonshot',
+      modelId: 'moonshotai/kimi-k2.6:thinking',
+      modelName: 'Kimi K2.6 Thinking',
+      modelConfig: {
+        reasoning: false,
+        temperature: 0.6
+      },
+      reasoningPortrait: {
+        supported: true,
+        defaultEnabled: false,
+        mode: 'budget',
+        budget: { min: 0, max: 32768, default: 8192 }
+      }
+    })
+
+    expect((wrapper.vm as any).isMoonshotKimiTemperatureLocked).toBe(true)
+    expect((wrapper.vm as any).moonshotKimiTemperatureHint).toBe(
+      'settings.model.modelConfig.temperature.fixedMoonshotKimi'
+    )
+    expect((wrapper.vm as any).config.temperature).toBe(1)
+    expect((wrapper.vm as any).config.reasoning).toBe(true)
+    expect((wrapper.vm as any).reasoningToggleMode).toBe('indicator')
+    expect((wrapper.vm as any).reasoningToggleValue).toBe(true)
+  })
+
+  it('locks Kimi temperatures for proxy-style providers too, not only the official Moonshot provider', async () => {
+    const { wrapper } = await setup({
+      providerId: 'new-api',
+      providerApiType: 'new-api',
+      modelId: 'kimi-k2.6',
+      modelName: 'Kimi K2.6',
+      modelConfig: {
+        reasoning: true,
+        temperature: 1.4
+      },
+      reasoningPortrait: {
+        supported: true,
+        defaultEnabled: true,
+        mode: 'budget',
+        budget: { min: 0, max: 32768, default: 8192 }
+      }
+    })
+
+    expect((wrapper.vm as any).isMoonshotKimiTemperatureLocked).toBe(true)
+    expect((wrapper.vm as any).config.temperature).toBe(1)
+  })
 })
 
 describe('ModelConfigDialog new-api endpoint normalization', () => {


### PR DESCRIPTION
https://platform.kimi.com/docs/guide/kimi-k2-6-quickstart#%E5%8F%82%E6%95%B0%E5%8F%98%E5%8A%A8%E8%AF%B4%E6%98%8E
<img width="814" height="163" alt="image" src="https://github.com/user-attachments/assets/8b8fb399-e41d-44bf-9895-9b07d5bf2878" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Moonshot Kimi K2.5/K2.6 models now automatically lock temperature based on thinking mode (1.0 when enabled, 0.6 when disabled). Temperature controls become disabled in chat and settings interfaces when this policy is active.

* **Localization**
  - Added temperature-locking explanations across 12 supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->