### PR TITLE
fix(settings): add model initialization and respect chat mode option …

### DIFF
--- a/src/renderer/settings/App.vue
+++ b/src/renderer/settings/App.vue
@@ -607,6 +607,13 @@ onMounted(async () => {
     console.error(`${SETTINGS_STARTUP_LOG_PREFIX} provider summaries failed:`, error)
   }
 
+  try {
+    await modelStore.initialize()
+    logSettingsStartup('enabled models ready')
+  } catch (error) {
+    console.error(`${SETTINGS_STARTUP_LOG_PREFIX} enabled models failed:`, error)
+  }
+
   markStartupInteractive()
   window.addEventListener('focus', handleWindowFocus)
   await syncPendingProviderInstall()

--- a/src/renderer/settings/components/BuiltinKnowledgeSettings.vue
+++ b/src/renderer/settings/components/BuiltinKnowledgeSettings.vue
@@ -204,6 +204,7 @@
                   <PopoverContent class="w-80 p-0">
                     <ModelSelect
                       :type="[ModelType.Embedding]"
+                      :respect-chat-mode="false"
                       @update:model="handleEmbeddingModelSelect"
                     />
                   </PopoverContent>
@@ -254,6 +255,7 @@
                   <PopoverContent class="w-80 p-0">
                     <ModelSelect
                       :type="[ModelType.Rerank]"
+                      :respect-chat-mode="false"
                       @update:model="handleRerankModelSelect"
                     />
                   </PopoverContent>

--- a/src/renderer/settings/components/DeepChatAgentsSettings.vue
+++ b/src/renderer/settings/components/DeepChatAgentsSettings.vue
@@ -259,6 +259,7 @@
                   </div>
                   <ModelSelect
                     :exclude-providers="['acp']"
+                    :respect-chat-mode="false"
                     :vision-only="field.key === 'visionModel'"
                     @update:model="(model, providerId) => selectModel(field.key, model, providerId)"
                   />

--- a/src/renderer/settings/components/common/DefaultModelSettingsSection.vue
+++ b/src/renderer/settings/components/common/DefaultModelSettingsSection.vue
@@ -31,7 +31,11 @@
             </Button>
           </PopoverTrigger>
           <PopoverContent class="w-[320px] p-0" align="end">
-            <ModelSelect :exclude-providers="['acp']" @update:model="handleAssistantModelSelect" />
+            <ModelSelect
+              :exclude-providers="['acp']"
+              :respect-chat-mode="false"
+              @update:model="handleAssistantModelSelect"
+            />
           </PopoverContent>
         </Popover>
       </div>
@@ -63,7 +67,11 @@
             </Button>
           </PopoverTrigger>
           <PopoverContent class="w-[320px] p-0" align="end">
-            <ModelSelect :exclude-providers="['acp']" @update:model="handleChatModelSelect" />
+            <ModelSelect
+              :exclude-providers="['acp']"
+              :respect-chat-mode="false"
+              @update:model="handleChatModelSelect"
+            />
           </PopoverContent>
         </Popover>
       </div>

--- a/src/renderer/src/components/ModelSelect.vue
+++ b/src/renderer/src/components/ModelSelect.vue
@@ -66,6 +66,10 @@ const props = defineProps({
     type: Array as PropType<ModelType[]>,
     default: undefined
   },
+  respectChatMode: {
+    type: Boolean,
+    default: true
+  },
   excludeProviders: {
     type: Array as PropType<string[]>,
     default: () => []
@@ -92,11 +96,13 @@ const providers = computed(() => {
   return sortedProviders
     .filter((provider) => provider.enable && !props.excludeProviders.includes(provider.id))
     .map((provider) => {
-      if (currentMode === 'acp agent' && provider.id !== 'acp') {
-        return null
-      }
-      if (currentMode !== 'acp agent' && provider.id === 'acp') {
-        return null
+      if (props.respectChatMode) {
+        if (currentMode === 'acp agent' && provider.id !== 'acp') {
+          return null
+        }
+        if (currentMode !== 'acp agent' && provider.id === 'acp') {
+          return null
+        }
       }
 
       const enabledProvider = enabledModels.find((item) => item.providerId === provider.id)

--- a/test/renderer/components/ModelSelect.test.ts
+++ b/test/renderer/components/ModelSelect.test.ts
@@ -3,12 +3,20 @@ import { mount } from '@vue/test-utils'
 import { ref } from 'vue'
 import { ModelType } from '../../../src/shared/model'
 
-const setup = async () => {
+const setup = async (
+  options: {
+    currentMode?: 'agent' | 'acp agent'
+    props?: Record<string, unknown>
+  } = {}
+) => {
   vi.resetModules()
+
+  const currentMode = options.currentMode ?? 'agent'
 
   vi.doMock('@/stores/providerStore', () => ({
     useProviderStore: () => ({
       sortedProviders: [
+        { id: 'acp', name: 'ACP', enable: true },
         { id: 'ollama', name: 'Ollama', enable: true },
         { id: 'openai', name: 'OpenAI', enable: true }
       ]
@@ -24,6 +32,10 @@ const setup = async () => {
             { id: 'deepseek-r1:1.5b', name: 'deepseek-r1:1.5b', type: 'chat' },
             { id: 'nomic-embed-text:latest', name: 'nomic-embed-text:latest', type: 'embedding' }
           ]
+        },
+        {
+          providerId: 'acp',
+          models: [{ id: 'acp-agent', name: 'ACP Agent', type: 'chat' }]
         }
       ]
     })
@@ -43,7 +55,7 @@ const setup = async () => {
 
   vi.doMock('@/components/chat-input/composables/useChatMode', () => ({
     useChatMode: () => ({
-      currentMode: ref('agent')
+      currentMode: ref(currentMode)
     })
   }))
 
@@ -74,7 +86,8 @@ const setup = async () => {
 
   return mount(ModelSelect, {
     props: {
-      type: [ModelType.Chat]
+      type: [ModelType.Chat],
+      ...options.props
     }
   })
 }
@@ -92,5 +105,18 @@ describe('ModelSelect', () => {
     expect(wrapper.emitted('update:model')).toEqual([
       [{ id: 'deepseek-r1:1.5b', name: 'deepseek-r1:1.5b', type: 'chat' }, 'ollama']
     ])
+  })
+
+  it('can ignore chat mode filtering for settings pickers', async () => {
+    const wrapper = await setup({
+      currentMode: 'acp agent',
+      props: {
+        excludeProviders: ['acp'],
+        respectChatMode: false
+      }
+    })
+
+    expect(wrapper.text()).toContain('deepseek-r1:1.5b')
+    expect(wrapper.text()).not.toContain('ACP Agent')
   })
 })

--- a/test/renderer/components/SettingsApp.test.ts
+++ b/test/renderer/components/SettingsApp.test.ts
@@ -17,6 +17,7 @@ describe('Settings App', () => {
     const ipcRemoveListener = vi.fn()
     const ipcRemoveAllListeners = vi.fn()
     const ipcSend = vi.fn()
+    const initializeModelStore = vi.fn().mockResolvedValue(undefined)
 
     ;(window as any).electron = {
       ipcRenderer: {
@@ -119,7 +120,7 @@ describe('Settings App', () => {
     }))
     vi.doMock('../../../src/renderer/src/stores/modelStore', () => ({
       useModelStore: () => ({
-        initialize: vi.fn().mockResolvedValue(undefined),
+        initialize: initializeModelStore,
         ensureProviderModelsReady: vi.fn().mockResolvedValue(undefined)
       })
     }))
@@ -207,6 +208,7 @@ describe('Settings App', () => {
     await flushPromises()
 
     expect(isReady).toHaveBeenCalledTimes(1)
+    expect(initializeModelStore).toHaveBeenCalledTimes(1)
     expect(ipcSend).toHaveBeenCalledWith(SETTINGS_EVENTS.READY)
   }, 15000)
 


### PR DESCRIPTION
…in ModelSelect

fix 

<img width="1588" height="506" alt="39d03c5f8b35e582617232467d802b74" src="https://github.com/user-attachments/assets/0e3c380f-1de2-4f51-af1d-3e864607f493" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Model selection in settings pages (Built-in Knowledge, DeepChat Agents, and Default Models) now displays all available models regardless of current chat mode context, providing greater flexibility when configuring settings.

* **Changes**
  * Settings app startup sequence now includes an additional initialization step to ensure models are fully loaded before the interface becomes interactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->