### PR TITLE
chore(release): prepare v1.0.3-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.0.3-beta.6 (2026-04-22)
+- Added model initialization in settings so ModelSelect respects the current chat mode and restores default model controls more reliably
+- Added ACP registry icon request handling in the floating widget to improve agent icon rendering and related session visuals
+- Simplified YoBrowser host readiness handling to keep the embedded browser lifecycle more predictable
+- 新增设置页模型初始化流程，使 ModelSelect 更准确地遵循当前聊天模式，并提升默认模型配置恢复稳定性
+- 新增悬浮组件中的 ACP registry 图标请求处理，优化 Agent 图标渲染与相关会话视觉表现
+- 精简 YoBrowser host readiness 处理逻辑，提升内嵌浏览器生命周期的可预测性
+
 ## v1.0.3-beta.5 (2026-04-22)
 - Added privacy mode and inline chat session renaming to improve workspace discretion and session organization
 - Added request timeout controls with a higher default range, and refined Kimi fixed-temperature plus Gemini v1beta compatibility handling

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DeepChat",
-  "version": "1.0.3-beta.5",
+  "version": "1.0.3-beta.6",
   "description": "DeepChat，一个简单易用的 Agent 客户端",
   "main": "./out/main/index.js",
   "author": "ThinkInAIXYZ",

--- a/src/main/events.ts
+++ b/src/main/events.ts
@@ -237,6 +237,7 @@ export const FLOATING_BUTTON_EVENTS = {
   LANGUAGE_CHANGED: 'floating-button:language-changed',
   THEME_REQUEST: 'floating-button:theme-request',
   THEME_CHANGED: 'floating-button:theme-changed',
+  ACP_REGISTRY_ICON_REQUEST: 'floating-button:acp-registry-icon-request',
   TOGGLE_EXPANDED: 'floating-button:toggle-expanded',
   SET_EXPANDED: 'floating-button:set-expanded',
   OPEN_SESSION: 'floating-button:open-session',

--- a/src/main/presenter/browser/YoBrowserPresenter.ts
+++ b/src/main/presenter/browser/YoBrowserPresenter.ts
@@ -28,7 +28,6 @@ type SessionBrowserState = {
   visible: boolean
   attachedWindowId: number | null
   lastBounds: Rectangle | null
-  hostReady: boolean
 }
 
 type HostWindowListeners = {
@@ -38,25 +37,13 @@ type HostWindowListeners = {
   closed: () => void
 }
 
-type HostReadyWaiter = {
-  sessionId: string
-  hostWindowId: number
-  timeoutId: NodeJS.Timeout
-  stableTimerId: NodeJS.Timeout | null
-  resolve: () => void
-  reject: (error: Error) => void
-}
-
 export class YoBrowserPresenter implements IYoBrowserPresenter {
   private readonly sessionBrowsers = new Map<string, SessionBrowserState>()
   private readonly hostWindowListeners = new Map<number, HostWindowListeners>()
-  private readonly hostReadyWaiters = new Map<string, HostReadyWaiter>()
   private readonly cdpManager = new CDPManager()
   private readonly screenshotManager = new ScreenshotManager(this.cdpManager)
   private readonly downloadManager = new DownloadManager()
   private readonly windowPresenter: IWindowPresenter
-  private readonly embeddedHostReadyTimeoutMs = 5000
-  private readonly embeddedHostReadyStableMs = 120
   readonly toolHandler: YoBrowserToolHandler
 
   constructor(windowPresenter: IWindowPresenter) {
@@ -92,7 +79,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
     }
 
     const state = this.ensureSessionBrowserState(normalizedSessionId)
-    this.markHostNotReady(state)
     this.logLifecycle('open requested', {
       sessionId: normalizedSessionId,
       windowId: resolvedHostWindowId,
@@ -100,9 +86,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
     })
 
     this.emitOpenRequested(normalizedSessionId, resolvedHostWindowId, url)
-    this.windowPresenter.show(resolvedHostWindowId, true)
-
-    await this.waitForSessionHostReady(normalizedSessionId, resolvedHostWindowId, state)
     await state.page.navigateUntilDomReady(url, timeoutMs ?? 30000)
     state.updatedAt = Date.now()
     this.emitWindowUpdated(normalizedSessionId)
@@ -127,7 +110,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
     }
 
     if (state.attachedWindowId !== hostWindowId) {
-      this.markHostNotReady(state)
       try {
         hostWindow.contentView.addChildView(state.view)
       } catch {
@@ -163,7 +145,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
     state.updatedAt = Date.now()
 
     if (!visible || normalizedBounds.width <= 0 || normalizedBounds.height <= 0) {
-      this.markHostNotReady(state)
       this.setSessionVisibility(state, false)
       return
     }
@@ -177,7 +158,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
 
     state.view.setBounds(normalizedBounds)
     this.setSessionVisibility(state, true)
-    this.scheduleSessionHostReady(sessionId, hostWindowId, normalizedBounds)
   }
 
   async detachSessionBrowser(sessionId: string): Promise<void> {
@@ -187,7 +167,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
     }
 
     this.detachFromWindow(state, state.attachedWindowId)
-    this.markHostNotReady(state)
     state.updatedAt = Date.now()
     this.setSessionVisibility(state, false)
   }
@@ -198,10 +177,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       return
     }
 
-    this.resolveOrRejectHostReadyWait(
-      sessionId,
-      new Error(`Session browser ${sessionId} was destroyed before it became ready`)
-    )
     await this.detachSessionBrowser(sessionId)
     state.page.destroy()
     this.sessionBrowsers.delete(sessionId)
@@ -353,8 +328,7 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       updatedAt: now,
       visible: false,
       attachedWindowId: null,
-      lastBounds: null,
-      hostReady: false
+      lastBounds: null
     }
 
     this.sessionBrowsers.set(sessionId, state)
@@ -460,14 +434,9 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       return
     }
 
-    this.resolveOrRejectHostReadyWait(
-      sessionId,
-      new Error(`Session browser ${sessionId} was destroyed before it became ready`)
-    )
     state.page.destroy()
     state.attachedWindowId = null
     state.visible = false
-    state.hostReady = false
     this.sessionBrowsers.delete(sessionId)
     this.emitWindowClosed(sessionId)
     this.emitWindowCount()
@@ -513,7 +482,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       const state = this.findAttachedStateByWindowId(windowId)
       if (state) {
         state.attachedWindowId = null
-        state.hostReady = false
         this.setSessionVisibility(state, false)
       }
       this.detachHostWindowListeners(windowId)
@@ -550,7 +518,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       }
 
       this.detachFromWindow(state, hostWindowId)
-      this.markHostNotReady(state)
       this.setSessionVisibility(state, false)
       state.updatedAt = Date.now()
       this.emitWindowUpdated(state.sessionId)
@@ -609,120 +576,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
     return firstWindow && !firstWindow.isDestroyed() ? firstWindow.id : null
   }
 
-  private async waitForSessionHostReady(
-    sessionId: string,
-    hostWindowId: number,
-    state: SessionBrowserState
-  ): Promise<void> {
-    if (
-      state.hostReady &&
-      state.attachedWindowId === hostWindowId &&
-      state.visible &&
-      state.lastBounds &&
-      state.lastBounds.width > 0 &&
-      state.lastBounds.height > 0
-    ) {
-      return
-    }
-
-    this.resolveOrRejectHostReadyWait(
-      sessionId,
-      new Error(
-        `Session browser host wait was interrupted before host ${hostWindowId} became ready`
-      )
-    )
-
-    await new Promise<void>((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        const error = new Error(
-          `Session browser host ${hostWindowId} did not become ready within ${this.embeddedHostReadyTimeoutMs}ms`
-        )
-        this.resolveOrRejectHostReadyWait(sessionId, error)
-      }, this.embeddedHostReadyTimeoutMs)
-
-      this.hostReadyWaiters.set(sessionId, {
-        sessionId,
-        hostWindowId,
-        timeoutId,
-        stableTimerId: null,
-        resolve,
-        reject
-      })
-    })
-  }
-
-  private scheduleSessionHostReady(
-    sessionId: string,
-    hostWindowId: number,
-    bounds: Rectangle
-  ): void {
-    const state = this.sessionBrowsers.get(sessionId)
-    const waiter = this.hostReadyWaiters.get(sessionId)
-    if (!state || !waiter || waiter.hostWindowId !== hostWindowId) {
-      return
-    }
-
-    if (waiter.stableTimerId) {
-      clearTimeout(waiter.stableTimerId)
-      waiter.stableTimerId = null
-    }
-
-    const expectedBoundsKey = this.boundsKey(bounds)
-    waiter.stableTimerId = setTimeout(() => {
-      const currentState = this.sessionBrowsers.get(sessionId)
-      const currentWaiter = this.hostReadyWaiters.get(sessionId)
-      if (
-        !currentState ||
-        !currentWaiter ||
-        currentWaiter !== waiter ||
-        currentWaiter.hostWindowId !== hostWindowId ||
-        currentState.attachedWindowId !== hostWindowId ||
-        !currentState.visible ||
-        this.boundsKey(currentState.lastBounds) !== expectedBoundsKey
-      ) {
-        return
-      }
-
-      currentState.hostReady = true
-      this.logLifecycle('host ready', {
-        sessionId,
-        windowId: hostWindowId,
-        pageId: currentState.page.pageId,
-        url: currentState.page.url
-      })
-      this.resolveOrRejectHostReadyWait(sessionId)
-    }, this.embeddedHostReadyStableMs)
-  }
-
-  private markHostNotReady(state: SessionBrowserState): void {
-    state.hostReady = false
-    const waiter = this.hostReadyWaiters.get(state.sessionId)
-    if (waiter?.stableTimerId) {
-      clearTimeout(waiter.stableTimerId)
-      waiter.stableTimerId = null
-    }
-  }
-
-  private resolveOrRejectHostReadyWait(sessionId: string, error?: Error): void {
-    const waiter = this.hostReadyWaiters.get(sessionId)
-    if (!waiter) {
-      return
-    }
-
-    clearTimeout(waiter.timeoutId)
-    if (waiter.stableTimerId) {
-      clearTimeout(waiter.stableTimerId)
-    }
-    this.hostReadyWaiters.delete(sessionId)
-
-    if (error) {
-      waiter.reject(error)
-      return
-    }
-
-    waiter.resolve()
-  }
-
   private toStatus(state: SessionBrowserState | null): YoBrowserStatus {
     if (!state || state.page.contents.isDestroyed()) {
       return {
@@ -760,13 +613,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       width: Math.max(0, Math.round(bounds.width)),
       height: Math.max(0, Math.round(bounds.height))
     }
-  }
-
-  private boundsKey(bounds?: Rectangle | null): string {
-    if (!bounds) {
-      return 'null'
-    }
-    return `${bounds.x}:${bounds.y}:${bounds.width}:${bounds.height}`
   }
 
   private logLifecycle(message: string, context: Record<string, unknown>): void {

--- a/src/main/presenter/floatingButtonPresenter/index.ts
+++ b/src/main/presenter/floatingButtonPresenter/index.ts
@@ -9,7 +9,7 @@ import {
   type WidgetRect
 } from './layout'
 import type { FloatingWidgetSnapshot } from '@shared/types/floating-widget'
-import type { SessionWithState } from '@shared/types/agent-interface'
+import type { Agent, SessionWithState } from '@shared/types/agent-interface'
 import { BrowserWindow, ipcMain, Menu, app, screen } from 'electron'
 import { FLOATING_BUTTON_EVENTS } from '@/events'
 import { presenter } from '../index'
@@ -95,6 +95,7 @@ export class FloatingButtonPresenter {
     ipcMain.removeHandler(FLOATING_BUTTON_EVENTS.SNAPSHOT_REQUEST)
     ipcMain.removeHandler(FLOATING_BUTTON_EVENTS.LANGUAGE_REQUEST)
     ipcMain.removeHandler(FLOATING_BUTTON_EVENTS.THEME_REQUEST)
+    ipcMain.removeHandler(FLOATING_BUTTON_EVENTS.ACP_REGISTRY_ICON_REQUEST)
     ipcMain.removeAllListeners(FLOATING_BUTTON_EVENTS.CLICKED)
     ipcMain.removeAllListeners(FLOATING_BUTTON_EVENTS.RIGHT_CLICKED)
     ipcMain.removeAllListeners(FLOATING_BUTTON_EVENTS.HOVER_STATE_CHANGED)
@@ -154,8 +155,8 @@ export class FloatingButtonPresenter {
 
   public async refreshWidgetState(): Promise<void> {
     try {
-      const sessions = await this.loadSessions()
-      this.snapshot = buildFloatingWidgetSnapshot(sessions, this.snapshot.expanded)
+      const [sessions, agents] = await Promise.all([this.loadSessions(), this.loadAgents()])
+      this.snapshot = buildFloatingWidgetSnapshot(sessions, agents, this.snapshot.expanded)
       this.applyWindowLayout()
       this.pushSnapshotToRenderer()
     } catch (error) {
@@ -210,6 +211,7 @@ export class FloatingButtonPresenter {
     ipcMain.removeHandler(FLOATING_BUTTON_EVENTS.SNAPSHOT_REQUEST)
     ipcMain.removeHandler(FLOATING_BUTTON_EVENTS.LANGUAGE_REQUEST)
     ipcMain.removeHandler(FLOATING_BUTTON_EVENTS.THEME_REQUEST)
+    ipcMain.removeHandler(FLOATING_BUTTON_EVENTS.ACP_REGISTRY_ICON_REQUEST)
     ipcMain.removeAllListeners(FLOATING_BUTTON_EVENTS.CLICKED)
     ipcMain.removeAllListeners(FLOATING_BUTTON_EVENTS.RIGHT_CLICKED)
     ipcMain.removeAllListeners(FLOATING_BUTTON_EVENTS.HOVER_STATE_CHANGED)
@@ -236,6 +238,25 @@ export class FloatingButtonPresenter {
     ipcMain.handle(FLOATING_BUTTON_EVENTS.THEME_REQUEST, async () => {
       return await this.resolveTheme()
     })
+
+    ipcMain.handle(
+      FLOATING_BUTTON_EVENTS.ACP_REGISTRY_ICON_REQUEST,
+      async (_event, payload: { agentId?: string; iconUrl?: string }) => {
+        const agentId = payload?.agentId?.trim()
+        const iconUrl = payload?.iconUrl?.trim()
+
+        if (!agentId || !iconUrl) {
+          return ''
+        }
+
+        try {
+          return (await this.configPresenter.getAcpRegistryIconMarkup(agentId, iconUrl)) ?? ''
+        } catch (error) {
+          console.warn('Failed to resolve floating ACP registry icon markup:', error)
+          return ''
+        }
+      }
+    )
 
     ipcMain.on(FLOATING_BUTTON_EVENTS.CLICKED, () => {
       this.toggleExpanded()
@@ -556,6 +577,20 @@ export class FloatingButtonPresenter {
     }
 
     return await agentSessionPresenter.getSessionList()
+  }
+
+  private async loadAgents(): Promise<Agent[]> {
+    const agentSessionPresenter = presenter.agentSessionPresenter as
+      | {
+          getAgents?: () => Promise<Agent[]>
+        }
+      | undefined
+
+    if (!agentSessionPresenter?.getAgents) {
+      return []
+    }
+
+    return await agentSessionPresenter.getAgents()
   }
 
   private async openSession(sessionId: string): Promise<void> {

--- a/src/main/presenter/floatingButtonPresenter/layout.ts
+++ b/src/main/presenter/floatingButtonPresenter/layout.ts
@@ -1,5 +1,6 @@
-import type { SessionWithState } from '@shared/types/agent-interface'
+import type { Agent, SessionWithState } from '@shared/types/agent-interface'
 import type {
+  FloatingWidgetSessionAgent,
   FloatingWidgetSessionItem,
   FloatingWidgetSessionStatus,
   FloatingWidgetSnapshot
@@ -50,17 +51,48 @@ function getStatusPriority(status: FloatingWidgetSessionStatus): number {
   }
 }
 
+function mapSessionAgent(
+  session: SessionWithState,
+  agentsById: Map<string, FloatingWidgetSessionAgent>
+): FloatingWidgetSessionAgent {
+  const matchedAgent = agentsById.get(session.agentId)
+  if (matchedAgent) {
+    return matchedAgent
+  }
+
+  return {
+    id: session.agentId,
+    name: session.agentId,
+    type: session.agentId === 'deepchat' ? 'deepchat' : 'acp'
+  }
+}
+
 export function buildFloatingWidgetSnapshot(
   sessions: SessionWithState[],
+  agents: Agent[],
   expanded: boolean
 ): FloatingWidgetSnapshot {
+  const agentsById = new Map<string, FloatingWidgetSessionAgent>(
+    agents.map((agent) => [
+      agent.id,
+      {
+        id: agent.id,
+        name: agent.name,
+        type: agent.type,
+        icon: agent.icon,
+        avatar: agent.avatar
+      }
+    ])
+  )
+
   const mappedSessions: FloatingWidgetSessionItem[] = sessions
     .filter((session) => !session.isDraft)
     .map((session) => ({
       id: session.id,
       title: session.title.trim(),
       status: mapSessionStatus(session.status),
-      updatedAt: session.updatedAt
+      updatedAt: session.updatedAt,
+      agent: mapSessionAgent(session, agentsById)
     }))
     .sort((left, right) => {
       const statusDiff = getStatusPriority(left.status) - getStatusPriority(right.status)

--- a/src/preload/floating-preload.ts
+++ b/src/preload/floating-preload.ts
@@ -12,6 +12,7 @@ const FLOATING_BUTTON_EVENTS = {
   LANGUAGE_CHANGED: 'floating-button:language-changed',
   THEME_REQUEST: 'floating-button:theme-request',
   THEME_CHANGED: 'floating-button:theme-changed',
+  ACP_REGISTRY_ICON_REQUEST: 'floating-button:acp-registry-icon-request',
   TOGGLE_EXPANDED: 'floating-button:toggle-expanded',
   SET_EXPANDED: 'floating-button:set-expanded',
   OPEN_SESSION: 'floating-button:open-session',
@@ -49,6 +50,13 @@ const floatingButtonAPI = {
 
   getTheme: async (): Promise<'dark' | 'light'> => {
     return await ipcRenderer.invoke(FLOATING_BUTTON_EVENTS.THEME_REQUEST)
+  },
+
+  getAcpRegistryIconMarkup: async (agentId: string, iconUrl: string): Promise<string> => {
+    return await ipcRenderer.invoke(FLOATING_BUTTON_EVENTS.ACP_REGISTRY_ICON_REQUEST, {
+      agentId,
+      iconUrl
+    })
   },
 
   toggleExpanded: () => {

--- a/src/renderer/floating/FloatingButton.vue
+++ b/src/renderer/floating/FloatingButton.vue
@@ -387,7 +387,11 @@ onUnmounted(() => {
                 class="session-row"
                 :style="{ '--session-index': Math.min(index, 6) }"
               >
-                <FloatingSessionItem :session="session" @select="handleOpenSession" />
+                <FloatingSessionItem
+                  :session="session"
+                  :theme="props.theme"
+                  @select="handleOpenSession"
+                />
               </div>
             </div>
           </div>

--- a/src/renderer/floating/components/FloatingSessionItem.vue
+++ b/src/renderer/floating/components/FloatingSessionItem.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { FloatingWidgetSessionItem } from '@shared/types/floating-widget'
+import AgentAvatar from '@/components/icons/AgentAvatar.vue'
 
 defineOptions({
   name: 'FloatingSessionItem'
@@ -9,6 +10,7 @@ defineOptions({
 
 const props = defineProps<{
   session: FloatingWidgetSessionItem
+  theme: 'dark' | 'light'
 }>()
 
 const emit = defineEmits<{
@@ -82,11 +84,18 @@ const dotClass = computed(() => {
   <button
     type="button"
     data-no-drag
-    class="session-card group flex w-full items-center gap-3 border pl-4 pr-5 py-3 text-left"
+    class="session-card group flex w-full items-center gap-3 border px-4 py-3 text-left"
     :class="itemClass"
     @click="emit('select', session.id)"
   >
     <span class="h-8 w-1.5 shrink-0 rounded-full" :class="accentClass"></span>
+
+    <AgentAvatar
+      :agent="session.agent"
+      :theme="theme"
+      class-name="h-5 w-5"
+      fallback-class-name="rounded-lg"
+    />
 
     <div
       class="min-w-0 flex-1 truncate text-[13px] font-medium leading-5 text-foreground/90 dark:text-white/94"

--- a/src/renderer/floating/env.d.ts
+++ b/src/renderer/floating/env.d.ts
@@ -17,6 +17,7 @@ declare global {
       getSnapshot: () => Promise<FloatingWidgetSnapshot>
       getLanguage: () => Promise<string>
       getTheme: () => Promise<'dark' | 'light'>
+      getAcpRegistryIconMarkup: (agentId: string, iconUrl: string) => Promise<string>
       toggleExpanded: () => void
       setExpanded: (expanded: boolean) => void
       setHovering: (hovering: boolean) => void

--- a/src/renderer/settings/App.vue
+++ b/src/renderer/settings/App.vue
@@ -607,6 +607,13 @@ onMounted(async () => {
     console.error(`${SETTINGS_STARTUP_LOG_PREFIX} provider summaries failed:`, error)
   }
 
+  try {
+    await modelStore.initialize()
+    logSettingsStartup('enabled models ready')
+  } catch (error) {
+    console.error(`${SETTINGS_STARTUP_LOG_PREFIX} enabled models failed:`, error)
+  }
+
   markStartupInteractive()
   window.addEventListener('focus', handleWindowFocus)
   await syncPendingProviderInstall()

--- a/src/renderer/settings/components/BuiltinKnowledgeSettings.vue
+++ b/src/renderer/settings/components/BuiltinKnowledgeSettings.vue
@@ -204,6 +204,7 @@
                   <PopoverContent class="w-80 p-0">
                     <ModelSelect
                       :type="[ModelType.Embedding]"
+                      :respect-chat-mode="false"
                       @update:model="handleEmbeddingModelSelect"
                     />
                   </PopoverContent>
@@ -254,6 +255,7 @@
                   <PopoverContent class="w-80 p-0">
                     <ModelSelect
                       :type="[ModelType.Rerank]"
+                      :respect-chat-mode="false"
                       @update:model="handleRerankModelSelect"
                     />
                   </PopoverContent>

--- a/src/renderer/settings/components/DeepChatAgentsSettings.vue
+++ b/src/renderer/settings/components/DeepChatAgentsSettings.vue
@@ -259,6 +259,7 @@
                   </div>
                   <ModelSelect
                     :exclude-providers="['acp']"
+                    :respect-chat-mode="false"
                     :vision-only="field.key === 'visionModel'"
                     @update:model="(model, providerId) => selectModel(field.key, model, providerId)"
                   />

--- a/src/renderer/settings/components/common/DefaultModelSettingsSection.vue
+++ b/src/renderer/settings/components/common/DefaultModelSettingsSection.vue
@@ -31,7 +31,11 @@
             </Button>
           </PopoverTrigger>
           <PopoverContent class="w-[320px] p-0" align="end">
-            <ModelSelect :exclude-providers="['acp']" @update:model="handleAssistantModelSelect" />
+            <ModelSelect
+              :exclude-providers="['acp']"
+              :respect-chat-mode="false"
+              @update:model="handleAssistantModelSelect"
+            />
           </PopoverContent>
         </Popover>
       </div>
@@ -63,7 +67,11 @@
             </Button>
           </PopoverTrigger>
           <PopoverContent class="w-[320px] p-0" align="end">
-            <ModelSelect :exclude-providers="['acp']" @update:model="handleChatModelSelect" />
+            <ModelSelect
+              :exclude-providers="['acp']"
+              :respect-chat-mode="false"
+              @update:model="handleChatModelSelect"
+            />
           </PopoverContent>
         </Popover>
       </div>

--- a/src/renderer/src/components/ModelSelect.vue
+++ b/src/renderer/src/components/ModelSelect.vue
@@ -66,6 +66,10 @@ const props = defineProps({
     type: Array as PropType<ModelType[]>,
     default: undefined
   },
+  respectChatMode: {
+    type: Boolean,
+    default: true
+  },
   excludeProviders: {
     type: Array as PropType<string[]>,
     default: () => []
@@ -92,11 +96,13 @@ const providers = computed(() => {
   return sortedProviders
     .filter((provider) => provider.enable && !props.excludeProviders.includes(provider.id))
     .map((provider) => {
-      if (currentMode === 'acp agent' && provider.id !== 'acp') {
-        return null
-      }
-      if (currentMode !== 'acp agent' && provider.id === 'acp') {
-        return null
+      if (props.respectChatMode) {
+        if (currentMode === 'acp agent' && provider.id !== 'acp') {
+          return null
+        }
+        if (currentMode !== 'acp agent' && provider.id === 'acp') {
+          return null
+        }
       }
 
       const enabledProvider = enabledModels.find((item) => item.providerId === provider.id)

--- a/src/renderer/src/components/icons/AcpAgentIcon.vue
+++ b/src/renderer/src/components/icons/AcpAgentIcon.vue
@@ -28,7 +28,6 @@ const props = withDefaults(
 const svgMarkup = ref('')
 const imageLoadFailed = ref(false)
 const requestSeq = ref(0)
-const configClient = createConfigClient()
 
 const isThemeableRegistryIcon = computed(() => {
   const icon = props.icon.trim()
@@ -60,6 +59,22 @@ const normalizeSvgMarkup = (markup: string): string => {
   return trimmed
 }
 
+const resolveIconMarkup = async (agentId: string, iconUrl: string): Promise<string> => {
+  const floatingButtonApi = (
+    window as Window & {
+      floatingButtonAPI?: {
+        getAcpRegistryIconMarkup?: (agentId: string, iconUrl: string) => Promise<string>
+      }
+    }
+  ).floatingButtonAPI
+
+  if (typeof floatingButtonApi?.getAcpRegistryIconMarkup === 'function') {
+    return await floatingButtonApi.getAcpRegistryIconMarkup(agentId, iconUrl)
+  }
+
+  return await createConfigClient().getAcpRegistryIconMarkup(agentId, iconUrl)
+}
+
 const loadSvgMarkup = async () => {
   const icon = props.icon.trim()
   const agentId = props.agentId.trim()
@@ -83,8 +98,7 @@ const loadSvgMarkup = async () => {
 
     let pending = cached
     if (!pending) {
-      pending = configClient
-        .getAcpRegistryIconMarkup(agentId, icon)
+      pending = resolveIconMarkup(agentId, icon)
         .then((markup) => {
           const normalized = markup ? normalizeSvgMarkup(markup) : ''
           if (normalized) {

--- a/src/renderer/src/components/icons/AgentAvatar.vue
+++ b/src/renderer/src/components/icons/AgentAvatar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { Icon } from '@iconify/vue'
+import { getActivePinia } from 'pinia'
 import type { UIAgent } from '@/stores/ui/agent'
 import { useThemeStore } from '@/stores/theme'
 import AcpAgentIcon from './AcpAgentIcon.vue'
@@ -11,6 +12,7 @@ const props = withDefaults(
     agent: Pick<UIAgent, 'id' | 'name' | 'type' | 'icon' | 'avatar'>
     className?: string
     fallbackClassName?: string
+    theme?: 'dark' | 'light'
   }>(),
   {
     className: 'h-4 w-4',
@@ -18,7 +20,16 @@ const props = withDefaults(
   }
 )
 
-const themeStore = useThemeStore()
+const activePinia = getActivePinia()
+const themeStore = activePinia ? useThemeStore(activePinia) : null
+
+const isDarkTheme = computed(() => {
+  if (props.theme) {
+    return props.theme === 'dark'
+  }
+
+  return Boolean(themeStore?.isDark)
+})
 
 const initials = computed(() => {
   const name = props.agent.name.trim()
@@ -42,7 +53,7 @@ const lucideColor = computed(() => {
   if (props.agent.avatar?.kind !== 'lucide') {
     return undefined
   }
-  return themeStore.isDark ? props.agent.avatar.darkColor : props.agent.avatar.lightColor
+  return isDarkTheme.value ? props.agent.avatar.darkColor : props.agent.avatar.lightColor
 })
 
 const showBuiltinDeepChatLogo = computed(

--- a/src/renderer/src/events.ts
+++ b/src/renderer/src/events.ts
@@ -200,6 +200,7 @@ export const FLOATING_BUTTON_EVENTS = {
   LANGUAGE_CHANGED: 'floating-button:language-changed',
   THEME_REQUEST: 'floating-button:theme-request',
   THEME_CHANGED: 'floating-button:theme-changed',
+  ACP_REGISTRY_ICON_REQUEST: 'floating-button:acp-registry-icon-request',
   TOGGLE_EXPANDED: 'floating-button:toggle-expanded',
   SET_EXPANDED: 'floating-button:set-expanded',
   OPEN_SESSION: 'floating-button:open-session',

--- a/src/shared/types/floating-widget.ts
+++ b/src/shared/types/floating-widget.ts
@@ -1,10 +1,21 @@
+import type { Agent } from './agent-interface'
+
 export type FloatingWidgetSessionStatus = 'in_progress' | 'done' | 'error'
+
+export interface FloatingWidgetSessionAgent {
+  id: string
+  name: string
+  type: Agent['type']
+  icon?: string
+  avatar?: Agent['avatar']
+}
 
 export interface FloatingWidgetSessionItem {
   id: string
   title: string
   status: FloatingWidgetSessionStatus
   updatedAt: number
+  agent: FloatingWidgetSessionAgent
 }
 
 export interface FloatingWidgetSnapshot {

--- a/test/main/presenter/floatingButtonPresenter/index.test.ts
+++ b/test/main/presenter/floatingButtonPresenter/index.test.ts
@@ -12,6 +12,7 @@ const {
   presenterState,
   sendToRendererMock,
   menuPopupMock,
+  getAgentsMock,
   getSessionListMock
 } = vi.hoisted(() => {
   const eventHandlers = new Map<string, (...args: unknown[]) => unknown>()
@@ -52,6 +53,23 @@ const {
 
   const presenterState = {
     sessions: [] as SessionWithState[],
+    agents: [
+      {
+        id: 'deepchat',
+        name: 'DeepChat',
+        type: 'deepchat' as const,
+        enabled: true,
+        avatar: null
+      },
+      {
+        id: 'acp-agent',
+        name: 'ACP Agent',
+        type: 'acp' as const,
+        enabled: true,
+        avatar: null,
+        icon: 'https://example.com/acp-agent.svg'
+      }
+    ],
     reset() {
       this.sessions = []
     }
@@ -59,6 +77,7 @@ const {
 
   const sendToRendererMock = vi.fn()
   const menuPopupMock = vi.fn()
+  const getAgentsMock = vi.fn(async () => presenterState.agents)
   const getSessionListMock = vi.fn(async () => presenterState.sessions)
 
   return {
@@ -75,6 +94,7 @@ const {
     presenterState,
     sendToRendererMock,
     menuPopupMock,
+    getAgentsMock,
     getSessionListMock
   }
 })
@@ -147,6 +167,7 @@ vi.mock('../../../../src/main/presenter/floatingButtonPresenter/FloatingButtonWi
 vi.mock('../../../../src/main/presenter/index', () => ({
   presenter: {
     agentSessionPresenter: {
+      getAgents: getAgentsMock,
       getSessionList: getSessionListMock,
       activateSession: vi.fn()
     },
@@ -191,6 +212,7 @@ describe('FloatingButtonPresenter drag layout sync', () => {
     presenterState.reset()
     sendToRendererMock.mockReset()
     menuPopupMock.mockReset()
+    getAgentsMock.mockClear()
     getSessionListMock.mockClear()
   })
 

--- a/test/main/presenter/floatingButtonPresenter/layout.test.ts
+++ b/test/main/presenter/floatingButtonPresenter/layout.test.ts
@@ -52,6 +52,24 @@ describe('floating widget layout helpers', () => {
           modelId: 'acp-agent'
         }
       ],
+      [
+        {
+          id: 'deepchat',
+          name: 'DeepChat',
+          type: 'deepchat',
+          enabled: true,
+          icon: undefined,
+          avatar: null
+        },
+        {
+          id: 'acp-agent',
+          name: 'ACP Agent',
+          type: 'acp',
+          enabled: true,
+          icon: 'https://example.com/acp-agent.svg',
+          avatar: null
+        }
+      ],
       false
     )
 
@@ -62,6 +80,12 @@ describe('floating widget layout helpers', () => {
       'in_progress',
       'done'
     ])
+    expect(snapshot.sessions[0]?.agent).toMatchObject({
+      id: 'acp-agent',
+      name: 'ACP Agent',
+      type: 'acp',
+      icon: 'https://example.com/acp-agent.svg'
+    })
   })
 
   it('keeps the right edge fixed when resizing a right-docked widget', () => {

--- a/test/renderer/components/ModelSelect.test.ts
+++ b/test/renderer/components/ModelSelect.test.ts
@@ -3,12 +3,20 @@ import { mount } from '@vue/test-utils'
 import { ref } from 'vue'
 import { ModelType } from '../../../src/shared/model'
 
-const setup = async () => {
+const setup = async (
+  options: {
+    currentMode?: 'agent' | 'acp agent'
+    props?: Record<string, unknown>
+  } = {}
+) => {
   vi.resetModules()
+
+  const currentMode = options.currentMode ?? 'agent'
 
   vi.doMock('@/stores/providerStore', () => ({
     useProviderStore: () => ({
       sortedProviders: [
+        { id: 'acp', name: 'ACP', enable: true },
         { id: 'ollama', name: 'Ollama', enable: true },
         { id: 'openai', name: 'OpenAI', enable: true }
       ]
@@ -24,6 +32,10 @@ const setup = async () => {
             { id: 'deepseek-r1:1.5b', name: 'deepseek-r1:1.5b', type: 'chat' },
             { id: 'nomic-embed-text:latest', name: 'nomic-embed-text:latest', type: 'embedding' }
           ]
+        },
+        {
+          providerId: 'acp',
+          models: [{ id: 'acp-agent', name: 'ACP Agent', type: 'chat' }]
         }
       ]
     })
@@ -43,7 +55,7 @@ const setup = async () => {
 
   vi.doMock('@/components/chat-input/composables/useChatMode', () => ({
     useChatMode: () => ({
-      currentMode: ref('agent')
+      currentMode: ref(currentMode)
     })
   }))
 
@@ -74,7 +86,8 @@ const setup = async () => {
 
   return mount(ModelSelect, {
     props: {
-      type: [ModelType.Chat]
+      type: [ModelType.Chat],
+      ...options.props
     }
   })
 }
@@ -92,5 +105,18 @@ describe('ModelSelect', () => {
     expect(wrapper.emitted('update:model')).toEqual([
       [{ id: 'deepseek-r1:1.5b', name: 'deepseek-r1:1.5b', type: 'chat' }, 'ollama']
     ])
+  })
+
+  it('can ignore chat mode filtering for settings pickers', async () => {
+    const wrapper = await setup({
+      currentMode: 'acp agent',
+      props: {
+        excludeProviders: ['acp'],
+        respectChatMode: false
+      }
+    })
+
+    expect(wrapper.text()).toContain('deepseek-r1:1.5b')
+    expect(wrapper.text()).not.toContain('ACP Agent')
   })
 })

--- a/test/renderer/components/SettingsApp.test.ts
+++ b/test/renderer/components/SettingsApp.test.ts
@@ -17,6 +17,7 @@ describe('Settings App', () => {
     const ipcRemoveListener = vi.fn()
     const ipcRemoveAllListeners = vi.fn()
     const ipcSend = vi.fn()
+    const initializeModelStore = vi.fn().mockResolvedValue(undefined)
 
     ;(window as any).electron = {
       ipcRenderer: {
@@ -119,7 +120,7 @@ describe('Settings App', () => {
     }))
     vi.doMock('../../../src/renderer/src/stores/modelStore', () => ({
       useModelStore: () => ({
-        initialize: vi.fn().mockResolvedValue(undefined),
+        initialize: initializeModelStore,
         ensureProviderModelsReady: vi.fn().mockResolvedValue(undefined)
       })
     }))
@@ -207,6 +208,7 @@ describe('Settings App', () => {
     await flushPromises()
 
     expect(isReady).toHaveBeenCalledTimes(1)
+    expect(initializeModelStore).toHaveBeenCalledTimes(1)
     expect(ipcSend).toHaveBeenCalledWith(SETTINGS_EVENTS.READY)
   }, 15000)
 


### PR DESCRIPTION
## Summary
- bump package version to v1.0.3-beta.6
- update CHANGELOG.md with the release notes for settings model initialization, chat mode aware ModelSelect behavior, ACP registry icon handling in the floating widget, and YoBrowser lifecycle cleanup
- keep the release branch identical to the reviewed dev commit

## Checks
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck

## Approach
- derived the release notes from commits since v1.0.3-beta.5 on dev
- prepared release metadata on dev first, then cut release/v1.0.3-beta.6 from the same commit for the fast-forward release flow