### PR TITLE
fix(gemini): drop vertex-only tool arg option

### DIFF
--- a/src/main/presenter/llmProviderPresenter/aiSdk/providerOptionsMapper.ts
+++ b/src/main/presenter/llmProviderPresenter/aiSdk/providerOptionsMapper.ts
@@ -287,9 +287,6 @@ export function buildProviderOptions(
 
     case 'google': {
       const config: Record<string, unknown> = {}
-      if (params.tools.length > 0) {
-        config.streamFunctionCallArguments = true
-      }
       if (shouldSendThinkingConfig) {
         config.thinkingConfig = {
           ...(params.modelConfig.thinkingBudget !== undefined

--- a/test/main/presenter/llmProviderPresenter/aiSdkProviderOptionsMapper.test.ts
+++ b/test/main/presenter/llmProviderPresenter/aiSdkProviderOptionsMapper.test.ts
@@ -633,7 +633,7 @@ describe('AI SDK provider options', () => {
     expect(result.providerOptions?.anthropic).not.toHaveProperty('thinking')
   })
 
-  it('does not send google thinking config when a budget portrait defaults to disabled', () => {
+  it('does not send vertex-only tool argument streaming to the google provider', () => {
     mockGetReasoningPortrait.mockReturnValue({
       supported: true,
       defaultEnabled: false,
@@ -667,9 +667,42 @@ describe('AI SDK provider options', () => {
       messages: []
     })
 
+    expect(result.providerOptions).toBeUndefined()
+  })
+
+  it('keeps google thinking config when tools are present without adding vertex-only options', () => {
+    const result = buildProviderOptions({
+      providerId: 'google',
+      capabilityProviderId: 'google',
+      providerOptionsKey: 'google',
+      apiType: 'google',
+      modelId: 'gemini-3.1-flash-lite-preview',
+      modelConfig: {
+        reasoning: true,
+        thinkingBudget: 1024
+      },
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'search_web',
+            description: 'Search the web',
+            parameters: {
+              type: 'object',
+              properties: {}
+            }
+          }
+        }
+      ] as any,
+      messages: []
+    })
+
     expect(result.providerOptions).toEqual({
       google: {
-        streamFunctionCallArguments: true
+        thinkingConfig: {
+          thinkingBudget: 1024,
+          includeThoughts: true
+        }
       }
     })
   })


### PR DESCRIPTION
Resolve warnings: `AI SDK Warning (google.generative-ai / gemini-3.1-flash-lite-preview): 'streamFunctionCallArguments' is only supported on the Vertex AI API and will be ignored with the current Google provider (google.generative-ai). See https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling#streaming-fc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Google provider configuration to address function call argument streaming behavior. Previously, the provider would automatically enable streaming when tools were available. This has been corrected to ensure thinking configuration settings and provider options are applied consistently across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->