### PR TITLE
fix: image paste submit failure in chat input

### DIFF
--- a/src/main/presenter/agentSessionPresenter/index.ts
+++ b/src/main/presenter/agentSessionPresenter/index.ts
@@ -749,7 +749,7 @@ export class AgentSessionPresenter {
   async listPendingInputs(sessionId: string) {
     const session = this.sessionManager.get(sessionId)
     if (!session) {
-      throw new Error(`Session not found: ${sessionId}`)
+      return []
     }
     const agent = await this.resolveAgentImplementation(session.agentId)
     if (!agent.listPendingInputs) {

--- a/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
@@ -1051,6 +1051,7 @@ export class AgentToolManager {
 
     addPath(path.join(app.getPath('home'), '.deepchat'))
     addPath(app.getPath('temp'))
+    addPath(path.join(app.getPath('userData'), 'temp'))
 
     if (conversationId) {
       const approved = this.runtimePort.getApprovedFilePaths(conversationId)

--- a/src/renderer/src/components/chat/composables/useChatInputFiles.ts
+++ b/src/renderer/src/components/chat/composables/useChatInputFiles.ts
@@ -44,8 +44,8 @@ export function useChatInputFiles(
             fileName: file.name ?? 'image',
             fileSize: file.size,
             fileDescription: file.type,
-            fileCreated: new Date(),
-            fileModified: new Date()
+            fileCreated: new Date().toISOString(),
+            fileModified: new Date().toISOString()
           },
           token: calculateImageTokens(imageInfo.width, imageInfo.height),
           path: tempFilePath,
@@ -173,8 +173,8 @@ export function useChatInputFiles(
             fileName: fileItem.name,
             fileSize: fileItem.size || 0,
             fileDescription: fileItem.description || '',
-            fileCreated: new Date(fileItem.createdAt || Date.now()),
-            fileModified: new Date(fileItem.createdAt || Date.now())
+            fileCreated: new Date(fileItem.createdAt || Date.now()).toISOString(),
+            fileModified: new Date(fileItem.createdAt || Date.now()).toISOString()
           },
           token: approximateTokenSize(fileItem.content || ''),
           path: fileItem.path || fileItem.name

--- a/src/renderer/src/pages/ChatPage.vue
+++ b/src/renderer/src/pages/ChatPage.vue
@@ -103,7 +103,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, nextTick, onMounted, onUnmounted, toRaw } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { TooltipProvider } from '@shadcn/components/ui/tooltip'
 import ChatTopBar from '@/components/chat/ChatTopBar.vue'
@@ -852,7 +852,7 @@ async function onSubmit() {
   if (isAcpWorkdirMissing.value) return
   if (activePendingInteraction.value || isHandlingInteraction.value) return
   const text = message.value.trim()
-  const files = [...attachedFiles.value]
+  const files = [...attachedFiles.value].map((f) => toRaw(f))
   if (!text && files.length === 0) return
   await pendingInputStore.queueInput(props.sessionId, { text, files })
   message.value = ''

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -336,10 +336,14 @@ async function onSubmit() {
   const text = message.value.trim()
   if (!text) return
   const files = [...attachedFiles.value].map((f) => toRaw(f))
-  message.value = ''
-  attachedFiles.value = []
 
-  await submitText(text, files)
+  try {
+    await submitText(text, files)
+    message.value = ''
+    attachedFiles.value = []
+  } catch (e) {
+    console.error('[NewThreadPage] submit failed:', e)
+  }
 }
 
 async function onCommandSubmit(command: string) {
@@ -347,8 +351,12 @@ async function onCommandSubmit(command: string) {
   const text = command.trim()
   if (!text) return
   const files = [...attachedFiles.value].map((f) => toRaw(f))
-  attachedFiles.value = []
-  await submitText(text, files)
+  try {
+    await submitText(text, files)
+    attachedFiles.value = []
+  } catch (e) {
+    console.error('[NewThreadPage] submit failed:', e)
+  }
 }
 
 async function submitText(text: string, files: MessageFile[]) {

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -92,7 +92,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, toRaw, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { TooltipProvider } from '@shadcn/components/ui/tooltip'
 import { Button } from '@shadcn/components/ui/button'
@@ -335,7 +335,7 @@ async function onSubmit() {
 
   const text = message.value.trim()
   if (!text) return
-  const files = [...attachedFiles.value]
+  const files = [...attachedFiles.value].map((f) => toRaw(f))
   message.value = ''
   attachedFiles.value = []
 
@@ -346,7 +346,7 @@ async function onCommandSubmit(command: string) {
   if (isAcpWorkdirMissing.value) return
   const text = command.trim()
   if (!text) return
-  const files = [...attachedFiles.value]
+  const files = [...attachedFiles.value].map((f) => toRaw(f))
   attachedFiles.value = []
   await submitText(text, files)
 }

--- a/src/shared/types/agent-interface.d.ts
+++ b/src/shared/types/agent-interface.d.ts
@@ -195,8 +195,8 @@ export interface MessageFile {
     fileName?: string
     fileSize?: number
     fileDescription?: string
-    fileCreated?: Date
-    fileModified?: Date
+    fileCreated?: string
+    fileModified?: string
     [key: string]: unknown
   }
 }


### PR DESCRIPTION
Fix image paste submit failure in chat input

  Three bugs preventing users from sending pasted images in chat:

  1. Vue reactive Proxy not serializable via IPC (ChatPage.vue, NewThreadPage.vue) —
  attachedFiles contained Vue Proxy objects that failed Electron's structured clone
  with An object could not be cloned. Fixed by unwrapping with toRaw() before passing
   to IPC.
  2. Agent file access denied for temp images (agentToolManager.ts) — Pasted images
  are written to Application Support/DeepChat/temp/, but the agent's allowed
  directory list only included the system temp dir (/var/folders/...). Added the
  app's userData temp directory to buildAllowedDirectories.
  3. New session submit silently swallowed (useChatInputFiles.ts, NewThreadPage.vue,
  agent-interface.d.ts) — File metadata used Date objects which failed Zod's
  JsonValueSchema validation during createSession, but the error was caught silently
  and input was cleared before the async call. Fixed by using ISO strings instead of
  Date, and moving input clearing after successful submit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for file submissions with automatic recovery on failure
  * Missing session requests now handled gracefully without errors

* **New Features**
  * Extended file access permissions to include additional temporary storage directory

* **Refactor**
  * Optimized file object handling during message submission
  * Standardized file metadata timestamps to use consistent string format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->