### PR TITLE
chore: Update vue-virtual-scroller to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "vue-router": "4",
     "vue-sonner": "^2.0.9",
     "vue-tsgo": "0.0.1-yggdrasill.11",
-    "vue-virtual-scroller": "^2.0.0-beta.10",
+    "vue-virtual-scroller": "^3.0.0",
     "vuedraggable": "^4.1.0",
     "yaml": "^2.8.3",
     "zod-to-json-schema": "^3.25.1"

--- a/src/renderer/settings/components/ProviderModelList.vue
+++ b/src/renderer/settings/components/ProviderModelList.vue
@@ -192,9 +192,10 @@
         page-mode
         :buffer="500"
       >
-        <template #default="{ item, active }">
+        <template #default="{ item, index, active }">
           <DynamicScrollerItem
             :item="item"
+            :index="index"
             :active="active"
             :size-dependencies="getScrollerItemSizeDependencies(item)"
           >

--- a/test/renderer/components/ProviderModelList.test.ts
+++ b/test/renderer/components/ProviderModelList.test.ts
@@ -42,11 +42,30 @@ const DynamicScrollerStub = defineComponent({
       default: () => []
     }
   },
-  template: '<div><slot v-for="item in items" :key="item.id" :item="item" :active="true" /></div>'
+  template:
+    '<div><slot v-for="(item, index) in items" :key="item.id" :item="item" :index="index" :active="true" /></div>'
 })
 
 const DynamicScrollerItemStub = defineComponent({
   name: 'DynamicScrollerItemStub',
+  props: {
+    item: {
+      type: Object,
+      required: true
+    },
+    active: {
+      type: Boolean,
+      required: true
+    },
+    index: {
+      type: Number,
+      required: true
+    },
+    sizeDependencies: {
+      type: Array,
+      default: () => []
+    }
+  },
   template: '<div><slot /></div>'
 })
 


### PR DESCRIPTION
## Summary
- Upgrade `vue-virtual-scroller` to `3.0.0`
- Apply the v2-to-v3 component migration in `ProviderModelList` by passing `index` into `DynamicScrollerItem`
- Refresh the renderer test stub so it matches the v3 slot props and item props

## Testing
- `pnpm exec vitest --config vitest.config.renderer.ts test/renderer/components/ProviderModelList.test.ts --run`
- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`

## Approach
- Followed the upstream migration guide and limited the code change to the only active `vue-virtual-scroller` consumer in the settings UI
- Updated the test stub alongside the component so the migration stays covered at the behavior level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded virtual scroller library to stable 3.x version for improved stability and performance

* **Tests**
  * Updated test infrastructure to ensure compatibility with library changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->