### PR TITLE
fix(renderer): guard stale model capability state

### DIFF
--- a/src/renderer/src/composables/useModelCapabilities.ts
+++ b/src/renderer/src/composables/useModelCapabilities.ts
@@ -46,6 +46,7 @@ export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
     strategy?: 'turbo' | 'max'
   } | null>(null)
   const isLoading = ref(false)
+  let requestId = 0
 
   // === Internal Methods ===
   const resetCapabilities = () => {
@@ -56,29 +57,40 @@ export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
   }
 
   const fetchCapabilities = async () => {
-    if (!providerId.value || !modelId.value) {
+    const currentRequestId = ++requestId
+    const currentProviderId = providerId.value
+    const currentModelId = modelId.value
+
+    if (!currentProviderId || !currentModelId) {
       resetCapabilities()
+      isLoading.value = false
       return
     }
 
     isLoading.value = true
     try {
       const [sr, br, ss, sd] = await Promise.all([
-        modelClient.supportsReasoningCapability(providerId.value, modelId.value),
-        modelClient.getThinkingBudgetRange(providerId.value, modelId.value),
-        modelClient.supportsSearchCapability(providerId.value, modelId.value),
-        modelClient.getSearchDefaults(providerId.value, modelId.value)
+        modelClient.supportsReasoningCapability(currentProviderId, currentModelId),
+        modelClient.getThinkingBudgetRange(currentProviderId, currentModelId),
+        modelClient.supportsSearchCapability(currentProviderId, currentModelId),
+        modelClient.getSearchDefaults(currentProviderId, currentModelId)
       ])
+
+      if (currentRequestId !== requestId) return
 
       capabilitySupportsReasoning.value = typeof sr === 'boolean' ? sr : null
       capabilityBudgetRange.value = br || {}
       capabilitySupportsSearch.value = typeof ss === 'boolean' ? ss : null
       capabilitySearchDefaults.value = sd || {}
     } catch (error) {
+      if (currentRequestId !== requestId) return
+
       resetCapabilities()
       console.error(error)
     } finally {
-      isLoading.value = false
+      if (currentRequestId === requestId) {
+        isLoading.value = false
+      }
     }
   }
 

--- a/src/renderer/src/composables/useModelTypeDetection.ts
+++ b/src/renderer/src/composables/useModelTypeDetection.ts
@@ -30,6 +30,7 @@ export function useModelTypeDetection(
 
   // === Local State ===
   const modelReasoning = ref(false)
+  let requestId = 0
 
   // === Computed Properties ===
 
@@ -57,15 +58,23 @@ export function useModelTypeDetection(
 
   // === Internal Methods ===
   const fetchModelReasoning = async () => {
-    if (!modelId.value || !providerId.value) {
+    const currentRequestId = ++requestId
+    const currentModelId = modelId.value
+    const currentProviderId = providerId.value
+
+    if (!currentModelId || !currentProviderId) {
       modelReasoning.value = false
       return
     }
 
     try {
-      const modelConfig = await modelConfigStore.getModelConfig(modelId.value, providerId.value)
+      const modelConfig = await modelConfigStore.getModelConfig(currentModelId, currentProviderId)
+      if (currentRequestId !== requestId) return
+
       modelReasoning.value = modelConfig.reasoning || false
     } catch (error) {
+      if (currentRequestId !== requestId) return
+
       modelReasoning.value = false
       console.error(error)
     }

--- a/test/renderer/composables/useModelCapabilities.test.ts
+++ b/test/renderer/composables/useModelCapabilities.test.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue'
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 const modelClient = vi.hoisted(() => ({
   supportsReasoningCapability: vi.fn(),
   getThinkingBudgetRange: vi.fn(),
@@ -13,7 +13,20 @@ vi.mock('@api/ModelClient', () => ({
 
 import { useModelCapabilities } from '@/composables/useModelCapabilities'
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+
+  return { promise, resolve }
+}
+
 describe('useModelCapabilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('fetches capabilities and resets when ids missing', async () => {
     const providerId = ref<string | undefined>('openai')
     const modelId = ref<string | undefined>('gpt-4')
@@ -39,5 +52,64 @@ describe('useModelCapabilities', () => {
     await vi.waitFor(() => expect(api.isLoading.value).toBe(false))
     expect(api.supportsReasoning.value).toBeNull()
     expect(api.budgetRange.value).toBeNull()
+  })
+
+  it('ignores stale capability responses after model changes', async () => {
+    const providerId = ref<string | undefined>('openai')
+    const modelId = ref<string | undefined>('gpt-old')
+    const oldResponse = {
+      supportsReasoning: deferred<boolean>(),
+      budgetRange: deferred<{ min: number; max: number }>(),
+      supportsSearch: deferred<boolean>(),
+      searchDefaults: deferred<{ strategy: 'turbo' | 'max' }>()
+    }
+    const newResponse = {
+      supportsReasoning: deferred<boolean>(),
+      budgetRange: deferred<{ min: number; max: number }>(),
+      supportsSearch: deferred<boolean>(),
+      searchDefaults: deferred<{ strategy: 'turbo' | 'max' }>()
+    }
+
+    modelClient.supportsReasoningCapability.mockImplementation((_provider, model) =>
+      model === 'gpt-old'
+        ? oldResponse.supportsReasoning.promise
+        : newResponse.supportsReasoning.promise
+    )
+    modelClient.getThinkingBudgetRange.mockImplementation((_provider, model) =>
+      model === 'gpt-old' ? oldResponse.budgetRange.promise : newResponse.budgetRange.promise
+    )
+    modelClient.supportsSearchCapability.mockImplementation((_provider, model) =>
+      model === 'gpt-old' ? oldResponse.supportsSearch.promise : newResponse.supportsSearch.promise
+    )
+    modelClient.getSearchDefaults.mockImplementation((_provider, model) =>
+      model === 'gpt-old' ? oldResponse.searchDefaults.promise : newResponse.searchDefaults.promise
+    )
+
+    const api = useModelCapabilities({ providerId, modelId })
+    await vi.waitFor(() => expect(modelClient.supportsReasoningCapability).toHaveBeenCalledTimes(1))
+
+    modelId.value = 'gpt-new'
+    await vi.waitFor(() => expect(modelClient.supportsReasoningCapability).toHaveBeenCalledTimes(2))
+
+    newResponse.supportsReasoning.resolve(false)
+    newResponse.budgetRange.resolve({ min: 10, max: 20 })
+    newResponse.supportsSearch.resolve(false)
+    newResponse.searchDefaults.resolve({ strategy: 'max' })
+
+    await vi.waitFor(() => expect(api.budgetRange.value?.max).toBe(20))
+    expect(api.supportsReasoning.value).toBe(false)
+    expect(api.supportsSearch.value).toBe(false)
+    expect(api.searchDefaults.value?.strategy).toBe('max')
+
+    oldResponse.supportsReasoning.resolve(true)
+    oldResponse.budgetRange.resolve({ min: 100, max: 200 })
+    oldResponse.supportsSearch.resolve(true)
+    oldResponse.searchDefaults.resolve({ strategy: 'turbo' })
+    await Promise.resolve()
+
+    expect(api.budgetRange.value?.max).toBe(20)
+    expect(api.supportsReasoning.value).toBe(false)
+    expect(api.supportsSearch.value).toBe(false)
+    expect(api.searchDefaults.value?.strategy).toBe('max')
   })
 })

--- a/test/renderer/composables/useModelTypeDetection.test.ts
+++ b/test/renderer/composables/useModelTypeDetection.test.ts
@@ -1,14 +1,30 @@
 import { ref } from 'vue'
-import { describe, it, expect } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { useModelTypeDetection } from '@/composables/useModelTypeDetection'
+
+const getModelConfig = vi.hoisted(() => vi.fn())
 
 vi.mock('@/stores/modelConfigStore', () => ({
   useModelConfigStore: () => ({
-    getModelConfig: vi.fn().mockResolvedValue({ reasoning: true })
+    getModelConfig
   })
 }))
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+
+  return { promise, resolve }
+}
+
 describe('useModelTypeDetection', () => {
+  beforeEach(() => {
+    getModelConfig.mockReset()
+    getModelConfig.mockResolvedValue({ reasoning: true })
+  })
+
   it('detects provider/model type and loads reasoning flag', async () => {
     const modelId = ref<string | undefined>('gpt-5-pro')
     const providerId = ref<string | undefined>('gemini')
@@ -23,5 +39,31 @@ describe('useModelTypeDetection', () => {
 
     await Promise.resolve()
     expect(api.modelReasoning.value).toBe(true)
+  })
+
+  it('ignores stale reasoning responses after model changes', async () => {
+    const modelId = ref<string | undefined>('gpt-old')
+    const providerId = ref<string | undefined>('openai')
+    const modelType = ref<'chat' | 'imageGeneration' | 'embedding' | 'rerank' | undefined>('chat')
+    const oldResponse = deferred<{ reasoning: boolean }>()
+    const newResponse = deferred<{ reasoning: boolean }>()
+
+    getModelConfig.mockImplementation((model) =>
+      model === 'gpt-old' ? oldResponse.promise : newResponse.promise
+    )
+
+    const api = useModelTypeDetection({ modelId, providerId, modelType })
+    await vi.waitFor(() => expect(getModelConfig).toHaveBeenCalledTimes(1))
+
+    modelId.value = 'gpt-new'
+    await vi.waitFor(() => expect(getModelConfig).toHaveBeenCalledTimes(2))
+
+    newResponse.resolve({ reasoning: false })
+    await vi.waitFor(() => expect(api.modelReasoning.value).toBe(false))
+
+    oldResponse.resolve({ reasoning: true })
+    await Promise.resolve()
+
+    expect(api.modelReasoning.value).toBe(false)
   })
 })


### PR DESCRIPTION
## 概述

这个 PR 修复了模型能力状态加载时的异步竞态问题。

当用户快速切换模型时，`useModelCapabilities` 和 `useModelTypeDetection` 可能会同时发起多个异步请求。修改前，每个请求完成后都会直接写回同一份响应式状态。如果旧模型的请求比新模型的请求更晚返回，就可能用旧模型的数据覆盖当前模型的状态。

例如，用户从模型 A 快速切换到模型 B 后，如果模型 A 的能力查询最后才返回，界面上可能仍然显示模型 A 的 reasoning、search、thinking budget 等能力信息。

## 问题原因

这两个 composable 会监听 `providerId` 和 `modelId`，然后异步加载模型相关数据：

- 是否支持 reasoning
- thinking budget 范围
- 是否支持 search 以及 search 默认配置
- 当前模型的 reasoning 配置

但原来的实现没有判断“这个响应是否还属于当前选中的模型”，因此旧请求晚返回时仍然可以更新状态。

## 修改内容

本 PR 在以下两个 composable 中加入递增的 `requestId`：

- `useModelCapabilities`
- `useModelTypeDetection`

每次请求开始时都会固定当前的 `requestId`、`providerId` 和 `modelId`。请求完成后，只有当它仍然是最新请求时，才允许写回状态。

过期响应会被忽略，不再覆盖当前模型的状态。

## 达成效果

快速切换模型时，旧模型的异步返回结果不会再覆盖当前模型的数据。界面上的 reasoning、search、thinking budget 等能力状态会始终和当前选中的 provider/model 保持一致。

## 测试

新增了两个回归测试：

- `useModelCapabilities`：验证旧模型能力请求晚返回时不会覆盖新模型状态。
- `useModelTypeDetection`：验证旧模型 reasoning 配置请求晚返回时不会覆盖新模型状态。

本地已验证：

- `pnpm exec vitest --config vitest.config.renderer.ts test/renderer/composables/useModelCapabilities.test.ts test/renderer/composables/useModelTypeDetection.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/composables/useModelCapabilities.ts src/renderer/src/composables/useModelTypeDetection.ts test/renderer/composables/useModelCapabilities.test.ts test/renderer/composables/useModelTypeDetection.test.ts`
- `pnpm run i18n`
- `pnpm run lint:agent-cleanup`
- `pnpm run lint:architecture`
- `pnpm exec oxlint .`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`

说明：本地 Node.js 是 `v22.14.0`，项目声明要求 `>=24.14.1 <25`，但上述检查都已成功通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where stale capability and reasoning responses could incorrectly overwrite fresh data when switching models.
  * Improved handling of concurrent model requests to ensure the latest information is always displayed.

* **Tests**
  * Added test coverage for stale response scenarios to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->