### PR TITLE
fix: interleaved reasoning persistence across tool calls

### DIFF
--- a/src/main/presenter/agentRuntimePresenter/contextBuilder.ts
+++ b/src/main/presenter/agentRuntimePresenter/contextBuilder.ts
@@ -269,6 +269,33 @@ export function recordToChatMessages(
     .filter((block) => block.type === 'reasoning_content')
     .map((block) => block.content)
     .join('')
+  const contentParts = blocks
+    .filter(
+      (block): block is AssistantMessageBlock & { content: string } =>
+        block.type === 'content' && typeof block.content === 'string' && block.content.length > 0
+    )
+    .map((block) => {
+      const providerOptions = getBlockProviderOptions(block)
+      return {
+        type: 'text' as const,
+        text: block.content,
+        ...(providerOptions ? { provider_options: providerOptions } : {})
+      }
+    })
+  const assistantContent = contentParts.some((part) => part.provider_options) ? contentParts : text
+  const applyReasoningContent = (assistantMessage: ChatMessage): ChatMessage => {
+    if (preserveInterleavedReasoning && reasoning) {
+      assistantMessage.reasoning_content = reasoning
+      const reasoningProviderOptions = blocks
+        .filter((block) => block.type === 'reasoning_content')
+        .map((block) => getBlockProviderOptions(block))
+        .find(Boolean)
+      if (reasoningProviderOptions) {
+        assistantMessage.reasoning_provider_options = reasoningProviderOptions
+      }
+    }
+    return assistantMessage
+  }
 
   const toolCallBlocks = blocks.filter(
     (block) =>
@@ -281,6 +308,9 @@ export function recordToChatMessages(
   )
 
   if (toolCallBlocks.length === 0) {
+    if (preserveInterleavedReasoning && reasoning) {
+      return [applyReasoningContent({ role: 'assistant', content: assistantContent })]
+    }
     return [{ role: 'assistant', content: combinedText }]
   }
 
@@ -301,38 +331,18 @@ export function recordToChatMessages(
   }
 
   if (toolCalls.length === 0) {
+    if (preserveInterleavedReasoning && reasoning) {
+      return [applyReasoningContent({ role: 'assistant', content: assistantContent })]
+    }
     return [{ role: 'assistant', content: combinedText }]
   }
 
-  const contentParts = blocks
-    .filter(
-      (block): block is AssistantMessageBlock & { content: string } =>
-        block.type === 'content' && typeof block.content === 'string' && block.content.length > 0
-    )
-    .map((block) => {
-      const providerOptions = getBlockProviderOptions(block)
-      return {
-        type: 'text' as const,
-        text: block.content,
-        ...(providerOptions ? { provider_options: providerOptions } : {})
-      }
-    })
-
   const assistantMessage: ChatMessage = {
     role: 'assistant',
-    content: contentParts.some((part) => part.provider_options) ? contentParts : text,
+    content: assistantContent,
     tool_calls: toolCalls
   }
-  if (preserveInterleavedReasoning && reasoning) {
-    assistantMessage.reasoning_content = reasoning
-    const reasoningProviderOptions = blocks
-      .filter((block) => block.type === 'reasoning_content')
-      .map((block) => getBlockProviderOptions(block))
-      .find(Boolean)
-    if (reasoningProviderOptions) {
-      assistantMessage.reasoning_provider_options = reasoningProviderOptions
-    }
-  }
+  applyReasoningContent(assistantMessage)
 
   const result: ChatMessage[] = [assistantMessage]
   for (const block of toolCallBlocks) {

--- a/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
@@ -3231,6 +3231,80 @@ describe('AgentRuntimePresenter', () => {
       expect(processStream).toHaveBeenCalledTimes(1)
     })
 
+    it('preserves reasoning_content when resuming after a question answer', async () => {
+      await agent.initSession('s1', {
+        providerId: 'openai',
+        modelId: 'gpt-4',
+        generationSettings: { forceInterleavedThinkingCompat: true }
+      })
+      const row = makeAssistantRow({
+        blocks: [
+          {
+            type: 'reasoning_content',
+            content: 'Think before asking.',
+            status: 'success',
+            timestamp: 1
+          },
+          {
+            type: 'content',
+            content: 'Need a user choice.',
+            status: 'success',
+            timestamp: 2
+          },
+          {
+            type: 'tool_call',
+            status: 'pending',
+            timestamp: 3,
+            tool_call: { id: 'tc1', name: 'ask_question', params: '{}', response: '' }
+          },
+          {
+            type: 'action',
+            action_type: 'question_request',
+            status: 'pending',
+            timestamp: 4,
+            content: 'Pick one',
+            tool_call: { id: 'tc1', name: 'ask_question', params: '{}' },
+            extra: {
+              needsUserAction: true,
+              questionText: 'Pick one',
+              questionOptions: [{ label: 'A' }]
+            }
+          }
+        ]
+      })
+      sqlitePresenter.deepchatMessagesTable.updateContent.mockImplementation(
+        (id: string, content: string) => {
+          if (id === row.id) {
+            row.content = content
+          }
+        }
+      )
+
+      const result = await agent.respondToolInteraction('s1', 'm1', 'tc1', {
+        kind: 'question_option',
+        optionLabel: 'A'
+      })
+
+      expect(result).toEqual({ resumed: true })
+      const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const assistantMessage = callArgs.messages.find(
+        (message: any) => message.role === 'assistant'
+      )
+      expect(callArgs.interleavedReasoning.preserveReasoningContent).toBe(true)
+      expect(assistantMessage).toEqual({
+        role: 'assistant',
+        content: 'Need a user choice.',
+        reasoning_content: 'Think before asking.',
+        tool_calls: [
+          {
+            id: 'tc1',
+            type: 'function',
+            function: { name: 'ask_question', arguments: '{}' }
+          }
+        ]
+      })
+    })
+
     it('treats an aborted resume signal as cancellation even for non-abort errors', async () => {
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
       makeAssistantRow({ blocks: [] })

--- a/test/main/presenter/agentRuntimePresenter/contextBuilder.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/contextBuilder.test.ts
@@ -372,6 +372,23 @@ describe('buildContext', () => {
     })
   })
 
+  it('preserves reasoning_content separately for non-tool assistant history when enabled', () => {
+    const messages = [
+      makeUserRecord(1, 'Think about this'),
+      makeAssistantWithReasoningRecord(2, 'The answer is 42', 'Let me think...')
+    ]
+    const store = createMockMessageStore(messages)
+    const result = buildContext('s1', 'Follow up', '', 10000, 4096, store, false, {
+      preserveInterleavedReasoning: true
+    })
+
+    expect(result[1]).toEqual({
+      role: 'assistant',
+      content: 'The answer is 42',
+      reasoning_content: 'Let me think...'
+    })
+  })
+
   it('preserves reasoning_content separately for settled tool calls when enabled', () => {
     const messages = [
       makeUserRecord(1, 'Use a tool'),
@@ -662,6 +679,73 @@ describe('buildResumeContext', () => {
     expect(result.slice(-2)).toEqual([
       { role: 'user', content: 'recent user' },
       { role: 'assistant', content: 'partial answer' }
+    ])
+  })
+
+  it('preserves reasoning_content for pending resume targets with resolved tool calls', () => {
+    const messages = [
+      makeUserRecord(1, 'recent user'),
+      {
+        id: 'resume-target',
+        sessionId: 's1',
+        orderSeq: 2,
+        role: 'assistant' as const,
+        content: JSON.stringify([
+          {
+            type: 'reasoning_content',
+            content: 'Need a tool first.',
+            status: 'success',
+            timestamp: Date.now()
+          },
+          { type: 'content', content: 'Running tool...', status: 'success', timestamp: Date.now() },
+          {
+            type: 'tool_call',
+            status: 'success',
+            timestamp: Date.now(),
+            tool_call: {
+              id: 'tc-resume',
+              name: 'example_tool',
+              params: '{"foo":"bar"}',
+              response: 'tool result'
+            }
+          },
+          {
+            type: 'action',
+            action_type: 'question_request',
+            status: 'success',
+            timestamp: Date.now(),
+            content: 'Pick one',
+            tool_call: { id: 'tc-resume', name: 'example_tool', params: '{"foo":"bar"}' },
+            extra: { needsUserAction: false, answerText: 'A' }
+          }
+        ]),
+        status: 'pending' as const,
+        isContextEdge: 0,
+        metadata: '{}',
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      }
+    ]
+    const store = createMockMessageStore(messages)
+    const result = buildResumeContext('s1', 'resume-target', '', 10000, 4096, store, false, {
+      preserveInterleavedReasoning: true
+    })
+
+    expect(result).toEqual([
+      { role: 'user', content: 'recent user' },
+      {
+        role: 'assistant',
+        content: 'Running tool...',
+        reasoning_content: 'Need a tool first.',
+        tool_calls: [
+          {
+            id: 'tc-resume',
+            type: 'function',
+            function: { name: 'example_tool', arguments: '{"foo":"bar"}' }
+          }
+        ]
+      },
+      { role: 'tool', tool_call_id: 'tc-resume', content: 'tool result' }
     ])
   })
 })

--- a/test/main/presenter/agentRuntimePresenter/process.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/process.test.ts
@@ -727,6 +727,71 @@ describe('processStream', () => {
     expect(toolPresenter.callTool).toHaveBeenCalledTimes(2)
   })
 
+  it('passes reasoning_content back after each interleaved tool-call loop', async () => {
+    let callCount = 0
+    const toolPresenter = createMockToolPresenter({ get_weather: 'Sunny' })
+
+    const coreStream = vi.fn(function () {
+      callCount++
+      const round = callCount
+      if (round <= 2) {
+        return (async function* () {
+          yield {
+            type: 'reasoning',
+            reasoning_content: `Think ${round}`
+          } as LLMCoreStreamEvent
+          yield {
+            type: 'tool_call_start',
+            tool_call_id: `tc${round}`,
+            tool_call_name: 'get_weather'
+          } as LLMCoreStreamEvent
+          yield {
+            type: 'tool_call_end',
+            tool_call_id: `tc${round}`,
+            tool_call_arguments_complete: `{"round":${round}}`
+          } as LLMCoreStreamEvent
+          yield { type: 'stop', stop_reason: 'tool_use' } as LLMCoreStreamEvent
+        })()
+      }
+
+      return (async function* () {
+        yield { type: 'text', content: 'Final answer' } as LLMCoreStreamEvent
+        yield { type: 'stop', stop_reason: 'complete' } as LLMCoreStreamEvent
+      })()
+    }) as unknown as ProcessParams['coreStream']
+
+    const params = createParams({
+      coreStream,
+      toolPresenter,
+      tools: [makeTool('get_weather')],
+      interleavedReasoning: {
+        ...DEFAULT_INTERLEAVED_REASONING,
+        preserveReasoningContent: true,
+        portraitInterleaved: true
+      }
+    })
+
+    const promise = processStream(params)
+    await vi.runAllTimersAsync()
+    await promise
+
+    expect(coreStream).toHaveBeenCalledTimes(3)
+    const secondCallMessages = (coreStream as ReturnType<typeof vi.fn>).mock.calls[1][0]
+    const firstAssistantMessage = secondCallMessages.find(
+      (message: any) => message.role === 'assistant' && message.tool_calls?.[0]?.id === 'tc1'
+    )
+    expect(firstAssistantMessage.reasoning_content).toBe('Think 1')
+
+    const thirdCallMessages = (coreStream as ReturnType<typeof vi.fn>).mock.calls[2][0]
+    const toolCallAssistantMessages = thirdCallMessages.filter(
+      (message: any) => message.role === 'assistant' && message.tool_calls?.length
+    )
+    expect(toolCallAssistantMessages.map((message: any) => message.reasoning_content)).toEqual([
+      'Think 1',
+      'Think 2'
+    ])
+  })
+
   it('max tool calls limit', async () => {
     let callCount = 0
     const toolPresenter = createMockToolPresenter({ action: 'done' })

--- a/test/main/presenter/llmProviderPresenter/aiSdkMessageMapper.test.ts
+++ b/test/main/presenter/llmProviderPresenter/aiSdkMessageMapper.test.ts
@@ -35,4 +35,43 @@ describe('AI SDK message mapper', () => {
       }
     ])
   })
+
+  it('maps interleaved reasoning and native tool calls into assistant parts', () => {
+    const result = mapMessagesToModelMessages(
+      [
+        {
+          role: 'assistant',
+          content: 'I need current data.',
+          reasoning_content: 'Plan the lookup first.',
+          tool_calls: [
+            {
+              id: 'tc1',
+              type: 'function',
+              function: { name: 'search', arguments: '{"query":"weather"}' }
+            }
+          ]
+        }
+      ],
+      {
+        tools: [],
+        supportsNativeTools: true
+      }
+    )
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'Plan the lookup first.' },
+          { type: 'text', text: 'I need current data.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'tc1',
+            toolName: 'search',
+            input: { query: 'weather' }
+          }
+        ]
+      }
+    ])
+  })
 })


### PR DESCRIPTION
## Summary
- Preserve `reasoning_content` when rebuilding assistant history and resume contexts for interleaved-thinking models.
- Keep native tool-call messages intact while carrying reasoning through follow-up turns so the next API request can include it again.
- Add regression coverage for history reconstruction, resume flow, multi-turn tool loops, and AI SDK message mapping.
- Implementation followed a narrow trace: locate the assistant-message rebuild path, keep reasoning as structured data across tool-call boundaries, then verify the mapped AI SDK payload matches the provider contract.

## Testing
- Added unit and integration-style regressions for `contextBuilder`, `processStream`, `respondToolInteraction`, and `aiSdk` message mapping.
- Ran `format`, `i18n`, `lint`, and the related Vitest suites; all passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of reasoning content preservation across conversation continuity, particularly when the AI uses internal thinking processes alongside tool calls.

* **Tests**
  * Added comprehensive test coverage for reasoning content preservation in resumed conversations and tool-call scenarios with interleaved thinking enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->