### PR TITLE
Release v1.0.4-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.4-beta.3 (2026-04-27)
+- Fixed attachment date metadata transfer across IPC payloads so attachment records stay valid in chat flows
+- 修复附件日期元数据在 IPC 载荷中的传递，确保聊天流程中的附件记录保持有效
+
 ## v1.0.4-beta.2 (2026-04-27)
 - Preserved interleaved reasoning output so mixed reasoning and answer streams stay in the correct order
 - Updated the Markstream renderer to the stable 0.0.13 release for more reliable Markdown streaming

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DeepChat",
-  "version": "1.0.4-beta.2",
+  "version": "1.0.4-beta.3",
   "description": "DeepChat，一个简单易用的 Agent 客户端",
   "main": "./out/main/index.js",
   "author": "ThinkInAIXYZ",

--- a/src/renderer/src/stores/ui/session.ts
+++ b/src/renderer/src/stores/ui/session.ts
@@ -591,6 +591,7 @@ export const useSessionStore = defineStore('session', () => {
       pageRouter.goToChat(session.id)
     } catch (createError) {
       error.value = `Failed to create session: ${createError}`
+      throw createError
     }
   }
 
@@ -649,6 +650,7 @@ export const useSessionStore = defineStore('session', () => {
       await chatClient.sendMessage(sessionId, content)
     } catch (sendError) {
       error.value = `Failed to send message: ${sendError}`
+      throw sendError
     }
   }
 

--- a/src/shared/contracts/common.ts
+++ b/src/shared/contracts/common.ts
@@ -31,6 +31,8 @@ export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
   ])
 )
 
+export const FileMetadataValueSchema = z.union([JsonValueSchema, z.date()])
+
 export const AppErrorSchema = z.object({
   code: z.string(),
   message: z.string(),
@@ -76,7 +78,7 @@ export const MessageFileSchema = z.object({
   mimeType: z.string().optional(),
   token: z.number().optional(),
   thumbnail: z.string().optional(),
-  metadata: z.record(JsonValueSchema).optional()
+  metadata: z.record(FileMetadataValueSchema).optional()
 })
 
 export const SendMessageInputSchema = z.object({

--- a/src/shared/contracts/domainSchemas.ts
+++ b/src/shared/contracts/domainSchemas.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { BrowserPageStatus } from '../types/browser'
 import { ApiEndpointType, ModelType, NEW_API_ENDPOINT_TYPES } from '../model'
-import { JsonValueSchema, ProviderModelSummarySchema } from './common'
+import { FileMetadataValueSchema, JsonValueSchema, ProviderModelSummarySchema } from './common'
 import {
   ReasoningEffortSchema,
   ReasoningModeSchema,
@@ -376,8 +376,6 @@ export const ConfigValueSchema = z.union([
   z.null(),
   JsonValueSchema
 ])
-
-const FileMetadataValueSchema = z.union([JsonValueSchema, z.date()])
 
 export const PreparedMessageFileSchema = z.object({
   name: z.string(),

--- a/test/main/routes/contracts.test.ts
+++ b/test/main/routes/contracts.test.ts
@@ -201,6 +201,53 @@ describe('main kernel contracts', () => {
     })
   })
 
+  it('accepts prepared attachment metadata dates in message route contracts', () => {
+    const fileCreated = new Date('2024-01-01T00:00:00.000Z')
+    const fileModified = new Date('2024-01-02T00:00:00.000Z')
+    const pdfAttachment = {
+      name: 'sample.pdf',
+      path: '/tmp/sample.pdf',
+      mimeType: 'application/pdf',
+      content: '# PDF file description',
+      token: 128,
+      metadata: {
+        fileName: 'sample.pdf',
+        fileSize: 1024,
+        fileDescription: 'PDF Document',
+        fileCreated,
+        fileModified
+      }
+    }
+
+    expect(
+      sessionsCreateRoute.input.parse({
+        agentId: 'deepchat',
+        message: 'summarize this',
+        files: [pdfAttachment]
+      })
+    ).toEqual({
+      agentId: 'deepchat',
+      message: 'summarize this',
+      files: [pdfAttachment]
+    })
+
+    expect(
+      chatSendMessageRoute.input.parse({
+        sessionId: 'session-1',
+        content: {
+          text: 'summarize this',
+          files: [pdfAttachment]
+        }
+      })
+    ).toEqual({
+      sessionId: 'session-1',
+      content: {
+        text: 'summarize this',
+        files: [pdfAttachment]
+      }
+    })
+  })
+
   it('validates typed provider and tool interaction routes through the shared contract catalog', () => {
     expect(
       providersListModelsRoute.output.parse({

--- a/test/renderer/components/NewThreadPage.test.ts
+++ b/test/renderer/components/NewThreadPage.test.ts
@@ -300,6 +300,29 @@ describe('NewThreadPage ACP draft session bootstrap', () => {
     expect(sessionStore.createSession).not.toHaveBeenCalled()
   })
 
+  it('keeps draft input when ACP draft send fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const { wrapper, sessionStore } = await setup()
+      const file = { name: 'a.pdf', path: '/tmp/a.pdf', mimeType: 'application/pdf' }
+      ;(wrapper.vm as any).message = 'hello from draft'
+      ;(wrapper.vm as any).attachedFiles = [file]
+      sessionStore.sendMessage.mockRejectedValueOnce(new Error('send failed'))
+
+      await (wrapper.vm as any).onSubmit()
+      await flushPromises()
+
+      expect(sessionStore.sendMessage).toHaveBeenCalledWith('draft-1', {
+        text: 'hello from draft',
+        files: [file]
+      })
+      expect((wrapper.vm as any).message).toBe('hello from draft')
+      expect((wrapper.vm as any).attachedFiles).toEqual([file])
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
   it('passes draft generation settings when creating a deepchat session', async () => {
     const { wrapper, sessionStore, agentStore, modelStore, draftStore } = await setup()
 
@@ -341,6 +364,42 @@ describe('NewThreadPage ACP draft session bootstrap', () => {
         }
       })
     )
+  })
+
+  it('keeps draft input when deepchat session creation fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const { wrapper, sessionStore, agentStore, modelStore, draftStore } = await setup()
+      const file = { name: 'a.pdf', path: '/tmp/a.pdf', mimeType: 'application/pdf' }
+
+      agentStore.selectedAgentId = 'deepchat'
+      await flushPromises()
+      modelStore.enabledModels = [
+        {
+          providerId: 'openai',
+          models: [{ id: 'gpt-4', name: 'GPT-4' }]
+        }
+      ]
+      draftStore.providerId = 'openai'
+      draftStore.modelId = 'gpt-4'
+      ;(wrapper.vm as any).message = 'hello deepchat'
+      ;(wrapper.vm as any).attachedFiles = [file]
+      sessionStore.createSession.mockRejectedValueOnce(new Error('create failed'))
+
+      await (wrapper.vm as any).onSubmit()
+      await flushPromises()
+
+      expect(sessionStore.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'hello deepchat',
+          files: [file]
+        })
+      )
+      expect((wrapper.vm as any).message).toBe('hello deepchat')
+      expect((wrapper.vm as any).attachedFiles).toEqual([file])
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
   })
 
   it('awaits full model initialization before creating a deepchat session', async () => {


### PR DESCRIPTION
## Summary
- Prepare v1.0.4-beta.3 release metadata
- Include the attachment date metadata IPC fix from #1547

## Agent Prompting Approach
- Followed the repository DeepChat release flow: inspect release state, bump version, update bilingual changelog, run release checks, and cut a release branch from dev

## Verification
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck
- pnpm test -- --run test/main/routes/contracts.test.ts test/renderer/components/NewThreadPage.test.ts

The Vitest command ran the full suite and passed: 294 files passed, 2 skipped; 2365 tests passed, 20 skipped.