### PR TITLE
fix(agent): account for tool schemas and cap output tokens in context…

### DIFF
--- a/docs/specs/agent-tool-context-budget/plan.md
+++ b/docs/specs/agent-tool-context-budget/plan.md
@@ -1,0 +1,46 @@
+# Agent Tool Context Budget Plan
+
+## Diagnosis
+
+The core issue is request budgeting, not MiniMax alone. MiniMax exposes the issue quickly because
+its model metadata advertises a very large output limit and reasoning-capable tool calls. DeepChat
+was using that limit as the session default and reserving it on every turn, while the tool schema
+payload was not included in initial history selection.
+
+Function-call failures have a second path: models that do not use native tools fall back to a text
+protocol appended to the latest user message. That protocol is verbose and brittle, so it both
+consumes more context and fails on small formatting deviations.
+
+## First Increment
+
+- Cap agent-loop default max output tokens to a practical default and never reserve more than half
+  of the context window for output.
+- Reserve tool definition tokens when building the initial/resume context.
+- Fit request messages again immediately before each provider call.
+- Preserve the active tool continuation tail during trimming.
+- Resolve an effective per-request max output value from the fitted request and tool-schema budget.
+- Make legacy function-call parsing tolerant of code fences and a missing closing tag at end of
+  stream.
+
+## Follow-Up Work
+
+- Add request trace telemetry for message tokens, tool tokens, system tokens, output reserve, and
+  final effective output cap.
+- Add a reasoning retention budget: keep provider-required continuation metadata, but summarize or
+  omit old reasoning text once it is no longer needed.
+- Add provider capability overrides for services whose model metadata says `tool_call: true` but
+  whose endpoint rejects native tool payloads.
+- Add a compact tool-schema mode for legacy function-call fallback.
+- Add UI diagnostics for "context budget pressure" and suggested remediation.
+
+## Manual Validation Notes
+
+For a MiniMax-M2.7 agent session, inspect trace/log output rather than running automated test
+suites:
+
+- New session default `maxTokens` should be capped.
+- Requests with tools should reserve tool schema tokens before selecting history.
+- After a tool result, the next request should retain the assistant tool call and corresponding tool
+  result while dropping older history first.
+- A legacy response like `<function_call>{"function_call":...}` at end of stream should still parse
+  if JSON is repairable.

--- a/docs/specs/agent-tool-context-budget/spec.md
+++ b/docs/specs/agent-tool-context-budget/spec.md
@@ -1,0 +1,55 @@
+# Agent Tool Context Budget And Function Call Reliability
+
+> Status: Draft
+> Date: 2026-04-27
+
+## Background
+
+DeepChat agent sessions can fail after only a few tool calls on MiniMax and other providers. The
+same class of issue appears outside ACP, so the failure is not isolated to ACP transport.
+
+Observed risk points:
+
+- Agent default `maxTokens` can inherit very large provider output limits, for example 131072.
+- Context selection reserves output tokens but did not reserve request-level tool schemas.
+- Provider loop iterations after tool execution relied on tool-output fitting, but did not preflight
+  the whole request before sending it.
+- Legacy text-based function calls depend on exact `<function_call>...</function_call>` output.
+  Small provider formatting deviations can turn a valid intent into plain assistant text.
+- Interleaved reasoning models may preserve reasoning content across tool calls, increasing history
+  size much faster than normal chat.
+
+## Goals
+
+- Make the agent loop treat tools as first-class context budget consumers.
+- Avoid pathological default output reservations for agent sessions.
+- Preflight every provider request, not just the initial user turn.
+- Improve legacy function-call parsing tolerance without changing the public tool protocol.
+- Keep the first increment provider-agnostic and applicable beyond MiniMax.
+
+## Non-Goals
+
+- Do not replace the AI SDK provider runtime.
+- Do not redesign ACP.
+- Do not remove reasoning continuation support.
+- Do not change the renderer UI in this increment.
+
+## User Stories
+
+1. As a user, I want tool-heavy sessions to continue beyond a few tool calls without context window
+   failures caused by avoidable budgeting errors.
+2. As a provider adapter, I want each request to account for messages, tool schemas, and output
+   reserve before it is sent.
+3. As a legacy function-call model, I want minor formatting differences to still be parsed when the
+   intended tool call is recoverable.
+
+## Acceptance Criteria
+
+- New agent sessions do not default to provider-scale output limits above the agent loop cap.
+- Initial user turn and resume turn reserve tokens for tool definitions.
+- Every provider-loop iteration fits messages to the effective request budget before sending.
+- Tool-continuation turns preserve the assistant tool-call message and matching tool results when
+  trimming older context.
+- Legacy parser accepts complete function-call tags, a trailing unclosed function-call tag, and JSON
+  wrapped in Markdown fences.
+- No ACP-specific behavior is required for the first increment.

--- a/docs/specs/agent-tool-context-budget/tasks.md
+++ b/docs/specs/agent-tool-context-budget/tasks.md
@@ -1,0 +1,11 @@
+# Agent Tool Context Budget Tasks
+
+- [x] Document diagnosis and first increment.
+- [x] Add tool-definition token estimation to context budgeting.
+- [x] Cap agent-loop default output budget.
+- [x] Preflight-fit provider-loop requests.
+- [x] Add effective per-request output cap and shared budget module.
+- [x] Harden legacy function-call parsing.
+- [ ] Add request budget telemetry.
+- [ ] Add reasoning retention budget.
+- [ ] Add compact legacy tool schema mode.

--- a/src/main/presenter/agentRuntimePresenter/compactionService.ts
+++ b/src/main/presenter/agentRuntimePresenter/compactionService.ts
@@ -231,6 +231,7 @@ export class CompactionService {
     systemPrompt: string
     contextLength: number
     reserveTokens: number
+    extraReserveTokens?: number
     supportsVision: boolean
     preserveInterleavedReasoning: boolean
     newUserContent: string | SendMessageInput
@@ -265,6 +266,7 @@ export class CompactionService {
     systemPrompt: string
     contextLength: number
     reserveTokens: number
+    extraReserveTokens?: number
     supportsVision: boolean
     preserveInterleavedReasoning: boolean
     signal?: AbortSignal
@@ -361,6 +363,7 @@ export class CompactionService {
     systemPrompt: string
     contextLength: number
     reserveTokens: number
+    extraReserveTokens?: number
     supportsVision: boolean
     preserveInterleavedReasoning: boolean
     records: ChatMessageRecord[]
@@ -397,7 +400,10 @@ export class CompactionService {
       ...projectedHistory,
       ...params.projectedMessages
     ]
-    const requestBudget = Math.floor((params.contextLength - params.reserveTokens) / SAFETY_MARGIN)
+    const requestBudget = Math.floor(
+      (params.contextLength - params.reserveTokens - (params.extraReserveTokens ?? 0)) /
+        SAFETY_MARGIN
+    )
     const triggerBudget = Math.max(0, Math.floor((requestBudget * params.triggerThreshold) / 100))
     if (estimateMessagesTokens(projectedPrompt) <= triggerBudget) {
       return null

--- a/src/main/presenter/agentRuntimePresenter/contextBudget.ts
+++ b/src/main/presenter/agentRuntimePresenter/contextBudget.ts
@@ -1,0 +1,133 @@
+import type { ChatMessage } from '@shared/types/core/chat-message'
+import type { MCPToolDefinition } from '@shared/types/core/mcp'
+import {
+  estimateMessagesTokens,
+  estimateToolDefinitionTokens,
+  fitMessagesToContextWindow
+} from './contextBuilder'
+
+export const AGENT_DEFAULT_MAX_OUTPUT_TOKENS_CAP = 16_384
+export const AGENT_REQUEST_MAX_OUTPUT_TOKENS_CAP = 32_768
+export const AGENT_MIN_EFFECTIVE_OUTPUT_TOKENS = 1
+
+export type RequestContextBudget = {
+  outputReserveTokens: number
+  toolReserveTokens: number
+  totalReserveTokens: number
+}
+
+export function estimateToolReserveTokens(tools: MCPToolDefinition[]): number {
+  return estimateToolDefinitionTokens(tools)
+}
+
+export function capAgentRequestMaxTokens(
+  maxTokens: number,
+  contextLength: number = Number.MAX_SAFE_INTEGER
+): number {
+  const normalizedMaxTokens = Number.isFinite(maxTokens)
+    ? Math.floor(maxTokens)
+    : AGENT_MIN_EFFECTIVE_OUTPUT_TOKENS
+  const requested = Math.max(AGENT_MIN_EFFECTIVE_OUTPUT_TOKENS, normalizedMaxTokens)
+
+  return Math.max(
+    AGENT_MIN_EFFECTIVE_OUTPUT_TOKENS,
+    Math.min(requested, AGENT_REQUEST_MAX_OUTPUT_TOKENS_CAP, getContextOutputCap(contextLength))
+  )
+}
+
+export function capAgentDefaultMaxTokens(maxTokens: number, contextLength: number): number {
+  return Math.min(
+    capAgentRequestMaxTokens(maxTokens, contextLength),
+    AGENT_DEFAULT_MAX_OUTPUT_TOKENS_CAP
+  )
+}
+
+export function buildRequestContextBudget(
+  maxTokens: number,
+  contextLength: number,
+  tools: MCPToolDefinition[]
+): RequestContextBudget {
+  const outputReserveTokens = capAgentRequestMaxTokens(maxTokens, contextLength)
+  const toolReserveTokens = estimateToolReserveTokens(tools)
+  return {
+    outputReserveTokens,
+    toolReserveTokens,
+    totalReserveTokens: outputReserveTokens + toolReserveTokens
+  }
+}
+
+export function fitRequestMessagesToContextWindow(params: {
+  messages: ChatMessage[]
+  contextLength: number
+  reserveTokens: number
+  minimumProtectedTailCount?: number
+}): ChatMessage[] {
+  if (!Number.isFinite(params.contextLength) || params.contextLength <= 0) {
+    return params.messages
+  }
+
+  return fitMessagesToContextWindow(
+    params.messages,
+    params.contextLength,
+    params.reserveTokens,
+    Math.max(
+      params.minimumProtectedTailCount ?? 0,
+      resolveProtectedRequestTailCount(params.messages)
+    )
+  )
+}
+
+export function resolveEffectiveRequestMaxTokens(params: {
+  messages: ChatMessage[]
+  toolReserveTokens: number
+  contextLength: number
+  requestedMaxTokens: number
+}): number {
+  const requested = capAgentRequestMaxTokens(params.requestedMaxTokens, params.contextLength)
+  if (!Number.isFinite(params.contextLength) || params.contextLength <= 0) {
+    return requested
+  }
+
+  const remaining = Math.floor(
+    params.contextLength - estimateMessagesTokens(params.messages) - params.toolReserveTokens
+  )
+  if (remaining <= 0) {
+    return AGENT_MIN_EFFECTIVE_OUTPUT_TOKENS
+  }
+
+  return Math.max(AGENT_MIN_EFFECTIVE_OUTPUT_TOKENS, Math.min(requested, remaining))
+}
+
+function resolveProtectedRequestTailCount(messages: ChatMessage[]): number {
+  if (messages.length === 0) {
+    return 0
+  }
+
+  if (messages[messages.length - 1]?.role === 'user') {
+    return 1
+  }
+
+  let toolTailStart = messages.length - 1
+  while (toolTailStart >= 0 && messages[toolTailStart]?.role === 'tool') {
+    toolTailStart -= 1
+  }
+
+  if (
+    toolTailStart < messages.length - 1 &&
+    messages[toolTailStart]?.role === 'assistant' &&
+    Array.isArray(messages[toolTailStart]?.tool_calls) &&
+    messages[toolTailStart]?.tool_calls?.length
+  ) {
+    return messages.length - toolTailStart
+  }
+
+  return 1
+}
+
+function getContextOutputCap(contextLength: number): number {
+  if (!Number.isFinite(contextLength) || contextLength <= 0) {
+    return Number.MAX_SAFE_INTEGER
+  }
+
+  return Math.max(AGENT_MIN_EFFECTIVE_OUTPUT_TOKENS, Math.floor(contextLength / 2))
+}

--- a/src/main/presenter/agentRuntimePresenter/contextBuilder.ts
+++ b/src/main/presenter/agentRuntimePresenter/contextBuilder.ts
@@ -1,5 +1,6 @@
 import { approximateTokenSize } from 'tokenx'
 import type { ChatMessage, ChatMessageProviderOptions } from '@shared/types/core/chat-message'
+import type { MCPToolDefinition } from '@shared/types/core/mcp'
 import type {
   ChatMessageRecord,
   AssistantMessageBlock,
@@ -16,6 +17,7 @@ export type ContextBuildOptions = {
   historyRecords?: ChatMessageRecord[]
   fallbackProtectedTurnCount?: number
   preserveInterleavedReasoning?: boolean
+  extraReserveTokens?: number
 }
 
 type TokenizedTurn = {
@@ -236,6 +238,13 @@ function estimateMessageTokens(message: ChatMessage): number {
 
 export function estimateMessagesTokens(messages: ChatMessage[]): number {
   return messages.reduce((total, message) => total + estimateMessageTokens(message), 0)
+}
+
+export function estimateToolDefinitionTokens(toolDefinitions: MCPToolDefinition[]): number {
+  return toolDefinitions.reduce(
+    (total, tool) => total + approximateTokenSize(JSON.stringify(tool)),
+    0
+  )
 }
 
 /**
@@ -526,7 +535,12 @@ export function buildContext(
   const newUserMessage = createUserChatMessage(newUserContent, supportsVision)
   const systemPromptTokens = systemPrompt ? approximateTokenSize(systemPrompt) : 0
   const newUserTokens = estimateMessageTokens(newUserMessage)
-  const available = contextLength - systemPromptTokens - newUserTokens - reserveTokens
+  const available =
+    contextLength -
+    systemPromptTokens -
+    newUserTokens -
+    reserveTokens -
+    (options.extraReserveTokens ?? 0)
   const selectedHistory = selectTurnHistory(
     historyTurns,
     available,
@@ -617,7 +631,8 @@ export function buildResumeContext(
     options.preserveInterleavedReasoning ?? false
   )
   const systemPromptTokens = systemPrompt ? approximateTokenSize(systemPrompt) : 0
-  const available = contextLength - systemPromptTokens - reserveTokens
+  const available =
+    contextLength - systemPromptTokens - reserveTokens - (options.extraReserveTokens ?? 0)
   const selectedHistory = selectTurnHistory(
     historyTurns,
     available,

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -62,6 +62,14 @@ import {
   createUserChatMessage,
   fitMessagesToContextWindow
 } from './contextBuilder'
+import {
+  buildRequestContextBudget,
+  capAgentDefaultMaxTokens,
+  capAgentRequestMaxTokens,
+  estimateToolReserveTokens,
+  fitRequestMessagesToContextWindow,
+  resolveEffectiveRequestMaxTokens
+} from './contextBudget'
 import { appendSummarySection, CompactionService, type CompactionIntent } from './compactionService'
 import { buildPersistableMessageTracePayload } from './messageTracePayload'
 import { buildTerminalErrorBlocks, DeepChatMessageStore } from './messageStore'
@@ -488,8 +496,12 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         state.modelId,
         generationSettings
       )
-      const maxTokens = generationSettings.maxTokens
+      const maxTokens = capAgentRequestMaxTokens(
+        generationSettings.maxTokens,
+        generationSettings.contextLength
+      )
       const tools = await this.loadToolDefinitionsForSession(sessionId, projectDir)
+      const toolReserveTokens = estimateToolReserveTokens(tools)
       this.throwIfAbortRequested(preStreamAbortSignal)
       const baseSystemPrompt = await this.buildSystemPromptWithSkills(
         sessionId,
@@ -515,6 +527,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         systemPrompt: baseSystemPrompt,
         contextLength: generationSettings.contextLength,
         reserveTokens: maxTokens,
+        extraReserveTokens: toolReserveTokens,
         supportsVision,
         preserveInterleavedReasoning: interleavedReasoning.preserveReasoningContent,
         newUserContent: normalizedInput,
@@ -579,6 +592,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         {
           summaryCursorOrderSeq: summaryState.summaryCursorOrderSeq,
           historyRecords,
+          extraReserveTokens: toolReserveTokens,
           preserveInterleavedReasoning: interleavedReasoning.preserveReasoningContent
         }
       )
@@ -1539,7 +1553,10 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       ...baseModelConfig,
       temperature: generationSettings.temperature,
       contextLength: generationSettings.contextLength,
-      maxTokens: generationSettings.maxTokens,
+      maxTokens: capAgentRequestMaxTokens(
+        generationSettings.maxTokens,
+        generationSettings.contextLength
+      ),
       timeout: generationSettings.timeout,
       thinkingBudget: generationSettings.thinkingBudget,
       reasoningEffort: generationSettings.reasoningEffort,
@@ -1579,7 +1596,10 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     }
 
     const temperature = generationSettings.temperature
-    const maxTokens = generationSettings.maxTokens
+    const maxTokens = capAgentRequestMaxTokens(
+      generationSettings.maxTokens,
+      generationSettings.contextLength
+    )
 
     const tools = providedTools ?? (await this.loadToolDefinitionsForSession(sessionId, projectDir))
     const supportsVision = this.supportsVision(state.providerId, state.modelId)
@@ -1626,6 +1646,21 @@ export class AgentRuntimePresenter implements IAgentImplementation {
           let queuedForRateLimit = false
 
           try {
+            const requestBudget = buildRequestContextBudget(
+              requestMaxTokens,
+              requestModelConfig.contextLength,
+              requestTools
+            )
+            const protectedSteerTailCount =
+              claimedSteerBatch.length > 0
+                ? claimedSteerBatch.length + (requestMessages.at(-1)?.role === 'user' ? 1 : 0)
+                : 0
+            const fittedMessages = fitRequestMessagesToContextWindow({
+              messages: injectedMessages,
+              contextLength: requestModelConfig.contextLength,
+              reserveTokens: requestBudget.totalReserveTokens,
+              minimumProtectedTailCount: protectedSteerTailCount
+            })
             await llmProviderPresenter.executeWithRateLimit(state.providerId, {
               signal: abortController.signal,
               onQueued: (snapshot) => {
@@ -1647,11 +1682,16 @@ export class AgentRuntimePresenter implements IAgentImplementation {
             }
 
             for await (const event of provider.coreStream(
-              injectedMessages,
+              fittedMessages,
               requestModelId,
               requestModelConfig,
               requestTemperature,
-              requestMaxTokens,
+              resolveEffectiveRequestMaxTokens({
+                messages: fittedMessages,
+                toolReserveTokens: requestBudget.toolReserveTokens,
+                contextLength: requestModelConfig.contextLength,
+                requestedMaxTokens: requestMaxTokens
+              }),
               requestTools
             )) {
               if (!didConsumeSteerBatch && claimedSteerBatch.length > 0) {
@@ -2069,9 +2109,13 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         state.modelId,
         generationSettings
       )
-      const maxTokens = generationSettings.maxTokens
+      const maxTokens = capAgentRequestMaxTokens(
+        generationSettings.maxTokens,
+        generationSettings.contextLength
+      )
       const projectDir = this.resolveProjectDir(sessionId)
       const tools = await this.loadToolDefinitionsForSession(sessionId, projectDir)
+      const toolReserveTokens = estimateToolReserveTokens(tools)
       this.throwIfAbortRequested(preStreamAbortSignal)
       const baseSystemPrompt = await this.buildSystemPromptWithSkills(
         sessionId,
@@ -2087,6 +2131,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         systemPrompt: baseSystemPrompt,
         contextLength: generationSettings.contextLength,
         reserveTokens: maxTokens,
+        extraReserveTokens: toolReserveTokens,
         supportsVision: this.supportsVision(state.providerId, state.modelId),
         preserveInterleavedReasoning: interleavedReasoning.preserveReasoningContent,
         signal: preStreamAbortSignal
@@ -2104,6 +2149,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         {
           summaryCursorOrderSeq: summaryState.summaryCursorOrderSeq,
           fallbackProtectedTurnCount: 1,
+          extraReserveTokens: toolReserveTokens,
           preserveInterleavedReasoning: interleavedReasoning.preserveReasoningContent
         }
       )
@@ -2741,8 +2787,15 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       : true
     const defaultSystemPrompt = await this.configPresenter.getDefaultSystemPrompt()
     const contextLengthDefault = toValidNonNegativeInteger(modelConfig.contextLength) ?? 32000
-    const maxTokensDefault =
-      toValidNonNegativeInteger(modelConfig.maxTokens) ?? Math.min(4096, contextLengthDefault)
+    const rawProviderMaxTokensDefault = toValidNonNegativeInteger(modelConfig.maxTokens)
+    const providerMaxTokensDefault =
+      rawProviderMaxTokensDefault && rawProviderMaxTokensDefault > 0
+        ? rawProviderMaxTokensDefault
+        : Math.min(4096, contextLengthDefault)
+    const maxTokensDefault = capAgentDefaultMaxTokens(
+      providerMaxTokensDefault,
+      contextLengthDefault
+    )
     const timeoutDefault = toValidNonNegativeInteger(modelConfig.timeout) ?? DEFAULT_MODEL_TIMEOUT
 
     const defaults: SessionGenerationSettings = {
@@ -4110,6 +4163,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     systemPrompt: string
     contextLength: number
     reserveTokens: number
+    extraReserveTokens?: number
     supportsVision: boolean
     preserveInterleavedReasoning: boolean
     signal?: AbortSignal

--- a/src/main/presenter/llmProviderPresenter/aiSdk/streamAdapter.ts
+++ b/src/main/presenter/llmProviderPresenter/aiSdk/streamAdapter.ts
@@ -23,6 +23,9 @@ function mapFinishReason(
 ): 'tool_use' | 'max_tokens' | 'stop_sequence' | 'error' | 'complete' {
   switch (reason) {
     case 'tool-calls':
+    case 'tool_calls':
+    case 'tool-call':
+    case 'tool_use':
       return 'tool_use'
     case 'length':
       return 'max_tokens'
@@ -103,6 +106,22 @@ export async function* adaptAiSdkStream(
 
       const endIndex = bufferedLegacyText.indexOf(FUNCTION_CALL_CLOSE_TAG)
       if (endIndex === -1) {
+        if (flushAll) {
+          const block = bufferedLegacyText
+          bufferedLegacyText = ''
+          const toolCalls = parseLegacyFunctionCalls(block)
+          if (!toolCalls.length) {
+            yield createStreamEvent.text(block)
+            return
+          }
+
+          legacyToolUseDetected = true
+          for (const toolCall of toolCalls) {
+            yield createStreamEvent.toolCallStart(toolCall.id, toolCall.function.name)
+            yield createStreamEvent.toolCallChunk(toolCall.id, toolCall.function.arguments)
+            yield createStreamEvent.toolCallEnd(toolCall.id, toolCall.function.arguments)
+          }
+        }
         return
       }
 

--- a/src/main/presenter/llmProviderPresenter/aiSdk/toolProtocol.ts
+++ b/src/main/presenter/llmProviderPresenter/aiSdk/toolProtocol.ts
@@ -51,14 +51,25 @@ export function parseLegacyFunctionCalls(
   response: string,
   fallbackIdPrefix = 'tool-call'
 ): ParsedLegacyToolCall[] {
-  const functionCallMatches = response.match(/<function_call>([\s\S]*?)<\/function_call>/g)
-  if (!functionCallMatches) {
+  const functionCallMatches = [
+    ...response.matchAll(/<function_call>([\s\S]*?)<\/function_call>/g)
+  ].map((match) => match[1])
+
+  const trailingOpenTagIndex = response.lastIndexOf('<function_call>')
+  if (
+    trailingOpenTagIndex !== -1 &&
+    response.indexOf('</function_call>', trailingOpenTagIndex) === -1
+  ) {
+    functionCallMatches.push(response.slice(trailingOpenTagIndex + '<function_call>'.length))
+  }
+
+  if (functionCallMatches.length === 0) {
     return []
   }
 
   return functionCallMatches
     .map((match, index) => {
-      const content = match.replace(/<\/?function_call>/g, '').trim()
+      const content = normalizeLegacyFunctionCallContent(match)
       if (!content) {
         return null
       }
@@ -112,6 +123,17 @@ export function parseLegacyFunctionCalls(
       }
     })
     .filter((call): call is ParsedLegacyToolCall => call !== null)
+}
+
+function normalizeLegacyFunctionCallContent(content: string): string {
+  let normalized = content.replace(/<\/?function_call>/g, '').trim()
+
+  const fenced = normalized.match(/^```(?:json|JSON)?\s*([\s\S]*?)\s*```$/)
+  if (fenced?.[1]) {
+    normalized = fenced[1].trim()
+  }
+
+  return normalized
 }
 
 export function buildFunctionCallRecordContent(


### PR DESCRIPTION
… budget

- Cap agent-session default maxTokens to 16 384 and never reserve more than half the context window for output
- Reserve tool-definition token cost when building initial and resume context, preventing silent context overflow on tool-heavy sessions
- Preflight-fit request messages to the effective budget before every provider-loop call, protecting the active tool-continuation tail
- Resolve a per-request effective output cap from fitted message size and tool-schema cost rather than using the raw maxTokens value
- Harden legacy function-call parsing: tolerate JSON wrapped in Markdown fences, a trailing unclosed <function_call> tag at end of stream, and extra finish-reason aliases from non-standard providers

Closes the first increment of docs/specs/agent-tool-context-budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Agents now more efficiently manage context budgets during conversations with multiple tools, improving reliability
  * Enhanced tool call detection in streaming scenarios with better completion signal recognition

* **Bug Fixes**
  * Tool call parser now gracefully handles incomplete tags and markdown-fenced JSON, reducing parsing failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->