### PR TITLE
feat(provider): add Xiaomi Token Plan providers for CN, SGP, and AMS

### DIFF
--- a/src/main/presenter/configPresenter/providers.ts
+++ b/src/main/presenter/configPresenter/providers.ts
@@ -778,6 +778,51 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
     }
   },
   {
+    id: 'xiaomi-token-plan-cn',
+    name: 'Xiaomi Token Plan (China)',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+    enable: false,
+    websites: {
+      official: 'https://platform.xiaomimimo.com/',
+      apiKey: 'https://platform.xiaomimimo.com/#/console/plan-manage',
+      docs: 'https://platform.xiaomimimo.com/#/docs',
+      models: 'https://platform.xiaomimimo.com/#/docs',
+      defaultBaseUrl: 'https://token-plan-cn.xiaomimimo.com/v1'
+    }
+  },
+  {
+    id: 'xiaomi-token-plan-sgp',
+    name: 'Xiaomi Token Plan (Singapore)',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://token-plan-sgp.xiaomimimo.com/v1',
+    enable: false,
+    websites: {
+      official: 'https://platform.xiaomimimo.com/',
+      apiKey: 'https://platform.xiaomimimo.com/#/console/plan-manage',
+      docs: 'https://platform.xiaomimimo.com/#/docs',
+      models: 'https://platform.xiaomimimo.com/#/docs',
+      defaultBaseUrl: 'https://token-plan-sgp.xiaomimimo.com/v1'
+    }
+  },
+  {
+    id: 'xiaomi-token-plan-ams',
+    name: 'Xiaomi Token Plan (Europe)',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://token-plan-ams.xiaomimimo.com/v1',
+    enable: false,
+    websites: {
+      official: 'https://platform.xiaomimimo.com/',
+      apiKey: 'https://platform.xiaomimimo.com/#/console/plan-manage',
+      docs: 'https://platform.xiaomimimo.com/#/docs',
+      models: 'https://platform.xiaomimimo.com/#/docs',
+      defaultBaseUrl: 'https://token-plan-ams.xiaomimimo.com/v1'
+    }
+  },
+  {
     id: 'o3fan',
     name: 'o3.fan',
     apiType: 'o3fan',

--- a/src/main/presenter/llmProviderPresenter/providerRegistry.ts
+++ b/src/main/presenter/llmProviderPresenter/providerRegistry.ts
@@ -397,6 +397,33 @@ const PROVIDER_ID_REGISTRY = new Map<string, AiSdkProviderDefinition>([
       ...OPENAI_BASE,
       modelSource: 'astraflow'
     })
+  ],
+  [
+    'xiaomi-token-plan-cn',
+    createDefinition({
+      ...CHINESE_SUMMARY_OPENAI,
+      modelSource: 'provider-db',
+      providerDbSourceId: 'xiaomi-token-plan-cn',
+      providerDbGroup: 'token-plan'
+    })
+  ],
+  [
+    'xiaomi-token-plan-sgp',
+    createDefinition({
+      ...CHINESE_SUMMARY_OPENAI,
+      modelSource: 'provider-db',
+      providerDbSourceId: 'xiaomi-token-plan-sgp',
+      providerDbGroup: 'token-plan'
+    })
+  ],
+  [
+    'xiaomi-token-plan-ams',
+    createDefinition({
+      ...CHINESE_SUMMARY_OPENAI,
+      modelSource: 'provider-db',
+      providerDbSourceId: 'xiaomi-token-plan-ams',
+      providerDbGroup: 'token-plan'
+    })
   ]
 ])
 

--- a/src/renderer/settings/components/ModelProviderSettings.vue
+++ b/src/renderer/settings/components/ModelProviderSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="showProviderSkeleton" class="w-full h-full flex flex-row animate-pulse">
-    <div class="w-64 h-full border-r p-4 space-y-3">
+    <div class="w-80 h-full border-r p-4 space-y-3">
       <div class="h-9 rounded-md bg-muted/60"></div>
       <div
         v-for="index in 8"
@@ -22,7 +22,7 @@
     </div>
   </div>
   <div v-else data-testid="settings-provider-page" class="w-full h-full flex flex-row">
-    <ScrollArea class="w-64 border-r h-full">
+    <ScrollArea class="w-80 border-r h-full">
       <div class="space-y-4 p-4">
         <!-- 搜索框 -->
         <div class="sticky top-4 z-10">
@@ -91,9 +91,11 @@
                   @click.stop
                 />
                 <template v-else>
-                  <span class="text-sm font-medium flex-1" :dir="languageStore.dir">{{
-                    t(provider.name)
-                  }}</span>
+                  <span
+                    class="text-sm font-medium flex-1 min-w-0 truncate"
+                    :dir="languageStore.dir"
+                    >{{ t(provider.name) }}</span
+                  >
                   <Icon
                     v-if="provider.custom"
                     icon="lucide:pencil"
@@ -153,9 +155,11 @@
                   @click.stop
                 />
                 <template v-else>
-                  <span class="text-sm font-medium flex-1" :dir="languageStore.dir">{{
-                    t(provider.name)
-                  }}</span>
+                  <span
+                    class="text-sm font-medium flex-1 min-w-0 truncate"
+                    :dir="languageStore.dir"
+                    >{{ t(provider.name) }}</span
+                  >
                   <Icon
                     v-if="provider.custom"
                     icon="lucide:pencil"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new Xiaomi Token Plan providers enabling support for additional regions: China, Singapore, and Amsterdam.

* **UI Improvements**
  * Expanded the sidebar width in the model provider settings interface for improved visibility and content accommodation.
  * Enhanced provider name display behavior with improved text truncation to prevent overflow in both enabled and disabled provider lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->