### PR TITLE
fix(model-list): add model fetching with fallback for Anthropic an…

### DIFF
--- a/src/main/presenter/llmProviderPresenter/baseProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/baseProvider.ts
@@ -235,7 +235,8 @@ export abstract class BaseLLMProvider {
    * 获取提供商的模型列表
    * @returns 模型列表
    */
-  public async fetchModels(): Promise<MODEL_META[]> {
+  public async fetchModels(options?: { suppressErrors?: boolean }): Promise<MODEL_META[]> {
+    const suppressErrors = options?.suppressErrors ?? true
     try {
       return this.fetchProviderModels().then((models) => {
         logger.info(
@@ -260,6 +261,9 @@ export abstract class BaseLLMProvider {
         `[Provider] fetchModels: Failed to fetch models for provider "${this.provider.id}":`,
         e
       )
+      if (!suppressErrors) {
+        throw e
+      }
       if (!this.models) {
         this.models = []
       }
@@ -276,7 +280,7 @@ export abstract class BaseLLMProvider {
     logger.info(
       `[Provider] refreshModels: force refreshing models for provider "${this.provider.id}" (${this.provider.name})`
     )
-    await this.fetchModels()
+    await this.fetchModels({ suppressErrors: false })
     await this.autoEnableModelsIfNeeded()
     logger.info(
       `[Provider] refreshModels: sending MODEL_LIST_CHANGED event for provider "${this.provider.id}"`

--- a/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
@@ -878,6 +878,181 @@ export class AiSdkProvider extends BaseLLMProvider {
     }))
   }
 
+  private async fetchAnthropicModelsWithFallback(): Promise<MODEL_META[]> {
+    const fallbackModels = this.mapConfigDbModels(this.definition.providerDbSourceId)
+    const apiKey = this.provider.apiKey?.trim()
+    if (!apiKey) {
+      return fallbackModels
+    }
+
+    const normalizedBaseUrl = (this.provider.baseUrl || 'https://api.anthropic.com')
+      .trim()
+      .replace(/\/+$/, '')
+    const modelsUrl = /\/v1$/i.test(normalizedBaseUrl)
+      ? `${normalizedBaseUrl}/models`
+      : `${normalizedBaseUrl}/v1/models`
+    const { signal, dispose } = this.createModelRequestSignal(null)
+
+    try {
+      const dispatcher = this.getFetchDispatcher()
+      const response = await fetch(modelsUrl, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'anthropic-version': '2023-06-01',
+          'x-api-key': apiKey,
+          ...this.defaultHeaders,
+          ...this.definition.defaultHeadersPatch
+        },
+        signal,
+        ...(dispatcher ? ({ dispatcher } as Record<string, unknown>) : {})
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(errorText || `Failed to fetch Anthropic models: ${response.status}`)
+      }
+
+      const payload = (await response.json()) as {
+        data?: Array<{ id?: string; display_name?: string }>
+      }
+
+      const models = Array.isArray(payload.data)
+        ? payload.data
+            .filter((model): model is { id: string; display_name?: string } => !!model?.id)
+            .map((model) => {
+              const existingConfig = this.getProviderModelConfig(model.id)
+              return {
+                id: model.id,
+                name: model.display_name || model.id,
+                providerId: this.provider.id,
+                maxTokens: existingConfig.maxTokens || 64_000,
+                group: 'Claude',
+                isCustom: false,
+                contextLength: existingConfig.contextLength || 200_000,
+                vision: existingConfig.vision || false,
+                functionCall: existingConfig.functionCall || false,
+                reasoning: existingConfig.reasoning || false
+              }
+            })
+        : []
+
+      return models.length > 0 ? models : fallbackModels
+    } catch (error) {
+      console.error('Failed to fetch Anthropic models:', error)
+      if (fallbackModels.length > 0 && !this.provider.custom) {
+        return fallbackModels
+      }
+      throw error
+    } finally {
+      dispose()
+    }
+  }
+
+  private async fetchGeminiModelsWithFallback(): Promise<MODEL_META[]> {
+    const fallbackModels = this.mapConfigDbModels(this.definition.providerDbSourceId)
+    const apiKey = this.provider.apiKey?.trim()
+    if (!apiKey) {
+      return fallbackModels
+    }
+
+    const modelsUrl = `${normalizeGeminiBaseUrl(this.provider.baseUrl || undefined).replace(/\/+$/, '')}/models`
+    const { signal, dispose } = this.createModelRequestSignal(null)
+
+    try {
+      const dispatcher = this.getFetchDispatcher()
+      const response = await fetch(modelsUrl, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': apiKey,
+          ...this.defaultHeaders,
+          ...this.definition.defaultHeadersPatch
+        },
+        signal,
+        ...(dispatcher ? ({ dispatcher } as Record<string, unknown>) : {})
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(errorText || `Failed to fetch Gemini models: ${response.status}`)
+      }
+
+      const payload = (await response.json()) as {
+        models?: Array<{
+          name?: string
+          displayName?: string
+          inputTokenLimit?: number
+          outputTokenLimit?: number
+        }>
+      }
+
+      const models = Array.isArray(payload.models)
+        ? payload.models
+            .filter(
+              (
+                model
+              ): model is {
+                name: string
+                displayName?: string
+                inputTokenLimit?: number
+                outputTokenLimit?: number
+              } => !!model?.name
+            )
+            .filter((model) => {
+              const lowerName = model.name.toLowerCase()
+              return (
+                !lowerName.includes('embedding') &&
+                !lowerName.includes('aqa') &&
+                !lowerName.includes('text-embedding') &&
+                !lowerName.includes('gemma-3n-e4b-it')
+              )
+            })
+            .map((model) => ({
+              id: model.name,
+              name: model.displayName || model.name,
+              group: /\b(exp|preview)\b/i.test(model.name)
+                ? 'experimental'
+                : /\bgemma\b/i.test(model.name)
+                  ? 'gemma'
+                  : 'default',
+              providerId: this.provider.id,
+              isCustom: false,
+              contextLength: model.inputTokenLimit,
+              maxTokens: model.outputTokenLimit,
+              vision: false,
+              functionCall: false,
+              reasoning: false
+            }))
+        : []
+
+      return models.length > 0 ? models : fallbackModels
+    } catch (error) {
+      console.error('Failed to fetch Gemini models:', error)
+      if (fallbackModels.length > 0 && !this.provider.custom) {
+        return fallbackModels
+      }
+      throw error
+    } finally {
+      dispose()
+    }
+  }
+
+  private async fetchConfigDbModels(): Promise<MODEL_META[]> {
+    if (!this.provider.custom) {
+      return this.mapConfigDbModels(this.definition.providerDbSourceId)
+    }
+
+    switch (this.definition.runtimeKind) {
+      case 'anthropic':
+        return this.fetchAnthropicModelsWithFallback()
+      case 'gemini':
+        return this.fetchGeminiModelsWithFallback()
+      default:
+        return this.mapConfigDbModels(this.definition.providerDbSourceId)
+    }
+  }
+
   private mapProviderDbModels(group: string): MODEL_META[] {
     const resolvedId = modelCapabilities.resolveProviderId(this.provider.id) || this.provider.id
     const provider = providerDbLoader.getProvider(resolvedId)
@@ -930,7 +1105,7 @@ export class AiSdkProvider extends BaseLLMProvider {
   ): Promise<MODEL_META[]> {
     switch (strategy) {
       case 'config-db':
-        return this.mapConfigDbModels(this.definition.providerDbSourceId)
+        return this.fetchConfigDbModels()
       case 'provider-db':
         return this.mapProviderDbModels(this.definition.providerDbGroup || 'default')
       case 'github': {

--- a/src/renderer/settings/components/ProviderApiConfig.vue
+++ b/src/renderer/settings/components/ProviderApiConfig.vue
@@ -209,7 +209,7 @@ interface ProviderWebsites {
 }
 
 const { t } = useI18n()
-const llmProviderPresenter = useLegacyPresenter('llmproviderPresenter')
+const llmProviderPresenter = useLegacyPresenter('llmproviderPresenter', { safeCall: false })
 const modelCheckStore = useModelCheckStore()
 const { toast } = useToast()
 
@@ -325,6 +325,34 @@ const openModelCheckDialog = () => {
   modelCheckStore.openDialog(props.provider.id)
 }
 
+const extractRefreshErrorMessage = (error: unknown): string | null => {
+  const rawMessage = error instanceof Error ? error.message : String(error)
+  const normalizedMessage = rawMessage.trim()
+
+  if (!normalizedMessage) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(normalizedMessage) as {
+      error?: { message?: string }
+      message?: string
+    }
+
+    if (typeof parsed.error?.message === 'string' && parsed.error.message.trim()) {
+      return parsed.error.message.trim()
+    }
+
+    if (typeof parsed.message === 'string' && parsed.message.trim()) {
+      return parsed.message.trim()
+    }
+  } catch {
+    // ignore JSON parse errors and fall back to the original message
+  }
+
+  return normalizedMessage
+}
+
 const getKeyStatus = async () => {
   if (
     ['ppio', 'openrouter', 'siliconcloud', 'silicon', 'deepseek', '302ai', 'cherryin'].includes(
@@ -358,13 +386,15 @@ const refreshModels = async () => {
     })
   } catch (error) {
     console.error('Failed to refresh models:', error)
+    const fallbackDescription = t(
+      shouldRefreshProviderDbFirst.value
+        ? 'settings.provider.toast.refreshModelsFailedDescriptionWithMetadata'
+        : 'settings.provider.toast.refreshModelsFailedDescription'
+    )
+    const errorMessage = extractRefreshErrorMessage(error)
     toast({
       title: t('settings.provider.toast.refreshModelsFailedTitle'),
-      description: t(
-        shouldRefreshProviderDbFirst.value
-          ? 'settings.provider.toast.refreshModelsFailedDescriptionWithMetadata'
-          : 'settings.provider.toast.refreshModelsFailedDescription'
-      ),
+      description: errorMessage ? `${fallbackDescription}: ${errorMessage}` : fallbackDescription,
       variant: 'destructive',
       duration: 4000
     })

--- a/test/main/presenter/llmProviderPresenter/anthropicProvider.test.ts
+++ b/test/main/presenter/llmProviderPresenter/anthropicProvider.test.ts
@@ -167,4 +167,63 @@ describe('AiSdkProvider anthropic', () => {
       })
     ])
   })
+
+  it('fetches remote models for custom anthropic-compatible providers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        data: [{ id: 'claude-3-7-sonnet-latest', display_name: 'Claude 3.7 Sonnet' }]
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: 'custom-anthropic',
+        name: 'Custom Anthropic',
+        custom: true
+      }),
+      createConfigPresenter()
+    )
+    const models = await provider.fetchModels()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/models',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'x-api-key': 'test-key',
+          'anthropic-version': '2023-06-01'
+        })
+      })
+    )
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: 'claude-3-7-sonnet-latest',
+        providerId: 'custom-anthropic',
+        name: 'Claude 3.7 Sonnet'
+      })
+    ])
+  })
+
+  it('throws refresh errors for custom anthropic-compatible providers when remote fetch fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      text: vi
+        .fn()
+        .mockResolvedValue('{"error":{"type":"Unauthorized","message":"Invalid API key"}}')
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: 'custom-anthropic',
+        name: 'Custom Anthropic',
+        custom: true
+      }),
+      createConfigPresenter()
+    )
+
+    await expect(provider.refreshModels()).rejects.toThrow('Invalid API key')
+  })
 })

--- a/test/main/presenter/llmProviderPresenter/geminiProvider.test.ts
+++ b/test/main/presenter/llmProviderPresenter/geminiProvider.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IConfigPresenter, LLM_PROVIDER } from '../../../../src/shared/presenter'
+import { AiSdkProvider } from '../../../../src/main/presenter/llmProviderPresenter/providers/aiSdkProvider'
+
+const { mockRunAiSdkCoreStream, mockRunAiSdkGenerateText } = vi.hoisted(() => ({
+  mockRunAiSdkCoreStream: vi.fn(),
+  mockRunAiSdkGenerateText: vi.fn().mockResolvedValue({ content: 'ok' })
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getName: vi.fn(() => 'DeepChat'),
+    getVersion: vi.fn(() => '0.0.0-test'),
+    getPath: vi.fn(() => '/mock/path'),
+    isReady: vi.fn(() => true),
+    on: vi.fn()
+  }
+}))
+
+vi.mock('@/eventbus', () => ({
+  eventBus: {
+    on: vi.fn(),
+    sendToRenderer: vi.fn()
+  },
+  SendTarget: {
+    ALL_WINDOWS: 'ALL_WINDOWS'
+  }
+}))
+
+vi.mock('@/events', () => ({
+  CONFIG_EVENTS: {
+    MODEL_LIST_CHANGED: 'MODEL_LIST_CHANGED'
+  },
+  PROVIDER_DB_EVENTS: {
+    LOADED: 'LOADED',
+    UPDATED: 'UPDATED'
+  }
+}))
+
+vi.mock('../../../../src/main/presenter/llmProviderPresenter/aiSdk', () => ({
+  runAiSdkCoreStream: mockRunAiSdkCoreStream,
+  runAiSdkGenerateText: mockRunAiSdkGenerateText
+}))
+
+const createProvider = (overrides?: Partial<LLM_PROVIDER>): LLM_PROVIDER => ({
+  id: 'gemini',
+  name: 'Gemini',
+  apiType: 'gemini',
+  apiKey: 'test-key',
+  baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+  enable: false,
+  ...overrides
+})
+
+const createConfigPresenter = (): IConfigPresenter =>
+  ({
+    getProviderModels: vi.fn().mockReturnValue([]),
+    getCustomModels: vi.fn().mockReturnValue([]),
+    getDbProviderModels: vi.fn().mockReturnValue([
+      {
+        id: 'models/gemini-2.0-flash',
+        name: 'Gemini 2.0 Flash',
+        group: 'default',
+        contextLength: 1048576,
+        maxTokens: 8192,
+        vision: true,
+        functionCall: true,
+        reasoning: false
+      }
+    ]),
+    getModelConfig: vi.fn().mockReturnValue(undefined),
+    getSetting: vi.fn().mockReturnValue(undefined),
+    setProviderModels: vi.fn(),
+    getModelStatus: vi.fn().mockReturnValue(true)
+  }) as unknown as IConfigPresenter
+
+describe('AiSdkProvider gemini', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('fetches remote models for custom gemini-compatible providers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        models: [
+          {
+            name: 'models/gemini-2.5-flash',
+            displayName: 'Gemini 2.5 Flash',
+            inputTokenLimit: 1048576,
+            outputTokenLimit: 8192
+          }
+        ]
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: 'custom-gemini',
+        name: 'Custom Gemini',
+        custom: true,
+        baseUrl: 'https://generativelanguage.googleapis.com/v1'
+      }),
+      createConfigPresenter()
+    )
+    const models = await provider.fetchModels()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://generativelanguage.googleapis.com/v1beta/models',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'x-goog-api-key': 'test-key'
+        })
+      })
+    )
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: 'models/gemini-2.5-flash',
+        providerId: 'custom-gemini',
+        name: 'Gemini 2.5 Flash'
+      })
+    ])
+  })
+
+  it('throws refresh errors for custom gemini-compatible providers when remote fetch fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      text: vi.fn().mockResolvedValue('{"error":{"message":"API key not valid"}}')
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: 'custom-gemini',
+        name: 'Custom Gemini',
+        custom: true
+      }),
+      createConfigPresenter()
+    )
+
+    await expect(provider.refreshModels()).rejects.toThrow('API key not valid')
+  })
+})

--- a/test/renderer/components/ProviderApiConfig.test.ts
+++ b/test/renderer/components/ProviderApiConfig.test.ts
@@ -98,7 +98,7 @@ async function setup(options?: {
   }))
 
   vi.doMock('@api/legacy/presenters', () => ({
-    useLegacyPresenter: (name: string) => {
+    useLegacyPresenter: (name: string, options?: { safeCall?: boolean }) => {
       if (name === 'llmproviderPresenter') return llmproviderPresenter
       throw new Error(`Unexpected presenter: ${name}`)
     }
@@ -306,9 +306,100 @@ describe('ProviderApiConfig', () => {
     expect(llmproviderPresenter.refreshModels).toHaveBeenCalledWith('doubao')
     expect(toast).toHaveBeenCalledWith({
       title: 'settings.provider.toast.refreshModelsFailedTitle',
-      description: 'settings.provider.toast.refreshModelsFailedDescriptionWithMetadata',
+      description:
+        'settings.provider.toast.refreshModelsFailedDescriptionWithMetadata: network down',
       variant: 'destructive',
       duration: 4000
     })
+  })
+
+  it('extracts nested API error messages for refresh failures', async () => {
+    const { wrapper, toast, llmproviderPresenter } = await setup({
+      provider: createProvider({
+        id: 'custom-anthropic',
+        name: 'Custom Anthropic',
+        apiType: 'anthropic',
+        custom: true,
+        baseUrl: 'https://anthropic-proxy.example.com'
+      })
+    })
+    llmproviderPresenter.refreshModels.mockRejectedValueOnce(
+      new Error('{"error":{"type":"Unauthorized","message":"Invalid API key"}}')
+    )
+
+    const refreshButton = findButtonByText(wrapper, 'settings.provider.refreshModels')
+    expect(refreshButton).toBeDefined()
+
+    await refreshButton!.trigger('click')
+    await flushPromises()
+
+    expect(toast).toHaveBeenCalledWith({
+      title: 'settings.provider.toast.refreshModelsFailedTitle',
+      description: 'settings.provider.toast.refreshModelsFailedDescription: Invalid API key',
+      variant: 'destructive',
+      duration: 4000
+    })
+  })
+
+  it('requests the presenter with safeCall disabled so refresh errors can surface', async () => {
+    const useLegacyPresenter = vi.fn((name: string) => {
+      if (name === 'llmproviderPresenter') return { getKeyStatus: vi.fn(), refreshModels: vi.fn() }
+      throw new Error(`Unexpected presenter: ${name}`)
+    })
+
+    vi.resetModules()
+    vi.doMock('vue-i18n', () => ({
+      useI18n: () => ({
+        t: (key: string) => key
+      })
+    }))
+    vi.doMock('@api/legacy/presenters', () => ({
+      useLegacyPresenter
+    }))
+    vi.doMock('@/stores/modelCheck', () => ({
+      useModelCheckStore: () => ({ openDialog: vi.fn() })
+    }))
+    vi.doMock('@/components/use-toast', () => ({
+      useToast: () => ({ toast: vi.fn() })
+    }))
+    vi.doMock('@shadcn/components/ui/input', () => ({ Input: createInputStub() }))
+    vi.doMock('@shadcn/components/ui/button', () => ({ Button: buttonStub }))
+    vi.doMock('@shadcn/components/ui/label', () => ({ Label: labelStub }))
+    vi.doMock('@shadcn/components/ui/tooltip', () => ({
+      Tooltip: passthrough('Tooltip'),
+      TooltipContent: passthrough('TooltipContent'),
+      TooltipProvider: passthrough('TooltipProvider'),
+      TooltipTrigger: passthrough('TooltipTrigger')
+    }))
+    vi.doMock('@iconify/vue', () => ({
+      Icon: defineComponent({
+        name: 'Icon',
+        template: '<i />'
+      })
+    }))
+
+    const ProviderApiConfig = (
+      await import('../../../src/renderer/settings/components/ProviderApiConfig.vue')
+    ).default
+
+    mount(ProviderApiConfig, {
+      props: {
+        provider: createProvider(),
+        providerWebsites: {
+          official: 'https://example.com',
+          apiKey: 'https://example.com/key',
+          docs: 'https://example.com/docs',
+          models: 'https://example.com/models',
+          defaultBaseUrl: 'https://api.deepseek.com/v1'
+        }
+      },
+      global: {
+        stubs: {
+          GitHubCopilotOAuth: true
+        }
+      }
+    })
+
+    expect(useLegacyPresenter).toHaveBeenCalledWith('llmproviderPresenter', { safeCall: false })
   })
 })


### PR DESCRIPTION
…d Gemini

- Add suppressErrors option to fetchModels in baseProvider
- Implement fetchAnthropicModelsWithFallback and fetchGeminiModelsWithFallback
- Update ProviderApiConfig component to handle new provider types
- Add comprehensive tests for Anthropic and Gemini providers
- Add tests for ProviderApiConfig component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live model discovery from Anthropic and Gemini APIs with fallback to cached configurations when unavailable

* **Bug Fixes**
  * Enhanced error messaging during model refresh to display specific API error details instead of generic messages

* **Tests**
  * Added comprehensive test coverage for live model discovery and error propagation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->