### PR TITLE
fix(model): hide disabled provider models

### DIFF
--- a/src/renderer/src/components/chat/ChatStatusBar.vue
+++ b/src/renderer/src/components/chat/ChatStatusBar.vue
@@ -1202,6 +1202,9 @@ const providerNameMap = computed(() => {
   })
   return map
 })
+const activeEnabledModelGroups = computed(
+  () => modelStore.activeEnabledModels ?? modelStore.enabledModels
+)
 const isModelOptionsReady = computed(() => isAcpAgent.value || modelStore.initialized)
 const hasModelOptionsError = computed(
   () => !isAcpAgent.value && !modelStore.initialized && Boolean(modelStore.initializationError)
@@ -1221,41 +1224,23 @@ const modelGroups = computed<GroupedModelList[]>(() => {
     return []
   }
 
-  const groupsById = new Map(
-    modelStore.enabledModels
-      .filter((group) => group.providerId !== 'acp')
-      .map((group) => [group.providerId, getChatSelectableModels(group.models)] as const)
-      .filter(([, models]) => models.length > 0)
-  )
-
-  const result: GroupedModelList[] = []
-
-  providerStore.sortedProviders
+  return providerStore.sortedProviders
     .filter((provider) => provider.enable && provider.id !== 'acp')
-    .forEach((provider) => {
-      const models = groupsById.get(provider.id)
-      if (!models || models.length === 0) {
-        return
+    .map((provider) => {
+      const enabledGroup = activeEnabledModelGroups.value.find(
+        (group) => group.providerId === provider.id
+      )
+      const models = enabledGroup ? getChatSelectableModels(enabledGroup.models) : []
+      if (models.length === 0) {
+        return null
       }
-      result.push({
+      return {
         providerId: provider.id,
         providerName: provider.name,
         models
-      })
-      groupsById.delete(provider.id)
+      }
     })
-
-  Array.from(groupsById.entries())
-    .sort(([left], [right]) => left.localeCompare(right))
-    .forEach(([providerId, models]) => {
-      result.push({
-        providerId,
-        providerName: providerNameMap.value.get(providerId) ?? providerId,
-        models
-      })
-    })
-
-  return result
+    .filter((group): group is GroupedModelList => group !== null)
 })
 
 const filteredModelGroups = computed<GroupedModelList[]>(() => {
@@ -1609,7 +1594,7 @@ const getAcpOptionDisplayValue = (option: AcpConfigOption): string => {
 }
 
 const findEnabledModelMeta = (providerId: string, modelId: string): RENDERER_MODEL_META | null => {
-  const group = modelStore.enabledModels.find((item) => item.providerId === providerId)
+  const group = activeEnabledModelGroups.value.find((item) => item.providerId === providerId)
   return (
     group?.models.find((model) => model.id === modelId && isChatSelectableModelType(model.type)) ??
     null
@@ -1762,14 +1747,14 @@ const findEnabledModel = (providerId: string, modelId: string): ModelSelection |
 }
 
 const pickFirstEnabledModel = (): ModelSelection | null => {
-  for (const group of modelStore.enabledModels) {
+  for (const group of activeEnabledModelGroups.value) {
     if (group.providerId === 'acp') continue
     const firstModel = group.models.find((model) => isChatSelectableModelType(model.type))
     if (firstModel) {
       return { providerId: group.providerId, modelId: firstModel.id }
     }
   }
-  for (const group of modelStore.enabledModels) {
+  for (const group of activeEnabledModelGroups.value) {
     const firstModel = group.models.find((model) => isChatSelectableModelType(model.type))
     if (firstModel) {
       return { providerId: group.providerId, modelId: firstModel.id }
@@ -2584,7 +2569,7 @@ watch(
     isAcpAgent,
     () => agentStore.selectedAgentId,
     () => modelStore.initialized,
-    () => modelStore.enabledModels
+    () => activeEnabledModelGroups.value
   ],
   () => {
     if (hasActiveSession.value) return

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -132,6 +132,9 @@ const draftStore = useDraftStore()
 const configClient = createConfigClient()
 const sessionClient = createSessionClient()
 const { t } = useI18n()
+const activeEnabledModelGroups = computed(
+  () => modelStore.activeEnabledModels ?? modelStore.enabledModels
+)
 
 const message = ref('')
 const attachedFiles = ref<MessageFile[]>([])
@@ -205,7 +208,7 @@ const getEnabledModel = (
   modelId?: string
 ): { providerId: string; modelId: string } | null => {
   if (!providerId || !modelId) return null
-  const matched = modelStore.enabledModels.some(
+  const matched = activeEnabledModelGroups.value.some(
     (group) =>
       group.providerId === providerId &&
       group.models.some((model) => model.id === modelId && isChatSelectableModel(model))
@@ -261,7 +264,7 @@ async function resolveModel(): Promise<{ providerId: string; modelId: string } |
   }
 
   // 3. First available enabled model
-  for (const group of modelStore.enabledModels) {
+  for (const group of activeEnabledModelGroups.value) {
     const firstChatSelectableModel = group.models.find(isChatSelectableModel)
     if (firstChatSelectableModel) {
       return { providerId: group.providerId, modelId: firstChatSelectableModel.id }
@@ -289,7 +292,7 @@ const resolveStartModelSelection = (
     return null
   }
 
-  for (const group of modelStore.enabledModels) {
+  for (const group of activeEnabledModelGroups.value) {
     const matched = group.models.find(
       (model) => model.id.toLowerCase() === normalizedModelId && isChatSelectableModel(model)
     )
@@ -298,7 +301,7 @@ const resolveStartModelSelection = (
     }
   }
 
-  for (const group of modelStore.enabledModels) {
+  for (const group of activeEnabledModelGroups.value) {
     const matched = group.models.find(
       (model) => model.id.toLowerCase().includes(normalizedModelId) && isChatSelectableModel(model)
     )

--- a/src/renderer/src/stores/mcpSampling.ts
+++ b/src/renderer/src/stores/mcpSampling.ts
@@ -118,6 +118,9 @@ export const useMcpSamplingStore = defineStore('mcpSampling', () => {
 
   const requiresVision = computed(() => request.value?.requiresVision ?? false)
   const selectedModelSupportsVision = computed(() => selectedModel.value?.vision ?? false)
+  const activeEnabledModelGroups = computed(
+    () => modelStore.activeEnabledModels ?? modelStore.enabledModels
+  )
   const selectedProviderLabel = computed(() => {
     if (!selectedProviderId.value) {
       return null
@@ -177,7 +180,7 @@ export const useMcpSamplingStore = defineStore('mcpSampling', () => {
         : null
 
     const selection = resolveSamplingDefaultModel({
-      enabledModels: modelStore.enabledModels,
+      enabledModels: activeEnabledModelGroups.value,
       providerOrder,
       requiresVision: requiresVision.value,
       activeSelection,
@@ -194,7 +197,7 @@ export const useMcpSamplingStore = defineStore('mcpSampling', () => {
     }
 
     const requiresVisionValue = requiresVision.value
-    return modelStore.enabledModels.some((entry) =>
+    return activeEnabledModelGroups.value.some((entry) =>
       entry.models.some((model) => !requiresVisionValue || model.vision)
     )
   })
@@ -250,7 +253,7 @@ export const useMcpSamplingStore = defineStore('mcpSampling', () => {
       return false
     }
 
-    const providerEntry = modelStore.enabledModels.find(
+    const providerEntry = activeEnabledModelGroups.value.find(
       (entry) => entry.providerId === sessionInfo.providerId
     )
 

--- a/src/renderer/src/stores/modelStore.ts
+++ b/src/renderer/src/stores/modelStore.ts
@@ -1,4 +1,4 @@
-import { computed, type ComputedRef, readonly, ref } from 'vue'
+import { computed, type ComputedRef, readonly, ref, watch } from 'vue'
 import { defineStore } from 'pinia'
 import { useQueryCache, type DataState, type EntryKey, type UseQueryEntry } from '@pinia/colada'
 import { useThrottleFn } from '@vueuse/core'
@@ -55,6 +55,15 @@ export const useModelStore = defineStore('model', () => {
   const pendingRefreshStarts = new Set<string>()
   const pendingModelStatusEchoes = new Map<string, boolean>()
   const providerModelsReadyAt = new Map<string, number>()
+  const activeProviderIds = computed(
+    () =>
+      new Set(
+        providerStore.providers.filter((provider) => provider.enable).map((provider) => provider.id)
+      )
+  )
+  const activeEnabledModels = computed(() =>
+    enabledModels.value.filter((group) => activeProviderIds.value.has(group.providerId))
+  )
 
   const MODEL_TOGGLE_PERF_LOG_PREFIX = '[ModelTogglePerf]'
   const getPerfNow = () => (typeof performance !== 'undefined' ? performance.now() : Date.now())
@@ -108,6 +117,43 @@ export const useModelStore = defineStore('model', () => {
       ])
     ).filter((providerId): providerId is string => Boolean(providerId))
   }
+
+  const removeProviderGroups = (
+    groups: { providerId: string; models: RENDERER_MODEL_META[] }[],
+    providerId: string
+  ) => {
+    return groups.filter((group) => group.providerId !== providerId)
+  }
+
+  const purgeRemovedProviderState = (providerId: string) => {
+    allProviderModels.value = removeProviderGroups(allProviderModels.value, providerId)
+    customModels.value = removeProviderGroups(customModels.value, providerId)
+    enabledModels.value = removeProviderGroups(enabledModels.value, providerId)
+    providerModelQueries.delete(providerId)
+    customModelQueries.delete(providerId)
+    enabledModelQueries.delete(providerId)
+    pendingRefreshStarts.delete(providerId)
+    rerunRequested.delete(providerId)
+    clearProviderModelsReady(providerId)
+
+    for (const statusKey of Array.from(pendingModelStatusEchoes.keys())) {
+      if (statusKey.startsWith(`${providerId}:`)) {
+        pendingModelStatusEchoes.delete(statusKey)
+      }
+    }
+  }
+
+  watch(
+    () => providerStore.providers.map((provider) => provider.id),
+    (providerIds) => {
+      const providerIdSet = new Set(providerIds)
+      for (const materializedProviderId of getMaterializedProviderIds()) {
+        if (!providerIdSet.has(materializedProviderId)) {
+          purgeRemovedProviderState(materializedProviderId)
+        }
+      }
+    }
+  )
 
   const refreshMaterializedProviders = async () => {
     const providerIds = getMaterializedProviderIds()
@@ -775,7 +821,7 @@ export const useModelStore = defineStore('model', () => {
 
   const searchModels = (query: string) => {
     const normalized = query.toLowerCase()
-    return enabledModels.value
+    return activeEnabledModels.value
       .map((group) => ({
         providerId: group.providerId,
         models: group.models.filter(
@@ -1233,6 +1279,7 @@ export const useModelStore = defineStore('model', () => {
 
   return {
     enabledModels,
+    activeEnabledModels,
     allProviderModels,
     customModels,
     initialized: readonly(initialized),

--- a/test/renderer/stores/modelStore.test.ts
+++ b/test/renderer/stores/modelStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { ref } from 'vue'
+import { reactive, ref } from 'vue'
 import { ModelType } from '../../../src/shared/model'
 
 const createQueryCache = () => {
@@ -51,11 +51,11 @@ const setupStore = async (overrides?: {
     onModelConfigChanged: vi.fn(() => vi.fn()),
     ...overrides?.modelClient
   }
-  const providerStore = {
+  const providerStore = reactive({
     providers: [],
     ensureInitialized: vi.fn(async () => undefined),
     ...overrides?.providerStore
-  }
+  })
 
   vi.doMock('pinia', async () => {
     const actual = await vi.importActual<typeof import('pinia')>('pinia')
@@ -95,7 +95,8 @@ const setupStore = async (overrides?: {
   return {
     store,
     agentModelStore,
-    modelClient
+    modelClient,
+    providerStore
   }
 }
 
@@ -194,6 +195,81 @@ describe('modelStore.refreshProviderModels', () => {
     expect(agentModelStore.refreshAgentModels).not.toHaveBeenCalled()
     expect(modelClient.getDbProviderModels).toHaveBeenCalledWith('openai')
     expect(modelClient.getProviderModels).toHaveBeenCalledWith('openai')
+  })
+
+  it('exposes only enabled provider groups through activeEnabledModels', async () => {
+    const { store } = await setupStore({
+      providerStore: {
+        providers: [
+          { id: 'openai', enable: true },
+          { id: 'deepseek', enable: false }
+        ]
+      }
+    })
+
+    store.enabledModels.value = [
+      {
+        providerId: 'openai',
+        models: [{ id: 'gpt-5', name: 'GPT-5', providerId: 'openai' } as any]
+      },
+      {
+        providerId: 'deepseek',
+        models: [{ id: 'deepseek-chat', name: 'DeepSeek Chat', providerId: 'deepseek' } as any]
+      }
+    ]
+
+    expect(store.activeEnabledModels.value).toEqual([
+      {
+        providerId: 'openai',
+        models: [expect.objectContaining({ id: 'gpt-5' })]
+      }
+    ])
+  })
+
+  it('purges deleted providers from local model state', async () => {
+    const { store, providerStore } = await setupStore({
+      providerStore: {
+        providers: [
+          { id: 'openai', enable: true },
+          { id: 'deepseek', enable: true }
+        ]
+      }
+    })
+
+    store.enabledModels.value = [
+      {
+        providerId: 'openai',
+        models: [{ id: 'gpt-5', name: 'GPT-5', providerId: 'openai' } as any]
+      },
+      {
+        providerId: 'deepseek',
+        models: [{ id: 'deepseek-chat', name: 'DeepSeek Chat', providerId: 'deepseek' } as any]
+      }
+    ]
+    store.allProviderModels.value = [...store.enabledModels.value]
+    store.customModels.value = [
+      {
+        providerId: 'deepseek',
+        models: [{ id: 'deepseek-custom', name: 'DeepSeek Custom', providerId: 'deepseek' } as any]
+      }
+    ]
+
+    providerStore.providers = [{ id: 'openai', enable: true }]
+    await flushMicrotasks()
+
+    expect(store.enabledModels.value).toEqual([
+      {
+        providerId: 'openai',
+        models: [expect.objectContaining({ id: 'gpt-5' })]
+      }
+    ])
+    expect(store.allProviderModels.value).toEqual([
+      {
+        providerId: 'openai',
+        models: [expect.objectContaining({ id: 'gpt-5' })]
+      }
+    ])
+    expect(store.customModels.value).toEqual([])
   })
 
   it('merges same-tick concurrent refreshes into a single provider fetch', async () => {


### PR DESCRIPTION
## Summary
- hide stale enabled models when a provider is disabled or removed
- purge removed provider model state from the renderer store
- keep new thread, chat status bar, and MCP sampling model pickers aligned

## Testing
- Not run manually (per request)
- Git hooks auto-ran staged formatting and typecheck during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Models from disabled providers are now properly filtered out from model selection lists and sampling defaults, ensuring only active providers' models appear in the interface.

* **Refactor**
  * Optimized model availability tracking to dynamically filter enabled models based on currently-enabled providers, with automatic cleanup of disabled providers' cached data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->