### PR TITLE
refactor(model): unify selection resolver

### DIFF
--- a/src/renderer/src/components/chat/ChatStatusBar.vue
+++ b/src/renderer/src/components/chat/ChatStatusBar.vue
@@ -927,6 +927,7 @@ import {
   MODEL_TIMEOUT_MAX_MS,
   MODEL_TIMEOUT_MIN_MS
 } from '@shared/modelConfigDefaults'
+import { resolvePreferredChatModel, type ChatModelSelection } from '@/lib/chatModelSelection'
 import McpIndicator from '@/components/chat-input/McpIndicator.vue'
 import ModelIcon from '@/components/icons/ModelIcon.vue'
 import { createConfigClient } from '@api/ConfigClient'
@@ -1711,22 +1712,6 @@ const normalizeReasoningVisibility = (
   return normalizeAnthropicReasoningVisibilityValue(value) ?? 'omitted'
 }
 
-const findEnabledModel = (providerId: string, modelId: string): ModelSelection | null => {
-  const hit = findEnabledModelMeta(providerId, modelId)
-  if (!hit) {
-    return null
-  }
-  return { providerId, modelId: hit.id }
-}
-
-const pickFirstEnabledModel = (): ModelSelection | null => {
-  const firstSelectableModel = modelStore.pickFirstChatSelectableModel()
-  if (firstSelectableModel) {
-    return { providerId: firstSelectableModel.providerId, modelId: firstSelectableModel.model.id }
-  }
-  return null
-}
-
 const resolveModelName = (providerId?: string | null, modelId?: string | null): string => {
   if (!modelId) {
     return ''
@@ -2018,51 +2003,39 @@ const syncDraftModelSelection = async () => {
   }
 
   try {
-    const currentDraft = findEnabledModel(draftStore.providerId || '', draftStore.modelId || '')
-    if (currentDraft) {
-      applyDraftSelection(currentDraft)
-      return
-    }
-
     const deepChatAgentId = selectedDeepChatAgentId.value ?? 'deepchat'
-    const agentConfig = await resolveDeepChatAgentConfig(deepChatAgentId)
+    const [agentConfig, preferredModel, defaultModel] = await Promise.all([
+      resolveDeepChatAgentConfig(deepChatAgentId),
+      configClient.getSetting('preferredModel'),
+      configClient.getSetting('defaultModel')
+    ])
     if (token !== draftModelSyncToken) return
-    if (isModelSelection(agentConfig.defaultModelPreset)) {
-      const resolvedAgentDefault = findEnabledModel(
-        agentConfig.defaultModelPreset.providerId,
-        agentConfig.defaultModelPreset.modelId
-      )
-      if (resolvedAgentDefault) {
-        applyDraftSelection(resolvedAgentDefault)
-        return
-      }
-    }
 
-    const preferredModel = (await configClient.getSetting('preferredModel')) as unknown
-    if (token !== draftModelSyncToken) return
-    if (isModelSelection(preferredModel)) {
-      const resolvedPreferred = findEnabledModel(preferredModel.providerId, preferredModel.modelId)
-      if (resolvedPreferred) {
-        applyDraftSelection(resolvedPreferred)
-        return
-      }
-    }
-
-    const defaultModel = (await configClient.getSetting('defaultModel')) as unknown
-    if (token !== draftModelSyncToken) return
-    if (isModelSelection(defaultModel)) {
-      const resolvedDefault = findEnabledModel(defaultModel.providerId, defaultModel.modelId)
-      if (resolvedDefault) {
-        applyDraftSelection(resolvedDefault)
-        return
-      }
-    }
+    const resolvedModel = resolvePreferredChatModel({
+      modelGroups: modelStore.chatSelectableModelGroups,
+      selections: [
+        draftStore.providerId && draftStore.modelId
+          ? { providerId: draftStore.providerId, modelId: draftStore.modelId }
+          : null,
+        isModelSelection(agentConfig.defaultModelPreset)
+          ? (agentConfig.defaultModelPreset as ChatModelSelection)
+          : null,
+        isModelSelection(preferredModel) ? (preferredModel as ChatModelSelection) : null,
+        isModelSelection(defaultModel) ? (defaultModel as ChatModelSelection) : null
+      ]
+    })
+    applyDraftSelection(
+      resolvedModel
+        ? { providerId: resolvedModel.providerId, modelId: resolvedModel.model.id }
+        : null
+    )
+    return
   } catch (error) {
     console.warn('[ChatStatusBar] Failed to resolve draft model:', error)
   }
 
   if (token !== draftModelSyncToken) return
-  applyDraftSelection(pickFirstEnabledModel())
+  applyDraftSelection(null)
 }
 
 const resolveDefaultGenerationSettings = async (

--- a/src/renderer/src/lib/chatModelSelection.ts
+++ b/src/renderer/src/lib/chatModelSelection.ts
@@ -1,0 +1,117 @@
+import type { RENDERER_MODEL_META } from '@shared/presenter'
+
+export type ChatModelSelection = {
+  providerId: string
+  modelId?: string | null
+}
+
+export type ChatSelectableModelGroup = {
+  providerId: string
+  models: RENDERER_MODEL_META[]
+}
+
+export type ResolvedChatModel = {
+  providerId: string
+  model: RENDERER_MODEL_META
+}
+
+const getEligibleModels = (
+  group: ChatSelectableModelGroup | undefined,
+  requiresVision: boolean
+): RENDERER_MODEL_META[] => {
+  if (!group) {
+    return []
+  }
+
+  return requiresVision ? group.models.filter((model) => model.vision) : group.models
+}
+
+export const pickFirstChatModel = (
+  modelGroups: ChatSelectableModelGroup[],
+  requiresVision = false
+): ResolvedChatModel | null => {
+  for (const group of modelGroups) {
+    const [firstModel] = getEligibleModels(group, requiresVision)
+    if (firstModel) {
+      return { providerId: group.providerId, model: firstModel }
+    }
+  }
+
+  return null
+}
+
+export const resolvePreferredChatModel = (input: {
+  modelGroups: ChatSelectableModelGroup[]
+  selections: Array<ChatModelSelection | null | undefined>
+}): ResolvedChatModel | null => {
+  for (const selection of input.selections) {
+    if (!selection?.providerId || !selection.modelId) {
+      continue
+    }
+
+    const group = input.modelGroups.find((entry) => entry.providerId === selection.providerId)
+    const model = group?.models.find((entry) => entry.id === selection.modelId)
+    if (group && model) {
+      return { providerId: group.providerId, model }
+    }
+  }
+
+  return pickFirstChatModel(input.modelGroups)
+}
+
+export const resolveSamplingChatModel = (input: {
+  modelGroups: ChatSelectableModelGroup[]
+  requiresVision: boolean
+  selections: Array<ChatModelSelection | null | undefined>
+}): ResolvedChatModel | null => {
+  for (const selection of input.selections) {
+    if (!selection?.providerId) {
+      continue
+    }
+
+    const group = input.modelGroups.find((entry) => entry.providerId === selection.providerId)
+    const models = getEligibleModels(group, input.requiresVision)
+    if (models.length === 0) {
+      continue
+    }
+
+    if (selection.modelId) {
+      const preferredModel = models.find((model) => model.id === selection.modelId)
+      if (preferredModel) {
+        return { providerId: selection.providerId, model: preferredModel }
+      }
+    }
+
+    return { providerId: selection.providerId, model: models[0] }
+  }
+
+  return pickFirstChatModel(input.modelGroups, input.requiresVision)
+}
+
+export const resolveChatModelByQuery = (
+  modelGroups: ChatSelectableModelGroup[],
+  query: string | null | undefined
+): ResolvedChatModel | null => {
+  const normalizedQuery = query?.trim().toLowerCase()
+  if (!normalizedQuery) {
+    return null
+  }
+
+  for (const group of modelGroups) {
+    const exactModel = group.models.find((model) => model.id.toLowerCase() === normalizedQuery)
+    if (exactModel) {
+      return { providerId: group.providerId, model: exactModel }
+    }
+  }
+
+  for (const group of modelGroups) {
+    const fuzzyModel = group.models.find((model) =>
+      model.id.toLowerCase().includes(normalizedQuery)
+    )
+    if (fuzzyModel) {
+      return { providerId: group.providerId, model: fuzzyModel }
+    }
+  }
+
+  return null
+}

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -121,6 +121,11 @@ import type {
   SessionGenerationSettings
 } from '@shared/types/agent-interface'
 import { normalizeDeepChatSubagentConfig } from '@shared/lib/deepchatSubagents'
+import {
+  resolveChatModelByQuery,
+  resolvePreferredChatModel,
+  type ChatModelSelection
+} from '@/lib/chatModelSelection'
 import { scheduleStartupDeferredTask } from '@/lib/startupDeferred'
 
 const projectStore = useProjectStore()
@@ -197,15 +202,6 @@ const isAcpWorkdirMissing = computed(() => {
   return !projectStore.selectedProject?.path?.trim()
 })
 
-const getEnabledModel = (
-  providerId?: string,
-  modelId?: string
-): { providerId: string; modelId: string } | null => {
-  if (!providerId || !modelId) return null
-  const matched = modelStore.findChatSelectableModel(providerId, modelId)
-  return matched ? { providerId: matched.providerId, modelId: matched.model.id } : null
-}
-
 const ensureEnabledModelsReady = async (): Promise<boolean> => {
   if (modelStore.initialized) {
     return true
@@ -226,37 +222,23 @@ async function resolveModel(): Promise<{ providerId: string; modelId: string } |
     return null
   }
 
-  // 0. model manually selected in current NewThread page
-  const draftModel = getEnabledModel(draftStore.providerId, draftStore.modelId)
-  if (draftModel) {
-    return draftModel
-  }
+  const [preferredModel, defaultModel] = await Promise.all([
+    configClient.getSetting('preferredModel') as Promise<ChatModelSelection | undefined>,
+    configClient.getSetting('defaultModel') as Promise<ChatModelSelection | undefined>
+  ])
 
-  // 1. preferredModel (last user selection)
-  const preferredModel = (await configClient.getSetting('preferredModel')) as
-    | { providerId: string; modelId: string }
-    | undefined
-  const resolvedPreferredModel = getEnabledModel(
-    preferredModel?.providerId,
-    preferredModel?.modelId
-  )
-  if (resolvedPreferredModel) {
-    return resolvedPreferredModel
-  }
-
-  // 2. defaultModel from settings
-  const defaultModel = (await configClient.getSetting('defaultModel')) as
-    | { providerId: string; modelId: string }
-    | undefined
-  const resolvedDefaultModel = getEnabledModel(defaultModel?.providerId, defaultModel?.modelId)
-  if (resolvedDefaultModel) {
-    return resolvedDefaultModel
-  }
-
-  // 3. First available enabled model
-  const firstSelectableModel = modelStore.pickFirstChatSelectableModel()
-  if (firstSelectableModel) {
-    return { providerId: firstSelectableModel.providerId, modelId: firstSelectableModel.model.id }
+  const resolvedModel = resolvePreferredChatModel({
+    modelGroups: modelStore.chatSelectableModelGroups,
+    selections: [
+      draftStore.providerId && draftStore.modelId
+        ? { providerId: draftStore.providerId, modelId: draftStore.modelId }
+        : null,
+      preferredModel,
+      defaultModel
+    ]
+  })
+  if (resolvedModel) {
+    return { providerId: resolvedModel.providerId, modelId: resolvedModel.model.id }
   }
 
   return null
@@ -275,28 +257,10 @@ const buildStartMessage = (payload: StartDeeplinkPayload): string => {
 const resolveStartModelSelection = (
   requestedModelId: string | null
 ): { providerId: string; modelId: string } | null => {
-  const normalizedModelId = requestedModelId?.trim().toLowerCase()
-  if (!normalizedModelId) {
-    return null
-  }
-
-  for (const group of modelStore.chatSelectableModelGroups) {
-    const matched = group.models.find((model) => model.id.toLowerCase() === normalizedModelId)
-    if (matched) {
-      return { providerId: group.providerId, modelId: matched.id }
-    }
-  }
-
-  for (const group of modelStore.chatSelectableModelGroups) {
-    const matched = group.models.find((model) =>
-      model.id.toLowerCase().includes(normalizedModelId)
-    )
-    if (matched) {
-      return { providerId: group.providerId, modelId: matched.id }
-    }
-  }
-
-  return null
+  const resolvedModel = resolveChatModelByQuery(modelStore.chatSelectableModelGroups, requestedModelId)
+  return resolvedModel
+    ? { providerId: resolvedModel.providerId, modelId: resolvedModel.model.id }
+    : null
 }
 
 const applyStartDeeplink = async (payload: StartDeeplinkPayload) => {

--- a/src/renderer/src/stores/mcpSampling.ts
+++ b/src/renderer/src/stores/mcpSampling.ts
@@ -6,6 +6,7 @@ import type {
   McpSamplingRequestPayload,
   RENDERER_MODEL_META
 } from '@shared/presenter'
+import { resolveSamplingChatModel, type ChatModelSelection } from '@/lib/chatModelSelection'
 import { useModelStore } from '@/stores/modelStore'
 import { useProviderStore } from '@/stores/providerStore'
 import { useSessionStore } from '@/stores/ui/session'
@@ -20,72 +21,21 @@ interface ApprovedServerInfo {
 // Session timeout: 30 minutes
 const SESSION_TIMEOUT = 30 * 60 * 1000
 
-type ModelSelection = {
-  providerId: string
-  modelId?: string | null
-}
-
-const pickEligibleModel = (
-  providerEntry: { providerId: string; models: RENDERER_MODEL_META[] } | undefined,
-  requiresVision: boolean,
-  preferredModelId?: string | null
-): { providerId: string | null; model: RENDERER_MODEL_META | null } => {
-  if (!providerEntry) {
-    return { providerId: null, model: null }
-  }
-
-  const models = requiresVision
-    ? providerEntry.models.filter((model) => model.vision)
-    : providerEntry.models
-
-  if (models.length === 0) {
-    return { providerId: null, model: null }
-  }
-
-  if (preferredModelId) {
-    const preferredModel = models.find((model) => model.id === preferredModelId)
-    if (preferredModel) {
-      return { providerId: providerEntry.providerId, model: preferredModel }
-    }
-  }
-
-  return { providerId: providerEntry.providerId, model: models[0] }
-}
-
 export const resolveSamplingDefaultModel = (input: {
   modelGroups: Array<{ providerId: string; models: RENDERER_MODEL_META[] }>
   requiresVision: boolean
-  activeSelection?: ModelSelection | null
-  draftSelection?: ModelSelection | null
+  activeSelection?: ChatModelSelection | null
+  draftSelection?: ChatModelSelection | null
 }): { providerId: string | null; model: RENDERER_MODEL_META | null } => {
-  const selectFrom = (selection?: ModelSelection | null) => {
-    if (!selection?.providerId) {
-      return { providerId: null, model: null as RENDERER_MODEL_META | null }
-    }
-    const providerEntry = input.modelGroups.find(
-      (entry) => entry.providerId === selection.providerId
-    )
-    return pickEligibleModel(providerEntry, input.requiresVision, selection.modelId)
-  }
+  const resolvedModel = resolveSamplingChatModel({
+    modelGroups: input.modelGroups,
+    requiresVision: input.requiresVision,
+    selections: [input.activeSelection, input.draftSelection]
+  })
 
-  const activeMatch = selectFrom(input.activeSelection)
-  if (activeMatch.providerId && activeMatch.model) {
-    return activeMatch
-  }
-
-  const draftMatch = selectFrom(input.draftSelection)
-  if (draftMatch.providerId && draftMatch.model) {
-    return draftMatch
-  }
-
-  for (const providerEntry of input.modelGroups) {
-    const match = pickEligibleModel(providerEntry, input.requiresVision)
-    if (match.providerId && match.model) {
-      return match
-    }
-  }
-
-  return { providerId: null, model: null }
+  return resolvedModel
+    ? { providerId: resolvedModel.providerId, model: resolvedModel.model }
+    : { providerId: null, model: null }
 }
 
 export const useMcpSamplingStore = defineStore('mcpSampling', () => {

--- a/test/renderer/lib/chatModelSelection.test.ts
+++ b/test/renderer/lib/chatModelSelection.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import type { RENDERER_MODEL_META } from '@shared/presenter'
+import {
+  resolveChatModelByQuery,
+  resolvePreferredChatModel,
+  resolveSamplingChatModel
+} from '@/lib/chatModelSelection'
+
+const makeModel = (
+  id: string,
+  providerId: string,
+  options?: { vision?: boolean }
+): RENDERER_MODEL_META => ({
+  id,
+  name: id,
+  group: 'default',
+  providerId,
+  vision: options?.vision ?? false
+})
+
+describe('chatModelSelection', () => {
+  it('resolves preferred chat models by exact candidate priority', () => {
+    const result = resolvePreferredChatModel({
+      modelGroups: [
+        { providerId: 'openai', models: [makeModel('gpt-4o', 'openai')] },
+        { providerId: 'anthropic', models: [makeModel('claude-sonnet', 'anthropic')] }
+      ],
+      selections: [
+        { providerId: 'openai', modelId: 'missing-model' },
+        { providerId: 'anthropic', modelId: 'claude-sonnet' }
+      ]
+    })
+
+    expect(result?.providerId).toBe('anthropic')
+    expect(result?.model.id).toBe('claude-sonnet')
+  })
+
+  it('falls back to the first available chat model when no preferred candidate matches', () => {
+    const result = resolvePreferredChatModel({
+      modelGroups: [
+        { providerId: 'openai', models: [makeModel('gpt-4o', 'openai')] },
+        { providerId: 'anthropic', models: [makeModel('claude-sonnet', 'anthropic')] }
+      ],
+      selections: [{ providerId: 'openai', modelId: 'missing-model' }]
+    })
+
+    expect(result?.providerId).toBe('openai')
+    expect(result?.model.id).toBe('gpt-4o')
+  })
+
+  it('keeps sampling on the same provider when vision is required but the preferred model is ineligible', () => {
+    const result = resolveSamplingChatModel({
+      modelGroups: [
+        {
+          providerId: 'openai',
+          models: [
+            makeModel('gpt-4.1', 'openai', { vision: false }),
+            makeModel('gpt-4o', 'openai', { vision: true })
+          ]
+        },
+        {
+          providerId: 'anthropic',
+          models: [makeModel('claude-sonnet', 'anthropic', { vision: true })]
+        }
+      ],
+      requiresVision: true,
+      selections: [{ providerId: 'openai', modelId: 'gpt-4.1' }]
+    })
+
+    expect(result?.providerId).toBe('openai')
+    expect(result?.model.id).toBe('gpt-4o')
+  })
+
+  it('matches deeplink model queries by exact id before fuzzy id', () => {
+    const result = resolveChatModelByQuery(
+      [
+        {
+          providerId: 'openai',
+          models: [makeModel('gpt-4o-mini', 'openai'), makeModel('gpt-4o', 'openai')]
+        }
+      ],
+      'gpt-4o'
+    )
+
+    expect(result?.providerId).toBe('openai')
+    expect(result?.model.id).toBe('gpt-4o')
+  })
+})


### PR DESCRIPTION
## Summary\n- extract shared chat model selection helpers for exact candidate resolution, sampling fallback, and deeplink matching\n- switch NewThreadPage and ChatStatusBar to the shared preferred-model resolver\n- reuse the same sampling resolver in the MCP sampling store and add focused utility tests\n\n## Testing\n- commit hook ran oxfmt and typecheck automatically during git commit\n