### PR TITLE
fix(provider): gc removed model state

### DIFF
--- a/src/main/presenter/configPresenter/index.ts
+++ b/src/main/presenter/configPresenter/index.ts
@@ -508,6 +508,14 @@ export class ConfigPresenter implements IConfigPresenter {
       setModelStatus: this.modelStatusHelper.setModelStatus.bind(this.modelStatusHelper),
       deleteModelStatus: this.modelStatusHelper.deleteModelStatus.bind(this.modelStatusHelper)
     })
+    this.providerHelper.setCleanupHooks({
+      deleteProviderModelStatuses: this.modelStatusHelper.deleteProviderModelStatuses.bind(
+        this.modelStatusHelper
+      ),
+      clearProviderModelStore: this.providerModelHelper.clearProviderModelStore.bind(
+        this.providerModelHelper
+      )
+    })
 
     // Initialize built-in ACP agents on first run or version upgrade
     // Initialize provider models directory

--- a/src/main/presenter/configPresenter/modelStatusHelper.ts
+++ b/src/main/presenter/configPresenter/modelStatusHelper.ts
@@ -231,4 +231,22 @@ export class ModelStatusHelper {
     this.cache.delete(statusKey)
     this.statusSnapshot?.delete(statusKey)
   }
+
+  deleteProviderModelStatuses(providerId: string): void {
+    const prefix = `${MODEL_STATUS_KEY_PREFIX}${providerId}_`
+    const candidate = this.store as ElectronStore<any> & {
+      store?: Record<string, unknown>
+    }
+    const rawStore = candidate.store
+
+    if (rawStore && typeof rawStore === 'object') {
+      for (const key of Object.keys(rawStore)) {
+        if (key.startsWith(prefix)) {
+          this.store.delete(key)
+        }
+      }
+    }
+
+    this.clearProviderModelStatusCache(providerId)
+  }
 }

--- a/src/main/presenter/configPresenter/providerHelper.ts
+++ b/src/main/presenter/configPresenter/providerHelper.ts
@@ -18,15 +18,25 @@ interface ProviderHelperOptions {
   defaultProviders: LLM_PROVIDER[]
 }
 
+interface ProviderCleanupHooks {
+  deleteProviderModelStatuses?: (providerId: string) => void
+  clearProviderModelStore?: (providerId: string) => void
+}
+
 export class ProviderHelper {
   private readonly store: ElectronStore<any>
   private readonly setSetting: SetSetting
   private readonly defaultProviders: LLM_PROVIDER[]
+  private cleanupHooks: ProviderCleanupHooks = {}
 
   constructor(options: ProviderHelperOptions) {
     this.store = options.store
     this.setSetting = options.setSetting
     this.defaultProviders = options.defaultProviders
+  }
+
+  setCleanupHooks(hooks: ProviderCleanupHooks): void {
+    this.cleanupHooks = hooks
   }
 
   getProviders(): LLM_PROVIDER[] {
@@ -195,6 +205,18 @@ export class ProviderHelper {
     const providers = this.getProviders()
     const filteredProviders = providers.filter((p) => p.id !== providerId)
     this.setSetting<LLM_PROVIDER[]>(PROVIDERS_STORE_KEY, filteredProviders)
+
+    try {
+      this.cleanupHooks.deleteProviderModelStatuses?.(providerId)
+    } catch (error) {
+      console.error(`[Config] Failed to delete model statuses for ${providerId}:`, error)
+    }
+
+    try {
+      this.cleanupHooks.clearProviderModelStore?.(providerId)
+    } catch (error) {
+      console.error(`[Config] Failed to clear provider model store for ${providerId}:`, error)
+    }
 
     const change: ProviderChange = {
       operation: 'remove',

--- a/src/main/presenter/configPresenter/providerModelHelper.ts
+++ b/src/main/presenter/configPresenter/providerModelHelper.ts
@@ -238,6 +238,22 @@ export class ProviderModelHelper {
     this.invalidateProviderModelsCache(providerId)
   }
 
+  clearProviderModelStore(providerId: string): void {
+    const store = this.getProviderModelStore(providerId) as ElectronStore<IModelStore> & {
+      clear?: () => void
+    }
+
+    if (typeof store.clear === 'function') {
+      store.clear()
+    } else {
+      store.set('models', [])
+      store.set('custom_models', [])
+    }
+
+    this.stores.delete(providerId)
+    this.invalidateProviderModelsCache(providerId)
+  }
+
   addCustomModel(providerId: string, model: MODEL_META): void {
     const models = this.getCustomModels(providerId)
     const existingIndex = models.findIndex((m) => m.id === model.id)

--- a/test/main/presenter/configPresenter/modelStatusHelper.test.ts
+++ b/test/main/presenter/configPresenter/modelStatusHelper.test.ts
@@ -117,4 +117,26 @@ describe('ModelStatusHelper.ensureModelStatus', () => {
     })
     expect(store.snapshotReadCount).toBe(1)
   })
+
+  it('removes every persisted model status for a provider in one pass', () => {
+    const store = new MockElectronStore()
+    store.set('model_status_openai_gpt-5-4', true)
+    store.set('model_status_openai_gpt-4-1', false)
+    store.set('model_status_anthropic_claude-3-5-sonnet', true)
+
+    const helper = new ModelStatusHelper({
+      store: store as any,
+      setSetting: (key, value) => store.set(key, value)
+    })
+
+    helper.deleteProviderModelStatuses('openai')
+
+    expect(helper.getBatchModelStatus('openai', ['gpt-5.4', 'gpt-4.1'])).toEqual({
+      'gpt-5.4': false,
+      'gpt-4.1': false
+    })
+    expect(helper.getBatchModelStatus('anthropic', ['claude-3.5-sonnet'])).toEqual({
+      'claude-3.5-sonnet': true
+    })
+  })
 })

--- a/test/main/presenter/configPresenter/providerHelper.test.ts
+++ b/test/main/presenter/configPresenter/providerHelper.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProviderHelper } from '../../../../src/main/presenter/configPresenter/providerHelper'
+import type { LLM_PROVIDER } from '../../../../src/shared/presenter'
+
+const { send } = vi.hoisted(() => ({
+  send: vi.fn()
+}))
+
+vi.mock('@/eventbus', () => ({
+  eventBus: {
+    send
+  },
+  SendTarget: {
+    ALL_WINDOWS: 'ALL_WINDOWS'
+  }
+}))
+
+class MockElectronStore {
+  private readonly data = new Map<string, unknown>()
+
+  get(key: string) {
+    return this.data.get(key)
+  }
+
+  set(key: string, value: unknown) {
+    this.data.set(key, value)
+  }
+}
+
+const createProvider = (id: string): LLM_PROVIDER => ({
+  id,
+  name: id,
+  apiType: 'openai-compatible',
+  apiKey: '',
+  baseUrl: '',
+  enable: true,
+  websites: {
+    official: '',
+    apiKey: '',
+    docs: '',
+    models: '',
+    defaultBaseUrl: ''
+  }
+})
+
+describe('ProviderHelper.removeProviderAtomic', () => {
+  beforeEach(() => {
+    send.mockReset()
+  })
+
+  it('cleans persisted model state when removing a provider', () => {
+    const store = new MockElectronStore()
+    const providers = [createProvider('openai'), createProvider('anthropic')]
+    store.set('providers', providers)
+
+    const helper = new ProviderHelper({
+      store: store as any,
+      setSetting: (key, value) => store.set(key, value),
+      defaultProviders: providers
+    })
+    const deleteProviderModelStatuses = vi.fn()
+    const clearProviderModelStore = vi.fn()
+
+    helper.setCleanupHooks({
+      deleteProviderModelStatuses,
+      clearProviderModelStore
+    })
+    helper.removeProviderAtomic('openai')
+
+    expect(store.get('providers')).toEqual([createProvider('anthropic')])
+    expect(deleteProviderModelStatuses).toHaveBeenCalledWith('openai')
+    expect(clearProviderModelStore).toHaveBeenCalledWith('openai')
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/main/presenter/configPresenter/providerModelHelper.test.ts
+++ b/test/main/presenter/configPresenter/providerModelHelper.test.ts
@@ -10,6 +10,7 @@ const storeStates = vi.hoisted(
         data: Record<string, unknown>
         get: ReturnType<typeof vi.fn>
         set: ReturnType<typeof vi.fn>
+        clear: ReturnType<typeof vi.fn>
       }
     >()
 )
@@ -26,6 +27,7 @@ vi.mock('electron-store', () => ({
       data: Record<string, unknown>
       get: ReturnType<typeof vi.fn>
       set: ReturnType<typeof vi.fn>
+      clear: ReturnType<typeof vi.fn>
     }
 
     constructor(options: { name: string; defaults?: Record<string, unknown> }) {
@@ -41,6 +43,11 @@ vi.mock('electron-store', () => ({
         get: vi.fn((key: string) => data[key]),
         set: vi.fn((key: string, value: unknown) => {
           data[key] = value
+        }),
+        clear: vi.fn(() => {
+          Object.keys(data).forEach((key) => {
+            delete data[key]
+          })
         })
       }
       storeStates.set(options.name, state)
@@ -53,6 +60,10 @@ vi.mock('electron-store', () => ({
 
     set(key: string, value: unknown) {
       this.state.set(key, value)
+    }
+
+    clear() {
+      this.state.clear()
     }
   }
 }))
@@ -204,6 +215,31 @@ describe('ProviderModelHelper cache', () => {
     helper.getProviderModels('openai')
 
     expect(storeState.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears persisted provider models and custom models for a removed provider', async () => {
+    const { ProviderModelHelper } =
+      await import('../../../../src/main/presenter/configPresenter/providerModelHelper')
+    const helper = new ProviderModelHelper({
+      userDataPath: 'C:/mock-user-data',
+      getModelConfig: () => undefined as unknown as ModelConfig,
+      setModelStatus: vi.fn(),
+      deleteModelStatus: vi.fn()
+    })
+
+    helper.setProviderModels('openai', [createBaseModel('openai', 'gpt-5')])
+    helper.setCustomModels('openai', [
+      {
+        ...createBaseModel('openai', 'custom-gpt-5'),
+        isCustom: true
+      }
+    ])
+
+    helper.clearProviderModelStore('openai')
+
+    expect(helper.getProviderModels('openai')).toEqual([])
+    expect(helper.getCustomModels('openai')).toEqual([])
+    expect(storeStates.get('models_openai')?.clear).toHaveBeenCalledTimes(1)
   })
 
   it('encodes invalid provider id characters before creating store files', async () => {


### PR DESCRIPTION
## Summary\n- clean persisted model status entries when a provider is removed\n- clear the provider-specific stored model/custom-model payload at the same time\n- wire provider removal through cleanup hooks and cover the helper behavior with focused main-process tests\n\n## Testing\n- commit hook ran oxfmt and typecheck automatically during git commit\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider removal to ensure all associated model statuses and stored data are properly cleaned up, preventing orphaned data from persisting in the system.

* **Tests**
  * Added comprehensive test coverage for provider cleanup operations to ensure data consistency during removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->