### PR TITLE
refactor(chat): split acp status bar state

### DIFF
--- a/src/renderer/src/components/chat/ChatStatusBar.vue
+++ b/src/renderer/src/components/chat/ChatStatusBar.vue
@@ -881,12 +881,7 @@ import {
   SelectValue
 } from '@shadcn/components/ui/select'
 import { Switch } from '@shadcn/components/ui/switch'
-import type {
-  AcpConfigOption,
-  AcpConfigState,
-  RENDERER_MODEL_META,
-  SystemPrompt
-} from '@shared/presenter'
+import type { RENDERER_MODEL_META, SystemPrompt } from '@shared/presenter'
 import type {
   DeepChatAgentConfig,
   PermissionMode,
@@ -942,6 +937,7 @@ import { useDraftStore } from '@/stores/ui/draft'
 import { useProjectStore } from '@/stores/ui/project'
 import { useSessionStore } from '@/stores/ui/session'
 import { scheduleStartupDeferredTask } from '@/lib/startupDeferred'
+import { useChatStatusBarAcpConfig } from './composables/useChatStatusBarAcpConfig'
 
 const props = withDefaults(
   defineProps<{
@@ -979,7 +975,6 @@ const TIMEOUT_STEP = 1000
 const TIMEOUT_MIN = MODEL_TIMEOUT_MIN_MS
 const TIMEOUT_MAX = MODEL_TIMEOUT_MAX_MS
 const THINKING_BUDGET_STEP = 128
-const ACP_INLINE_OPTION_LIMIT = 3
 const DEFAULT_VERBOSITY_OPTIONS: SessionGenerationSettings['verbosity'][] = [
   'low',
   'medium',
@@ -1009,12 +1004,6 @@ const isModelPanelOpen = ref(false)
 const isModelSettingsExpanded = ref(false)
 const modelSearchKeyword = ref('')
 const modelSettingsSelection = ref<ModelSelection | null>(null)
-const acpConfigState = ref<AcpConfigState | null>(null)
-const acpConfigLoadedRequestKey = ref<string | null>(null)
-const acpConfigLoadingRequestKey = ref<string | null>(null)
-const acpInlineOpenOptionId = ref<string | null>(null)
-const acpOptionSavingIds = ref<string[]>([])
-const acpConfigCacheByAgent = new Map<string, AcpConfigState>()
 const activeNumericInput = ref<GenerationNumericField | null>(null)
 const numericInputDrafts = ref<Record<GenerationNumericField, string>>({
   temperature: '',
@@ -1041,7 +1030,6 @@ const capabilityProviderId = ref('')
 let draftModelSyncToken = 0
 let permissionSyncToken = 0
 let generationSyncToken = 0
-let acpConfigSyncToken = 0
 let generationPersistTimer: ReturnType<typeof setTimeout> | null = null
 let pendingGenerationPatch: Partial<SessionGenerationSettings> = {}
 let generationPersistRequestToken = 0
@@ -1248,122 +1236,6 @@ const modelSettingsTarget = computed<ModelSelection | null>(() => {
   return modelSettingsSelection.value ?? effectiveModelSelection.value
 })
 
-const acpConfigCacheKey = computed(() => {
-  if (!isAcpAgent.value || activeAcpSessionId.value) {
-    return null
-  }
-  return activeAcpAgentId.value
-})
-
-const acpConfigRequestKey = computed(() => {
-  if (!isAcpAgent.value) {
-    return null
-  }
-  if (activeAcpSessionId.value) {
-    return `session:${activeAcpSessionId.value}`
-  }
-  if (acpConfigCacheKey.value && acpWorkspacePath.value) {
-    return `process:${acpConfigCacheKey.value}::${acpWorkspacePath.value}`
-  }
-  if (acpConfigCacheKey.value) {
-    return `agent:${acpConfigCacheKey.value}`
-  }
-  return null
-})
-
-const getCachedAcpConfigState = (agentId?: string | null): AcpConfigState | null => {
-  if (!agentId) {
-    return null
-  }
-  return acpConfigCacheByAgent.get(agentId) ?? null
-}
-
-const setCachedAcpConfigState = (
-  agentId: string | null | undefined,
-  state: AcpConfigState | null | undefined
-): void => {
-  if (!agentId || !hasAcpConfigStateData(state)) {
-    return
-  }
-  acpConfigCacheByAgent.set(agentId, state)
-}
-
-const acpConfigOptions = computed(() => acpConfigState.value?.options ?? [])
-const isAcpConfigLoading = computed(() => {
-  if (!isAcpAgent.value || activeAcpSessionId.value) {
-    return false
-  }
-
-  const requestKey = acpConfigRequestKey.value
-  return Boolean(requestKey && acpConfigLoadingRequestKey.value === requestKey)
-})
-const isAcpSessionConfigLoaded = computed(() => {
-  if (!activeAcpSessionId.value) {
-    return false
-  }
-
-  return acpConfigLoadedRequestKey.value === acpConfigRequestKey.value
-})
-
-const acpConfigReadOnly = computed(() => {
-  if (!isAcpAgent.value) {
-    return false
-  }
-
-  if (!activeAcpSessionId.value) {
-    return true
-  }
-
-  return !isAcpSessionConfigLoaded.value
-})
-const acpInlineOptions = computed(() =>
-  acpConfigOptions.value
-    .filter((option) => option.type === 'select')
-    .slice(0, ACP_INLINE_OPTION_LIMIT)
-)
-const acpOverflowOptions = computed(() => {
-  const inlineIds = new Set(acpInlineOptions.value.map((option) => option.id))
-  return acpConfigOptions.value.filter((option) => !inlineIds.has(option.id))
-})
-const acpAgentLabel = computed(() => {
-  const modelId = activeAcpAgentId.value ?? agentStore.selectedAgentId
-  return (
-    resolveModelName('acp', modelId) ||
-    agentStore.selectedAgent?.name ||
-    modelId ||
-    t('chat.mode.acpAgent')
-  )
-})
-const acpAgentIconId = computed(() =>
-  resolveModelIconId('acp', activeAcpAgentId.value ?? agentStore.selectedAgentId)
-)
-
-const setAcpConfigLoadingRequest = (requestKey: string | null | undefined): void => {
-  acpConfigLoadingRequestKey.value = requestKey?.trim() ? requestKey : null
-}
-
-const clearAcpConfigLoadingRequest = (requestKey?: string | null): void => {
-  if (!requestKey || acpConfigLoadingRequestKey.value === requestKey) {
-    acpConfigLoadingRequestKey.value = null
-  }
-}
-
-const matchesCurrentAcpWarmupTarget = (
-  agentId: string | null | undefined,
-  workdir: string | null | undefined
-): boolean => {
-  if (activeAcpSessionId.value || !agentId || activeAcpAgentId.value !== agentId) {
-    return false
-  }
-
-  const expectedWorkdir = acpWorkspacePath.value?.trim()
-  if (!expectedWorkdir) {
-    return true
-  }
-
-  return workdir?.trim() === expectedWorkdir
-}
-
 const permissionModeLabel = computed(() =>
   permissionMode.value === 'default'
     ? t('chat.permissionMode.default')
@@ -1500,75 +1372,6 @@ const getNumericInputErrorMessage = (field: GenerationNumericField): string => {
     case 'timeout_too_large':
       return t('settings.model.modelConfig.validation.timeoutMax')
   }
-}
-
-const isAcpConfigOptionValue = (
-  value: unknown
-): value is NonNullable<AcpConfigOption['options']>[number] => {
-  if (!value || typeof value !== 'object') {
-    return false
-  }
-  const candidate = value as Record<string, unknown>
-  return typeof candidate.value === 'string' && typeof candidate.label === 'string'
-}
-
-const isAcpConfigOption = (value: unknown): value is AcpConfigOption => {
-  if (!value || typeof value !== 'object') {
-    return false
-  }
-  const candidate = value as Record<string, unknown>
-  if (
-    typeof candidate.id !== 'string' ||
-    typeof candidate.label !== 'string' ||
-    (candidate.type !== 'select' && candidate.type !== 'boolean')
-  ) {
-    return false
-  }
-  if (!('currentValue' in candidate)) {
-    return false
-  }
-  if (candidate.type === 'select' && candidate.options !== undefined) {
-    return Array.isArray(candidate.options) && candidate.options.every(isAcpConfigOptionValue)
-  }
-  return true
-}
-
-const isAcpConfigState = (value: unknown): value is AcpConfigState => {
-  if (!value || typeof value !== 'object') {
-    return false
-  }
-  const candidate = value as Record<string, unknown>
-  return (
-    (candidate.source === 'configOptions' || candidate.source === 'legacy') &&
-    Array.isArray(candidate.options) &&
-    candidate.options.every(isAcpConfigOption)
-  )
-}
-
-const hasAcpConfigStateData = (state: AcpConfigState | null | undefined): state is AcpConfigState =>
-  Boolean(state?.options.length)
-
-const getAcpOptionCurrentLabel = (option?: AcpConfigOption | null): string | null => {
-  if (!option) {
-    return null
-  }
-  if (option.type !== 'select') {
-    return null
-  }
-  const currentValue = typeof option.currentValue === 'string' ? option.currentValue : ''
-  return option.options?.find((entry) => entry.value === currentValue)?.label ?? currentValue
-}
-
-const getAcpOptionDisplayValue = (option: AcpConfigOption): string => {
-  if (option.type === 'boolean') {
-    return t(option.currentValue ? 'common.enabled' : 'common.disabled')
-  }
-
-  if (typeof option.currentValue === 'string' && option.currentValue.trim()) {
-    return option.currentValue
-  }
-
-  return getAcpOptionCurrentLabel(option) ?? ''
 }
 
 const findEnabledModelMeta = (providerId: string, modelId: string): RENDERER_MODEL_META | null => {
@@ -1733,6 +1536,36 @@ const resolveModelIconId = (providerId?: string | null, modelId?: string | null)
   }
   return providerId || 'anthropic'
 }
+
+const {
+  acpConfigState,
+  acpInlineOpenOptionId,
+  acpConfigReadOnly,
+  acpInlineOptions,
+  acpOverflowOptions,
+  acpAgentLabel,
+  acpAgentIconId,
+  isAcpConfigLoading,
+  getAcpOptionDisplayValue,
+  isAcpOptionSaving,
+  syncAcpConfigOptions,
+  handleAcpConfigOptionsReady,
+  onAcpInlineOptionOpenChange,
+  onAcpSelectOption,
+  onAcpBooleanOption
+} = useChatStatusBarAcpConfig({
+  t,
+  isAcpAgent,
+  activeAcpAgentId,
+  activeAcpSessionId,
+  acpWorkspacePath,
+  selectedAgentId: computed(() => agentStore.selectedAgentId),
+  selectedAgentName: computed(() => agentStore.selectedAgent?.name ?? null),
+  providerClient,
+  sessionClient,
+  resolveModelName,
+  resolveModelIconId
+})
 
 const clearPendingGenerationPersist = () => {
   if (generationPersistTimer) {
@@ -2336,167 +2169,12 @@ const syncGenerationSettings = async () => {
   loadedSettingsSelection.value = { ...selection }
 }
 
-const syncAcpConfigOptions = async () => {
-  const token = ++acpConfigSyncToken
-  const requestKey = acpConfigRequestKey.value
-  acpInlineOpenOptionId.value = null
-
-  if (!isAcpAgent.value || !requestKey) {
-    acpConfigState.value = null
-    acpConfigLoadedRequestKey.value = null
-    clearAcpConfigLoadingRequest()
-    return
-  }
-
-  const agentId = activeAcpAgentId.value
-
-  if (activeAcpSessionId.value) {
-    clearAcpConfigLoadingRequest()
-    acpConfigState.value = null
-    acpConfigLoadedRequestKey.value = null
-
-    try {
-      const state = await sessionClient.getAcpSessionConfigOptions(activeAcpSessionId.value)
-      if (token !== acpConfigSyncToken || acpConfigRequestKey.value !== requestKey) {
-        return
-      }
-      acpConfigState.value = state
-      acpConfigLoadedRequestKey.value = requestKey
-      setCachedAcpConfigState(agentId, state)
-      clearAcpConfigLoadingRequest(requestKey)
-      return
-    } catch (error) {
-      console.warn('[ChatStatusBar] Failed to load ACP session config options:', error)
-      if (token !== acpConfigSyncToken || acpConfigRequestKey.value !== requestKey) {
-        return
-      }
-      acpConfigState.value = null
-      acpConfigLoadedRequestKey.value = null
-      clearAcpConfigLoadingRequest(requestKey)
-      return
-    }
-  }
-
-  acpConfigLoadedRequestKey.value = null
-  const cachedState = getCachedAcpConfigState(agentId)
-  acpConfigState.value = cachedState
-
-  if (hasAcpConfigStateData(cachedState)) {
-    clearAcpConfigLoadingRequest(requestKey)
-  } else {
-    setAcpConfigLoadingRequest(requestKey)
-  }
-
-  if (agentId) {
-    try {
-      let warmupFailed = false
-      try {
-        await providerClient.warmupAcpProcess(agentId, acpWorkspacePath.value ?? undefined)
-      } catch (error) {
-        warmupFailed = true
-        console.warn('[ChatStatusBar] Failed to warmup ACP process:', error)
-      }
-
-      const state = await providerClient.getAcpProcessConfigOptions(
-        agentId,
-        acpWorkspacePath.value ?? undefined
-      )
-      if (token !== acpConfigSyncToken || acpConfigRequestKey.value !== requestKey) {
-        return
-      }
-
-      if (!hasAcpConfigStateData(state)) {
-        acpConfigState.value = getCachedAcpConfigState(agentId)
-        if (warmupFailed) {
-          clearAcpConfigLoadingRequest(requestKey)
-        }
-        return
-      }
-
-      setCachedAcpConfigState(agentId, state)
-      acpConfigState.value = state
-      clearAcpConfigLoadingRequest(requestKey)
-    } catch (error) {
-      console.warn('[ChatStatusBar] Failed to load ACP process config options:', error)
-      if (token !== acpConfigSyncToken || acpConfigRequestKey.value !== requestKey) {
-        return
-      }
-      acpConfigState.value = getCachedAcpConfigState(agentId)
-      clearAcpConfigLoadingRequest(requestKey)
-    }
-  }
-}
-
-const updateAcpConfigOption = async (configId: string, value: string | boolean) => {
-  const sessionId = activeAcpSessionId.value
-  const agentId = activeAcpAgentId.value
-  if (!sessionId || !isAcpSessionConfigLoaded.value) {
-    return
-  }
-
-  if (acpOptionSavingIds.value.includes(configId)) {
-    return
-  }
-
-  acpOptionSavingIds.value = [...acpOptionSavingIds.value, configId]
-  try {
-    const updated = await sessionClient.setAcpSessionConfigOption(sessionId, configId, value)
-    setCachedAcpConfigState(agentId, updated)
-    if (activeAcpSessionId.value !== sessionId) {
-      return
-    }
-    acpConfigState.value = updated
-  } catch (error) {
-    console.warn('[ChatStatusBar] Failed to update ACP config option:', error)
-  } finally {
-    acpOptionSavingIds.value = acpOptionSavingIds.value.filter((id) => id !== configId)
-  }
-}
-
-const isAcpOptionSaving = (configId: string) => acpOptionSavingIds.value.includes(configId)
-
 const reloadSystemPrompts = async () => {
   try {
     systemPromptList.value = await configClient.getSystemPrompts()
   } catch (error) {
     console.warn('[ChatStatusBar] Failed to load system prompt options:', error)
     systemPromptList.value = []
-  }
-}
-
-const handleAcpConfigOptionsReady = (payload?: Record<string, unknown>) => {
-  if (!payload || !isAcpAgent.value) {
-    return
-  }
-
-  const conversationId = typeof payload.conversationId === 'string' ? payload.conversationId : ''
-  const agentId = typeof payload.agentId === 'string' ? payload.agentId : ''
-  const workdir = typeof payload.workdir === 'string' ? payload.workdir : ''
-
-  if (!isAcpConfigState(payload.configState)) {
-    return
-  }
-
-  if (conversationId) {
-    if (activeAcpSessionId.value !== conversationId) {
-      return
-    }
-    setCachedAcpConfigState(agentId || activeAcpAgentId.value, payload.configState)
-    acpConfigState.value = payload.configState
-    acpConfigLoadedRequestKey.value = `session:${conversationId}`
-    clearAcpConfigLoadingRequest(`session:${conversationId}`)
-    return
-  }
-
-  if (!matchesCurrentAcpWarmupTarget(agentId, workdir)) {
-    return
-  }
-
-  setCachedAcpConfigState(agentId, payload.configState)
-
-  if (!activeAcpSessionId.value) {
-    acpConfigState.value = payload.configState
-    clearAcpConfigLoadingRequest(acpConfigRequestKey.value)
   }
 }
 
@@ -2598,15 +2276,6 @@ watch(
     })
   },
   { immediate: true }
-)
-
-watch(
-  () => acpInlineOptions.value.map((option) => option.id),
-  (optionIds) => {
-    if (acpInlineOpenOptionId.value && !optionIds.includes(acpInlineOpenOptionId.value)) {
-      acpInlineOpenOptionId.value = null
-    }
-  }
 )
 
 function getEffectiveModelSelectionSnapshot(): ModelSelection | null {
@@ -3050,29 +2719,6 @@ function onInterleavedThinkingToggle(enabled: boolean) {
   updateLocalGenerationSettings({
     forceInterleavedThinkingCompat: enabled
   })
-}
-
-function onAcpInlineOptionOpenChange(optionId: string, open: boolean) {
-  if (open) {
-    acpInlineOpenOptionId.value = optionId
-    return
-  }
-
-  if (acpInlineOpenOptionId.value === optionId) {
-    acpInlineOpenOptionId.value = null
-  }
-}
-
-function onAcpSelectOption(configId: string, value: string) {
-  if (!value) {
-    return
-  }
-  acpInlineOpenOptionId.value = null
-  void updateAcpConfigOption(configId, value)
-}
-
-function onAcpBooleanOption(configId: string, value: boolean) {
-  void updateAcpConfigOption(configId, value)
 }
 
 async function selectPermissionMode(mode: PermissionMode) {

--- a/src/renderer/src/components/chat/ChatStatusBar.vue
+++ b/src/renderer/src/components/chat/ChatStatusBar.vue
@@ -927,6 +927,7 @@ import {
   MODEL_TIMEOUT_MAX_MS,
   MODEL_TIMEOUT_MIN_MS
 } from '@shared/modelConfigDefaults'
+import { resolvePreferredChatModel, type ChatModelSelection } from '@/lib/chatModelSelection'
 import McpIndicator from '@/components/chat-input/McpIndicator.vue'
 import ModelIcon from '@/components/icons/ModelIcon.vue'
 import { createConfigClient } from '@api/ConfigClient'
@@ -1711,22 +1712,6 @@ const normalizeReasoningVisibility = (
   return normalizeAnthropicReasoningVisibilityValue(value) ?? 'omitted'
 }
 
-const findEnabledModel = (providerId: string, modelId: string): ModelSelection | null => {
-  const hit = findEnabledModelMeta(providerId, modelId)
-  if (!hit) {
-    return null
-  }
-  return { providerId, modelId: hit.id }
-}
-
-const pickFirstEnabledModel = (): ModelSelection | null => {
-  const firstSelectableModel = modelStore.pickFirstChatSelectableModel()
-  if (firstSelectableModel) {
-    return { providerId: firstSelectableModel.providerId, modelId: firstSelectableModel.model.id }
-  }
-  return null
-}
-
 const resolveModelName = (providerId?: string | null, modelId?: string | null): string => {
   if (!modelId) {
     return ''
@@ -2018,51 +2003,39 @@ const syncDraftModelSelection = async () => {
   }
 
   try {
-    const currentDraft = findEnabledModel(draftStore.providerId || '', draftStore.modelId || '')
-    if (currentDraft) {
-      applyDraftSelection(currentDraft)
-      return
-    }
-
     const deepChatAgentId = selectedDeepChatAgentId.value ?? 'deepchat'
-    const agentConfig = await resolveDeepChatAgentConfig(deepChatAgentId)
+    const [agentConfig, preferredModel, defaultModel] = await Promise.all([
+      resolveDeepChatAgentConfig(deepChatAgentId),
+      configClient.getSetting('preferredModel'),
+      configClient.getSetting('defaultModel')
+    ])
     if (token !== draftModelSyncToken) return
-    if (isModelSelection(agentConfig.defaultModelPreset)) {
-      const resolvedAgentDefault = findEnabledModel(
-        agentConfig.defaultModelPreset.providerId,
-        agentConfig.defaultModelPreset.modelId
-      )
-      if (resolvedAgentDefault) {
-        applyDraftSelection(resolvedAgentDefault)
-        return
-      }
-    }
 
-    const preferredModel = (await configClient.getSetting('preferredModel')) as unknown
-    if (token !== draftModelSyncToken) return
-    if (isModelSelection(preferredModel)) {
-      const resolvedPreferred = findEnabledModel(preferredModel.providerId, preferredModel.modelId)
-      if (resolvedPreferred) {
-        applyDraftSelection(resolvedPreferred)
-        return
-      }
-    }
-
-    const defaultModel = (await configClient.getSetting('defaultModel')) as unknown
-    if (token !== draftModelSyncToken) return
-    if (isModelSelection(defaultModel)) {
-      const resolvedDefault = findEnabledModel(defaultModel.providerId, defaultModel.modelId)
-      if (resolvedDefault) {
-        applyDraftSelection(resolvedDefault)
-        return
-      }
-    }
+    const resolvedModel = resolvePreferredChatModel({
+      modelGroups: modelStore.chatSelectableModelGroups,
+      selections: [
+        draftStore.providerId && draftStore.modelId
+          ? { providerId: draftStore.providerId, modelId: draftStore.modelId }
+          : null,
+        isModelSelection(agentConfig.defaultModelPreset)
+          ? (agentConfig.defaultModelPreset as ChatModelSelection)
+          : null,
+        isModelSelection(preferredModel) ? (preferredModel as ChatModelSelection) : null,
+        isModelSelection(defaultModel) ? (defaultModel as ChatModelSelection) : null
+      ]
+    })
+    applyDraftSelection(
+      resolvedModel
+        ? { providerId: resolvedModel.providerId, modelId: resolvedModel.model.id }
+        : null
+    )
+    return
   } catch (error) {
     console.warn('[ChatStatusBar] Failed to resolve draft model:', error)
   }
 
   if (token !== draftModelSyncToken) return
-  applyDraftSelection(pickFirstEnabledModel())
+  applyDraftSelection(null)
 }
 
 const resolveDefaultGenerationSettings = async (

--- a/src/renderer/src/components/chat/composables/useChatStatusBarAcpConfig.ts
+++ b/src/renderer/src/components/chat/composables/useChatStatusBarAcpConfig.ts
@@ -1,0 +1,462 @@
+import { computed, ref, watch, type ComputedRef, type Ref } from 'vue'
+import type { ProviderClient } from '@api/ProviderClient'
+import type { SessionClient } from '@api/SessionClient'
+import type { AcpConfigOption, AcpConfigState } from '@shared/presenter'
+
+const ACP_INLINE_OPTION_LIMIT = 3
+
+type Readable<T> = Ref<T> | ComputedRef<T>
+
+type UseChatStatusBarAcpConfigOptions = {
+  t: (key: string) => string
+  isAcpAgent: Readable<boolean>
+  activeAcpAgentId: Readable<string | null>
+  activeAcpSessionId: Readable<string | null>
+  acpWorkspacePath: Readable<string | null>
+  selectedAgentId: Readable<string | null | undefined>
+  selectedAgentName: Readable<string | null | undefined>
+  providerClient: ProviderClient
+  sessionClient: SessionClient
+  resolveModelName: (providerId?: string | null, modelId?: string | null) => string
+  resolveModelIconId: (providerId?: string | null, modelId?: string | null) => string
+}
+
+const isAcpConfigOptionValue = (
+  value: unknown
+): value is NonNullable<AcpConfigOption['options']>[number] => {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  return typeof candidate.value === 'string' && typeof candidate.label === 'string'
+}
+
+const isAcpConfigOption = (value: unknown): value is AcpConfigOption => {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  if (
+    typeof candidate.id !== 'string' ||
+    typeof candidate.label !== 'string' ||
+    (candidate.type !== 'select' && candidate.type !== 'boolean')
+  ) {
+    return false
+  }
+
+  if (!('currentValue' in candidate)) {
+    return false
+  }
+
+  if (candidate.type === 'select' && candidate.options !== undefined) {
+    return Array.isArray(candidate.options) && candidate.options.every(isAcpConfigOptionValue)
+  }
+
+  return true
+}
+
+const isAcpConfigState = (value: unknown): value is AcpConfigState => {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  return (
+    (candidate.source === 'configOptions' || candidate.source === 'legacy') &&
+    Array.isArray(candidate.options) &&
+    candidate.options.every(isAcpConfigOption)
+  )
+}
+
+const hasAcpConfigStateData = (state: AcpConfigState | null | undefined): state is AcpConfigState =>
+  Boolean(state?.options.length)
+
+const getAcpOptionCurrentLabel = (option?: AcpConfigOption | null): string | null => {
+  if (!option || option.type !== 'select') {
+    return null
+  }
+
+  const currentValue = typeof option.currentValue === 'string' ? option.currentValue : ''
+  return option.options?.find((entry) => entry.value === currentValue)?.label ?? currentValue
+}
+
+export function useChatStatusBarAcpConfig(options: UseChatStatusBarAcpConfigOptions) {
+  const acpConfigState = ref<AcpConfigState | null>(null)
+  const acpConfigLoadedRequestKey = ref<string | null>(null)
+  const acpConfigLoadingRequestKey = ref<string | null>(null)
+  const acpInlineOpenOptionId = ref<string | null>(null)
+  const acpOptionSavingIds = ref<string[]>([])
+  const acpConfigCacheByAgent = new Map<string, AcpConfigState>()
+  let acpConfigSyncToken = 0
+
+  const acpConfigCacheKey = computed(() => {
+    if (!options.isAcpAgent.value || options.activeAcpSessionId.value) {
+      return null
+    }
+
+    return options.activeAcpAgentId.value
+  })
+
+  const acpConfigRequestKey = computed(() => {
+    if (!options.isAcpAgent.value) {
+      return null
+    }
+
+    if (options.activeAcpSessionId.value) {
+      return `session:${options.activeAcpSessionId.value}`
+    }
+
+    if (acpConfigCacheKey.value && options.acpWorkspacePath.value) {
+      return `process:${acpConfigCacheKey.value}::${options.acpWorkspacePath.value}`
+    }
+
+    if (acpConfigCacheKey.value) {
+      return `agent:${acpConfigCacheKey.value}`
+    }
+
+    return null
+  })
+
+  const getCachedAcpConfigState = (agentId?: string | null): AcpConfigState | null => {
+    if (!agentId) {
+      return null
+    }
+
+    return acpConfigCacheByAgent.get(agentId) ?? null
+  }
+
+  const setCachedAcpConfigState = (
+    agentId: string | null | undefined,
+    state: AcpConfigState | null | undefined
+  ): void => {
+    if (!agentId || !hasAcpConfigStateData(state)) {
+      return
+    }
+
+    acpConfigCacheByAgent.set(agentId, state)
+  }
+
+  const acpConfigOptions = computed(() => acpConfigState.value?.options ?? [])
+  const isAcpConfigLoading = computed(() => {
+    if (!options.isAcpAgent.value || options.activeAcpSessionId.value) {
+      return false
+    }
+
+    const requestKey = acpConfigRequestKey.value
+    return Boolean(requestKey && acpConfigLoadingRequestKey.value === requestKey)
+  })
+
+  const isAcpSessionConfigLoaded = computed(() => {
+    if (!options.activeAcpSessionId.value) {
+      return false
+    }
+
+    return acpConfigLoadedRequestKey.value === acpConfigRequestKey.value
+  })
+
+  const acpConfigReadOnly = computed(() => {
+    if (!options.isAcpAgent.value) {
+      return false
+    }
+
+    if (!options.activeAcpSessionId.value) {
+      return true
+    }
+
+    return !isAcpSessionConfigLoaded.value
+  })
+
+  const acpInlineOptions = computed(() =>
+    acpConfigOptions.value
+      .filter((option) => option.type === 'select')
+      .slice(0, ACP_INLINE_OPTION_LIMIT)
+  )
+
+  const acpOverflowOptions = computed(() => {
+    const inlineIds = new Set(acpInlineOptions.value.map((option) => option.id))
+    return acpConfigOptions.value.filter((option) => !inlineIds.has(option.id))
+  })
+
+  const acpAgentLabel = computed(() => {
+    const modelId = options.activeAcpAgentId.value ?? options.selectedAgentId.value
+    return (
+      options.resolveModelName('acp', modelId) ||
+      options.selectedAgentName.value ||
+      modelId ||
+      options.t('chat.mode.acpAgent')
+    )
+  })
+
+  const acpAgentIconId = computed(() =>
+    options.resolveModelIconId(
+      'acp',
+      options.activeAcpAgentId.value ?? options.selectedAgentId.value
+    )
+  )
+
+  const getAcpOptionDisplayValue = (option: AcpConfigOption): string => {
+    if (option.type === 'boolean') {
+      return options.t(option.currentValue ? 'common.enabled' : 'common.disabled')
+    }
+
+    if (typeof option.currentValue === 'string' && option.currentValue.trim()) {
+      return option.currentValue
+    }
+
+    return getAcpOptionCurrentLabel(option) ?? ''
+  }
+
+  const setAcpConfigLoadingRequest = (requestKey: string | null | undefined): void => {
+    acpConfigLoadingRequestKey.value = requestKey?.trim() ? requestKey : null
+  }
+
+  const clearAcpConfigLoadingRequest = (requestKey?: string | null): void => {
+    if (!requestKey || acpConfigLoadingRequestKey.value === requestKey) {
+      acpConfigLoadingRequestKey.value = null
+    }
+  }
+
+  const matchesCurrentAcpWarmupTarget = (
+    agentId: string | null | undefined,
+    workdir: string | null | undefined
+  ): boolean => {
+    if (
+      options.activeAcpSessionId.value ||
+      !agentId ||
+      options.activeAcpAgentId.value !== agentId
+    ) {
+      return false
+    }
+
+    const expectedWorkdir = options.acpWorkspacePath.value?.trim()
+    if (!expectedWorkdir) {
+      return true
+    }
+
+    return workdir?.trim() === expectedWorkdir
+  }
+
+  const syncAcpConfigOptions = async () => {
+    const token = ++acpConfigSyncToken
+    const requestKey = acpConfigRequestKey.value
+    acpInlineOpenOptionId.value = null
+
+    if (!options.isAcpAgent.value || !requestKey) {
+      acpConfigState.value = null
+      acpConfigLoadedRequestKey.value = null
+      clearAcpConfigLoadingRequest()
+      return
+    }
+
+    const agentId = options.activeAcpAgentId.value
+
+    if (options.activeAcpSessionId.value) {
+      clearAcpConfigLoadingRequest()
+      acpConfigState.value = null
+      acpConfigLoadedRequestKey.value = null
+
+      try {
+        const state = await options.sessionClient.getAcpSessionConfigOptions(
+          options.activeAcpSessionId.value
+        )
+        if (token !== acpConfigSyncToken || acpConfigRequestKey.value !== requestKey) {
+          return
+        }
+
+        acpConfigState.value = state
+        acpConfigLoadedRequestKey.value = requestKey
+        setCachedAcpConfigState(agentId, state)
+        clearAcpConfigLoadingRequest(requestKey)
+        return
+      } catch (error) {
+        console.warn('[ChatStatusBar] Failed to load ACP session config options:', error)
+        if (token !== acpConfigSyncToken || acpConfigRequestKey.value !== requestKey) {
+          return
+        }
+
+        acpConfigState.value = null
+        acpConfigLoadedRequestKey.value = null
+        clearAcpConfigLoadingRequest(requestKey)
+        return
+      }
+    }
+
+    acpConfigLoadedRequestKey.value = null
+    const cachedState = getCachedAcpConfigState(agentId)
+    acpConfigState.value = cachedState
+
+    if (hasAcpConfigStateData(cachedState)) {
+      clearAcpConfigLoadingRequest(requestKey)
+    } else {
+      setAcpConfigLoadingRequest(requestKey)
+    }
+
+    if (!agentId) {
+      return
+    }
+
+    try {
+      let warmupFailed = false
+      try {
+        await options.providerClient.warmupAcpProcess(
+          agentId,
+          options.acpWorkspacePath.value ?? undefined
+        )
+      } catch (error) {
+        warmupFailed = true
+        console.warn('[ChatStatusBar] Failed to warmup ACP process:', error)
+      }
+
+      const state = await options.providerClient.getAcpProcessConfigOptions(
+        agentId,
+        options.acpWorkspacePath.value ?? undefined
+      )
+      if (token !== acpConfigSyncToken || acpConfigRequestKey.value !== requestKey) {
+        return
+      }
+
+      if (!hasAcpConfigStateData(state)) {
+        acpConfigState.value = getCachedAcpConfigState(agentId)
+        if (warmupFailed) {
+          clearAcpConfigLoadingRequest(requestKey)
+        }
+        return
+      }
+
+      setCachedAcpConfigState(agentId, state)
+      acpConfigState.value = state
+      clearAcpConfigLoadingRequest(requestKey)
+    } catch (error) {
+      console.warn('[ChatStatusBar] Failed to load ACP process config options:', error)
+      if (token !== acpConfigSyncToken || acpConfigRequestKey.value !== requestKey) {
+        return
+      }
+
+      acpConfigState.value = getCachedAcpConfigState(agentId)
+      clearAcpConfigLoadingRequest(requestKey)
+    }
+  }
+
+  const updateAcpConfigOption = async (configId: string, value: string | boolean) => {
+    const sessionId = options.activeAcpSessionId.value
+    const agentId = options.activeAcpAgentId.value
+    if (!sessionId || !isAcpSessionConfigLoaded.value) {
+      return
+    }
+
+    if (acpOptionSavingIds.value.includes(configId)) {
+      return
+    }
+
+    acpOptionSavingIds.value = [...acpOptionSavingIds.value, configId]
+    try {
+      const updated = await options.sessionClient.setAcpSessionConfigOption(
+        sessionId,
+        configId,
+        value
+      )
+      setCachedAcpConfigState(agentId, updated)
+      if (options.activeAcpSessionId.value !== sessionId) {
+        return
+      }
+
+      acpConfigState.value = updated
+    } catch (error) {
+      console.warn('[ChatStatusBar] Failed to update ACP config option:', error)
+    } finally {
+      acpOptionSavingIds.value = acpOptionSavingIds.value.filter((id) => id !== configId)
+    }
+  }
+
+  const isAcpOptionSaving = (configId: string) => acpOptionSavingIds.value.includes(configId)
+
+  const handleAcpConfigOptionsReady = (payload?: Record<string, unknown>) => {
+    if (!payload || !options.isAcpAgent.value) {
+      return
+    }
+
+    const conversationId = typeof payload.conversationId === 'string' ? payload.conversationId : ''
+    const agentId = typeof payload.agentId === 'string' ? payload.agentId : ''
+    const workdir = typeof payload.workdir === 'string' ? payload.workdir : ''
+
+    if (!isAcpConfigState(payload.configState)) {
+      return
+    }
+
+    if (conversationId) {
+      if (options.activeAcpSessionId.value !== conversationId) {
+        return
+      }
+
+      setCachedAcpConfigState(agentId || options.activeAcpAgentId.value, payload.configState)
+      acpConfigState.value = payload.configState
+      acpConfigLoadedRequestKey.value = `session:${conversationId}`
+      clearAcpConfigLoadingRequest(`session:${conversationId}`)
+      return
+    }
+
+    if (!matchesCurrentAcpWarmupTarget(agentId, workdir)) {
+      return
+    }
+
+    setCachedAcpConfigState(agentId, payload.configState)
+
+    if (!options.activeAcpSessionId.value) {
+      acpConfigState.value = payload.configState
+      clearAcpConfigLoadingRequest(acpConfigRequestKey.value)
+    }
+  }
+
+  const onAcpInlineOptionOpenChange = (optionId: string, open: boolean) => {
+    if (open) {
+      acpInlineOpenOptionId.value = optionId
+      return
+    }
+
+    if (acpInlineOpenOptionId.value === optionId) {
+      acpInlineOpenOptionId.value = null
+    }
+  }
+
+  const onAcpSelectOption = (configId: string, value: string) => {
+    if (!value) {
+      return
+    }
+
+    acpInlineOpenOptionId.value = null
+    void updateAcpConfigOption(configId, value)
+  }
+
+  const onAcpBooleanOption = (configId: string, value: boolean) => {
+    void updateAcpConfigOption(configId, value)
+  }
+
+  watch(
+    () => acpInlineOptions.value.map((option) => option.id),
+    (optionIds) => {
+      if (acpInlineOpenOptionId.value && !optionIds.includes(acpInlineOpenOptionId.value)) {
+        acpInlineOpenOptionId.value = null
+      }
+    }
+  )
+
+  return {
+    acpConfigState,
+    acpInlineOpenOptionId,
+    acpConfigReadOnly,
+    acpInlineOptions,
+    acpOverflowOptions,
+    acpAgentLabel,
+    acpAgentIconId,
+    isAcpConfigLoading,
+    getAcpOptionDisplayValue,
+    isAcpOptionSaving,
+    syncAcpConfigOptions,
+    handleAcpConfigOptionsReady,
+    onAcpInlineOptionOpenChange,
+    onAcpSelectOption,
+    onAcpBooleanOption
+  }
+}

--- a/src/renderer/src/lib/chatModelSelection.ts
+++ b/src/renderer/src/lib/chatModelSelection.ts
@@ -1,0 +1,117 @@
+import type { RENDERER_MODEL_META } from '@shared/presenter'
+
+export type ChatModelSelection = {
+  providerId: string
+  modelId?: string | null
+}
+
+export type ChatSelectableModelGroup = {
+  providerId: string
+  models: RENDERER_MODEL_META[]
+}
+
+export type ResolvedChatModel = {
+  providerId: string
+  model: RENDERER_MODEL_META
+}
+
+const getEligibleModels = (
+  group: ChatSelectableModelGroup | undefined,
+  requiresVision: boolean
+): RENDERER_MODEL_META[] => {
+  if (!group) {
+    return []
+  }
+
+  return requiresVision ? group.models.filter((model) => model.vision) : group.models
+}
+
+export const pickFirstChatModel = (
+  modelGroups: ChatSelectableModelGroup[],
+  requiresVision = false
+): ResolvedChatModel | null => {
+  for (const group of modelGroups) {
+    const [firstModel] = getEligibleModels(group, requiresVision)
+    if (firstModel) {
+      return { providerId: group.providerId, model: firstModel }
+    }
+  }
+
+  return null
+}
+
+export const resolvePreferredChatModel = (input: {
+  modelGroups: ChatSelectableModelGroup[]
+  selections: Array<ChatModelSelection | null | undefined>
+}): ResolvedChatModel | null => {
+  for (const selection of input.selections) {
+    if (!selection?.providerId || !selection.modelId) {
+      continue
+    }
+
+    const group = input.modelGroups.find((entry) => entry.providerId === selection.providerId)
+    const model = group?.models.find((entry) => entry.id === selection.modelId)
+    if (group && model) {
+      return { providerId: group.providerId, model }
+    }
+  }
+
+  return pickFirstChatModel(input.modelGroups)
+}
+
+export const resolveSamplingChatModel = (input: {
+  modelGroups: ChatSelectableModelGroup[]
+  requiresVision: boolean
+  selections: Array<ChatModelSelection | null | undefined>
+}): ResolvedChatModel | null => {
+  for (const selection of input.selections) {
+    if (!selection?.providerId) {
+      continue
+    }
+
+    const group = input.modelGroups.find((entry) => entry.providerId === selection.providerId)
+    const models = getEligibleModels(group, input.requiresVision)
+    if (models.length === 0) {
+      continue
+    }
+
+    if (selection.modelId) {
+      const preferredModel = models.find((model) => model.id === selection.modelId)
+      if (preferredModel) {
+        return { providerId: selection.providerId, model: preferredModel }
+      }
+    }
+
+    return { providerId: selection.providerId, model: models[0] }
+  }
+
+  return pickFirstChatModel(input.modelGroups, input.requiresVision)
+}
+
+export const resolveChatModelByQuery = (
+  modelGroups: ChatSelectableModelGroup[],
+  query: string | null | undefined
+): ResolvedChatModel | null => {
+  const normalizedQuery = query?.trim().toLowerCase()
+  if (!normalizedQuery) {
+    return null
+  }
+
+  for (const group of modelGroups) {
+    const exactModel = group.models.find((model) => model.id.toLowerCase() === normalizedQuery)
+    if (exactModel) {
+      return { providerId: group.providerId, model: exactModel }
+    }
+  }
+
+  for (const group of modelGroups) {
+    const fuzzyModel = group.models.find((model) =>
+      model.id.toLowerCase().includes(normalizedQuery)
+    )
+    if (fuzzyModel) {
+      return { providerId: group.providerId, model: fuzzyModel }
+    }
+  }
+
+  return null
+}

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -121,6 +121,11 @@ import type {
   SessionGenerationSettings
 } from '@shared/types/agent-interface'
 import { normalizeDeepChatSubagentConfig } from '@shared/lib/deepchatSubagents'
+import {
+  resolveChatModelByQuery,
+  resolvePreferredChatModel,
+  type ChatModelSelection
+} from '@/lib/chatModelSelection'
 import { scheduleStartupDeferredTask } from '@/lib/startupDeferred'
 
 const projectStore = useProjectStore()
@@ -197,15 +202,6 @@ const isAcpWorkdirMissing = computed(() => {
   return !projectStore.selectedProject?.path?.trim()
 })
 
-const getEnabledModel = (
-  providerId?: string,
-  modelId?: string
-): { providerId: string; modelId: string } | null => {
-  if (!providerId || !modelId) return null
-  const matched = modelStore.findChatSelectableModel(providerId, modelId)
-  return matched ? { providerId: matched.providerId, modelId: matched.model.id } : null
-}
-
 const ensureEnabledModelsReady = async (): Promise<boolean> => {
   if (modelStore.initialized) {
     return true
@@ -226,37 +222,23 @@ async function resolveModel(): Promise<{ providerId: string; modelId: string } |
     return null
   }
 
-  // 0. model manually selected in current NewThread page
-  const draftModel = getEnabledModel(draftStore.providerId, draftStore.modelId)
-  if (draftModel) {
-    return draftModel
-  }
+  const [preferredModel, defaultModel] = await Promise.all([
+    configClient.getSetting('preferredModel') as Promise<ChatModelSelection | undefined>,
+    configClient.getSetting('defaultModel') as Promise<ChatModelSelection | undefined>
+  ])
 
-  // 1. preferredModel (last user selection)
-  const preferredModel = (await configClient.getSetting('preferredModel')) as
-    | { providerId: string; modelId: string }
-    | undefined
-  const resolvedPreferredModel = getEnabledModel(
-    preferredModel?.providerId,
-    preferredModel?.modelId
-  )
-  if (resolvedPreferredModel) {
-    return resolvedPreferredModel
-  }
-
-  // 2. defaultModel from settings
-  const defaultModel = (await configClient.getSetting('defaultModel')) as
-    | { providerId: string; modelId: string }
-    | undefined
-  const resolvedDefaultModel = getEnabledModel(defaultModel?.providerId, defaultModel?.modelId)
-  if (resolvedDefaultModel) {
-    return resolvedDefaultModel
-  }
-
-  // 3. First available enabled model
-  const firstSelectableModel = modelStore.pickFirstChatSelectableModel()
-  if (firstSelectableModel) {
-    return { providerId: firstSelectableModel.providerId, modelId: firstSelectableModel.model.id }
+  const resolvedModel = resolvePreferredChatModel({
+    modelGroups: modelStore.chatSelectableModelGroups,
+    selections: [
+      draftStore.providerId && draftStore.modelId
+        ? { providerId: draftStore.providerId, modelId: draftStore.modelId }
+        : null,
+      preferredModel,
+      defaultModel
+    ]
+  })
+  if (resolvedModel) {
+    return { providerId: resolvedModel.providerId, modelId: resolvedModel.model.id }
   }
 
   return null
@@ -275,28 +257,10 @@ const buildStartMessage = (payload: StartDeeplinkPayload): string => {
 const resolveStartModelSelection = (
   requestedModelId: string | null
 ): { providerId: string; modelId: string } | null => {
-  const normalizedModelId = requestedModelId?.trim().toLowerCase()
-  if (!normalizedModelId) {
-    return null
-  }
-
-  for (const group of modelStore.chatSelectableModelGroups) {
-    const matched = group.models.find((model) => model.id.toLowerCase() === normalizedModelId)
-    if (matched) {
-      return { providerId: group.providerId, modelId: matched.id }
-    }
-  }
-
-  for (const group of modelStore.chatSelectableModelGroups) {
-    const matched = group.models.find((model) =>
-      model.id.toLowerCase().includes(normalizedModelId)
-    )
-    if (matched) {
-      return { providerId: group.providerId, modelId: matched.id }
-    }
-  }
-
-  return null
+  const resolvedModel = resolveChatModelByQuery(modelStore.chatSelectableModelGroups, requestedModelId)
+  return resolvedModel
+    ? { providerId: resolvedModel.providerId, modelId: resolvedModel.model.id }
+    : null
 }
 
 const applyStartDeeplink = async (payload: StartDeeplinkPayload) => {

--- a/src/renderer/src/stores/mcpSampling.ts
+++ b/src/renderer/src/stores/mcpSampling.ts
@@ -6,6 +6,7 @@ import type {
   McpSamplingRequestPayload,
   RENDERER_MODEL_META
 } from '@shared/presenter'
+import { resolveSamplingChatModel, type ChatModelSelection } from '@/lib/chatModelSelection'
 import { useModelStore } from '@/stores/modelStore'
 import { useProviderStore } from '@/stores/providerStore'
 import { useSessionStore } from '@/stores/ui/session'
@@ -20,72 +21,21 @@ interface ApprovedServerInfo {
 // Session timeout: 30 minutes
 const SESSION_TIMEOUT = 30 * 60 * 1000
 
-type ModelSelection = {
-  providerId: string
-  modelId?: string | null
-}
-
-const pickEligibleModel = (
-  providerEntry: { providerId: string; models: RENDERER_MODEL_META[] } | undefined,
-  requiresVision: boolean,
-  preferredModelId?: string | null
-): { providerId: string | null; model: RENDERER_MODEL_META | null } => {
-  if (!providerEntry) {
-    return { providerId: null, model: null }
-  }
-
-  const models = requiresVision
-    ? providerEntry.models.filter((model) => model.vision)
-    : providerEntry.models
-
-  if (models.length === 0) {
-    return { providerId: null, model: null }
-  }
-
-  if (preferredModelId) {
-    const preferredModel = models.find((model) => model.id === preferredModelId)
-    if (preferredModel) {
-      return { providerId: providerEntry.providerId, model: preferredModel }
-    }
-  }
-
-  return { providerId: providerEntry.providerId, model: models[0] }
-}
-
 export const resolveSamplingDefaultModel = (input: {
   modelGroups: Array<{ providerId: string; models: RENDERER_MODEL_META[] }>
   requiresVision: boolean
-  activeSelection?: ModelSelection | null
-  draftSelection?: ModelSelection | null
+  activeSelection?: ChatModelSelection | null
+  draftSelection?: ChatModelSelection | null
 }): { providerId: string | null; model: RENDERER_MODEL_META | null } => {
-  const selectFrom = (selection?: ModelSelection | null) => {
-    if (!selection?.providerId) {
-      return { providerId: null, model: null as RENDERER_MODEL_META | null }
-    }
-    const providerEntry = input.modelGroups.find(
-      (entry) => entry.providerId === selection.providerId
-    )
-    return pickEligibleModel(providerEntry, input.requiresVision, selection.modelId)
-  }
+  const resolvedModel = resolveSamplingChatModel({
+    modelGroups: input.modelGroups,
+    requiresVision: input.requiresVision,
+    selections: [input.activeSelection, input.draftSelection]
+  })
 
-  const activeMatch = selectFrom(input.activeSelection)
-  if (activeMatch.providerId && activeMatch.model) {
-    return activeMatch
-  }
-
-  const draftMatch = selectFrom(input.draftSelection)
-  if (draftMatch.providerId && draftMatch.model) {
-    return draftMatch
-  }
-
-  for (const providerEntry of input.modelGroups) {
-    const match = pickEligibleModel(providerEntry, input.requiresVision)
-    if (match.providerId && match.model) {
-      return match
-    }
-  }
-
-  return { providerId: null, model: null }
+  return resolvedModel
+    ? { providerId: resolvedModel.providerId, model: resolvedModel.model }
+    : { providerId: null, model: null }
 }
 
 export const useMcpSamplingStore = defineStore('mcpSampling', () => {

--- a/test/renderer/lib/chatModelSelection.test.ts
+++ b/test/renderer/lib/chatModelSelection.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import type { RENDERER_MODEL_META } from '@shared/presenter'
+import {
+  resolveChatModelByQuery,
+  resolvePreferredChatModel,
+  resolveSamplingChatModel
+} from '@/lib/chatModelSelection'
+
+const makeModel = (
+  id: string,
+  providerId: string,
+  options?: { vision?: boolean }
+): RENDERER_MODEL_META => ({
+  id,
+  name: id,
+  group: 'default',
+  providerId,
+  vision: options?.vision ?? false
+})
+
+describe('chatModelSelection', () => {
+  it('resolves preferred chat models by exact candidate priority', () => {
+    const result = resolvePreferredChatModel({
+      modelGroups: [
+        { providerId: 'openai', models: [makeModel('gpt-4o', 'openai')] },
+        { providerId: 'anthropic', models: [makeModel('claude-sonnet', 'anthropic')] }
+      ],
+      selections: [
+        { providerId: 'openai', modelId: 'missing-model' },
+        { providerId: 'anthropic', modelId: 'claude-sonnet' }
+      ]
+    })
+
+    expect(result?.providerId).toBe('anthropic')
+    expect(result?.model.id).toBe('claude-sonnet')
+  })
+
+  it('falls back to the first available chat model when no preferred candidate matches', () => {
+    const result = resolvePreferredChatModel({
+      modelGroups: [
+        { providerId: 'openai', models: [makeModel('gpt-4o', 'openai')] },
+        { providerId: 'anthropic', models: [makeModel('claude-sonnet', 'anthropic')] }
+      ],
+      selections: [{ providerId: 'openai', modelId: 'missing-model' }]
+    })
+
+    expect(result?.providerId).toBe('openai')
+    expect(result?.model.id).toBe('gpt-4o')
+  })
+
+  it('keeps sampling on the same provider when vision is required but the preferred model is ineligible', () => {
+    const result = resolveSamplingChatModel({
+      modelGroups: [
+        {
+          providerId: 'openai',
+          models: [
+            makeModel('gpt-4.1', 'openai', { vision: false }),
+            makeModel('gpt-4o', 'openai', { vision: true })
+          ]
+        },
+        {
+          providerId: 'anthropic',
+          models: [makeModel('claude-sonnet', 'anthropic', { vision: true })]
+        }
+      ],
+      requiresVision: true,
+      selections: [{ providerId: 'openai', modelId: 'gpt-4.1' }]
+    })
+
+    expect(result?.providerId).toBe('openai')
+    expect(result?.model.id).toBe('gpt-4o')
+  })
+
+  it('matches deeplink model queries by exact id before fuzzy id', () => {
+    const result = resolveChatModelByQuery(
+      [
+        {
+          providerId: 'openai',
+          models: [makeModel('gpt-4o-mini', 'openai'), makeModel('gpt-4o', 'openai')]
+        }
+      ],
+      'gpt-4o'
+    )
+
+    expect(result?.providerId).toBe('openai')
+    expect(result?.model.id).toBe('gpt-4o')
+  })
+})


### PR DESCRIPTION
## Summary\n- extract ACP config state, caching, and option update flow into a dedicated  composable\n- keep  focused on view orchestration, deferred sync scheduling, and event subscriptions\n- preserve the existing ACP inline option and session/process sync behavior while reducing component size\n\n## Testing\n- not run (per request)