### PR TITLE
fix(exec): preserve windows UTF-8 output

### DIFF
--- a/docs/issues/windows-exec-output-encoding/plan.md
+++ b/docs/issues/windows-exec-output-encoding/plan.md
@@ -1,0 +1,21 @@
+# Windows Exec Output Encoding Plan
+
+## Approach
+
+- Normalize Windows shell sessions to UTF-8 before running user commands.
+- Decode stdout and stderr from user-visible subprocesses as byte streams with a streaming
+  decoder instead of per-chunk string conversion.
+- Share the command wrapping and decoder helper across exec, background exec, and skill
+  execution paths.
+
+## Affected Paths
+
+- `agent-filesystem.exec` detached and managed foreground execution.
+- Background exec sessions.
+- Skill script foreground execution.
+
+## Compatibility
+
+- Non-Windows commands are passed through unchanged.
+- Existing output formatting stays the same: command output first, then `Exit Code`, timeout,
+  and offload metadata.

--- a/docs/issues/windows-exec-output-encoding/spec.md
+++ b/docs/issues/windows-exec-output-encoding/spec.md
@@ -1,0 +1,24 @@
+# Windows Exec Output Encoding
+
+## User Story
+
+Windows users can run `agent-filesystem.exec` and skill scripts against files with Chinese
+names and read the command output without mojibake.
+
+## Acceptance Criteria
+
+- `agent-filesystem.exec` preserves Chinese output from PowerShell and cmd on Windows.
+- Foreground and background exec paths decode output with streaming UTF-8 semantics.
+- Skill script foreground output preserves Chinese text on Windows.
+- Existing exit code, timeout, and output offload messages are unchanged.
+
+## Non-goals
+
+- Do not change tool call rendering in the renderer.
+- Do not change plugin, hook notification, or RTK internal command output handling.
+- Do not support commands that intentionally switch the console back to a non-UTF-8 code page.
+
+## Constraints
+
+- Do not add third-party dependencies.
+- Keep user-facing command output behavior compatible outside of encoding fixes.

--- a/docs/issues/windows-exec-output-encoding/spec.md
+++ b/docs/issues/windows-exec-output-encoding/spec.md
@@ -17,6 +17,8 @@ names and read the command output without mojibake.
 - Do not change tool call rendering in the renderer.
 - Do not change plugin, hook notification, or RTK internal command output handling.
 - Do not support commands that intentionally switch the console back to a non-UTF-8 code page.
+- Do not add Git Bash or WSL-specific encoding setup; those shells are expected to provide their
+  own UTF-8 behavior.
 
 ## Constraints
 

--- a/docs/issues/windows-exec-output-encoding/tasks.md
+++ b/docs/issues/windows-exec-output-encoding/tasks.md
@@ -1,0 +1,8 @@
+# Windows Exec Output Encoding Tasks
+
+- [x] Document the issue and intended behavior.
+- [x] Add shared shell encoding helpers.
+- [x] Apply UTF-8 command wrapping to exec and skill shell invocations.
+- [x] Replace direct UTF-8 chunk conversion with streaming decoding for user-visible output.
+- [x] Add unit tests for Windows wrapping and split Chinese UTF-8 chunks.
+- [x] Run format, i18n, lint, and targeted tests.

--- a/src/main/lib/agentRuntime/backgroundExecSessionManager.ts
+++ b/src/main/lib/agentRuntime/backgroundExecSessionManager.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import { nanoid } from 'nanoid'
 import logger from '@shared/logger'
 import { getUserShell } from './shellEnvHelper'
+import { createUtf8StreamDecoder, prepareShellCommandForUtf8Output } from './shellOutputEncoding'
 import { terminateProcessTree } from './processTree'
 import { resolveSessionDir } from './sessionPaths'
 
@@ -72,6 +73,7 @@ interface BackgroundSession {
   closePromise: Promise<void>
   resolveClose: () => void
   closeSettled: boolean
+  flushOutputDecoders?: () => void
   killTimeoutId?: NodeJS.Timeout
   timedOut: boolean
 }
@@ -121,6 +123,7 @@ export class BackgroundExecSessionManager {
     const config = getConfig()
     const sessionId = `bg_${nanoid(12)}`
     const { shell, args } = getUserShell()
+    const shellCommand = prepareShellCommandForUtf8Output(shell, command)
 
     const sessionDir = resolveSessionDir(conversationId)
     if (sessionDir) {
@@ -131,7 +134,7 @@ export class BackgroundExecSessionManager {
       ? this.createOutputFilePath(sessionDir, sessionId, options?.outputPrefix)
       : null
 
-    const child = spawn(shell, [...args, command], {
+    const child = spawn(shell, [...args, shellCommand], {
       cwd,
       env: { ...process.env, ...options?.env },
       detached: process.platform !== 'win32',
@@ -444,22 +447,54 @@ export class BackgroundExecSessionManager {
     session: BackgroundSession,
     config: ReturnType<typeof getConfig>
   ): void {
-    const stdoutHandler = (data: Buffer) => {
-      this.appendOutput(session, data.toString('utf-8'), config)
+    const stdoutDecoder = createUtf8StreamDecoder((data) =>
+      this.appendOutput(session, data, config)
+    )
+    const stderrDecoder = createUtf8StreamDecoder((data) =>
+      this.appendOutput(session, data, config)
+    )
+    let stdoutFlushed = false
+    let stderrFlushed = false
+
+    const flushStdout = () => {
+      if (stdoutFlushed) {
+        return
+      }
+      stdoutFlushed = true
+      stdoutDecoder.end()
     }
 
-    const stderrHandler = (data: Buffer) => {
-      this.appendOutput(session, data.toString('utf-8'), config)
+    const flushStderr = () => {
+      if (stderrFlushed) {
+        return
+      }
+      stderrFlushed = true
+      stderrDecoder.end()
+    }
+
+    session.flushOutputDecoders = () => {
+      flushStdout()
+      flushStderr()
+    }
+
+    const stdoutHandler = (data: Buffer | string) => {
+      stdoutDecoder.write(data)
+    }
+
+    const stderrHandler = (data: Buffer | string) => {
+      stderrDecoder.write(data)
     }
 
     session.child.stdout?.on('data', stdoutHandler)
     session.child.stderr?.on('data', stderrHandler)
 
     session.child.stdout?.on('end', () => {
+      flushStdout()
       session.stdoutEof = true
     })
 
     session.child.stderr?.on('end', () => {
+      flushStderr()
       session.stderrEof = true
     })
   }
@@ -731,6 +766,7 @@ export class BackgroundExecSessionManager {
     signal: NodeJS.Signals | null
   ): Promise<void> {
     try {
+      session.flushOutputDecoders?.()
       await session.outputWriteQueue.catch((error) => {
         logger.warn('[BackgroundExec] Failed while draining output queue:', error)
       })

--- a/src/main/lib/agentRuntime/backgroundExecSessionManager.ts
+++ b/src/main/lib/agentRuntime/backgroundExecSessionManager.ts
@@ -4,7 +4,10 @@ import path from 'path'
 import { nanoid } from 'nanoid'
 import logger from '@shared/logger'
 import { getUserShell } from './shellEnvHelper'
-import { createUtf8StreamDecoder, prepareShellCommandForUtf8Output } from './shellOutputEncoding'
+import {
+  createUtf8OutputDecoderPair,
+  prepareShellCommandForUtf8Output
+} from './shellOutputEncoding'
 import { terminateProcessTree } from './processTree'
 import { resolveSessionDir } from './sessionPaths'
 
@@ -447,54 +450,29 @@ export class BackgroundExecSessionManager {
     session: BackgroundSession,
     config: ReturnType<typeof getConfig>
   ): void {
-    const stdoutDecoder = createUtf8StreamDecoder((data) =>
+    const outputDecoders = createUtf8OutputDecoderPair((data) =>
       this.appendOutput(session, data, config)
     )
-    const stderrDecoder = createUtf8StreamDecoder((data) =>
-      this.appendOutput(session, data, config)
-    )
-    let stdoutFlushed = false
-    let stderrFlushed = false
-
-    const flushStdout = () => {
-      if (stdoutFlushed) {
-        return
-      }
-      stdoutFlushed = true
-      stdoutDecoder.end()
-    }
-
-    const flushStderr = () => {
-      if (stderrFlushed) {
-        return
-      }
-      stderrFlushed = true
-      stderrDecoder.end()
-    }
-
-    session.flushOutputDecoders = () => {
-      flushStdout()
-      flushStderr()
-    }
+    session.flushOutputDecoders = outputDecoders.flush
 
     const stdoutHandler = (data: Buffer | string) => {
-      stdoutDecoder.write(data)
+      outputDecoders.writeStdout(data)
     }
 
     const stderrHandler = (data: Buffer | string) => {
-      stderrDecoder.write(data)
+      outputDecoders.writeStderr(data)
     }
 
     session.child.stdout?.on('data', stdoutHandler)
     session.child.stderr?.on('data', stderrHandler)
 
     session.child.stdout?.on('end', () => {
-      flushStdout()
+      outputDecoders.flushStdout()
       session.stdoutEof = true
     })
 
     session.child.stderr?.on('end', () => {
-      flushStderr()
+      outputDecoders.flushStderr()
       session.stderrEof = true
     })
   }

--- a/src/main/lib/agentRuntime/shellOutputEncoding.ts
+++ b/src/main/lib/agentRuntime/shellOutputEncoding.ts
@@ -1,0 +1,53 @@
+import path from 'path'
+import { StringDecoder } from 'string_decoder'
+
+const POWERSHELL_UTF8_PREAMBLE =
+  '[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false); ' +
+  '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); ' +
+  '$OutputEncoding = [System.Text.UTF8Encoding]::new($false);'
+
+const CMD_UTF8_PREAMBLE = 'chcp 65001 > nul'
+
+export function prepareShellCommandForUtf8Output(shell: string, command: string): string {
+  if (process.platform !== 'win32') {
+    return command
+  }
+
+  const shellName = path.basename(shell).toLowerCase()
+  if (
+    shellName === 'powershell.exe' ||
+    shellName === 'powershell' ||
+    shellName === 'pwsh.exe' ||
+    shellName === 'pwsh'
+  ) {
+    return `${POWERSHELL_UTF8_PREAMBLE} ${command}`
+  }
+
+  if (shellName === 'cmd.exe' || shellName === 'cmd') {
+    return `${CMD_UTF8_PREAMBLE} && ${command}`
+  }
+
+  return command
+}
+
+export function createUtf8StreamDecoder(onText: (text: string) => void): {
+  write: (chunk: Buffer | string) => void
+  end: () => void
+} {
+  const decoder = new StringDecoder('utf8')
+
+  return {
+    write(chunk) {
+      const text = Buffer.isBuffer(chunk) ? decoder.write(chunk) : decoder.write(Buffer.from(chunk))
+      if (text) {
+        onText(text)
+      }
+    },
+    end() {
+      const text = decoder.end()
+      if (text) {
+        onText(text)
+      }
+    }
+  }
+}

--- a/src/main/lib/agentRuntime/shellOutputEncoding.ts
+++ b/src/main/lib/agentRuntime/shellOutputEncoding.ts
@@ -8,6 +8,20 @@ const POWERSHELL_UTF8_PREAMBLE =
 
 const CMD_UTF8_PREAMBLE = 'chcp 65001 > nul'
 
+export function prepareProcessEnvForUtf8Output(
+  env: Record<string, string>
+): Record<string, string> {
+  if (process.platform !== 'win32') {
+    return env
+  }
+
+  return {
+    ...env,
+    PYTHONIOENCODING: 'utf-8',
+    PYTHONUTF8: '1'
+  }
+}
+
 export function prepareShellCommandForUtf8Output(shell: string, command: string): string {
   if (process.platform !== 'win32') {
     return command

--- a/src/main/lib/agentRuntime/shellOutputEncoding.ts
+++ b/src/main/lib/agentRuntime/shellOutputEncoding.ts
@@ -4,7 +4,7 @@ import { StringDecoder } from 'string_decoder'
 const POWERSHELL_UTF8_PREAMBLE =
   '[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false); ' +
   '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); ' +
-  '$OutputEncoding = [System.Text.UTF8Encoding]::new($false);'
+  '$OutputEncoding = [System.Text.UTF8Encoding]::new($false)'
 
 const CMD_UTF8_PREAMBLE = 'chcp 65001 > nul'
 
@@ -20,7 +20,7 @@ export function prepareShellCommandForUtf8Output(shell: string, command: string)
     shellName === 'pwsh.exe' ||
     shellName === 'pwsh'
   ) {
-    return `${POWERSHELL_UTF8_PREAMBLE} ${command}`
+    return `${POWERSHELL_UTF8_PREAMBLE}; ${command}`
   }
 
   if (shellName === 'cmd.exe' || shellName === 'cmd') {
@@ -38,7 +38,14 @@ export function createUtf8StreamDecoder(onText: (text: string) => void): {
 
   return {
     write(chunk) {
-      const text = Buffer.isBuffer(chunk) ? decoder.write(chunk) : decoder.write(Buffer.from(chunk))
+      if (typeof chunk === 'string') {
+        if (chunk) {
+          onText(chunk)
+        }
+        return
+      }
+
+      const text = decoder.write(chunk)
       if (text) {
         onText(text)
       }
@@ -48,6 +55,50 @@ export function createUtf8StreamDecoder(onText: (text: string) => void): {
       if (text) {
         onText(text)
       }
+    }
+  }
+}
+
+export function createUtf8OutputDecoderPair(onText: (text: string) => void): {
+  writeStdout: (chunk: Buffer | string) => void
+  writeStderr: (chunk: Buffer | string) => void
+  flushStdout: () => void
+  flushStderr: () => void
+  flush: () => void
+} {
+  const stdout = createUtf8StreamDecoder(onText)
+  const stderr = createUtf8StreamDecoder(onText)
+  let stdoutFlushed = false
+  let stderrFlushed = false
+
+  const flushStdout = () => {
+    if (stdoutFlushed) {
+      return
+    }
+    stdoutFlushed = true
+    stdout.end()
+  }
+
+  const flushStderr = () => {
+    if (stderrFlushed) {
+      return
+    }
+    stderrFlushed = true
+    stderr.end()
+  }
+
+  return {
+    writeStdout(chunk) {
+      stdout.write(chunk)
+    },
+    writeStderr(chunk) {
+      stderr.write(chunk)
+    },
+    flushStdout,
+    flushStderr,
+    flush() {
+      flushStdout()
+      flushStderr()
     }
   }
 }

--- a/src/main/presenter/skillPresenter/skillExecutionService.ts
+++ b/src/main/presenter/skillPresenter/skillExecutionService.ts
@@ -17,7 +17,7 @@ import {
   mergeCommandEnvironment
 } from '@/lib/agentRuntime/shellEnvHelper'
 import {
-  createUtf8StreamDecoder,
+  createUtf8OutputDecoderPair,
   prepareShellCommandForUtf8Output
 } from '@/lib/agentRuntime/shellOutputEncoding'
 import { resolveSessionDir } from '@/lib/agentRuntime/sessionPaths'
@@ -432,18 +432,7 @@ export class SkillExecutionService {
       let forceSettleTimeoutId: NodeJS.Timeout | null = null
       let settled = false
 
-      const stdoutDecoder = createUtf8StreamDecoder((data) => appendOutput(data))
-      const stderrDecoder = createUtf8StreamDecoder((data) => appendOutput(data))
-      let outputDecodersFlushed = false
-
-      const flushOutputDecoders = () => {
-        if (outputDecodersFlushed) {
-          return
-        }
-        outputDecodersFlushed = true
-        stdoutDecoder.end()
-        stderrDecoder.end()
-      }
+      const outputDecoders = createUtf8OutputDecoderPair((data) => appendOutput(data))
 
       const cleanupTimers = () => {
         if (timeoutId) {
@@ -468,7 +457,7 @@ export class SkillExecutionService {
         cleanupTimers()
         child.removeAllListeners('error')
         child.removeAllListeners('close')
-        flushOutputDecoders()
+        outputDecoders.flush()
 
         try {
           await outputWriteQueue
@@ -573,8 +562,8 @@ export class SkillExecutionService {
         queueOutputWrite(chunk)
       }
 
-      child.stdout?.on('data', (data: Buffer | string) => stdoutDecoder.write(data))
-      child.stderr?.on('data', (data: Buffer | string) => stderrDecoder.write(data))
+      child.stdout?.on('data', (data: Buffer | string) => outputDecoders.writeStdout(data))
+      child.stderr?.on('data', (data: Buffer | string) => outputDecoders.writeStderr(data))
 
       if (stdin !== undefined) {
         child.stdin?.write(stdin)

--- a/src/main/presenter/skillPresenter/skillExecutionService.ts
+++ b/src/main/presenter/skillPresenter/skillExecutionService.ts
@@ -16,6 +16,10 @@ import {
   getUserShell,
   mergeCommandEnvironment
 } from '@/lib/agentRuntime/shellEnvHelper'
+import {
+  createUtf8StreamDecoder,
+  prepareShellCommandForUtf8Output
+} from '@/lib/agentRuntime/shellOutputEncoding'
 import { resolveSessionDir } from '@/lib/agentRuntime/sessionPaths'
 import { RuntimeHelper } from '@/lib/runtimeHelper'
 
@@ -405,7 +409,10 @@ export class SkillExecutionService {
     return await new Promise((resolve, reject) => {
       const shellRuntime = plan.spawnMode === 'shell' ? getUserShell() : null
       const command = shellRuntime ? shellRuntime.shell : plan.command
-      const args = shellRuntime ? [...shellRuntime.args, plan.shellCommand] : plan.args
+      const shellCommand = shellRuntime
+        ? prepareShellCommandForUtf8Output(shellRuntime.shell, plan.shellCommand)
+        : plan.shellCommand
+      const args = shellRuntime ? [...shellRuntime.args, shellCommand] : plan.args
       const child = spawn(command, args, {
         cwd: plan.cwd,
         env: plan.env,
@@ -424,6 +431,19 @@ export class SkillExecutionService {
       let killTimeoutId: NodeJS.Timeout | null = null
       let forceSettleTimeoutId: NodeJS.Timeout | null = null
       let settled = false
+
+      const stdoutDecoder = createUtf8StreamDecoder((data) => appendOutput(data))
+      const stderrDecoder = createUtf8StreamDecoder((data) => appendOutput(data))
+      let outputDecodersFlushed = false
+
+      const flushOutputDecoders = () => {
+        if (outputDecodersFlushed) {
+          return
+        }
+        outputDecodersFlushed = true
+        stdoutDecoder.end()
+        stderrDecoder.end()
+      }
 
       const cleanupTimers = () => {
         if (timeoutId) {
@@ -448,6 +468,7 @@ export class SkillExecutionService {
         cleanupTimers()
         child.removeAllListeners('error')
         child.removeAllListeners('close')
+        flushOutputDecoders()
 
         try {
           await outputWriteQueue
@@ -552,10 +573,8 @@ export class SkillExecutionService {
         queueOutputWrite(chunk)
       }
 
-      child.stdout?.setEncoding('utf-8')
-      child.stderr?.setEncoding('utf-8')
-      child.stdout?.on('data', (data: string) => appendOutput(data))
-      child.stderr?.on('data', (data: string) => appendOutput(data))
+      child.stdout?.on('data', (data: Buffer | string) => stdoutDecoder.write(data))
+      child.stderr?.on('data', (data: Buffer | string) => stderrDecoder.write(data))
 
       if (stdin !== undefined) {
         child.stdin?.write(stdin)

--- a/src/main/presenter/skillPresenter/skillExecutionService.ts
+++ b/src/main/presenter/skillPresenter/skillExecutionService.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/agentRuntime/shellEnvHelper'
 import {
   createUtf8OutputDecoderPair,
+  prepareProcessEnvForUtf8Output,
   prepareShellCommandForUtf8Output
 } from '@/lib/agentRuntime/shellOutputEncoding'
 import { resolveSessionDir } from '@/lib/agentRuntime/sessionPaths'
@@ -413,9 +414,10 @@ export class SkillExecutionService {
         ? prepareShellCommandForUtf8Output(shellRuntime.shell, plan.shellCommand)
         : plan.shellCommand
       const args = shellRuntime ? [...shellRuntime.args, shellCommand] : plan.args
+      const env = shellRuntime ? plan.env : prepareProcessEnvForUtf8Output(plan.env)
       const child = spawn(command, args, {
         cwd: plan.cwd,
-        env: plan.env,
+        env,
         stdio: ['pipe', 'pipe', 'pipe'],
         shell: false
       })

--- a/src/main/presenter/toolPresenter/agentTools/agentBashHandler.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentBashHandler.ts
@@ -15,7 +15,7 @@ import {
   mergeCommandEnvironment
 } from '@/lib/agentRuntime/shellEnvHelper'
 import {
-  createUtf8StreamDecoder,
+  createUtf8OutputDecoderPair,
   prepareShellCommandForUtf8Output
 } from '@/lib/agentRuntime/shellOutputEncoding'
 import { resolveSessionDir } from '@/lib/agentRuntime/sessionPaths'
@@ -351,18 +351,7 @@ export class AgentBashHandler {
       let outputWriteQueue = Promise.resolve()
       let timeoutId: NodeJS.Timeout | null = null
 
-      const stdoutDecoder = createUtf8StreamDecoder((data) => appendOutput(data))
-      const stderrDecoder = createUtf8StreamDecoder((data) => appendOutput(data))
-      let outputDecodersFlushed = false
-
-      const flushOutputDecoders = () => {
-        if (outputDecodersFlushed) {
-          return
-        }
-        outputDecodersFlushed = true
-        stdoutDecoder.end()
-        stderrDecoder.end()
-      }
+      const outputDecoders = createUtf8OutputDecoderPair((data) => appendOutput(data))
 
       const cleanupTimeout = () => {
         if (timeoutId) {
@@ -375,7 +364,7 @@ export class AgentBashHandler {
         if (settled) return
         settled = true
         cleanupTimeout()
-        flushOutputDecoders()
+        outputDecoders.flush()
 
         try {
           await outputWriteQueue
@@ -414,11 +403,11 @@ export class AgentBashHandler {
       }
 
       child.stdout?.on('data', (data: Buffer | string) => {
-        stdoutDecoder.write(data)
+        outputDecoders.writeStdout(data)
       })
 
       child.stderr?.on('data', (data: Buffer | string) => {
-        stderrDecoder.write(data)
+        outputDecoders.writeStderr(data)
       })
 
       if (options.stdin !== undefined) {
@@ -433,7 +422,7 @@ export class AgentBashHandler {
             return
           }
 
-          flushOutputDecoders()
+          outputDecoders.flush()
           const preview =
             offloaded && outputFilePath
               ? this.readLastCharsFromFile(outputFilePath, COMMAND_PREVIEW_CHARS)
@@ -452,11 +441,12 @@ export class AgentBashHandler {
 
       child.on('error', (error) => {
         cleanupTimeout()
+        outputDecoders.flush()
         reject(error)
       })
 
       child.on('close', async (code, signal) => {
-        flushOutputDecoders()
+        outputDecoders.flush()
         const preview =
           offloaded && outputFilePath
             ? this.readLastCharsFromFile(outputFilePath, COMMAND_PREVIEW_CHARS)

--- a/src/main/presenter/toolPresenter/agentTools/agentBashHandler.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentBashHandler.ts
@@ -14,6 +14,10 @@ import {
   getUserShell,
   mergeCommandEnvironment
 } from '@/lib/agentRuntime/shellEnvHelper'
+import {
+  createUtf8StreamDecoder,
+  prepareShellCommandForUtf8Output
+} from '@/lib/agentRuntime/shellOutputEncoding'
 import { resolveSessionDir } from '@/lib/agentRuntime/sessionPaths'
 
 // Consider moving to a shared handlers location in future refactoring
@@ -328,10 +332,11 @@ export class AgentBashHandler {
     options: ExecuteCommandOptions
   ): Promise<CompletedShellProcessResult> {
     const { shell, args } = getUserShell()
+    const shellCommand = prepareShellCommandForUtf8Output(shell, command)
     const outputFilePath = this.createOutputFilePath(options.conversationId, options.outputPrefix)
 
     return new Promise((resolve, reject) => {
-      const child = spawn(shell, [...args, command], {
+      const child = spawn(shell, [...args, shellCommand], {
         cwd,
         env: options.env ? { ...options.env } : { ...process.env },
         detached: process.platform !== 'win32',
@@ -346,6 +351,19 @@ export class AgentBashHandler {
       let outputWriteQueue = Promise.resolve()
       let timeoutId: NodeJS.Timeout | null = null
 
+      const stdoutDecoder = createUtf8StreamDecoder((data) => appendOutput(data))
+      const stderrDecoder = createUtf8StreamDecoder((data) => appendOutput(data))
+      let outputDecodersFlushed = false
+
+      const flushOutputDecoders = () => {
+        if (outputDecodersFlushed) {
+          return
+        }
+        outputDecodersFlushed = true
+        stdoutDecoder.end()
+        stderrDecoder.end()
+      }
+
       const cleanupTimeout = () => {
         if (timeoutId) {
           clearTimeout(timeoutId)
@@ -357,6 +375,7 @@ export class AgentBashHandler {
         if (settled) return
         settled = true
         cleanupTimeout()
+        flushOutputDecoders()
 
         try {
           await outputWriteQueue
@@ -394,15 +413,12 @@ export class AgentBashHandler {
           })
       }
 
-      child.stdout?.setEncoding('utf-8')
-      child.stderr?.setEncoding('utf-8')
-
-      child.stdout?.on('data', (data: string) => {
-        appendOutput(data)
+      child.stdout?.on('data', (data: Buffer | string) => {
+        stdoutDecoder.write(data)
       })
 
-      child.stderr?.on('data', (data: string) => {
-        appendOutput(data)
+      child.stderr?.on('data', (data: Buffer | string) => {
+        stderrDecoder.write(data)
       })
 
       if (options.stdin !== undefined) {
@@ -417,6 +433,7 @@ export class AgentBashHandler {
             return
           }
 
+          flushOutputDecoders()
           const preview =
             offloaded && outputFilePath
               ? this.readLastCharsFromFile(outputFilePath, COMMAND_PREVIEW_CHARS)
@@ -439,6 +456,7 @@ export class AgentBashHandler {
       })
 
       child.on('close', async (code, signal) => {
+        flushOutputDecoders()
         const preview =
           offloaded && outputFilePath
             ? this.readLastCharsFromFile(outputFilePath, COMMAND_PREVIEW_CHARS)

--- a/test/main/lib/agentRuntime/backgroundExecSessionManager.test.ts
+++ b/test/main/lib/agentRuntime/backgroundExecSessionManager.test.ts
@@ -45,6 +45,8 @@ class MockChildProcess extends EventEmitter {
 
 describe('BackgroundExecSessionManager', () => {
   let manager: BackgroundExecSessionManager
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  const originalPsModulePath = process.env.PSModulePath
 
   beforeEach(() => {
     manager = new BackgroundExecSessionManager()
@@ -55,6 +57,14 @@ describe('BackgroundExecSessionManager', () => {
     vi.useRealTimers()
     vi.restoreAllMocks()
     ;(manager as never).sessions.clear()
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+    if (originalPsModulePath === undefined) {
+      delete process.env.PSModulePath
+    } else {
+      process.env.PSModulePath = originalPsModulePath
+    }
   })
 
   const createSession = (overrides: Record<string, unknown> = {}) => ({
@@ -267,5 +277,52 @@ describe('BackgroundExecSessionManager', () => {
     } finally {
       delete process.env.BASELINE_FLAG
     }
+  })
+
+  it('wraps Windows PowerShell commands before starting a session', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    process.env.PSModulePath = 'C:\\PowerShell\\Modules'
+    const child = new MockChildProcess()
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    await manager.start('conv-1', 'dir', '/workspace', { timeout: 0 })
+
+    expect(spawn).toHaveBeenCalledWith(
+      'powershell.exe',
+      ['-NoProfile', '-Command', expect.stringContaining('[Console]::OutputEncoding')],
+      expect.objectContaining({
+        detached: false
+      })
+    )
+  })
+
+  it('decodes split UTF-8 output from running sessions', async () => {
+    const child = new MockChildProcess()
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    const result = await manager.start('conv-1', 'echo test', '/workspace', { timeout: 0 })
+    const bytes = Buffer.from('中文.txt\n', 'utf8')
+
+    child.stdout.emit('data', bytes.subarray(0, 2))
+    child.stdout.emit('data', bytes.subarray(2))
+    child.stdout.emit('end')
+    child.stderr.emit('end')
+    child.emit('close', 0, null)
+
+    await expect(
+      manager.waitForCompletionOrYield('conv-1', result.sessionId, 100)
+    ).resolves.toMatchObject({
+      kind: 'completed',
+      result: {
+        status: 'done',
+        output: '中文.txt\n',
+        exitCode: 0,
+        offloaded: false,
+        timedOut: false
+      }
+    })
   })
 })

--- a/test/main/lib/agentRuntime/shellOutputEncoding.test.ts
+++ b/test/main/lib/agentRuntime/shellOutputEncoding.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   createUtf8StreamDecoder,
+  prepareProcessEnvForUtf8Output,
   prepareShellCommandForUtf8Output
 } from '@/lib/agentRuntime/shellOutputEncoding'
 
@@ -42,6 +43,29 @@ describe('shellOutputEncoding', () => {
     })
 
     expect(prepareShellCommandForUtf8Output('/bin/zsh', 'ls')).toBe('ls')
+  })
+
+  it('adds Python UTF-8 environment for Windows direct processes', () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+
+    expect(prepareProcessEnvForUtf8Output({ PATH: 'C:\\bin' })).toEqual({
+      PATH: 'C:\\bin',
+      PYTHONIOENCODING: 'utf-8',
+      PYTHONUTF8: '1'
+    })
+  })
+
+  it('keeps direct process environment unchanged outside Windows', () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'linux'
+    })
+    const env = { PATH: '/bin' }
+
+    expect(prepareProcessEnvForUtf8Output(env)).toBe(env)
   })
 
   it('decodes UTF-8 text split across chunks', () => {

--- a/test/main/lib/agentRuntime/shellOutputEncoding.test.ts
+++ b/test/main/lib/agentRuntime/shellOutputEncoding.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  createUtf8StreamDecoder,
+  prepareShellCommandForUtf8Output
+} from '@/lib/agentRuntime/shellOutputEncoding'
+
+describe('shellOutputEncoding', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  it('wraps Windows PowerShell commands with UTF-8 console encoding', () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+
+    const command = prepareShellCommandForUtf8Output('powershell.exe', 'dir')
+
+    expect(command).toContain('[Console]::OutputEncoding')
+    expect(command).toContain('$OutputEncoding')
+    expect(command).toMatch(/dir$/)
+  })
+
+  it('wraps Windows cmd commands with UTF-8 code page setup', () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+
+    expect(prepareShellCommandForUtf8Output('cmd.exe', 'dir')).toBe('chcp 65001 > nul && dir')
+  })
+
+  it('keeps non-Windows commands unchanged', () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'linux'
+    })
+
+    expect(prepareShellCommandForUtf8Output('/bin/zsh', 'ls')).toBe('ls')
+  })
+
+  it('decodes UTF-8 text split across chunks', () => {
+    let output = ''
+    const decoder = createUtf8StreamDecoder((text) => {
+      output += text
+    })
+    const bytes = Buffer.from('中文.txt\n', 'utf8')
+
+    decoder.write(bytes.subarray(0, 2))
+    decoder.write(bytes.subarray(2))
+    decoder.end()
+
+    expect(output).toBe('中文.txt\n')
+  })
+})

--- a/test/main/lib/agentRuntime/shellOutputEncoding.test.ts
+++ b/test/main/lib/agentRuntime/shellOutputEncoding.test.ts
@@ -23,7 +23,7 @@ describe('shellOutputEncoding', () => {
 
     expect(command).toContain('[Console]::OutputEncoding')
     expect(command).toContain('$OutputEncoding')
-    expect(command).toMatch(/dir$/)
+    expect(command).toMatch(/; dir$/)
   })
 
   it('wraps Windows cmd commands with UTF-8 code page setup', () => {
@@ -53,6 +53,18 @@ describe('shellOutputEncoding', () => {
 
     decoder.write(bytes.subarray(0, 2))
     decoder.write(bytes.subarray(2))
+    decoder.end()
+
+    expect(output).toBe('中文.txt\n')
+  })
+
+  it('passes string chunks through without re-encoding', () => {
+    let output = ''
+    const decoder = createUtf8StreamDecoder((text) => {
+      output += text
+    })
+
+    decoder.write('中文.txt\n')
     decoder.end()
 
     expect(output).toBe('中文.txt\n')

--- a/test/main/presenter/skillPresenter/skillExecutionService.test.ts
+++ b/test/main/presenter/skillPresenter/skillExecutionService.test.ts
@@ -297,6 +297,11 @@ describe('SkillExecutionService', () => {
   })
 
   it('decodes split UTF-8 foreground output', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+
     class MockStream extends EventEmitter {
       destroy = vi.fn()
     }
@@ -337,6 +342,16 @@ describe('SkillExecutionService', () => {
 
     const result = await resultPromise
 
+    expect(spawn).toHaveBeenCalledWith(
+      'python',
+      ['script.py'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          PYTHONIOENCODING: 'utf-8',
+          PYTHONUTF8: '1'
+        })
+      })
+    )
     expect(result).toContain('中文.txt')
     expect(result).toContain('Exit Code: 0')
   })

--- a/test/main/presenter/skillPresenter/skillExecutionService.test.ts
+++ b/test/main/presenter/skillPresenter/skillExecutionService.test.ts
@@ -44,6 +44,7 @@ vi.mock('../../../../src/main/lib/agentRuntime/rtkRuntimeService', () => ({
 }))
 
 import { spawn } from 'child_process'
+import * as shellEnvHelper from '../../../../src/main/lib/agentRuntime/shellEnvHelper'
 import { rtkRuntimeService } from '../../../../src/main/lib/agentRuntime/rtkRuntimeService'
 
 describe('SkillExecutionService', () => {
@@ -54,6 +55,7 @@ describe('SkillExecutionService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(shellEnvHelper.getUserShell).mockReturnValue({ shell: '/bin/zsh', args: ['-c'] })
     vi.spyOn(fs, 'existsSync').mockReturnValue(false)
     vi.mocked(fs.promises.stat).mockResolvedValue({
       isDirectory: () => true
@@ -233,6 +235,110 @@ describe('SkillExecutionService', () => {
     })
 
     expect((service as never).quoteForShell('value%"PATH"%')).toBe('"value%%\\"PATH\\"%%"')
+  })
+
+  it('wraps Windows shell-mode foreground commands with UTF-8 output setup', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    vi.mocked(shellEnvHelper.getUserShell).mockReturnValue({
+      shell: 'powershell.exe',
+      args: ['-NoProfile', '-Command']
+    })
+
+    class MockStream extends EventEmitter {
+      destroy = vi.fn()
+    }
+
+    class MockChild extends EventEmitter {
+      stdout = new MockStream()
+      stderr = new MockStream()
+      stdin = {
+        write: vi.fn(),
+        end: vi.fn(),
+        destroy: vi.fn()
+      }
+      kill = vi.fn()
+    }
+
+    const child = new MockChild()
+    vi.mocked(spawn).mockReturnValue(child as never)
+    vi.spyOn(service as never, 'createForegroundOutputPath' as never).mockReturnValue(null)
+
+    const resultPromise = (service as never).runForeground(
+      {
+        command: 'node',
+        args: ['script.js'],
+        cwd: '/skills/ocr',
+        env: { PATH: '/bin' },
+        shellCommand: 'dir',
+        outputPrefix: 'skill_ocr',
+        spawnMode: 'shell'
+      },
+      1000,
+      'conv-1'
+    )
+
+    child.stdout.emit('data', Buffer.from('ok\n'))
+    child.emit('close', 0)
+
+    const result = await resultPromise
+
+    expect(spawn).toHaveBeenCalledWith(
+      'powershell.exe',
+      ['-NoProfile', '-Command', expect.stringContaining('[Console]::OutputEncoding')],
+      expect.objectContaining({
+        shell: false
+      })
+    )
+    expect(result).toContain('ok')
+    expect(result).toContain('Exit Code: 0')
+  })
+
+  it('decodes split UTF-8 foreground output', async () => {
+    class MockStream extends EventEmitter {
+      destroy = vi.fn()
+    }
+
+    class MockChild extends EventEmitter {
+      stdout = new MockStream()
+      stderr = new MockStream()
+      stdin = {
+        write: vi.fn(),
+        end: vi.fn(),
+        destroy: vi.fn()
+      }
+      kill = vi.fn()
+    }
+
+    const child = new MockChild()
+    vi.mocked(spawn).mockReturnValue(child as never)
+    vi.spyOn(service as never, 'createForegroundOutputPath' as never).mockReturnValue(null)
+
+    const resultPromise = (service as never).runForeground(
+      {
+        command: 'python',
+        args: ['script.py'],
+        cwd: '/skills/ocr',
+        env: { PATH: '/bin' },
+        shellCommand: 'python script.py',
+        outputPrefix: 'skill_ocr',
+        spawnMode: 'direct'
+      },
+      1000,
+      'conv-1'
+    )
+
+    const bytes = Buffer.from('中文.txt\n', 'utf8')
+    child.stdout.emit('data', bytes.subarray(0, 2))
+    child.stdout.emit('data', bytes.subarray(2))
+    child.emit('close', 0)
+
+    const result = await resultPromise
+
+    expect(result).toContain('中文.txt')
+    expect(result).toContain('Exit Code: 0')
   })
 
   it('escalates to SIGKILL when foreground timeout grace expires', async () => {

--- a/test/main/presenter/toolPresenter/agentTools/agentBashHandlerEncoding.test.ts
+++ b/test/main/presenter/toolPresenter/agentTools/agentBashHandlerEncoding.test.ts
@@ -1,0 +1,97 @@
+import { EventEmitter } from 'events'
+import { spawn } from 'child_process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((name: string) => (name === 'home' ? '/mock/home' : '/mock/userData'))
+  }
+}))
+
+vi.mock('@shared/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('../../../../../src/main/lib/agentRuntime/shellEnvHelper', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../../src/main/lib/agentRuntime/shellEnvHelper')>()
+
+  return {
+    ...actual,
+    getUserShell: vi
+      .fn()
+      .mockReturnValue({ shell: 'powershell.exe', args: ['-NoProfile', '-Command'] })
+  }
+})
+
+import { AgentBashHandler } from '../../../../../src/main/presenter/toolPresenter/agentTools/agentBashHandler'
+
+class MockStream extends EventEmitter {}
+
+class MockChild extends EventEmitter {
+  stdout = new MockStream()
+  stderr = new MockStream()
+  stdin = {
+    write: vi.fn(),
+    end: vi.fn()
+  }
+  kill = vi.fn()
+}
+
+describe('AgentBashHandler output encoding', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  it('wraps Windows shell commands and decodes split UTF-8 output', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    const child = new MockChild()
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    const handler = new AgentBashHandler(['/workspace'])
+    const resultPromise = (
+      handler as unknown as {
+        runDetachedShellProcess: (
+          command: string,
+          cwd: string,
+          timeout: number,
+          options: Record<string, unknown>
+        ) => Promise<{ output: string; exitCode: number | null }>
+      }
+    ).runDetachedShellProcess('dir', '/workspace', 1000, {})
+
+    const bytes = Buffer.from('中文.txt\n', 'utf8')
+    child.stdout.emit('data', bytes.subarray(0, 2))
+    child.stdout.emit('data', bytes.subarray(2))
+    child.emit('close', 0, null)
+
+    const result = await resultPromise
+    expect(spawn).toHaveBeenCalledWith(
+      'powershell.exe',
+      ['-NoProfile', '-Command', expect.stringContaining('[Console]::OutputEncoding')],
+      expect.objectContaining({
+        cwd: '/workspace',
+        detached: false
+      })
+    )
+    expect(result.output).toBe('中文.txt\n')
+    expect(result.exitCode).toBe(0)
+  })
+})


### PR DESCRIPTION
fix #1583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commands on Windows now reliably display non-ASCII output (e.g., Chinese) across foreground, background, and skill executions; multibyte characters split across chunks decode correctly while output order and exit-code/timing metadata are preserved.

* **Documentation**
  * Added spec, plan, and task docs describing the Windows exec output encoding approach.

* **Tests**
  * Added tests validating Windows UTF-8 wrapping, streaming decode behavior, and split-byte decoding across execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->