### PR TITLE
fix: cua unknow

### DIFF
--- a/docs/issues/cua-settings-empty-message/plan.md
+++ b/docs/issues/cua-settings-empty-message/plan.md
@@ -1,0 +1,23 @@
+# CUA Settings Empty Message Plan
+
+## Scope
+
+The issue is isolated to the static Computer Use plugin settings UI in
+`plugins/cua/settings/assets/index.js`.
+
+## Implementation
+
+- Keep `setText()` as the fallback helper for data rows that should display `Unknown`.
+- Change `setMessage()` so the transient status/error area writes the provided text verbatim and
+  allows an empty string after success.
+- Add a jsdom regression test that loads the static settings script, invokes the Check button, and
+  verifies the message area is empty after a successful permission check.
+
+## Test Strategy
+
+- Run the focused renderer test for the plugin settings script.
+- Run repository-required formatting, i18n, and lint checks.
+
+## Risks
+
+- Low. The change only affects the bottom message element and keeps status rows unchanged.

--- a/docs/issues/cua-settings-empty-message/spec.md
+++ b/docs/issues/cua-settings-empty-message/spec.md
@@ -1,0 +1,22 @@
+# CUA Settings Empty Message
+
+## User Story
+
+As a user checking Computer Use plugin permissions, I want the plugin settings page to show the
+permission results only in the status rows so that a completed check does not leave an unrelated
+`Unknown` message at the bottom of the page.
+
+## Acceptance Criteria
+
+- A successful permission check updates the Accessibility and Screen Recording rows.
+- After a successful permission check with no diagnostic error, the bottom message area is empty.
+- Runtime fields can still show `Unknown` when their underlying status values are unavailable.
+
+## Non-goals
+
+- Redesigning the plugin settings layout.
+- Changing runtime or permission detection behavior.
+
+## Open Questions
+
+None.

--- a/docs/issues/cua-settings-empty-message/tasks.md
+++ b/docs/issues/cua-settings-empty-message/tasks.md
@@ -1,0 +1,6 @@
+# CUA Settings Empty Message Tasks
+
+- [x] Confirm the source of the bottom `Unknown` message.
+- [x] Update message rendering to allow an empty success state.
+- [x] Add focused regression coverage.
+- [x] Run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint`.

--- a/plugins/cua/settings/assets/index.js
+++ b/plugins/cua/settings/assets/index.js
@@ -16,7 +16,9 @@ function setText(node, value) {
 }
 
 function setMessage(value) {
-  setText(messageNode, value)
+  if (messageNode) {
+    messageNode.textContent = value || ''
+  }
 }
 
 function setState(enabled) {

--- a/test/renderer/plugins/cuaSettings.test.ts
+++ b/test/renderer/plugins/cuaSettings.test.ts
@@ -1,0 +1,77 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const scriptPath = resolve(process.cwd(), 'plugins/cua/settings/assets/index.js')
+
+const flushPromises = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+const renderSettingsDom = (): void => {
+  document.body.innerHTML = `
+    <span id="plugin-state"></span>
+    <strong id="runtime-state"></strong>
+    <strong id="runtime-version"></strong>
+    <code id="runtime-command"></code>
+    <code id="runtime-helper-app"></code>
+    <strong id="mcp-state"></strong>
+    <strong id="permission-accessibility"></strong>
+    <strong id="permission-screen-recording"></strong>
+    <p id="message"></p>
+    <a id="project-link"></a>
+    <button id="check"></button>
+    <button id="guide"></button>
+    <button id="disable"></button>
+  `
+}
+
+type CuaSettingsWindow = Window & { deepchatPlugin?: unknown }
+
+describe('CUA plugin settings', () => {
+  beforeEach(() => {
+    renderSettingsDom()
+    delete (window as CuaSettingsWindow).deepchatPlugin
+  })
+
+  it('clears the bottom message after a successful permission check', async () => {
+    const pluginWindow = window as CuaSettingsWindow
+
+    pluginWindow.deepchatPlugin = {
+      getStatus: vi.fn().mockResolvedValue({
+        enabled: true,
+        runtime: {
+          state: 'ready',
+          version: '0.1.5',
+          command: '/mock/cua-driver',
+          helperAppPath: '/mock/DeepChat Computer Use.app'
+        },
+        mcpServers: [
+          {
+            serverId: 'cua-driver',
+            enabled: true,
+            running: true
+          }
+        ]
+      }),
+      invokeAction: vi.fn().mockResolvedValue({
+        ok: true,
+        data: {
+          accessibility: 'granted',
+          screenRecording: 'denied'
+        }
+      }),
+      disable: vi.fn()
+    }
+
+    window.eval(await readFile(scriptPath, 'utf8'))
+    await flushPromises()
+
+    document.getElementById('check')?.click()
+    await flushPromises()
+
+    expect(document.getElementById('permission-accessibility')?.textContent).toBe('Granted')
+    expect(document.getElementById('permission-screen-recording')?.textContent).toBe('Denied')
+    expect(document.getElementById('message')?.textContent).toBe('')
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CUA Settings: Message area now clears after successful permission checks instead of displaying "Unknown"
  * Permission status updates display correctly in the settings UI

* **Tests**
  * Added regression test coverage for CUA plugin settings behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->