### PR TITLE
fix(mcp): isolate plugin server lifecycle

### DIFF
--- a/docs/issues/plugin-mcp-lifecycle-isolation/plan.md
+++ b/docs/issues/plugin-mcp-lifecycle-isolation/plan.md
@@ -1,0 +1,32 @@
+# Plugin MCP Lifecycle Isolation Plan
+
+## Architecture
+
+- Treat plugin MCP servers as managed plugin resources when `ownerPluginId` is present or
+  `source/sourceId` identifies a plugin.
+- Keep plugin-owned server configs in the MCP config store for compatibility, but branch lifecycle
+  behavior in `McpPresenter`.
+- Store transient per-server runtime errors in `ServerManager` and expose them through
+  `IMCPPresenter.getServerLastError`.
+
+## Implementation
+
+- Update MCP initialization and global enable/disable to skip plugin-owned servers when applying the
+  global switch.
+- Start plugin MCP servers from `PluginPresenter` without checking the global MCP setting.
+- Filter tools, prompts, and resources so global MCP disabled hides non-plugin results but keeps
+  plugin-owned results.
+- Suppress global MCP error notifications for plugin-owned start/listTools failures.
+- Surface plugin MCP errors in plugin list and CUA settings status.
+
+## Test Strategy
+
+- Add main-process tests for global switch isolation and plugin start behavior.
+- Add error-notification tests for plugin-owned connection and tool-list failures.
+- Add renderer tests for disabled-global MCP state with plugin tools still visible.
+- Add CUA settings regression coverage for MCP error state.
+
+## Risks
+
+- Moderate. MCP tools are shared across runtime and UI surfaces, so filtering must happen in the
+  presenter/store boundaries without changing stored config.

--- a/docs/issues/plugin-mcp-lifecycle-isolation/spec.md
+++ b/docs/issues/plugin-mcp-lifecycle-isolation/spec.md
@@ -1,0 +1,26 @@
+# Plugin MCP Lifecycle Isolation
+
+## User Story
+
+As a user with the CUA plugin enabled, I want the plugin MCP runtime to follow plugin state rather
+than the global MCP switch, so Computer Use remains available when I disable normal MCP tools and
+does not spam global connection failure toasts.
+
+## Acceptance Criteria
+
+- The global MCP switch starts and stops only non-plugin MCP servers.
+- Plugin-owned MCP servers are identified by `ownerPluginId` or `source: plugin`.
+- Enabled plugin MCP servers start when the plugin is active even if global MCP is disabled.
+- Plugin MCP connection and tool-list failures do not show global MCP error toasts.
+- Plugin MCP failures are visible from plugin status surfaces.
+- DeepChat agent tools can still include plugin MCP tools while global MCP is disabled.
+
+## Non-goals
+
+- Redesigning plugin installation or runtime detection.
+- Changing ACP agent MCP selection behavior.
+- Migrating existing MCP settings.
+
+## Open Questions
+
+None.

--- a/docs/issues/plugin-mcp-lifecycle-isolation/tasks.md
+++ b/docs/issues/plugin-mcp-lifecycle-isolation/tasks.md
@@ -1,0 +1,9 @@
+# Plugin MCP Lifecycle Isolation Tasks
+
+- [x] Document plugin MCP lifecycle requirements.
+- [x] Make MCP presenter lifecycle owner-aware.
+- [x] Suppress plugin MCP global notifications and track last error.
+- [x] Keep plugin MCP visible in renderer state when global MCP is disabled.
+- [x] Surface plugin MCP errors in plugin settings UI.
+- [x] Add focused regression coverage.
+- [x] Run format, i18n, lint, and focused tests.

--- a/plugins/cua/settings/assets/index.js
+++ b/plugins/cua/settings/assets/index.js
@@ -72,12 +72,19 @@ async function refreshStatus() {
   const cuaMcp = status.mcpServers?.find((server) => server.serverId === 'cua-driver')
   if (!cuaMcp) {
     setText(mcpStateNode, 'Unavailable')
+    setMessage('')
+  } else if (cuaMcp.lastError) {
+    setText(mcpStateNode, 'Error')
+    setMessage(cuaMcp.lastError)
   } else if (cuaMcp.running) {
     setText(mcpStateNode, 'Running')
+    setMessage('')
   } else if (cuaMcp.enabled) {
     setText(mcpStateNode, 'Stopped')
+    setMessage('')
   } else {
     setText(mcpStateNode, 'Disabled')
+    setMessage('')
   }
 }
 

--- a/src/main/presenter/mcpPresenter/index.ts
+++ b/src/main/presenter/mcpPresenter/index.ts
@@ -56,6 +56,15 @@ export class McpPresenter implements IMCPPresenter {
     return Boolean(this.configPresenter.getPrivacyModeEnabled())
   }
 
+  private isPluginOwnedServerConfig(config?: Partial<MCPServerConfig> | null): boolean {
+    return Boolean(config?.ownerPluginId || config?.source === 'plugin')
+  }
+
+  private async isPluginOwnedServerName(serverName: string): Promise<boolean> {
+    const servers = await this.configPresenter.getMcpServers()
+    return this.isPluginOwnedServerConfig(servers[serverName])
+  }
+
   async initialize() {
     if (this.isInitialized) {
       return
@@ -70,9 +79,10 @@ export class McpPresenter implements IMCPPresenter {
       }
 
       // Load configuration
-      const [servers, enabledServers] = await Promise.all([
+      const [servers, enabledServers, mcpEnabled] = await Promise.all([
         this.configPresenter.getMcpServers(),
-        this.configPresenter.getEnabledMcpServers()
+        this.configPresenter.getEnabledMcpServers(),
+        this.configPresenter.getMcpEnabled()
       ])
 
       // Initialize npm registry (prefer cache if available)
@@ -90,7 +100,7 @@ export class McpPresenter implements IMCPPresenter {
 
       // Check and start deepchat-inmemory/custom-prompts-server
       const customPromptsServerName = 'deepchat-inmemory/custom-prompts-server'
-      if (servers[customPromptsServerName]) {
+      if (mcpEnabled && servers[customPromptsServerName]) {
         console.log(`[MCP] Attempting to start custom prompts server: ${customPromptsServerName}`)
 
         try {
@@ -109,7 +119,8 @@ export class McpPresenter implements IMCPPresenter {
 
       if (enabledServers.length > 0) {
         for (const serverName of enabledServers) {
-          if (servers[serverName]) {
+          const serverConfig = servers[serverName]
+          if (serverConfig && (mcpEnabled || this.isPluginOwnedServerConfig(serverConfig))) {
             console.log(`[MCP] Attempting to start enabled server: ${serverName}`)
 
             try {
@@ -241,7 +252,11 @@ export class McpPresenter implements IMCPPresenter {
 
   // Get all MCP servers
   async getMcpClients(): Promise<McpClient[]> {
-    const clients = await this.toolManager.getRunningClients()
+    const enabled = await this.configPresenter.getMcpEnabled()
+    const servers = await this.configPresenter.getMcpServers()
+    const clients = (await this.toolManager.getRunningClients()).filter(
+      (client) => enabled || this.isPluginOwnedServerConfig(servers[client.serverName])
+    )
     const clientsList: McpClient[] = []
     for (const client of clients) {
       const results: MCPToolDefinition[] = []
@@ -330,7 +345,12 @@ export class McpPresenter implements IMCPPresenter {
   async setMcpServerEnabled(serverName: string, enabled: boolean): Promise<void> {
     await this.configPresenter.setMcpServerEnabled(serverName, enabled)
 
-    if (!(await this.configPresenter.getMcpEnabled())) {
+    const servers = await this.configPresenter.getMcpServers()
+    const serverConfig = servers[serverName]
+    if (
+      !this.isPluginOwnedServerConfig(serverConfig) &&
+      !(await this.configPresenter.getMcpEnabled())
+    ) {
       return
     }
 
@@ -408,12 +428,19 @@ export class McpPresenter implements IMCPPresenter {
     // Notify renderer process that server has stopped
     eventBus.send(MCP_EVENTS.SERVER_STOPPED, SendTarget.ALL_WINDOWS, serverName)
   }
+
+  getServerLastError(serverName: string): string | undefined {
+    return this.serverManager.getServerLastError(serverName)
+  }
+
   async getAllToolDefinitions(enabledMcpTools?: string[]): Promise<MCPToolDefinition[]> {
     const enabled = await this.configPresenter.getMcpEnabled()
+    const tools = await this.toolManager.getAllToolDefinitions(enabledMcpTools)
     if (enabled) {
-      return await this.toolManager.getAllToolDefinitions(enabledMcpTools)
+      return tools
     }
-    return []
+    const servers = await this.configPresenter.getMcpServers()
+    return tools.filter((tool) => this.isPluginOwnedServerConfig(servers[tool.server.name]))
   }
 
   /**
@@ -422,11 +449,10 @@ export class McpPresenter implements IMCPPresenter {
    */
   async getAllPrompts(): Promise<Array<PromptListEntry>> {
     const enabled = await this.configPresenter.getMcpEnabled()
-    if (!enabled) {
-      return []
-    }
-
-    const clients = await this.toolManager.getRunningClients()
+    const servers = await this.configPresenter.getMcpServers()
+    const clients = (await this.toolManager.getRunningClients()).filter(
+      (client) => enabled || this.isPluginOwnedServerConfig(servers[client.serverName])
+    )
     const promptsList: Array<Prompt & { client: { name: string; icon: string } }> = []
 
     for (const client of clients) {
@@ -468,11 +494,10 @@ export class McpPresenter implements IMCPPresenter {
     Array<ResourceListEntry & { client: { name: string; icon: string } }>
   > {
     const enabled = await this.configPresenter.getMcpEnabled()
-    if (!enabled) {
-      return []
-    }
-
-    const clients = await this.toolManager.getRunningClients()
+    const servers = await this.configPresenter.getMcpServers()
+    const clients = (await this.toolManager.getRunningClients()).filter(
+      (client) => enabled || this.isPluginOwnedServerConfig(servers[client.serverName])
+    )
     const resourcesList: Array<ResourceListEntry & { client: { name: string; icon: string } }> = []
 
     for (const client of clients) {
@@ -657,8 +682,12 @@ export class McpPresenter implements IMCPPresenter {
     await this.configPresenter?.setMcpEnabled(enabled)
 
     if (enabled) {
+      const servers = await this.configPresenter.getMcpServers()
       const enabledServers = await this.configPresenter.getEnabledMcpServers()
       for (const serverName of enabledServers) {
+        if (this.isPluginOwnedServerConfig(servers[serverName])) {
+          continue
+        }
         try {
           await this.startServer(serverName)
         } catch (error) {
@@ -669,7 +698,11 @@ export class McpPresenter implements IMCPPresenter {
     }
 
     const runningClients = await this.serverManager.getRunningClients()
+    const servers = await this.configPresenter.getMcpServers()
     for (const client of runningClients) {
+      if (this.isPluginOwnedServerConfig(servers[client.serverName])) {
+        continue
+      }
       try {
         await this.stopServer(client.serverName)
       } catch (error) {
@@ -712,7 +745,7 @@ export class McpPresenter implements IMCPPresenter {
 
     // For MCP server prompts, check if MCP is enabled
     const enabled = await this.configPresenter.getMcpEnabled()
-    if (!enabled) {
+    if (!enabled && !(await this.isPluginOwnedServerName(prompt.client.name))) {
       throw new Error('MCP functionality is disabled')
     }
 
@@ -727,7 +760,7 @@ export class McpPresenter implements IMCPPresenter {
    */
   async readResource(resource: ResourceListEntry): Promise<Resource> {
     const enabled = await this.configPresenter.getMcpEnabled()
-    if (!enabled) {
+    if (!enabled && !(await this.isPluginOwnedServerName(resource.client.name))) {
       throw new Error('MCP functionality is disabled')
     }
 

--- a/src/main/presenter/mcpPresenter/serverManager.ts
+++ b/src/main/presenter/mcpPresenter/serverManager.ts
@@ -1,4 +1,4 @@
-import { IConfigPresenter } from '@shared/presenter'
+import { IConfigPresenter, MCPServerConfig } from '@shared/presenter'
 import { McpClient } from './mcpClient'
 import axios from 'axios'
 import { proxyConfig } from '@/presenter/proxyConfig'
@@ -15,6 +15,7 @@ const NPM_REGISTRY_LIST = [
 
 export class ServerManager {
   private clients: Map<string, McpClient> = new Map()
+  private serverLastErrors: Map<string, string> = new Map()
   private configPresenter: IConfigPresenter
   private npmRegistry: string | null = null
   private uvRegistry: string | null = null
@@ -26,6 +27,23 @@ export class ServerManager {
 
   private isPrivacyModeEnabled(): boolean {
     return Boolean(this.configPresenter.getPrivacyModeEnabled())
+  }
+
+  private isPluginOwnedServerConfig(config?: Partial<MCPServerConfig> | null): boolean {
+    return Boolean(config?.ownerPluginId || config?.source === 'plugin')
+  }
+
+  getServerLastError(serverName: string): string | undefined {
+    return this.serverLastErrors.get(serverName)
+  }
+
+  setServerLastError(serverName: string, error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error || 'Unknown error')
+    this.serverLastErrors.set(serverName, message)
+  }
+
+  clearServerLastError(serverName: string): void {
+    this.serverLastErrors.delete(serverName)
   }
 
   loadRegistryFromCache(): void {
@@ -229,14 +247,18 @@ export class ServerManager {
 
       // Connect to server, this will start the service
       await client.connect()
+      this.clearServerLastError(name)
     } catch (error) {
       console.error(`Failed to start MCP server ${name}:`, error)
 
       // Remove client reference
       this.clients.delete(name)
+      this.setServerLastError(name, error)
 
-      // Send global error notification
-      this.sendMcpConnectionError(name, error)
+      if (!this.isPluginOwnedServerConfig(serverConfig)) {
+        // Send global error notification only for normal MCP servers.
+        this.sendMcpConnectionError(name, error)
+      }
 
       throw error
     } finally {
@@ -282,6 +304,7 @@ export class ServerManager {
 
       // Remove from client list
       this.clients.delete(name)
+      this.clearServerLastError(name)
 
       console.info(`MCP server ${name} has been stopped`)
       eventBus.send(MCP_EVENTS.CLIENT_LIST_UPDATED, SendTarget.ALL_WINDOWS)

--- a/src/main/presenter/mcpPresenter/toolManager.ts
+++ b/src/main/presenter/mcpPresenter/toolManager.ts
@@ -44,6 +44,14 @@ export class ToolManager {
     this.toolNameToTargetMap = null
   }
 
+  private isPluginOwnedClient(client: McpClient): boolean {
+    const serverConfig = client.serverConfig as {
+      ownerPluginId?: unknown
+      source?: unknown
+    }
+    return Boolean(serverConfig.ownerPluginId || serverConfig.source === 'plugin')
+  }
+
   public async getRunningClients(): Promise<McpClient[]> {
     return this.serverManager.getRunningClients()
   }
@@ -85,6 +93,7 @@ export class ToolManager {
     for (const client of clients) {
       try {
         const clientTools = await client.listTools()
+        this.serverManager.clearServerLastError(client.serverName)
         if (!clientTools) continue
 
         const currentServerRenames: Set<string> = toolsToRename.get(client.serverName) || new Set()
@@ -118,20 +127,24 @@ export class ToolManager {
           `Pass 1 Error: Failed to get tool list from server '${serverName}':`,
           errorMessage
         )
-        // Send notification (existing logic from previous commit)
-        const locale = this.configPresenter.getLanguage?.() || 'zh-CN'
-        const errorMessages = getErrorMessageLabels(locale)
-        const formattedMessage =
-          errorMessages.getMcpToolListErrorMessage
-            ?.replace('{serverName}', serverName)
-            .replace('{errorMessage}', errorMessage) ||
-          `Failed to get tool list from server '${serverName}': ${errorMessage}`
-        eventBus.sendToRenderer(NOTIFICATION_EVENTS.SHOW_ERROR, SendTarget.ALL_WINDOWS, {
-          title: errorMessages.getMcpToolListErrorTitle || 'Failed to get tool definitions',
-          message: formattedMessage,
-          id: `mcp-error-pass1-${serverName}-${Date.now()}`,
-          type: 'error'
-        })
+        this.serverManager.setServerLastError(serverName, errorMessage)
+        if (!this.isPluginOwnedClient(client)) {
+          // Send notification for normal MCP servers. Plugin-owned MCP errors are shown in
+          // plugin status surfaces instead of global toasts.
+          const locale = this.configPresenter.getLanguage?.() || 'zh-CN'
+          const errorMessages = getErrorMessageLabels(locale)
+          const formattedMessage =
+            errorMessages.getMcpToolListErrorMessage
+              ?.replace('{serverName}', serverName)
+              .replace('{errorMessage}', errorMessage) ||
+            `Failed to get tool list from server '${serverName}': ${errorMessage}`
+          eventBus.sendToRenderer(NOTIFICATION_EVENTS.SHOW_ERROR, SendTarget.ALL_WINDOWS, {
+            title: errorMessages.getMcpToolListErrorTitle || 'Failed to get tool definitions',
+            message: formattedMessage,
+            id: `mcp-error-pass1-${serverName}-${Date.now()}`,
+            type: 'error'
+          })
+        }
         continue // Continue to next client
       }
     }
@@ -140,6 +153,7 @@ export class ToolManager {
     for (const client of clients) {
       try {
         const clientTools = await client.listTools()
+        this.serverManager.clearServerLastError(client.serverName)
         if (!clientTools) continue
 
         const renamesForThisServer = toolsToRename.get(client.serverName) || new Set()
@@ -202,6 +216,7 @@ export class ToolManager {
           `Pass 2 Error: Error processing tools from server '${serverName}':`,
           errorMessage
         )
+        this.serverManager.setServerLastError(serverName, errorMessage)
         // Maybe skip adding tools from this client if listTools fails here again,
         // though it succeeded in Pass 1. Or rely on the notification from Pass 1.
         continue // Continue to next client

--- a/src/main/presenter/pluginPresenter/index.ts
+++ b/src/main/presenter/pluginPresenter/index.ts
@@ -263,7 +263,10 @@ export class PluginPresenter {
   private async disableByOwner(pluginId: string): Promise<void> {
     const servers = await this.configPresenter.getMcpServers()
     for (const [serverName, serverConfig] of Object.entries(servers)) {
-      if (serverConfig.ownerPluginId === pluginId) {
+      if (
+        serverConfig.ownerPluginId === pluginId ||
+        (serverConfig.source === 'plugin' && serverConfig.sourceId === pluginId)
+      ) {
         try {
           if (await this.mcpPresenter.isServerRunning(serverName)) {
             await this.mcpPresenter.stopServer(serverName)
@@ -1250,10 +1253,6 @@ export class PluginPresenter {
       return
     }
 
-    if (!(await this.configPresenter.getMcpEnabled())) {
-      return
-    }
-
     for (const serverName of serverNames) {
       try {
         if (!(await this.mcpPresenter.isServerRunning(serverName))) {
@@ -1279,7 +1278,10 @@ export class PluginPresenter {
       statuses.push({
         serverId: server.id,
         enabled: Boolean(serverConfig?.enabled),
-        running: await this.mcpPresenter.isServerRunning(server.id)
+        running: await this.mcpPresenter.isServerRunning(server.id),
+        lastError: serverConfig?.enabled
+          ? this.mcpPresenter.getServerLastError?.(server.id)
+          : undefined
       })
     }
     return statuses

--- a/src/renderer/settings/components/PluginsSettings.vue
+++ b/src/renderer/settings/components/PluginsSettings.vue
@@ -85,6 +85,15 @@
           {{ plugin.runtime.lastError }}
         </div>
 
+        <div
+          v-if="getPluginMcpErrors(plugin).length > 0"
+          class="space-y-1 text-xs text-destructive"
+        >
+          <div v-for="error in getPluginMcpErrors(plugin)" :key="error">
+            {{ error }}
+          </div>
+        </div>
+
         <div class="flex flex-wrap gap-2">
           <Button
             v-if="!plugin.enabled"
@@ -145,6 +154,12 @@ function formatRuntimeState(state?: PluginRuntimeState): string {
     return '-'
   }
   return t(`settings.plugins.runtimeStates.${state}`)
+}
+
+function getPluginMcpErrors(plugin: PluginListItem): string[] {
+  return (plugin.mcpServers ?? [])
+    .filter((server) => Boolean(server.lastError))
+    .map((server) => `${server.serverId}: ${server.lastError}`)
 }
 
 async function loadPlugins(): Promise<void> {

--- a/src/renderer/src/stores/mcp.ts
+++ b/src/renderer/src/stores/mcp.ts
@@ -132,21 +132,21 @@ export const useMcpStore = defineStore('mcp', () => {
   const toolsQuery = useIpcQuery({
     key: () => ['mcp', 'tools'],
     query: () => mcpClient.getAllToolDefinitions(),
-    enabled: () => config.value.ready && config.value.mcpEnabled,
+    enabled: () => config.value.ready,
     staleTime: 30_000
   }) as UseQueryReturn<MCPToolDefinition[]>
 
   const clientsQuery = useIpcQuery({
     key: () => ['mcp', 'clients'],
     query: () => mcpClient.getMcpClients(),
-    enabled: () => config.value.ready && config.value.mcpEnabled,
+    enabled: () => config.value.ready,
     staleTime: 30_000
   }) as UseQueryReturn<McpRuntimeClient[]>
 
   const resourcesQuery = useIpcQuery({
     key: () => ['mcp', 'resources'],
     query: () => mcpClient.getAllResources(),
-    enabled: () => config.value.ready && config.value.mcpEnabled,
+    enabled: () => config.value.ready,
     staleTime: 30_000
   }) as UseQueryReturn<ResourceListEntry[]>
 
@@ -184,22 +184,16 @@ export const useMcpStore = defineStore('mcp', () => {
     gcTime: 300_000,
     query: async () => {
       const customPrompts = await loadCustomPrompts()
-      if (!config.value.mcpEnabled) {
-        return customPrompts
-      }
-
       const mcpPrompts = await loadMcpPrompts()
       return [...customPrompts, ...mcpPrompts]
     }
   })
 
-  const tools = computed(() => (config.value.mcpEnabled ? (toolsQuery.data.value ?? []) : []))
+  const tools = computed(() => toolsQuery.data.value ?? [])
 
-  const clients = computed(() => (config.value.mcpEnabled ? (clientsQuery.data.value ?? []) : []))
+  const clients = computed(() => clientsQuery.data.value ?? [])
 
-  const resources = computed(() =>
-    config.value.mcpEnabled ? (resourcesQuery.data.value ?? []) : []
-  )
+  const resources = computed(() => resourcesQuery.data.value ?? [])
 
   const prompts = computed(() => promptsQuery.data.value ?? [])
 
@@ -432,7 +426,7 @@ export const useMcpStore = defineStore('mcp', () => {
     config.value.mcpEnabled ? serverList.value.filter((server) => server.enabled) : []
   )
   const enabledPluginServers = computed(() =>
-    config.value.mcpEnabled ? pluginServerList.value.filter((server) => server.enabled) : []
+    pluginServerList.value.filter((server) => server.enabled)
   )
   const enabledServerCount = computed(() => enabledServers.value.length)
 
@@ -505,7 +499,7 @@ export const useMcpStore = defineStore('mcp', () => {
   // 设置MCP启用状态
   const startEnabledServers = async () => {
     for (const [serverName, serverConfig] of Object.entries(config.value.mcpServers)) {
-      if (!serverConfig.enabled) {
+      if (!serverConfig.enabled || isPluginOwnedServerConfig(serverConfig)) {
         continue
       }
       try {
@@ -553,10 +547,16 @@ export const useMcpStore = defineStore('mcp', () => {
         }, 1000)
       } else {
         await Promise.allSettled(
-          Object.keys(config.value.mcpServers).map((serverName) => mcpClient.stopServer(serverName))
+          Object.entries(config.value.mcpServers)
+            .filter(([, serverConfig]) => !isPluginOwnedServerConfig(serverConfig))
+            .map(([serverName]) => mcpClient.stopServer(serverName))
         )
         // clearing server/tool state when disabling
-        serverStatuses.value = {}
+        serverStatuses.value = Object.fromEntries(
+          Object.entries(serverStatuses.value).filter(([serverName]) =>
+            isPluginOwnedServerName(serverName)
+          )
+        )
         toolInputs.value = {}
         toolResults.value = {}
         // Force refresh queries to get empty results
@@ -579,10 +579,6 @@ export const useMcpStore = defineStore('mcp', () => {
 
   // 更新所有服务器状态
   const updateAllServerStatuses = async () => {
-    if (!config.value.mcpEnabled) {
-      return
-    }
-
     for (const serverName of Object.keys(config.value.mcpServers)) {
       await updateServerStatus(serverName, true)
     }
@@ -595,7 +591,8 @@ export const useMcpStore = defineStore('mcp', () => {
   // 更新单个服务器状态
   const updateServerStatus = async (serverName: string, noRefresh: boolean = false) => {
     try {
-      if (!config.value.mcpEnabled) {
+      const serverConfig = config.value.mcpServers[serverName]
+      if (!config.value.mcpEnabled && !isPluginOwnedServerConfig(serverConfig)) {
         serverStatuses.value[serverName] = false
         return
       }
@@ -607,6 +604,10 @@ export const useMcpStore = defineStore('mcp', () => {
       }
       // 根据服务器的状态，关闭或者开启该服务器的所有工具
       const isRunning = serverStatuses.value[serverName] || false
+      if (!config.value.mcpEnabled) {
+        return
+      }
+
       if (isRunning) {
         // Get server tools after refresh
         const serverTools = tools.value
@@ -713,10 +714,6 @@ export const useMcpStore = defineStore('mcp', () => {
   }
 
   const loadClients = async (options?: QueryExecuteOptions) => {
-    if (!config.value.mcpEnabled) {
-      return
-    }
-
     try {
       const state = await runQuery(clientsQuery, options)
       if (state.status === 'success') {
@@ -728,13 +725,9 @@ export const useMcpStore = defineStore('mcp', () => {
   }
 
   const loadTools = async (options?: QueryExecuteOptions) => {
-    if (!config.value.mcpEnabled) {
-      return
-    }
-
     try {
       const state = await runQuery(toolsQuery, options)
-      if (state.status === 'success') {
+      if (state.status === 'success' && config.value.mcpEnabled) {
         await syncEnabledToolsWithDefinitions(state.data ?? [])
       }
     } catch (error) {
@@ -753,10 +746,6 @@ export const useMcpStore = defineStore('mcp', () => {
 
   // 加载资源列表
   const loadResources = async (options?: QueryExecuteOptions) => {
-    if (!config.value.mcpEnabled) {
-      return
-    }
-
     try {
       await runQuery(resourcesQuery, options)
     } catch (error) {
@@ -899,7 +888,7 @@ export const useMcpStore = defineStore('mcp', () => {
       }
 
       // MCP prompt 需要检查 MCP 是否启用
-      if (!config.value.mcpEnabled) {
+      if (!config.value.mcpEnabled && !isPluginOwnedServerName(prompt.client?.name)) {
         throw new Error(t('mcp.errors.mcpDisabled'))
       }
 
@@ -913,7 +902,7 @@ export const useMcpStore = defineStore('mcp', () => {
 
   // 读取资源内容
   const readResource = async (resource: ResourceListEntry): Promise<Resource> => {
-    if (!config.value.mcpEnabled) {
+    if (!config.value.mcpEnabled && !isPluginOwnedServerName(resource.client?.name)) {
       throw new Error(t('mcp.errors.mcpDisabled'))
     }
 

--- a/src/shared/types/plugin.ts
+++ b/src/shared/types/plugin.ts
@@ -144,6 +144,7 @@ export interface PluginMcpRuntimeStatus {
   serverId: string
   enabled: boolean
   running: boolean
+  lastError?: string
 }
 
 export interface PluginSettingsContribution {

--- a/src/shared/types/presenters/legacy.presenters.d.ts
+++ b/src/shared/types/presenters/legacy.presenters.d.ts
@@ -1811,6 +1811,7 @@ export interface IMCPPresenter {
   isServerRunning(serverName: string): Promise<boolean>
   startServer(serverName: string): Promise<void>
   stopServer(serverName: string): Promise<void>
+  getServerLastError?(serverName: string): string | undefined
   getAllToolDefinitions(enabledMcpTools?: string[]): Promise<MCPToolDefinition[]>
   getAllPrompts(): Promise<Array<PromptListEntry & { client: { name: string; icon: string } }>>
   getAllResources(): Promise<Array<ResourceListEntry & { client: { name: string; icon: string } }>>

--- a/test/main/presenter/mcpPresenter.test.ts
+++ b/test/main/presenter/mcpPresenter.test.ts
@@ -80,9 +80,11 @@ describe('McpPresenter#setMcpServerEnabled', () => {
     serverManagerMocks.startServer.mockResolvedValue(undefined)
     serverManagerMocks.stopServer.mockResolvedValue(undefined)
     serverManagerMocks.isServerRunning.mockReturnValue(false)
+    serverManagerMocks.getRunningClients.mockResolvedValue([])
     serverManagerMocks.testNpmRegistrySpeed.mockResolvedValue('https://registry.npmjs.org/')
     serverManagerMocks.updateNpmRegistryInBackground.mockResolvedValue(undefined)
     serverManagerMocks.refreshNpmRegistry.mockResolvedValue('https://registry.npmjs.org/')
+    toolManagerMocks.getAllToolDefinitions.mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -90,12 +92,18 @@ describe('McpPresenter#setMcpServerEnabled', () => {
     vi.useRealTimers()
   })
 
-  const createConfigPresenter = (mcpEnabled: boolean, privacyModeEnabled = false) =>
+  const createConfigPresenter = (
+    mcpEnabled: boolean,
+    privacyModeEnabled = false,
+    servers: Record<string, any> = {},
+    enabledServers: string[] = []
+  ) =>
     ({
       setMcpServerEnabled: vi.fn().mockResolvedValue(undefined),
       getMcpEnabled: vi.fn().mockResolvedValue(mcpEnabled),
-      getMcpServers: vi.fn().mockResolvedValue({}),
-      getEnabledMcpServers: vi.fn().mockResolvedValue([]),
+      setMcpEnabled: vi.fn().mockResolvedValue(undefined),
+      getMcpServers: vi.fn().mockResolvedValue(servers),
+      getEnabledMcpServers: vi.fn().mockResolvedValue(enabledServers),
       getLanguage: vi.fn().mockReturnValue('en-US'),
       getPrivacyModeEnabled: vi.fn(() => privacyModeEnabled)
     }) as any
@@ -140,6 +148,107 @@ describe('McpPresenter#setMcpServerEnabled', () => {
     expect(configPresenter.setMcpServerEnabled).toHaveBeenCalledWith('demo-server', true)
     expect(startSpy).not.toHaveBeenCalled()
     expect(stopSpy).not.toHaveBeenCalled()
+  })
+
+  it('starts plugin-owned servers even when MCP is globally disabled', async () => {
+    const configPresenter = createConfigPresenter(
+      false,
+      false,
+      {
+        regular: { enabled: true },
+        plugin: { enabled: true, source: 'plugin', ownerPluginId: 'com.deepchat.fixture' }
+      },
+      ['regular', 'plugin']
+    )
+    const presenter = new McpPresenter(configPresenter)
+    ;(presenter as any).serverManager = {
+      startServer: serverManagerMocks.startServer,
+      testNpmRegistrySpeed: serverManagerMocks.testNpmRegistrySpeed,
+      getNpmRegistry: serverManagerMocks.getNpmRegistry,
+      updateNpmRegistryInBackground: serverManagerMocks.updateNpmRegistryInBackground
+    }
+
+    await presenter.initialize()
+
+    expect(serverManagerMocks.startServer).toHaveBeenCalledTimes(1)
+    expect(serverManagerMocks.startServer).toHaveBeenCalledWith('plugin')
+  })
+
+  it('does not start plugin-owned servers when enabling the global MCP switch', async () => {
+    const configPresenter = createConfigPresenter(
+      true,
+      false,
+      {
+        regular: { enabled: true },
+        plugin: { enabled: true, source: 'plugin', ownerPluginId: 'com.deepchat.fixture' }
+      },
+      ['regular', 'plugin']
+    )
+    const presenter = new McpPresenter(configPresenter)
+    const startSpy = vi.spyOn(presenter, 'startServer').mockResolvedValue(undefined)
+
+    await presenter.setMcpEnabled(true)
+
+    expect(configPresenter.setMcpEnabled).toHaveBeenCalledWith(true)
+    expect(startSpy).toHaveBeenCalledTimes(1)
+    expect(startSpy).toHaveBeenCalledWith('regular')
+  })
+
+  it('does not stop plugin-owned servers when disabling the global MCP switch', async () => {
+    const configPresenter = createConfigPresenter(false, false, {
+      regular: { enabled: true },
+      plugin: { enabled: true, source: 'plugin', ownerPluginId: 'com.deepchat.fixture' }
+    })
+    serverManagerMocks.getRunningClients.mockResolvedValue([
+      { serverName: 'regular' },
+      { serverName: 'plugin' }
+    ])
+    const presenter = new McpPresenter(configPresenter)
+    ;(presenter as any).serverManager = {
+      getRunningClients: serverManagerMocks.getRunningClients
+    }
+    const stopSpy = vi.spyOn(presenter, 'stopServer').mockResolvedValue(undefined)
+
+    await presenter.setMcpEnabled(false)
+
+    expect(configPresenter.setMcpEnabled).toHaveBeenCalledWith(false)
+    expect(stopSpy).toHaveBeenCalledTimes(1)
+    expect(stopSpy).toHaveBeenCalledWith('regular')
+  })
+
+  it('keeps plugin-owned tool definitions available when MCP is globally disabled', async () => {
+    const configPresenter = createConfigPresenter(false, false, {
+      regular: { enabled: true },
+      plugin: { enabled: true, source: 'plugin', ownerPluginId: 'com.deepchat.fixture' }
+    })
+    toolManagerMocks.getAllToolDefinitions.mockResolvedValueOnce([
+      {
+        type: 'function',
+        function: {
+          name: 'regular_tool',
+          description: '',
+          parameters: { type: 'object', properties: {} }
+        },
+        server: { name: 'regular', icons: '', description: '' }
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'plugin_tool',
+          description: '',
+          parameters: { type: 'object', properties: {} }
+        },
+        server: { name: 'plugin', icons: '', description: '' }
+      }
+    ])
+    const presenter = new McpPresenter(configPresenter)
+    ;(presenter as any).toolManager = {
+      getAllToolDefinitions: toolManagerMocks.getAllToolDefinitions
+    }
+
+    const tools = await presenter.getAllToolDefinitions()
+
+    expect(tools.map((tool) => tool.function.name)).toEqual(['plugin_tool'])
   })
 
   it('rejects when the runtime transition fails after persisting config', async () => {

--- a/test/main/presenter/mcpPresenter/serverManager.test.ts
+++ b/test/main/presenter/mcpPresenter/serverManager.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const eventBusMocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  sendToRenderer: vi.fn()
+}))
+
+const clientMocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  isServerRunning: vi.fn()
+}))
+
+vi.mock('@/eventbus', () => ({
+  eventBus: eventBusMocks,
+  SendTarget: {
+    ALL_WINDOWS: 'ALL_WINDOWS'
+  }
+}))
+
+vi.mock('@/events', () => ({
+  MCP_EVENTS: {
+    CLIENT_LIST_UPDATED: 'client-list-updated'
+  },
+  NOTIFICATION_EVENTS: {
+    SHOW_ERROR: 'show-error'
+  }
+}))
+
+vi.mock('@/presenter/proxyConfig', () => ({
+  proxyConfig: {
+    getProxyUrl: vi.fn(() => '')
+  }
+}))
+
+vi.mock('../../../../src/main/presenter/mcpPresenter/mcpClient', () => ({
+  McpClient: vi.fn().mockImplementation(() => ({
+    connect: clientMocks.connect,
+    disconnect: clientMocks.disconnect,
+    isServerRunning: clientMocks.isServerRunning
+  }))
+}))
+
+import { ServerManager } from '../../../../src/main/presenter/mcpPresenter/serverManager'
+import { McpClient } from '../../../../src/main/presenter/mcpPresenter/mcpClient'
+
+describe('ServerManager plugin MCP errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clientMocks.connect.mockResolvedValue(undefined)
+    clientMocks.disconnect.mockResolvedValue(undefined)
+    clientMocks.isServerRunning.mockReturnValue(true)
+    vi.mocked(McpClient).mockImplementation(
+      () =>
+        ({
+          connect: clientMocks.connect,
+          disconnect: clientMocks.disconnect,
+          isServerRunning: clientMocks.isServerRunning
+        }) as never
+    )
+  })
+
+  function createConfigPresenter(servers: Record<string, any>) {
+    return {
+      getMcpServers: vi.fn().mockResolvedValue(servers),
+      getLanguage: vi.fn().mockReturnValue('en-US'),
+      getEffectiveNpmRegistry: vi.fn().mockReturnValue(null),
+      getPrivacyModeEnabled: vi.fn().mockReturnValue(false)
+    }
+  }
+
+  it('suppresses global connection toasts for plugin-owned MCP servers', async () => {
+    const manager = new ServerManager(
+      createConfigPresenter({
+        plugin: {
+          command: 'plugin-command',
+          args: [],
+          env: {},
+          type: 'stdio',
+          source: 'plugin',
+          ownerPluginId: 'com.deepchat.fixture'
+        }
+      }) as never
+    )
+    clientMocks.connect.mockRejectedValueOnce(new Error('connect failed'))
+
+    await expect(manager.startServer('plugin')).rejects.toThrow('connect failed')
+
+    expect(manager.getServerLastError('plugin')).toBe('connect failed')
+    expect(eventBusMocks.sendToRenderer).not.toHaveBeenCalled()
+  })
+
+  it('keeps global connection toasts for normal MCP servers', async () => {
+    const manager = new ServerManager(
+      createConfigPresenter({
+        regular: {
+          command: 'regular-command',
+          args: [],
+          env: {},
+          type: 'stdio'
+        }
+      }) as never
+    )
+    clientMocks.connect.mockRejectedValueOnce(new Error('connect failed'))
+
+    await expect(manager.startServer('regular')).rejects.toThrow('connect failed')
+
+    expect(manager.getServerLastError('regular')).toBe('connect failed')
+    expect(eventBusMocks.sendToRenderer).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/main/presenter/mcpPresenter/toolManager.test.ts
+++ b/test/main/presenter/mcpPresenter/toolManager.test.ts
@@ -60,13 +60,15 @@ describe('ToolManager', () => {
           required: []
         }
       }
-    ]
+    ],
+    serverConfig: Record<string, unknown> = {}
   ) {
     return {
       serverName,
       serverConfig: {
         icons: '',
-        descriptions: ''
+        descriptions: '',
+        ...serverConfig
       },
       listTools: vi.fn().mockResolvedValue(tools),
       callTool: vi.fn().mockResolvedValue({
@@ -89,6 +91,14 @@ describe('ToolManager', () => {
       getAcpAgents: vi.fn().mockResolvedValue([]),
       getAgentMcpSelections: vi.fn().mockResolvedValue([]),
       getLanguage: vi.fn().mockReturnValue('en-US')
+    }
+  }
+
+  function createServerManager(clients: unknown[]) {
+    return {
+      getRunningClients: vi.fn().mockResolvedValue(clients),
+      setServerLastError: vi.fn(),
+      clearServerLastError: vi.fn()
     }
   }
 
@@ -123,9 +133,7 @@ describe('ToolManager', () => {
     const configPresenter = createConfigPresenter(serverName)
     const manager = new ToolManager(
       configPresenter as never,
-      {
-        getRunningClients: vi.fn().mockResolvedValue([client])
-      } as never
+      createServerManager([client]) as never
     )
 
     const definitions = await manager.getAllToolDefinitions()
@@ -160,9 +168,7 @@ describe('ToolManager', () => {
     const configPresenter = createConfigPresenter('regular-server')
     const manager = new ToolManager(
       configPresenter as never,
-      {
-        getRunningClients: vi.fn().mockResolvedValue([client])
-      } as never
+      createServerManager([client]) as never
     )
 
     const definitions = await manager.getAllToolDefinitions()
@@ -197,9 +203,7 @@ describe('ToolManager', () => {
 
     const manager = new ToolManager(
       configPresenter as never,
-      {
-        getRunningClients: vi.fn().mockResolvedValue([client])
-      } as never
+      createServerManager([client]) as never
     )
 
     const result = await manager.callTool({
@@ -220,6 +224,26 @@ describe('ToolManager', () => {
     expect(configPresenter.getAgentMcpSelections).toHaveBeenCalledWith('agent-1')
   })
 
+  it('records plugin tool-list failures without showing a global toast', async () => {
+    const client = createClient('plugin-server', [], {
+      source: 'plugin',
+      ownerPluginId: 'com.deepchat.fixture'
+    })
+    client.listTools.mockRejectedValue(new Error('tool list failed'))
+    const configPresenter = createConfigPresenter('plugin-server')
+    const serverManager = createServerManager([client])
+    const manager = new ToolManager(configPresenter as never, serverManager as never)
+
+    const definitions = await manager.getAllToolDefinitions()
+
+    expect(definitions).toEqual([])
+    expect(serverManager.setServerLastError).toHaveBeenCalledWith(
+      'plugin-server',
+      'tool list failed'
+    )
+    expect(eventBusMocks.sendToRenderer).not.toHaveBeenCalled()
+  })
+
   it('skips ACP session resolution when provider hint is non-ACP', async () => {
     const client = createClient('open-server')
     const configPresenter = createConfigPresenter('open-server')
@@ -227,9 +251,7 @@ describe('ToolManager', () => {
 
     const manager = new ToolManager(
       configPresenter as never,
-      {
-        getRunningClients: vi.fn().mockResolvedValue([client])
-      } as never
+      createServerManager([client]) as never
     )
 
     const result = await manager.callTool({
@@ -275,9 +297,7 @@ describe('ToolManager', () => {
 
     const manager = new ToolManager(
       configPresenter as never,
-      {
-        getRunningClients: vi.fn().mockResolvedValue([client])
-      } as never
+      createServerManager([client]) as never
     )
 
     const result = await manager.callTool({
@@ -303,9 +323,7 @@ describe('ToolManager', () => {
 
     const manager = new ToolManager(
       configPresenter as never,
-      {
-        getRunningClients: vi.fn().mockResolvedValue([client])
-      } as never
+      createServerManager([client]) as never
     )
 
     const result = await manager.callTool({

--- a/test/main/presenter/pluginPresenter.test.ts
+++ b/test/main/presenter/pluginPresenter.test.ts
@@ -40,6 +40,7 @@ type CreatePluginPresenterOptions = {
   appPath?: string
   isPackaged?: boolean
   resourcesPath?: string
+  mcpEnabled?: boolean
 }
 
 const createPluginPresenter = async (
@@ -61,7 +62,7 @@ const createPluginPresenter = async (
     removeMcpServer: vi.fn().mockImplementation(async (serverName: string) => {
       delete mcpServers[serverName]
     }),
-    getMcpEnabled: vi.fn().mockResolvedValue(true)
+    getMcpEnabled: vi.fn().mockResolvedValue(options.mcpEnabled ?? true)
   }
   const mcpPresenter = {
     isReady: vi.fn(() => true),
@@ -72,7 +73,7 @@ const createPluginPresenter = async (
   const skillPresenter = {
     unregisterPluginSkillsByOwner: vi.fn().mockResolvedValue(undefined)
   }
-  return new PluginPresenter({
+  const presenter = new PluginPresenter({
     platform,
     appPath: options.appPath ?? process.cwd(),
     isPackaged: options.isPackaged,
@@ -81,6 +82,13 @@ const createPluginPresenter = async (
     mcpPresenter,
     skillPresenter
   } as any)
+  return Object.assign(presenter, {
+    __mocks: {
+      configPresenter,
+      mcpPresenter,
+      skillPresenter
+    }
+  })
 }
 
 const createBundledFixture = async (
@@ -277,7 +285,20 @@ describe('PluginPresenter', () => {
     expect(presenterSource).toContain('resolvePluginTemplateRecord')
     expect(presenterSource).toContain('startPluginMcpServersIfReady')
     expect(presenterSource).toContain('this.mcpPresenter.startServer(serverName)')
-    expect(presenterSource).toContain('this.configPresenter.getMcpEnabled()')
+    expect(presenterSource).not.toContain('if (!(await this.configPresenter.getMcpEnabled()))')
+  })
+
+  it('starts plugin MCP servers even when the global MCP switch is off', async () => {
+    const fixture = await createBundledFixture()
+    const presenter = await createPluginPresenter('darwin', {
+      appPath: fixture.appPath,
+      mcpEnabled: false
+    })
+
+    const result = await presenter.enablePlugin(fixture.pluginId)
+
+    expect(result.ok).toBe(true)
+    expect(presenter.__mocks.mcpPresenter.startServer).toHaveBeenCalledWith('fixture-runtime')
   })
 
   it('declares the CUA MCP server with plugin helper context', async () => {

--- a/test/renderer/components/McpIndicator.test.ts
+++ b/test/renderer/components/McpIndicator.test.ts
@@ -56,6 +56,7 @@ const setup = async (options?: {
   showSubagentToggle?: boolean
   subagentEnabled?: boolean
   pluginEnabled?: boolean
+  regularMcpEnabled?: boolean
 }) => {
   vi.resetModules()
   let skillSessionChangedHandler:
@@ -87,14 +88,15 @@ const setup = async (options?: {
   const pluginTools = options?.pluginEnabled
     ? [buildTool('check_permissions', 'cua-driver', 'mcp')]
     : []
+  const regularMcpEnabled = options?.regularMcpEnabled ?? true
   const mcpStore = reactive({
-    enabledServers: [{ name: 'demo-server', icons: 'D', enabled: true }],
+    enabledServers: regularMcpEnabled ? [{ name: 'demo-server', icons: 'D', enabled: true }] : [],
     enabledPluginServers: options?.pluginEnabled
       ? [{ name: 'cua-driver', icons: 'plugin', descriptions: 'CUA Driver', enabled: true }]
       : [],
-    enabledServerCount: 1,
-    tools: [buildTool('mcp_tool', 'demo-server', 'mcp')],
-    visibleTools: [buildTool('mcp_tool', 'demo-server', 'mcp')],
+    enabledServerCount: regularMcpEnabled ? 1 : 0,
+    tools: regularMcpEnabled ? [buildTool('mcp_tool', 'demo-server', 'mcp')] : [],
+    visibleTools: regularMcpEnabled ? [buildTool('mcp_tool', 'demo-server', 'mcp')] : [],
     pluginTools
   })
 
@@ -366,6 +368,21 @@ describe('McpIndicator', () => {
     expect(wrapper.text()).toContain('demo-server')
     expect(wrapper.text()).toContain('Plugins')
     expect(wrapper.text()).toContain('CUA Driver')
+  })
+
+  it('shows plugin MCP when global MCP has no enabled regular servers', async () => {
+    const { wrapper } = await setup({
+      hasActiveSession: true,
+      activeAgentId: 'acp-coder',
+      pluginEnabled: true,
+      regularMcpEnabled: false
+    })
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons[0].text()).toContain('MCP 0')
+    expect(wrapper.text()).toContain('Plugins')
+    expect(wrapper.text()).toContain('CUA Driver')
+    expect(wrapper.text()).not.toContain('demo-server')
   })
 
   it('updates draft disabled tools for deepchat new thread mode', async () => {

--- a/test/renderer/plugins/cuaSettings.test.ts
+++ b/test/renderer/plugins/cuaSettings.test.ts
@@ -28,6 +28,11 @@ const renderSettingsDom = (): void => {
 
 type CuaSettingsWindow = Window & { deepchatPlugin?: unknown }
 
+const runSettingsScript = async (): Promise<void> => {
+  const script = await readFile(scriptPath, 'utf8')
+  window.eval(`(() => {\n${script}\n})()`)
+}
+
 describe('CUA plugin settings', () => {
   beforeEach(() => {
     renderSettingsDom()
@@ -64,7 +69,7 @@ describe('CUA plugin settings', () => {
       disable: vi.fn()
     }
 
-    window.eval(await readFile(scriptPath, 'utf8'))
+    await runSettingsScript()
     await flushPromises()
 
     document.getElementById('check')?.click()
@@ -73,5 +78,37 @@ describe('CUA plugin settings', () => {
     expect(document.getElementById('permission-accessibility')?.textContent).toBe('Granted')
     expect(document.getElementById('permission-screen-recording')?.textContent).toBe('Denied')
     expect(document.getElementById('message')?.textContent).toBe('')
+  })
+
+  it('shows plugin MCP errors in the status row and message area', async () => {
+    const pluginWindow = window as CuaSettingsWindow
+
+    pluginWindow.deepchatPlugin = {
+      getStatus: vi.fn().mockResolvedValue({
+        enabled: true,
+        runtime: {
+          state: 'installed',
+          version: '0.1.5',
+          command: '/mock/cua-driver',
+          helperAppPath: '/mock/DeepChat Computer Use.app'
+        },
+        mcpServers: [
+          {
+            serverId: 'cua-driver',
+            enabled: true,
+            running: false,
+            lastError: 'connect failed'
+          }
+        ]
+      }),
+      invokeAction: vi.fn(),
+      disable: vi.fn()
+    }
+
+    await runSettingsScript()
+    await flushPromises()
+
+    expect(document.getElementById('mcp-state')?.textContent).toBe('Error')
+    expect(document.getElementById('message')?.textContent).toBe('connect failed')
   })
 })

--- a/test/renderer/stores/mcpStore.test.ts
+++ b/test/renderer/stores/mcpStore.test.ts
@@ -146,6 +146,20 @@ describe('useMcpStore toggleServer rollback', () => {
           disable: false,
           type: 'stdio',
           enabled: true
+        },
+        'cua-driver': {
+          command: '/mock/cua-driver',
+          args: ['mcp'],
+          env: {},
+          descriptions: 'Computer Use',
+          icons: 'plugin',
+          autoApprove: [],
+          disable: false,
+          type: 'stdio',
+          enabled: true,
+          source: 'plugin',
+          sourceId: 'com.deepchat.plugins.cua',
+          ownerPluginId: 'com.deepchat.plugins.cua'
         }
       },
       mcpEnabled: false,
@@ -153,7 +167,9 @@ describe('useMcpStore toggleServer rollback', () => {
     }
 
     expect(store.serverList).toHaveLength(1)
+    expect(store.pluginServerList.map((server) => server.name)).toEqual(['cua-driver'])
     expect(store.enabledServers).toEqual([])
+    expect(store.enabledPluginServers.map((server) => server.name)).toEqual(['cua-driver'])
     expect(store.enabledServerCount).toBe(0)
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specification, implementation plan, and task checklist for plugin MCP lifecycle isolation.

* **New Features**
  * Plugin-owned MCP servers now operate independently of the global MCP on/off switch and continue running when global MCP is disabled.
  * Plugin MCP server errors are now visible in plugin settings UI.

* **Bug Fixes**
  * Plugin MCP connection failures no longer trigger global error notifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1597)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->