### PR TITLE
fix(renderer): revert stream code block rendering

### DIFF
--- a/src/renderer/src/components/markdown/MarkdownRenderer.vue
+++ b/src/renderer/src/components/markdown/MarkdownRenderer.vue
@@ -7,9 +7,6 @@
       :codeBlockDarkTheme="codeBlockDarkTheme"
       :codeBlockLightTheme="codeBlockLightTheme"
       :codeBlockMonacoOptions="codeBlockMonacoOption"
-      :final="!props.loading"
-      :typewriter="!!props.loading"
-      :codeBlockStream="!!props.loading"
       @copy="$emit('copy', $event)"
     />
   </div>
@@ -38,7 +35,6 @@ import type { MarkdownLinkContext } from './linkTypes'
 const props = defineProps<{
   content: string
   debug?: boolean
-  loading?: boolean
   messageId?: string
   threadId?: string
   linkContext?: MarkdownLinkContext

--- a/src/renderer/src/components/message/MessageBlockContent.vue
+++ b/src/renderer/src/components/message/MessageBlockContent.vue
@@ -5,7 +5,7 @@
     <MarkdownRenderer
       v-if="part.type === 'text'"
       :content="part.content"
-      :loading="props.block.status === 'loading'"
+      :loading="part.loading"
       :message-id="messageId"
       :thread-id="threadId"
       :link-context="{

--- a/src/renderer/src/components/think-content/ThinkContent.vue
+++ b/src/renderer/src/components/think-content/ThinkContent.vue
@@ -36,9 +36,6 @@
         :maxLiveNodes="120"
         :liveNodeBuffer="30"
         :customId="customId"
-        :final="!props.thinking"
-        :typewriter="props.thinking"
-        :codeBlockStream="props.thinking"
       />
     </div>
 

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -11,9 +11,6 @@ import 'katex/dist/katex.min.css'
 import {
   clearKaTeXWorker,
   clearMermaidWorker,
-  enableKatex,
-  enableMermaid,
-  preloadCodeBlockRuntime,
   setKaTeXWorker,
   setMermaidWorker,
   terminateWorker
@@ -37,9 +34,6 @@ if (!globalScope.__markdownWorkers) {
   setMermaidWorker(mermaid)
 }
 
-enableKatex()
-enableMermaid(() => import('mermaid'))
-
 window.addEventListener('beforeunload', () => {
   const workers = globalScope.__markdownWorkers
   if (workers) {
@@ -51,82 +45,6 @@ window.addEventListener('beforeunload', () => {
   clearMermaidWorker()
   terminateWorker()
 })
-
-const codeBlockThemes = ['vitesse-dark', 'vitesse-light']
-const codeBlockLanguages = [
-  'jsx',
-  'tsx',
-  'vue',
-  'csharp',
-  'python',
-  'java',
-  'c',
-  'cpp',
-  'rust',
-  'go',
-  'shell',
-  'shellscript',
-  'powershell',
-  'sql',
-  'json',
-  'html',
-  'javascript',
-  'typescript',
-  'css',
-  'markdown',
-  'xml',
-  'yaml',
-  'toml',
-  'dockerfile',
-  'kotlin',
-  'objective-c',
-  'objective-cpp',
-  'php',
-  'ruby',
-  'scala',
-  'svelte',
-  'swift',
-  'erlang',
-  'angular-html',
-  'angular-ts',
-  'dart',
-  'lua',
-  'mermaid',
-  'cmake',
-  'nginx',
-  'plaintext'
-]
-
-const preloadCodeBlockRuntimeAsync = async () => {
-  try {
-    const { registerMonacoThemes } = await import('stream-monaco')
-
-    await Promise.all([
-      preloadCodeBlockRuntime(),
-      registerMonacoThemes(codeBlockThemes, codeBlockLanguages)
-    ])
-  } catch (error) {
-    console.error('[deepchat] failed to preload code block runtime', error)
-  }
-}
-
-const scheduleCodeBlockRuntimePreload = () => {
-  const requestIdleCallback = window.requestIdleCallback
-
-  if (typeof requestIdleCallback === 'function') {
-    requestIdleCallback(
-      () => {
-        void preloadCodeBlockRuntimeAsync()
-      },
-      { timeout: 1500 }
-    )
-    return
-  }
-
-  window.setTimeout(() => {
-    void preloadCodeBlockRuntimeAsync()
-  }, 0)
-}
 
 const i18n = createI18n({
   locale: 'zh-CN',
@@ -158,5 +76,3 @@ setTimeout(() => {
     console.error('Failed to preload icons:', error)
   })
 }, 0)
-
-scheduleCodeBlockRuntimePreload()


### PR DESCRIPTION
## Summary
- Revert the source-level stream rendering flags for Markdown code blocks.
- Restore message Markdown loading behavior to the previous part-level state.
- Remove renderer startup preloading for the new code block runtime path.

## Tests
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck
- pnpm exec vitest run test/renderer/components/MarkdownRenderer.test.ts test/renderer/components/message/MessageBlockContent.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined loading state handling to improve accuracy when displaying markdown content
  * Optimized worker initialization for mathematical expressions and diagram rendering
  * Streamlined rendering configuration across content blocks and thinking sections
  * Removed unnecessary preloading logic for cleaner initialization

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1602)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->