### PR TITLE
fix: improve context budget and streaming

### DIFF
--- a/docs/issues/agent-tool-context-budget/plan.md
+++ b/docs/issues/agent-tool-context-budget/plan.md
@@ -57,6 +57,17 @@ consumes more context and fails on small formatting deviations.
 - Judge tool-output continuation fitting against the next preflight-fitted request shape, so older
   history that would be trimmed before the next provider call does not falsely fail the tool result.
 
+## Retry Overflow Hardening
+
+- Route unfittable provider-call preflight results through the existing context-pressure recovery
+  path once before failing.
+- Keep the latest user/system/tool payload protected; recovery may compact persisted history,
+  replace stale summary-bearing system prompt text, trim older in-memory history, and reduce only
+  the per-call output cap.
+- When recovery still cannot fit, fail before rate-limit wait/provider streaming with a budget
+  diagnostic that includes usable context, estimated input, tool-schema reserve, requested/effective
+  output, and remaining output room.
+
 ## Manual Validation Notes
 
 For a MiniMax-M2.7 agent session, inspect trace/log output rather than running automated test

--- a/docs/issues/agent-tool-context-budget/spec.md
+++ b/docs/issues/agent-tool-context-budget/spec.md
@@ -72,3 +72,16 @@ Additional acceptance criteria:
   instead of a positive budget.
 - Context-pressure recovery updates the in-memory request history used by later tool-continuation
   loops.
+
+## Retry Overflow Hardening
+
+Additional acceptance criteria:
+
+- Retry and resume provider calls that still cannot fit after request fitting attempt the same
+  internal recovery pass before failing, even when the user configured fewer than 4000 output
+  tokens.
+- If recovery cannot make the latest user/system/tool payload fit, DeepChat fails before sending a
+  provider request and stores a clear budget error on the assistant message.
+- The error explains that no provider request was sent and suggests shortening current input or
+  attachments, reducing active tools/skills/system prompt content, lowering max output tokens, or
+  increasing context length.

--- a/docs/issues/agent-tool-context-budget/tasks.md
+++ b/docs/issues/agent-tool-context-budget/tasks.md
@@ -13,6 +13,8 @@
 - [x] Drop orphaned tool results and invalid provider options before AI SDK requests.
 - [x] Report zero effective output tokens for unfittable preflight results.
 - [x] Harden preflight for unknown context windows and refitted tool continuations.
+- [x] Recover unfittable retry/resume preflights before provider calls.
+- [x] Add actionable budget diagnostics for irreducible retry/resume overflow.
 - [ ] Add request budget telemetry.
 - [ ] Add reasoning retention budget.
 - [ ] Add compact legacy tool schema mode.

--- a/docs/issues/markdown-smooth-streaming-control/plan.md
+++ b/docs/issues/markdown-smooth-streaming-control/plan.md
@@ -1,0 +1,19 @@
+# Markdown Smooth Streaming Control Plan
+
+## Approach
+
+- Add a `smoothStreaming` prop to `MarkdownRenderer`, defaulting to `false`.
+- Forward that prop to `markstream-vue`'s `NodeRenderer`.
+- In chat message text rendering, enable the prop only when the assistant content block status is `pending` or `loading`.
+- Do not derive this from parsed part loading state, because that state reflects artifact/tag parsing rather than message generation.
+
+## Compatibility
+
+- Existing non-chat markdown surfaces inherit the default `false`.
+- Existing `fade=false` behavior remains unchanged.
+
+## Validation
+
+- Cover the markdown renderer default and explicit prop behavior.
+- Cover completed versus generating message block behavior.
+- Run targeted renderer tests plus formatting, i18n, and lint checks.

--- a/docs/issues/markdown-smooth-streaming-control/spec.md
+++ b/docs/issues/markdown-smooth-streaming-control/spec.md
@@ -1,0 +1,17 @@
+# Markdown Smooth Streaming Control
+
+## User Story
+
+As a chat reader, I want completed markdown messages to render without streaming animation so that history and already-generated responses feel stable.
+
+## Acceptance Criteria
+
+- Assistant text blocks that are actively generating use `smoothStreaming`.
+- Completed assistant text blocks do not use `smoothStreaming`.
+- Markdown artifact previews and workspace markdown previews keep non-streaming behavior by default.
+- The change does not alter markdown content parsing, references, code previews, or artifact syncing.
+
+## Non-Goals
+
+- No new user setting is added.
+- No IPC, database, or shared message schema changes are needed.

--- a/docs/issues/markdown-smooth-streaming-control/tasks.md
+++ b/docs/issues/markdown-smooth-streaming-control/tasks.md
@@ -1,0 +1,8 @@
+# Markdown Smooth Streaming Control Tasks
+
+- [x] Document the intended behavior and implementation approach.
+- [x] Add the `smoothStreaming` prop to `MarkdownRenderer`.
+- [x] Enable smooth streaming only for pending/loading assistant content blocks.
+- [x] Add renderer tests for default, explicit, completed, and generating states.
+- [x] Run targeted renderer tests.
+- [x] Run final format, i18n, and lint checks.

--- a/src/main/presenter/agentRuntimePresenter/contextBudget.ts
+++ b/src/main/presenter/agentRuntimePresenter/contextBudget.ts
@@ -32,6 +32,16 @@ export type RequestContextPreflightResult = {
   requiresContextPressureRecovery: boolean
 }
 
+export type RequestContextBudgetDiagnostics = {
+  usableContextLength: number
+  inputTokens: number
+  toolReserveTokens: number
+  requestedMaxTokens: number
+  effectiveMaxTokens: number
+  remainingOutputTokens: number
+  totalRequestTokens: number
+}
+
 export function estimateToolReserveTokens(tools: MCPToolDefinition[]): number {
   return estimateToolDefinitionTokens(tools)
 }
@@ -193,6 +203,34 @@ export function preflightRequestContext(params: {
     shrunkByContextPressure,
     requiresContextPressureRecovery
   }
+}
+
+export function buildRequestContextBudgetDiagnostics(
+  preflight: RequestContextPreflightResult
+): RequestContextBudgetDiagnostics {
+  return {
+    usableContextLength: preflight.usableContextLength,
+    inputTokens: preflight.inputTokens,
+    toolReserveTokens: preflight.toolReserveTokens,
+    requestedMaxTokens: preflight.requestedMaxTokens,
+    effectiveMaxTokens: preflight.effectiveMaxTokens,
+    remainingOutputTokens: preflight.remainingOutputTokens,
+    totalRequestTokens: preflight.totalRequestTokens
+  }
+}
+
+export function buildRequestContextOverflowErrorMessage(
+  preflight: RequestContextPreflightResult
+): string {
+  const diagnostics = buildRequestContextBudgetDiagnostics(preflight)
+  const formatTokenCount = (value: number): string =>
+    Number.isFinite(value) ? String(Math.floor(value)) : 'unknown'
+
+  return [
+    'Request was not sent because it cannot fit within the model context window after applying the safety margin.',
+    `Budget: usable context ${formatTokenCount(diagnostics.usableContextLength)} tokens, estimated input ${formatTokenCount(diagnostics.inputTokens)} tokens, tool schemas ${formatTokenCount(diagnostics.toolReserveTokens)} tokens, requested output ${formatTokenCount(diagnostics.requestedMaxTokens)} tokens, effective output ${formatTokenCount(diagnostics.effectiveMaxTokens)} tokens, remaining output room ${formatTokenCount(diagnostics.remainingOutputTokens)} tokens.`,
+    'Try shortening the latest input or attachments, reducing active tools, skills, or system prompt content, lowering max output tokens, or increasing context length.'
+  ].join(' ')
 }
 
 function resolveProtectedRequestTailCount(messages: ChatMessage[]): number {

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -75,6 +75,7 @@ import {
 import {
   capAgentDefaultMaxTokens,
   capAgentRequestMaxTokens,
+  buildRequestContextOverflowErrorMessage,
   estimateToolReserveTokens,
   fitRequestMessagesToContextWindow,
   preflightRequestContext
@@ -1874,7 +1875,10 @@ export class AgentRuntimePresenter implements IAgentImplementation {
               requestedMaxTokens: requestMaxTokens,
               minimumProtectedTailCount: protectedSteerTailCount
             })
-            if (requestPreflight.requiresContextPressureRecovery) {
+            if (
+              requestPreflight.requiresContextPressureRecovery ||
+              !requestPreflight.fitsWithinContext
+            ) {
               const recovered = await recoverContextPressure({
                 sessionId,
                 providerId: state.providerId,
@@ -1903,9 +1907,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
               requestMessages.splice(0, requestMessages.length, ...requestPreflight.messages)
             }
             if (!requestPreflight.fitsWithinContext) {
-              throw new Error(
-                'Request cannot fit within the model context window after applying the safety margin.'
-              )
+              throw new Error(buildRequestContextOverflowErrorMessage(requestPreflight))
             }
             await llmProviderPresenter.executeWithRateLimit(state.providerId, {
               signal: abortController.signal,

--- a/src/renderer/src/components/markdown/MarkdownRenderer.vue
+++ b/src/renderer/src/components/markdown/MarkdownRenderer.vue
@@ -4,6 +4,8 @@
       :content="debouncedContent"
       :custom-id="customRendererId"
       :isDark="themeStore.isDark"
+      :smooth-streaming="smoothStreaming"
+      :fade="false"
       :codeBlockDarkTheme="codeBlockDarkTheme"
       :codeBlockLightTheme="codeBlockLightTheme"
       :codeBlockMonacoOptions="codeBlockMonacoOption"
@@ -32,13 +34,19 @@ import LinkNode from './LinkNode.vue'
 import { useMarkdownLinkNavigation } from './useMarkdownLinkNavigation'
 import type { MarkdownLinkContext } from './linkTypes'
 
-const props = defineProps<{
-  content: string
-  debug?: boolean
-  messageId?: string
-  threadId?: string
-  linkContext?: MarkdownLinkContext
-}>()
+const props = withDefaults(
+  defineProps<{
+    content: string
+    debug?: boolean
+    messageId?: string
+    threadId?: string
+    linkContext?: MarkdownLinkContext
+    smoothStreaming?: boolean
+  }>(),
+  {
+    smoothStreaming: false
+  }
+)
 const themeStore = useThemeStore()
 const uiSettingsStore = useUiSettingsStore()
 // 组件映射表

--- a/src/renderer/src/components/message/MessageBlockContent.vue
+++ b/src/renderer/src/components/message/MessageBlockContent.vue
@@ -6,6 +6,7 @@
       v-if="part.type === 'text'"
       :content="part.content"
       :loading="part.loading"
+      :smooth-streaming="shouldSmoothStream"
       :message-id="messageId"
       :thread-id="threadId"
       :link-context="{
@@ -54,6 +55,9 @@ const props = defineProps<{
 
 const { processedContent } = useBlockContent(props)
 const lastArtifactSnapshot = ref<string>('')
+const shouldSmoothStream = computed(
+  () => props.block.status === 'pending' || props.block.status === 'loading'
+)
 
 const artifactSnapshot = computed(() =>
   processedContent.value

--- a/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
@@ -367,6 +367,43 @@ function makeTextWithEstimatedTokens(minTokens: number): string {
   return 'x'.repeat(low)
 }
 
+function makeDeepchatUserRow(orderSeq: number, text: string, id = `u${orderSeq}`) {
+  return {
+    id,
+    session_id: 's1',
+    order_seq: orderSeq,
+    role: 'user' as const,
+    content: JSON.stringify({ text, files: [], links: [], search: false, think: false }),
+    status: 'sent' as const,
+    is_context_edge: 0,
+    metadata: '{}',
+    created_at: Date.now(),
+    updated_at: Date.now()
+  }
+}
+
+function makeDeepchatAssistantRow(
+  orderSeq: number,
+  content: string,
+  id = `a${orderSeq}`,
+  status: 'sent' | 'pending' | 'error' = 'sent'
+) {
+  return {
+    id,
+    session_id: 's1',
+    order_seq: orderSeq,
+    role: 'assistant' as const,
+    content: JSON.stringify([
+      { type: 'content', content, status: 'success', timestamp: Date.now() }
+    ]),
+    status,
+    is_context_edge: 0,
+    metadata: '{}',
+    created_at: Date.now(),
+    updated_at: Date.now()
+  }
+}
+
 describe('AgentRuntimePresenter', () => {
   let sqlitePresenter: ReturnType<typeof createMockSqlitePresenter>
   let llmProvider: ReturnType<typeof createMockLlmProviderPresenter>
@@ -420,6 +457,47 @@ describe('AgentRuntimePresenter', () => {
       tempHome = null
     }
   })
+
+  function installSessionRows(initialRows: any[]) {
+    let rows = [...initialRows]
+    sqlitePresenter.deepchatMessagesTable.getBySession.mockImplementation((sessionId: string) =>
+      rows.filter((row) => row.session_id === sessionId)
+    )
+    sqlitePresenter.deepchatMessagesTable.get.mockImplementation((id: string) =>
+      rows.find((row) => row.id === id)
+    )
+    sqlitePresenter.deepchatMessagesTable.getLastUserMessageBeforeOrAtOrderSeq.mockImplementation(
+      (sessionId: string, orderSeq: number) =>
+        [...rows]
+          .reverse()
+          .find(
+            (row) =>
+              row.session_id === sessionId && row.role === 'user' && row.order_seq <= orderSeq
+          )
+    )
+    sqlitePresenter.deepchatMessagesTable.getIdsFromOrderSeq.mockImplementation(
+      (sessionId: string, fromOrderSeq: number) =>
+        rows
+          .filter((row) => row.session_id === sessionId && row.order_seq >= fromOrderSeq)
+          .map((row) => row.id)
+    )
+    sqlitePresenter.deepchatMessagesTable.deleteFromOrderSeq.mockImplementation(
+      (sessionId: string, fromOrderSeq: number) => {
+        rows = rows.filter((row) => row.session_id !== sessionId || row.order_seq < fromOrderSeq)
+      }
+    )
+    sqlitePresenter.deepchatMessagesTable.getMaxOrderSeq.mockImplementation((sessionId: string) =>
+      rows.reduce(
+        (maxOrderSeq, row) =>
+          row.session_id === sessionId ? Math.max(maxOrderSeq, row.order_seq) : maxOrderSeq,
+        0
+      )
+    )
+
+    return {
+      getRows: () => rows
+    }
+  }
 
   describe('constructor (crash recovery)', () => {
     it('calls pending status query on init', () => {
@@ -3658,6 +3736,114 @@ describe('AgentRuntimePresenter', () => {
         cursorOrderSeq: 3,
         summaryUpdatedAt: 333
       })
+    })
+  })
+
+  describe('retry context overflow recovery', () => {
+    it('recovers an unfittable retry provider request before calling the provider', async () => {
+      await agent.initSession('s1', {
+        providerId: 'openai',
+        modelId: 'gpt-4',
+        generationSettings: {
+          contextLength: 8192,
+          maxTokens: 1024
+        }
+      })
+      installSessionRows([
+        makeDeepchatUserRow(1, 'A'.repeat(100)),
+        makeDeepchatAssistantRow(2, 'B'.repeat(100)),
+        makeDeepchatUserRow(3, 'C'.repeat(100)),
+        makeDeepchatAssistantRow(4, 'D'.repeat(100)),
+        makeDeepchatUserRow(5, 'E'.repeat(100)),
+        makeDeepchatAssistantRow(6, 'F'.repeat(100)),
+        makeDeepchatUserRow(7, 'retry target', 'retry-user'),
+        makeDeepchatAssistantRow(8, 'failed answer', 'retry-assistant', 'error')
+      ])
+
+      await agent.retryMessage('s1', 'retry-assistant')
+
+      const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const providerCoreStream = llmProvider.getProviderInstance.mock.results[0].value.coreStream
+      providerCoreStream.mockClear()
+      llmProvider.generateText.mockClear()
+      const oversizedSystemPrompt = makeTextWithEstimatedTokens(9000)
+      for await (const _event of callArgs.coreStream(
+        [
+          { role: 'system', content: oversizedSystemPrompt },
+          { role: 'user', content: 'retry target' }
+        ],
+        callArgs.modelId,
+        callArgs.modelConfig,
+        callArgs.temperature,
+        callArgs.maxTokens,
+        callArgs.tools
+      )) {
+      }
+
+      const providerCall = providerCoreStream.mock.calls[0]
+      const providerMessages = providerCall[0]
+      const providerMaxTokens = providerCall[4]
+      const providerTools = providerCall[5]
+      const totalRequestTokens =
+        estimateMessagesTokens(providerMessages) +
+        estimateToolReserveTokens(providerTools) +
+        providerMaxTokens
+
+      expect(llmProvider.generateText).toHaveBeenCalled()
+      expect(providerCoreStream).toHaveBeenCalledTimes(1)
+      expect(providerMessages[0].content).not.toBe(oversizedSystemPrompt)
+      expect(providerMessages[0].content).toContain('## Conversation Summary')
+      expect(providerMaxTokens).toBeGreaterThan(0)
+      expect(totalRequestTokens).toBeLessThanOrEqual(getUsableContextLength(8192))
+    })
+
+    it('fails retry with budget guidance when the current input cannot fit', async () => {
+      const actualProcessModule = await vi.importActual<
+        typeof import('@/presenter/agentRuntimePresenter/process')
+      >('@/presenter/agentRuntimePresenter/process')
+      ;(processStream as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        actualProcessModule.processStream
+      )
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      await agent.initSession('s1', {
+        providerId: 'openai',
+        modelId: 'gpt-4',
+        generationSettings: {
+          contextLength: 8192,
+          maxTokens: 1024
+        }
+      })
+      installSessionRows([
+        makeDeepchatUserRow(1, makeTextWithEstimatedTokens(9000), 'retry-user'),
+        makeDeepchatAssistantRow(2, 'failed answer', 'retry-assistant', 'error')
+      ])
+
+      await agent.retryMessage('s1', 'retry-assistant')
+      consoleError.mockRestore()
+
+      const providerCoreStream = llmProvider.getProviderInstance.mock.results[0].value.coreStream
+      const errorUpdate = sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls
+        .filter((call) => call[2] === 'error')
+        .find((call) => String(call[1]).includes('Request was not sent'))
+      const errorBlocks = JSON.parse(errorUpdate?.[1] ?? '[]')
+
+      expect(providerCoreStream).not.toHaveBeenCalled()
+      expect(errorUpdate).toBeTruthy()
+      expect(errorBlocks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'error',
+            content: expect.stringContaining('lowering max output tokens')
+          })
+        ])
+      )
+      expect(eventBus.sendToRenderer).toHaveBeenCalledWith(
+        'stream:error',
+        'all',
+        expect.objectContaining({
+          error: expect.stringContaining('Request was not sent')
+        })
+      )
     })
   })
 

--- a/test/main/presenter/agentRuntimePresenter/contextBudget.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/contextBudget.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   AGENT_CONTEXT_PRESSURE_MIN_OUTPUT_TOKENS,
+  buildRequestContextBudgetDiagnostics,
+  buildRequestContextOverflowErrorMessage,
   getUsableContextLength,
   preflightRequestContext
 } from '@/presenter/agentRuntimePresenter/contextBudget'
@@ -97,5 +99,27 @@ describe('agent request context budget', () => {
       { role: 'system', content: 'sys' },
       { role: 'user', content: 'continue' }
     ])
+  })
+
+  it('formats diagnostics for unfittable preflight results', () => {
+    const result = preflightRequestContext({
+      messages: [{ role: 'user', content: 'x'.repeat(9000) }],
+      tools: [],
+      contextLength: 8192,
+      requestedMaxTokens: 4096
+    })
+
+    expect(buildRequestContextBudgetDiagnostics(result)).toMatchObject({
+      usableContextLength: 7936,
+      inputTokens: result.inputTokens,
+      toolReserveTokens: 0,
+      requestedMaxTokens: 4096,
+      effectiveMaxTokens: 0,
+      remainingOutputTokens: expect.any(Number),
+      totalRequestTokens: result.inputTokens
+    })
+    expect(buildRequestContextOverflowErrorMessage(result)).toContain('Request was not sent')
+    expect(buildRequestContextOverflowErrorMessage(result)).toContain('remaining output room')
+    expect(buildRequestContextOverflowErrorMessage(result)).toContain('lowering max output tokens')
   })
 })

--- a/test/renderer/components/MarkdownRenderer.test.ts
+++ b/test/renderer/components/MarkdownRenderer.test.ts
@@ -78,15 +78,30 @@ const setup = async (props: Record<string, unknown> = {}) => {
 
     const NodeRenderer = defineComponent({
       name: 'NodeRenderer',
-      setup() {
+      props: {
+        smoothStreaming: {
+          type: Boolean,
+          default: false
+        }
+      },
+      setup(props) {
         return () =>
-          customComponents.code_block?.({
-            node: {
-              language: 'html',
-              code: '<h1>Hello</h1>',
-              raw: '<h1>Hello</h1>'
-            }
-          }) ?? h('div')
+          h(
+            'div',
+            {
+              'data-testid': 'node-renderer',
+              'data-smooth-streaming': String(props.smoothStreaming)
+            },
+            [
+              customComponents.code_block?.({
+                node: {
+                  language: 'html',
+                  code: '<h1>Hello</h1>',
+                  raw: '<h1>Hello</h1>'
+                }
+              }) ?? h('div')
+            ]
+          )
       }
     })
 
@@ -197,6 +212,24 @@ describe('MarkdownRenderer', () => {
       'artifact-msg-fallback-message',
       'artifact-thread-fallback-thread',
       { force: true }
+    )
+  })
+
+  it('disables smooth streaming by default', async () => {
+    const { wrapper } = await setup()
+
+    expect(wrapper.get('[data-testid="node-renderer"]').attributes('data-smooth-streaming')).toBe(
+      'false'
+    )
+  })
+
+  it('passes explicit smooth streaming to NodeRenderer', async () => {
+    const { wrapper } = await setup({
+      smoothStreaming: true
+    })
+
+    expect(wrapper.get('[data-testid="node-renderer"]').attributes('data-smooth-streaming')).toBe(
+      'true'
     )
   })
 

--- a/test/renderer/components/message/MessageBlockContent.test.ts
+++ b/test/renderer/components/message/MessageBlockContent.test.ts
@@ -67,13 +67,17 @@ vi.mock('@/components/markdown/MarkdownRenderer.vue', () => ({
         type: String,
         default: undefined
       },
+      smoothStreaming: {
+        type: Boolean,
+        default: false
+      },
       linkContext: {
         type: Object as () => MarkdownLinkContext | undefined,
         default: undefined
       }
     },
     template:
-      '<div class="markdown-stub" :data-message-id="messageId" :data-thread-id="threadId" :data-link-source="linkContext?.source" :data-link-session-id="linkContext?.sessionId">{{ content }}</div>'
+      '<div class="markdown-stub" :data-message-id="messageId" :data-thread-id="threadId" :data-link-source="linkContext?.source" :data-link-session-id="linkContext?.sessionId" :data-smooth-streaming="String(smoothStreaming)">{{ content }}</div>'
   })
 }))
 
@@ -177,4 +181,41 @@ describe('MessageBlockContent', () => {
     expect(markdown.attributes('data-link-session-id')).toBe('s3')
     expect(markdown.text()).toContain('plain markdown content')
   })
+
+  it('disables smooth streaming for completed content blocks', async () => {
+    const wrapper = mount(MessageBlockContent, {
+      props: {
+        block: createBlock({
+          status: 'success',
+          content: 'completed markdown content'
+        }),
+        messageId: 'm4',
+        threadId: 's4'
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.get('.markdown-stub').attributes('data-smooth-streaming')).toBe('false')
+  })
+
+  it.each(['pending', 'loading'] as const)(
+    'enables smooth streaming for %s content blocks',
+    async (status) => {
+      const wrapper = mount(MessageBlockContent, {
+        props: {
+          block: createBlock({
+            status,
+            content: `${status} markdown content`
+          }),
+          messageId: 'm5',
+          threadId: 's5'
+        }
+      })
+
+      await flushPromises()
+
+      expect(wrapper.get('.markdown-stub').attributes('data-smooth-streaming')).toBe('true')
+    }
+  )
 })


### PR DESCRIPTION
## Summary

- Add context-budget diagnostics to overflow errors and trigger recovery for unrecoverable preflight pressure.
- Add an explicit smoothStreaming prop for markdown rendering and enable it only while message blocks are generating.
- Document both fixes with SDD notes and expand main/renderer test coverage.

## UI Structure

BEFORE
```
MessageBlockContent
└─ MarkdownRenderer
   └─ NodeRenderer streaming behavior not controlled by block status
```

AFTER
```
MessageBlockContent pending/loading
└─ MarkdownRenderer smoothStreaming=true

MessageBlockContent completed
└─ MarkdownRenderer smoothStreaming=false
```

## Tests

- pnpm run format
- pnpm run i18n
- pnpm run lint
- commit hook: pnpm run typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling when requests exceed model context limits, providing actionable guidance to reduce input size or adjust output settings
  * Smooth streaming control for markdown rendering: completed messages display without animation while actively generating content streams smoothly

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1605)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->