### PR TITLE
fix(agent): preserve failed context

### DIFF
--- a/docs/issues/failed-message-context/plan.md
+++ b/docs/issues/failed-message-context/plan.md
@@ -1,0 +1,19 @@
+# Failed Message Context Preservation Plan
+
+## Approach
+
+- Add a shared runtime predicate for context-eligible records: include `sent` records and `assistant:error` records, exclude `pending` and `user:error`.
+- Update `recordToChatMessages` to append a readable assistant summary for error blocks while preserving existing content, reasoning, and settled tool call replay behavior.
+- Use the same eligibility predicate in new-turn history collection, resume context, and compaction inputs.
+
+## Data Flow
+
+- Failed generation already persists an assistant `error` record with terminal error blocks.
+- On the next turn, `buildContext` selects eligible records and converts the failed assistant record into provider-facing assistant text.
+- Compaction receives the same eligible assistant error records so summarized history matches provider context.
+
+## Compatibility
+
+- Stored records are unchanged.
+- Existing sent history behavior and provider tool-message ordering remain unchanged.
+- Pending interactions keep their existing resume path and are not included in normal next-turn context.

--- a/docs/issues/failed-message-context/spec.md
+++ b/docs/issues/failed-message-context/spec.md
@@ -1,0 +1,22 @@
+# Failed Message Context Preservation
+
+## User Story
+
+When an agent loop fails or is canceled, the next user turn should still know what happened. The failed assistant message, including any partial progress and the failure reason, must be included in the next request context so the model can recover instead of repeating work.
+
+## Acceptance Criteria
+
+- Assistant messages with status `error` are eligible for future agent context.
+- User messages with status `error` and all `pending` messages remain excluded from normal next-turn context.
+- Error blocks are converted into readable context text:
+  - `common.error.userCanceledGeneration` becomes `User canceled generation`.
+  - Unknown error text is preserved as-is.
+- If the failed assistant message has partial content, that content is preserved and followed by a failure or cancellation summary.
+- Settled tool calls with non-empty responses are still replayed; unfinished tool calls are not fabricated into tool results.
+- Auto-compaction and resume context budgeting consider assistant error records consistently with next-turn context.
+
+## Non-Goals
+
+- No database schema changes.
+- No IPC, renderer UI, or message storage format changes.
+- No attempt to resume unfinished tool calls without stored tool responses.

--- a/docs/issues/failed-message-context/tasks.md
+++ b/docs/issues/failed-message-context/tasks.md
@@ -1,0 +1,7 @@
+# Failed Message Context Preservation Tasks
+
+- [x] Add SDD spec, plan, and task documents.
+- [x] Add focused context-builder tests for assistant error and cancel records.
+- [x] Update context-builder record eligibility and assistant error conversion.
+- [x] Reuse eligibility in agent runtime and compaction history selection.
+- [x] Run focused tests and required repository quality commands.

--- a/src/main/presenter/agentRuntimePresenter/compactionService.ts
+++ b/src/main/presenter/agentRuntimePresenter/compactionService.ts
@@ -15,6 +15,8 @@ import {
   buildUserMessageContent,
   createUserChatMessage,
   estimateMessagesTokens,
+  formatAssistantErrorSummary,
+  isContextHistoryRecord,
   normalizeUserInput
 } from './contextBuilder'
 
@@ -144,6 +146,7 @@ function serializeUserRecord(record: ChatMessageRecord): string {
 function serializeAssistantRecord(record: ChatMessageRecord): string {
   const blocks = parseAssistantBlocks(record)
   const lines: string[] = [`[Assistant][order=${record.orderSeq}]`]
+  const errorMessages: string[] = []
 
   for (const block of blocks) {
     if ((block.type === 'content' || block.type === 'reasoning_content') && block.content) {
@@ -171,7 +174,16 @@ function serializeAssistantRecord(record: ChatMessageRecord): string {
       if (actionContent) {
         lines.push(actionContent)
       }
+      continue
     }
+    if (block.type === 'error' && block.content) {
+      errorMessages.push(block.content)
+    }
+  }
+
+  const errorSummary = formatAssistantErrorSummary(errorMessages)
+  if (errorSummary) {
+    lines.push(errorSummary)
   }
 
   return lines.join('\n')
@@ -246,14 +258,14 @@ export class CompactionService {
       return null
     }
 
-    const sentRecords = this.messageStore
+    const historyRecords = this.messageStore
       .getMessages(params.sessionId)
-      .filter((record) => record.status === 'sent' && !isCompactionRecord(record))
+      .filter(isContextHistoryRecord)
       .sort((a, b) => a.orderSeq - b.orderSeq)
 
     return this.prepareCompaction({
       ...params,
-      records: sentRecords,
+      records: historyRecords,
       protectedTurnCount: settings.retainRecentPairs,
       triggerThreshold: settings.triggerThreshold,
       projectedMessages: [createUserChatMessage(params.newUserContent, params.supportsVision)]
@@ -297,7 +309,7 @@ export class CompactionService {
       if (record.id === params.messageId) {
         return true
       }
-      return record.status === 'sent'
+      return isContextHistoryRecord(record)
     })
 
     return this.prepareCompaction({
@@ -330,14 +342,14 @@ export class CompactionService {
       return null
     }
 
-    const sentRecords = this.messageStore
+    const historyRecords = this.messageStore
       .getMessages(params.sessionId)
-      .filter((record) => record.status === 'sent' && !isCompactionRecord(record))
+      .filter(isContextHistoryRecord)
       .sort((a, b) => a.orderSeq - b.orderSeq)
 
     return this.prepareCompaction({
       ...params,
-      records: sentRecords,
+      records: historyRecords,
       protectedTurnCount: settings.retainRecentPairs,
       triggerThreshold: settings.triggerThreshold,
       projectedMessages: params.projectedMessages,

--- a/src/main/presenter/agentRuntimePresenter/compactionService.ts
+++ b/src/main/presenter/agentRuntimePresenter/compactionService.ts
@@ -184,6 +184,11 @@ function serializeAssistantRecord(record: ChatMessageRecord): string {
   const errorSummary = formatAssistantErrorSummary(errorMessages)
   if (errorSummary) {
     lines.push(errorSummary)
+  } else if (record.status === 'error') {
+    const fallbackSummary = formatAssistantErrorSummary(['Unknown error'])
+    if (fallbackSummary) {
+      lines.push(fallbackSummary)
+    }
   }
 
   return lines.join('\n')

--- a/src/main/presenter/agentRuntimePresenter/contextBuilder.ts
+++ b/src/main/presenter/agentRuntimePresenter/contextBuilder.ts
@@ -11,6 +11,13 @@ import type {
 import type { DeepChatMessageStore } from './messageStore'
 
 const IMAGE_TOKEN_ESTIMATE = 512
+const UNKNOWN_ASSISTANT_ERROR = 'Unknown error'
+const KNOWN_ERROR_REASON_TEXT: Record<string, string> = {
+  'common.error.userCanceledGeneration': 'User canceled generation',
+  'common.error.sessionInterrupted':
+    'Session was unexpectedly interrupted, generation is incomplete',
+  'common.error.noModelResponse': 'Model did not return any content, it may have timed out'
+}
 
 export type ContextBuildOptions = {
   summaryCursorOrderSeq?: number
@@ -104,6 +111,16 @@ function isCompactionRecord(record: ChatMessageRecord): boolean {
   } catch {
     return false
   }
+}
+
+export function isContextHistoryRecord(record: ChatMessageRecord): boolean {
+  if (isCompactionRecord(record)) {
+    return false
+  }
+  if (record.status === 'sent') {
+    return true
+  }
+  return record.role === 'assistant' && record.status === 'error'
 }
 
 function buildNonImageFileContext(files: MessageFile[]): string {
@@ -248,6 +265,69 @@ export function estimateToolDefinitionTokens(toolDefinitions: MCPToolDefinition[
   )
 }
 
+export function normalizeAssistantErrorReason(value: string): string {
+  const trimmed = value.trim()
+  return KNOWN_ERROR_REASON_TEXT[trimmed] ?? trimmed
+}
+
+export function formatAssistantErrorSummary(errorMessages: string[]): string | null {
+  const reasons = errorMessages
+    .map(normalizeAssistantErrorReason)
+    .filter((message) => message.length > 0)
+
+  if (reasons.length === 0) {
+    return null
+  }
+
+  const uniqueReasons = [...new Set(reasons)]
+  const onlyUserCanceled =
+    uniqueReasons.length === 1 &&
+    uniqueReasons[0] === KNOWN_ERROR_REASON_TEXT['common.error.userCanceledGeneration']
+  const label = onlyUserCanceled ? 'Generation canceled' : 'Generation failed'
+  return `[${label}]\nReason: ${uniqueReasons.join('\n')}`
+}
+
+function buildAssistantErrorSummary(
+  blocks: AssistantMessageBlock[],
+  record: ChatMessageRecord
+): string | null {
+  const errorMessages = blocks
+    .filter(
+      (block): block is AssistantMessageBlock & { content: string } =>
+        block.type === 'error' &&
+        typeof block.content === 'string' &&
+        block.content.trim().length > 0
+    )
+    .map((block) => block.content)
+
+  if (errorMessages.length > 0) {
+    return formatAssistantErrorSummary(errorMessages)
+  }
+
+  if (record.status === 'error') {
+    return formatAssistantErrorSummary([UNKNOWN_ASSISTANT_ERROR])
+  }
+
+  return null
+}
+
+function appendAssistantTextContent(
+  content: ChatMessage['content'],
+  extraText: string | null
+): ChatMessage['content'] {
+  if (!extraText) {
+    return content
+  }
+
+  if (Array.isArray(content)) {
+    return [...content, { type: 'text', text: extraText }]
+  }
+
+  return [typeof content === 'string' ? content : '', extraText]
+    .filter((value) => value.trim().length > 0)
+    .join('\n\n')
+}
+
 /**
  * Convert a ChatMessageRecord from the DB into one or more ChatMessages for the LLM.
  * Only settled tool calls (with a non-empty response) are included in history.
@@ -268,6 +348,7 @@ export function recordToChatMessages(
   }
 
   const blocks = JSON.parse(record.content) as AssistantMessageBlock[]
+  const errorSummary = buildAssistantErrorSummary(blocks, record)
   const combinedText = blocks
     .filter((block) => block.type === 'content' || block.type === 'reasoning_content')
     .map((block) => block.content)
@@ -325,13 +406,19 @@ export function recordToChatMessages(
   )
 
   if (toolCallBlocks.length === 0) {
+    const contentWithErrorSummary = appendAssistantTextContent(
+      preserveEmptyInterleavedReasoning || shouldPreserveReasoning
+        ? assistantContent
+        : combinedText,
+      errorSummary
+    )
     if (shouldPreserveReasoning) {
-      return [applyReasoningContent({ role: 'assistant', content: assistantContent })]
+      return [applyReasoningContent({ role: 'assistant', content: contentWithErrorSummary })]
     }
     if (preserveEmptyInterleavedReasoning) {
-      return [{ role: 'assistant', content: assistantContent }]
+      return [{ role: 'assistant', content: contentWithErrorSummary }]
     }
-    return [{ role: 'assistant', content: combinedText }]
+    return [{ role: 'assistant', content: contentWithErrorSummary }]
   }
 
   const toolCalls: NonNullable<ChatMessage['tool_calls']> = []
@@ -351,13 +438,19 @@ export function recordToChatMessages(
   }
 
   if (toolCalls.length === 0) {
+    const contentWithErrorSummary = appendAssistantTextContent(
+      preserveEmptyInterleavedReasoning || shouldPreserveReasoning
+        ? assistantContent
+        : combinedText,
+      errorSummary
+    )
     if (shouldPreserveReasoning) {
-      return [applyReasoningContent({ role: 'assistant', content: assistantContent })]
+      return [applyReasoningContent({ role: 'assistant', content: contentWithErrorSummary })]
     }
     if (preserveEmptyInterleavedReasoning) {
-      return [{ role: 'assistant', content: assistantContent }]
+      return [{ role: 'assistant', content: contentWithErrorSummary }]
     }
-    return [{ role: 'assistant', content: combinedText }]
+    return [{ role: 'assistant', content: contentWithErrorSummary }]
   }
 
   const assistantMessage: ChatMessage = {
@@ -374,6 +467,9 @@ export function recordToChatMessages(
       tool_call_id: block.tool_call!.id,
       content: block.tool_call!.response || ''
     })
+  }
+  if (errorSummary) {
+    result.push({ role: 'assistant', content: errorSummary })
   }
 
   return result
@@ -542,10 +638,11 @@ export function buildContext(
   supportsVision: boolean = false,
   options: ContextBuildOptions = {}
 ): ChatMessage[] {
-  const sentRecords =
-    options.historyRecords ??
-    messageStore.getMessages(sessionId).filter((message) => message.status === 'sent')
-  const historyRecords = filterRecordsFromCursor(sentRecords, options.summaryCursorOrderSeq ?? 1)
+  const candidateRecords = options.historyRecords ?? messageStore.getMessages(sessionId)
+  const historyRecords = filterRecordsFromCursor(
+    candidateRecords.filter(isContextHistoryRecord),
+    options.summaryCursorOrderSeq ?? 1
+  )
   const historyTurns = buildHistoryTurns(
     historyRecords,
     supportsVision,
@@ -640,7 +737,7 @@ export function buildResumeContext(
     if (message.id === assistantMessageId) {
       return true
     }
-    if (message.status !== 'sent') {
+    if (!isContextHistoryRecord(message)) {
       return false
     }
     return message.orderSeq >= cursor

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -70,7 +70,8 @@ import {
   buildContext,
   buildResumeContext,
   createUserChatMessage,
-  fitMessagesToContextWindow
+  fitMessagesToContextWindow,
+  isContextHistoryRecord
 } from './contextBuilder'
 import {
   capAgentDefaultMaxTokens,
@@ -644,9 +645,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         activeSkillNames
       )
       this.throwIfAbortRequested(preStreamAbortSignal)
-      const historyRecords = this.messageStore
-        .getMessages(sessionId)
-        .filter((message) => message.status === 'sent')
+      const historyRecords = this.messageStore.getMessages(sessionId).filter(isContextHistoryRecord)
       const userContent: UserMessageContent = {
         text: normalizedInput.text,
         files: normalizedInput.files || [],

--- a/test/main/presenter/agentRuntimePresenter/compactionService.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/compactionService.test.ts
@@ -24,7 +24,8 @@ vi.mock('@/presenter/agentRuntimePresenter/contextBuilder', async (importOrigina
 function makeUserRecord(
   orderSeq: number,
   text: string,
-  files: Array<Record<string, unknown>> = []
+  files: Array<Record<string, unknown>> = [],
+  status: 'sent' | 'pending' | 'error' = 'sent'
 ) {
   return {
     id: `user-${orderSeq}`,
@@ -32,7 +33,7 @@ function makeUserRecord(
     orderSeq,
     role: 'user' as const,
     content: JSON.stringify({ text, files, links: [], search: false, think: false }),
-    status: 'sent' as const,
+    status,
     isContextEdge: 0,
     metadata: '{}',
     createdAt: Date.now(),
@@ -40,7 +41,11 @@ function makeUserRecord(
   }
 }
 
-function makeAssistantRecord(orderSeq: number, text: string) {
+function makeAssistantRecord(
+  orderSeq: number,
+  text: string,
+  status: 'sent' | 'pending' | 'error' = 'sent'
+) {
   return {
     id: `assistant-${orderSeq}`,
     sessionId: 's1',
@@ -49,7 +54,24 @@ function makeAssistantRecord(orderSeq: number, text: string) {
     content: JSON.stringify([
       { type: 'content', content: text, status: 'success', timestamp: Date.now() }
     ]),
-    status: 'sent' as const,
+    status,
+    isContextEdge: 0,
+    metadata: '{}',
+    createdAt: Date.now(),
+    updatedAt: Date.now()
+  }
+}
+
+function makeAssistantErrorRecord(orderSeq: number, errorMessage: string) {
+  return {
+    id: `assistant-${orderSeq}`,
+    sessionId: 's1',
+    orderSeq,
+    role: 'assistant' as const,
+    content: JSON.stringify([
+      { type: 'error', content: errorMessage, status: 'error', timestamp: Date.now() }
+    ]),
+    status: 'error' as const,
     isContextEdge: 0,
     metadata: '{}',
     createdAt: Date.now(),
@@ -370,6 +392,66 @@ describe('CompactionService', () => {
 
     expect(buildHistoryTurns).toHaveBeenNthCalledWith(1, expect.any(Array), false, false, false)
     expect(buildHistoryTurns).toHaveBeenNthCalledWith(2, expect.any(Array), false, true, false)
+  })
+
+  it('passes assistant error records into next-turn compaction but excludes errored users', async () => {
+    const { service, messageStore } = createService({
+      sessionConfig: {
+        autoCompactionRetainRecentPairs: 1
+      }
+    })
+    messageStore.getMessages.mockReturnValue([
+      makeUserRecord(1, 'first turn '.repeat(20)),
+      makeAssistantErrorRecord(2, 'provider failed'),
+      makeUserRecord(3, 'failed user', [], 'error'),
+      makeUserRecord(4, 'second turn '.repeat(20)),
+      makeAssistantRecord(5, 'second reply '.repeat(20)),
+      makeUserRecord(6, 'third turn '.repeat(20)),
+      makeAssistantRecord(7, 'third reply '.repeat(20))
+    ])
+
+    await service.prepareForNextUserTurn({
+      sessionId: 's1',
+      providerId: 'openai',
+      modelId: 'gpt-4o',
+      systemPrompt: '',
+      contextLength: 700,
+      reserveTokens: 100,
+      supportsVision: false,
+      preserveInterleavedReasoning: false,
+      newUserContent: 'latest turn'
+    })
+
+    const buildHistoryTurns = vi.mocked(contextBuilderModule.buildHistoryTurns)
+    const records = buildHistoryTurns.mock.calls.at(-1)?.[0] ?? []
+    expect(records.map((record) => record.id)).toContain('assistant-2')
+    expect(records.map((record) => record.id)).not.toContain('user-3')
+  })
+
+  it('passes assistant error records into forced context-pressure compaction', async () => {
+    const { service, messageStore } = createService()
+    messageStore.getMessages.mockReturnValue([
+      makeUserRecord(1, 'first turn '.repeat(20)),
+      makeAssistantErrorRecord(2, 'provider failed'),
+      makeUserRecord(3, 'second turn '.repeat(20)),
+      makeAssistantRecord(4, 'second reply '.repeat(20))
+    ])
+
+    await service.prepareForContextPressureRecovery({
+      sessionId: 's1',
+      providerId: 'openai',
+      modelId: 'gpt-4o',
+      systemPrompt: '',
+      contextLength: 700,
+      reserveTokens: 100,
+      supportsVision: false,
+      preserveInterleavedReasoning: false,
+      projectedMessages: []
+    })
+
+    const buildHistoryTurns = vi.mocked(contextBuilderModule.buildHistoryTurns)
+    const records = buildHistoryTurns.mock.calls.at(-1)?.[0] ?? []
+    expect(records.map((record) => record.id)).toContain('assistant-2')
   })
 
   it('retains the configured recent pairs plus the resume target turn', async () => {

--- a/test/main/presenter/agentRuntimePresenter/compactionService.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/compactionService.test.ts
@@ -428,6 +428,36 @@ describe('CompactionService', () => {
     expect(records.map((record) => record.id)).not.toContain('user-3')
   })
 
+  it('summarizes assistant error records without explicit error blocks as unknown failures', async () => {
+    const { service, messageStore } = createService({
+      sessionConfig: {
+        autoCompactionRetainRecentPairs: 1
+      }
+    })
+    messageStore.getMessages.mockReturnValue([
+      makeUserRecord(1, 'first turn '.repeat(20)),
+      makeAssistantRecord(2, 'partial answer', 'error'),
+      makeUserRecord(3, 'second turn '.repeat(20)),
+      makeAssistantRecord(4, 'second reply '.repeat(20)),
+      makeUserRecord(5, 'third turn '.repeat(20)),
+      makeAssistantRecord(6, 'third reply '.repeat(20))
+    ])
+
+    const intent = await service.prepareForNextUserTurn({
+      sessionId: 's1',
+      providerId: 'openai',
+      modelId: 'gpt-4o',
+      systemPrompt: '',
+      contextLength: 700,
+      reserveTokens: 100,
+      supportsVision: false,
+      preserveInterleavedReasoning: false,
+      newUserContent: 'latest turn'
+    })
+
+    expect(intent?.summaryBlocks.join('\n')).toContain('[Generation failed]\nReason: Unknown error')
+  })
+
   it('passes assistant error records into forced context-pressure compaction', async () => {
     const { service, messageStore } = createService()
     messageStore.getMessages.mockReturnValue([

--- a/test/main/presenter/agentRuntimePresenter/contextBuilder.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/contextBuilder.test.ts
@@ -78,6 +78,64 @@ function makeAssistantRecord(
   }
 }
 
+function makeAssistantErrorRecord(
+  orderSeq: number,
+  errorMessage: string,
+  partialText: string = ''
+) {
+  return {
+    id: `asst-${orderSeq}`,
+    sessionId: 's1',
+    orderSeq,
+    role: 'assistant' as const,
+    content: JSON.stringify([
+      ...(partialText
+        ? [{ type: 'content', content: partialText, status: 'success', timestamp: Date.now() }]
+        : []),
+      { type: 'error', content: errorMessage, status: 'error', timestamp: Date.now() }
+    ]),
+    status: 'error' as const,
+    isContextEdge: 0,
+    metadata: '{}',
+    createdAt: Date.now(),
+    updatedAt: Date.now()
+  }
+}
+
+function makeAssistantErrorWithToolRecord(
+  orderSeq: number,
+  text: string,
+  toolResponse: string,
+  errorMessage: string
+) {
+  return {
+    id: `asst-${orderSeq}`,
+    sessionId: 's1',
+    orderSeq,
+    role: 'assistant' as const,
+    content: JSON.stringify([
+      { type: 'content', content: text, status: 'success', timestamp: Date.now() },
+      {
+        type: 'tool_call',
+        status: 'success',
+        timestamp: Date.now(),
+        tool_call: {
+          id: `tc-${orderSeq}`,
+          name: 'example_tool',
+          params: '{"foo":"bar"}',
+          response: toolResponse
+        }
+      },
+      { type: 'error', content: errorMessage, status: 'error', timestamp: Date.now() }
+    ]),
+    status: 'error' as const,
+    isContextEdge: 0,
+    metadata: '{}',
+    createdAt: Date.now(),
+    updatedAt: Date.now()
+  }
+}
+
 function makeAssistantWithReasoningRecord(orderSeq: number, text: string, reasoning: string) {
   return {
     id: `asst-${orderSeq}`,
@@ -328,19 +386,19 @@ describe('buildContext', () => {
     expect(result[5]).toEqual({ role: 'user', content: 'msg3' })
   })
 
-  it('filters out error messages', () => {
+  it('includes assistant error messages with readable failure reasons', () => {
     const messages = [
       makeUserRecord(1, 'msg1'),
-      makeAssistantRecord(2, 'error reply', 'error'),
+      makeAssistantErrorRecord(2, 'provider exploded'),
       makeUserRecord(3, 'msg2'),
       makeAssistantRecord(4, 'good reply')
     ]
     const store = createMockMessageStore(messages)
     const result = buildContext('s1', 'msg3', '', 10000, 4096, store)
 
-    // Should only include msg1, msg2, good reply (skip error)
     expect(result).toEqual([
       { role: 'user', content: 'msg1' },
+      { role: 'assistant', content: '[Generation failed]\nReason: provider exploded' },
       { role: 'user', content: 'msg2' },
       { role: 'assistant', content: 'good reply' },
       { role: 'user', content: 'msg3' }
@@ -355,6 +413,80 @@ describe('buildContext', () => {
     expect(result).toEqual([
       { role: 'user', content: 'msg1' },
       { role: 'user', content: 'msg2' }
+    ])
+  })
+
+  it('filters out errored user messages', () => {
+    const messages = [makeUserRecord(1, 'failed submit', 'error'), makeUserRecord(2, 'msg2')]
+    const store = createMockMessageStore(messages)
+    const result = buildContext('s1', 'msg3', '', 10000, 4096, store)
+
+    expect(result).toEqual([
+      { role: 'user', content: 'msg2' },
+      { role: 'user', content: 'msg3' }
+    ])
+  })
+
+  it('converts canceled assistant messages to a readable cancel summary', () => {
+    const messages = [
+      makeUserRecord(1, 'stop this'),
+      makeAssistantErrorRecord(2, 'common.error.userCanceledGeneration')
+    ]
+    const store = createMockMessageStore(messages)
+    const result = buildContext('s1', 'continue', '', 10000, 4096, store)
+
+    expect(result).toEqual([
+      { role: 'user', content: 'stop this' },
+      {
+        role: 'assistant',
+        content: '[Generation canceled]\nReason: User canceled generation'
+      },
+      { role: 'user', content: 'continue' }
+    ])
+  })
+
+  it('preserves partial assistant content before the failure reason', () => {
+    const messages = [
+      makeUserRecord(1, 'do work'),
+      makeAssistantErrorRecord(2, 'timeout', 'Partial answer')
+    ]
+    const store = createMockMessageStore(messages)
+    const result = buildContext('s1', 'continue', '', 10000, 4096, store)
+
+    expect(result).toEqual([
+      { role: 'user', content: 'do work' },
+      {
+        role: 'assistant',
+        content: 'Partial answer\n\n[Generation failed]\nReason: timeout'
+      },
+      { role: 'user', content: 'continue' }
+    ])
+  })
+
+  it('replays settled tool calls before appending terminal failure context', () => {
+    const messages = [
+      makeUserRecord(1, 'use a tool'),
+      makeAssistantErrorWithToolRecord(2, 'Checking...', 'tool result', 'terminal failure')
+    ]
+    const store = createMockMessageStore(messages)
+    const result = buildContext('s1', 'continue', '', 10000, 4096, store)
+
+    expect(result).toEqual([
+      { role: 'user', content: 'use a tool' },
+      {
+        role: 'assistant',
+        content: 'Checking...',
+        tool_calls: [
+          {
+            id: 'tc-2',
+            type: 'function',
+            function: { name: 'example_tool', arguments: '{"foo":"bar"}' }
+          }
+        ]
+      },
+      { role: 'tool', tool_call_id: 'tc-2', content: 'tool result' },
+      { role: 'assistant', content: '[Generation failed]\nReason: terminal failure' },
+      { role: 'user', content: 'continue' }
     ])
   })
 
@@ -813,6 +945,37 @@ describe('buildResumeContext', () => {
         ]
       },
       { role: 'tool', tool_call_id: 'tc-resume', content: 'tool result' }
+    ])
+  })
+
+  it('includes prior assistant error records when building resume context', () => {
+    const messages = [
+      makeUserRecord(1, 'previous user'),
+      makeAssistantErrorRecord(2, 'previous failure'),
+      makeUserRecord(3, 'recent user'),
+      {
+        id: 'resume-target',
+        sessionId: 's1',
+        orderSeq: 4,
+        role: 'assistant' as const,
+        content: JSON.stringify([
+          { type: 'content', content: 'partial answer', status: 'success', timestamp: Date.now() }
+        ]),
+        status: 'pending' as const,
+        isContextEdge: 0,
+        metadata: '{}',
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      }
+    ]
+    const store = createMockMessageStore(messages)
+    const result = buildResumeContext('s1', 'resume-target', '', 10000, 4096, store)
+
+    expect(result).toEqual([
+      { role: 'user', content: 'previous user' },
+      { role: 'assistant', content: '[Generation failed]\nReason: previous failure' },
+      { role: 'user', content: 'recent user' },
+      { role: 'assistant', content: 'partial answer' }
     ])
   })
 })


### PR DESCRIPTION
## Summary
- include assistant error/cancel messages in future agent context
- convert stored error blocks into readable failure/cancel summaries
- keep settled tool call replay and compaction history aligned with context building

## Tests
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm exec vitest --config vitest.config.ts test/main/presenter/agentRuntimePresenter/contextBuilder.test.ts test/main/presenter/agentRuntimePresenter/compactionService.test.ts --run
- pnpm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failed assistant messages and readable failure/cancellation summaries are preserved and included in subsequent turns and resume contexts.
  * History selection now consistently includes eligible assistant error records for context and compaction.

* **Documentation**
  * Added spec, plan, and task docs describing failed-message context preservation and acceptance criteria.

* **Tests**
  * Added focused tests covering error/cancel handling, partial assistant content, replayed tool results, and compaction behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1608)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->