### PR TITLE
fix(remote): deliver weixin generated images

### DIFF
--- a/src/main/presenter/remoteControlPresenter/services/remoteConversationRunner.ts
+++ b/src/main/presenter/remoteControlPresenter/services/remoteConversationRunner.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import crypto from 'node:crypto'
 import fs from 'node:fs/promises'
 import path from 'node:path'
@@ -51,6 +51,7 @@ const sleep = async (ms: number): Promise<void> => {
 }
 
 const REMOTE_ASSET_ROOT = '.deepchat/remote-assets'
+const REMOTE_GENERATED_ASSET_ROOT = 'remote-assets'
 const REMOTE_ATTACHMENT_FETCH_TIMEOUT_MS = 35_000
 
 const MIME_EXTENSION: Record<string, string> = {
@@ -58,9 +59,24 @@ const MIME_EXTENSION: Record<string, string> = {
   'image/png': '.png',
   'image/webp': '.webp',
   'image/gif': '.gif',
+  'image/bmp': '.bmp',
+  'image/avif': '.avif',
   'application/pdf': '.pdf',
   'text/plain': '.txt'
 }
+
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.bmp': 'image/bmp',
+  '.avif': 'image/avif'
+}
+
+const IMAGE_DATA_URL_PATTERN = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.*)$/s
+const IMGCACHE_URL_PREFIX = 'imgcache://'
 
 const isInvalidPathSegment = (value: string): boolean =>
   value.length === 0 || value === '.' || value === '..'
@@ -110,6 +126,80 @@ const channelFromEndpointKey = (endpointKey: string): string =>
 const stripDataUrlPrefix = (data: string): string => {
   const commaIndex = data.indexOf(',')
   return data.startsWith('data:') && commaIndex >= 0 ? data.slice(commaIndex + 1) : data
+}
+
+const normalizeImageMimeType = (value: string | undefined | null): string | null => {
+  const normalized = value?.split(';')[0]?.trim().toLowerCase()
+  return normalized?.startsWith('image/') ? normalized : null
+}
+
+const inferImageMimeTypeFromPath = (filePath: string): string | null =>
+  IMAGE_MIME_BY_EXTENSION[path.extname(filePath).toLowerCase()] ?? null
+
+const safeDecodePath = (value: string): string => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+const resolveCachedImagePath = (source: string): string => {
+  const cacheDir = path.join(app.getPath('userData'), 'images')
+  const cachePath = safeDecodePath(source.slice(IMGCACHE_URL_PREFIX.length))
+  const fullPath = path.resolve(cacheDir, cachePath)
+  const relativePath = path.relative(cacheDir, fullPath)
+
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error('Invalid cached generated image path.')
+  }
+
+  return fullPath
+}
+
+const decodeBase64Image = (value: string, label: string): Buffer => {
+  const data = Buffer.from(value.replace(/\s/g, ''), 'base64')
+  if (data.length === 0) {
+    throw new Error(`Invalid ${label} image data.`)
+  }
+  return data
+}
+
+const resolveGeneratedImageContent = async (
+  source: string,
+  fallbackMimeType: string
+): Promise<{
+  data: Buffer
+  mimeType: string
+}> => {
+  const normalizedSource = source.trim()
+  const dataUrlMatch = IMAGE_DATA_URL_PATTERN.exec(normalizedSource)
+  if (dataUrlMatch) {
+    return {
+      data: decodeBase64Image(dataUrlMatch[2], 'data URL'),
+      mimeType: dataUrlMatch[1].toLowerCase()
+    }
+  }
+
+  if (normalizedSource.startsWith('data:')) {
+    throw new Error('Unsupported generated image data URL.')
+  }
+
+  if (normalizedSource.startsWith(IMGCACHE_URL_PREFIX)) {
+    const imagePath = resolveCachedImagePath(normalizedSource)
+    return {
+      data: await fs.readFile(imagePath),
+      mimeType:
+        normalizeImageMimeType(fallbackMimeType) ??
+        inferImageMimeTypeFromPath(imagePath) ??
+        'image/png'
+    }
+  }
+
+  return {
+    data: decodeBase64Image(stripDataUrlPrefix(normalizedSource), 'base64'),
+    mimeType: normalizeImageMimeType(fallbackMimeType) ?? 'image/png'
+  }
 }
 
 const hasAttachmentDownloadSource = (attachment: RemoteInputAttachment): boolean =>
@@ -605,10 +695,10 @@ export class RemoteConversationRunner {
     return this.getGlobalDefaultWorkdir()
   }
 
-  private async resolveAssetWorkspace(
+  private async resolveOptionalAssetWorkspace(
     endpointKey: string,
     session: Pick<SessionWithState, 'projectDir' | 'agentId'>
-  ): Promise<string> {
+  ): Promise<string | null> {
     const projectDir = session.projectDir?.trim()
     if (projectDir) {
       return projectDir
@@ -619,7 +709,31 @@ export class RemoteConversationRunner {
       return defaultWorkdir
     }
 
+    return null
+  }
+
+  private async resolveAssetWorkspace(
+    endpointKey: string,
+    session: Pick<SessionWithState, 'projectDir' | 'agentId'>
+  ): Promise<string> {
+    const workspace = await this.resolveOptionalAssetWorkspace(endpointKey, session)
+    if (workspace) {
+      return workspace
+    }
+
     throw new Error('Remote attachments require a workspace directory.')
+  }
+
+  private async resolveGeneratedImageAssetRoot(
+    endpointKey: string,
+    session: Pick<SessionWithState, 'projectDir' | 'agentId'>
+  ): Promise<string> {
+    const workspace = await this.resolveOptionalAssetWorkspace(endpointKey, session)
+    if (workspace) {
+      return path.join(workspace, REMOTE_ASSET_ROOT)
+    }
+
+    return path.join(app.getPath('userData'), REMOTE_GENERATED_ASSET_ROOT)
   }
 
   private async prepareRemoteAttachments(
@@ -932,11 +1046,11 @@ export class RemoteConversationRunner {
       return []
     }
 
-    let workspace: string
+    let assetRoot: string
     try {
-      workspace = await this.resolveAssetWorkspace(endpointKey, session)
+      assetRoot = await this.resolveGeneratedImageAssetRoot(endpointKey, session)
     } catch (error) {
-      console.warn('[RemoteConversationRunner] Failed to resolve generated image workspace:', {
+      console.warn('[RemoteConversationRunner] Failed to resolve generated image asset root:', {
         endpointKey,
         messageId,
         error
@@ -945,8 +1059,7 @@ export class RemoteConversationRunner {
     }
 
     const assetDir = path.join(
-      workspace,
-      REMOTE_ASSET_ROOT,
+      assetRoot,
       channelFromEndpointKey(endpointKey),
       hashEndpointKey(endpointKey),
       sanitizePathSegment(messageId, 'assistant-message')
@@ -970,22 +1083,25 @@ export class RemoteConversationRunner {
         continue
       }
 
-      const mimeType = block.image_data?.mimeType?.trim() || 'image/png'
-      const extension = MIME_EXTENSION[mimeType.toLowerCase()] || '.img'
-      const filename = `generated-${index + 1}${extension}`
-      const filePath = path.join(assetDir, filename)
-
       try {
+        const imageContent = await resolveGeneratedImageContent(
+          data,
+          block.image_data?.mimeType?.trim() || 'image/png'
+        )
+        const extension = MIME_EXTENSION[imageContent.mimeType.toLowerCase()] || '.img'
+        const filename = `generated-${index + 1}${extension}`
+        const filePath = path.join(assetDir, filename)
+
         try {
           await fs.access(filePath)
         } catch {
-          await fs.writeFile(filePath, Buffer.from(stripDataUrlPrefix(data), 'base64'))
+          await fs.writeFile(filePath, imageContent.data)
         }
 
         assets.push({
           key: `${messageId}:${index}:image`,
           path: filePath,
-          mimeType,
+          mimeType: imageContent.mimeType,
           filename,
           sourceMessageId: messageId
         })

--- a/src/main/presenter/remoteControlPresenter/weixinIlink/weixinIlinkClient.ts
+++ b/src/main/presenter/remoteControlPresenter/weixinIlink/weixinIlinkClient.ts
@@ -1,4 +1,4 @@
-import { randomBytes, randomUUID } from 'node:crypto'
+import { createCipheriv, createHash, randomBytes, randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
 
 type WeixinIlinkQrCodeResponse = {
@@ -20,6 +20,22 @@ type WeixinIlinkCdnMedia = {
   aes_key?: string
   encrypt_type?: number
   full_url?: string
+}
+
+type WeixinIlinkApiResult = {
+  ret?: number
+  errcode?: number
+  errmsg?: string
+  message?: string
+}
+
+type WeixinIlinkGetUploadUrlResponse = WeixinIlinkApiResult & {
+  upload_param?: string
+  thumb_upload_param?: string
+}
+
+type WeixinIlinkBaseInfo = {
+  channel_version?: string
 }
 
 export type WeixinIlinkMessageItem = {
@@ -124,15 +140,70 @@ const WEIXIN_ILINK_LOGIN_TTL_MS = 5 * 60_000
 const WEIXIN_ILINK_QR_POLL_TIMEOUT_MS = 35_000
 const WEIXIN_ILINK_REQUEST_TIMEOUT_MS = 15_000
 const WEIXIN_ILINK_LONG_POLL_TIMEOUT_MS = 35_000
+const WEIXIN_ILINK_CHANNEL_VERSION = '1.0.0'
 
 const activeLogins = new Map<string, ActiveWeixinIlinkLogin>()
 
 const ensureTrailingSlash = (url: string): string => (url.endsWith('/') ? url : `${url}/`)
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const buildBaseInfo = (value: unknown): WeixinIlinkBaseInfo => {
+  const baseInfo = isRecord(value) ? value : {}
+  const channelVersion =
+    String(baseInfo.channel_version ?? '').trim() || WEIXIN_ILINK_CHANNEL_VERSION
+  return {
+    ...baseInfo,
+    channel_version: channelVersion
+  }
+}
+
+const withBaseInfo = (body: Record<string, unknown>): Record<string, unknown> => ({
+  ...body,
+  base_info: buildBaseInfo(body.base_info)
+})
+
 const buildRandomWechatUin = (): string => {
   const uint32 = randomBytes(4).readUInt32BE(0)
   return Buffer.from(String(uint32), 'utf8').toString('base64')
 }
+
+const withImageSendStage = async <T>(stage: string, operation: () => Promise<T>): Promise<T> => {
+  try {
+    return await operation()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Weixin iLink image ${stage} failed: ${message}`)
+  }
+}
+
+const assertWeixinIlinkSuccess = (response: WeixinIlinkApiResult, fallback: string): void => {
+  const ret = response.ret
+  const errcode = response.errcode
+  const failed =
+    (typeof ret === 'number' && ret !== 0) || (typeof errcode === 'number' && errcode !== 0)
+
+  if (!failed) {
+    return
+  }
+
+  throw new WeixinIlinkApiError(
+    response.errmsg?.trim() || response.message?.trim() || fallback,
+    undefined,
+    typeof errcode === 'number' ? errcode : ret
+  )
+}
+
+const encryptAes128Ecb = (content: Buffer, key: Buffer): Buffer => {
+  const cipher = createCipheriv('aes-128-ecb', key, null)
+  return Buffer.concat([cipher.update(content), cipher.final()])
+}
+
+const md5Hex = (content: Buffer): string => createHash('md5').update(content).digest('hex')
+
+const encodeIlinkMediaAesKey = (aesKeyHex: string): string =>
+  Buffer.from(aesKeyHex, 'utf8').toString('base64')
 
 const isFreshLogin = (login: ActiveWeixinIlinkLogin): boolean =>
   Date.now() - login.startedAt < WEIXIN_ILINK_LOGIN_TTL_MS
@@ -220,7 +291,7 @@ const fetchPostJson = async <T>(params: {
   timeoutMs?: number
 }): Promise<T> => {
   return await withTimeout(params.timeoutMs, async (signal) => {
-    const payload = JSON.stringify(params.body)
+    const payload = JSON.stringify(withBaseInfo(params.body))
     const response = await fetch(
       new URL(params.endpoint, ensureTrailingSlash(params.baseUrl)).toString(),
       {
@@ -459,35 +530,113 @@ export class WeixinIlinkClient {
     mimeType?: string
     contextToken?: string | null
   }): Promise<void> {
-    const imageContent = (await fs.readFile(params.imagePath)).toString('base64')
-    await fetchPostJson<Record<string, unknown>>({
-      baseUrl: this.credentials.baseUrl,
-      endpoint: 'ilink/bot/sendmessage',
-      token: this.credentials.botToken,
-      timeoutMs: WEIXIN_ILINK_REQUEST_TIMEOUT_MS,
-      body: {
-        msg: {
-          from_user_id: '',
+    const imageContent = await fs.readFile(params.imagePath)
+    const aesKey = randomBytes(16)
+    const aesKeyHex = aesKey.toString('hex')
+    const fileKey = randomBytes(16).toString('hex')
+    const encryptedContent = encryptAes128Ecb(imageContent, aesKey)
+    const uploadResponse = await withImageSendStage('getuploadurl', async () => {
+      const response = await fetchPostJson<WeixinIlinkGetUploadUrlResponse>({
+        baseUrl: this.credentials.baseUrl,
+        endpoint: 'ilink/bot/getuploadurl',
+        token: this.credentials.botToken,
+        timeoutMs: WEIXIN_ILINK_REQUEST_TIMEOUT_MS,
+        body: {
+          filekey: fileKey,
+          media_type: 1,
           to_user_id: params.toUserId,
-          client_id: randomUUID(),
-          message_type: 2,
-          message_state: 2,
-          item_list: [
-            {
-              type: 2,
-              image_item: {
-                content_type: params.mimeType || 'image/png',
-                data: imageContent
-              }
-            }
-          ],
-          ...(params.contextToken?.trim()
-            ? {
-                context_token: params.contextToken.trim()
-              }
-            : {})
+          rawsize: imageContent.byteLength,
+          rawfilemd5: md5Hex(imageContent),
+          filesize: encryptedContent.byteLength,
+          no_need_thumb: true,
+          aeskey: aesKeyHex
         }
+      })
+      assertWeixinIlinkSuccess(response, 'Weixin iLink getUploadUrl failed.')
+      return response
+    })
+
+    const uploadParam = uploadResponse.upload_param?.trim()
+    if (!uploadParam) {
+      throw new Error(
+        'Weixin iLink image getuploadurl failed: Weixin iLink getUploadUrl did not return upload_param.'
+      )
+    }
+
+    const encryptedQueryParam = await withImageSendStage('cdn-upload', async () =>
+      this.uploadCdnMedia({
+        uploadParam,
+        fileKey,
+        content: encryptedContent
+      })
+    )
+    await withImageSendStage('sendmessage', async () => {
+      const response = await fetchPostJson<WeixinIlinkApiResult>({
+        baseUrl: this.credentials.baseUrl,
+        endpoint: 'ilink/bot/sendmessage',
+        token: this.credentials.botToken,
+        timeoutMs: WEIXIN_ILINK_REQUEST_TIMEOUT_MS,
+        body: {
+          msg: {
+            from_user_id: '',
+            to_user_id: params.toUserId,
+            client_id: randomUUID(),
+            message_type: 2,
+            message_state: 2,
+            item_list: [
+              {
+                type: 2,
+                image_item: {
+                  content_type: params.mimeType || 'image/png',
+                  media: {
+                    encrypt_query_param: encryptedQueryParam,
+                    aes_key: encodeIlinkMediaAesKey(aesKeyHex),
+                    encrypt_type: 1
+                  },
+                  mid_size: encryptedContent.byteLength
+                }
+              }
+            ],
+            ...(params.contextToken?.trim()
+              ? {
+                  context_token: params.contextToken.trim()
+                }
+              : {})
+          }
+        }
+      })
+      assertWeixinIlinkSuccess(response, 'Weixin iLink sendMessage failed.')
+    })
+  }
+
+  private async uploadCdnMedia(params: {
+    uploadParam: string
+    fileKey: string
+    content: Buffer
+  }): Promise<string> {
+    return await withTimeout(WEIXIN_ILINK_REQUEST_TIMEOUT_MS, async (signal) => {
+      const response = await fetch(
+        `${WEIXIN_ILINK_CDN_BASE_URL.replace(/\/+$/, '')}/upload?encrypted_query_param=${encodeURIComponent(params.uploadParam)}&filekey=${encodeURIComponent(params.fileKey)}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/octet-stream'
+          },
+          body: Uint8Array.from(params.content),
+          ...(signal ? { signal } : {})
+        }
+      )
+
+      if (!response.ok) {
+        throw new WeixinIlinkApiError(await normalizeHttpError(response), response.status)
       }
+
+      const encryptedParam = response.headers.get('x-encrypted-param')?.trim()
+      if (!encryptedParam) {
+        throw new Error('Weixin iLink CDN upload did not return x-encrypted-param.')
+      }
+
+      return encryptedParam
     })
   }
 

--- a/test/main/presenter/remoteControlPresenter/remoteConversationRunner.test.ts
+++ b/test/main/presenter/remoteControlPresenter/remoteConversationRunner.test.ts
@@ -3,6 +3,7 @@ import crypto from 'node:crypto'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import { app } from 'electron'
 import { RemoteConversationRunner } from '@/presenter/remoteControlPresenter/services/remoteConversationRunner'
 
 const createSession = (overrides: Record<string, unknown> = {}) => ({
@@ -34,6 +35,7 @@ const encryptAes128Ecb = (content: Buffer, key: Buffer): Buffer => {
 describe('RemoteConversationRunner', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.mocked(app.getPath).mockImplementation(() => '/mock/path')
   })
 
   it('creates new sessions with the current default deepchat agent', async () => {
@@ -565,6 +567,188 @@ describe('RemoteConversationRunner', () => {
         })
       ]
     })
+  })
+
+  it('persists generated remote images from cached and base64 sources', async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'deepchat-remote-images-'))
+    const userData = await fs.mkdtemp(path.join(os.tmpdir(), 'deepchat-user-data-'))
+    const cacheDir = path.join(userData, 'images')
+    await fs.mkdir(cacheDir, { recursive: true })
+
+    const cachedImage = Buffer.from('cached generated image')
+    const dataUrlImage = Buffer.from('data url generated image')
+    const rawBase64Image = Buffer.from('raw base64 generated image')
+    await fs.writeFile(path.join(cacheDir, 'generated.png'), cachedImage)
+    vi.mocked(app.getPath).mockImplementation((name: string) =>
+      name === 'userData' ? userData : '/mock/path'
+    )
+
+    const assistantMessage = {
+      id: 'assistant-images',
+      role: 'assistant',
+      orderSeq: 2,
+      status: 'success',
+      content: JSON.stringify([
+        {
+          type: 'image',
+          status: 'success',
+          timestamp: 1,
+          image_data: {
+            data: 'imgcache://generated.png',
+            mimeType: 'image/png'
+          }
+        },
+        {
+          type: 'image',
+          status: 'success',
+          timestamp: 2,
+          image_data: {
+            data: `data:image/jpeg;base64,${dataUrlImage.toString('base64')}`,
+            mimeType: 'image/png'
+          }
+        },
+        {
+          type: 'image',
+          status: 'success',
+          timestamp: 3,
+          image_data: {
+            data: rawBase64Image.toString('base64'),
+            mimeType: 'image/webp'
+          }
+        }
+      ])
+    }
+    const session = createSession({
+      id: 'session-bound',
+      projectDir: workspace
+    })
+    const agentSessionPresenter = {
+      getSession: vi.fn().mockResolvedValue(session),
+      getMessages: vi.fn().mockResolvedValueOnce([]).mockResolvedValue([assistantMessage]),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      getMessage: vi.fn().mockResolvedValue(assistantMessage),
+      getSearchResults: vi.fn().mockResolvedValue([])
+    }
+    const runner = new RemoteConversationRunner(
+      {
+        configPresenter: createConfigPresenter() as any,
+        agentSessionPresenter: agentSessionPresenter as any,
+        agentRuntimePresenter: {
+          getActiveGeneration: vi.fn().mockReturnValue(null)
+        } as any,
+        windowPresenter: {} as any,
+        tabPresenter: {} as any,
+        resolveDefaultAgentId: vi.fn().mockResolvedValue('deepchat')
+      },
+      {
+        getBinding: vi.fn().mockReturnValue({
+          sessionId: 'session-bound',
+          updatedAt: 1
+        }),
+        clearBinding: vi.fn(),
+        clearActiveEvent: vi.fn(),
+        rememberActiveEvent: vi.fn()
+      } as any
+    )
+
+    const execution = await runner.sendText('weixin-ilink:account:user', 'draw a sunset')
+    const snapshot = await execution.getSnapshot()
+
+    expect(snapshot.generatedImages).toEqual([
+      expect.objectContaining({
+        key: 'assistant-images:0:image',
+        mimeType: 'image/png',
+        filename: 'generated-1.png'
+      }),
+      expect.objectContaining({
+        key: 'assistant-images:1:image',
+        mimeType: 'image/jpeg',
+        filename: 'generated-2.jpg'
+      }),
+      expect.objectContaining({
+        key: 'assistant-images:2:image',
+        mimeType: 'image/webp',
+        filename: 'generated-3.webp'
+      })
+    ])
+    await expect(fs.readFile(snapshot.generatedImages![0].path)).resolves.toEqual(cachedImage)
+    await expect(fs.readFile(snapshot.generatedImages![1].path)).resolves.toEqual(dataUrlImage)
+    await expect(fs.readFile(snapshot.generatedImages![2].path)).resolves.toEqual(rawBase64Image)
+    expect(snapshot.finalText).toBe('')
+  })
+
+  it('persists generated remote images in user data when no workspace is available', async () => {
+    const userData = await fs.mkdtemp(path.join(os.tmpdir(), 'deepchat-user-data-'))
+    const image = Buffer.from('generated image without workspace')
+    vi.mocked(app.getPath).mockImplementation((name: string) =>
+      name === 'userData' ? userData : '/mock/path'
+    )
+
+    const assistantMessage = {
+      id: 'assistant-images-no-workspace',
+      role: 'assistant',
+      orderSeq: 2,
+      status: 'success',
+      content: JSON.stringify([
+        {
+          type: 'image',
+          status: 'success',
+          timestamp: 1,
+          image_data: {
+            data: `data:image/png;base64,${image.toString('base64')}`,
+            mimeType: 'image/png'
+          }
+        }
+      ])
+    }
+    const session = createSession({
+      id: 'session-bound',
+      projectDir: null
+    })
+    const agentSessionPresenter = {
+      getSession: vi.fn().mockResolvedValue(session),
+      getMessages: vi.fn().mockResolvedValueOnce([]).mockResolvedValue([assistantMessage]),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      getMessage: vi.fn().mockResolvedValue(assistantMessage),
+      getSearchResults: vi.fn().mockResolvedValue([])
+    }
+    const runner = new RemoteConversationRunner(
+      {
+        configPresenter: createConfigPresenter() as any,
+        agentSessionPresenter: agentSessionPresenter as any,
+        agentRuntimePresenter: {
+          getActiveGeneration: vi.fn().mockReturnValue(null)
+        } as any,
+        windowPresenter: {} as any,
+        tabPresenter: {} as any,
+        resolveDefaultAgentId: vi.fn().mockResolvedValue('deepchat')
+      },
+      {
+        getBinding: vi.fn().mockReturnValue({
+          sessionId: 'session-bound',
+          updatedAt: 1
+        }),
+        clearBinding: vi.fn(),
+        clearActiveEvent: vi.fn(),
+        rememberActiveEvent: vi.fn()
+      } as any
+    )
+
+    const execution = await runner.sendText('weixin-ilink:account:user', 'draw a sunrise')
+    const snapshot = await execution.getSnapshot()
+
+    expect(snapshot.generatedImages).toEqual([
+      expect.objectContaining({
+        key: 'assistant-images-no-workspace:0:image',
+        mimeType: 'image/png',
+        filename: 'generated-1.png'
+      })
+    ])
+    expect(snapshot.generatedImages![0].path).toContain(
+      path.join(userData, 'remote-assets', 'weixin-ilink')
+    )
+    await expect(fs.readFile(snapshot.generatedImages![0].path)).resolves.toEqual(image)
+    expect(snapshot.finalText).toBe('')
   })
 
   it('lists recent sessions for the currently bound agent before falling back to default agent', async () => {

--- a/test/main/presenter/remoteControlPresenter/weixinIlinkRuntime.test.ts
+++ b/test/main/presenter/remoteControlPresenter/weixinIlinkRuntime.test.ts
@@ -1,7 +1,13 @@
 import { WeixinIlinkRuntime } from '@/presenter/remoteControlPresenter/weixinIlink/weixinIlinkRuntime'
+import type {
+  RemoteGeneratedImageAsset,
+  WeixinIlinkInboundMessage
+} from '@/presenter/remoteControlPresenter/types'
 
 describe('WeixinIlinkRuntime', () => {
-  const createRuntime = () =>
+  const createRuntime = (
+    overrides: Partial<ConstructorParameters<typeof WeixinIlinkRuntime>[0]> = {}
+  ) =>
     new WeixinIlinkRuntime({
       accountId: 'wx-account-1',
       ownerUserId: 'owner-1',
@@ -13,8 +19,24 @@ describe('WeixinIlinkRuntime', () => {
       logger: {
         info: vi.fn(),
         error: vi.fn()
-      }
+      },
+      ...overrides
     })
+
+  const createInboundMessage = (
+    overrides: Partial<WeixinIlinkInboundMessage> = {}
+  ): WeixinIlinkInboundMessage => ({
+    kind: 'message',
+    accountId: 'wx-account-1',
+    userId: 'wx-user-1',
+    text: 'hello',
+    messageId: 'wx-message-1',
+    contextToken: 'ctx-1',
+    command: null,
+    createdAt: null,
+    attachments: [],
+    ...overrides
+  })
 
   it('skips terminal delivery when the final text matches the last answer segment', () => {
     const runtime = createRuntime()
@@ -34,5 +56,61 @@ describe('WeixinIlinkRuntime', () => {
     )
 
     expect(nextSegments).toEqual(segments)
+  })
+
+  it('sends generated images from completed conversation snapshots', async () => {
+    const generatedImage: RemoteGeneratedImageAsset = {
+      key: 'assistant-message:0:image',
+      path: '/tmp/generated.png',
+      mimeType: 'image/png',
+      filename: 'generated.png',
+      sourceMessageId: 'assistant-message'
+    }
+    const client = {
+      sendTextMessage: vi.fn().mockResolvedValue(undefined),
+      sendImageMessage: vi.fn().mockResolvedValue(undefined)
+    }
+    const bindingStore = {
+      getRemoteDeliveryState: vi.fn().mockReturnValue(null),
+      rememberRemoteDeliveryState: vi.fn(),
+      clearRemoteDeliveryState: vi.fn()
+    }
+    const runtime = createRuntime({
+      client: client as any,
+      bindingStore: bindingStore as any
+    })
+    ;(runtime as any).started = true
+
+    await (runtime as any).deliverConversation(
+      createInboundMessage(),
+      {
+        userId: 'wx-user-1',
+        contextToken: 'ctx-1'
+      },
+      {
+        sessionId: 'session-1',
+        eventId: 'assistant-message',
+        getSnapshot: vi.fn().mockResolvedValue({
+          messageId: 'assistant-message',
+          text: '',
+          traceText: '',
+          deliverySegments: [],
+          finalText: '',
+          fullText: '',
+          generatedImages: [generatedImage],
+          completed: true,
+          pendingInteraction: null
+        })
+      },
+      0
+    )
+
+    expect(client.sendTextMessage).not.toHaveBeenCalled()
+    expect(client.sendImageMessage).toHaveBeenCalledWith({
+      toUserId: 'wx-user-1',
+      contextToken: 'ctx-1',
+      imagePath: '/tmp/generated.png',
+      mimeType: 'image/png'
+    })
   })
 })


### PR DESCRIPTION
deliver weixin generated images
<img width="638" height="401" alt="image" src="https://github.com/user-attachments/assets/3453f86a-0900-4cad-9fef-fe886747e59f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Enhanced image handling with support for multiple source formats and improved persistence
  * Secure encrypted image transmission for enhanced data protection

* **Improvements**
  * Better image caching and session-aware storage management

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1610)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->