### PR TITLE
fix(acp): guard invalid workdirs

### DIFF
--- a/docs/issues/acp-initialization-logging/plan.md
+++ b/docs/issues/acp-initialization-logging/plan.md
@@ -1,0 +1,29 @@
+# ACP Initialization Logging Plan
+
+## Scope
+
+Implement a focused diagnostics increment in the existing ACP runtime:
+
+- `AcpProcessManager` owns subprocess startup, JSON-RPC stream creation, initialize, and lifecycle monitoring.
+- `AcpSessionManager` owns normal chat session setup through `loadSession` and `newSession`.
+- `AcpProvider` owns normal chat prompt dispatch through `session/prompt`.
+
+## Implementation
+
+1. Replace the direct SDK `ndJsonStream` use with an equivalent traced NDJSON stream wrapper inside `AcpProcessManager`.
+   - Log inbound and outbound JSON-RPC summaries as messages pass through the same stream used by the SDK.
+   - Track request ids to correlate responses with methods.
+   - Record parse failures from stdout as ACP debug errors.
+
+2. Attach subprocess stderr/error/exit monitoring before `initialize`.
+   - Keep the monitor after initialization so process exits still clear handles.
+   - Race initialization with process exit and connection closure in addition to the existing timeout.
+
+3. Add session and prompt logs.
+   - Record summarized `session/load`, `session/new`, and `session/prompt` request/response/error events.
+   - Avoid storing full prompt text or full MCP server/env payloads.
+
+## Test Strategy
+
+- Run focused ACP main-process tests for the touched runtime paths where practical.
+- Run repository formatting/i18n/lint gates after implementation as required by project instructions.

--- a/docs/issues/acp-initialization-logging/spec.md
+++ b/docs/issues/acp-initialization-logging/spec.md
@@ -1,0 +1,26 @@
+# ACP Initialization Logging
+
+## Problem
+
+Claude Code over ACP can remain in a loading state with too little diagnostic information from the normal chat path. Existing logs show some high-level initialization results, but they do not consistently expose early subprocess exits, initialization-time stderr, stream closure before an initialize response, or the request/response stages for session setup.
+
+## Goals
+
+- Log ACP subprocess startup, initialization request/response timing, initialization failure, early process exit, and stream closure.
+- Add protocol-level JSON-RPC frame summaries without consuming stdout separately from the ACP stream.
+- Log normal chat-path `newSession`, `loadSession`, and `prompt` request/response/error stages.
+- Keep logged protocol payloads summarized so prompts, file contents, and environment details are not dumped by default.
+
+## Acceptance Criteria
+
+- When an ACP process starts, logs include agent id, workdir, pid, command summary, and initialization start.
+- If the ACP process exits, emits stderr, or the protocol stream closes during initialization, the failure is logged and initialization rejects with a concrete message instead of waiting only for the long timeout.
+- ACP debug event history includes lifecycle/request/response/error entries for initialization and session setup.
+- Protocol frame logging does not add an extra `stdout` data listener that could steal bytes from the ACP SDK stream.
+- No `[NEEDS CLARIFICATION]` markers remain.
+
+## Non-Goals
+
+- No ACP protocol redesign.
+- No renderer UI redesign for the ACP inspector.
+- No full raw prompt/content logging by default.

--- a/docs/issues/acp-initialization-logging/tasks.md
+++ b/docs/issues/acp-initialization-logging/tasks.md
@@ -1,0 +1,8 @@
+# ACP Initialization Logging Tasks
+
+- [x] Confirm [spec.md](./spec.md) has no unresolved `[NEEDS CLARIFICATION]` markers.
+- [x] Add traced ACP protocol stream summaries.
+- [x] Attach initialization-time process stderr/error/exit monitoring.
+- [x] Race initialize against process exit and connection closure.
+- [x] Add session setup and prompt request/response debug events.
+- [x] Run format, i18n, lint, and focused ACP tests.

--- a/docs/issues/acp-workdir-npx-recovery/plan.md
+++ b/docs/issues/acp-workdir-npx-recovery/plan.md
@@ -1,0 +1,21 @@
+# Implementation Plan
+
+## Renderer
+
+- Add a `FileClient.isDirectory` check in `NewThreadPage`.
+- Track directory status as `none`, `checking`, `valid`, or `invalid`.
+- Use a monotonically increasing request sequence so late async results are ignored.
+- Render a `lucide:circle-alert` icon with a localized title when the selected project path is invalid.
+- Include ACP workdir unavailability in `submit-disabled`, toolbar `send-disabled`, submit handlers, and the ACP draft watcher.
+
+## Main
+
+- Replace ACP spawn cwd HOME fallback with explicit directory validation.
+- Keep fallback workdir behavior only for empty workdir input.
+- Wrap ACP process spawn in one npx repair retry.
+- Parse `_npx/<hash>/package.json` ENOENT from stderr/error text, rename only that hash directory, and retry once.
+
+## Tests
+
+- Extend NewThreadPage tests for universal warning, DeepChat non-blocking behavior, ACP blocking behavior, and draft suppression.
+- Add AcpProcessManager tests for missing cwd rejection and npx repair gating/rename/retry behavior.

--- a/docs/issues/acp-workdir-npx-recovery/spec.md
+++ b/docs/issues/acp-workdir-npx-recovery/spec.md
@@ -1,0 +1,26 @@
+# ACP Workdir Validation and npx Recovery
+
+## User Story
+
+When a project directory selected for a new thread no longer exists or cannot be read, users should see that state immediately instead of silently running in a different directory. ACP agents must not create draft sessions, warm up, or send messages against an invalid workdir.
+
+When an npx ACP package launch fails because npm left a broken `_npx/<hash>` cache directory, DeepChat should repair only that broken cache directory and retry once.
+
+## Acceptance Criteria
+
+- The new thread project selector validates the selected project path with `FileClient.isDirectory`.
+- An empty project selection is not treated as an invalid directory.
+- Stale directory checks cannot overwrite newer project selections.
+- Any selected agent shows a warning icon next to the project selector when the selected directory is missing or inaccessible.
+- ACP agents disable sending and skip draft session creation while the selected workdir is missing, invalid, or still being checked.
+- DeepChat agents show the same warning but keep sending enabled.
+- Main process ACP launch throws when an explicit workdir/cwd does not exist or is not a directory.
+- Empty ACP workdir continues using the existing fallback directory.
+- npx repair only triggers for `distributionType === 'npx'` and `_npx/<hash>/package.json` ENOENT failures.
+- npx repair moves only the named bad hash directory and retries once.
+
+## Non-Goals
+
+- Do not change DeepChat Agent send behavior for invalid project directories.
+- Do not introduce a new IPC surface for directory checks.
+- Do not clear the whole npm cache.

--- a/docs/issues/acp-workdir-npx-recovery/tasks.md
+++ b/docs/issues/acp-workdir-npx-recovery/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] Add renderer directory validation state and warning icon.
+- [x] Block ACP draft/send paths when workdir is missing or invalid.
+- [x] Add main process explicit cwd validation.
+- [x] Add npx `_npx/<hash>/package.json` repair and one retry.
+- [x] Add focused renderer and main tests.
+- [x] Run format, i18n, lint, focused tests, and affected typecheck.

--- a/src/main/presenter/llmProviderPresenter/acp/acpProcessManager.ts
+++ b/src/main/presenter/llmProviderPresenter/acp/acpProcessManager.ts
@@ -983,6 +983,13 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
       launchSignature
     }
     readyHandle = handle
+    if (!this.isHandleAlive(handle)) {
+      this.removeHandleReferences(handle)
+      this.clearSessionsForAgent(agent.id)
+      throw new Error(
+        `[ACP] Agent process ${agent.id} exited before becoming ready (PID: ${child.pid})`
+      )
+    }
     this.debugLog.append(agent.id, {
       kind: 'lifecycle',
       action: 'process.ready',

--- a/src/main/presenter/llmProviderPresenter/acp/acpProcessManager.ts
+++ b/src/main/presenter/llmProviderPresenter/acp/acpProcessManager.ts
@@ -4,7 +4,7 @@ import { Readable, Writable } from 'node:stream'
 import { app } from 'electron'
 import * as fs from 'fs'
 import * as path from 'path'
-import { ClientSideConnection, PROTOCOL_VERSION, ndJsonStream } from '@agentclientprotocol/sdk'
+import { ClientSideConnection, PROTOCOL_VERSION } from '@agentclientprotocol/sdk'
 import type {
   ClientSideConnection as ClientSideConnectionType,
   Client
@@ -79,6 +79,19 @@ interface SessionListenerEntry {
   handlers: Set<SessionNotificationHandler>
 }
 
+interface NpxCacheRepairTarget {
+  packageJsonPath: string
+  cacheDir: string
+  npxRoot: string
+}
+
+interface NpxCacheRepairResult {
+  repaired: boolean
+  message: string
+  target?: NpxCacheRepairTarget
+  movedTo?: string
+}
+
 /**
  * Check if running in Electron environment.
  * Reference: @modelcontextprotocol/sdk/client/stdio.js
@@ -91,6 +104,44 @@ interface PermissionResolverEntry {
   agentId: string
   resolver: PermissionResolver
 }
+
+type JsonRpcId = string | number
+type JsonRpcMessageRecord = Record<string, unknown>
+type ProtocolDirection = 'in' | 'out'
+type ErrorWithAcpStderr = Error & { acpStderr?: string }
+
+interface ProtocolMessageSummary {
+  direction: ProtocolDirection
+  kind: 'request' | 'notification' | 'response' | 'unknown'
+  id?: JsonRpcId
+  method?: string
+  paramsKeys?: string[]
+  resultKeys?: string[]
+  error?: {
+    code?: unknown
+    message?: string
+  }
+  keys: string[]
+  label: string
+}
+
+const MAX_PROTOCOL_LOG_LINE_LENGTH = 4000
+const IMPORTANT_PROTOCOL_METHODS = new Set([
+  'initialize',
+  'session/new',
+  'session/load',
+  'session/prompt',
+  'session/cancel',
+  'authenticate'
+])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+const truncateForLog = (value: string): string =>
+  value.length > MAX_PROTOCOL_LOG_LINE_LENGTH
+    ? `${value.slice(0, MAX_PROTOCOL_LOG_LINE_LENGTH)}...<truncated ${value.length - MAX_PROTOCOL_LOG_LINE_LENGTH} chars>`
+    : value
 
 export const parseLoadSessionCapability = (initializeResult: unknown): boolean | undefined => {
   if (!initializeResult || typeof initializeResult !== 'object') {
@@ -148,6 +199,8 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
     }
   >()
   private readonly debugLog = new AcpDebugLog()
+  private readonly protocolRequestsToAgent = new Map<string, Map<JsonRpcId, string>>()
+  private readonly protocolRequestsFromAgent = new Map<string, Map<JsonRpcId, string>>()
   private shuttingDown = false
 
   constructor(options: AcpProcessManagerOptions) {
@@ -670,11 +723,89 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
     launchSpec: AcpResolvedLaunchSpec,
     launchSignature: string
   ): Promise<AcpProcessHandle> {
+    try {
+      return await this.spawnProcessOnce(agent, workdir, launchSpec, launchSignature)
+    } catch (error) {
+      const repairResult = this.repairNpxCacheIfNeeded(agent.id, launchSpec, error)
+      if (!repairResult.repaired) {
+        throw error
+      }
+
+      console.warn(
+        `[ACP] Retrying npx agent ${agent.id} after cache repair: ${repairResult.message}`
+      )
+      try {
+        return await this.spawnProcessOnce(agent, workdir, launchSpec, launchSignature)
+      } catch (retryError) {
+        throw this.createNpxRepairRetryError(agent.id, error, retryError, repairResult)
+      }
+    }
+  }
+
+  private async spawnProcessOnce(
+    agent: AcpAgentConfig,
+    workdir: string,
+    launchSpec: AcpResolvedLaunchSpec,
+    launchSignature: string
+  ): Promise<AcpProcessHandle> {
     const child = await this.spawnAgentProcess(agent, workdir, launchSpec)
-    const stream = this.createAgentStream(child)
+    const stderrChunks: string[] = []
+    const stream = this.createAgentStream(agent.id, child)
     const client = this.createClientProxy()
     const connection = new ClientSideConnection(() => client, stream)
     const handleSeed: Partial<AcpProcessHandle> = {}
+    let readyHandle: AcpProcessHandle | null = null
+
+    const handleProcessExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      console.warn(
+        `[ACP] Agent process for ${agent.id} exited (PID: ${child.pid}, code=${code ?? 'null'}, signal=${signal ?? 'null'})`
+      )
+      this.debugLog.append(agent.id, {
+        kind: 'lifecycle',
+        action: 'process.exit',
+        payload: { pid: child.pid, code, signal, workdir }
+      })
+      if (readyHandle) {
+        this.removeHandleReferences(readyHandle)
+        this.clearSessionsForAgent(agent.id)
+      }
+    }
+
+    child.on('exit', handleProcessExit)
+    child.stderr?.on('data', (chunk: Buffer) => {
+      const error = chunk.toString().trim()
+      if (error) {
+        stderrChunks.push(error)
+        console.error(`[ACP] ${agent.id} stderr: ${error}`)
+        this.debugLog.append(agent.id, {
+          kind: 'stderr',
+          action: 'process.stderr',
+          message: error,
+          payload: error
+        })
+      }
+    })
+    child.on('error', (error) => {
+      console.error(`[ACP] Agent process ${agent.id} encountered error:`, error)
+      this.debugLog.append(agent.id, {
+        kind: 'error',
+        action: 'process.error',
+        message: error.message,
+        payload: { name: error.name, stack: error.stack, workdir }
+      })
+    })
+    console.info(`[ACP] Process monitoring set up for agent ${agent.id} (PID: ${child.pid})`)
+    this.debugLog.append(agent.id, {
+      kind: 'lifecycle',
+      action: 'process.spawned',
+      payload: {
+        pid: child.pid,
+        workdir,
+        command: launchSpec.command,
+        argsCount: launchSpec.args?.length ?? 0,
+        distributionType: launchSpec.distributionType
+      }
+    })
 
     // Add process health check before initialization
     if (child.killed) {
@@ -704,6 +835,27 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
       const initPromise = connection.initialize(initPayload)
 
       let timeoutHandle: NodeJS.Timeout | null = null
+      let initializationSettled = false
+      let cleanupInitExitListener: (() => void) | null = null
+      const processExitPromise = new Promise<never>((_, reject) => {
+        const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+          reject(
+            new Error(
+              `[ACP] Agent process ${agent.id} exited during initialization (PID: ${child.pid}, code=${code ?? 'null'}, signal=${signal ?? 'null'})`
+            )
+          )
+        }
+        child.once('exit', onExit)
+        cleanupInitExitListener = () => child.removeListener('exit', onExit)
+      })
+      const connectionClosedPromise = connection.closed.then(() => {
+        if (!initializationSettled) {
+          throw new Error(
+            `[ACP] Protocol stream closed before initialization completed for agent ${agent.id}`
+          )
+        }
+        return new Promise<never>(() => {})
+      })
       const timeoutPromise = new Promise<never>((_, reject) => {
         timeoutHandle = setTimeout(() => {
           reject(
@@ -714,7 +866,14 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
         }, timeoutMs)
       })
 
-      const initResult = await Promise.race([initPromise, timeoutPromise]).finally(() => {
+      const initResult = await Promise.race([
+        initPromise,
+        timeoutPromise,
+        processExitPromise,
+        connectionClosedPromise
+      ]).finally(() => {
+        initializationSettled = true
+        cleanupInitExitListener?.()
         if (timeoutHandle) {
           clearTimeout(timeoutHandle)
         }
@@ -795,6 +954,7 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
         }
       }
 
+      this.attachStderrToError(error, stderrChunks)
       throw error
     }
 
@@ -822,52 +982,7 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
       supportsLoadSession: handleSeed.supportsLoadSession,
       launchSignature
     }
-
-    child.on('exit', (code, signal) => {
-      console.warn(
-        `[ACP] Agent process for ${agent.id} exited (PID: ${child.pid}, code=${code ?? 'null'}, signal=${signal ?? 'null'})`
-      )
-      this.debugLog.append(agent.id, {
-        kind: 'lifecycle',
-        action: 'process.exit',
-        payload: { pid: child.pid, code, signal }
-      })
-      this.removeHandleReferences(handle)
-      this.clearSessionsForAgent(agent.id)
-    })
-
-    // child.stdout?.on('data', (chunk: Buffer) => {
-    //   const output = chunk.toString().trim()
-    //   if (output) {
-    //     console.info(`[ACP] ${agent.id} stdout: ${output}`)
-    //   }
-    // })
-
-    child.stderr?.on('data', (chunk: Buffer) => {
-      const error = chunk.toString().trim()
-      if (error) {
-        console.error(`[ACP] ${agent.id} stderr: ${error}`)
-        this.debugLog.append(agent.id, {
-          kind: 'stderr',
-          action: 'process.stderr',
-          message: error,
-          payload: error
-        })
-      }
-    })
-
-    // Add additional process monitoring
-    child.on('error', (error) => {
-      console.error(`[ACP] Agent process ${agent.id} encountered error:`, error)
-      this.debugLog.append(agent.id, {
-        kind: 'error',
-        action: 'process.error',
-        message: error.message,
-        payload: { name: error.name, stack: error.stack }
-      })
-    })
-
-    console.info(`[ACP] Process monitoring set up for agent ${agent.id} (PID: ${child.pid})`)
+    readyHandle = handle
     this.debugLog.append(agent.id, {
       kind: 'lifecycle',
       action: 'process.ready',
@@ -875,6 +990,180 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
     })
 
     return handle
+  }
+
+  private attachStderrToError(error: unknown, stderrChunks: string[]): void {
+    if (!stderrChunks.length || !(error instanceof Error)) {
+      return
+    }
+    ;(error as ErrorWithAcpStderr).acpStderr = stderrChunks.join('\n')
+  }
+
+  private repairNpxCacheIfNeeded(
+    agentId: string,
+    launchSpec: AcpResolvedLaunchSpec,
+    error: unknown
+  ): NpxCacheRepairResult {
+    if (launchSpec.distributionType !== 'npx') {
+      return { repaired: false, message: 'agent distribution is not npx' }
+    }
+
+    const target = this.findNpxCacheRepairTarget(error)
+    if (!target) {
+      return { repaired: false, message: 'error is not a _npx package.json ENOENT' }
+    }
+
+    const result = this.repairNpxCacheDirectory(target)
+    this.debugLog.append(agentId, {
+      kind: result.repaired ? 'lifecycle' : 'error',
+      action: 'npx.cache.repair',
+      message: result.message,
+      payload: {
+        packageJsonPath: target.packageJsonPath,
+        cacheDir: target.cacheDir,
+        movedTo: result.movedTo,
+        repaired: result.repaired
+      }
+    })
+    return result
+  }
+
+  private findNpxCacheRepairTarget(error: unknown): NpxCacheRepairTarget | null {
+    const text = this.stringifyErrorWithStderr(error)
+    if (!/\bENOENT\b/i.test(text)) {
+      return null
+    }
+
+    const packageJsonPathPattern =
+      /((?:[A-Za-z]:)?[\\/][^'"\r\n]*[\\/]_npx[\\/][^\\/ "'\r\n]+[\\/]package\.json)/i
+    const packageJsonPath = text.match(packageJsonPathPattern)?.[1]
+    if (!packageJsonPath) {
+      return null
+    }
+
+    const normalizedPackageJsonPath = path.normalize(packageJsonPath)
+    if (path.basename(normalizedPackageJsonPath) !== 'package.json') {
+      return null
+    }
+
+    const cacheDir = path.dirname(normalizedPackageJsonPath)
+    const npxRoot = path.dirname(cacheDir)
+    if (path.basename(npxRoot) !== '_npx') {
+      return null
+    }
+
+    const relativeCacheDir = path.relative(npxRoot, cacheDir)
+    if (
+      !relativeCacheDir ||
+      relativeCacheDir.startsWith('..') ||
+      path.isAbsolute(relativeCacheDir) ||
+      relativeCacheDir.includes(path.sep)
+    ) {
+      return null
+    }
+
+    return {
+      packageJsonPath: normalizedPackageJsonPath,
+      cacheDir,
+      npxRoot
+    }
+  }
+
+  private repairNpxCacheDirectory(target: NpxCacheRepairTarget): NpxCacheRepairResult {
+    let cacheStat: fs.Stats | null = null
+    try {
+      cacheStat = fs.statSync(target.cacheDir)
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code === 'ENOENT') {
+        return {
+          repaired: true,
+          message: `npx cache directory was already missing: ${target.cacheDir}`,
+          target
+        }
+      }
+      return {
+        repaired: false,
+        message: `failed to inspect npx cache directory "${target.cacheDir}": ${error instanceof Error ? error.message : String(error)}`,
+        target
+      }
+    }
+
+    if (!cacheStat.isDirectory()) {
+      return {
+        repaired: false,
+        message: `npx cache path is not a directory: ${target.cacheDir}`,
+        target
+      }
+    }
+
+    const movedTo = this.createBadNpxCachePath(target.cacheDir)
+    try {
+      fs.renameSync(target.cacheDir, movedTo)
+      return {
+        repaired: true,
+        message: `moved broken npx cache directory "${target.cacheDir}" to "${movedTo}"`,
+        target,
+        movedTo
+      }
+    } catch (error) {
+      return {
+        repaired: false,
+        message: `failed to move npx cache directory "${target.cacheDir}": ${error instanceof Error ? error.message : String(error)}`,
+        target
+      }
+    }
+  }
+
+  private createBadNpxCachePath(cacheDir: string): string {
+    const base = `${cacheDir}.bad-${Date.now()}`
+    let candidate = base
+    let suffix = 1
+    while (fs.existsSync(candidate)) {
+      candidate = `${base}-${suffix}`
+      suffix += 1
+    }
+    return candidate
+  }
+
+  private createNpxRepairRetryError(
+    agentId: string,
+    originalError: unknown,
+    retryError: unknown,
+    repairResult: NpxCacheRepairResult
+  ): Error {
+    const error = new Error(
+      `[ACP] npx cache repair for agent ${agentId} was attempted but retry failed. Repair: ${repairResult.message}. Original error: ${this.stringifyErrorWithStderr(originalError)}. Retry error: ${this.stringifyErrorWithStderr(retryError)}`
+    )
+    ;(error as Error & { cause?: unknown }).cause = retryError
+    return error
+  }
+
+  private stringifyErrorWithStderr(error: unknown): string {
+    if (error instanceof Error) {
+      const stderr = (error as ErrorWithAcpStderr).acpStderr
+      return [error.message, stderr].filter(Boolean).join('\n')
+    }
+    return String(error)
+  }
+
+  private validateSpawnCwd(agentId: string, cwd: string, source: 'configured cwd' | 'workdir') {
+    if (!fs.existsSync(cwd)) {
+      throw new Error(`[ACP] ${source} "${cwd}" does not exist for agent ${agentId}`)
+    }
+
+    let stat: fs.Stats
+    try {
+      stat = fs.statSync(cwd)
+    } catch (error) {
+      throw new Error(
+        `[ACP] ${source} "${cwd}" is not accessible for agent ${agentId}: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+
+    if (!stat.isDirectory()) {
+      throw new Error(`[ACP] ${source} "${cwd}" is not a directory for agent ${agentId}`)
+    }
   }
 
   private async spawnAgentProcess(
@@ -930,7 +1219,6 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
     // Use expanded args
     const processedArgs = expandedArgs
 
-    const HOME_DIR = app.getPath('home')
     let env = mergeCommandEnvironment()
 
     let shellEnv: Record<string, string> = {}
@@ -1018,12 +1306,9 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
       userOverrideKeys: Object.keys(userEnvOverride ?? {})
     })
 
-    // Use the provided workdir as cwd if it exists, otherwise fall back to home directory
-    let cwd = launchSpec.cwd?.trim() ? launchSpec.cwd : workdir
-    if (!fs.existsSync(cwd)) {
-      console.warn(`[ACP] Workdir "${cwd}" does not exist for agent ${agent.id}, using HOME_DIR`)
-      cwd = HOME_DIR
-    }
+    const configuredCwd = launchSpec.cwd?.trim()
+    const cwd = configuredCwd || workdir
+    this.validateSpawnCwd(agent.id, cwd, configuredCwd ? 'configured cwd' : 'workdir')
     console.info(`[ACP] Using workdir as cwd for agent ${agent.id}: ${cwd}`)
 
     console.info(`[ACP] Spawning process with options:`, {
@@ -1046,7 +1331,7 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
     return child
   }
 
-  private createAgentStream(child: ChildProcessWithoutNullStreams): Stream {
+  private createAgentStream(agentId: string, child: ChildProcessWithoutNullStreams): Stream {
     // Add error handler for stdin to prevent EPIPE errors when process exits
     child.stdin.on('error', (error: NodeJS.ErrnoException) => {
       // EPIPE errors occur when trying to write to a closed pipe (process already exited)
@@ -1058,7 +1343,200 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
 
     const writable = Writable.toWeb(child.stdin) as unknown as WritableStream<Uint8Array>
     const readable = Readable.toWeb(child.stdout) as unknown as ReadableStream<Uint8Array>
-    return ndJsonStream(writable, readable)
+    return this.createTracedNdJsonStream(agentId, writable, readable)
+  }
+
+  private createTracedNdJsonStream(
+    agentId: string,
+    output: WritableStream<Uint8Array>,
+    input: ReadableStream<Uint8Array>
+  ): Stream {
+    const textEncoder = new TextEncoder()
+    const textDecoder = new TextDecoder()
+
+    const readable = new ReadableStream<JsonRpcMessageRecord>({
+      start: async (controller) => {
+        let content = ''
+        let didError = false
+        const reader = input.getReader()
+
+        const emitLine = (line: string, action: string) => {
+          const trimmedLine = line.trim()
+          if (!trimmedLine) return
+          try {
+            const message = JSON.parse(trimmedLine) as JsonRpcMessageRecord
+            this.logProtocolMessage(agentId, 'in', message)
+            controller.enqueue(message)
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error)
+            console.error(`[ACP] ${agentId} protocol parse error from stdout:`, {
+              error: errorMessage,
+              line: truncateForLog(trimmedLine),
+              length: trimmedLine.length
+            })
+            this.debugLog.append(agentId, {
+              kind: 'error',
+              action,
+              message: errorMessage,
+              payload: {
+                line: truncateForLog(trimmedLine),
+                length: trimmedLine.length
+              }
+            })
+          }
+        }
+
+        try {
+          while (true) {
+            const { value, done } = await reader.read()
+            if (done) {
+              break
+            }
+            if (!value) {
+              continue
+            }
+            content += textDecoder.decode(value, { stream: true })
+            const lines = content.split('\n')
+            content = lines.pop() || ''
+            lines.forEach((line) => emitLine(line, 'protocol.stdout.parse'))
+          }
+
+          if (content.trim()) {
+            emitLine(content, 'protocol.stdout.trailing_parse')
+          }
+        } catch (error) {
+          didError = true
+          console.error(`[ACP] ${agentId} protocol stdout stream failed:`, error)
+          this.debugLog.append(agentId, {
+            kind: 'error',
+            action: 'protocol.stdout.stream',
+            message: error instanceof Error ? error.message : String(error),
+            payload: error instanceof Error ? { name: error.name, stack: error.stack } : error
+          })
+          controller.error(error)
+        } finally {
+          reader.releaseLock()
+          if (!didError) {
+            controller.close()
+          }
+        }
+      }
+    })
+
+    const writable = new WritableStream<JsonRpcMessageRecord>({
+      write: async (message) => {
+        this.logProtocolMessage(agentId, 'out', message)
+        const content = `${JSON.stringify(message)}\n`
+        const writer = output.getWriter()
+        try {
+          await writer.write(textEncoder.encode(content))
+        } finally {
+          writer.releaseLock()
+        }
+      }
+    })
+
+    return { readable, writable } as unknown as Stream
+  }
+
+  private getProtocolRequestMap(
+    store: Map<string, Map<JsonRpcId, string>>,
+    agentId: string
+  ): Map<JsonRpcId, string> {
+    const existing = store.get(agentId)
+    if (existing) return existing
+
+    const created = new Map<JsonRpcId, string>()
+    store.set(agentId, created)
+    return created
+  }
+
+  private summarizeProtocolMessage(
+    agentId: string,
+    direction: ProtocolDirection,
+    message: unknown
+  ): ProtocolMessageSummary {
+    const record = isRecord(message) ? message : {}
+    const keys = Object.keys(record)
+    const idValue = record.id
+    const id = typeof idValue === 'string' || typeof idValue === 'number' ? idValue : undefined
+    const directMethod = typeof record.method === 'string' ? record.method : undefined
+    const paramsKeys = isRecord(record.params) ? Object.keys(record.params) : undefined
+    const resultKeys = isRecord(record.result) ? Object.keys(record.result) : undefined
+    const errorRecord = isRecord(record.error) ? record.error : undefined
+    const error = errorRecord
+      ? {
+          code: errorRecord.code,
+          message: typeof errorRecord.message === 'string' ? errorRecord.message : undefined
+        }
+      : undefined
+
+    let kind: ProtocolMessageSummary['kind'] = 'unknown'
+    let method = directMethod
+    if (directMethod && id !== undefined) {
+      kind = 'request'
+      const store =
+        direction === 'out' ? this.protocolRequestsToAgent : this.protocolRequestsFromAgent
+      this.getProtocolRequestMap(store, agentId).set(id, directMethod)
+    } else if (directMethod) {
+      kind = 'notification'
+    } else if (id !== undefined) {
+      kind = 'response'
+      const store =
+        direction === 'in' ? this.protocolRequestsToAgent : this.protocolRequestsFromAgent
+      const requests = store.get(agentId)
+      method = requests?.get(id)
+      requests?.delete(id)
+    }
+
+    const labelParts: string[] = [kind]
+    if (method) {
+      labelParts.push(method)
+    }
+    if (id !== undefined) {
+      labelParts.push(`#${id}`)
+    }
+    if (error?.message) {
+      labelParts.push(`error=${error.message}`)
+    }
+
+    return {
+      direction,
+      kind,
+      id,
+      method,
+      paramsKeys,
+      resultKeys,
+      error,
+      keys,
+      label: labelParts.join(' ')
+    }
+  }
+
+  private logProtocolMessage(
+    agentId: string,
+    direction: ProtocolDirection,
+    message: unknown
+  ): void {
+    const summary = this.summarizeProtocolMessage(agentId, direction, message)
+    const route = direction === 'out' ? 'client->agent' : 'agent->client'
+    const isImportant =
+      Boolean(summary.error) ||
+      (summary.method ? IMPORTANT_PROTOCOL_METHODS.has(summary.method) : false)
+    const logMessage = `[ACP] ${agentId} protocol ${route}: ${summary.label}`
+
+    if (isImportant) {
+      console.info(logMessage, summary)
+    } else {
+      console.debug(logMessage, summary)
+    }
+
+    this.debugLog.append(agentId, {
+      kind: 'lifecycle',
+      action: `protocol.${direction}`,
+      message: summary.label,
+      payload: summary
+    })
   }
 
   private createClientProxy(): Client {
@@ -1280,6 +1758,9 @@ export class AcpProcessManager implements AgentProcessManager<AcpProcessHandle, 
   }
 
   private clearSessionsForAgent(agentId: string): void {
+    this.protocolRequestsToAgent.delete(agentId)
+    this.protocolRequestsFromAgent.delete(agentId)
+
     for (const [sessionId, entry] of this.sessionListeners.entries()) {
       if (entry.agentId === agentId) {
         this.sessionListeners.delete(sessionId)

--- a/src/main/presenter/llmProviderPresenter/acp/acpSessionManager.ts
+++ b/src/main/presenter/llmProviderPresenter/acp/acpSessionManager.ts
@@ -33,6 +33,27 @@ interface SessionHooks {
   onPermission: PermissionResolver
 }
 
+const summarizeMcpServers = (mcpServers: schema.McpServer[]) =>
+  mcpServers.map((server) => {
+    const record = server as Record<string, unknown>
+    return {
+      name: typeof record.name === 'string' ? record.name : 'unknown',
+      type: typeof record.type === 'string' ? record.type : 'stdio'
+    }
+  })
+
+const summarizeSessionResponse = (
+  response: schema.LoadSessionResponse | schema.NewSessionResponse
+) => ({
+  sessionId: 'sessionId' in response ? response.sessionId : undefined,
+  keys: Object.keys(response as Record<string, unknown>),
+  configOptionCount: response.configOptions?.length ?? 0,
+  modelCount: response.models?.availableModels?.length ?? 0,
+  currentModelId: response.models?.currentModelId,
+  modeCount: response.modes?.availableModes?.length ?? 0,
+  currentModeId: response.modes?.currentModeId
+})
+
 export interface AcpSessionRecord extends AgentSessionState {
   connection: ClientSideConnectionType
   detachHandlers: Array<() => void>
@@ -338,8 +359,31 @@ export class AcpSessionManager {
       let sessionResponse: schema.LoadSessionResponse | schema.NewSessionResponse | undefined
 
       const canLoadSession = Boolean(handle.supportsLoadSession)
+      console.info(`[ACP] Initializing ACP session for agent ${agent.id}:`, {
+        conversationId,
+        workdir,
+        canLoadSession,
+        persistedSessionId,
+        mcpServerCount: mcpServers.length
+      })
       if (canLoadSession && persistedSessionId) {
         try {
+          const loadRequestSummary = {
+            cwd: workdir,
+            sessionId: persistedSessionId,
+            mcpServerCount: mcpServers.length,
+            mcpServers: summarizeMcpServers(mcpServers)
+          }
+          console.info(
+            `[ACP] Loading persisted ACP session ${persistedSessionId} for conversation ${conversationId}`,
+            loadRequestSummary
+          )
+          this.processManager.appendDebugEvent?.(agent.id, {
+            kind: 'request',
+            action: 'session/load',
+            sessionId: persistedSessionId,
+            payload: loadRequestSummary
+          })
           this.processManager.registerSessionWorkdir(persistedSessionId, workdir, conversationId)
           detachHandlers = this.attachSessionHooks(agent.id, persistedSessionId, hooks)
           const loadResponse = await handle.connection.loadSession({
@@ -361,6 +405,12 @@ export class AcpSessionManager {
           console.info(
             `[ACP] Loaded persisted session ${sessionId} for conversation ${conversationId} (agent ${agent.id})`
           )
+          this.processManager.appendDebugEvent?.(agent.id, {
+            kind: 'response',
+            action: 'session/load',
+            sessionId,
+            payload: summarizeSessionResponse(loadResponse)
+          })
         } catch (error) {
           detachHandlers?.forEach((dispose) => {
             try {
@@ -375,10 +425,31 @@ export class AcpSessionManager {
             `[ACP] Failed to load persisted session ${persistedSessionId} for conversation ${conversationId}; falling back to newSession.`,
             error
           )
+          this.processManager.appendDebugEvent?.(agent.id, {
+            kind: 'error',
+            action: 'session/load',
+            sessionId: persistedSessionId,
+            message: error instanceof Error ? error.message : String(error),
+            payload: error instanceof Error ? { name: error.name, stack: error.stack } : error
+          })
         }
       }
 
       if (!sessionId) {
+        const newSessionRequestSummary = {
+          cwd: workdir,
+          mcpServerCount: mcpServers.length,
+          mcpServers: summarizeMcpServers(mcpServers)
+        }
+        console.info(
+          `[ACP] Creating new ACP session for conversation ${conversationId} (agent ${agent.id})`,
+          newSessionRequestSummary
+        )
+        this.processManager.appendDebugEvent?.(agent.id, {
+          kind: 'request',
+          action: 'session/new',
+          payload: newSessionRequestSummary
+        })
         const response = await handle.connection.newSession({
           cwd: workdir,
           mcpServers
@@ -394,6 +465,15 @@ export class AcpSessionManager {
         if (hasAcpConfigStateData(nextConfigState)) {
           configState = nextConfigState
         }
+        console.info(
+          `[ACP] Created new ACP session ${sessionId} for conversation ${conversationId} (agent ${agent.id})`
+        )
+        this.processManager.appendDebugEvent?.(agent.id, {
+          kind: 'response',
+          action: 'session/new',
+          sessionId,
+          payload: summarizeSessionResponse(response)
+        })
       }
 
       if (!sessionResponse) {
@@ -453,6 +533,12 @@ export class AcpSessionManager {
       }
     } catch (error) {
       console.error(`[ACP] Failed to initialize session for agent ${agent.id}:`, error)
+      this.processManager.appendDebugEvent?.(agent.id, {
+        kind: 'error',
+        action: 'session/initialize',
+        message: error instanceof Error ? error.message : String(error),
+        payload: error instanceof Error ? { name: error.name, stack: error.stack } : error
+      })
       throw error
     }
   }

--- a/src/main/presenter/llmProviderPresenter/providers/acpProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/acpProvider.ts
@@ -98,6 +98,23 @@ type AcpConnectionWithModelSelection = {
   ) => Promise<schema.SetSessionModelResponse>
 }
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+const summarizePromptBlocks = (blocks: schema.ContentBlock[]) =>
+  blocks.map((block) => {
+    if (!isRecord(block)) {
+      return { type: 'unknown', keys: [] }
+    }
+    const record = block as unknown as Record<string, unknown>
+    const text = typeof record.text === 'string' ? record.text : undefined
+    return {
+      type: typeof record.type === 'string' ? record.type : 'unknown',
+      textLength: text?.length,
+      keys: Object.keys(record)
+    }
+  })
+
 async function setSessionModelCompat(
   connection: AcpConnectionWithModelSelection,
   params: schema.SetSessionModelRequest
@@ -920,6 +937,22 @@ export class AcpProvider extends BaseLLMProvider {
         sessionId: session.sessionId,
         prompt
       }
+      const promptSummary = {
+        sessionId: session.sessionId,
+        conversationId,
+        agentId: session.agentId,
+        turnId: turn.id,
+        blockCount: prompt.length,
+        blocks: summarizePromptBlocks(prompt),
+        timeoutMs
+      }
+      console.info(`[ACP] Sending prompt to ACP session ${session.sessionId}:`, promptSummary)
+      this.processManager?.appendDebugEvent?.(session.agentId, {
+        kind: 'request',
+        action: 'session/prompt',
+        sessionId: session.sessionId,
+        payload: promptSummary
+      })
       await this.emitRequestTrace(modelConfig, {
         endpoint: 'acp://session/prompt',
         headers: {},
@@ -940,7 +973,21 @@ export class AcpProvider extends BaseLLMProvider {
             })
           ])
         : promptRequest)
-      console.log('[ACP] runPrompt: response:', response)
+      const responseSummary = {
+        sessionId: session.sessionId,
+        conversationId,
+        agentId: session.agentId,
+        turnId: turn.id,
+        stopReason: response.stopReason,
+        keys: Object.keys(response as Record<string, unknown>)
+      }
+      console.info(`[ACP] Prompt completed for ACP session ${session.sessionId}:`, responseSummary)
+      this.processManager?.appendDebugEvent?.(session.agentId, {
+        kind: 'response',
+        action: 'session/prompt',
+        sessionId: session.sessionId,
+        payload: responseSummary
+      })
       const completedTurn = this.promptController.complete(session.sessionId, response.stopReason)
       if (completedTurn) {
         await this.persistTurnFinish({
@@ -980,6 +1027,14 @@ export class AcpProvider extends BaseLLMProvider {
       }
       const message =
         error instanceof Error ? error.message : typeof error === 'string' ? error : 'Unknown error'
+      console.error(`[ACP] Prompt failed for ACP session ${session.sessionId}:`, error)
+      this.processManager?.appendDebugEvent?.(session.agentId, {
+        kind: 'error',
+        action: 'session/prompt',
+        sessionId: session.sessionId,
+        message,
+        payload: error instanceof Error ? { name: error.name, stack: error.stack } : error
+      })
       queue.push(createStreamEvent.error(`ACP: ${message}`))
     } finally {
       if (timeoutId) {

--- a/src/renderer/src/i18n/da-DK/chat.json
+++ b/src/renderer/src/i18n/da-DK/chat.json
@@ -31,6 +31,7 @@
     "rateLimitWaitingTooltip": "Vent {seconds} sekunder, interval {interval} sekunder",
     "fileArea": "fil område",
     "agentWorkspaceCurrent": "Nuværende arbejdsmappe: {path}",
+    "workspaceUnavailableTooltip": "Mappen findes ikke eller kan ikke tilgås: {path}",
     "agentWorkspaceSelect": "Vælg arbejdsmappe",
     "agentWorkspaceTooltip": "Indstil agentens arbejdsmappe",
     "attach": "Vedhæft",

--- a/src/renderer/src/i18n/en-US/chat.json
+++ b/src/renderer/src/i18n/en-US/chat.json
@@ -32,6 +32,7 @@
     "agentWorkspaceTooltip": "Set Agent workspace directory",
     "agentWorkspaceSelect": "Select a folder to use as the workspace",
     "agentWorkspaceCurrent": "Current workspace: {path}",
+    "workspaceUnavailableTooltip": "Directory does not exist or cannot be accessed: {path}",
     "mcp": {
       "badge": "MCP {count}",
       "title": "Enabled MCP",

--- a/src/renderer/src/i18n/fa-IR/chat.json
+++ b/src/renderer/src/i18n/fa-IR/chat.json
@@ -24,7 +24,7 @@
     "acpMode": "حالت",
     "acpModeTooltip": "حالت فعلی: {mode}",
     "agentWorkspaceCurrent": "فهرست کاری فعلی: {path}",
-    "workspaceUnavailableTooltip": "Directory does not exist or cannot be accessed: {path}",
+    "workspaceUnavailableTooltip": "فهرست وجود ندارد یا قابل دسترسی نیست: {path}",
     "agentWorkspaceSelect": "پوشه کاری را انتخاب کنید",
     "agentWorkspaceTooltip": "دایرکتوری کاری عامل را تنظیم کنید",
     "attach": "پیوست",

--- a/src/renderer/src/i18n/fa-IR/chat.json
+++ b/src/renderer/src/i18n/fa-IR/chat.json
@@ -24,6 +24,7 @@
     "acpMode": "حالت",
     "acpModeTooltip": "حالت فعلی: {mode}",
     "agentWorkspaceCurrent": "فهرست کاری فعلی: {path}",
+    "workspaceUnavailableTooltip": "Directory does not exist or cannot be accessed: {path}",
     "agentWorkspaceSelect": "پوشه کاری را انتخاب کنید",
     "agentWorkspaceTooltip": "دایرکتوری کاری عامل را تنظیم کنید",
     "attach": "پیوست",

--- a/src/renderer/src/i18n/fr-FR/chat.json
+++ b/src/renderer/src/i18n/fr-FR/chat.json
@@ -24,6 +24,7 @@
     "acpMode": "Mode",
     "acpModeTooltip": "Mode actuel : {mode}",
     "agentWorkspaceCurrent": "Répertoire de travail actuel : {path}",
+    "workspaceUnavailableTooltip": "Le répertoire n’existe pas ou est inaccessible : {path}",
     "agentWorkspaceSelect": "Sélectionnez le répertoire de travail",
     "agentWorkspaceTooltip": "Définir le répertoire de travail de l'agent",
     "attach": "Joindre",

--- a/src/renderer/src/i18n/he-IL/chat.json
+++ b/src/renderer/src/i18n/he-IL/chat.json
@@ -24,7 +24,7 @@
     "acpMode": "דֶגֶם",
     "acpModeTooltip": "מצב נוכחי: {mode}",
     "agentWorkspaceCurrent": "ספריית עבודה נוכחית: {path}",
-    "workspaceUnavailableTooltip": "Directory does not exist or cannot be accessed: {path}",
+    "workspaceUnavailableTooltip": "התיקייה אינה קיימת או לא ניתנת לגישה: {path}",
     "agentWorkspaceSelect": "בחר ספריית עבודה",
     "agentWorkspaceTooltip": "הגדר את ספריית העבודה של הסוכן",
     "attach": "צרף",

--- a/src/renderer/src/i18n/he-IL/chat.json
+++ b/src/renderer/src/i18n/he-IL/chat.json
@@ -24,6 +24,7 @@
     "acpMode": "דֶגֶם",
     "acpModeTooltip": "מצב נוכחי: {mode}",
     "agentWorkspaceCurrent": "ספריית עבודה נוכחית: {path}",
+    "workspaceUnavailableTooltip": "Directory does not exist or cannot be accessed: {path}",
     "agentWorkspaceSelect": "בחר ספריית עבודה",
     "agentWorkspaceTooltip": "הגדר את ספריית העבודה של הסוכן",
     "attach": "צרף",

--- a/src/renderer/src/i18n/ja-JP/chat.json
+++ b/src/renderer/src/i18n/ja-JP/chat.json
@@ -24,6 +24,7 @@
     "acpMode": "モード",
     "acpModeTooltip": "現在のモード：{mode}",
     "agentWorkspaceCurrent": "現在の作業ディレクトリ: {パス}",
+    "workspaceUnavailableTooltip": "ディレクトリが存在しないかアクセスできません: {path}",
     "agentWorkspaceSelect": "作業ディレクトリを選択",
     "agentWorkspaceTooltip": "エージェントの作業ディレクトリを設定する",
     "attach": "添付",

--- a/src/renderer/src/i18n/ko-KR/chat.json
+++ b/src/renderer/src/i18n/ko-KR/chat.json
@@ -24,6 +24,7 @@
     "acpMode": "모드",
     "acpModeTooltip": "현재 모드: {mode}",
     "agentWorkspaceCurrent": "현재 작업 디렉터리: {path}",
+    "workspaceUnavailableTooltip": "디렉터리가 없거나 접근할 수 없습니다: {path}",
     "agentWorkspaceSelect": "작업 디렉터리 선택",
     "agentWorkspaceTooltip": "에이전트 작업 디렉터리 설정",
     "attach": "첨부",

--- a/src/renderer/src/i18n/pt-BR/chat.json
+++ b/src/renderer/src/i18n/pt-BR/chat.json
@@ -24,6 +24,7 @@
     "acpMode": "Modo",
     "acpModeTooltip": "Modo atual: {mode}",
     "agentWorkspaceCurrent": "Diretório de trabalho atual: {path}",
+    "workspaceUnavailableTooltip": "O diretório não existe ou não pode ser acessado: {path}",
     "agentWorkspaceSelect": "Selecione o diretório de trabalho",
     "agentWorkspaceTooltip": "Definir diretório de trabalho do agente",
     "attach": "Anexar",

--- a/src/renderer/src/i18n/ru-RU/chat.json
+++ b/src/renderer/src/i18n/ru-RU/chat.json
@@ -24,7 +24,7 @@
     "acpMode": "Режим",
     "acpModeTooltip": "Текущий режим: {mode}",
     "agentWorkspaceCurrent": "Текущий рабочий каталог: {path}",
-    "workspaceUnavailableTooltip": "Directory does not exist or cannot be accessed: {path}",
+    "workspaceUnavailableTooltip": "Каталог не существует или недоступен: {path}",
     "agentWorkspaceSelect": "Выберите рабочий каталог",
     "agentWorkspaceTooltip": "Установить рабочий каталог агента",
     "attach": "Прикрепить",

--- a/src/renderer/src/i18n/ru-RU/chat.json
+++ b/src/renderer/src/i18n/ru-RU/chat.json
@@ -24,6 +24,7 @@
     "acpMode": "Режим",
     "acpModeTooltip": "Текущий режим: {mode}",
     "agentWorkspaceCurrent": "Текущий рабочий каталог: {path}",
+    "workspaceUnavailableTooltip": "Directory does not exist or cannot be accessed: {path}",
     "agentWorkspaceSelect": "Выберите рабочий каталог",
     "agentWorkspaceTooltip": "Установить рабочий каталог агента",
     "attach": "Прикрепить",

--- a/src/renderer/src/i18n/zh-CN/chat.json
+++ b/src/renderer/src/i18n/zh-CN/chat.json
@@ -32,6 +32,7 @@
     "agentWorkspaceTooltip": "设置 Agent 工作目录",
     "agentWorkspaceSelect": "选择工作目录",
     "agentWorkspaceCurrent": "当前工作目录：{path}",
+    "workspaceUnavailableTooltip": "目录不存在或无法访问：{path}",
     "mcp": {
       "badge": "MCP {count}",
       "title": "已启用 MCP",

--- a/src/renderer/src/i18n/zh-HK/chat.json
+++ b/src/renderer/src/i18n/zh-HK/chat.json
@@ -24,6 +24,7 @@
     "acpMode": "模式",
     "acpModeTooltip": "目前模式：{mode}",
     "agentWorkspaceCurrent": "當前工作目錄：{path}",
+    "workspaceUnavailableTooltip": "目錄不存在或無法存取：{path}",
     "agentWorkspaceSelect": "選擇工作目錄",
     "agentWorkspaceTooltip": "設置 Agent 工作目錄",
     "attach": "添加附件",

--- a/src/renderer/src/i18n/zh-TW/chat.json
+++ b/src/renderer/src/i18n/zh-TW/chat.json
@@ -24,6 +24,7 @@
     "acpMode": "模式",
     "acpModeTooltip": "目前模式：{mode}",
     "agentWorkspaceCurrent": "當前工作目錄：{path}",
+    "workspaceUnavailableTooltip": "目錄不存在或無法存取：{path}",
     "agentWorkspaceSelect": "選擇工作目錄",
     "agentWorkspaceTooltip": "設置 Agent 工作目錄",
     "attach": "新增附件",

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -24,6 +24,13 @@
             >
               <Icon icon="lucide:folder" class="w-3.5 h-3.5" />
               <span>{{ selectedProjectName }}</span>
+              <Icon
+                v-if="selectedProjectDirectoryInvalid"
+                icon="lucide:circle-alert"
+                data-testid="new-thread-project-missing-warning"
+                class="w-3.5 h-3.5 text-amber-500"
+                :title="selectedProjectUnavailableTooltip"
+              />
               <Icon icon="lucide:chevron-down" class="w-3 h-3" />
             </Button>
           </DropdownMenuTrigger>
@@ -46,10 +53,17 @@
               @click="projectStore.selectProject(project.path)"
             >
               <Icon icon="lucide:folder" class="w-3.5 h-3.5 text-muted-foreground" />
-              <div class="flex flex-col min-w-0">
+              <div class="flex flex-col min-w-0 flex-1">
                 <span class="truncate">{{ project.name }}</span>
                 <span class="text-[10px] text-muted-foreground truncate">{{ project.path }}</span>
               </div>
+              <Icon
+                v-if="isSelectedInvalidProjectPath(project.path)"
+                icon="lucide:circle-alert"
+                data-testid="new-thread-project-menu-missing-warning"
+                class="w-3.5 h-3.5 text-amber-500 shrink-0"
+                :title="selectedProjectUnavailableTooltip"
+              />
             </DropdownMenuItem>
             <DropdownMenuItem
               class="gap-2 text-xs py-1.5 px-2"
@@ -69,7 +83,7 @@
           :session-id="acpDraftSessionId"
           :workspace-path="projectStore.selectedProject?.path ?? null"
           :is-acp-session="isAcpSelectedAgent"
-          :submit-disabled="isAcpWorkdirMissing"
+          :submit-disabled="isAcpWorkdirUnavailable"
           @update:files="onFilesChange"
           @pending-skills-change="onPendingSkillsChange"
           @command-submit="onCommandSubmit"
@@ -77,7 +91,7 @@
         >
           <template #toolbar>
             <ChatInputToolbar
-              :send-disabled="isAcpWorkdirMissing || !message.trim()"
+              :send-disabled="isAcpWorkdirUnavailable || !message.trim()"
               @attach="onAttach"
               @send="onSubmit"
             />
@@ -114,6 +128,7 @@ import { useAgentStore } from '@/stores/ui/agent'
 import { useModelStore } from '@/stores/modelStore'
 import { useDraftStore, type StartDeeplinkPayload } from '@/stores/ui/draft'
 import { createConfigClient } from '@api/ConfigClient'
+import { createFileClient } from '@api/FileClient'
 import { createSessionClient } from '@api/SessionClient'
 import type {
   DeepChatAgentConfig,
@@ -135,6 +150,7 @@ const agentStore = useAgentStore()
 const modelStore = useModelStore()
 const draftStore = useDraftStore()
 const configClient = createConfigClient()
+const fileClient = createFileClient()
 const sessionClient = createSessionClient()
 const { t } = useI18n()
 
@@ -186,6 +202,7 @@ const normalizeProjectPath = (value: string | null | undefined) => {
   const normalized = value?.trim()
   return normalized ? normalized : null
 }
+const selectedProjectPath = computed(() => normalizeProjectPath(projectStore.selectedProject?.path))
 const hasExplicitNoProjectSelection = computed(
   () => projectStore.selectionSource === 'manual' && !projectStore.selectedProject?.path?.trim()
 )
@@ -196,12 +213,41 @@ const selectedProjectName = computed(() => {
   return hasExplicitNoProjectSelection.value ? t('common.project.none') : t('common.project.select')
 })
 const canClearProjectSelection = computed(() => Boolean(projectStore.selectedProject?.path?.trim()))
+type ProjectDirectoryStatus = 'none' | 'checking' | 'valid' | 'invalid'
+const selectedProjectDirectoryStatus = ref<ProjectDirectoryStatus>('none')
+const selectedProjectDirectoryCheckSeq = ref(0)
+const selectedProjectDirectoryInvalid = computed(
+  () => selectedProjectDirectoryStatus.value === 'invalid'
+)
+const selectedProjectUnavailableTooltip = computed(() =>
+  selectedProjectPath.value
+    ? t('chat.input.workspaceUnavailableTooltip', { path: selectedProjectPath.value })
+    : ''
+)
+const isSelectedInvalidProjectPath = (projectPath: string | null | undefined): boolean =>
+  selectedProjectDirectoryInvalid.value &&
+  normalizeProjectPath(projectPath) === selectedProjectPath.value
 const isAcpWorkdirMissing = computed(() => {
   if (!isAcpSelectedAgent.value) {
     return false
   }
-  return !projectStore.selectedProject?.path?.trim()
+  return !selectedProjectPath.value
 })
+const isAcpWorkdirInvalid = computed(
+  () =>
+    isAcpSelectedAgent.value &&
+    Boolean(selectedProjectPath.value) &&
+    selectedProjectDirectoryInvalid.value
+)
+const isAcpWorkdirChecking = computed(
+  () =>
+    isAcpSelectedAgent.value &&
+    Boolean(selectedProjectPath.value) &&
+    selectedProjectDirectoryStatus.value === 'checking'
+)
+const isAcpWorkdirUnavailable = computed(
+  () => isAcpWorkdirMissing.value || isAcpWorkdirInvalid.value || isAcpWorkdirChecking.value
+)
 
 const ensureEnabledModelsReady = async (): Promise<boolean> => {
   if (modelStore.initialized) {
@@ -288,7 +334,7 @@ const applyStartDeeplink = async (payload: StartDeeplinkPayload) => {
 }
 
 async function onSubmit() {
-  if (isAcpWorkdirMissing.value) return
+  if (isAcpWorkdirUnavailable.value) return
 
   const text = message.value.trim()
   if (!text) return
@@ -305,7 +351,7 @@ async function onSubmit() {
 }
 
 async function onCommandSubmit(command: string) {
-  if (isAcpWorkdirMissing.value) return
+  if (isAcpWorkdirUnavailable.value) return
   const text = command.trim()
   if (!text) return
   if (shouldIgnoreManualCompactionDraft(text)) return
@@ -324,6 +370,7 @@ function shouldIgnoreManualCompactionDraft(text: string): boolean {
 
 async function submitText(text: string, files: MessageFile[]) {
   if (!text.trim()) return
+  if (isAcpWorkdirUnavailable.value) return
 
   const agentId = selectedAgent.value.id
   const isAcp = isAcpSelectedAgent.value
@@ -521,12 +568,49 @@ const ensureAcpDraftSession = async (agentId: string, projectPath: string) => {
 }
 
 watch(
-  () => [agentStore.selectedAgentId, projectStore.selectedProject?.path] as const,
-  ([selectedAgentId, projectPath]) => {
+  () => selectedProjectPath.value,
+  async (projectPath) => {
+    const requestSeq = ++selectedProjectDirectoryCheckSeq.value
+    if (!projectPath) {
+      selectedProjectDirectoryStatus.value = 'none'
+      return
+    }
+
+    selectedProjectDirectoryStatus.value = 'checking'
+    try {
+      const isDirectory = await fileClient.isDirectory(projectPath)
+      if (requestSeq !== selectedProjectDirectoryCheckSeq.value) {
+        return
+      }
+      selectedProjectDirectoryStatus.value = isDirectory ? 'valid' : 'invalid'
+    } catch (error) {
+      if (requestSeq !== selectedProjectDirectoryCheckSeq.value) {
+        return
+      }
+      console.warn('[NewThreadPage] Failed to validate selected project directory:', error)
+      selectedProjectDirectoryStatus.value = 'invalid'
+    }
+  },
+  { immediate: true }
+)
+
+watch(
+  () =>
+    [
+      agentStore.selectedAgentId,
+      selectedProjectPath.value,
+      selectedProjectDirectoryStatus.value
+    ] as const,
+  ([selectedAgentId, projectPath, directoryStatus]) => {
     acpDraftRequestSeq.value += 1
     cancelEnsureDraftTask?.()
     cancelEnsureDraftTask = null
-    if (!selectedAgentId || selectedAgent.value.type === 'deepchat' || !projectPath?.trim()) {
+    if (
+      !selectedAgentId ||
+      selectedAgent.value.type === 'deepchat' ||
+      !projectPath ||
+      directoryStatus !== 'valid'
+    ) {
       acpDraftSessionId.value = null
       lastAcpDraftKey.value = null
       return

--- a/test/main/presenter/llmProviderPresenter/acp/acpProcessManager.test.ts
+++ b/test/main/presenter/llmProviderPresenter/acp/acpProcessManager.test.ts
@@ -454,11 +454,11 @@ describe('AcpProcessManager config cache fallback', () => {
     const badHashDir = `${npxRoot}/286fc3b7ffd18687`
     const otherHashDir = `${npxRoot}/keep-me`
     const existingDirs = new Set([badHashDir, otherHashDir])
-    const renameSync = vi.fn((from: string, to: string) => {
+    const renameImpl = vi.fn((from: string, to: string) => {
       existingDirs.delete(from)
       existingDirs.add(to)
     })
-    ;(fs as unknown as { renameSync: typeof renameSync }).renameSync = renameSync
+    const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation(renameImpl)
     const existsSpy = vi
       .spyOn(fs, 'existsSync')
       .mockImplementation((input) => existingDirs.has(String(input)))
@@ -507,13 +507,14 @@ describe('AcpProcessManager config cache fallback', () => {
       ).resolves.toBe(readyHandle)
 
       expect(spawnOnceSpy).toHaveBeenCalledTimes(2)
-      expect(renameSync).toHaveBeenCalledWith(
+      expect(renameImpl).toHaveBeenCalledWith(
         badHashDir,
         expect.stringMatching(/\/286fc3b7ffd18687\.bad-\d+$/)
       )
       expect(existingDirs.has(badHashDir)).toBe(false)
       expect(existingDirs.has(otherHashDir)).toBe(true)
     } finally {
+      renameSpy.mockRestore()
       existsSpy.mockRestore()
       statSpy.mockRestore()
     }
@@ -523,8 +524,8 @@ describe('AcpProcessManager config cache fallback', () => {
     const tmpRoot = '/tmp/deepchat-acp-npx-skip'
     const npxRoot = `${tmpRoot}/_npx`
     const badHashDir = `${npxRoot}/286fc3b7ffd18687`
-    const renameSync = vi.fn()
-    ;(fs as unknown as { renameSync: typeof renameSync }).renameSync = renameSync
+    const renameImpl = vi.fn()
+    const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation(renameImpl)
 
     try {
       const cases = [
@@ -570,10 +571,10 @@ describe('AcpProcessManager config cache fallback', () => {
         ).rejects.toBe(error)
 
         expect(spawnOnceSpy).toHaveBeenCalledTimes(1)
-        expect(renameSync).not.toHaveBeenCalled()
+        expect(renameImpl).not.toHaveBeenCalled()
       }
     } finally {
-      renameSync.mockReset()
+      renameSpy.mockRestore()
     }
   })
 

--- a/test/main/presenter/llmProviderPresenter/acp/acpProcessManager.test.ts
+++ b/test/main/presenter/llmProviderPresenter/acp/acpProcessManager.test.ts
@@ -315,6 +315,8 @@ describe('AcpProcessManager config cache fallback', () => {
   it('keeps explicit PATH overrides ahead of bundled runtime and shell PATH', async () => {
     const originalPath = process.env.PATH
     process.env.PATH = '/usr/bin:/bin'
+    let existsSpy: { mockRestore: () => void } | null = null
+    let statSpy: { mockRestore: () => void } | null = null
 
     try {
       const launchSpec = {
@@ -365,7 +367,10 @@ describe('AcpProcessManager config cache fallback', () => {
         false
       )
       vi.spyOn((manager as any).runtimeHelper, 'getUserNpmPrefix').mockReturnValue(null)
-      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      existsSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      statSpy = vi.spyOn(fs, 'statSync').mockReturnValue({
+        isDirectory: () => true
+      } as fs.Stats)
 
       await (manager as any).spawnAgentProcess(
         {
@@ -398,6 +403,177 @@ describe('AcpProcessManager config cache fallback', () => {
       expect(pathValue.indexOf('/launch/bin')).toBeLessThan(pathValue.indexOf('/runtime/bin'))
     } finally {
       process.env.PATH = originalPath
+      existsSpy?.mockRestore()
+      statSpy?.mockRestore()
+    }
+  })
+
+  it('throws for a missing explicit workdir instead of falling back to home', async () => {
+    const manager = createManager()
+    const launchSpec = {
+      agentId: 'agent-1',
+      source: 'manual',
+      distributionType: 'manual' as const,
+      command: 'agent',
+      args: [],
+      env: {}
+    }
+    const existsSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false)
+    vi.mocked(spawn).mockClear()
+    vi.spyOn(shellEnvHelper, 'getShellEnvironment').mockResolvedValue({
+      PATH: '/shell/bin'
+    })
+    vi.spyOn((manager as any).runtimeHelper, 'initializeRuntimes').mockImplementation(() => {})
+    vi.spyOn((manager as any).runtimeHelper, 'expandPath').mockImplementation(
+      (value: string) => value
+    )
+    vi.spyOn((manager as any).runtimeHelper, 'replaceWithRuntimeCommand').mockImplementation(
+      (value: string) => value
+    )
+
+    try {
+      await expect(
+        (manager as any).spawnAgentProcess(
+          {
+            id: 'agent-1',
+            name: 'Agent One',
+            command: 'agent'
+          },
+          '/tmp/missing-workspace',
+          launchSpec
+        )
+      ).rejects.toThrow('[ACP] workdir "/tmp/missing-workspace" does not exist for agent agent-1')
+      expect(spawn).not.toHaveBeenCalled()
+    } finally {
+      existsSpy.mockRestore()
+    }
+  })
+
+  it('moves only the broken npx hash directory and retries once', async () => {
+    const npxRoot = '/tmp/deepchat-acp-npx/_npx'
+    const badHashDir = `${npxRoot}/286fc3b7ffd18687`
+    const otherHashDir = `${npxRoot}/keep-me`
+    const existingDirs = new Set([badHashDir, otherHashDir])
+    const renameSync = vi.fn((from: string, to: string) => {
+      existingDirs.delete(from)
+      existingDirs.add(to)
+    })
+    ;(fs as unknown as { renameSync: typeof renameSync }).renameSync = renameSync
+    const existsSpy = vi
+      .spyOn(fs, 'existsSync')
+      .mockImplementation((input) => existingDirs.has(String(input)))
+    const statSpy = vi.spyOn(fs, 'statSync').mockImplementation((input) => {
+      if (existingDirs.has(String(input))) {
+        return { isDirectory: () => true } as fs.Stats
+      }
+      const error = new Error('ENOENT') as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      throw error
+    })
+
+    try {
+      const manager = createManager()
+      const launchSpec = {
+        agentId: 'agent-1',
+        source: 'manual',
+        distributionType: 'npx' as const,
+        command: 'npx',
+        args: ['-y', 'agent'],
+        env: {}
+      }
+      const firstError = new Error('initialization failed')
+      ;(firstError as Error & { acpStderr?: string }).acpStderr = [
+        'npm error code ENOENT',
+        `npm error path ${badHashDir}/package.json`,
+        'npm error enoent Could not read package.json'
+      ].join('\n')
+      const readyHandle = { agentId: 'agent-1', status: 'ready' }
+      const spawnOnceSpy = vi
+        .spyOn(manager as any, 'spawnProcessOnce')
+        .mockRejectedValueOnce(firstError)
+        .mockResolvedValueOnce(readyHandle)
+
+      await expect(
+        (manager as any).spawnProcess(
+          {
+            id: 'agent-1',
+            name: 'Agent One',
+            command: 'npx'
+          },
+          '/tmp/workspace',
+          launchSpec,
+          'signature'
+        )
+      ).resolves.toBe(readyHandle)
+
+      expect(spawnOnceSpy).toHaveBeenCalledTimes(2)
+      expect(renameSync).toHaveBeenCalledWith(
+        badHashDir,
+        expect.stringMatching(/\/286fc3b7ffd18687\.bad-\d+$/)
+      )
+      expect(existingDirs.has(badHashDir)).toBe(false)
+      expect(existingDirs.has(otherHashDir)).toBe(true)
+    } finally {
+      existsSpy.mockRestore()
+      statSpy.mockRestore()
+    }
+  })
+
+  it('does not repair npx cache for non-npx or unrelated ENOENT failures', async () => {
+    const tmpRoot = '/tmp/deepchat-acp-npx-skip'
+    const npxRoot = `${tmpRoot}/_npx`
+    const badHashDir = `${npxRoot}/286fc3b7ffd18687`
+    const renameSync = vi.fn()
+    ;(fs as unknown as { renameSync: typeof renameSync }).renameSync = renameSync
+
+    try {
+      const cases = [
+        {
+          distributionType: 'manual' as const,
+          stderr: ['npm error code ENOENT', `npm error path ${badHashDir}/package.json`].join('\n')
+        },
+        {
+          distributionType: 'npx' as const,
+          stderr: `npm error path ${badHashDir}/package.json`
+        },
+        {
+          distributionType: 'npx' as const,
+          stderr: `npm error code ENOENT\nnpm error path ${tmpRoot}/package.json`
+        }
+      ]
+
+      for (const testCase of cases) {
+        const manager = createManager()
+        const launchSpec = {
+          agentId: 'agent-1',
+          source: 'manual',
+          distributionType: testCase.distributionType,
+          command: 'npx',
+          args: [],
+          env: {}
+        }
+        const error = new Error('initialization failed')
+        ;(error as Error & { acpStderr?: string }).acpStderr = testCase.stderr
+        const spawnOnceSpy = vi.spyOn(manager as any, 'spawnProcessOnce').mockRejectedValue(error)
+
+        await expect(
+          (manager as any).spawnProcess(
+            {
+              id: 'agent-1',
+              name: 'Agent One',
+              command: 'npx'
+            },
+            '/tmp/workspace',
+            launchSpec,
+            'signature'
+          )
+        ).rejects.toBe(error)
+
+        expect(spawnOnceSpy).toHaveBeenCalledTimes(1)
+        expect(renameSync).not.toHaveBeenCalled()
+      }
+    } finally {
+      renameSync.mockReset()
     }
   })
 

--- a/test/renderer/components/NewThreadPage.test.ts
+++ b/test/renderer/components/NewThreadPage.test.ts
@@ -30,12 +30,18 @@ const createChatInputBoxStub = () =>
       'command-submit',
       'pending-skills-change'
     ],
-    setup(_props, { expose }) {
+    setup(props, { expose }) {
       expose({
         triggerAttach: chatInputTriggerAttachMock,
         getPendingSkillsSnapshot: () => [...chatInputPendingSkillsSnapshotRef.value]
       })
-      return () => h('div')
+      return () =>
+        h('div', {
+          'data-testid': 'chat-input-box',
+          'data-submit-disabled': String(props.submitDisabled),
+          'data-workspace-path': props.workspacePath ?? '',
+          'data-is-acp-session': String(props.isAcpSession)
+        })
     }
   })
 
@@ -48,7 +54,8 @@ const setup = async (options?: {
   selectedProject?: {
     path: string
     name: string
-  }
+  } | null
+  isDirectory?: boolean | ((path: string) => Promise<boolean> | boolean)
   defaultProjectPath?: string | null
   defaultModel?: { providerId: string; modelId: string }
   preferredModel?: { providerId: string; modelId: string }
@@ -67,9 +74,11 @@ const setup = async (options?: {
       name: 'workspace'
     }) as { path: string; name: string } | null,
     selectedProjectName: options?.selectedProject?.name ?? 'workspace',
+    selectionSource: 'manual' as 'manual' | 'default',
     defaultProjectPath: options?.defaultProjectPath ?? null,
     projects: [],
-    selectProject: vi.fn((path: string | null) => {
+    selectProject: vi.fn((path: string | null, source: 'manual' | 'default' = 'manual') => {
+      projectStore.selectionSource = source
       projectStore.selectedProject = path
         ? {
             path,
@@ -169,6 +178,10 @@ const setup = async (options?: {
         })
     )
   }
+  const isDirectoryMock = vi.fn((path: string) => {
+    const resolver = options?.isDirectory ?? true
+    return Promise.resolve(typeof resolver === 'function' ? resolver(path) : resolver)
+  })
   const startupDeferredTasks: Array<() => void | Promise<void>> = []
 
   vi.doMock('@/stores/ui/project', () => ({
@@ -191,6 +204,11 @@ const setup = async (options?: {
   }))
   vi.doMock('@api/SessionClient', () => ({
     createSessionClient: vi.fn(() => sessionClient)
+  }))
+  vi.doMock('@api/FileClient', () => ({
+    createFileClient: vi.fn(() => ({
+      isDirectory: isDirectoryMock
+    }))
   }))
   vi.doMock('@/lib/startupDeferred', () => ({
     scheduleStartupDeferredTask: vi.fn((task: () => void | Promise<void>) => {
@@ -226,14 +244,14 @@ const setup = async (options?: {
   const wrapper = mount(NewThreadPage, {
     global: {
       stubs: {
-        TooltipProvider: true,
-        Button: true,
-        DropdownMenu: true,
-        DropdownMenuTrigger: true,
-        DropdownMenuContent: true,
-        DropdownMenuItem: true,
-        DropdownMenuLabel: true,
-        DropdownMenuSeparator: true,
+        TooltipProvider: passthrough('TooltipProvider'),
+        Button: passthrough('Button'),
+        DropdownMenu: passthrough('DropdownMenu'),
+        DropdownMenuTrigger: passthrough('DropdownMenuTrigger'),
+        DropdownMenuContent: passthrough('DropdownMenuContent'),
+        DropdownMenuItem: passthrough('DropdownMenuItem'),
+        DropdownMenuLabel: passthrough('DropdownMenuLabel'),
+        DropdownMenuSeparator: passthrough('DropdownMenuSeparator'),
         Icon: true,
         ChatInputToolbar: true,
         ChatStatusBar: true
@@ -251,6 +269,7 @@ const setup = async (options?: {
     modelStore,
     draftStore,
     sessionClient,
+    isDirectoryMock,
     flushStartupDeferredTasks: async () => {
       while (startupDeferredTasks.length > 0) {
         const task = startupDeferredTasks.shift()
@@ -305,6 +324,81 @@ describe('NewThreadPage ACP draft session bootstrap', () => {
     })
 
     expect((wrapper.vm as any).acpDraftSessionId).toBe('draft-1')
+  })
+
+  it('shows a warning and blocks ACP draft/send when the selected workdir is invalid', async () => {
+    const { wrapper, sessionClient, sessionStore } = await setup({
+      isDirectory: false
+    })
+
+    expect(wrapper.find('[data-testid="new-thread-project-missing-warning"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="chat-input-box"]').attributes('data-submit-disabled')).toBe(
+      'true'
+    )
+    expect(sessionClient.ensureAcpDraftSession).not.toHaveBeenCalled()
+
+    ;(wrapper.vm as any).message = 'hello invalid acp'
+    await (wrapper.vm as any).onSubmit()
+    await flushPromises()
+
+    expect(sessionStore.createSession).not.toHaveBeenCalled()
+    expect(sessionStore.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('shows the same invalid-directory warning for DeepChat without blocking send', async () => {
+    const { wrapper, sessionStore, agentStore, modelStore, draftStore } = await setup({
+      isDirectory: false
+    })
+
+    agentStore.selectedAgentId = 'deepchat'
+    await flushPromises()
+    modelStore.enabledModels = [
+      {
+        providerId: 'openai',
+        models: [{ id: 'gpt-4', name: 'GPT-4' }]
+      }
+    ]
+    draftStore.providerId = 'openai'
+    draftStore.modelId = 'gpt-4'
+    ;(wrapper.vm as any).message = 'hello deepchat invalid workdir'
+
+    expect(wrapper.find('[data-testid="new-thread-project-missing-warning"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="chat-input-box"]').attributes('data-submit-disabled')).toBe(
+      'false'
+    )
+
+    await (wrapper.vm as any).onSubmit()
+    await flushPromises()
+
+    expect(sessionStore.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'hello deepchat invalid workdir',
+        agentId: 'deepchat',
+        projectDir: '/tmp/workspace'
+      })
+    )
+  })
+
+  it('clears the warning and resumes ACP draft creation after switching to a valid workdir', async () => {
+    const { wrapper, projectStore, sessionClient } = await setup({
+      isDirectory: (path) => path === '/tmp/valid-workspace'
+    })
+
+    expect(wrapper.find('[data-testid="new-thread-project-missing-warning"]').exists()).toBe(true)
+    expect(sessionClient.ensureAcpDraftSession).not.toHaveBeenCalled()
+
+    projectStore.selectedProject = {
+      path: '/tmp/valid-workspace',
+      name: 'valid-workspace'
+    }
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="new-thread-project-missing-warning"]').exists()).toBe(false)
+    expect(sessionClient.ensureAcpDraftSession).toHaveBeenCalledWith({
+      agentId: 'acp-agent',
+      projectDir: '/tmp/valid-workspace',
+      permissionMode: 'full_access'
+    })
   })
 
   it('reuses ensured draft session on first submit', async () => {
@@ -597,10 +691,7 @@ describe('NewThreadPage ACP draft session bootstrap', () => {
       }
     ]
     ;(wrapper.vm as any).onPendingSkillsChange(['stale-skill'])
-    ;(wrapper.vm as any).chatInputRef = {
-      triggerAttach: vi.fn(),
-      getPendingSkillsSnapshot: () => ['live-skill', 'live-skill']
-    }
+    chatInputPendingSkillsSnapshotRef.value = ['live-skill', 'live-skill']
     ;(wrapper.vm as any).message = 'hello deepchat'
 
     await (wrapper.vm as any).onSubmit()

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -176,6 +176,7 @@ vi.mock('fs', () => {
     writeFileSync: vi.fn(),
     mkdirSync: vi.fn(),
     readdirSync: vi.fn(),
+    renameSync: vi.fn(),
     constants: {
       X_OK: 1
     },


### PR DESCRIPTION
## Summary
- add universal new-thread selected-directory validation and warning icon
- block ACP draft creation, warmup path, and send when the workdir is missing or invalid
- make ACP process launch reject explicit missing/non-directory cwd instead of falling back to HOME
- auto-repair the exact broken npm _npx hash directory for package.json ENOENT and retry once
- add ACP initialization/protocol diagnostics for easier debugging

## Tests
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck:node
- pnpm run typecheck:web
- pnpm exec vitest --config vitest.config.renderer.ts test/renderer/components/NewThreadPage.test.ts
- pnpm exec vitest --config vitest.config.ts test/main/presenter/llmProviderPresenter/acp/acpProcessManager.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace directory validation with warning UI and disabled send/draft flows when ACP workdir is unavailable.
  * One-time npx cache repair retry on eligible agent startup failures.
  * Summarized protocol and session-level diagnostics during ACP startup and prompts.

* **Localization**
  * Added workspace-unavailable tooltip translations across multiple locales.

* **Documentation**
  * Added plans, specs, and task checklists for ACP initialization logging and workdir/npx recovery.

* **Tests**
  * Added and expanded focused tests covering workdir validation, spawn/retry behavior, and logging paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1620)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->