### PR TITLE
test(questionTool): add parser coverage and reject unsupported fields

### DIFF
--- a/src/main/lib/agentRuntime/questionTool.ts
+++ b/src/main/lib/agentRuntime/questionTool.ts
@@ -59,6 +59,7 @@ export const questionToolSchema = z
         'Whether free-form input is allowed for this question. The field name is `custom`, not `allowOther`.'
       )
   })
+  .strict()
   .describe(
     'Ask exactly one blocking clarification question. For multiple clarifications, use multiple deepchat_question tool calls instead of sending a `questions` array.'
   )

--- a/test/main/lib/agentRuntime/questionTool.test.ts
+++ b/test/main/lib/agentRuntime/questionTool.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseQuestionToolArgs,
+  QUESTION_TOOL_CONTRACT_HINT,
+  QUESTION_TOOL_NAME
+} from '../../../../src/main/lib/agentRuntime/questionTool'
+
+describe('parseQuestionToolArgs', () => {
+  it('normalizes valid question tool arguments and applies defaults', () => {
+    const result = parseQuestionToolArgs(
+      JSON.stringify({
+        header: '  Clarify  ',
+        question: '  Which option should we use?  ',
+        options: [
+          { label: '  Option A  ', description: '  First choice  ' },
+          { label: 'Option B', description: '   ' }
+        ]
+      })
+    )
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        header: 'Clarify',
+        question: 'Which option should we use?',
+        options: [{ label: 'Option A', description: 'First choice' }, { label: 'Option B' }],
+        multiple: false,
+        custom: true
+      }
+    })
+  })
+
+  it('repairs recoverable JSON before validation', () => {
+    const result = parseQuestionToolArgs(
+      '{"question":"Pick one","options":[{"label":"A","description":"  Alpha  ",},],}'
+    )
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        question: 'Pick one',
+        options: [{ label: 'A', description: 'Alpha' }],
+        multiple: false,
+        custom: true
+      }
+    })
+  })
+
+  it('returns a contract hint when the JSON is not parseable', () => {
+    expect(parseQuestionToolArgs('{"question":"\\uZZZZ"}')).toEqual({
+      success: false,
+      error: `Invalid JSON for question tool arguments. ${QUESTION_TOOL_CONTRACT_HINT}`
+    })
+  })
+
+  it('rejects unsupported top-level fields even when required fields are present', () => {
+    const cases = [
+      {
+        fieldName: 'allowOther',
+        payload: {
+          question: 'Pick one',
+          options: [{ label: 'A' }],
+          allowOther: true
+        }
+      },
+      {
+        fieldName: 'questions',
+        payload: {
+          question: 'Pick one',
+          options: [{ label: 'A' }],
+          questions: [{ question: 'Nested', options: [{ label: 'B' }] }]
+        }
+      }
+    ] as const
+
+    for (const testCase of cases) {
+      const result = parseQuestionToolArgs(JSON.stringify(testCase.payload))
+
+      expect(result.success).toBe(false)
+      if (result.success) {
+        throw new Error(`Expected ${testCase.fieldName} payload to be rejected`)
+      }
+
+      expect(result.error).toContain(`Invalid arguments for ${QUESTION_TOOL_NAME}.`)
+      expect(result.error).toContain(QUESTION_TOOL_CONTRACT_HINT)
+      expect(result.error).toContain(testCase.fieldName)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- add direct unit coverage for `parseQuestionToolArgs`
- verify normalization, default values, and `jsonrepair` recovery behavior
- reject unsupported top-level fields like `allowOther` and `questions` by making the top-level schema strict

## Why

`src/main/lib/agentRuntime/questionTool.ts` did not have dedicated unit coverage, and its Zod schema
silently accepted unsupported top-level keys when the required fields were otherwise valid. That
made the documented tool contract looser in practice than the prompt guidance claims.

## Verification

- `pnpm exec vitest run test/main/lib/agentRuntime/questionTool.test.ts`
- `pnpm exec vitest run test/main/presenter/toolPresenter/toolPresenter.test.ts -t "describes the question schema and returns actionable validation errors"`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`

## Notes

- Non-UI change; no screenshots needed.
- Verification was run with the bundled Codex Node runtime `v24.14.0`, so npm scripts emit an
  engine warning because the repo asks for `>=24.14.1 <25`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Question tool validation now strictly enforces expected fields, rejecting payloads with unsupported or unknown fields for improved data integrity.

* **Tests**
  * Added comprehensive test suite for question tool argument parsing, covering JSON recovery, normalization, and validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1631)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->