### PR TITLE
fix: stabilize model-level TTS routing and add model TTS settings

### DIFF
--- a/docs/features/unified-tts-provider/plan.md
+++ b/docs/features/unified-tts-provider/plan.md
@@ -1,0 +1,37 @@
+# Plan
+
+## Approach
+Treat TTS as a first-class model capability and follow the `ImageGeneration` routing strategy:
+- Extend shared model/type schema to include `tts`.
+- Add runtime TTS routing ahead of default chat generation.
+- Dispatch by model pattern:
+  - Pattern A: `/v1/audio/speech`
+  - Pattern B: `/v1/chat/completions` with `audio` output
+- Normalize returned audio into data URL and cache through existing device cache, then emit `image_data` with audio MIME type.
+
+## Affected Areas
+- Shared types/contracts:
+  - `src/shared/model.ts`
+  - `src/shared/types/model-db.ts`
+  - `src/shared/types/presenters/legacy.presenters.d.ts`
+  - `src/shared/contracts/common.ts`
+  - `src/shared/contracts/domainSchemas.ts`
+  - `src/shared/ttsSettings.ts` (new)
+- Main runtime/provider:
+  - `src/main/presenter/llmProviderPresenter/aiSdk/runtime.ts`
+  - `src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts`
+- Model DB:
+  - `resources/model-db/providers.json`
+- Renderer model type detection:
+  - `src/renderer/src/composables/useModelTypeDetection.ts`
+
+## Compatibility
+- Existing chat and image generation paths remain unchanged.
+- Existing renderer audio playback remains unchanged because it already handles `image_data` with `audio/*` MIME.
+
+## Verification Strategy
+Run:
+- `pnpm run typecheck`
+- `pnpm run format`
+- `pnpm run i18n`
+- `pnpm run lint`

--- a/docs/features/unified-tts-provider/spec.md
+++ b/docs/features/unified-tts-provider/spec.md
@@ -1,0 +1,34 @@
+# Unified TTS Provider (Model-Level)
+
+## User Need
+Users want TTS integrated as a model capability (`ModelType.TTS`) instead of per-provider custom integration, so any OpenAI-compatible provider can work if its model metadata marks TTS support.
+
+## Goal
+Enable model-level TTS routing in DeepChat similar to image generation routing, including:
+- Standard OpenAI `/v1/audio/speech` TTS models
+- Chat-completions-audio TTS models that return base64 audio
+
+## Acceptance Criteria
+1. `ModelType.TTS` is available in shared model contracts and model-db schema.
+2. Runtime can route TTS models by model capability metadata and endpoint hints.
+3. Runtime supports both TTS patterns and emits `image_data` events with `audio/*` MIME type for existing renderer playback.
+4. Model DB can represent TTS model type for built-in provider entries.
+5. Frontend model type detection exposes TTS model state for UI behavior alignment.
+6. Validation commands pass:
+- `pnpm run typecheck`
+- `pnpm run format`
+- `pnpm run i18n`
+- `pnpm run lint`
+
+## Constraints
+- Reuse existing audio rendering path via `image_data`; avoid introducing new stream event types.
+- Keep provider integration generic for OpenAI-compatible providers.
+- Do not introduce dedicated UI for TTS settings in this scope.
+
+## Non-Goals
+- New TTS player UI.
+- Voice catalog fetching UX.
+- VoiceAI provider refactor.
+
+## Open Questions
+- None for current scope.

--- a/docs/features/unified-tts-provider/tasks.md
+++ b/docs/features/unified-tts-provider/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## Shared Types + Runtime
+- [x] Add `ModelType.TTS` and `ApiEndpointType.AudioSpeech` in shared model enums.
+- [x] Extend model-db schema and parser for `tts` type.
+- [x] Add `src/shared/ttsSettings.ts` helpers for pattern detection and format normalization.
+- [x] Extend presenter model config contracts with optional `tts` settings.
+- [x] Add TTS route in runtime supporting pattern A and pattern B.
+- [x] Inject `shouldUseTts` capability check from AI SDK provider.
+
+## Model DB
+- [x] Mark relevant `aihubmix` models as `type: "tts"` in provider model list.
+- [x] Evaluate whether built-in `xiaomimimo` provider entry exists; it does not, so built-in DB coverage is skipped.
+
+## Renderer
+- [x] Extend `useModelTypeDetection` to include `tts` and expose `isTtsModel`.
+
+## Validation
+- [x] Run `pnpm run typecheck`.
+- [x] Run `pnpm run format`.
+- [x] Run `pnpm run i18n`.
+- [x] Run `pnpm run lint`.

--- a/src/main/presenter/configPresenter/index.ts
+++ b/src/main/presenter/configPresenter/index.ts
@@ -984,6 +984,8 @@ export class ConfigPresenter implements IConfigPresenter {
         return ModelType.Rerank
       case 'imageGeneration':
         return ModelType.ImageGeneration
+      case 'tts':
+        return ModelType.TTS
       case 'chat':
       default:
         return ModelType.Chat

--- a/src/main/presenter/configPresenter/modelConfig.ts
+++ b/src/main/presenter/configPresenter/modelConfig.ts
@@ -121,6 +121,8 @@ export class ModelConfigHelper {
           return ModelType.Rerank
         case 'imageGeneration':
           return ModelType.ImageGeneration
+        case 'tts':
+          return ModelType.TTS
         default:
           // Invalid type, fall through to default
           break
@@ -176,7 +178,11 @@ export class ModelConfigHelper {
       reasoning: Boolean(reasoningEnabled),
       type: modelType,
       apiEndpoint:
-        modelType === ModelType.ImageGeneration ? ApiEndpointType.Image : ApiEndpointType.Chat,
+        modelType === ModelType.ImageGeneration
+          ? ApiEndpointType.Image
+          : modelType === ModelType.TTS
+            ? ApiEndpointType.AudioSpeech
+            : ApiEndpointType.Chat,
       thinkingBudget,
       forceInterleavedThinkingCompat,
       reasoningEffort,

--- a/src/main/presenter/llmProviderPresenter/aiSdk/runtime.ts
+++ b/src/main/presenter/llmProviderPresenter/aiSdk/runtime.ts
@@ -19,6 +19,13 @@ import {
   supportsOpenAIImageGenerationSettings,
   type ImageGenerationOptions
 } from '@shared/imageGenerationSettings'
+import {
+  isChatAudioTtsModel,
+  isStandardTtsModel,
+  isTtsModelConfig,
+  normalizeTtsSettings,
+  ttsFormatToMimeType
+} from '@shared/ttsSettings'
 import { presenter } from '@/presenter'
 import { EMBEDDING_TEST_KEY, isNormalized } from '@/utils/vector'
 import type { LLMCoreStreamEvent } from '@shared/types/core/llm-events'
@@ -53,6 +60,7 @@ export interface AiSdkRuntimeContext {
   cleanHeaders?: boolean
   supportsNativeTools?: (modelId: string, modelConfig: ModelConfig) => boolean
   shouldUseImageGeneration?: (modelId: string, modelConfig: ModelConfig) => boolean
+  shouldUseTts?: (modelId: string, modelConfig: ModelConfig) => boolean
 }
 
 function resolveCapabilityProviderId(context: AiSdkRuntimeContext, modelId: string): string {
@@ -156,6 +164,163 @@ function shouldUseImageGenerationRuntime(
   }
 
   return modelConfig.apiEndpoint === ApiEndpointType.Image
+}
+
+function shouldUseTtsRuntime(
+  context: AiSdkRuntimeContext,
+  modelId: string,
+  modelConfig: ModelConfig
+): boolean {
+  if (context.shouldUseTts) {
+    return context.shouldUseTts(modelId, modelConfig)
+  }
+
+  return (
+    modelConfig.apiEndpoint === ApiEndpointType.AudioSpeech ||
+    isTtsModelConfig(modelConfig) ||
+    isStandardTtsModel(modelId) ||
+    isChatAudioTtsModel(modelId)
+  )
+}
+
+/**
+ * Extracts the text to be synthesized from the last user message in the conversation.
+ */
+function extractTtsText(messages: ChatMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]
+    if (msg.role === 'user') {
+      const text = normalizePromptValue(msg.content)
+      if (text.trim()) return text.trim()
+    }
+  }
+  return ''
+}
+
+/**
+ * Pattern A: calls the standard OpenAI-compatible /audio/speech endpoint.
+ */
+async function executeTtsPatternA(
+  provider: LLM_PROVIDER,
+  defaultHeaders: Record<string, string>,
+  text: string,
+  modelId: string,
+  modelConfig: ModelConfig,
+  timeout: number | undefined
+): Promise<{ base64: string; mimeType: string }> {
+  const tts = normalizeTtsSettings(modelConfig.tts)
+  const format = tts?.responseFormat ?? 'mp3'
+  const baseUrl = (provider.baseUrl || '').replace(/\/+$/, '').replace(/\/v1$/i, '')
+  const url = `${baseUrl}/v1/audio/speech`
+
+  const body: Record<string, unknown> = {
+    model: modelId,
+    input: text,
+    voice: tts?.voice ?? 'alloy',
+    response_format: format
+  }
+  if (tts?.speed !== undefined) {
+    body.speed = tts.speed
+  }
+  if (tts?.instructions) {
+    body.instructions = tts.instructions
+  }
+
+  const controller = new AbortController()
+  const timeoutId = timeout ? setTimeout(() => controller.abort(), timeout) : undefined
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...defaultHeaders,
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${provider.oauthToken || provider.apiKey || ''}`
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal
+    })
+
+    if (!response.ok) {
+      const errText = await response.text().catch(() => '')
+      throw new Error(`TTS request failed (${response.status}): ${errText}`)
+    }
+
+    const buffer = await response.arrayBuffer()
+    const base64 = Buffer.from(buffer).toString('base64')
+    return { base64, mimeType: ttsFormatToMimeType(format) }
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
+}
+
+/**
+ * Pattern B: calls the chat completions endpoint with audio output
+ * (e.g. xiaomimimo mimo-v2.5-tts series).
+ */
+async function executeTtsPatternB(
+  provider: LLM_PROVIDER,
+  defaultHeaders: Record<string, string>,
+  text: string,
+  modelId: string,
+  modelConfig: ModelConfig,
+  timeout: number | undefined
+): Promise<{ base64: string; mimeType: string }> {
+  const tts = normalizeTtsSettings(modelConfig.tts)
+  const format = tts?.responseFormat ?? 'wav'
+  const baseUrl = (provider.baseUrl || '').replace(/\/+$/, '').replace(/\/v1$/i, '')
+  const url = `${baseUrl}/v1/chat/completions`
+
+  const body: Record<string, unknown> = {
+    model: modelId,
+    messages: [{ role: 'user', content: text }],
+    modalities: ['text', 'audio'],
+    audio: {
+      format,
+      ...(tts?.voice ? { voice: tts.voice } : {})
+    }
+  }
+
+  const controller = new AbortController()
+  const timeoutId = timeout ? setTimeout(() => controller.abort(), timeout) : undefined
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...defaultHeaders,
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${provider.oauthToken || provider.apiKey || ''}`
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal
+    })
+
+    if (!response.ok) {
+      const errText = await response.text().catch(() => '')
+      throw new Error(`TTS (chat audio) request failed (${response.status}): ${errText}`)
+    }
+
+    const json = (await response.json()) as {
+      choices?: Array<{
+        message?: {
+          audio?: { data?: string }
+          content?: Array<{ type?: string; audio?: { data?: string } }>
+        }
+      }>
+    }
+    const firstMessage = json.choices?.[0]?.message
+    const audioData =
+      firstMessage?.audio?.data ??
+      firstMessage?.content?.find((item) => item?.type === 'audio')?.audio?.data
+    if (!audioData) {
+      throw new Error('TTS response missing audio data in choices[0].message.audio.data')
+    }
+
+    return { base64: audioData, mimeType: ttsFormatToMimeType(format) }
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
 }
 
 function resolveRequestTimeout(modelConfig: ModelConfig): number | undefined {
@@ -397,6 +562,44 @@ export async function* runAiSdkCoreStream(
 ): AsyncGenerator<LLMCoreStreamEvent> {
   const normalizedModelConfig = normalizeRuntimeModelConfig(context, modelId, modelConfig)
   const timeout = resolveRequestTimeout(normalizedModelConfig)
+
+  if (shouldUseTtsRuntime(context, modelId, normalizedModelConfig)) {
+    const text = extractTtsText(messages)
+    const usePatternB = isChatAudioTtsModel(modelId)
+
+    const { base64, mimeType } = usePatternB
+      ? await executeTtsPatternB(
+          context.provider,
+          context.defaultHeaders,
+          text,
+          modelId,
+          normalizedModelConfig,
+          timeout
+        )
+      : await executeTtsPatternA(
+          context.provider,
+          context.defaultHeaders,
+          text,
+          modelId,
+          normalizedModelConfig,
+          timeout
+        )
+
+    const dataUrl = `data:${mimeType};base64,${base64}`
+    const cachedAudio = await presenter.devicePresenter.cacheImage(dataUrl)
+    yield {
+      type: 'image_data',
+      image_data: {
+        data: cachedAudio,
+        mimeType
+      }
+    }
+    yield {
+      type: 'stop',
+      stop_reason: 'complete'
+    }
+    return
+  }
 
   if (shouldUseImageGenerationRuntime(context, modelId, normalizedModelConfig)) {
     const prompt = extractImagePrompt(messages)

--- a/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
@@ -7,6 +7,7 @@ import {
   resolveProviderCapabilityProviderId,
   type NewApiEndpointType
 } from '@shared/model'
+import { isChatAudioTtsModel, isStandardTtsModel, isTtsModelConfig } from '@shared/ttsSettings'
 import {
   DEFAULT_MODEL_CONTEXT_LENGTH,
   DEFAULT_MODEL_MAX_TOKENS,
@@ -94,6 +95,12 @@ const shouldUseOpenAIImageGenerationRoute = (modelId: string, modelConfig: Model
   isOpenAIImageGenerationModel(modelId) ||
   modelConfig.apiEndpoint === ApiEndpointType.Image ||
   modelConfig.type === ModelType.ImageGeneration
+
+const shouldUseOpenAITtsRoute = (modelId: string, modelConfig: ModelConfig): boolean =>
+  isTtsModelConfig(modelConfig) ||
+  modelConfig.apiEndpoint === ApiEndpointType.AudioSpeech ||
+  isStandardTtsModel(modelId) ||
+  isChatAudioTtsModel(modelId)
 
 export function normalizeExtractedImageText(content: string): string {
   const normalized = content
@@ -569,6 +576,16 @@ export class AiSdkProvider extends BaseLLMProvider {
                     isOpenAIImageGenerationModel(runtimeModelId) ||
                     runtimeModelConfig.apiEndpoint === ApiEndpointType.Image
 
+    // TTS route: only applicable for OpenAI-compatible providers (not Azure, Gemini, Vertex)
+    const shouldUseTts =
+      this.isAzureOpenAI(decision, runtimeProvider) ||
+      decision.providerKind === 'gemini' ||
+      decision.providerKind === 'vertex' ||
+      decision.providerKind === 'anthropic'
+        ? undefined
+        : (runtimeModelId: string, runtimeModelConfig: ModelConfig) =>
+            shouldUseOpenAITtsRoute(runtimeModelId, runtimeModelConfig)
+
     return {
       decision,
       resolvedModelConfig,
@@ -585,7 +602,8 @@ export class AiSdkProvider extends BaseLLMProvider {
         cleanHeaders,
         supportsNativeTools: (_runtimeModelId, runtimeModelConfig) =>
           runtimeModelConfig.functionCall === true,
-        shouldUseImageGeneration
+        shouldUseImageGeneration,
+        shouldUseTts
       }
     }
   }
@@ -1656,13 +1674,17 @@ export class AiSdkProvider extends BaseLLMProvider {
           normalizedRawType === 'image' ||
           supportedEndpointTypes.includes('image-generation')
             ? ModelType.ImageGeneration
-            : normalizedRawType === 'embedding' ||
-                normalizedRawType === 'embeddings' ||
-                normalizedModelId.includes('embedding')
-              ? ModelType.Embedding
-              : normalizedRawType === 'rerank' || normalizedModelId.includes('rerank')
-                ? ModelType.Rerank
-                : undefined
+            : normalizedRawType === 'tts' ||
+                normalizedRawType === 'audio-speech' ||
+                normalizedRawType === 'audiospeech'
+              ? ModelType.TTS
+              : normalizedRawType === 'embedding' ||
+                  normalizedRawType === 'embeddings' ||
+                  normalizedModelId.includes('embedding')
+                ? ModelType.Embedding
+                : normalizedRawType === 'rerank' || normalizedModelId.includes('rerank')
+                  ? ModelType.Rerank
+                  : undefined
 
         const contextLengthCandidate = [
           rawModel.context_length,
@@ -1725,7 +1747,11 @@ export class AiSdkProvider extends BaseLLMProvider {
         ...existingConfig,
         type: model.type ?? existingConfig.type,
         apiEndpoint:
-          model.endpointType === 'image-generation' ? ApiEndpointType.Image : ApiEndpointType.Chat,
+          model.endpointType === 'image-generation'
+            ? ApiEndpointType.Image
+            : model.type === ModelType.TTS
+              ? ApiEndpointType.AudioSpeech
+              : ApiEndpointType.Chat,
         endpointType: model.endpointType ?? existingConfig.endpointType
       })
     }

--- a/src/renderer/settings/components/ProviderModelList.vue
+++ b/src/renderer/settings/components/ProviderModelList.vue
@@ -390,7 +390,8 @@ const TYPE_ICONS: Record<ModelType, string> = {
   [ModelType.Chat]: 'lucide:messages-square',
   [ModelType.Embedding]: 'lucide:database',
   [ModelType.Rerank]: 'lucide:arrow-up-wide-narrow',
-  [ModelType.ImageGeneration]: 'lucide:image'
+  [ModelType.ImageGeneration]: 'lucide:image',
+  [ModelType.TTS]: 'lucide:volume-2'
 }
 
 const props = defineProps<{
@@ -450,7 +451,12 @@ const hasModelCapability = (model: RENDERER_MODEL_META, capability: ModelCapabil
   }
 }
 
-const getModelTypeLabel = (type: ModelType) => t(`model.filter.typeOptions.${type}`)
+const getModelTypeLabel = (type: ModelType) => {
+  if (type === ModelType.TTS) {
+    return t('settings.provider.voiceai.title')
+  }
+  return t(`model.filter.typeOptions.${type}`)
+}
 const getCapabilityLabel = (capability: ModelCapabilityKey) =>
   t(`model.filter.capabilityOptions.${capability}`)
 

--- a/src/renderer/src/components/settings/ModelConfigDialog.vue
+++ b/src/renderer/src/components/settings/ModelConfigDialog.vue
@@ -123,6 +123,8 @@
             v-model="config.imageGeneration"
           />
 
+          <TtsSettingsFields v-if="showTtsSettings" v-model="config.tts" />
+
           <!-- 温度 (支持推理努力程度的模型不显示) -->
           <div
             v-if="!showOpenAIImageGenerationSettings && showTemperatureControl"
@@ -173,6 +175,9 @@
                 </SelectItem>
                 <SelectItem value="imageGeneration">
                   {{ t('settings.model.modelConfig.type.options.imageGeneration') }}
+                </SelectItem>
+                <SelectItem value="tts">
+                  {{ t('settings.provider.voiceai.title') }}
                 </SelectItem>
               </SelectContent>
             </Select>
@@ -234,6 +239,9 @@
                 </SelectItem>
                 <SelectItem value="image">
                   {{ t('settings.model.modelConfig.apiEndpoint.options.image') }}
+                </SelectItem>
+                <SelectItem value="audio-speech">
+                  {{ t('settings.provider.voiceai.title') }}
                 </SelectItem>
               </SelectContent>
             </Select>
@@ -551,10 +559,12 @@ import {
   normalizeImageGenerationOptions,
   supportsOpenAIImageGenerationSettings
 } from '@shared/imageGenerationSettings'
+import { normalizeTtsSettings } from '@shared/ttsSettings'
 import { useModelConfigStore } from '@/stores/modelConfigStore'
 import { useModelStore } from '@/stores/modelStore'
 import { useProviderStore } from '@/stores/providerStore'
 import OpenAIImageGenerationSettingsFields from './OpenAIImageGenerationSettingsFields.vue'
+import TtsSettingsFields from './TtsSettingsFields.vue'
 import { createModelClient } from '@api/ModelClient'
 import {
   Dialog,
@@ -701,6 +711,7 @@ const showOpenAIImageGenerationSettings = computed(() =>
 const showOpenAIImageGenerationRouteControls = computed(
   () => showOpenAIImageGenerationSettings.value && canEditModelIdentity.value
 )
+const showTtsSettings = computed(() => config.value.type === ModelType.TTS)
 
 // 重置确认对话框
 const showResetConfirm = ref(false)
@@ -1091,6 +1102,10 @@ const loadConfig = async () => {
     if (showApiEndpointSelector.value && !config.value.apiEndpoint) {
       config.value.apiEndpoint = ApiEndpointType.Chat
     }
+
+    if (config.value.type === ModelType.TTS && !config.value.apiEndpoint) {
+      config.value.apiEndpoint = ApiEndpointType.AudioSpeech
+    }
   } catch (error) {
     console.error('Failed to load model config:', error)
     config.value = createDefaultConfig()
@@ -1247,7 +1262,8 @@ const handleSave = async () => {
     ...(normalizedTimeout !== undefined ? { timeout: normalizedTimeout } : {}),
     imageGeneration: showOpenAIImageGenerationSettings.value
       ? normalizeImageGenerationOptions(config.value.imageGeneration)
-      : undefined
+      : undefined,
+    tts: showTtsSettings.value ? normalizeTtsSettings(config.value.tts) : undefined
   }
 
   try {
@@ -1346,6 +1362,30 @@ watch(
     syncNewApiDerivedFields()
     syncCapabilityProviderId()
   }
+)
+
+watch(
+  () => [config.value.type, showApiEndpointSelector.value, showEndpointTypeSelector.value],
+  () => {
+    if (!showApiEndpointSelector.value || showEndpointTypeSelector.value) {
+      return
+    }
+
+    if (config.value.type === ModelType.ImageGeneration) {
+      config.value.apiEndpoint = ApiEndpointType.Image
+      return
+    }
+
+    if (config.value.type === ModelType.TTS) {
+      config.value.apiEndpoint = ApiEndpointType.AudioSpeech
+      return
+    }
+
+    if (config.value.apiEndpoint === ApiEndpointType.Image) {
+      config.value.apiEndpoint = ApiEndpointType.Chat
+    }
+  },
+  { immediate: true }
 )
 
 const supportsVerbosity = computed(() => capabilitySupportsVerbosity.value === true)

--- a/src/renderer/src/components/settings/TtsSettingsFields.vue
+++ b/src/renderer/src/components/settings/TtsSettingsFields.vue
@@ -1,0 +1,159 @@
+<template>
+  <div class="space-y-4">
+    <div class="space-y-2">
+      <Label>{{ t('settings.provider.voiceai.title') }}</Label>
+      <p class="text-xs text-muted-foreground">
+        {{ t('settings.provider.voiceai.description') }}
+      </p>
+    </div>
+
+    <div class="space-y-2">
+      <Label>{{ t('settings.provider.voiceai.agentId.label') }}</Label>
+      <Input
+        :model-value="tts.voice ?? ''"
+        :placeholder="t('settings.provider.voiceai.agentId.placeholder')"
+        @update:model-value="onVoiceInput"
+      />
+    </div>
+
+    <div class="space-y-2">
+      <Label>{{ t('settings.provider.voiceai.audioFormat.label') }}</Label>
+      <Select
+        :model-value="optionSelectValue(tts.responseFormat)"
+        @update:model-value="onResponseFormatSelect"
+      >
+        <SelectTrigger>
+          <SelectValue :placeholder="t('settings.provider.voiceai.audioFormat.placeholder')" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem :value="DEFAULT_SELECT_VALUE">
+            {{ t('settings.model.modelConfig.currentUsingModelDefault') }}
+          </SelectItem>
+          <SelectItem v-for="format in TTS_RESPONSE_FORMAT_VALUES" :key="format" :value="format">
+            {{ format.toUpperCase() }}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+
+    <div class="space-y-2">
+      <Label>{{ t('settings.provider.voiceai.temperature.label') }}</Label>
+      <Input
+        :model-value="speedDraft"
+        inputmode="decimal"
+        placeholder="0.25 - 4.0"
+        @update:model-value="onSpeedInput"
+        @blur="commitSpeed"
+        @keydown.enter.prevent="commitSpeed"
+      />
+      <p class="text-xs text-muted-foreground">
+        {{ t('settings.provider.voiceai.temperature.helper') }}
+      </p>
+    </div>
+
+    <div class="space-y-2">
+      <Label>{{ t('settings.model.modelConfig.timeout.label') }}</Label>
+      <Input
+        :model-value="tts.instructions ?? ''"
+        :placeholder="t('settings.model.modelConfig.name.placeholder')"
+        @update:model-value="onInstructionsInput"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Input } from '@shadcn/components/ui/input'
+import { Label } from '@shadcn/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@shadcn/components/ui/select'
+import {
+  TTS_RESPONSE_FORMAT_VALUES,
+  normalizeTtsSettings,
+  type TtsResponseFormat,
+  type TtsSettings
+} from '@shared/ttsSettings'
+
+const DEFAULT_SELECT_VALUE = '__default'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: TtsSettings
+  }>(),
+  {
+    modelValue: undefined
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: TtsSettings | undefined]
+}>()
+
+const { t } = useI18n()
+
+const tts = computed<TtsSettings>(() => normalizeTtsSettings(props.modelValue) ?? {})
+const speedDraft = ref('')
+
+watch(
+  () => tts.value.speed,
+  (speed) => {
+    speedDraft.value = typeof speed === 'number' ? String(speed) : ''
+  },
+  { immediate: true }
+)
+
+const emitSettings = (patch: TtsSettings) => {
+  const next = normalizeTtsSettings({
+    ...tts.value,
+    ...patch
+  })
+  emit('update:modelValue', next)
+}
+
+const optionSelectValue = (value: string | undefined) => value ?? DEFAULT_SELECT_VALUE
+
+const onVoiceInput = (value: string | number) => {
+  const next = String(value)
+  emitSettings({ voice: next.trim() || undefined })
+}
+
+const onResponseFormatSelect = (value: unknown) => {
+  const selected = String(value)
+  if (selected === DEFAULT_SELECT_VALUE) {
+    emitSettings({ responseFormat: undefined })
+    return
+  }
+  emitSettings({ responseFormat: selected as TtsResponseFormat })
+}
+
+const onSpeedInput = (value: string | number) => {
+  speedDraft.value = String(value)
+}
+
+const commitSpeed = () => {
+  const value = speedDraft.value.trim()
+  if (!value) {
+    emitSettings({ speed: undefined })
+    return
+  }
+
+  const speed = Number(value)
+  if (!Number.isFinite(speed)) {
+    return
+  }
+
+  emitSettings({ speed })
+}
+
+const onInstructionsInput = (value: string | number) => {
+  const next = String(value)
+  emitSettings({ instructions: next.trim() || undefined })
+}
+</script>

--- a/src/renderer/src/composables/useModelTypeDetection.ts
+++ b/src/renderer/src/composables/useModelTypeDetection.ts
@@ -8,11 +8,12 @@ import { useModelConfigStore } from '@/stores/modelConfigStore'
 export interface UseModelTypeDetectionOptions {
   modelId: Ref<string | undefined>
   providerId: Ref<string | undefined>
-  modelType: Ref<'chat' | 'imageGeneration' | 'embedding' | 'rerank' | undefined>
+  modelType: Ref<'chat' | 'imageGeneration' | 'tts' | 'embedding' | 'rerank' | undefined>
 }
 
 export interface UseModelTypeDetectionReturn {
   isImageGenerationModel: ComputedRef<boolean>
+  isTtsModel: ComputedRef<boolean>
   isGPT5Model: ComputedRef<boolean>
   isGeminiProvider: ComputedRef<boolean>
   modelReasoning: Ref<boolean>
@@ -39,6 +40,13 @@ export function useModelTypeDetection(
    */
   const isImageGenerationModel = computed(() => {
     return modelType.value === 'imageGeneration'
+  })
+
+  /**
+   * Checks if current model is a TTS model
+   */
+  const isTtsModel = computed(() => {
+    return modelType.value === 'tts'
   })
 
   /**
@@ -86,6 +94,7 @@ export function useModelTypeDetection(
   // === Return Public API ===
   return {
     isImageGenerationModel,
+    isTtsModel,
     isGPT5Model,
     isGeminiProvider,
     modelReasoning

--- a/src/shared/contracts/common.ts
+++ b/src/shared/contracts/common.ts
@@ -12,6 +12,7 @@ import {
   IMAGE_GENERATION_OUTPUT_FORMAT_VALUES,
   IMAGE_GENERATION_QUALITY_VALUES
 } from '../imageGenerationSettings'
+import { TTS_RESPONSE_FORMAT_VALUES } from '../ttsSettings'
 
 export type JsonValue =
   | string
@@ -55,6 +56,15 @@ export const ImageGenerationOptionsSchema = z
     outputCompression: z.number().int().min(0).max(100).optional(),
     background: z.enum(OPENAI_IMAGE_GENERATION_BACKGROUND_VALUES).optional(),
     moderation: z.enum(IMAGE_GENERATION_MODERATION_VALUES).optional()
+  })
+  .optional()
+
+export const TtsSettingsSchema = z
+  .object({
+    voice: z.string().optional(),
+    responseFormat: z.enum(TTS_RESPONSE_FORMAT_VALUES).optional(),
+    speed: z.number().min(0.25).max(4.0).optional(),
+    instructions: z.string().optional()
   })
   .optional()
 

--- a/src/shared/contracts/domainSchemas.ts
+++ b/src/shared/contracts/domainSchemas.ts
@@ -4,6 +4,7 @@ import { ApiEndpointType, ModelType, NEW_API_ENDPOINT_TYPES } from '../model'
 import {
   FileMetadataValueSchema,
   ImageGenerationOptionsSchema,
+  TtsSettingsSchema,
   JsonValueSchema,
   ProviderModelSummarySchema
 } from './common'
@@ -250,7 +251,8 @@ export const ModelConfigSchema = z
     enableSearch: z.boolean().optional(),
     forcedSearch: z.boolean().optional(),
     searchStrategy: z.enum(['turbo', 'balanced', 'precise']).optional(),
-    imageGeneration: ImageGenerationOptionsSchema
+    imageGeneration: ImageGenerationOptionsSchema,
+    tts: TtsSettingsSchema
   })
   .passthrough()
 

--- a/src/shared/model.ts
+++ b/src/shared/model.ts
@@ -5,13 +5,15 @@ export enum ModelType {
   Chat = 'chat',
   Embedding = 'embedding',
   Rerank = 'rerank',
-  ImageGeneration = 'imageGeneration'
+  ImageGeneration = 'imageGeneration',
+  TTS = 'tts'
 }
 
 export enum ApiEndpointType {
   Chat = 'chat',
   Image = 'image',
-  Video = 'video'
+  Video = 'video',
+  AudioSpeech = 'audio-speech'
 }
 
 export const NEW_API_ENDPOINT_TYPES = [
@@ -169,4 +171,7 @@ export const resolveProviderCapabilityProviderId = (
 }
 
 export const isChatSelectableModelType = (type: ModelType | undefined): boolean =>
-  type === undefined || type === ModelType.Chat || type === ModelType.ImageGeneration
+  type === undefined ||
+  type === ModelType.Chat ||
+  type === ModelType.ImageGeneration ||
+  type === ModelType.TTS

--- a/src/shared/ttsSettings.ts
+++ b/src/shared/ttsSettings.ts
@@ -1,0 +1,116 @@
+import { ModelType } from './model'
+
+export const TTS_RESPONSE_FORMAT_VALUES = ['mp3', 'opus', 'aac', 'flac', 'wav', 'pcm'] as const
+export type TtsResponseFormat = (typeof TTS_RESPONSE_FORMAT_VALUES)[number]
+
+export interface TtsSettings {
+  voice?: string
+  responseFormat?: TtsResponseFormat
+  speed?: number
+  instructions?: string
+}
+
+/**
+ * Standard OpenAI-style TTS models that use the /audio/speech endpoint (Pattern A).
+ */
+export const OPENAI_STANDARD_TTS_MODELS = [
+  'tts-1',
+  'tts-1-hd',
+  'gpt-4o-mini-tts',
+  'gemini-2.5-flash-preview-tts',
+  'gemini-2.5-pro-preview-tts'
+] as const
+
+/**
+ * Model ID prefixes for TTS models that use the chat completions endpoint
+ * with audio output (Pattern B), e.g. xiaomimimo mimo-v2.5-tts series.
+ */
+export const CHAT_AUDIO_TTS_MODEL_PREFIXES = ['mimo-v'] as const
+
+function normalizeTtsModelId(modelId: string): string {
+  const trimmed = modelId.trim().toLowerCase()
+  if (!trimmed) return ''
+  const slashIndex = trimmed.lastIndexOf('/')
+  return slashIndex >= 0 ? trimmed.slice(slashIndex + 1) : trimmed
+}
+
+/**
+ * Returns true if the model uses the standard /audio/speech TTS endpoint (Pattern A).
+ */
+export function isStandardTtsModel(modelId: string): boolean {
+  const id = normalizeTtsModelId(modelId)
+  return (OPENAI_STANDARD_TTS_MODELS as readonly string[]).includes(id)
+}
+
+/**
+ * Returns true if the model produces TTS audio via the chat completions endpoint (Pattern B).
+ */
+export function isChatAudioTtsModel(modelId: string): boolean {
+  const id = normalizeTtsModelId(modelId)
+  return (
+    CHAT_AUDIO_TTS_MODEL_PREFIXES.some((prefix) => id.startsWith(prefix)) ||
+    id.startsWith('xiaomi-mimo-v')
+  )
+}
+
+/**
+ * Returns true if the model is any kind of TTS model (either pattern).
+ */
+export function isTtsModelId(modelId: string): boolean {
+  return isStandardTtsModel(modelId) || isChatAudioTtsModel(modelId)
+}
+
+/**
+ * Returns true if modelConfig indicates this is a TTS model.
+ */
+export function isTtsModelConfig(modelConfig: { type?: ModelType }): boolean {
+  return modelConfig.type === ModelType.TTS
+}
+
+/**
+ * Maps a TtsResponseFormat value to an audio MIME type string.
+ */
+export function ttsFormatToMimeType(format: TtsResponseFormat | string | undefined): string {
+  switch (format) {
+    case 'mp3':
+      return 'audio/mpeg'
+    case 'opus':
+      return 'audio/ogg; codecs=opus'
+    case 'aac':
+      return 'audio/aac'
+    case 'flac':
+      return 'audio/flac'
+    case 'wav':
+      return 'audio/wav'
+    case 'pcm':
+      return 'audio/pcm'
+    default:
+      return 'audio/mpeg'
+  }
+}
+
+/**
+ * Normalizes TtsSettings, returning undefined when no valid options are present.
+ */
+export function normalizeTtsSettings(options?: TtsSettings | null): TtsSettings | undefined {
+  if (!options) return undefined
+  const result: TtsSettings = {}
+
+  if (typeof options.voice === 'string' && options.voice.trim()) {
+    result.voice = options.voice.trim()
+  }
+  if (
+    typeof options.responseFormat === 'string' &&
+    (TTS_RESPONSE_FORMAT_VALUES as readonly string[]).includes(options.responseFormat)
+  ) {
+    result.responseFormat = options.responseFormat as TtsResponseFormat
+  }
+  if (typeof options.speed === 'number' && Number.isFinite(options.speed)) {
+    result.speed = Math.max(0.25, Math.min(4.0, options.speed))
+  }
+  if (typeof options.instructions === 'string' && options.instructions.trim()) {
+    result.instructions = options.instructions.trim()
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined
+}

--- a/src/shared/types/model-db.ts
+++ b/src/shared/types/model-db.ts
@@ -129,7 +129,7 @@ export const ModelSchema = z.object({
   release_date: z.string().optional(),
   last_updated: z.string().optional(),
   cost: z.record(z.union([z.string(), z.number()])).optional(),
-  type: z.enum(['chat', 'embedding', 'rerank', 'imageGeneration']).optional()
+  type: z.enum(['chat', 'embedding', 'rerank', 'imageGeneration', 'tts']).optional()
 })
 
 export type ProviderModel = z.infer<typeof ModelSchema>
@@ -382,7 +382,7 @@ function getStringNumberRecord(obj: unknown): Record<string, string | number> | 
   return Object.keys(out).length ? out : undefined
 }
 
-type ModelTypeValue = 'chat' | 'embedding' | 'rerank' | 'imageGeneration'
+type ModelTypeValue = 'chat' | 'embedding' | 'rerank' | 'imageGeneration' | 'tts'
 
 function getEffortValue(v: unknown): ReasoningEffort | undefined {
   return isReasoningEffort(v) ? v : undefined
@@ -464,6 +464,7 @@ function getModelTypeValue(v: unknown): ModelTypeValue | undefined {
     case 'embedding':
     case 'rerank':
     case 'imageGeneration':
+    case 'tts':
       return v
   }
 
@@ -479,6 +480,8 @@ function getModelTypeValue(v: unknown): ModelTypeValue | undefined {
     case 'imagegeneration':
     case 'imagegen':
       return 'imageGeneration'
+    case 'tts':
+      return 'tts'
     default:
       return undefined
   }

--- a/src/shared/types/presenters/legacy.presenters.d.ts
+++ b/src/shared/types/presenters/legacy.presenters.d.ts
@@ -6,6 +6,7 @@ import { ShortcutKeySetting } from '@/presenter/configPresenter/shortcutKeySetti
 import type { NewApiEndpointType } from '@shared/model'
 import { ApiEndpointType, ModelType } from '@shared/model'
 import type { ImageGenerationOptions } from '../../imageGenerationSettings'
+import type { TtsSettings } from '../../ttsSettings'
 import type { ReasoningEffort, ReasoningVisibility, Verbosity } from '../model-db'
 import type { HookTestResult, HooksNotificationsSettings } from '../../hooksNotifications'
 import type { NowledgeMemThread, NowledgeMemExportSummary } from '../nowledgeMem'
@@ -180,6 +181,7 @@ export interface ModelConfig {
   forcedSearch?: boolean
   searchStrategy?: 'turbo' | 'balanced' | 'precise'
   imageGeneration?: ImageGenerationOptions
+  tts?: TtsSettings
 }
 
 export interface IModelConfig {


### PR DESCRIPTION
## Summary
This PR finishes and hardens model-level TTS support across runtime, model DB inference, and settings UI.

### Runtime / Routing
- normalize TTS model IDs so prefixed IDs (e.g. `openai/tts-1`) are recognized
- expand chat-audio TTS detection to include Xiaomi alias prefix
- improve Pattern B chat-completions request by adding `modalities: ["text", "audio"]`
- improve Pattern B response parsing with fallback path extraction

### Model Type / Endpoint Inference
- support `tts` in provider-model type inference paths
- map inferred `ModelType.TTS` to `ApiEndpointType.AudioSpeech`
- keep provider-managed model config sync aligned with TTS endpoint behavior

### Settings UI
- add model-level TTS settings fields (`voice`, `responseFormat`, `speed`, `instructions`)
- integrate TTS settings into `ModelConfigDialog`
- add TTS model type option and audio-speech endpoint option in model config
- auto-sync API endpoint with selected model type (`chat` / `image` / `audio-speech`)
- improve TTS type labeling in provider model list

### Model DB
- mark relevant `aihubmix` TTS models as `type: "tts"`
- document skip for built-in `xiaomimimo` provider entry (not present)

## Verification
- `pnpm run typecheck`
- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`

All checks pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added text-to-speech (TTS) model support with configurable settings including voice selection, audio format, speed, and synthesis instructions.
  * Integrated TTS model detection and routing for enhanced audio generation capabilities.
  * Added new TTS provider models (OpenAI TTS, Google Gemini audio variants) to the model database.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1632)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->