### PR TITLE
feat(provider): import CC Switch configs

### DIFF
--- a/docs/features/cc-switch-provider-import/plan.md
+++ b/docs/features/cc-switch-provider-import/plan.md
@@ -1,0 +1,25 @@
+# CC Switch Provider Import Plan
+
+## Implementation
+
+- Extend `ProviderImportService` with a `cc-switch` source that reads `~/.cc-switch/cc-switch.db` in readonly mode and uses the Windows HOME fallback only when the default profile path is missing.
+- Query the `providers` table for supported CC Switch app types except `codex`.
+- Parse app-specific JSON settings:
+  - Claude and Claude Desktop: `env.ANTHROPIC_AUTH_TOKEN` or `env.ANTHROPIC_API_KEY`, `env.ANTHROPIC_BASE_URL`, model env values, and desktop route metadata.
+  - Gemini: `env.GEMINI_API_KEY`, `env.GOOGLE_GEMINI_BASE_URL`, `env.GEMINI_MODEL`.
+  - OpenCode: `options.apiKey`, `options.baseURL`, AI SDK package name, and model keys.
+  - OpenClaw: `apiKey`, `baseUrl`, `api`, and `models`.
+  - Hermes: `api_key`, `base_url`, `api_mode`, and `models`.
+- Filter all import sources after raw read so blank/template API keys never reach the public preview list.
+- Add mapping metadata for credential-only imports so built-in providers keep their configured endpoint and runtime when CC Switch exposes a different wire protocol.
+
+## Compatibility
+
+- Existing import sessions remain in-memory and short-lived.
+- Existing Alma, Cherry Studio, Hermes, and OpenClaw parsing keeps the same file formats but now hides empty provider configs.
+- Custom provider API type override remains available for custom rows.
+
+## Risks
+
+- CC Switch may add new app types or settings shapes. Unknown rows should fail closed by hiding unsupported rows rather than guessing.
+- Some translated descriptions may not mention CC Switch yet, but the source row itself is localized by provider name.

--- a/docs/features/cc-switch-provider-import/plan.md
+++ b/docs/features/cc-switch-provider-import/plan.md
@@ -3,6 +3,8 @@
 ## Implementation
 
 - Extend `ProviderImportService` with a `cc-switch` source that reads `~/.cc-switch/cc-switch.db` in readonly mode and uses the Windows HOME fallback only when the default profile path is missing.
+- Put CC Switch first in the shared provider import source order.
+- Keep scan results complete, but filter the first renderer source list to detected sources so missing apps are not shown.
 - Query the `providers` table for supported CC Switch app types except `codex`.
 - Parse app-specific JSON settings:
   - Claude and Claude Desktop: `env.ANTHROPIC_AUTH_TOKEN` or `env.ANTHROPIC_API_KEY`, `env.ANTHROPIC_BASE_URL`, model env values, and desktop route metadata.

--- a/docs/features/cc-switch-provider-import/spec.md
+++ b/docs/features/cc-switch-provider-import/spec.md
@@ -12,7 +12,8 @@ Allow users to import configured provider credentials from CC Switch through the
 
 ## Acceptance Criteria
 
-- CC Switch appears after Alma, Cherry Studio, Hermes, and OpenClaw in the provider import source order.
+- CC Switch appears first in the provider import source order.
+- The first import page only lists detected sources, hiding sources whose config files are missing.
 - The scan reads CC Switch provider rows for `claude`, `claude-desktop`, `gemini`, `opencode`, `openclaw`, and `hermes`.
 - CC Switch `codex` rows are intentionally ignored; DeepChat does not parse TOML from CC Switch.
 - Rows with blank API keys or placeholder/template API keys are not shown in scan results.

--- a/docs/features/cc-switch-provider-import/spec.md
+++ b/docs/features/cc-switch-provider-import/spec.md
@@ -1,0 +1,29 @@
+# CC Switch Provider Import
+
+## Goal
+
+Allow users to import configured provider credentials from CC Switch through the existing provider import dialog, without copying API keys by hand.
+
+## User Stories
+
+- As a DeepChat user, I can see CC Switch as a detected provider import source when `~/.cc-switch/cc-switch.db` exists.
+- As a user with CC Switch providers, I only see rows that contain a real API key.
+- As a user importing Claude-compatible CC Switch providers, I do not accidentally switch DeepChat built-in providers to the wrong runtime.
+
+## Acceptance Criteria
+
+- CC Switch appears after Alma, Cherry Studio, Hermes, and OpenClaw in the provider import source order.
+- The scan reads CC Switch provider rows for `claude`, `claude-desktop`, `gemini`, `opencode`, `openclaw`, and `hermes`.
+- CC Switch `codex` rows are intentionally ignored; DeepChat does not parse TOML from CC Switch.
+- Rows with blank API keys or placeholder/template API keys are not shown in scan results.
+- DeepSeek rows exposed as Anthropic-compatible endpoints import only the API key into DeepChat's built-in `deepseek` provider, preserving its existing runtime and base URL.
+- MiniMax rows map to DeepChat's built-in `minimax` provider and keep Anthropic runtime behavior.
+- Unknown importable rows with an API key and HTTP endpoint import as custom providers with the safest inferred API type.
+- Raw API keys stay in the main process scan session and are never returned to the renderer during preview.
+
+## Non-Goals
+
+- Importing CC Switch Codex providers.
+- Reading CC Switch custom data directories.
+- Importing CC Switch conversations, prompts, MCP servers, skills, usage data, or failover settings.
+- Network validation of imported credentials.

--- a/docs/features/cc-switch-provider-import/tasks.md
+++ b/docs/features/cc-switch-provider-import/tasks.md
@@ -1,6 +1,8 @@
 # CC Switch Provider Import Tasks
 
 - [x] Add `cc-switch` to shared provider import source ids and route schemas.
+- [x] Move CC Switch to the front of the import source order.
+- [x] Hide missing import sources from the first renderer selection page.
 - [x] Add credential-only import mode and warning text.
 - [x] Implement CC Switch SQLite scan support for non-Codex app types.
 - [x] Filter blank/template API keys across all provider import sources.

--- a/docs/features/cc-switch-provider-import/tasks.md
+++ b/docs/features/cc-switch-provider-import/tasks.md
@@ -1,0 +1,9 @@
+# CC Switch Provider Import Tasks
+
+- [x] Add `cc-switch` to shared provider import source ids and route schemas.
+- [x] Add credential-only import mode and warning text.
+- [x] Implement CC Switch SQLite scan support for non-Codex app types.
+- [x] Filter blank/template API keys across all provider import sources.
+- [x] Preserve built-in provider runtime/base URL for credential-only imports.
+- [x] Add provider import unit tests for CC Switch and updated empty-key behavior.
+- [x] Run format, i18n, lint, focused provider import tests, and full typecheck.

--- a/src/main/routes/providers/providerImportService.ts
+++ b/src/main/routes/providers/providerImportService.ts
@@ -9,6 +9,7 @@ import { ModelType } from '@shared/model'
 import {
   PROVIDER_IMPORT_CUSTOM_API_TYPES,
   PROVIDER_IMPORT_SOURCE_IDS,
+  type ProviderImportApplyMode,
   type ProviderImportApplyResult,
   type ProviderImportApplyResultItem,
   type ProviderImportCustomApiType,
@@ -72,20 +73,29 @@ const SOURCE_DEFINITIONS: SourceDefinition[] = [
     unixRelativePath: '.openclaw/gateway.yaml',
     windowsBase: 'home',
     windowsRelativePath: '.openclaw/gateway.yaml'
+  },
+  {
+    id: 'cc-switch',
+    name: 'CC Switch',
+    unixRelativePath: '.cc-switch/cc-switch.db',
+    windowsBase: 'home',
+    windowsRelativePath: '.cc-switch/cc-switch.db'
   }
 ]
 
 const SCAN_SESSION_TTL_MS = 10 * 60 * 1000
-const API_TYPE_ALIASES: Record<string, string> = {
+const PROVIDER_ID_ALIASES: Record<string, string> = {
   'openai-response': 'openai-responses',
   'openai-responses': 'openai-responses',
   anthropic: 'anthropic',
-  gemini: 'gemini',
-  ollama: 'ollama',
+  claude: 'anthropic',
+  'claude-official': 'anthropic',
+  'anthropic-official': 'anthropic',
   'new-api': 'new-api',
   silicon: 'silicon',
   siliconflow: 'silicon',
   siliconcloud: 'silicon',
+  'silicon-flow': 'silicon',
   deepseek: 'deepseek',
   ppio: 'ppio',
   ppinfra: 'ppio',
@@ -98,9 +108,16 @@ const API_TYPE_ALIASES: Record<string, string> = {
   github: 'github',
   'github-copilot': 'github-copilot',
   doubao: 'doubao',
+  'doubao-seed': 'doubao',
+  doubaoseed: 'doubao',
   minimax: 'minimax',
+  'minimax-cn': 'minimax',
+  'minimax-en': 'minimax',
   zhipu: 'zhipu',
+  'zhipu-glm': 'zhipu',
+  bigmodel: 'zhipu',
   moonshot: 'moonshot',
+  kimi: 'moonshot',
   dashscope: 'dashscope',
   volcengine: 'doubao',
   ark: 'doubao',
@@ -122,17 +139,41 @@ const OPENAI_COMPATIBLE_TYPES = new Set([
   'openai-chat',
   'openai-compatible',
   'openai-completions',
+  'openai-responses',
   'gateway',
   'vertexai',
-  'mistral',
-  'aws-bedrock'
+  'mistral'
 ])
+
+const API_KEY_PLACEHOLDERS = new Set([
+  'api-key',
+  'apikey',
+  'your-api-key',
+  'your-api-key-here',
+  'replace-with-your-api-key',
+  'sk-xxx',
+  'sk-xxxx',
+  'xxx',
+  'xxxx',
+  '<api-key>',
+  '<your-api-key>'
+])
+
+const CC_SWITCH_APP_TYPES = [
+  'claude',
+  'claude-desktop',
+  'gemini',
+  'opencode',
+  'openclaw',
+  'hermes'
+] as const
 
 const SOURCE_PREFIX: Record<ProviderImportSourceId, string> = {
   alma: 'alma',
   'cherry-studio': 'cherry',
   hermes: 'hermes',
-  openclaw: 'openclaw'
+  openclaw: 'openclaw',
+  'cc-switch': 'ccswitch'
 }
 
 const normalizeToken = (value: string | undefined): string =>
@@ -173,6 +214,11 @@ const safeJsonParse = (value: unknown): unknown => {
 const toStringValue = (value: unknown): string =>
   typeof value === 'string' ? value.trim() : value == null ? '' : String(value).trim()
 
+const toObjectValue = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+
 const toBooleanValue = (value: unknown, fallback: boolean): boolean => {
   if (typeof value === 'boolean') return value
   if (typeof value === 'number') return value !== 0
@@ -201,6 +247,13 @@ const replaceDisallowedControlCharacters = (value: string): string => {
   return result
 }
 
+const isImportableApiKey = (value: string): boolean => {
+  const trimmed = value.trim()
+  if (!trimmed) return false
+  if (trimmed.includes('${') || trimmed.includes('{{')) return false
+  return !API_KEY_PLACEHOLDERS.has(trimmed.toLowerCase())
+}
+
 const normalizeModels = (models: unknown): ProviderImportRawModel[] => {
   if (!Array.isArray(models)) return []
 
@@ -227,10 +280,40 @@ const normalizeModels = (models: unknown): ProviderImportRawModel[] => {
     .filter((model, index, list) => list.findIndex((item) => item.id === model.id) === index)
 }
 
+const normalizeModelCollection = (models: unknown): ProviderImportRawModel[] => {
+  if (Array.isArray(models)) {
+    return normalizeModels(models)
+  }
+
+  if (!models || typeof models !== 'object') {
+    return []
+  }
+
+  return Object.entries(models as Record<string, unknown>)
+    .flatMap(([id, model]) => {
+      const modelId = id.trim()
+      if (!modelId) return []
+      const item = toObjectValue(model)
+      return [
+        {
+          id: modelId,
+          name: toStringValue(item.name ?? item.label ?? item.alias) || modelId,
+          group: toStringValue(item.group) || 'custom'
+        }
+      ]
+    })
+    .filter((model, index, list) => list.findIndex((item) => item.id === model.id) === index)
+}
+
+const modelFromStrings = (values: string[]): ProviderImportRawModel[] =>
+  normalizeModels(uniqueStrings(values).map((id) => ({ id, name: id })))
+
 const buildUnixDisplayPath = (relativePath: string): string => `~/${relativePath}`
 
-const buildWindowsDisplayPath = (base: '%APPDATA%' | '%USERPROFILE%', relativePath: string) =>
-  `${base}\\${relativePath.replaceAll('/', '\\')}`
+const buildWindowsDisplayPath = (
+  base: '%APPDATA%' | '%USERPROFILE%' | '%HOME%',
+  relativePath: string
+) => `${base}\\${relativePath.replaceAll('/', '\\')}`
 
 const isSupportedScanPlatform = (
   platform: NodeJS.Platform
@@ -457,8 +540,19 @@ export class ProviderImportService {
     }
 
     try {
-      const providers = await this.readProviders(definition, sourcePath)
-      const previews = providers.map((provider) => this.toPreview(provider))
+      const readableProviders = await this.readProviders(definition, sourcePath)
+      const previewPairs = readableProviders
+        .filter((provider) => isImportableApiKey(provider.apiKey))
+        .map((provider) => ({
+          provider,
+          preview: this.toPreview(provider)
+        }))
+        .filter(
+          ({ provider, preview }) =>
+            provider.sourceId !== 'cc-switch' || preview.targetKind !== 'unsupported'
+        )
+      const providers = previewPairs.map(({ provider }) => provider)
+      const previews = previewPairs.map(({ preview }) => preview)
       return {
         source: {
           id: definition.id,
@@ -502,6 +596,8 @@ export class ProviderImportService {
         return this.readHermes(definition, sourcePath)
       case 'openclaw':
         return this.readOpenClaw(definition, sourcePath)
+      case 'cc-switch':
+        return this.readCcSwitch(definition, sourcePath)
     }
   }
 
@@ -690,6 +786,225 @@ export class ProviderImportService {
     })
   }
 
+  private readCcSwitch(definition: SourceDefinition, dbPath: string): ProviderImportRawProvider[] {
+    const db = new Database(dbPath, {
+      readonly: true,
+      fileMustExist: true
+    })
+    try {
+      const table = db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'providers'")
+        .get()
+      if (!table) return []
+
+      const rows = db
+        .prepare(
+          [
+            'SELECT id, app_type, name, settings_config, meta',
+            'FROM providers',
+            `WHERE app_type IN (${CC_SWITCH_APP_TYPES.map(() => '?').join(', ')})`
+          ].join(' ')
+        )
+        .all(...CC_SWITCH_APP_TYPES) as Record<string, unknown>[]
+
+      return rows.flatMap((row, index) => this.readCcSwitchProvider(definition, row, index))
+    } finally {
+      db.close()
+    }
+  }
+
+  private readCcSwitchProvider(
+    definition: SourceDefinition,
+    row: Record<string, unknown>,
+    index: number
+  ): ProviderImportRawProvider[] {
+    const appType = normalizeToken(toStringValue(row.app_type))
+    if (!CC_SWITCH_APP_TYPES.includes(appType as (typeof CC_SWITCH_APP_TYPES)[number])) {
+      return []
+    }
+
+    const settingsConfig = safeJsonParse(row.settings_config)
+    if (!settingsConfig || typeof settingsConfig !== 'object') {
+      return []
+    }
+
+    const sourceProviderId = toStringValue(row.id) || `${appType}-provider-${index + 1}`
+    const meta = safeJsonParse(row.meta)
+    const parsed = this.parseCcSwitchSettingsConfig(
+      appType,
+      settingsConfig as Record<string, unknown>,
+      toObjectValue(meta)
+    )
+    if (!parsed) {
+      return []
+    }
+
+    return [
+      {
+        id: `${definition.id}:${appType}:${sourceProviderId}`,
+        sourceId: definition.id,
+        sourceName: definition.name,
+        sourceProviderId,
+        name: toStringValue(row.name) || sourceProviderId,
+        type: parsed.type,
+        apiKey: parsed.apiKey,
+        baseUrl: parsed.baseUrl,
+        enabled: true,
+        models: parsed.models
+      }
+    ]
+  }
+
+  private parseCcSwitchSettingsConfig(
+    appType: string,
+    settingsConfig: Record<string, unknown>,
+    meta: Record<string, unknown>
+  ): {
+    apiKey: string
+    baseUrl: string
+    type: string
+    models: ProviderImportRawModel[]
+  } | null {
+    switch (appType) {
+      case 'claude':
+      case 'claude-desktop':
+        return this.parseCcSwitchClaudeConfig(settingsConfig, meta)
+      case 'gemini':
+        return this.parseCcSwitchGeminiConfig(settingsConfig)
+      case 'opencode':
+        return this.parseCcSwitchOpenCodeConfig(settingsConfig)
+      case 'openclaw':
+        return this.parseCcSwitchOpenClawConfig(settingsConfig)
+      case 'hermes':
+        return this.parseCcSwitchHermesConfig(settingsConfig)
+      default:
+        return null
+    }
+  }
+
+  private parseCcSwitchClaudeConfig(
+    settingsConfig: Record<string, unknown>,
+    meta: Record<string, unknown>
+  ) {
+    const env = toObjectValue(settingsConfig.env)
+    const models = modelFromStrings([
+      toStringValue(env.ANTHROPIC_MODEL),
+      toStringValue(env.ANTHROPIC_DEFAULT_HAIKU_MODEL),
+      toStringValue(env.ANTHROPIC_DEFAULT_SONNET_MODEL),
+      toStringValue(env.ANTHROPIC_DEFAULT_OPUS_MODEL),
+      ...this.readCcSwitchClaudeDesktopRouteModels(meta)
+    ])
+
+    return {
+      apiKey: toStringValue(env.ANTHROPIC_AUTH_TOKEN || env.ANTHROPIC_API_KEY),
+      baseUrl: toStringValue(env.ANTHROPIC_BASE_URL),
+      type: 'anthropic',
+      models
+    }
+  }
+
+  private readCcSwitchClaudeDesktopRouteModels(meta: Record<string, unknown>): string[] {
+    const routes = toObjectValue(meta.claudeDesktopModelRoutes)
+    return Object.values(routes).flatMap((route) => {
+      const item = toObjectValue(route)
+      const model = toStringValue(item.model)
+      return model ? [model] : []
+    })
+  }
+
+  private parseCcSwitchGeminiConfig(settingsConfig: Record<string, unknown>) {
+    const env = toObjectValue(settingsConfig.env)
+    const model = toStringValue(env.GEMINI_MODEL)
+    return {
+      apiKey: toStringValue(env.GEMINI_API_KEY),
+      baseUrl: toStringValue(env.GOOGLE_GEMINI_BASE_URL),
+      type: 'gemini',
+      models: model ? [{ id: model, name: model }] : []
+    }
+  }
+
+  private parseCcSwitchOpenCodeConfig(settingsConfig: Record<string, unknown>) {
+    const options = toObjectValue(settingsConfig.options)
+    return {
+      apiKey: toStringValue(options.apiKey),
+      baseUrl: toStringValue(options.baseURL),
+      type: this.resolveCcSwitchOpenCodeApiType(toStringValue(settingsConfig.npm)),
+      models: normalizeModelCollection(settingsConfig.models)
+    }
+  }
+
+  private resolveCcSwitchOpenCodeApiType(npmPackage: string): string {
+    const normalized = npmPackage.trim().toLowerCase()
+    if (normalized.includes('anthropic')) return 'anthropic'
+    if (normalized.includes('google')) return 'gemini'
+    if (normalized.includes('amazon-bedrock')) return 'aws-bedrock'
+    if (normalized.includes('openai-compatible')) return 'openai-completions'
+    if (normalized.includes('openai')) return 'openai-responses'
+    return 'openai-completions'
+  }
+
+  private parseCcSwitchOpenClawConfig(settingsConfig: Record<string, unknown>) {
+    return {
+      apiKey: toStringValue(settingsConfig.apiKey),
+      baseUrl: toStringValue(settingsConfig.baseUrl),
+      type: this.normalizeSourceApiType(toStringValue(settingsConfig.api)),
+      models: normalizeModelCollection(settingsConfig.models)
+    }
+  }
+
+  private parseCcSwitchHermesConfig(settingsConfig: Record<string, unknown>) {
+    return {
+      apiKey: toStringValue(settingsConfig.api_key),
+      baseUrl: toStringValue(settingsConfig.base_url),
+      type: this.normalizeSourceApiType(toStringValue(settingsConfig.api_mode)),
+      models: normalizeModelCollection(settingsConfig.models)
+    }
+  }
+
+  private normalizeSourceApiType(value: string): string {
+    const normalized = normalizeToken(value)
+    if (
+      normalized === 'anthropic' ||
+      normalized === 'anthropic-messages' ||
+      normalized === 'anthropic-messages-api'
+    ) {
+      return 'anthropic'
+    }
+    if (
+      normalized === 'gemini' ||
+      normalized === 'gemini-native' ||
+      normalized === 'google-generative-ai'
+    ) {
+      return 'gemini'
+    }
+    if (
+      normalized === 'openai-responses' ||
+      normalized === 'openai-response' ||
+      normalized === 'codex-responses' ||
+      normalized === 'responses'
+    ) {
+      return 'openai-responses'
+    }
+    if (
+      normalized === 'chat-completions' ||
+      normalized === 'chat-completion' ||
+      normalized === 'openai-completions' ||
+      normalized === 'openai-compatible' ||
+      normalized === 'openai-chat' ||
+      normalized === 'openai'
+    ) {
+      return 'openai-completions'
+    }
+    if (
+      normalized === 'bedrock-converse' ||
+      normalized === 'bedrock-converse-stream' ||
+      normalized === 'aws-bedrock'
+    ) {
+      return 'aws-bedrock'
+    }
+    return normalized
+  }
+
   private toPreview(rawProvider: ProviderImportRawProvider): ProviderImportProviderPreview {
     const mapping = this.mapProvider(rawProvider)
     const configured = this.isConfigured(rawProvider, mapping)
@@ -702,7 +1017,8 @@ export class ProviderImportService {
       ...(!hasCredentials && mapping.targetKind !== 'unsupported'
         ? (['missing_api_key'] as const)
         : []),
-      ...(mapping.targetKind === 'unsupported' ? (['unsupported_provider'] as const) : [])
+      ...(mapping.targetKind === 'unsupported' ? (['unsupported_provider'] as const) : []),
+      ...(mapping.importMode === 'credentials_only' ? (['credential_only_import'] as const) : [])
     ]
 
     return {
@@ -735,15 +1051,15 @@ export class ProviderImportService {
     const providerById = new Map(providers.map((provider) => [provider.id.toLowerCase(), provider]))
     const sourceId = normalizeToken(rawProvider.sourceProviderId)
     const sourceName = normalizeName(rawProvider.name)
-    const sourceType = normalizeToken(rawProvider.apiFormat || rawProvider.type)
+    const sourceType = this.normalizeSourceApiType(rawProvider.apiFormat || rawProvider.type)
     const baseUrl = rawProvider.baseUrl.toLowerCase()
 
     const providerId =
-      (baseUrl.includes('ppinfra.com') ? 'ppio' : '') ||
+      this.detectProviderIdFromBaseUrl(baseUrl) ||
       (providerById.has(sourceId) ? sourceId : '') ||
-      API_TYPE_ALIASES[sourceId] ||
-      API_TYPE_ALIASES[sourceType] ||
-      (providerById.has(sourceName) ? sourceName : '')
+      PROVIDER_ID_ALIASES[sourceId] ||
+      (providerById.has(sourceName) ? sourceName : '') ||
+      PROVIDER_ID_ALIASES[sourceName]
 
     if (providerId && providerById.has(providerId)) {
       const target = providerById.get(providerId)!
@@ -751,14 +1067,13 @@ export class ProviderImportService {
         targetKind: 'builtin',
         targetProviderId: target.id,
         targetProviderName: target.name,
-        targetApiType: target.apiType
+        targetApiType: target.apiType,
+        importMode: this.resolveBuiltinImportMode(rawProvider, target, sourceType)
       }
     }
 
     if (
-      (sourceType === 'openai' ||
-        sourceType === 'openai-chat' ||
-        sourceType === 'openai-compatible') &&
+      (sourceType === 'openai-completions' || sourceType === 'openai-responses') &&
       (isOpenAIName(rawProvider.sourceProviderId) || isOpenAIName(rawProvider.name))
     ) {
       const target = providerById.get('openai')
@@ -767,7 +1082,8 @@ export class ProviderImportService {
           targetKind: 'builtin',
           targetProviderId: target.id,
           targetProviderName: target.name,
-          targetApiType: target.apiType
+          targetApiType: target.apiType,
+          importMode: this.resolveBuiltinImportMode(rawProvider, target, sourceType)
         }
       }
     }
@@ -777,7 +1093,18 @@ export class ProviderImportService {
         targetKind: 'custom',
         targetProviderId: this.buildCustomProviderBaseId(rawProvider),
         targetProviderName: rawProvider.name,
-        targetApiType: this.resolveCustomApiType(options?.targetApiType)
+        targetApiType: this.resolveCustomApiType(options?.targetApiType, sourceType),
+        importMode: 'full'
+      }
+    }
+
+    if (rawProvider.sourceId === 'cc-switch' && sourceType === 'aws-bedrock') {
+      return {
+        targetKind: 'unsupported',
+        targetProviderId: '',
+        targetProviderName: rawProvider.name,
+        targetApiType: '',
+        importMode: 'full'
       }
     }
 
@@ -786,7 +1113,8 @@ export class ProviderImportService {
         targetKind: 'custom',
         targetProviderId: this.buildCustomProviderBaseId(rawProvider),
         targetProviderName: rawProvider.name,
-        targetApiType: this.resolveCustomApiType(options?.targetApiType)
+        targetApiType: this.resolveCustomApiType(options?.targetApiType, sourceType),
+        importMode: 'full'
       }
     }
 
@@ -794,14 +1122,67 @@ export class ProviderImportService {
       targetKind: 'unsupported',
       targetProviderId: '',
       targetProviderName: rawProvider.name,
-      targetApiType: ''
+      targetApiType: '',
+      importMode: 'full'
     }
   }
 
-  private resolveCustomApiType(value?: string): ProviderImportCustomApiType {
+  private resolveCustomApiType(value?: string, sourceType?: string): ProviderImportCustomApiType {
     return PROVIDER_IMPORT_CUSTOM_API_TYPES.includes(value as ProviderImportCustomApiType)
       ? (value as ProviderImportCustomApiType)
-      : 'openai-completions'
+      : PROVIDER_IMPORT_CUSTOM_API_TYPES.includes(sourceType as ProviderImportCustomApiType)
+        ? (sourceType as ProviderImportCustomApiType)
+        : 'openai-completions'
+  }
+
+  private detectProviderIdFromBaseUrl(baseUrl: string): string {
+    if (baseUrl.includes('api.anthropic.com')) return 'anthropic'
+    if (baseUrl.includes('ppinfra.com')) return 'ppio'
+    if (baseUrl.includes('api.deepseek.com')) return 'deepseek'
+    if (baseUrl.includes('api.minimaxi.com') || baseUrl.includes('api.minimax.io')) {
+      return 'minimax'
+    }
+    if (baseUrl.includes('bigmodel.cn') || baseUrl.includes('api.z.ai')) return 'zhipu'
+    if (baseUrl.includes('api.moonshot.cn') || baseUrl.includes('api.kimi.com')) return 'moonshot'
+    if (baseUrl.includes('dashscope.aliyuncs.com')) return 'dashscope'
+    if (baseUrl.includes('volces.com') || baseUrl.includes('bytepluses.com')) return 'doubao'
+    if (baseUrl.includes('api.siliconflow.cn')) return 'silicon'
+    if (baseUrl.includes('openrouter.ai')) return 'openrouter'
+    if (baseUrl.includes('aihubmix.com')) return 'aihubmix'
+    if (baseUrl.includes('modelscope.cn')) return 'modelscope'
+    if (baseUrl.includes('api.mistral.ai')) return 'mistral'
+    if (baseUrl.includes('api.x.ai')) return 'grok'
+    if (baseUrl.includes('api.groq.com')) return 'groq'
+    if (baseUrl.includes('api.together.xyz')) return 'together'
+    if (baseUrl.includes('jiekou.ai')) return 'jiekou'
+    if (baseUrl.includes('zenmux.ai')) return 'zenmux'
+    if (baseUrl.includes('api.poe.com')) return 'poe'
+    if (baseUrl.includes('generativelanguage.googleapis.com')) return 'gemini'
+    return ''
+  }
+
+  private resolveBuiltinImportMode(
+    rawProvider: ProviderImportRawProvider,
+    target: LLM_PROVIDER,
+    sourceType: string
+  ): ProviderImportApplyMode {
+    if (rawProvider.sourceId !== 'cc-switch') {
+      return 'full'
+    }
+
+    if (sourceType === 'anthropic' && target.apiType !== 'anthropic') {
+      return 'credentials_only'
+    }
+
+    if (sourceType === 'gemini' && target.apiType !== 'gemini') {
+      return 'credentials_only'
+    }
+
+    if (sourceType === 'openai-responses' && target.apiType !== 'openai-responses') {
+      return 'credentials_only'
+    }
+
+    return 'full'
   }
 
   private canSelectCustomProviderWithOptions(
@@ -820,15 +1201,7 @@ export class ProviderImportService {
     }
 
     if (mapping.targetKind === 'custom') {
-      if (mapping.targetApiType === 'ollama') {
-        return Boolean(rawProvider.baseUrl.trim())
-      }
-
       return Boolean(rawProvider.apiKey.trim()) && hasHttpBaseUrl(rawProvider.baseUrl)
-    }
-
-    if (mapping.targetApiType === 'ollama') {
-      return Boolean(rawProvider.baseUrl.trim())
     }
 
     return Boolean(rawProvider.apiKey.trim())
@@ -924,7 +1297,10 @@ export class ProviderImportService {
               }
             : {}),
           apiKey: rawProvider.apiKey,
-          baseUrl: rawProvider.baseUrl || current.baseUrl,
+          baseUrl:
+            mapping.importMode === 'credentials_only'
+              ? current.baseUrl
+              : rawProvider.baseUrl || current.baseUrl,
           enable: true
         }
       : {
@@ -942,7 +1318,10 @@ export class ProviderImportService {
       mapping,
       targetProviderId,
       provider,
-      models: this.buildModelMeta(targetProviderId, rawProvider.models)
+      models:
+        mapping.importMode === 'credentials_only'
+          ? []
+          : this.buildModelMeta(targetProviderId, rawProvider.models)
     }
   }
 
@@ -1072,7 +1451,7 @@ export class ProviderImportService {
       targetProviderName:
         mapping.targetKind === 'custom' ? rawProvider.name : mapping.targetProviderName,
       status,
-      modelCount: status === 'created' || status === 'updated' ? rawProvider.models.length : 0
+      modelCount: status === 'created' || status === 'updated' ? (planned?.models.length ?? 0) : 0
     }
   }
 
@@ -1080,8 +1459,21 @@ export class ProviderImportService {
     if (this.platform === 'win32') {
       const basePath = definition.windowsBase === 'appData' ? this.appDataDir : this.homeDir
       const displayBase = definition.windowsBase === 'appData' ? '%APPDATA%' : '%USERPROFILE%'
+      const sourcePath = path.join(basePath, definition.windowsRelativePath)
+      if (definition.id === 'cc-switch' && !fs.existsSync(sourcePath)) {
+        const legacyHome = (process.env.HOME ?? '').trim()
+        if (legacyHome) {
+          const legacyPath = path.join(legacyHome, definition.windowsRelativePath)
+          if (fs.existsSync(legacyPath)) {
+            return {
+              sourcePath: legacyPath,
+              displayPath: buildWindowsDisplayPath('%HOME%', definition.windowsRelativePath)
+            }
+          }
+        }
+      }
       return {
-        sourcePath: path.join(basePath, definition.windowsRelativePath),
+        sourcePath,
         displayPath: buildWindowsDisplayPath(displayBase, definition.windowsRelativePath)
       }
     }

--- a/src/main/routes/providers/providerImportService.ts
+++ b/src/main/routes/providers/providerImportService.ts
@@ -47,6 +47,13 @@ type ProviderImportProviderOptions = NonNullable<ProviderImportSelection['provid
 
 const SOURCE_DEFINITIONS: SourceDefinition[] = [
   {
+    id: 'cc-switch',
+    name: 'CC Switch',
+    unixRelativePath: '.cc-switch/cc-switch.db',
+    windowsBase: 'home',
+    windowsRelativePath: '.cc-switch/cc-switch.db'
+  },
+  {
     id: 'alma',
     name: 'Alma',
     unixRelativePath: 'Library/Application Support/alma/chat_threads.db',
@@ -73,13 +80,6 @@ const SOURCE_DEFINITIONS: SourceDefinition[] = [
     unixRelativePath: '.openclaw/gateway.yaml',
     windowsBase: 'home',
     windowsRelativePath: '.openclaw/gateway.yaml'
-  },
-  {
-    id: 'cc-switch',
-    name: 'CC Switch',
-    unixRelativePath: '.cc-switch/cc-switch.db',
-    windowsBase: 'home',
-    windowsRelativePath: '.cc-switch/cc-switch.db'
   }
 ]
 

--- a/src/renderer/settings/components/ProviderConfigImportDialog.vue
+++ b/src/renderer/settings/components/ProviderConfigImportDialog.vue
@@ -81,7 +81,7 @@
 
             <div class="overflow-hidden rounded-lg border">
               <div
-                v-for="source in orderedSources"
+                v-for="source in visibleSources"
                 :key="source.id"
                 class="flex items-start gap-3 border-b px-4 py-3 last:border-b-0"
                 :class="source.selectable ? 'bg-background' : 'bg-muted/20 text-muted-foreground'"
@@ -494,12 +494,17 @@ const orderedSources = computed<ProviderImportSourceScan[]>(() => {
     return source ? [source] : []
   })
 })
+const visibleSources = computed<ProviderImportSourceScan[]>(() =>
+  orderedSources.value.filter(
+    (source) => source.status !== 'not_found' && source.status !== 'unsupported_platform'
+  )
+)
 
 const selectableSourceCount = computed(
-  () => orderedSources.value.filter((source) => source.selectable).length
+  () => visibleSources.value.filter((source) => source.selectable).length
 )
 const selectedSourceIds = computed(() =>
-  orderedSources.value
+  visibleSources.value
     .filter((source) => source.selectable && selectedSources.value.has(source.id))
     .map((source) => source.id)
 )

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -192,7 +192,7 @@
     },
     "providerImport": {
       "entryTitle": "Importer providerindstillinger",
-      "entryDescription": "Scan Alma, Cherry Studio, Hermes og OpenClaw for provider-legitimationsoplysninger og modellister.",
+      "entryDescription": "Scan CC Switch, Alma, Cherry Studio, Hermes og OpenClaw for provider-legitimationsoplysninger og modellister.",
       "entryButton": "Importer fra agenter",
       "dialogTitle": "Importer fra andre agenter",
       "dialogDescription": "Vælg først registrerede apps, og gennemgå derefter de providers, DeepChat kan importere.",
@@ -242,7 +242,7 @@
         "missing_api_key": "Mangler API-nøgle eller påkrævet endpoint.",
         "unsupported_provider": "DeepChat kan ikke importere denne provider automatisk.",
         "overwrites_previous_selection": "Dette valg er i konflikt med en tidligere kilde.",
-        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
+        "credential_only_import": "Kun API-nøglen importeres; DeepChat beholder den indbyggede providers endpoint og runtime."
       },
       "conflicts": {
         "overridesPrevious": "Dette valg overskriver en tidligere valgt provider.",

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -241,7 +241,8 @@
         "already_configured": "Allerede konfigureret i DeepChat, så den er ikke valgt som standard.",
         "missing_api_key": "Mangler API-nøgle eller påkrævet endpoint.",
         "unsupported_provider": "DeepChat kan ikke importere denne provider automatisk.",
-        "overwrites_previous_selection": "Dette valg er i konflikt med en tidligere kilde."
+        "overwrites_previous_selection": "Dette valg er i konflikt med en tidligere kilde.",
+        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
       },
       "conflicts": {
         "overridesPrevious": "Dette valg overskriver en tidligere valgt provider.",

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -322,7 +322,7 @@
     },
     "providerImport": {
       "entryTitle": "Import provider settings",
-      "entryDescription": "Scan Alma, Cherry Studio, Hermes, and OpenClaw for provider credentials and model lists.",
+      "entryDescription": "Scan Alma, Cherry Studio, Hermes, OpenClaw, and CC Switch for provider credentials and model lists.",
       "entryButton": "Import from agents",
       "dialogTitle": "Import from other agents",
       "dialogDescription": "Select detected apps first, then review the providers DeepChat can import.",
@@ -371,7 +371,8 @@
         "already_configured": "Already configured in DeepChat, so it is not selected by default.",
         "missing_api_key": "Missing API key or required endpoint.",
         "unsupported_provider": "DeepChat cannot import this provider automatically.",
-        "overwrites_previous_selection": "This selection conflicts with an earlier source."
+        "overwrites_previous_selection": "This selection conflicts with an earlier source.",
+        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
       },
       "conflicts": {
         "overridesPrevious": "This selection will overwrite an earlier selected provider.",

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -322,7 +322,7 @@
     },
     "providerImport": {
       "entryTitle": "Import provider settings",
-      "entryDescription": "Scan Alma, Cherry Studio, Hermes, OpenClaw, and CC Switch for provider credentials and model lists.",
+      "entryDescription": "Scan CC Switch, Alma, Cherry Studio, Hermes, and OpenClaw for provider credentials and model lists.",
       "entryButton": "Import from agents",
       "dialogTitle": "Import from other agents",
       "dialogDescription": "Select detected apps first, then review the providers DeepChat can import.",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -259,7 +259,7 @@
     },
     "providerImport": {
       "entryTitle": "وارد کردن تنظیمات ارائه‌دهنده",
-      "entryDescription": "Alma، Cherry Studio، Hermes و OpenClaw را برای اطلاعات ارائه‌دهنده و فهرست مدل‌ها اسکن می‌کند.",
+      "entryDescription": "CC Switch، Alma، Cherry Studio، Hermes و OpenClaw را برای اطلاعات ارائه‌دهنده و فهرست مدل‌ها اسکن می‌کند.",
       "entryButton": "وارد کردن از عامل‌ها",
       "dialogTitle": "وارد کردن از سایر عامل‌ها",
       "dialogDescription": "ابتدا برنامه‌های شناسایی‌شده را انتخاب کنید، سپس ارائه‌دهنده‌هایی را که DeepChat می‌تواند وارد کند بررسی کنید.",
@@ -309,7 +309,7 @@
         "missing_api_key": "کلید API یا endpoint لازم وجود ندارد.",
         "unsupported_provider": "DeepChat نمی‌تواند این ارائه‌دهنده را خودکار وارد کند.",
         "overwrites_previous_selection": "این انتخاب با یک منبع قبلی تداخل دارد.",
-        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
+        "credential_only_import": "فقط کلید API وارد می‌شود؛ DeepChat endpoint و runtime ارائه‌دهنده داخلی را حفظ می‌کند."
       },
       "conflicts": {
         "overridesPrevious": "این انتخاب ارائه‌دهنده انتخاب‌شده قبلی را بازنویسی می‌کند.",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -308,7 +308,8 @@
         "already_configured": "قبلاً در DeepChat پیکربندی شده است، بنابراین به‌صورت پیش‌فرض انتخاب نمی‌شود.",
         "missing_api_key": "کلید API یا endpoint لازم وجود ندارد.",
         "unsupported_provider": "DeepChat نمی‌تواند این ارائه‌دهنده را خودکار وارد کند.",
-        "overwrites_previous_selection": "این انتخاب با یک منبع قبلی تداخل دارد."
+        "overwrites_previous_selection": "این انتخاب با یک منبع قبلی تداخل دارد.",
+        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
       },
       "conflicts": {
         "overridesPrevious": "این انتخاب ارائه‌دهنده انتخاب‌شده قبلی را بازنویسی می‌کند.",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -259,7 +259,7 @@
     },
     "providerImport": {
       "entryTitle": "Importer les paramètres de provider",
-      "entryDescription": "Analyse Alma, Cherry Studio, Hermes et OpenClaw pour récupérer les identifiants de provider et les listes de modèles.",
+      "entryDescription": "Analyse CC Switch, Alma, Cherry Studio, Hermes et OpenClaw pour récupérer les identifiants de provider et les listes de modèles.",
       "entryButton": "Importer depuis des agents",
       "dialogTitle": "Importer depuis d’autres agents",
       "dialogDescription": "Sélectionnez d’abord les apps détectées, puis vérifiez les providers que DeepChat peut importer.",
@@ -309,7 +309,7 @@
         "missing_api_key": "Clé API ou endpoint requis manquant.",
         "unsupported_provider": "DeepChat ne peut pas importer ce provider automatiquement.",
         "overwrites_previous_selection": "Cette sélection entre en conflit avec une source précédente.",
-        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
+        "credential_only_import": "Seule la clé API sera importée ; DeepChat conserve l’endpoint et le runtime de son provider intégré."
       },
       "conflicts": {
         "overridesPrevious": "Cette sélection remplacera un provider sélectionné précédemment.",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -308,7 +308,8 @@
         "already_configured": "Déjà configuré dans DeepChat, il n’est donc pas sélectionné par défaut.",
         "missing_api_key": "Clé API ou endpoint requis manquant.",
         "unsupported_provider": "DeepChat ne peut pas importer ce provider automatiquement.",
-        "overwrites_previous_selection": "Cette sélection entre en conflit avec une source précédente."
+        "overwrites_previous_selection": "Cette sélection entre en conflit avec une source précédente.",
+        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
       },
       "conflicts": {
         "overridesPrevious": "Cette sélection remplacera un provider sélectionné précédemment.",

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -259,7 +259,7 @@
     },
     "providerImport": {
       "entryTitle": "ייבוא הגדרות ספק",
-      "entryDescription": "סריקת Alma, Cherry Studio, Hermes ו-OpenClaw לאיתור פרטי ספק ורשימות מודלים.",
+      "entryDescription": "סריקת CC Switch, Alma, Cherry Studio, Hermes ו-OpenClaw לאיתור פרטי ספק ורשימות מודלים.",
       "entryButton": "ייבוא מסוכנים",
       "dialogTitle": "ייבוא מסוכנים אחרים",
       "dialogDescription": "בחר תחילה את האפליקציות שזוהו, ואז בדוק את הספקים ש-DeepChat יכול לייבא.",
@@ -309,7 +309,7 @@
         "missing_api_key": "חסר מפתח API או endpoint נדרש.",
         "unsupported_provider": "DeepChat לא יכול לייבא את הספק הזה אוטומטית.",
         "overwrites_previous_selection": "הבחירה הזו מתנגשת עם מקור קודם.",
-        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
+        "credential_only_import": "רק מפתח ה-API ייובא; DeepChat ישמור את ה-endpoint וה-runtime של הספק המובנה."
       },
       "conflicts": {
         "overridesPrevious": "הבחירה הזו תחליף ספק שנבחר קודם.",

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -308,7 +308,8 @@
         "already_configured": "כבר מוגדר ב-DeepChat, לכן אינו נבחר כברירת מחדל.",
         "missing_api_key": "חסר מפתח API או endpoint נדרש.",
         "unsupported_provider": "DeepChat לא יכול לייבא את הספק הזה אוטומטית.",
-        "overwrites_previous_selection": "הבחירה הזו מתנגשת עם מקור קודם."
+        "overwrites_previous_selection": "הבחירה הזו מתנגשת עם מקור קודם.",
+        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
       },
       "conflicts": {
         "overridesPrevious": "הבחירה הזו תחליף ספק שנבחר קודם.",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -308,7 +308,8 @@
         "already_configured": "DeepChat で設定済みのため、デフォルトでは選択されません。",
         "missing_api_key": "API キーまたは必要な endpoint がありません。",
         "unsupported_provider": "DeepChat はこのプロバイダーを自動インポートできません。",
-        "overwrites_previous_selection": "この選択は前のソースと競合します。"
+        "overwrites_previous_selection": "この選択は前のソースと競合します。",
+        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
       },
       "conflicts": {
         "overridesPrevious": "この選択は前に選択したプロバイダーを上書きします。",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -259,7 +259,7 @@
     },
     "providerImport": {
       "entryTitle": "プロバイダー設定をインポート",
-      "entryDescription": "Alma、Cherry Studio、Hermes、OpenClaw からプロバイダー認証情報とモデル一覧をスキャンします。",
+      "entryDescription": "CC Switch、Alma、Cherry Studio、Hermes、OpenClaw からプロバイダー認証情報とモデル一覧をスキャンします。",
       "entryButton": "エージェントからインポート",
       "dialogTitle": "他のエージェントからインポート",
       "dialogDescription": "検出されたアプリを選択してから、DeepChat にインポートできるプロバイダーを確認します。",
@@ -309,7 +309,7 @@
         "missing_api_key": "API キーまたは必要な endpoint がありません。",
         "unsupported_provider": "DeepChat はこのプロバイダーを自動インポートできません。",
         "overwrites_previous_selection": "この選択は前のソースと競合します。",
-        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
+        "credential_only_import": "API キーのみをインポートし、DeepChat は組み込みプロバイダーの endpoint と runtime を保持します。"
       },
       "conflicts": {
         "overridesPrevious": "この選択は前に選択したプロバイダーを上書きします。",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -259,7 +259,7 @@
     },
     "providerImport": {
       "entryTitle": "제공자 설정 가져오기",
-      "entryDescription": "Alma, Cherry Studio, Hermes, OpenClaw에서 제공자 인증 정보와 모델 목록을 스캔합니다.",
+      "entryDescription": "CC Switch, Alma, Cherry Studio, Hermes, OpenClaw에서 제공자 인증 정보와 모델 목록을 스캔합니다.",
       "entryButton": "에이전트에서 가져오기",
       "dialogTitle": "다른 에이전트에서 가져오기",
       "dialogDescription": "먼저 감지된 앱을 선택한 다음 DeepChat이 가져올 수 있는 제공자를 검토하세요.",
@@ -309,7 +309,7 @@
         "missing_api_key": "API 키 또는 필요한 endpoint가 없습니다.",
         "unsupported_provider": "DeepChat이 이 제공자를 자동으로 가져올 수 없습니다.",
         "overwrites_previous_selection": "이 선택은 이전 소스와 충돌합니다.",
-        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
+        "credential_only_import": "API 키만 가져오며 DeepChat은 내장 제공자의 endpoint와 runtime을 유지합니다."
       },
       "conflicts": {
         "overridesPrevious": "이 선택은 이전에 선택한 제공자를 덮어씁니다.",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -308,7 +308,8 @@
         "already_configured": "DeepChat에 이미 설정되어 있어 기본 선택되지 않습니다.",
         "missing_api_key": "API 키 또는 필요한 endpoint가 없습니다.",
         "unsupported_provider": "DeepChat이 이 제공자를 자동으로 가져올 수 없습니다.",
-        "overwrites_previous_selection": "이 선택은 이전 소스와 충돌합니다."
+        "overwrites_previous_selection": "이 선택은 이전 소스와 충돌합니다.",
+        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
       },
       "conflicts": {
         "overridesPrevious": "이 선택은 이전에 선택한 제공자를 덮어씁니다.",

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -308,7 +308,8 @@
         "already_configured": "Já configurado no DeepChat, portanto não é selecionado por padrão.",
         "missing_api_key": "Chave de API ou endpoint necessário ausente.",
         "unsupported_provider": "O DeepChat não consegue importar este provider automaticamente.",
-        "overwrites_previous_selection": "Esta seleção conflita com uma fonte anterior."
+        "overwrites_previous_selection": "Esta seleção conflita com uma fonte anterior.",
+        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
       },
       "conflicts": {
         "overridesPrevious": "Esta seleção sobrescreverá um provider selecionado anteriormente.",

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -259,7 +259,7 @@
     },
     "providerImport": {
       "entryTitle": "Importar configurações de provider",
-      "entryDescription": "Escaneia Alma, Cherry Studio, Hermes e OpenClaw em busca de credenciais de provider e listas de modelos.",
+      "entryDescription": "Escaneia CC Switch, Alma, Cherry Studio, Hermes e OpenClaw em busca de credenciais de provider e listas de modelos.",
       "entryButton": "Importar de agentes",
       "dialogTitle": "Importar de outros agentes",
       "dialogDescription": "Selecione primeiro os apps detectados e depois revise os providers que o DeepChat pode importar.",
@@ -309,7 +309,7 @@
         "missing_api_key": "Chave de API ou endpoint necessário ausente.",
         "unsupported_provider": "O DeepChat não consegue importar este provider automaticamente.",
         "overwrites_previous_selection": "Esta seleção conflita com uma fonte anterior.",
-        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
+        "credential_only_import": "Somente a chave de API será importada; o DeepChat mantém o endpoint e o runtime do provider integrado."
       },
       "conflicts": {
         "overridesPrevious": "Esta seleção sobrescreverá um provider selecionado anteriormente.",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -308,7 +308,8 @@
         "already_configured": "Уже настроен в DeepChat, поэтому не выбран по умолчанию.",
         "missing_api_key": "Отсутствует API-ключ или необходимый endpoint.",
         "unsupported_provider": "DeepChat не может импортировать этот provider автоматически.",
-        "overwrites_previous_selection": "Этот выбор конфликтует с более ранним источником."
+        "overwrites_previous_selection": "Этот выбор конфликтует с более ранним источником.",
+        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
       },
       "conflicts": {
         "overridesPrevious": "Этот выбор перезапишет ранее выбранный provider.",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -259,7 +259,7 @@
     },
     "providerImport": {
       "entryTitle": "Импорт настроек provider",
-      "entryDescription": "Сканирует Alma, Cherry Studio, Hermes и OpenClaw для поиска учетных данных provider и списков моделей.",
+      "entryDescription": "Сканирует CC Switch, Alma, Cherry Studio, Hermes и OpenClaw для поиска учетных данных provider и списков моделей.",
       "entryButton": "Импорт из агентов",
       "dialogTitle": "Импорт из других агентов",
       "dialogDescription": "Сначала выберите найденные приложения, затем проверьте providers, которые DeepChat может импортировать.",
@@ -309,7 +309,7 @@
         "missing_api_key": "Отсутствует API-ключ или необходимый endpoint.",
         "unsupported_provider": "DeepChat не может импортировать этот provider автоматически.",
         "overwrites_previous_selection": "Этот выбор конфликтует с более ранним источником.",
-        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
+        "credential_only_import": "Будет импортирован только API-ключ; DeepChat сохранит endpoint и runtime встроенного provider."
       },
       "conflicts": {
         "overridesPrevious": "Этот выбор перезапишет ранее выбранный provider.",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -322,7 +322,7 @@
     },
     "providerImport": {
       "entryTitle": "导入其他 Agent 配置",
-      "entryDescription": "扫描 Alma、Cherry Studio、Hermes、OpenClaw 和 CC Switch 的本地 provider 配置，快速迁移密钥和模型列表。",
+      "entryDescription": "扫描 CC Switch、Alma、Cherry Studio、Hermes 和 OpenClaw 的本地 provider 配置，快速迁移密钥和模型列表。",
       "entryButton": "从其他 Agent 导入",
       "dialogTitle": "从其他 Agent 导入",
       "dialogDescription": "先选择检测到的应用，再逐个确认要导入到 DeepChat 的 provider。",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -322,7 +322,7 @@
     },
     "providerImport": {
       "entryTitle": "导入其他 Agent 配置",
-      "entryDescription": "扫描 Alma、Cherry Studio、Hermes 和 OpenClaw 的本地 provider 配置，快速迁移密钥和模型列表。",
+      "entryDescription": "扫描 Alma、Cherry Studio、Hermes、OpenClaw 和 CC Switch 的本地 provider 配置，快速迁移密钥和模型列表。",
       "entryButton": "从其他 Agent 导入",
       "dialogTitle": "从其他 Agent 导入",
       "dialogDescription": "先选择检测到的应用，再逐个确认要导入到 DeepChat 的 provider。",
@@ -371,7 +371,8 @@
         "already_configured": "DeepChat 中已有配置，默认不会选中。",
         "missing_api_key": "缺少 API Key 或必要的 endpoint。",
         "unsupported_provider": "DeepChat 暂时无法自动导入这个 provider。",
-        "overwrites_previous_selection": "这个选择与前面的来源冲突。"
+        "overwrites_previous_selection": "这个选择与前面的来源冲突。",
+        "credential_only_import": "仅导入 API Key，DeepChat 会保留内置 provider 的 endpoint 和 runtime。"
       },
       "conflicts": {
         "overridesPrevious": "这个选择会覆盖前面选中的同名 DeepChat provider。",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -308,7 +308,8 @@
         "already_configured": "DeepChat 中已有設定，預設不會選取。",
         "missing_api_key": "缺少 API Key 或必要的 endpoint。",
         "unsupported_provider": "DeepChat 暫時無法自動匯入這個 provider。",
-        "overwrites_previous_selection": "這個選擇與前面的來源衝突。"
+        "overwrites_previous_selection": "這個選擇與前面的來源衝突。",
+        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
       },
       "conflicts": {
         "overridesPrevious": "這個選擇會覆蓋前面選取的 DeepChat provider。",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -259,7 +259,7 @@
     },
     "providerImport": {
       "entryTitle": "匯入其他 Agent 設定",
-      "entryDescription": "掃描 Alma、Cherry Studio、Hermes 和 OpenClaw 的本機 provider 設定，快速遷移密鑰和模型列表。",
+      "entryDescription": "掃描 CC Switch、Alma、Cherry Studio、Hermes 和 OpenClaw 的本機 provider 設定，快速遷移密鑰和模型列表。",
       "entryButton": "從其他 Agent 匯入",
       "dialogTitle": "從其他 Agent 匯入",
       "dialogDescription": "先選擇偵測到的應用程式，再逐一確認要匯入 DeepChat 的 provider。",
@@ -309,7 +309,7 @@
         "missing_api_key": "缺少 API Key 或必要的 endpoint。",
         "unsupported_provider": "DeepChat 暫時無法自動匯入這個 provider。",
         "overwrites_previous_selection": "這個選擇與前面的來源衝突。",
-        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
+        "credential_only_import": "僅匯入 API Key，DeepChat 會保留內置 provider 的 endpoint 和 runtime。"
       },
       "conflicts": {
         "overridesPrevious": "這個選擇會覆蓋前面選取的 DeepChat provider。",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -308,7 +308,8 @@
         "already_configured": "DeepChat 中已有設定，預設不會選取。",
         "missing_api_key": "缺少 API Key 或必要的 endpoint。",
         "unsupported_provider": "DeepChat 暫時無法自動匯入這個 provider。",
-        "overwrites_previous_selection": "這個選擇與前面的來源衝突。"
+        "overwrites_previous_selection": "這個選擇與前面的來源衝突。",
+        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
       },
       "conflicts": {
         "overridesPrevious": "這個選擇會覆蓋前面選取的 DeepChat provider。",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -259,7 +259,7 @@
     },
     "providerImport": {
       "entryTitle": "匯入其他 Agent 設定",
-      "entryDescription": "掃描 Alma、Cherry Studio、Hermes 和 OpenClaw 的本機 provider 設定，快速遷移金鑰和模型列表。",
+      "entryDescription": "掃描 CC Switch、Alma、Cherry Studio、Hermes 和 OpenClaw 的本機 provider 設定，快速遷移金鑰和模型列表。",
       "entryButton": "從其他 Agent 匯入",
       "dialogTitle": "從其他 Agent 匯入",
       "dialogDescription": "先選擇偵測到的應用程式，再逐一確認要匯入 DeepChat 的 provider。",
@@ -309,7 +309,7 @@
         "missing_api_key": "缺少 API Key 或必要的 endpoint。",
         "unsupported_provider": "DeepChat 暫時無法自動匯入這個 provider。",
         "overwrites_previous_selection": "這個選擇與前面的來源衝突。",
-        "credential_only_import": "Only the API key will be imported; DeepChat keeps its built-in endpoint and runtime."
+        "credential_only_import": "僅匯入 API Key，DeepChat 會保留內建 provider 的 endpoint 和 runtime。"
       },
       "conflicts": {
         "overridesPrevious": "這個選擇會覆蓋前面選取的 DeepChat provider。",

--- a/src/shared/contracts/routes/providers.routes.ts
+++ b/src/shared/contracts/routes/providers.routes.ts
@@ -16,7 +16,8 @@ const ProviderImportWarningSchema = z.enum([
   'already_configured',
   'missing_api_key',
   'unsupported_provider',
-  'overwrites_previous_selection'
+  'overwrites_previous_selection',
+  'credential_only_import'
 ])
 const ProviderImportApplyStatusSchema = z.enum(['created', 'updated', 'skipped', 'overwritten'])
 

--- a/src/shared/providerImport.ts
+++ b/src/shared/providerImport.ts
@@ -1,11 +1,11 @@
 import type { LLM_PROVIDER, MODEL_META } from './presenter'
 
 export const PROVIDER_IMPORT_SOURCE_IDS = [
+  'cc-switch',
   'alma',
   'cherry-studio',
   'hermes',
-  'openclaw',
-  'cc-switch'
+  'openclaw'
 ] as const
 export const PROVIDER_IMPORT_CUSTOM_API_TYPES = [
   'openai-completions',

--- a/src/shared/providerImport.ts
+++ b/src/shared/providerImport.ts
@@ -1,6 +1,12 @@
 import type { LLM_PROVIDER, MODEL_META } from './presenter'
 
-export const PROVIDER_IMPORT_SOURCE_IDS = ['alma', 'cherry-studio', 'hermes', 'openclaw'] as const
+export const PROVIDER_IMPORT_SOURCE_IDS = [
+  'alma',
+  'cherry-studio',
+  'hermes',
+  'openclaw',
+  'cc-switch'
+] as const
 export const PROVIDER_IMPORT_CUSTOM_API_TYPES = [
   'openai-completions',
   'openai',
@@ -23,8 +29,10 @@ export type ProviderImportProviderWarning =
   | 'missing_api_key'
   | 'unsupported_provider'
   | 'overwrites_previous_selection'
+  | 'credential_only_import'
 
 export type ProviderImportApplyStatus = 'created' | 'updated' | 'skipped' | 'overwritten'
+export type ProviderImportApplyMode = 'full' | 'credentials_only'
 
 export interface ProviderImportSourceScan {
   id: ProviderImportSourceId
@@ -127,6 +135,7 @@ export interface ProviderImportMapping {
   targetProviderId: string
   targetProviderName: string
   targetApiType: string
+  importMode: ProviderImportApplyMode
 }
 
 export interface ProviderImportPlannedProvider {

--- a/test/main/routes/providers/providerImportService.test.ts
+++ b/test/main/routes/providers/providerImportService.test.ts
@@ -948,7 +948,7 @@ describe('ProviderImportService', () => {
 
     const scan = await service.scan()
 
-    expect(scan.sourceOrder.at(-1)).toBe('cc-switch')
+    expect(scan.sourceOrder[0]).toBe('cc-switch')
     expect(scan.sources.find((source) => source.id === 'cc-switch')).toMatchObject({
       status: 'found',
       configPath: '~/.cc-switch/cc-switch.db',

--- a/test/main/routes/providers/providerImportService.test.ts
+++ b/test/main/routes/providers/providerImportService.test.ts
@@ -5,6 +5,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ProviderImportService } from '../../../../src/main/routes/providers/providerImportService'
 import type { LLM_PROVIDER } from '../../../../src/shared/presenter'
 
+const mockSqlite = vi.hoisted(() => ({
+  rowsByPath: new Map<string, Record<string, unknown>[]>()
+}))
+
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
   return {
@@ -13,9 +17,72 @@ vi.mock('node:fs', async () => {
   }
 })
 
+vi.mock('better-sqlite3-multiple-ciphers', () => {
+  class MockDatabase {
+    private readonly dbPath: string
+
+    constructor(dbPath: string) {
+      this.dbPath = dbPath
+      if (!mockSqlite.rowsByPath.has(dbPath)) {
+        throw new Error(`Mock SQLite database is not registered: ${dbPath}`)
+      }
+    }
+
+    prepare(sql: string) {
+      if (sql.includes('sqlite_master')) {
+        return {
+          get: () => ({ name: 'providers' })
+        }
+      }
+
+      if (sql.includes('FROM providers')) {
+        return {
+          all: (...appTypes: string[]) => {
+            const rows = mockSqlite.rowsByPath.get(this.dbPath) ?? []
+            const allowed = new Set(appTypes)
+            return rows.filter((row) => allowed.size === 0 || allowed.has(String(row.app_type)))
+          }
+        }
+      }
+
+      throw new Error(`Unexpected SQLite query: ${sql}`)
+    }
+
+    close() {}
+  }
+
+  return {
+    default: MockDatabase
+  }
+})
+
 const writeFile = (filePath: string, content: string) => {
   mkdirSync(path.dirname(filePath), { recursive: true })
   writeFileSync(filePath, content)
+}
+
+const createCcSwitchDb = (
+  dbPath: string,
+  rows: Array<{
+    id: string
+    appType: string
+    name: string
+    settingsConfig: Record<string, unknown>
+    meta?: Record<string, unknown>
+  }>
+) => {
+  mkdirSync(path.dirname(dbPath), { recursive: true })
+  writeFileSync(dbPath, 'mock sqlite database')
+  mockSqlite.rowsByPath.set(
+    dbPath,
+    rows.map((row) => ({
+      id: row.id,
+      app_type: row.appType,
+      name: row.name,
+      settings_config: JSON.stringify(row.settingsConfig),
+      meta: JSON.stringify(row.meta ?? {})
+    }))
+  )
 }
 
 const createHome = () => mkdtempSync(path.join(tmpdir(), 'deepchat-provider-import-'))
@@ -59,6 +126,8 @@ describe('ProviderImportService', () => {
   let homeDir = ''
 
   afterEach(() => {
+    mockSqlite.rowsByPath.clear()
+    vi.unstubAllEnvs()
     if (homeDir) {
       rmSync(homeDir, { recursive: true, force: true })
       homeDir = ''
@@ -211,6 +280,41 @@ describe('ProviderImportService', () => {
     warnSpy.mockRestore()
   })
 
+  it('uses Windows HOME fallback for legacy CC Switch database paths', async () => {
+    homeDir = createHome()
+    const legacyHome = path.join(homeDir, 'legacy-home')
+    vi.stubEnv('HOME', legacyHome)
+    createCcSwitchDb(path.join(legacyHome, '.cc-switch/cc-switch.db'), [
+      {
+        id: 'deepseek',
+        appType: 'claude',
+        name: 'DeepSeek',
+        settingsConfig: {
+          env: {
+            ANTHROPIC_BASE_URL: 'https://api.deepseek.com/anthropic',
+            ANTHROPIC_AUTH_TOKEN: 'sk-deepseek'
+          }
+        }
+      }
+    ])
+
+    const configPresenter = createConfigPresenter()
+    const service = new ProviderImportService(configPresenter as any, {
+      homeDir,
+      platform: 'win32',
+      appDataDir: path.join(homeDir, 'AppData', 'Roaming')
+    })
+
+    const result = await service.scan()
+
+    expect(result.sources.find((source) => source.id === 'cc-switch')).toMatchObject({
+      status: 'found',
+      configPath: '%HOME%\\.cc-switch\\cc-switch.db',
+      providerCount: 1,
+      selectable: true
+    })
+  })
+
   it('scans Hermes and OpenClaw configs and maps builtin and custom providers', async () => {
     homeDir = createHome()
     writeFile(
@@ -335,7 +439,7 @@ describe('ProviderImportService', () => {
     expect(provider.warnings).toContain('already_configured')
   })
 
-  it('previews missing-key providers and maps unknown key-url providers to custom', async () => {
+  it('hides missing-key providers and maps unknown key-url providers to custom', async () => {
     homeDir = createHome()
     writeFile(
       path.join(homeDir, '.hermes/config.yaml'),
@@ -368,19 +472,12 @@ describe('ProviderImportService', () => {
 
     expect(result.sources.find((source) => source.id === 'hermes')).toMatchObject({
       status: 'found',
-      providerCount: 3,
+      providerCount: 2,
       selectable: true,
       defaultSelected: true
     })
     expect(result.providers).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          sourceProviderId: 'deepseek',
-          targetProviderId: 'deepseek',
-          selectable: false,
-          defaultSelected: false,
-          warnings: ['missing_api_key']
-        }),
         expect.objectContaining({
           sourceProviderId: 'legacy-only',
           targetKind: 'custom',
@@ -398,6 +495,9 @@ describe('ProviderImportService', () => {
           warnings: ['unsupported_provider']
         })
       ])
+    )
+    expect(result.providers).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ sourceProviderId: 'deepseek' })])
     )
   })
 
@@ -622,7 +722,7 @@ describe('ProviderImportService', () => {
     })
   })
 
-  it('allows custom base-url-only providers to import when overridden to ollama', async () => {
+  it('hides custom base-url-only providers even if they could be overridden to ollama', async () => {
     homeDir = createHome()
     writeFile(
       path.join(homeDir, '.hermes/config.yaml'),
@@ -642,45 +742,15 @@ describe('ProviderImportService', () => {
       platform: 'darwin'
     })
     const scan = await service.scan()
-    const provider = scan.providers[0]
 
-    expect(provider).toMatchObject({
-      targetKind: 'custom',
-      targetApiType: 'openai-completions',
-      selectable: true,
-      defaultSelected: false,
-      warnings: ['missing_api_key']
+    expect(scan.sources.find((source) => source.id === 'hermes')).toMatchObject({
+      status: 'found',
+      providerCount: 0,
+      selectable: false,
+      defaultSelected: false
     })
-
-    const result = service.apply({
-      sessionId: scan.sessionId,
-      selections: [
-        {
-          sourceId: 'hermes',
-          providerIds: [provider.id],
-          providerOptions: {
-            [provider.id]: {
-              targetApiType: 'ollama'
-            }
-          }
-        }
-      ]
-    })
-
-    expect(result.summary).toMatchObject({
-      imported: 1,
-      created: 1,
-      skipped: 0
-    })
-    expect(configPresenter.getCurrentProviders()).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: 'hermes_local-ollama',
-          apiType: 'ollama',
-          apiKey: '',
-          baseUrl: 'http://localhost:11434'
-        })
-      ])
+    expect(scan.providers).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ sourceProviderId: 'local-ollama' })])
     )
   })
 
@@ -733,6 +803,384 @@ describe('ProviderImportService', () => {
         })
       ])
     )
+  })
+
+  it('scans CC Switch non-Codex providers and hides empty or Codex rows', async () => {
+    homeDir = createHome()
+    createCcSwitchDb(path.join(homeDir, '.cc-switch/cc-switch.db'), [
+      {
+        id: 'claude-official',
+        appType: 'claude',
+        name: 'Claude Official',
+        settingsConfig: { env: {} }
+      },
+      {
+        id: 'deepseek',
+        appType: 'claude',
+        name: 'DeepSeek',
+        settingsConfig: {
+          env: {
+            ANTHROPIC_BASE_URL: 'https://api.deepseek.com/anthropic',
+            ANTHROPIC_AUTH_TOKEN: 'sk-deepseek',
+            ANTHROPIC_MODEL: 'deepseek-v4-pro'
+          }
+        }
+      },
+      {
+        id: 'minimax-en',
+        appType: 'claude-desktop',
+        name: 'MiniMax en',
+        settingsConfig: {
+          env: {
+            ANTHROPIC_BASE_URL: 'https://api.minimax.io/anthropic',
+            ANTHROPIC_API_KEY: 'sk-minimax',
+            ANTHROPIC_MODEL: 'MiniMax-M2.7'
+          }
+        },
+        meta: {
+          claudeDesktopModelRoutes: {
+            sonnet: {
+              model: 'MiniMax-M2.7'
+            }
+          }
+        }
+      },
+      {
+        id: 'gemini-native',
+        appType: 'gemini',
+        name: 'Gemini Native',
+        settingsConfig: {
+          env: {
+            GEMINI_API_KEY: 'sk-gemini',
+            GOOGLE_GEMINI_BASE_URL: 'https://generativelanguage.googleapis.com',
+            GEMINI_MODEL: 'gemini-3-pro'
+          }
+        }
+      },
+      {
+        id: 'opencode-gateway',
+        appType: 'opencode',
+        name: 'OpenCode Gateway',
+        settingsConfig: {
+          npm: '@ai-sdk/openai-compatible',
+          options: {
+            apiKey: 'sk-opencode',
+            baseURL: 'https://opencode.example.com/v1'
+          },
+          models: {
+            'gpt-5.4': { name: 'GPT-5.4' }
+          }
+        }
+      },
+      {
+        id: 'openclaw-gateway',
+        appType: 'openclaw',
+        name: 'OpenClaw Gateway',
+        settingsConfig: {
+          apiKey: 'sk-openclaw',
+          baseUrl: 'https://openclaw.example.com/v1',
+          api: 'openai-responses',
+          models: [{ id: 'gpt-5.4', name: 'GPT-5.4' }]
+        }
+      },
+      {
+        id: 'hermes-gateway',
+        appType: 'hermes',
+        name: 'Hermes Gateway',
+        settingsConfig: {
+          api_key: 'sk-hermes',
+          base_url: 'https://hermes.example.com/v1',
+          api_mode: 'anthropic_messages',
+          models: {
+            'claude-sonnet': { name: 'Claude Sonnet' }
+          }
+        }
+      },
+      {
+        id: 'codex-gateway',
+        appType: 'codex',
+        name: 'Codex Gateway',
+        settingsConfig: {
+          auth: { OPENAI_API_KEY: 'sk-codex' },
+          config: 'model = "gpt-5.4"'
+        }
+      }
+    ])
+
+    const configPresenter = createConfigPresenter([
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        apiType: 'openai',
+        apiKey: '',
+        baseUrl: 'https://api.openai.com/v1',
+        enable: false
+      },
+      {
+        id: 'deepseek',
+        name: 'DeepSeek',
+        apiType: 'deepseek',
+        apiKey: '',
+        baseUrl: 'https://api.deepseek.com/v1',
+        enable: false
+      },
+      {
+        id: 'minimax',
+        name: 'MiniMax',
+        apiType: 'anthropic',
+        apiKey: '',
+        baseUrl: 'https://api.minimaxi.com/anthropic',
+        enable: false
+      },
+      {
+        id: 'gemini',
+        name: 'Gemini',
+        apiType: 'gemini',
+        apiKey: '',
+        baseUrl: 'https://generativelanguage.googleapis.com',
+        enable: false
+      }
+    ] as LLM_PROVIDER[])
+    const service = new ProviderImportService(configPresenter as any, {
+      homeDir,
+      platform: 'darwin'
+    })
+
+    const scan = await service.scan()
+
+    expect(scan.sourceOrder.at(-1)).toBe('cc-switch')
+    expect(scan.sources.find((source) => source.id === 'cc-switch')).toMatchObject({
+      status: 'found',
+      configPath: '~/.cc-switch/cc-switch.db',
+      providerCount: 6,
+      selectable: true,
+      defaultSelected: true
+    })
+    expect(scan.providers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceId: 'cc-switch',
+          sourceProviderId: 'deepseek',
+          targetKind: 'builtin',
+          targetProviderId: 'deepseek',
+          modelPreview: ['deepseek-v4-pro'],
+          warnings: ['credential_only_import']
+        }),
+        expect.objectContaining({
+          sourceId: 'cc-switch',
+          sourceProviderId: 'minimax-en',
+          targetKind: 'builtin',
+          targetProviderId: 'minimax',
+          targetApiType: 'anthropic',
+          modelPreview: ['MiniMax-M2.7']
+        }),
+        expect.objectContaining({
+          sourceId: 'cc-switch',
+          sourceProviderId: 'gemini-native',
+          targetKind: 'builtin',
+          targetProviderId: 'gemini',
+          targetApiType: 'gemini'
+        }),
+        expect.objectContaining({
+          sourceId: 'cc-switch',
+          sourceProviderId: 'opencode-gateway',
+          targetKind: 'custom',
+          targetProviderId: 'ccswitch_opencode-gateway',
+          targetApiType: 'openai-completions',
+          modelPreview: ['GPT-5.4']
+        }),
+        expect.objectContaining({
+          sourceId: 'cc-switch',
+          sourceProviderId: 'openclaw-gateway',
+          targetKind: 'custom',
+          targetApiType: 'openai-responses'
+        }),
+        expect.objectContaining({
+          sourceId: 'cc-switch',
+          sourceProviderId: 'hermes-gateway',
+          targetKind: 'custom',
+          targetApiType: 'anthropic',
+          modelPreview: ['Claude Sonnet']
+        })
+      ])
+    )
+    expect(scan.providers).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceProviderId: 'claude-official' }),
+        expect.objectContaining({ sourceProviderId: 'codex-gateway' })
+      ])
+    )
+  })
+
+  it('imports only API key for CC Switch DeepSeek Anthropic-compatible provider', async () => {
+    homeDir = createHome()
+    createCcSwitchDb(path.join(homeDir, '.cc-switch/cc-switch.db'), [
+      {
+        id: 'deepseek',
+        appType: 'claude',
+        name: 'DeepSeek',
+        settingsConfig: {
+          env: {
+            ANTHROPIC_BASE_URL: 'https://api.deepseek.com/anthropic',
+            ANTHROPIC_AUTH_TOKEN: 'sk-deepseek',
+            ANTHROPIC_MODEL: 'deepseek-v4-pro'
+          }
+        }
+      }
+    ])
+
+    const configPresenter = createConfigPresenter([
+      {
+        id: 'deepseek',
+        name: 'DeepSeek',
+        apiType: 'deepseek',
+        apiKey: '',
+        baseUrl: 'https://api.deepseek.com/v1',
+        enable: false
+      }
+    ] as LLM_PROVIDER[])
+    const service = new ProviderImportService(configPresenter as any, {
+      homeDir,
+      platform: 'darwin'
+    })
+    const scan = await service.scan()
+    const provider = scan.providers[0]
+
+    expect(provider).toMatchObject({
+      sourceProviderId: 'deepseek',
+      targetProviderId: 'deepseek',
+      targetApiType: 'deepseek',
+      warnings: ['credential_only_import']
+    })
+
+    const result = service.apply({
+      sessionId: scan.sessionId,
+      selections: [{ sourceId: 'cc-switch', providerIds: [provider.id] }]
+    })
+
+    expect(result.summary).toMatchObject({
+      imported: 1,
+      updated: 1,
+      models: 0
+    })
+    expect(configPresenter.getCurrentProviders()[0]).toMatchObject({
+      id: 'deepseek',
+      apiType: 'deepseek',
+      apiKey: 'sk-deepseek',
+      baseUrl: 'https://api.deepseek.com/v1',
+      enable: true
+    })
+    expect(configPresenter.addCustomModel).not.toHaveBeenCalled()
+  })
+
+  it('maps CC Switch MiniMax to built-in Anthropic runtime provider', async () => {
+    homeDir = createHome()
+    createCcSwitchDb(path.join(homeDir, '.cc-switch/cc-switch.db'), [
+      {
+        id: 'minimax',
+        appType: 'claude',
+        name: 'MiniMax',
+        settingsConfig: {
+          env: {
+            ANTHROPIC_BASE_URL: 'https://api.minimaxi.com/anthropic',
+            ANTHROPIC_AUTH_TOKEN: 'sk-minimax',
+            ANTHROPIC_MODEL: 'MiniMax-M2.7'
+          }
+        }
+      }
+    ])
+
+    const configPresenter = createConfigPresenter([
+      {
+        id: 'minimax',
+        name: 'MiniMax',
+        apiType: 'anthropic',
+        apiKey: '',
+        baseUrl: 'https://api.minimaxi.com/anthropic',
+        enable: false
+      }
+    ] as LLM_PROVIDER[])
+    const service = new ProviderImportService(configPresenter as any, {
+      homeDir,
+      platform: 'darwin'
+    })
+    const scan = await service.scan()
+    const provider = scan.providers[0]
+
+    expect(provider).toMatchObject({
+      sourceProviderId: 'minimax',
+      targetKind: 'builtin',
+      targetProviderId: 'minimax',
+      targetApiType: 'anthropic',
+      warnings: []
+    })
+
+    const result = service.apply({
+      sessionId: scan.sessionId,
+      selections: [{ sourceId: 'cc-switch', providerIds: [provider.id] }]
+    })
+
+    expect(result.summary).toMatchObject({
+      imported: 1,
+      updated: 1,
+      models: 1
+    })
+    expect(configPresenter.getCurrentProviders()[0]).toMatchObject({
+      id: 'minimax',
+      apiType: 'anthropic',
+      apiKey: 'sk-minimax',
+      baseUrl: 'https://api.minimaxi.com/anthropic',
+      enable: true
+    })
+    expect(configPresenter.addCustomModel).toHaveBeenCalledWith(
+      'minimax',
+      expect.objectContaining({
+        id: 'MiniMax-M2.7',
+        providerId: 'minimax'
+      })
+    )
+  })
+
+  it('maps CC Switch Claude official identity to built-in Anthropic provider', async () => {
+    homeDir = createHome()
+    createCcSwitchDb(path.join(homeDir, '.cc-switch/cc-switch.db'), [
+      {
+        id: 'claude-official',
+        appType: 'claude',
+        name: 'Claude Official',
+        settingsConfig: {
+          env: {
+            ANTHROPIC_AUTH_TOKEN: 'sk-anthropic',
+            ANTHROPIC_MODEL: 'claude-sonnet-4-5'
+          }
+        }
+      }
+    ])
+
+    const configPresenter = createConfigPresenter([
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        apiType: 'anthropic',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        enable: false
+      }
+    ] as LLM_PROVIDER[])
+    const service = new ProviderImportService(configPresenter as any, {
+      homeDir,
+      platform: 'darwin'
+    })
+
+    const scan = await service.scan()
+
+    expect(scan.providers[0]).toMatchObject({
+      sourceProviderId: 'claude-official',
+      targetKind: 'builtin',
+      targetProviderId: 'anthropic',
+      targetApiType: 'anthropic',
+      warnings: []
+    })
   })
 
   it('reads Cherry Studio providers from a LevelDB snapshot', async () => {

--- a/test/main/routes/providers/providerRouteHandler.test.ts
+++ b/test/main/routes/providers/providerRouteHandler.test.ts
@@ -58,7 +58,7 @@ describe('dispatchProviderRoute provider import routes', () => {
     const providerImportService = {
       scan: vi.fn(() => ({
         sessionId: 'scan-1',
-        sourceOrder: ['alma', 'cherry-studio', 'hermes', 'openclaw', 'cc-switch'],
+        sourceOrder: ['cc-switch', 'alma', 'cherry-studio', 'hermes', 'openclaw'],
         sources: [],
         providers: []
       })),

--- a/test/main/routes/providers/providerRouteHandler.test.ts
+++ b/test/main/routes/providers/providerRouteHandler.test.ts
@@ -58,7 +58,7 @@ describe('dispatchProviderRoute provider import routes', () => {
     const providerImportService = {
       scan: vi.fn(() => ({
         sessionId: 'scan-1',
-        sourceOrder: ['alma', 'cherry-studio', 'hermes', 'openclaw'],
+        sourceOrder: ['alma', 'cherry-studio', 'hermes', 'openclaw', 'cc-switch'],
         sources: [],
         providers: []
       })),


### PR DESCRIPTION
## Summary
- Add CC Switch as a provider import source and prioritize it in the import flow
- Hide sources and providers without importable credentials from the preview UI
- Preserve built-in provider runtime/base URL for credential-only imports such as DeepSeek Anthropic-compatible configs
- Add SDD docs, i18n text, and provider import regression coverage

## Tests
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck
- pnpm exec vitest --config vitest.config.ts test/main/routes/providers/providerImportService.test.ts test/main/routes/providers/providerRouteHandler.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for importing provider credentials from CC Switch.
  * Introduced credential-only import mode, which imports API keys while preserving the app's built-in provider endpoint and runtime.

* **Improvements**
  * Enhanced provider import dialog to display only supported sources and show relevant warnings for different import scenarios.
  * Updated UI text across all languages to reflect expanded provider scanning options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->