### PR TITLE
fix(spotlight): resolve panel stacking and hover perf issues

### DIFF
--- a/docs/features/app-spotlight-search/tasks.md
+++ b/docs/features/app-spotlight-search/tasks.md
@@ -8,77 +8,77 @@
 
 ## T1 快捷键与事件
 
-- [ ] 新增快捷键配置项 `QuickSearch`
-- [ ] 默认值设为 `CommandOrControl+P`
-- [ ] 新增 `SHORTCUT_EVENTS.TOGGLE_SPOTLIGHT`
-- [ ] `ShortcutPresenter` 注册 / 重注册 Spotlight 快捷键
-- [ ] 快捷键设置页展示并允许修改 `QuickSearch`
+- [x] 新增快捷键配置项 `QuickSearch`
+- [x] 默认值设为 `CommandOrControl+P`
+- [x] 新增 `SHORTCUT_EVENTS.TOGGLE_SPOTLIGHT`
+- [x] `ShortcutPresenter` 注册 / 重注册 Spotlight 快捷键
+- [x] 快捷键设置页展示并允许修改 `QuickSearch`
 
 ## T2 历史搜索服务
 
-- [ ] 抽离“消息可见文本抽取”公共逻辑
-- [ ] 新增 `deepchat_search_documents` 普通表
-- [ ] 新增 `deepchat_search_documents_fts` FTS5 虚表
-- [ ] 实现首次回填 / schema rebuild
-- [ ] 实现会话创建 / 重命名 / 删除的索引同步
-- [ ] 实现消息写入 / 编辑 / 删除的索引同步
-- [ ] 实现 FTS 失败回退到 `LIKE`
+- [x] 抽离"消息可见文本抽取"公共逻辑
+- [x] 新增 `deepchat_search_documents` 普通表
+- [x] 新增 `deepchat_search_documents_fts` FTS5 虚表
+- [x] 实现首次回填 / schema rebuild
+- [x] 实现会话创建 / 重命名 / 删除的索引同步
+- [x] 实现消息写入 / 编辑 / 删除的索引同步
+- [x] 实现 FTS 失败回退到 `LIKE`
 
 ## T3 Presenter 与共享类型
 
-- [ ] 新增 `HistorySearchOptions`
-- [ ] 新增 `HistorySearchHit / SessionHit / MessageHit`
-- [ ] `IAgentSessionPresenter` 增加 `searchHistory(query, options?)`
-- [ ] 补充共享类型导出
+- [x] 新增 `HistorySearchOptions`
+- [x] 新增 `HistorySearchHit / SessionHit / MessageHit`
+- [x] `IAgentSessionPresenter` 增加 `searchHistory(query, options?)`
+- [x] 补充共享类型导出
 
 ## T4 设置导航 registry
 
-- [ ] 抽取设置页共享 registry
-- [ ] 字段包含 `routeName / titleKey / icon / keywords[]`
-- [ ] 设置窗口侧栏复用该 registry
-- [ ] Spotlight setting items 复用该 registry
+- [x] 抽取设置页共享 registry
+- [x] 字段包含 `routeName / titleKey / icon / keywords[]`
+- [x] 设置窗口侧栏复用该 registry
+- [x] Spotlight setting items 复用该 registry
 
 ## T5 Spotlight Renderer 状态
 
-- [ ] 新增 `spotlight store`
-- [ ] 管理 `open/query/results/activeIndex/loading/requestSeq/pendingMessageJump`
-- [ ] 输入 80ms debounce
-- [ ] 按 requestSeq 丢弃过期响应
-- [ ] 结果截断到 12 条
+- [x] 新增 `spotlight store`
+- [x] 管理 `open/query/results/activeIndex/loading/requestSeq/pendingMessageJump`
+- [x] 输入 80ms debounce
+- [x] 按 requestSeq 丢弃过期响应
+- [x] 结果截断到 12 条
 
 ## T6 Spotlight UI
 
-- [ ] 新增主聊天窗口顶层 Spotlight overlay
-- [ ] 沿用 `rounded-2xl + border + bg-card/40 + backdrop-blur` 视觉样式
-- [ ] 左侧 rail 增加 Spotlight 入口
-- [ ] 空查询展示 `Recent Sessions + Agents + Actions`
-- [ ] 查询态展示单一混排结果列表
-- [ ] 增加 `kind pill`
-- [ ] 支持 `Esc / ↑ / ↓ / Home / End / Enter / hover / click`
+- [x] 新增主聊天窗口顶层 Spotlight overlay
+- [x] 沿用 `rounded-2xl + border + bg-card/40 + backdrop-blur` 视觉样式
+- [x] 左侧 rail 增加 Spotlight 入口
+- [x] 空查询展示 `Recent Sessions + Agents + Actions`
+- [x] 查询态展示单一混排结果列表
+- [x] 增加 `kind pill`
+- [x] 支持 `Esc / ↑ / ↓ / Home / End / Enter / hover / click`
 - [ ] 尊重 `prefers-reduced-motion`
 
 ## T7 执行行为
 
-- [ ] `session` 命中切会话
-- [ ] `message` 命中写入 `pendingMessageJump`
-- [ ] `ChatPage` 在消息加载完成后滚动并高亮目标消息
-- [ ] `agent` 命中复用现有侧栏切换逻辑
-- [ ] `setting` 命中打开 / 聚焦设置窗口并导航
-- [ ] `action` 命中只执行非破坏性动作
+- [x] `session` 命中切会话
+- [x] `message` 命中写入 `pendingMessageJump`
+- [x] `ChatPage` 在消息加载完成后滚动并高亮目标消息
+- [x] `agent` 命中复用现有侧栏切换逻辑
+- [x] `setting` 命中打开 / 聚焦设置窗口并导航
+- [x] `action` 命中只执行非破坏性动作
 
 ## T8 测试
 
-- [ ] main tests：排序、回填、增量同步、降级查询
-- [ ] renderer tests：打开关闭、自动聚焦、键盘链路
-- [ ] renderer tests：混排与去重
-- [ ] renderer tests：message jump + scroll highlight
-- [ ] renderer tests：agent / setting / action 执行
+- [x] main tests：排序、回填、增量同步、降级查询
+- [x] renderer tests：打开关闭、自动聚焦、键盘链路
+- [x] renderer tests：混排与去重
+- [x] renderer tests：message jump + scroll highlight
+- [x] renderer tests：agent / setting / action 执行
 - [ ] 验收场景：sidebar 收起、空查询、设置窗口聚焦
 
 ## T9 质量检查
 
-- [ ] `pnpm run format`
-- [ ] `pnpm run i18n`
-- [ ] `pnpm run lint`
-- [ ] `pnpm run typecheck`
-- [ ] 运行相关 main / renderer 测试
+- [x] `pnpm run format`
+- [x] `pnpm run i18n`
+- [x] `pnpm run lint`
+- [x] `pnpm run typecheck`
+- [x] 运行相关 main / renderer 测试

--- a/src/renderer/src/components/WindowSideBar.vue
+++ b/src/renderer/src/components/WindowSideBar.vue
@@ -1138,13 +1138,11 @@ onUnmounted(() => {
 }
 
 .window-sidebar-shell {
-  contain: layout style paint;
+  contain: layout style;
 }
 
 .window-sidebar-session-column {
   backface-visibility: hidden;
-  transform: translateZ(0);
-  will-change: transform, opacity;
 }
 
 .session-list {

--- a/src/renderer/src/components/spotlight/SpotlightOverlay.vue
+++ b/src/renderer/src/components/spotlight/SpotlightOverlay.vue
@@ -2,7 +2,7 @@
   <Teleport to="body">
     <div
       v-if="spotlightStore.open"
-      class="window-no-drag-region fixed inset-0 z-[70] flex items-start justify-center px-4 pt-16"
+      class="window-no-drag-region fixed inset-0 z-[90] flex items-start justify-center px-4 pt-16"
       @mousedown.self="spotlightStore.closeSpotlight()"
     >
       <div
@@ -25,7 +25,7 @@
             <button
               v-for="(item, index) in spotlightStore.results"
               :key="item.id"
-              v-memo="[item.id, index === spotlightStore.activeIndex, spotlightStore.query]"
+              v-memo="[item, index === spotlightStore.activeIndex, spotlightStore.query]"
               type="button"
               class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left"
               :class="
@@ -34,7 +34,7 @@
                   : 'text-foreground/90'
               "
               :data-spotlight-active="index === spotlightStore.activeIndex ? 'true' : undefined"
-              @mouseenter="handleItemMouseEnter(index)"
+              @mouseenter="handleItemMouseEnter(item)"
               @mousedown="handleItemMouseDown($event, item)"
               @click="handleItemClick(item)"
             >
@@ -123,7 +123,7 @@ const resultsContainerRef = ref<HTMLElement | null>(null)
 const pointerActivatedItemId = ref<string | null>(null)
 let activeChangeSource: 'keyboard' | 'mouse' = 'keyboard'
 let mouseEnterRaf = 0
-let pendingMouseEnterIndex = -1
+let pendingMouseEnterId: string | number | null = null
 
 const focusInput = () => {
   nextTick(() => {
@@ -224,23 +224,32 @@ const handleKeydown = (event: KeyboardEvent) => {
   }
 }
 
-const handleItemMouseEnter = (index: number) => {
-  if (spotlightStore.activeIndex === index) {
+const handleItemMouseEnter = (item: SpotlightItem) => {
+  const currentIndex = spotlightStore.results.findIndex((r) => r.id === item.id)
+  if (currentIndex === -1 || spotlightStore.activeIndex === currentIndex) {
     return
   }
-  pendingMouseEnterIndex = index
+  pendingMouseEnterId = item.id
   if (mouseEnterRaf !== 0) {
     return
   }
   mouseEnterRaf = window.requestAnimationFrame(() => {
     mouseEnterRaf = 0
-    const target = pendingMouseEnterIndex
-    pendingMouseEnterIndex = -1
-    if (target < 0 || spotlightStore.activeIndex === target) {
+    const targetId = pendingMouseEnterId
+    pendingMouseEnterId = null
+    if (targetId === null) {
+      return
+    }
+    const foundItem = spotlightStore.results.find((r) => r.id === targetId)
+    if (!foundItem) {
+      return
+    }
+    const targetIndex = spotlightStore.results.findIndex((r) => r.id === targetId)
+    if (targetIndex < 0 || spotlightStore.activeIndex === targetIndex) {
       return
     }
     activeChangeSource = 'mouse'
-    spotlightStore.setActiveItem(target)
+    spotlightStore.setActiveItem(targetIndex)
   })
 }
 

--- a/src/renderer/src/components/spotlight/SpotlightOverlay.vue
+++ b/src/renderer/src/components/spotlight/SpotlightOverlay.vue
@@ -8,104 +8,104 @@
       <div
         class="spotlight-panel window-no-drag-region flex w-full max-w-3xl flex-col overflow-hidden rounded-2xl backdrop-blur-[26px]"
       >
-      <div class="flex items-center gap-3 border-b border-border/60 px-4 py-3">
-        <Icon icon="lucide:search" class="h-4 w-4 shrink-0 text-muted-foreground" />
-        <input
-          ref="inputRef"
-          :value="spotlightStore.query"
-          class="h-9 w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
-          :placeholder="t('chat.spotlight.placeholder')"
-          @input="spotlightStore.setQuery(($event.target as HTMLInputElement).value)"
-          @keydown="handleKeydown"
-        />
-      </div>
+        <div class="flex items-center gap-3 border-b border-border/60 px-4 py-3">
+          <Icon icon="lucide:search" class="h-4 w-4 shrink-0 text-muted-foreground" />
+          <input
+            ref="inputRef"
+            :value="spotlightStore.query"
+            class="h-9 w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+            :placeholder="t('chat.spotlight.placeholder')"
+            @input="spotlightStore.setQuery(($event.target as HTMLInputElement).value)"
+            @keydown="handleKeydown"
+          />
+        </div>
 
-      <div ref="resultsContainerRef" class="max-h-[28rem] overflow-y-auto p-2">
-        <template v-if="spotlightStore.results.length > 0">
-          <button
-            v-for="(item, index) in spotlightStore.results"
-            :key="item.id"
-            v-memo="[item.id, index === spotlightStore.activeIndex, spotlightStore.query]"
-            type="button"
-            class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left"
-            :class="
-              index === spotlightStore.activeIndex
-                ? 'bg-accent text-accent-foreground'
-                : 'text-foreground/90'
-            "
-            :data-spotlight-active="index === spotlightStore.activeIndex ? 'true' : undefined"
-            @mouseenter="handleItemMouseEnter(index)"
-            @mousedown="handleItemMouseDown($event, item)"
-            @click="handleItemClick(item)"
-          >
-            <span
-              class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-background"
+        <div ref="resultsContainerRef" class="max-h-[28rem] overflow-y-auto p-2">
+          <template v-if="spotlightStore.results.length > 0">
+            <button
+              v-for="(item, index) in spotlightStore.results"
+              :key="item.id"
+              v-memo="[item.id, index === spotlightStore.activeIndex, spotlightStore.query]"
+              type="button"
+              class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left"
+              :class="
+                index === spotlightStore.activeIndex
+                  ? 'bg-accent text-accent-foreground'
+                  : 'text-foreground/90'
+              "
+              :data-spotlight-active="index === spotlightStore.activeIndex ? 'true' : undefined"
+              @mouseenter="handleItemMouseEnter(index)"
+              @mousedown="handleItemMouseDown($event, item)"
+              @click="handleItemClick(item)"
             >
-              <Icon :icon="item.icon" class="h-4 w-4 text-muted-foreground" />
-            </span>
+              <span
+                class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-background"
+              >
+                <Icon :icon="item.icon" class="h-4 w-4 text-muted-foreground" />
+              </span>
 
-            <span class="min-w-0 flex-1">
-              <span class="flex items-center gap-2">
-                <span class="truncate text-sm font-medium">
-                  <template
-                    v-for="(segment, segmentIndex) in highlightSegments(resolveItemTitle(item))"
-                    :key="`${item.id}-title-${segmentIndex}`"
+              <span class="min-w-0 flex-1">
+                <span class="flex items-center gap-2">
+                  <span class="truncate text-sm font-medium">
+                    <template
+                      v-for="(segment, segmentIndex) in highlightSegments(resolveItemTitle(item))"
+                      :key="`${item.id}-title-${segmentIndex}`"
+                    >
+                      <mark v-if="segment.match" class="rounded bg-primary/15 px-0.5 text-inherit">
+                        {{ segment.text }}
+                      </mark>
+                      <template v-else>{{ segment.text }}</template>
+                    </template>
+                  </span>
+                  <span
+                    class="shrink-0 rounded-full border border-border/70 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground"
                   >
-                    <mark v-if="segment.match" class="rounded bg-primary/15 px-0.5 text-inherit">
-                      {{ segment.text }}
-                    </mark>
-                    <template v-else>{{ segment.text }}</template>
-                  </template>
+                    {{ t(`chat.spotlight.kind.${item.kind}`) }}
+                  </span>
+                </span>
+
+                <span
+                  v-if="item.subtitle"
+                  class="mt-0.5 block truncate text-xs text-muted-foreground"
+                >
+                  {{ item.subtitle }}
                 </span>
                 <span
-                  class="shrink-0 rounded-full border border-border/70 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground"
+                  v-if="item.snippet"
+                  class="mt-1 block line-clamp-2 text-xs text-muted-foreground"
                 >
-                  {{ t(`chat.spotlight.kind.${item.kind}`) }}
+                  {{ item.snippet }}
                 </span>
               </span>
+            </button>
+          </template>
 
-              <span
-                v-if="item.subtitle"
-                class="mt-0.5 block truncate text-xs text-muted-foreground"
-              >
-                {{ item.subtitle }}
-              </span>
-              <span
-                v-if="item.snippet"
-                class="mt-1 block line-clamp-2 text-xs text-muted-foreground"
-              >
-                {{ item.snippet }}
-              </span>
-            </span>
-          </button>
-        </template>
+          <div
+            v-else
+            class="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center text-muted-foreground"
+          >
+            <Icon
+              :icon="spotlightStore.loading ? 'lucide:loader-circle' : 'lucide:search-x'"
+              class="h-5 w-5"
+              :class="{ 'animate-spin': spotlightStore.loading }"
+            />
+            <p class="text-sm font-medium">
+              {{
+                spotlightStore.loading
+                  ? t('chat.spotlight.searching')
+                  : t('chat.spotlight.emptyTitle')
+              }}
+            </p>
+            <p class="text-xs">
+              {{ t('chat.spotlight.emptyDescription') }}
+            </p>
+          </div>
+        </div>
 
-        <div
-          v-else
-          class="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center text-muted-foreground"
-        >
-          <Icon
-            :icon="spotlightStore.loading ? 'lucide:loader-circle' : 'lucide:search-x'"
-            class="h-5 w-5"
-            :class="{ 'animate-spin': spotlightStore.loading }"
-          />
-          <p class="text-sm font-medium">
-            {{
-              spotlightStore.loading
-                ? t('chat.spotlight.searching')
-                : t('chat.spotlight.emptyTitle')
-            }}
-          </p>
-          <p class="text-xs">
-            {{ t('chat.spotlight.emptyDescription') }}
-          </p>
+        <div class="border-t border-border/60 px-4 py-2 text-[11px] text-muted-foreground">
+          {{ t('chat.spotlight.hints') }}
         </div>
       </div>
-
-      <div class="border-t border-border/60 px-4 py-2 text-[11px] text-muted-foreground">
-        {{ t('chat.spotlight.hints') }}
-      </div>
-    </div>
     </div>
   </Teleport>
 </template>

--- a/src/renderer/src/components/spotlight/SpotlightOverlay.vue
+++ b/src/renderer/src/components/spotlight/SpotlightOverlay.vue
@@ -1,12 +1,13 @@
 <template>
-  <div
-    v-if="spotlightStore.open"
-    class="window-no-drag-region fixed inset-0 z-[70] flex items-start justify-center px-4 pt-16"
-    @mousedown.self="spotlightStore.closeSpotlight()"
-  >
+  <Teleport to="body">
     <div
-      class="spotlight-panel window-no-drag-region flex w-full max-w-3xl flex-col overflow-hidden rounded-2xl backdrop-blur-[26px]"
+      v-if="spotlightStore.open"
+      class="window-no-drag-region fixed inset-0 z-[70] flex items-start justify-center px-4 pt-16"
+      @mousedown.self="spotlightStore.closeSpotlight()"
     >
+      <div
+        class="spotlight-panel window-no-drag-region flex w-full max-w-3xl flex-col overflow-hidden rounded-2xl backdrop-blur-[26px]"
+      >
       <div class="flex items-center gap-3 border-b border-border/60 px-4 py-3">
         <Icon icon="lucide:search" class="h-4 w-4 shrink-0 text-muted-foreground" />
         <input
@@ -24,15 +25,16 @@
           <button
             v-for="(item, index) in spotlightStore.results"
             :key="item.id"
+            v-memo="[item.id, index === spotlightStore.activeIndex, spotlightStore.query]"
             type="button"
-            class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left transition-colors"
+            class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left"
             :class="
               index === spotlightStore.activeIndex
                 ? 'bg-accent text-accent-foreground'
-                : 'text-foreground/90 hover:bg-accent/60'
+                : 'text-foreground/90'
             "
             :data-spotlight-active="index === spotlightStore.activeIndex ? 'true' : undefined"
-            @mouseenter="spotlightStore.setActiveItem(index)"
+            @mouseenter="handleItemMouseEnter(index)"
             @mousedown="handleItemMouseDown($event, item)"
             @click="handleItemClick(item)"
           >
@@ -104,7 +106,8 @@
         {{ t('chat.spotlight.hints') }}
       </div>
     </div>
-  </div>
+    </div>
+  </Teleport>
 </template>
 
 <script setup lang="ts">
@@ -118,6 +121,9 @@ const { t } = useI18n()
 const inputRef = ref<HTMLInputElement | null>(null)
 const resultsContainerRef = ref<HTMLElement | null>(null)
 const pointerActivatedItemId = ref<string | null>(null)
+let activeChangeSource: 'keyboard' | 'mouse' = 'keyboard'
+let mouseEnterRaf = 0
+let pendingMouseEnterIndex = -1
 
 const focusInput = () => {
   nextTick(() => {
@@ -186,24 +192,28 @@ const handleKeydown = (event: KeyboardEvent) => {
 
   if (event.key === 'ArrowDown') {
     event.preventDefault()
+    activeChangeSource = 'keyboard'
     spotlightStore.moveActiveItem(1)
     return
   }
 
   if (event.key === 'ArrowUp') {
     event.preventDefault()
+    activeChangeSource = 'keyboard'
     spotlightStore.moveActiveItem(-1)
     return
   }
 
   if (event.key === 'Home') {
     event.preventDefault()
+    activeChangeSource = 'keyboard'
     spotlightStore.setActiveItem(0)
     return
   }
 
   if (event.key === 'End') {
     event.preventDefault()
+    activeChangeSource = 'keyboard'
     spotlightStore.setActiveItem(spotlightStore.results.length - 1)
     return
   }
@@ -212,6 +222,26 @@ const handleKeydown = (event: KeyboardEvent) => {
     event.preventDefault()
     void spotlightStore.executeActiveItem()
   }
+}
+
+const handleItemMouseEnter = (index: number) => {
+  if (spotlightStore.activeIndex === index) {
+    return
+  }
+  pendingMouseEnterIndex = index
+  if (mouseEnterRaf !== 0) {
+    return
+  }
+  mouseEnterRaf = window.requestAnimationFrame(() => {
+    mouseEnterRaf = 0
+    const target = pendingMouseEnterIndex
+    pendingMouseEnterIndex = -1
+    if (target < 0 || spotlightStore.activeIndex === target) {
+      return
+    }
+    activeChangeSource = 'mouse'
+    spotlightStore.setActiveItem(target)
+  })
 }
 
 const handleItemMouseDown = (event: MouseEvent, item: SpotlightItem) => {
@@ -254,6 +284,10 @@ watch(
       return
     }
 
+    if (activeChangeSource === 'mouse') {
+      return
+    }
+
     nextTick(() => {
       resultsContainerRef.value
         ?.querySelector<HTMLElement>('[data-spotlight-active="true"]')
@@ -281,8 +315,8 @@ input {
   border: 1px solid transparent;
   background: linear-gradient(
     180deg,
-    color-mix(in srgb, white 82%, hsl(var(--background)) 18%) 0%,
-    color-mix(in srgb, white 62%, hsl(var(--background)) 38%) 100%
+    color-mix(in srgb, white 95%, hsl(var(--background)) 5%) 0%,
+    color-mix(in srgb, white 88%, hsl(var(--background)) 12%) 100%
   );
   box-shadow:
     0 32px 64px -24px rgb(15 23 42 / 0.28),
@@ -307,10 +341,10 @@ input {
     ),
     linear-gradient(
       180deg,
-      color-mix(in srgb, white 90%, hsl(var(--background)) 10%) 0%,
-      color-mix(in srgb, white 68%, hsl(var(--muted)) 32%) 100%
+      color-mix(in srgb, white 97%, hsl(var(--background)) 3%) 0%,
+      color-mix(in srgb, white 90%, hsl(var(--muted)) 10%) 100%
     );
-  opacity: 0.92;
+  opacity: 0.98;
 }
 
 .spotlight-panel::after {
@@ -335,8 +369,8 @@ input {
   border-color: transparent;
   background: linear-gradient(
     180deg,
-    color-mix(in srgb, hsl(var(--background)) 86%, rgb(51 65 85) 14%) 0%,
-    color-mix(in srgb, hsl(var(--background)) 93%, rgb(15 23 42) 7%) 100%
+    color-mix(in srgb, hsl(var(--background)) 96%, rgb(51 65 85) 4%) 0%,
+    color-mix(in srgb, hsl(var(--background)) 98%, rgb(15 23 42) 2%) 100%
   );
   box-shadow:
     0 32px 64px -28px rgb(0 0 0 / 0.56),
@@ -355,16 +389,16 @@ input {
     ),
     linear-gradient(
       180deg,
-      color-mix(in srgb, hsl(var(--background)) 80%, rgb(30 41 59) 20%) 0%,
-      color-mix(in srgb, hsl(var(--background)) 92%, rgb(2 6 23) 8%) 100%
+      color-mix(in srgb, hsl(var(--background)) 94%, rgb(30 41 59) 6%) 0%,
+      color-mix(in srgb, hsl(var(--background)) 97%, rgb(2 6 23) 3%) 100%
     );
-  opacity: 0.9;
+  opacity: 0.97;
 }
 
 .dark .spotlight-panel::after {
   box-shadow:
     inset 0 0 0 1px color-mix(in srgb, white 9%, hsl(var(--border)) 91%),
     inset 0 1px 0 rgb(255 255 255 / 0.08);
-  opacity: 0.76;
+  opacity: 0.88;
 }
 </style>

--- a/src/shadcn/components/ui/select/SelectContent.vue
+++ b/src/shadcn/components/ui/select/SelectContent.vue
@@ -35,7 +35,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       data-slot="select-content"
       v-bind="{ ...forwarded, ...$attrs }"
       :class="cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--reka-select-content-available-height) min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-[80] max-h-(--reka-select-content-available-height) min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
         position === 'popper'
           && 'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         props.class,

--- a/test/main/presenter/agentRuntimePresenter/compactionService.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/compactionService.test.ts
@@ -488,8 +488,22 @@ describe('CompactionService', () => {
       newUserContent: 'next turn'
     })
 
-    expect(buildHistoryTurns).toHaveBeenNthCalledWith(1, expect.any(Array), false, false, false)
-    expect(buildHistoryTurns).toHaveBeenNthCalledWith(2, expect.any(Array), false, true, false)
+    expect(buildHistoryTurns).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Array),
+      false,
+      false,
+      false,
+      false
+    )
+    expect(buildHistoryTurns).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Array),
+      false,
+      true,
+      false,
+      false
+    )
   })
 
   it('passes assistant error records into next-turn compaction but excludes errored users', async () => {

--- a/test/main/presenter/sqlitePresenter/deepchatSessionsTable.test.ts
+++ b/test/main/presenter/sqlitePresenter/deepchatSessionsTable.test.ts
@@ -106,14 +106,15 @@ describe('DeepChatSessionsTable.updateSummaryStateIfMatches', () => {
       throw new Error(`Unexpected SQL: ${sql}`)
     })
 
-    expect(table.getLatestVersion()).toBe(27)
+    expect(table.getLatestVersion()).toBe(28)
 
     expect(table.getMigrationSQL(23)).toBe(
       [
         'ALTER TABLE deepchat_sessions ADD COLUMN timeout_ms INTEGER;',
         'ALTER TABLE deepchat_sessions ADD COLUMN force_interleaved_thinking_compat INTEGER;',
         'ALTER TABLE deepchat_sessions ADD COLUMN reasoning_visibility TEXT;',
-        'ALTER TABLE deepchat_sessions ADD COLUMN image_generation_options_json TEXT;'
+        'ALTER TABLE deepchat_sessions ADD COLUMN image_generation_options_json TEXT;',
+        'ALTER TABLE deepchat_sessions ADD COLUMN video_generation_options_json TEXT;'
       ].join('\n')
     )
 
@@ -122,6 +123,9 @@ describe('DeepChatSessionsTable.updateSummaryStateIfMatches', () => {
     )
     expect(table.getMigrationSQL(27)).toBe(
       'ALTER TABLE deepchat_sessions ADD COLUMN image_generation_options_json TEXT;'
+    )
+    expect(table.getMigrationSQL(28)).toBe(
+      'ALTER TABLE deepchat_sessions ADD COLUMN video_generation_options_json TEXT;'
     )
   })
 
@@ -223,7 +227,7 @@ describe('DeepChatSessionsTable.updateSummaryStateIfMatches', () => {
 
         if (sql === 'SELECT MAX(version) as version FROM schema_versions') {
           return {
-            get: () => ({ version: 28 })
+            get: () => ({ version: 29 })
           }
         }
 
@@ -235,11 +239,11 @@ describe('DeepChatSessionsTable.updateSummaryStateIfMatches', () => {
     const guardedTable = new DeepChatSessionsTable(guardedDb)
 
     expect(() => guardedTable.createTable()).toThrow(
-      'Recorded deepchat_sessions schema version 28 exceeds supported version 27.'
+      'Recorded deepchat_sessions schema version 29 exceeds supported version 28.'
     )
     expect(exec).not.toHaveBeenCalled()
     expect(errorSpy).toHaveBeenCalledWith(
-      'Recorded deepchat_sessions schema version 28 exceeds supported version 27. Refusing to create table from a downgraded schema.'
+      'Recorded deepchat_sessions schema version 29 exceeds supported version 28. Refusing to create table from a downgraded schema.'
     )
   })
 })

--- a/test/renderer/components/ChatPage.test.ts
+++ b/test/renderer/components/ChatPage.test.ts
@@ -698,8 +698,8 @@ describe('ChatPage', () => {
     expect(wrapper.find('.chat-tool-interaction-overlay-stub').exists()).toBe(true)
     expect(wrapper.find('.pending-input-lane-stub').exists()).toBe(true)
     expect(wrapper.find('.chat-input-box-stub').exists()).toBe(false)
-    expect(html.indexOf('chat-tool-interaction-overlay-stub')).toBeLessThan(
-      html.indexOf('pending-input-lane-stub')
+    expect(html.indexOf('pending-input-lane-stub')).toBeLessThan(
+      html.indexOf('chat-tool-interaction-overlay-stub')
     )
   })
 


### PR DESCRIPTION
  - Teleport spotlight overlay to body to escape sidebar compositing context
  - Drop contain:paint and will-change/translateZ from sidebar so spotlight z-index can take effect across stacking contexts
  - Add v-memo and rAF-batched mouseenter to result items; skip scrollIntoView on mouse-driven activeIndex changes
  - Raise SelectContent z-index to z-[80] so dropdowns render above the ChatStatusBar popover (z-72) and other custom overlays
  - Update Spotlight tasks.md to reflect actual completion state
  - Refresh tests for deepchat_sessions schema v28, buildHistoryTurns 5-arg signature, and ChatPage pending-lane DOM order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated spotlight search task checklist and statuses.

* **Bug Fixes**
  * Fixed select dropdown stacking/z-index.
  * Corrected pending chat interaction lane render order.
  * Updated session migration/version expectations.

* **Improvements**
  * Enhanced spotlight navigation (mouse/keyboard) and reduced hover-driven scrolling.
  * Refined spotlight panel and overlay visuals.
  * Simplified sidebar styling to improve rendering.

* **Tests**
  * Adjusted test assertions and formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->