### PR TITLE
refactor(onboarding): rewrite spotlight via SVG path

### DIFF
--- a/src/renderer/src/components/onboarding/GuidedOnboardingOverlay.vue
+++ b/src/renderer/src/components/onboarding/GuidedOnboardingOverlay.vue
@@ -4,20 +4,11 @@
     data-testid="guided-onboarding-overlay"
     class="pointer-events-none fixed inset-0 z-70"
   >
-    <div
-      v-for="(blockerStyle, index) in blockerStyles"
-      :key="`blocker-${index}`"
-      data-testid="guided-onboarding-blocker"
-      class="pointer-events-auto absolute bg-slate-950/22"
-      :style="blockerStyle"
-      @click.stop.prevent
-    />
-
-    <div
-      v-if="spotlightStyle"
-      data-testid="guided-onboarding-spotlight"
-      class="pointer-events-none absolute rounded-3xl border border-primary/70 bg-transparent transition-all duration-200"
-      :style="spotlightStyle"
+    <OnBoardingSpotlight
+      :path-d="pathD"
+      :cutout-path-d="cutoutPathD"
+      :viewport-width="viewportWidth"
+      :viewport-height="viewportHeight"
     />
 
     <div
@@ -105,7 +96,10 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
+import { useElementBounding } from '@vueuse/core'
+import OnBoardingSpotlight from './OnBoardingSpotlight.vue'
+import { useOnBoarding } from '@/composables/useOnBoarding'
 
 type GuidedOnboardingPanelPlacement = 'auto' | 'above' | 'below'
 
@@ -155,157 +149,50 @@ defineEmits<{
   expert: []
 }>()
 
-const spotlightStyle = ref<Record<string, string> | null>(null)
-const blockerStyles = ref<Array<Record<string, string>>>([])
+const PANEL_MIN_HEIGHT = 156
 const panelRef = ref<HTMLElement | null>(null)
-const panelStyle = ref<Record<string, string>>({
-  top: '24px',
-  left: '24px',
-  width: 'min(320px, calc(100% - 32px))'
-})
 
-const resetLayout = () => {
-  spotlightStyle.value = null
-  blockerStyles.value = [
-    {
-      top: '0px',
-      left: '0px',
-      width: '100vw',
-      height: '100vh'
+const { spotlightRect, viewportWidth, viewportHeight, pathD, cutoutPathD } = useOnBoarding(
+  () => props.targetEl,
+  { visible: () => props.visible }
+)
+
+const { height: panelActualHeight } = useElementBounding(panelRef)
+
+const panelStyle = computed(() => {
+  const rect = spotlightRect.value
+  if (!rect) {
+    return {
+      top: '24px',
+      left: '24px',
+      width: 'min(320px, calc(100% - 32px))'
     }
-  ]
-  panelStyle.value = {
-    top: '24px',
-    left: '24px',
-    width: 'min(320px, calc(100% - 32px))'
-  }
-}
-
-const updateLayout = async () => {
-  await nextTick()
-
-  const targetElement = props.targetEl
-  if (!props.visible || !targetElement) {
-    resetLayout()
-    return
   }
 
-  const targetRect = targetElement.getBoundingClientRect()
-  const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0
-  const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0
-  if (viewportWidth < 1 || viewportHeight < 1 || targetRect.width < 1 || targetRect.height < 1) {
-    resetLayout()
-    return
-  }
-
-  const padding = 12
-  const spotlightTop = Math.max(targetRect.top - padding, 16)
-  const spotlightLeft = Math.max(targetRect.left - padding, 16)
-  const spotlightWidth = Math.min(
-    targetRect.width + padding * 2,
-    Math.max(viewportWidth - spotlightLeft - 16, 0)
-  )
-  const spotlightHeight = Math.min(
-    targetRect.height + padding * 2,
-    Math.max(viewportHeight - spotlightTop - 16, 0)
-  )
-  const spotlightRight = spotlightLeft + spotlightWidth
-  const spotlightBottom = spotlightTop + spotlightHeight
-
-  blockerStyles.value = [
-    {
-      top: '0px',
-      left: '0px',
-      width: `${viewportWidth}px`,
-      height: `${Math.max(spotlightTop, 0)}px`
-    },
-    {
-      top: `${spotlightTop}px`,
-      left: '0px',
-      width: `${Math.max(spotlightLeft, 0)}px`,
-      height: `${Math.max(spotlightHeight, 0)}px`
-    },
-    {
-      top: `${spotlightTop}px`,
-      left: `${Math.max(spotlightRight, 0)}px`,
-      width: `${Math.max(viewportWidth - spotlightRight, 0)}px`,
-      height: `${Math.max(spotlightHeight, 0)}px`
-    },
-    {
-      top: `${Math.max(spotlightBottom, 0)}px`,
-      left: '0px',
-      width: `${viewportWidth}px`,
-      height: `${Math.max(viewportHeight - spotlightBottom, 0)}px`
-    }
-  ].filter((style) => Number.parseFloat(style.width) > 0 && Number.parseFloat(style.height) > 0)
-
-  spotlightStyle.value = {
-    top: `${spotlightTop}px`,
-    left: `${spotlightLeft}px`,
-    width: `${spotlightWidth}px`,
-    height: `${spotlightHeight}px`,
-    boxShadow: '0 0 0 9999px rgba(15, 23, 42, 0.26)'
-  }
-
-  const panelWidth = Math.min(320, Math.max(180, viewportWidth - 32))
-  const panelHeightEstimate = Math.max(panelRef.value?.getBoundingClientRect().height ?? 0, 156)
-  const desiredTop = spotlightTop + spotlightHeight + 18
-  const maxPanelTop = Math.max(16, viewportHeight - panelHeightEstimate - 16)
-  const aboveTop = Math.max(16, spotlightTop - panelHeightEstimate - 18)
+  const panelWidth = Math.min(320, Math.max(180, viewportWidth.value - 32))
+  const panelHeightEstimate = Math.max(panelActualHeight.value, PANEL_MIN_HEIGHT)
+  const desiredTop = rect.y + rect.height + 18
+  const maxPanelTop = Math.max(16, viewportHeight.value - panelHeightEstimate - 16)
+  const aboveTop = Math.max(16, rect.y - panelHeightEstimate - 18)
   const belowTop = Math.min(maxPanelTop, desiredTop)
+
   const panelTop = (() => {
-    if (props.preferredPanelPlacement === 'above') {
-      return aboveTop
-    }
-
-    if (props.preferredPanelPlacement === 'below') {
-      return belowTop
-    }
-
-    const placeAbove = desiredTop + panelHeightEstimate > viewportHeight - 16
+    if (props.preferredPanelPlacement === 'above') return aboveTop
+    if (props.preferredPanelPlacement === 'below') return belowTop
+    const placeAbove = desiredTop + panelHeightEstimate > viewportHeight.value - 16
     return placeAbove ? aboveTop : belowTop
   })()
+
   const panelLeft = Math.min(
-    Math.max(16, spotlightLeft),
-    Math.max(16, viewportWidth - panelWidth - 16)
+    Math.max(16, rect.x),
+    Math.max(16, viewportWidth.value - panelWidth - 16)
   )
 
-  panelStyle.value = {
+  return {
     top: `${panelTop}px`,
     left: `${panelLeft}px`,
     width: `${panelWidth}px`
   }
-}
-
-onMounted(() => {
-  window.addEventListener('resize', updateLayout)
-  window.addEventListener('scroll', updateLayout, true)
-})
-
-watch(
-  () =>
-    [
-      props.visible,
-      props.containerEl,
-      props.targetEl,
-      props.stepIndex,
-      props.totalSteps,
-      props.preferredPanelPlacement
-    ] as const,
-  ([visible]) => {
-    if (!visible) {
-      resetLayout()
-      return
-    }
-
-    void updateLayout()
-  },
-  { flush: 'post', immediate: true }
-)
-
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', updateLayout)
-  window.removeEventListener('scroll', updateLayout, true)
 })
 </script>
 

--- a/src/renderer/src/components/onboarding/OnBoardingSpotlight.vue
+++ b/src/renderer/src/components/onboarding/OnBoardingSpotlight.vue
@@ -1,0 +1,72 @@
+<template>
+  <svg
+    class="onboarding-spotlight-svg"
+    :viewBox="`0 0 ${viewportWidth} ${viewportHeight}`"
+    preserveAspectRatio="xMinYMin slice"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path
+      data-testid="onboarding-spotlight-path"
+      :d="pathD"
+      :fill="fillColor"
+      :fill-opacity="fillOpacity"
+      fill-rule="evenodd"
+      @click.stop.prevent="$emit('dimClick')"
+    />
+    <path
+      v-if="cutoutPathD"
+      data-testid="onboarding-spotlight-border"
+      :d="cutoutPathD"
+      fill="none"
+      :stroke="borderColor"
+      :stroke-width="borderWidth"
+    />
+  </svg>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    pathD: string
+    cutoutPathD?: string
+    viewportWidth: number
+    viewportHeight: number
+    fillColor?: string
+    fillOpacity?: number
+    borderColor?: string
+    borderWidth?: number
+  }>(),
+  {
+    cutoutPathD: '',
+    fillColor: 'rgb(15, 23, 42)',
+    fillOpacity: 0.42,
+    borderColor: 'color-mix(in srgb, var(--primary) 70%, transparent)',
+    borderWidth: 1
+  }
+)
+
+defineEmits<{
+  dimClick: []
+}>()
+</script>
+
+<style scoped>
+/* Single SVG element with evenodd-filled path — driver.js technique.
+   The dim path catches clicks on the dim area; the cutout has no fill so
+   clicks fall through naturally to the highlighted target. The optional
+   border path renders inside the same SVG so it paints in lockstep with
+   the dim — no inter-element lag during resize. */
+.onboarding-spotlight-svg {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.onboarding-spotlight-svg path[data-testid='onboarding-spotlight-path'] {
+  pointer-events: auto;
+  cursor: auto;
+}
+</style>

--- a/src/renderer/src/composables/useOnBoarding.ts
+++ b/src/renderer/src/composables/useOnBoarding.ts
@@ -1,0 +1,118 @@
+import { computed, toValue, watch, type ComputedRef, type MaybeRefOrGetter, type Ref } from 'vue'
+import { useElementBounding, useElementSize } from '@vueuse/core'
+
+export interface SpotlightRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface UseOnBoardingOptions {
+  visible?: MaybeRefOrGetter<boolean>
+  padding?: number
+  radius?: number
+  edgeInset?: number
+}
+
+export interface UseOnBoardingReturn {
+  spotlightRect: ComputedRef<SpotlightRect | null>
+  viewportWidth: Ref<number>
+  viewportHeight: Ref<number>
+  pathD: ComputedRef<string>
+  cutoutPathD: ComputedRef<string>
+}
+
+/**
+ * Reactive spotlight cutout geometry. Tracks the target element and viewport
+ * via ResizeObserver (through @vueuse/core), so updates land in the same layout
+ * pass as the window resize and do not lag behind the compositor.
+ *
+ * The returned `pathD` follows driver.js' technique: a single SVG `<path>` with
+ * `fill-rule: evenodd` — outer subpath covers the viewport, inner rounded-rect
+ * subpath cuts the spotlight hole.
+ */
+export function useOnBoarding(
+  targetEl: MaybeRefOrGetter<HTMLElement | null>,
+  options: UseOnBoardingOptions = {}
+): UseOnBoardingReturn {
+  const padding = options.padding ?? 12
+  const radius = options.radius ?? 24
+  const edgeInset = options.edgeInset ?? 16
+
+  const documentEl = typeof document !== 'undefined' ? document.documentElement : null
+  const { width: viewportWidth, height: viewportHeight } = useElementSize(documentEl)
+
+  const targetElRef = computed(() => toValue(targetEl))
+  const {
+    x: targetX,
+    y: targetY,
+    width: targetWidth,
+    height: targetHeight,
+    update: updateTargetBounds
+  } = useElementBounding(targetElRef)
+
+  // Viewport changes via window resize don't necessarily change the target's
+  // box size, so its own ResizeObserver may not fire. Re-read its rect when the
+  // viewport resizes; this runs before the next paint and keeps the cutout in
+  // sync with the layout pass.
+  watch([viewportWidth, viewportHeight], () => updateTargetBounds())
+
+  const spotlightRect = computed<SpotlightRect | null>(() => {
+    const isVisible = options.visible === undefined ? true : Boolean(toValue(options.visible))
+    if (
+      !isVisible ||
+      !targetElRef.value ||
+      targetWidth.value < 1 ||
+      targetHeight.value < 1 ||
+      viewportWidth.value < 1 ||
+      viewportHeight.value < 1
+    ) {
+      return null
+    }
+
+    const top = Math.max(targetY.value - padding, edgeInset)
+    const left = Math.max(targetX.value - padding, edgeInset)
+    const width = Math.min(
+      targetWidth.value + padding * 2,
+      Math.max(viewportWidth.value - left - edgeInset, 0)
+    )
+    const height = Math.min(
+      targetHeight.value + padding * 2,
+      Math.max(viewportHeight.value - top - edgeInset, 0)
+    )
+
+    if (width <= 0 || height <= 0) {
+      return null
+    }
+
+    return { x: left, y: top, width, height }
+  })
+
+  const cutoutPathD = computed(() => {
+    const rect = spotlightRect.value
+    if (!rect) return ''
+    const r = Math.floor(Math.max(Math.min(radius, rect.width / 2, rect.height / 2), 0))
+    const vx = rect.x + r
+    const vy = rect.y
+    const innerWidth = rect.width - r * 2
+    const innerHeight = rect.height - r * 2
+    return (
+      `M${vx},${vy} h${innerWidth} ` +
+      `a${r},${r} 0 0 1 ${r},${r} v${innerHeight} ` +
+      `a${r},${r} 0 0 1 -${r},${r} h-${innerWidth} ` +
+      `a${r},${r} 0 0 1 -${r},-${r} v-${innerHeight} ` +
+      `a${r},${r} 0 0 1 ${r},-${r} z`
+    )
+  })
+
+  const pathD = computed(() => {
+    const vw = viewportWidth.value
+    const vh = viewportHeight.value
+    const outer = `M${vw},0L0,0L0,${vh}L${vw},${vh}L${vw},0Z`
+    if (!cutoutPathD.value) return outer
+    return `${outer} ${cutoutPathD.value}`
+  })
+
+  return { spotlightRect, viewportWidth, viewportHeight, pathD, cutoutPathD }
+}

--- a/src/renderer/src/pages/WelcomePage.vue
+++ b/src/renderer/src/pages/WelcomePage.vue
@@ -6,23 +6,16 @@
       :data-guide-target="coachmarkTargetSurface"
       class="pointer-events-none fixed inset-0 z-70"
     >
-      <div
-        v-for="(blockerStyle, blockerIndex) in coachmarkBlockerStyles"
-        :key="blockerIndex"
-        data-testid="welcome-guide-blocker"
-        class="pointer-events-auto absolute"
-        :style="blockerStyle"
-        @click.stop.prevent
+      <OnBoardingSpotlight
+        :path-d="coachmarkPathD"
+        :cutout-path-d="coachmarkCutoutPathD"
+        :viewport-width="coachmarkViewportWidth"
+        :viewport-height="coachmarkViewportHeight"
+        :fill-opacity="0.56"
       />
 
       <div
-        v-if="coachmarkSpotlightStyle"
-        data-testid="welcome-guide-spotlight"
-        class="pointer-events-none absolute rounded-[28px] border border-primary/70 bg-transparent transition-all duration-200"
-        :style="coachmarkSpotlightStyle"
-      />
-
-      <div
+        ref="coachmarkPanelRef"
         data-testid="welcome-guide-panel"
         role="dialog"
         aria-modal="true"
@@ -251,7 +244,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref } from 'vue'
+import { useElementBounding } from '@vueuse/core'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
@@ -271,6 +265,8 @@ import {
   type GuidedOnboardingSettingsRouteName
 } from '@shared/guidedOnboarding'
 import ModelIcon from '@/components/icons/ModelIcon.vue'
+import OnBoardingSpotlight from '@/components/onboarding/OnBoardingSpotlight.vue'
+import { useOnBoarding } from '@/composables/useOnBoarding'
 import type {
   GuidedOnboardingState,
   GuidedOnboardingStepId,
@@ -289,17 +285,7 @@ const rootRef = ref<HTMLElement | null>(null)
 const guideCardRef = ref<HTMLElement | null>(null)
 const providerGridRef = ref<HTMLElement | null>(null)
 const guideCoachmarkDismissed = ref(false)
-const coachmarkSpotlightStyle = ref<Record<string, string> | null>(null)
-const coachmarkBlockerStyles = ref<Record<string, string>[]>([
-  {
-    inset: '0'
-  }
-])
-const coachmarkPanelStyle = ref<Record<string, string>>({
-  top: '24px',
-  left: '24px',
-  width: 'min(320px, calc(100% - 32px))'
-})
+const coachmarkPanelRef = ref<HTMLElement | null>(null)
 
 const providers = [
   { id: 'claude', nameKey: 'welcome.page.providers.claude' },
@@ -389,106 +375,57 @@ const persistGuideResumeIntent = (
   persistGuidedOnboardingResumeIntent({ stepId, trigger })
 }
 
-const updateGuideCoachmarkLayout = async () => {
-  await nextTick()
+const coachmarkTargetEl = computed(() =>
+  showGuideCoachmark.value ? resolveCoachmarkTargetElement() : null
+)
 
-  const targetElement = resolveCoachmarkTargetElement()
-  if (!targetElement) {
-    coachmarkSpotlightStyle.value = null
-    coachmarkBlockerStyles.value = [{ inset: '0' }]
-    coachmarkPanelStyle.value = {
+const {
+  spotlightRect: coachmarkSpotlightRect,
+  viewportWidth: coachmarkViewportWidth,
+  viewportHeight: coachmarkViewportHeight,
+  pathD: coachmarkPathD,
+  cutoutPathD: coachmarkCutoutPathD
+} = useOnBoarding(coachmarkTargetEl, {
+  visible: showGuideCoachmark,
+  radius: 28
+})
+
+const { height: coachmarkPanelActualHeight } = useElementBounding(coachmarkPanelRef)
+
+const coachmarkPanelStyle = computed(() => {
+  const rect = coachmarkSpotlightRect.value
+  const fallbackWidth = showGuideImportAction.value
+    ? 'min(420px, calc(100% - 32px))'
+    : 'min(320px, calc(100% - 32px))'
+
+  if (!rect) {
+    return {
       top: '24px',
       left: '24px',
-      width: showGuideImportAction.value
-        ? 'min(420px, calc(100% - 32px))'
-        : 'min(320px, calc(100% - 32px))'
+      width: fallbackWidth
     }
-    return
   }
-
-  const targetRect = targetElement.getBoundingClientRect()
-  const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0
-  const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0
-  if (viewportWidth < 1 || viewportHeight < 1 || targetRect.width < 1 || targetRect.height < 1) {
-    coachmarkSpotlightStyle.value = null
-    coachmarkBlockerStyles.value = [{ inset: '0' }]
-    coachmarkPanelStyle.value = {
-      top: '24px',
-      left: '24px',
-      width: showGuideImportAction.value
-        ? 'min(420px, calc(100% - 32px))'
-        : 'min(320px, calc(100% - 32px))'
-    }
-    return
-  }
-
-  const padding = 12
-  const spotlightTop = Math.max(targetRect.top - padding, 16)
-  const spotlightLeft = Math.max(targetRect.left - padding, 16)
-  const spotlightWidth = Math.min(
-    targetRect.width + padding * 2,
-    Math.max(viewportWidth - spotlightLeft - 16, 0)
-  )
-  const spotlightHeight = Math.min(
-    targetRect.height + padding * 2,
-    Math.max(viewportHeight - spotlightTop - 16, 0)
-  )
-
-  coachmarkSpotlightStyle.value = {
-    top: `${spotlightTop}px`,
-    left: `${spotlightLeft}px`,
-    width: `${spotlightWidth}px`,
-    height: `${spotlightHeight}px`,
-    boxShadow: '0 0 0 9999px rgba(15, 23, 42, 0.56)'
-  }
-  const spotlightRight = spotlightLeft + spotlightWidth
-  const spotlightBottom = spotlightTop + spotlightHeight
-  coachmarkBlockerStyles.value = [
-    {
-      top: '0px',
-      left: '0px',
-      right: '0px',
-      height: `${spotlightTop}px`
-    },
-    {
-      top: `${spotlightTop}px`,
-      left: '0px',
-      width: `${spotlightLeft}px`,
-      height: `${spotlightHeight}px`
-    },
-    {
-      top: `${spotlightTop}px`,
-      left: `${spotlightRight}px`,
-      right: '0px',
-      height: `${spotlightHeight}px`
-    },
-    {
-      top: `${spotlightBottom}px`,
-      left: '0px',
-      right: '0px',
-      bottom: '0px'
-    }
-  ]
 
   const preferredPanelWidth = showGuideImportAction.value ? 420 : 320
-  const panelWidth = Math.min(preferredPanelWidth, Math.max(180, viewportWidth - 32))
-  const panelHeightEstimate = showGuideImportAction.value ? 172 : 168
-  const desiredTop = spotlightTop + spotlightHeight + 20
-  const placeAbove = desiredTop + panelHeightEstimate > viewportHeight - 16
+  const panelWidth = Math.min(preferredPanelWidth, Math.max(180, coachmarkViewportWidth.value - 32))
+  const fallbackHeight = showGuideImportAction.value ? 172 : 168
+  const panelHeightEstimate = Math.max(coachmarkPanelActualHeight.value, fallbackHeight)
+  const desiredTop = rect.y + rect.height + 20
+  const placeAbove = desiredTop + panelHeightEstimate > coachmarkViewportHeight.value - 16
   const panelTop = placeAbove
-    ? Math.max(16, spotlightTop - panelHeightEstimate - 20)
-    : Math.min(Math.max(16, viewportHeight - panelHeightEstimate - 16), desiredTop)
+    ? Math.max(16, rect.y - panelHeightEstimate - 20)
+    : Math.min(Math.max(16, coachmarkViewportHeight.value - panelHeightEstimate - 16), desiredTop)
   const panelLeft = Math.min(
-    Math.max(16, spotlightLeft),
-    Math.max(16, viewportWidth - panelWidth - 16)
+    Math.max(16, rect.x),
+    Math.max(16, coachmarkViewportWidth.value - panelWidth - 16)
   )
 
-  coachmarkPanelStyle.value = {
+  return {
     top: `${panelTop}px`,
     left: `${panelLeft}px`,
     width: `${panelWidth}px`
   }
-}
+})
 
 const dismissGuideCoachmark = () => {
   guideCoachmarkDismissed.value = true
@@ -685,23 +622,6 @@ const onSetupAcp = async () => {
 
 onMounted(() => {
   void syncOnboardingState()
-  window.addEventListener('resize', updateGuideCoachmarkLayout)
-})
-
-watch(
-  () => [showGuideCoachmark.value, coachmarkTargetSurface.value, coachmarkStepId.value] as const,
-  ([visible]) => {
-    if (!visible) {
-      return
-    }
-
-    void updateGuideCoachmarkLayout()
-  },
-  { flush: 'post', immediate: true }
-)
-
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', updateGuideCoachmarkLayout)
 })
 </script>
 


### PR DESCRIPTION
  Replace duplicated coachmark/spotlight implementations in
  GuidedOnboardingOverlay and WelcomePage with a shared
  OnBoardingSpotlight component + useOnBoarding composable. Render the
  dim overlay as a single SVG <path> with fill-rule=evenodd
  (driver.js technique), driven by VueUse's ResizeObserver-backed
  useElementBounding / useElementSize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced onboarding spotlight with improved panel positioning and dynamic placement logic.

* **Refactor**
  * Modernized guided onboarding system for better responsiveness and reliability. Spotlight overlay now adapts more efficiently to viewport changes and target element positioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->