### PR TITLE
chore(cua): sync driver v0.2.0

### DIFF
--- a/docs/issues/cua-driver-v0-2-0-sync/plan.md
+++ b/docs/issues/cua-driver-v0-2-0-sync/plan.md
@@ -1,0 +1,38 @@
+# Plan
+
+## Source Review
+
+- Compare upstream `trycua/cua` tags `cua-driver-v0.1.5` and
+  `cua-driver-v0.2.0`.
+- Apply the Swift driver delta with a three-way merge against DeepChat's
+  maintained fork.
+- Keep upstream Rust driver changes out of this sync.
+
+## Implementation
+
+- Merge upstream Swift runtime changes into
+  `plugins/cua/vendor/cua-driver/source`.
+- Adapt new upstream TCC, doctor, and MCP daemon-proxy text and commands to
+  `DeepChat Computer Use.app` and `com.wefonk.deepchat.computeruse`.
+- Preserve DeepChat-only CLI behavior: `deepchat-permission-probe`, nonblocking
+  MCP startup, and DeepChat-managed `update`.
+- Update `plugins/cua/vendor/cua-driver/upstream.json` to `cua-driver-v0.2.0`.
+- Leave packaged skills unchanged unless validation shows upstream skill content
+  changed in the Swift release.
+
+## Validation
+
+- Run `swift build --package-path plugins/cua/vendor/cua-driver/source --product cua-driver`.
+- Run `pnpm run format`.
+- Run `pnpm run i18n`.
+- Run `pnpm run lint`.
+- Run `git diff --check`.
+- Run `pnpm run plugin:cua:build:mac:arm64`.
+- Run `pnpm run plugin:validate -- --name cua --platform darwin --arch arm64`.
+
+## Risk
+
+The vendored driver is a local fork with DeepChat-specific TCC and packaging
+behavior. A direct replacement with upstream source would risk regressing the
+helper identity, permission flow, and plugin-managed update path, so the sync is
+kept as an explicit fork merge.

--- a/docs/issues/cua-driver-v0-2-0-sync/spec.md
+++ b/docs/issues/cua-driver-v0-2-0-sync/spec.md
@@ -1,0 +1,41 @@
+# CUA Driver v0.2.0 Sync
+
+## Problem
+
+The bundled DeepChat Computer Use helper is based on upstream
+`cua-driver-v0.1.5`. Upstream Swift CUA driver `cua-driver-v0.2.0` contains
+macOS reliability fixes for focus suppression, screenshot capture fallback,
+hidden app handling, side-effect detection, and MCP daemon proxying.
+
+## User Story
+
+As a DeepChat user using the bundled CUA plugin, I need the macOS helper to
+include current upstream Swift driver fixes while continuing to use DeepChat's
+helper app, TCC permissions, MCP registration, and plugin packaging.
+
+## Acceptance Criteria
+
+- Vendored upstream metadata records `cua-driver-v0.2.0` and commit
+  `d3f3b9325f49aa5302c15fb03f6b66bd1e688e27`.
+- The local fork includes the upstream Swift driver runtime improvements from
+  `v0.1.5` through `v0.2.0`.
+- DeepChat-specific behavior remains intact: `DeepChat Computer Use.app`,
+  bundle id `com.wefonk.deepchat.computeruse`, `deepchat-permission-probe`,
+  DeepChat-managed updates, and MCP-first plugin skills.
+- The Rust `cua-driver-rs` runtime is not introduced in this sync.
+- Validation covers Swift build, formatting, i18n, lint, diff checks, CUA
+  runtime build, and plugin validation where practical.
+
+## Non-goals
+
+- No migration to `cua-driver-rs`.
+- No changes to the CUA plugin manifest, settings UI, MCP server id, or tool
+  policy.
+- No adoption of upstream standalone installer behavior for DeepChat updates.
+
+## Constraints
+
+- Preserve DeepChat's local helper app identity for TCC attribution.
+- Keep packaged `plugins/cua/skills/cua-driver` guidance MCP-first.
+- Treat upstream standalone scripts as reference material unless required by
+  the bundled helper build.

--- a/docs/issues/cua-driver-v0-2-0-sync/tasks.md
+++ b/docs/issues/cua-driver-v0-2-0-sync/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+- [x] Identify latest upstream Swift CUA driver release.
+- [x] Confirm Rust `cua-driver-rs` remains out of scope.
+- [x] Compare `cua-driver-v0.1.5` to `cua-driver-v0.2.0`.
+- [x] Merge upstream Swift runtime changes into the DeepChat fork.
+- [x] Preserve DeepChat helper app identity, permission probe, update policy,
+      and MCP-first behavior.
+- [x] Update vendored upstream metadata.
+- [x] Run Swift build validation.
+- [x] Run formatting, i18n, lint, and diff checks.
+- [x] Build the CUA plugin runtime.
+- [x] Validate the CUA plugin package.

--- a/plugins/cua/vendor/cua-driver/source/.bumpversion.cfg
+++ b/plugins/cua/vendor/cua-driver/source/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.5
+current_version = 0.2.0
 commit = True
 tag = True
 tag_name = cua-driver-v{new_version}

--- a/plugins/cua/vendor/cua-driver/source/Package.swift
+++ b/plugins/cua/vendor/cua-driver/source/Package.swift
@@ -39,5 +39,9 @@ let package = Package(
             name: "ZoomMathTests",
             dependencies: ["CuaDriverCore"]
         ),
+        .testTarget(
+            name: "FocusStealPreventerTests",
+            dependencies: ["CuaDriverCore"]
+        ),
     ]
 )

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCLI/BundleHelpers.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCLI/BundleHelpers.swift
@@ -1,0 +1,35 @@
+import Darwin
+import Foundation
+
+/// Shared "is this binary running from inside an installed DeepChat Computer Use.app
+/// bundle?" heuristic used by both `ServeCommand` (for the
+/// auto-relaunch-via-`open` path) and `MCPCommand` (for the daemon proxy
+/// path). Resolves `Bundle.main.executablePath` (falling back to
+/// `CommandLine.arguments.first`) through any symlinks via `realpath` and
+/// checks whether the resolved path lives inside some
+/// `DeepChat Computer Use.app/Contents/MacOS/` directory.
+///
+/// That's the "installed via install-local.sh / install.sh" shape —
+/// `/usr/local/bin/cua-driver` is a symlink into
+/// `/Applications/DeepChat Computer Use.app`, and `realpath` walks into the
+/// bundle. Returns `false` for `swift run` /
+/// raw `.build/<config>/cua-driver` dev invocations, which have no installed
+/// bundle to relaunch into.
+///
+/// Subcommands may wrap this with additional gating (env vars, flags,
+/// parent-pid checks, etc.) when their relaunch heuristics diverge.
+func isExecutableInsideCuaDriverApp() -> Bool {
+    // Prefer Foundation's executablePath (stable, absolute).
+    // Fall back to argv[0] when unset, which realpath() still
+    // resolves via $PATH lookup at the shell level — good enough
+    // for the cases we care about.
+    let candidate = Bundle.main.executablePath
+        ?? CommandLine.arguments.first
+        ?? ""
+    guard !candidate.isEmpty else { return false }
+
+    var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+    guard realpath(candidate, &buffer) != nil else { return false }
+    let resolved = String(cString: buffer)
+    return resolved.contains("/DeepChat Computer Use.app/Contents/MacOS/")
+}

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCLI/CuaDriverCommand.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCLI/CuaDriverCommand.swift
@@ -25,6 +25,7 @@ struct CuaDriverCommand: AsyncParsableCommand {
             UpdateCommand.self,
             DiagnoseCommand.self,
             DoctorCommand.self,
+            CleanupCommand.self,
             DumpDocsCommand.self,
         ]
     )
@@ -249,6 +250,7 @@ struct CuaDriverEntryPoint {
         "update",
         "diagnose",
         "doctor",
+        "cleanup",
         "dump-docs",
         "help",
     ]
@@ -373,7 +375,23 @@ struct CuaDriverEntryPoint {
 struct MCPCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "mcp",
-        abstract: "Run the stdio MCP server."
+        abstract: "Run the stdio MCP server.",
+        discussion: """
+            When invoked from a shell or IDE terminal (Claude Code, Cursor, \
+            VS Code, Warp), macOS TCC attributes the process to the parent \
+            terminal — not to DeepChat Computer Use.app — so AX probes silently fail \
+            against the wrong bundle id. To sidestep this without breaking \
+            the stdio MCP transport, `mcp` detects the context, ensures a \
+            `cua-driver serve` daemon is running under LaunchServices \
+            (relaunching via `open -n -g -a "DeepChat Computer Use" --args serve` if not), \
+            and proxies every MCP tool call through the daemon's Unix \
+            socket. Tool semantics are identical to the in-process path. \
+            Pass `--no-daemon-relaunch` (or set CUA_DRIVER_MCP_NO_RELAUNCH=1) \
+            to force in-process execution — useful when the calling context \
+            already has the right TCC grants (e.g. spawned from \
+            DeepChat Computer Use.app directly), or for diagnosing \
+            in-process failures.
+            """
     )
 
     @Flag(
@@ -387,7 +405,38 @@ struct MCPCommand: ParsableCommand {
     )
     var claudeCodeComputerUseCompat: Bool = false
 
+    @Flag(
+        name: .long,
+        help: """
+            Stay in the current process instead of auto-launching a daemon \
+            and proxying through its Unix socket when invoked from a shell \
+            without DeepChat Computer Use.app's TCC grants. Also toggleable via \
+            CUA_DRIVER_MCP_NO_RELAUNCH=1.
+            """
+    )
+    var noDaemonRelaunch: Bool = false
+
+    @Option(
+        name: .long,
+        help: "Override the daemon Unix socket path used by the proxy fallback."
+    )
+    var socket: String?
+
     func run() throws {
+        // TCC sidestep. Same heuristic the `serve` subcommand uses
+        // (shell-spawned bare binary that resolves into DeepChat Computer Use.app
+        // bundle), gated by an explicit env / flag opt-out. When the
+        // shell already has the right TCC context (e.g. DeepChat Computer Use.app
+        // launched us directly), this returns false and we stay
+        // in-process exactly like before. The proxy path is purely
+        // additive: it gives stdio MCP clients spawned from IDE
+        // terminals a correct TCC context without requiring an external
+        // bridge.
+        if shouldUseDaemonProxy() {
+            try runViaDaemonProxy()
+            return
+        }
+
         // MCP stdio runs for the lifetime of the host process, so we
         // bootstrap AppKit here — the agent cursor overlay (disabled
         // by default, enabled via `set_agent_cursor_enabled`) needs a
@@ -418,6 +467,135 @@ struct MCPCommand: ParsableCommand {
             try await server.start(transport: transport)
             await server.waitUntilCompleted()
         }
+    }
+}
+
+extension MCPCommand {
+    /// Decide whether the current `mcp` invocation should auto-launch a
+    /// daemon and proxy every MCP tool call through its Unix socket.
+    /// Mirror of `ServeCommand.shouldRelaunchViaOpen()` — same heuristic,
+    /// same env override convention, separate flag so callers can opt
+    /// each surface in/out independently.
+    fileprivate func shouldUseDaemonProxy() -> Bool {
+        if noDaemonRelaunch { return false }
+        if isEnvTruthy(ProcessInfo.processInfo.environment["CUA_DRIVER_MCP_NO_RELAUNCH"]) {
+            return false
+        }
+        // When AppKit already attributes us to DeepChat Computer Use.app — either
+        // because LaunchServices spawned us, or the user invoked the
+        // bundle's main executable directly — `Bundle.main.bundlePath`
+        // ends in `.app`. Either case has the right TCC context.
+        if Bundle.main.bundlePath.hasSuffix(".app") { return false }
+        // The bare-binary path must resolve into an installed
+        // DeepChat Computer Use.app bundle, otherwise there's nothing for the
+        // daemon side to land in. Raw `swift run` dev invocations fail
+        // this check and stay in-process.
+        guard isExecutableInsideCuaDriverApp() else { return false }
+        // ppid == 1 means launchd already reparented us — we're
+        // post-LaunchServices and have the right TCC context.
+        if getppid() == 1 { return false }
+        return true
+    }
+
+    /// Ensure a `cua-driver serve` daemon is running under the right TCC
+    /// context, then run the MCP stdio server with `ListTools` /
+    /// `CallTool` handlers that forward every request through
+    /// `~/Library/Caches/cua-driver/cua-driver.sock`. Falls back to
+    /// in-process on launch failure with a diagnostic and a pointer at
+    /// the `--no-daemon-relaunch` escape hatch.
+    fileprivate func runViaDaemonProxy() throws {
+        let socketPath = socket ?? DaemonPaths.defaultSocketPath()
+
+        if !DaemonClient.isDaemonListening(socketPath: socketPath) {
+            FileHandle.standardError.write(
+                Data(
+                    "cua-driver: mcp launched without DeepChat Computer Use.app's TCC grants; auto-launching the daemon via `open -n -g -a \"DeepChat Computer Use\" --args serve` and proxying MCP requests through it. Pass --no-daemon-relaunch to stay in-process.\n"
+                        .utf8))
+            try launchDaemonViaOpen()
+            try waitForDaemon(socketPath: socketPath, timeout: 10.0)
+        }
+
+        let serverName = claudeCodeComputerUseCompat ? "computer-use" : "cua-driver"
+        let compat = claudeCodeComputerUseCompat
+
+        // The MCP `Server` actor + `StdioTransport` use Swift
+        // concurrency, so we need a live async runtime. Reuse
+        // `AppKitBootstrap` for that — it's the same sync→async bridge
+        // the in-process path already takes, and the idle AppKit
+        // run-loop costs us nothing here (no AX work runs in this
+        // process). Critically we skip PermissionsGate entirely: the
+        // daemon owns TCC, and AX probes against this process would
+        // lie because we're attributed to the calling shell.
+        AppKitBootstrap.runBlockingAppKitWith {
+            let server = try await CuaDriverMCPServer.makeProxy(
+                serverName: serverName,
+                socketPath: socketPath,
+                claudeCodeComputerUseCompat: compat
+            )
+            let transport = StdioTransport()
+            try await server.start(transport: transport)
+            await server.waitUntilCompleted()
+        }
+    }
+
+    /// Spawn `/usr/bin/open -n -g -a "DeepChat Computer Use" --args serve`. Mirror of
+    /// `ServeCommand.relaunchViaOpen` minus the post-launch probe (we
+    /// poll separately via `waitForDaemon`, since the timeout there is
+    /// MCP-specific).
+    fileprivate func launchDaemonViaOpen() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        // -n: force a new instance. DeepChat Computer Use.app may already be
+        //     running from a previous `mcp` (different MCP client
+        //     session); without -n, `open -a` would re-use it and
+        //     drop our `--args serve`, leaving no daemon up.
+        // -g: keep the new instance backgrounded. DeepChat Computer Use.app is
+        //     LSUIElement=true anyway, but this makes that explicit.
+        process.arguments = ["-n", "-g", "-a", "DeepChat Computer Use", "--args", "serve"]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            FileHandle.standardError.write(
+                Data(
+                    "cua-driver: failed to exec `/usr/bin/open`: \(error). Pass --no-daemon-relaunch to bypass.\n"
+                        .utf8))
+            throw ExitCode(1)
+        }
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            FileHandle.standardError.write(
+                Data(
+                    "cua-driver: `open -n -g -a \"DeepChat Computer Use\" --args serve` exited \(process.terminationStatus). Check that `/Applications/DeepChat Computer Use.app` is installed, or pass --no-daemon-relaunch to bypass.\n"
+                        .utf8))
+            throw ExitCode(1)
+        }
+    }
+
+    /// Block (up to `timeout` seconds) until `socketPath` accepts a
+    /// protocol-speaking probe. Throws `ExitCode(1)` with a diagnostic
+    /// if the daemon never appears — usually means the user hasn't
+    /// granted Accessibility / Screen Recording to DeepChat Computer Use.app yet
+    /// and the daemon's PermissionsGate is waiting on a dialog.
+    fileprivate func waitForDaemon(socketPath: String, timeout: TimeInterval) throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if DaemonClient.isDaemonListening(socketPath: socketPath) {
+                return
+            }
+            usleep(100_000)  // 100ms
+        }
+        FileHandle.standardError.write(
+            Data(
+                "cua-driver: daemon did not appear on \(socketPath) within \(Int(timeout))s. If this is the first launch, grant Accessibility + Screen Recording to DeepChat Computer Use.app in System Settings and retry. Pass --no-daemon-relaunch to stay in-process.\n"
+                    .utf8))
+        throw ExitCode(1)
+    }
+
+    private func isEnvTruthy(_ value: String?) -> Bool {
+        guard let value = value?.lowercased() else { return false }
+        return ["1", "true", "yes", "on"].contains(value)
     }
 }
 
@@ -502,7 +680,7 @@ struct UpdateCommand: AsyncParsableCommand {
     }
 }
 
-/// `cua-driver doctor` — clean up stale install bits left from older versions.
+/// `cua-driver cleanup` — clean up stale install bits left from older versions.
 ///
 /// v0.0.5 and earlier installed a weekly LaunchAgent at
 /// `~/Library/LaunchAgents/com.trycua.cua_driver_updater.plist` and a companion
@@ -514,9 +692,9 @@ struct UpdateCommand: AsyncParsableCommand {
 /// update script. The plist lives under `$HOME` (no sudo). The companion
 /// script under `/usr/local/bin` is root-owned, so we print the exact
 /// `sudo rm` command for the user to run if it still exists.
-struct DoctorCommand: ParsableCommand {
+struct CleanupCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
-        commandName: "doctor",
+        commandName: "cleanup",
         abstract: "Clean up stale install bits left from older cua-driver versions."
     )
 

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCLI/Docs/CLIDocExtractor.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCLI/Docs/CLIDocExtractor.swift
@@ -81,6 +81,7 @@ enum CLIDocExtractor {
             updateDoc,
             diagnoseDoc,
             doctorDoc,
+            cleanupDoc,
             dumpDocsDoc,
         ]
     }
@@ -91,11 +92,28 @@ enum CLIDocExtractor {
         CommandDoc(
             name: "mcp",
             abstract: "Run the stdio MCP server.",
-            discussion: nil,
+            discussion: """
+                When invoked from a shell or IDE terminal (Claude Code, Cursor,
+                VS Code, Warp), macOS TCC attributes the process to the parent
+                terminal — not to DeepChat Computer Use.app — so AX probes silently fail
+                against the wrong bundle id. To sidestep this without breaking
+                the stdio MCP transport, `mcp` detects the context, ensures a
+                `cua-driver serve` daemon is running under LaunchServices
+                (relaunching via `open -n -g -a "DeepChat Computer Use" --args serve` if not),
+                and proxies every MCP tool call through the daemon's Unix
+                socket. Tool semantics are identical to the in-process path.
+                Pass `--no-daemon-relaunch` (or set CUA_DRIVER_MCP_NO_RELAUNCH=1)
+                to force in-process execution — useful when the calling context
+                already has the right TCC grants (e.g. spawned from DeepChat Computer Use.app
+                directly), or for diagnosing in-process failures.
+                """,
             arguments: [],
-            options: [],
+            options: [
+                OptionDoc(name: "socket", shortName: nil, help: "Override the daemon Unix socket path used by the proxy fallback.", type: "String", defaultValue: nil, isOptional: true),
+            ],
             flags: [
                 FlagDoc(name: "claude-code-computer-use-compat", shortName: nil, help: "Expose normal CuaDriver tools, replacing only `screenshot` with a Claude Code-friendly window-only screenshot that establishes the vision coordinate frame.", defaultValue: false),
+                FlagDoc(name: "no-daemon-relaunch", shortName: nil, help: "Stay in the current process instead of auto-launching a daemon and proxying through its Unix socket when invoked from a shell without DeepChat Computer Use.app's TCC grants. Also toggleable via CUA_DRIVER_MCP_NO_RELAUNCH=1.", defaultValue: false),
             ],
             subcommands: []
         )
@@ -191,7 +209,7 @@ enum CLIDocExtractor {
                 OptionDoc(name: "socket", shortName: nil, help: "Override the Unix socket path.", type: "String", defaultValue: nil, isOptional: true),
             ],
             flags: [
-                FlagDoc(name: "no-relaunch", shortName: nil, help: "Stay in the current process instead of re-execing via `open -n -g -a CuaDriver`.", defaultValue: false),
+                FlagDoc(name: "no-relaunch", shortName: nil, help: "Stay in the current process instead of re-execing via `open -n -g -a \"DeepChat Computer Use\"`.", defaultValue: false),
             ],
             subcommands: []
         )
@@ -456,6 +474,22 @@ enum CLIDocExtractor {
     private static var doctorDoc: CommandDoc {
         CommandDoc(
             name: "doctor",
+            abstract: "Check Accessibility, Screen Recording, and SCK; recommend a capture mode.",
+            discussion: nil,
+            arguments: [],
+            options: [],
+            flags: [
+                FlagDoc(name: "json", shortName: nil, help: "Emit machine-readable JSON instead of human text.", defaultValue: false),
+            ],
+            subcommands: []
+        )
+    }
+
+    // MARK: - cleanup
+
+    private static var cleanupDoc: CommandDoc {
+        CommandDoc(
+            name: "cleanup",
             abstract: "Clean up stale install bits left from older cua-driver versions.",
             discussion: nil,
             arguments: [],

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCLI/DoctorCommand.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCLI/DoctorCommand.swift
@@ -1,0 +1,262 @@
+import AppKit
+import ArgumentParser
+import CuaDriverCore
+import Foundation
+import ScreenCaptureKit
+
+/// `cua-driver doctor` — probe TCC / SCK / AX and print a recommendation.
+///
+/// Unlike `diagnose` (which emits a raw paste-able block for support),
+/// `doctor` interprets the probe results and recommends a concrete next
+/// step. Use it to quickly discover why captures are failing and which
+/// `capture_mode` to set.
+struct DoctorCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "doctor",
+        abstract: "Check Accessibility, Screen Recording, and SCK; recommend a capture mode."
+    )
+
+    @Flag(name: .long, help: "Emit machine-readable JSON instead of human text.")
+    var json: Bool = false
+
+    func run() async throws {
+        let result = await runProbes()
+
+        if json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            if let data = try? encoder.encode(result),
+               let str = String(data: data, encoding: .utf8)
+            {
+                print(str)
+            }
+        } else {
+            print(result.formatted())
+        }
+
+        if !result.allOk {
+            throw ExitCode(1)
+        }
+    }
+
+    // MARK: - Probe runner
+
+    private func runProbes() async -> DoctorResult {
+        // 1. TCC / permission probes.
+        let axOk = AXIsProcessTrusted()
+        let sckOk = await probeSCK()
+
+        // 2. Attribution check — are we attributed to DeepChat Computer Use.app or a shell?
+        let bundleID = Bundle.main.bundleIdentifier ?? ""
+        let isCorrectBundle = bundleID == "com.wefonk.deepchat.computeruse"
+
+        // 3. AX tree smoke test on Finder.
+        let finderPid = finderPID()
+        let axTreeOk: Bool
+        if axOk, let pid = finderPid {
+            axTreeOk = probeAXTree(pid: pid)
+        } else {
+            axTreeOk = false
+        }
+
+        // 4. Environment info.
+        let arch = uname_m()
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersionString
+        let locale = Locale.current.identifier
+
+        // 5. Derive recommendation.
+        let recommendation = recommend(
+            axOk: axOk, sckOk: sckOk, isCorrectBundle: isCorrectBundle)
+
+        return DoctorResult(
+            axGranted: axOk,
+            screenRecordingGranted: sckOk,
+            correctBundleAttribution: isCorrectBundle,
+            axTreeSmoke: axTreeOk,
+            arch: arch,
+            osVersion: osVersion,
+            locale: locale,
+            bundleID: bundleID.isEmpty ? nil : bundleID,
+            recommendation: recommendation
+        )
+    }
+
+    // MARK: - Individual probes
+
+    /// Check SCK by enumerating shareable content. Cheap — no stream is
+    /// started. Returns false if SCK is denied or throws (Tahoe regression).
+    private func probeSCK() async -> Bool {
+        do {
+            _ = try await SCShareableContent.excludingDesktopWindows(
+                false, onScreenWindowsOnly: false)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Fetch the top-level AX children of `pid`. Returns true if we get
+    /// at least one element without an error — sufficient to confirm AX
+    /// round-trips are working.
+    private func probeAXTree(pid: pid_t) -> Bool {
+        let app = AXUIElementCreateApplication(pid)
+        var value: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(
+            app, kAXChildrenAttribute as CFString, &value)
+        return err == .success
+    }
+
+    /// PID of the running Finder process, or nil.
+    private func finderPID() -> pid_t? {
+        NSWorkspace.shared.runningApplications
+            .first { $0.bundleIdentifier == "com.apple.finder" }
+            .map { $0.processIdentifier }
+    }
+
+    private func uname_m() -> String {
+        var info = utsname()
+        uname(&info)
+        return withUnsafeBytes(of: &info.machine) { bytes in
+            let str = bytes.bindMemory(to: CChar.self)
+            return String(cString: str.baseAddress!)
+        }
+    }
+
+    // MARK: - Recommendation logic
+
+    private func recommend(
+        axOk: Bool, sckOk: Bool, isCorrectBundle: Bool
+    ) -> Recommendation {
+        if !axOk {
+            return Recommendation(
+                captureMode: nil,
+                severity: .error,
+                summary: "Accessibility is denied.",
+                detail: """
+                    Grant Accessibility to DeepChat Computer Use.app in System Settings → Privacy & Security → Accessibility, then restart the daemon:
+                      open -n -g -a "DeepChat Computer Use" --args serve
+                    DeepChat's bundled `cua-driver mcp` auto-relaunches through DeepChat Computer Use.app when needed.
+                    """
+            )
+        }
+
+        if !isCorrectBundle {
+            return Recommendation(
+                captureMode: nil,
+                severity: .warning,
+                summary: "TCC is attributed to the wrong process (not DeepChat Computer Use.app).",
+                detail: """
+                    Your shell or IDE is the responsible process for TCC, not DeepChat Computer Use.app.
+                    DeepChat's bundled `cua-driver mcp` auto-relaunches through DeepChat Computer Use.app.
+                    Or start the daemon manually: open -n -g -a "DeepChat Computer Use" --args serve
+                    """
+            )
+        }
+
+        if sckOk {
+            return Recommendation(
+                captureMode: "som",
+                severity: .ok,
+                summary: "All probes passed. Default `capture_mode: som` (or `vision`) recommended.",
+                detail: nil
+            )
+        } else {
+            return Recommendation(
+                captureMode: "ax",
+                severity: .warning,
+                summary: "ScreenCaptureKit is unavailable on this build.",
+                detail: """
+                    This is a known regression on some macOS builds (see #1467).
+                    Workaround: set capture_mode to `ax`:
+                      cua-driver config set capture_mode ax
+                    AX mode skips screen capture entirely and relies solely on the Accessibility tree.
+                    """
+            )
+        }
+    }
+}
+
+// MARK: - Result types
+
+struct DoctorResult: Encodable {
+    let axGranted: Bool
+    let screenRecordingGranted: Bool
+    let correctBundleAttribution: Bool
+    let axTreeSmoke: Bool
+    let arch: String
+    let osVersion: String
+    let locale: String
+    let bundleID: String?
+    let recommendation: Recommendation
+
+    var allOk: Bool { recommendation.severity == .ok }
+
+    func formatted() -> String {
+        let tick = "✅"
+        let warn = "⚠️ "
+        let fail = "❌"
+
+        func icon(_ ok: Bool) -> String { ok ? tick : fail }
+
+        var lines: [String] = ["── cua-driver doctor ──────────────────────"]
+        lines.append("")
+        lines.append("System")
+        lines.append("  arch:       \(arch)")
+        lines.append("  os:         \(osVersion)")
+        lines.append("  locale:     \(locale)")
+        if let bid = bundleID {
+            lines.append("  bundle:     \(bid)")
+        }
+        lines.append("")
+        lines.append("Probes")
+        lines.append("  \(icon(axGranted)) Accessibility (AXIsProcessTrusted)")
+        lines.append("  \(icon(screenRecordingGranted)) Screen Recording (SCShareableContent)")
+        lines.append("  \(icon(correctBundleAttribution)) Correct bundle attribution")
+        lines.append("  \(icon(axTreeSmoke)) AX tree smoke test (Finder)")
+        lines.append("")
+        lines.append("Recommendation")
+        let sevIcon: String
+        switch recommendation.severity {
+        case .ok:      sevIcon = tick
+        case .warning: sevIcon = warn
+        case .error:   sevIcon = fail
+        }
+        lines.append("  \(sevIcon) \(recommendation.summary)")
+        if let mode = recommendation.captureMode {
+            lines.append("  capture_mode: \(mode)")
+        }
+        if let detail = recommendation.detail {
+            lines.append("")
+            for line in detail.split(separator: "\n", omittingEmptySubsequences: false) {
+                lines.append("  \(line)")
+            }
+        }
+        lines.append("")
+        lines.append("────────────────────────────────────────────")
+        return lines.joined(separator: "\n")
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case axGranted = "ax_granted"
+        case screenRecordingGranted = "screen_recording_granted"
+        case correctBundleAttribution = "correct_bundle_attribution"
+        case axTreeSmoke = "ax_tree_smoke"
+        case arch, osVersion = "os_version", locale
+        case bundleID = "bundle_id"
+        case recommendation
+    }
+}
+
+struct Recommendation: Encodable {
+    enum Severity: String, Encodable, Equatable { case ok, warning, error }
+
+    let captureMode: String?
+    let severity: Severity
+    let summary: String
+    let detail: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case captureMode = "capture_mode"
+        case severity, summary, detail
+    }
+}

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCLI/ServeCommand.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCLI/ServeCommand.swift
@@ -194,7 +194,7 @@ extension ServeCommand {
         // bundle on disk — the symlink case. Raw `swift run` dev
         // invocations resolve into `.build/<config>/cua-driver`
         // instead, and have no bundle to relaunch into.
-        guard resolvedExecutableIsInsideCuaDriverApp() else { return false }
+        guard isExecutableInsideCuaDriverApp() else { return false }
         // ppid == 1 means we're already a LaunchServices-spawned process
         // (or orphaned into init, in which case relaunching wouldn't
         // change anything useful anyway).
@@ -288,31 +288,6 @@ extension ServeCommand {
                 "cua-driver: relaunched DeepChat Computer Use.app but no daemon appeared on \(socketPath) within 5s. Check Accessibility + Screen Recording grants for DeepChat Computer Use.app, or re-run with --no-relaunch to see in-process errors.\n"
                     .utf8))
         throw ExitCode(1)
-    }
-
-    /// True when the argv[0] / executablePath resolves (through any
-    /// symlinks) to a binary physically living inside some
-    /// `DeepChat Computer Use.app/Contents/MacOS/` directory. That's the "installed
-    /// via install-local.sh / install.sh" shape — `/usr/local/bin/cua-driver`
-    /// is a symlink into `/Applications/DeepChat Computer Use.app`, and `realpath`
-    /// walks into the bundle.
-    ///
-    /// Returns false for `swift run` / raw `.build/<config>/cua-driver`
-    /// dev invocations, which have no installed bundle to relaunch into.
-    private func resolvedExecutableIsInsideCuaDriverApp() -> Bool {
-        // Prefer Foundation's executablePath (stable, absolute).
-        // Fall back to argv[0] when unset, which realpath() still
-        // resolves via $PATH lookup at the shell level — good enough
-        // for the cases we care about.
-        let candidate = Bundle.main.executablePath
-            ?? CommandLine.arguments.first
-            ?? ""
-        guard !candidate.isEmpty else { return false }
-
-        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
-        guard realpath(candidate, &buffer) != nil else { return false }
-        let resolved = String(cString: buffer)
-        return resolved.contains("/DeepChat Computer Use.app/Contents/MacOS/")
     }
 
     /// Accepts the same truthy-value conventions the rest of the CLI

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/Apps/AppLauncher.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/Apps/AppLauncher.swift
@@ -228,6 +228,8 @@ public enum AppLauncher {
             throw LaunchError.notFound("bundle_id '\(bundleId)'")
         }
         if let name, !name.isEmpty {
+            // Pass 1 — filesystem lookup by bundle filename (fastest; locale-independent
+            // for English app names whose on-disk bundle name matches the display name).
             let appName = name.hasSuffix(".app") ? name : "\(name).app"
             // System roots first — they're canonical. User-local paths come
             // after so an app present in /Applications wins over a same-name
@@ -250,6 +252,62 @@ public enum AppLauncher {
                     return URL(fileURLWithPath: path)
                 }
             }
+
+            // Pass 2 — LaunchServices bundle-ID lookup, in case the caller
+            // passed a bundle identifier string as `name` rather than using
+            // the `bundle_id` parameter (e.g. "com.apple.calculator").
+            if let url = NSWorkspace.shared.urlForApplication(
+                withBundleIdentifier: name)
+            {
+                return url
+            }
+
+            // Pass 3 — scan all candidate directories and match against each
+            // bundle's metadata, in priority order:
+            //   a) localizedName from NSRunningApplication (locale-aware; works
+            //      on non-English systems, e.g. "計算機" on JP macOS)
+            //   b) CFBundleDisplayName / CFBundleName (English; from Info.plist)
+            //   c) bundle URL stem (filename minus .app)
+            //
+            // Matching is case-insensitive throughout so "calculator" and
+            // "Calculator" both resolve.
+            let needle = name.lowercased()
+
+            // Check running apps first — NSRunningApplication.localizedName
+            // gives the OS-locale display name without touching the disk.
+            for app in NSWorkspace.shared.runningApplications {
+                guard let url = app.bundleURL else { continue }
+                if (app.localizedName?.lowercased() == needle) {
+                    return url
+                }
+            }
+
+            // Fall back to scanning installed bundles in the same roots.
+            let fm = FileManager.default
+            for root in roots {
+                guard let children = try? fm.contentsOfDirectory(atPath: root)
+                else { continue }
+                for child in children where child.hasSuffix(".app") {
+                    let path = "\(root)/\(child)"
+                    guard let bundle = Bundle(path: path) else { continue }
+                    // CFBundleDisplayName > CFBundleName > stem
+                    let displayName =
+                        (bundle.infoDictionary?["CFBundleDisplayName"] as? String)
+                        ?? (bundle.infoDictionary?["CFBundleName"] as? String)
+                        ?? URL(fileURLWithPath: path)
+                            .deletingPathExtension().lastPathComponent
+                    if displayName.lowercased() == needle {
+                        return URL(fileURLWithPath: path)
+                    }
+                    // Also match against the raw stem ("Calculator" → "Calculator.app")
+                    let stem = URL(fileURLWithPath: path)
+                        .deletingPathExtension().lastPathComponent
+                    if stem.lowercased() == needle {
+                        return URL(fileURLWithPath: path)
+                    }
+                }
+            }
+
             throw LaunchError.notFound("name '\(name)'")
         }
         throw LaunchError.nothingSpecified

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/Capture/WindowCapture.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/Capture/WindowCapture.swift
@@ -33,6 +33,13 @@ public enum CaptureError: Error, Sendable, CustomStringConvertible {
     case encodeFailed
     case captureFailed(String)
     case windowNotFound(UInt32)
+    /// ScreenCaptureKit could not start streaming for this window. Distinct
+    /// from `captureFailed` so callers (e.g. `get_window_state`) can surface
+    /// an actionable hint — switch to `capture_mode: ax`, retry against a
+    /// different window — without having to grep error strings. Seen
+    /// regularly on macOS 26.4.x physical Macs against specific windows
+    /// where even `screencapture -l<id>` fails (rdar / openclaw/Peekaboo#121).
+    case streamingFailed(String)
 
     public var description: String {
         switch self {
@@ -41,6 +48,7 @@ public enum CaptureError: Error, Sendable, CustomStringConvertible {
         case .encodeFailed: return "failed to encode CGImage"
         case .captureFailed(let msg): return "capture failed: \(msg)"
         case .windowNotFound(let id): return "no shareable window with id \(id)"
+        case .streamingFailed(let msg): return "ScreenCaptureKit streaming failed: \(msg)"
         }
     }
 }
@@ -131,12 +139,43 @@ public actor WindowCapture {
         config.height = max(1, Int(window.frame.height * scale))
         config.showsCursor = false
 
+        // One-shot SCK call with a single retry on streaming-start failure.
+        // macOS 26.4.x has a regression where `SCScreenshotManager.captureImage`
+        // intermittently returns "Could not start streaming because audio/video
+        // capture failed" (SCStreamError code -3801) on physical Macs, often
+        // recovering on a second attempt a moment later. We retry once with a
+        // brief back-off; if it still fails, we surface `.streamingFailed` so
+        // the tool layer can hint the caller toward `capture_mode: ax` for
+        // `get_window_state` workflows.
         let cgImage: CGImage
         do {
-            cgImage = try await SCScreenshotManager.captureImage(
-                contentFilter: filter,
-                configuration: config
-            )
+            cgImage = try await captureSCKWithRetry(filter: filter, config: config)
+        } catch let error as CaptureError {
+            // Already classified — re-throw without wrapping. CGWindowList
+            // is intentionally NOT tried for permission errors (it'd just
+            // fail the same way and confuse the user-facing message).
+            if case .permissionDenied = error { throw error }
+            // For streaming / generic SCK failures, try the legacy
+            // CGWindowListCreateImage path. It's deprecated on macOS 15+
+            // but still works in many cases where SCK refuses — particularly
+            // useful as a last-ditch fallback for the 26.4 SCK regression.
+            if let fallback = legacyCaptureWindow(windowID: windowID) {
+                let origW = fallback.width
+                let origH = fallback.height
+                let resized = resizeIfNeeded(fallback, maxDim: maxImageDimension)
+                let didResize = resized.width != origW || resized.height != origH
+                let data = try encode(resized, format: format, quality: quality)
+                return Screenshot(
+                    imageData: data,
+                    format: format,
+                    width: resized.width,
+                    height: resized.height,
+                    scaleFactor: Double(scale),
+                    originalWidth: didResize ? origW : nil,
+                    originalHeight: didResize ? origH : nil
+                )
+            }
+            throw error
         } catch {
             throw classify(error)
         }
@@ -207,15 +246,119 @@ public actor WindowCapture {
         return (best ?? NSScreen.main)?.backingScaleFactor ?? 1.0
     }
 
+    /// Attempt `SCScreenshotManager.captureImage` once; on a streaming-start
+    /// failure, wait briefly and retry once more. Returns a classified
+    /// `CaptureError` on persistent failure so the caller can branch on the
+    /// kind (permission vs. streaming vs. generic) without string-matching.
+    ///
+    /// The retry covers the macOS 26.4.x SCK regression where the very first
+    /// call after the SCK daemon has been idle returns -3801 ("Could not
+    /// start streaming because audio/video capture failed") but a second
+    /// call ~250ms later succeeds. A second failure isn't transient and we
+    /// stop retrying — the caller falls back to CGWindowList or surfaces
+    /// the error.
+    private func captureSCKWithRetry(
+        filter: SCContentFilter,
+        config: SCStreamConfiguration
+    ) async throws -> CGImage {
+        do {
+            return try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: config
+            )
+        } catch {
+            let classified = classify(error)
+            // Only retry on streaming-start failures; permission errors and
+            // not-found errors won't change on a second attempt.
+            guard case .streamingFailed = classified else { throw classified }
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            do {
+                return try await SCScreenshotManager.captureImage(
+                    contentFilter: filter,
+                    configuration: config
+                )
+            } catch {
+                throw classify(error)
+            }
+        }
+    }
+
+    /// Legacy `CGWindowListCreateImage` fallback for the SCK 26.4 regression.
+    /// Deprecated by Apple in macOS 15 but still functional on most windows,
+    /// and frequently works where SCK refuses. Returns nil on failure — the
+    /// caller surfaces the original SCK error in that case so the user knows
+    /// the real cause.
+    ///
+    /// Marked with `@available(*, deprecated)` suppression because the API
+    /// is the entire point: we *want* the legacy path here.
+    private func legacyCaptureWindow(windowID: UInt32) -> CGImage? {
+        // CGWindowListCreateImage is deprecated on macOS 15+. The deprecation
+        // diagnostic is silenced with the @available pragma. Apple has not
+        // (yet) removed the symbol, and this path is the only practical
+        // fallback when SCK's streaming-start is broken for a given window.
+        let opts: CGWindowImageOption = [.boundsIgnoreFraming, .bestResolution]
+        let listOption: CGWindowListOption = .optionIncludingWindow
+        // Wrap the deprecated call so we keep the unsafePointer-style
+        // signature out of the rest of the code.
+        let image = legacyCGWindowImage(
+            windowID: windowID, listOption: listOption, imageOption: opts
+        )
+        // Reject 1×1 placeholder images that the legacy API sometimes returns
+        // for occluded / off-screen windows — they're worse than no image.
+        guard let image, image.width > 1, image.height > 1 else { return nil }
+        return image
+    }
+
     private func classify(_ error: Error) -> CaptureError {
         let ns = error as NSError
         let msg = ns.localizedDescription.lowercased()
+
+        // Permission failure — English and Japanese phrasings observed in
+        // SCK's `NSError.localizedDescription`. The Japanese strings cover
+        // users on JP system locale where the SCK error comes back
+        // localized rather than in English.
         if msg.contains("permission") || msg.contains("not authorized")
             || msg.contains("declined") || msg.contains("denied")
+            || ns.localizedDescription.contains("許可")     // "permission"
+            || ns.localizedDescription.contains("拒否")     // "denied"
         {
             return .permissionDenied
         }
+
+        // SCStreamError "could not start streaming" — code -3801 in
+        // `SCStreamErrorDomain`. macOS localizes the message ("Could not
+        // start streaming because audio/video capture failed" / Japanese:
+        // "オーディオ/ビデオの取り込みがうまくいかなかったため、ストリーミングを開始できませんでした"),
+        // so we match on code first and fall through to substring matching
+        // for the rare case where the domain isn't surfaced.
+        let isSCStreamDomain = ns.domain == "SCStreamErrorDomain"
+            || ns.domain == "com.apple.ScreenCaptureKit.SCStreamErrorDomain"
+        if (isSCStreamDomain && ns.code == -3801)
+            || msg.contains("could not start streaming")
+            || msg.contains("streaming")
+            || ns.localizedDescription.contains("ストリーミング")  // "streaming"
+        {
+            return .streamingFailed(ns.localizedDescription)
+        }
+
         return .captureFailed(ns.localizedDescription)
+    }
+
+    /// Thin shim around the deprecated `CGWindowListCreateImage` so the
+    /// deprecation-warning suppression is isolated to one place. Returns nil
+    /// if the legacy path also refuses to produce an image.
+    ///
+    /// Marking the wrapper itself deprecated downgrades the call-site
+    /// warning to a no-op — we *want* this legacy path because SCK has a
+    /// well-known regression on macOS 26.4.x where streaming-start fails
+    /// for specific windows on physical Macs.
+    @available(*, deprecated, message: "Intentional fallback for SCK streaming-start failures.")
+    private func legacyCGWindowImage(
+        windowID: UInt32,
+        listOption: CGWindowListOption,
+        imageOption: CGWindowImageOption
+    ) -> CGImage? {
+        CGWindowListCreateImage(.null, listOption, windowID, imageOption)
     }
 
     /// Capture the topmost layer-0 window owned by `pid`, or `nil` when the

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/CuaDriverCore.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/CuaDriverCore.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public enum CuaDriverCore {
-    public static let version = "0.1.5"
+    public static let version = "0.2.0"
 }

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/Focus/FocusGuard.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/Focus/FocusGuard.swift
@@ -29,6 +29,17 @@ public actor FocusGuard {
     private let enforcer: SyntheticAppFocusEnforcer
     private let systemPreventer: SystemFocusStealPreventer?
 
+    /// Construct a guard with the three focus-suppression layers wired in.
+    ///
+    /// - Parameters:
+    ///   - enablement: AX enablement assertion used to write synthetic
+    ///     focus on the target window/element.
+    ///   - enforcer: synthetic-focus enforcer that flips
+    ///     `kAXEnhancedUserInterface` etc. for the duration of the body.
+    ///   - systemPreventer: optional layer-3 reactive preventer. When
+    ///     supplied, the guard arms a lease around the body so any
+    ///     target self-activation triggered by the AX action is undone
+    ///     before the next compositor frame.
     public init(
         enablement: AXEnablementAssertion,
         enforcer: SyntheticAppFocusEnforcer,
@@ -84,15 +95,23 @@ public actor FocusGuard {
         // activation notification and immediately re-activates the prior
         // frontmost app. Only armed when the target isn't already
         // frontmost (no point suppressing self → self).
-        var suppressionHandle: SuppressionHandle?
+        //
+        // Lease form: ARC fires `deinit` on every exit path including the
+        // catch branch below. The lease replaces a previous bug-prone
+        // pattern of manually pairing begin/end across do/catch — if a
+        // future edit forgets one cleanup branch, the lease still
+        // releases when the local goes out of scope.
+        var suppressionLease: SuppressionLease?
         if let preventer = systemPreventer {
             let targetApp = NSRunningApplication(processIdentifier: pid)
             let isTargetFrontmost = targetApp?.isActive ?? false
             if !isTargetFrontmost,
                let frontmost = NSWorkspace.shared.frontmostApplication
             {
-                suppressionHandle = await preventer.beginSuppression(
-                    targetPid: pid, restoreTo: frontmost
+                suppressionLease = await preventer.leaseSuppression(
+                    targetPid: pid,
+                    restoreTo: frontmost,
+                    origin: "FocusGuard.withFocusSuppressed"
                 )
             }
         }
@@ -100,27 +119,43 @@ public actor FocusGuard {
         do {
             let result = try await body()
             if let focusState { await enforcer.reenableActivation(focusState) }
-            if let handle = suppressionHandle {
-                try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
-                await systemPreventer?.endSuppression(handle)
+            if let lease = suppressionLease {
+                // 50ms gives the target's reflex post-AXPress activation
+                // (Safari WebKit) time to fire before we tear down the
+                // observer that catches it. Explicit release awaits any
+                // pending reactivation tasks scheduled in that window.
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                await lease.release()
             }
             return result
         } catch {
             if let focusState { await enforcer.reenableActivation(focusState) }
-            if let handle = suppressionHandle {
-                await systemPreventer?.endSuppression(handle)
+            if let lease = suppressionLease {
+                await lease.release()
             }
             throw error
         }
+        // If a future edit ever drops one of the explicit `release()`
+        // calls above, ARC fires the lease's `deinit` when this scope
+        // unwinds — the entry still gets released. Belt + suspenders.
     }
 
     // MARK: - Helpers
 
 }
 
+/// Errors thrown by ``FocusGuard/withFocusSuppressed(pid:element:body:)``.
 public enum FocusGuardError: Error, CustomStringConvertible, Sendable {
+    /// The target window is minimized in the Dock; AX actions on it
+    /// would force-deminiaturize it (especially in Chrome). Caller must
+    /// either unminimize first or use a keyboard-input alternative
+    /// (`type_text_chars`, `press_key`) that does not have this side
+    /// effect.
     case windowMinimized(pid: pid_t)
 
+    /// Human-readable description of the error including the recovery
+    /// hint. `Tool.Content.text` propagates this directly to MCP
+    /// clients.
     public var description: String {
         switch self {
         case .windowMinimized(let pid):

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/Focus/SystemFocusStealPreventer.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/Focus/SystemFocusStealPreventer.swift
@@ -1,15 +1,96 @@
 import AppKit
 import Foundation
+import os
 
 /// An opaque handle returned by ``SystemFocusStealPreventer/beginSuppression``.
 /// Pass the same handle to ``SystemFocusStealPreventer/endSuppression`` to
 /// stop suppressing for that particular target; other concurrent suppressions
 /// stay active until their own handles are ended.
+///
+/// **Prefer ``SystemFocusStealPreventer/withSuppression(targetPid:restoreTo:origin:body:)``
+/// over manual `begin`/`end` whenever the suppression's lifetime fits inside
+/// a single async function** — the closure form is leak-proof by construction.
+/// When the lifetime must span function boundaries (e.g. a snapshot taken
+/// before an action and released after side-effect detection), prefer
+/// ``SuppressionLease`` over raw handles — the lease releases the entry in
+/// `deinit`, so ARC catches leaks that scope-bound defers cannot.
 public struct SuppressionHandle: Sendable, Hashable {
     fileprivate let id: UUID
 
     fileprivate init() {
         self.id = UUID()
+    }
+}
+
+/// Reference-typed lease for a focus suppression entry. Releases the entry
+/// in `deinit`, which is ARC's strongest available guarantee that no exit
+/// path — including thrown errors, task cancellation, or future call-site
+/// regressions — can leak the underlying registration.
+///
+/// Construct via ``SystemFocusStealPreventer/leaseSuppression(targetPid:restoreTo:origin:)``.
+/// Call ``release()`` explicitly when you want to await pending reactivation
+/// tasks; otherwise just drop the lease and ARC will fire a fire-and-forget
+/// cleanup. `release()` is idempotent.
+///
+/// This is the recommended API for the snapshot/detect pattern where the
+/// suppression's lifetime must span function boundaries — the lease can be
+/// stored in a struct and the cleanup is guaranteed by the language, not
+/// by call-site discipline.
+public final class SuppressionLease: @unchecked Sendable {
+    private let preventer: SystemFocusStealPreventer
+    private let handle: SuppressionHandle
+    /// `OSAllocatedUnfairLock<Bool>` rather than `NSLock`+`var` because Swift 6
+    /// bans `NSLock.lock()` from async contexts (the kernel-level priority-
+    /// inversion guarantees of `os_unfair_lock` mean the runtime can prove
+    /// the critical section is bounded). This is the platform-idiomatic
+    /// async-safe replacement for "lock + bool flag" patterns. macOS 13+,
+    /// and we target macOS 14, so it's freely available.
+    private let releasedFlag = OSAllocatedUnfairLock(initialState: false)
+
+    /// The handle for the underlying entry. Useful for callers that want to
+    /// pass through the legacy ``SystemFocusStealPreventer/endSuppression(_:)``
+    /// API; new code should prefer ``release()``.
+    public var rawHandle: SuppressionHandle { handle }
+
+    fileprivate init(preventer: SystemFocusStealPreventer, handle: SuppressionHandle) {
+        self.preventer = preventer
+        self.handle = handle
+    }
+
+    /// Release the lease and await any in-flight reactivation tasks.
+    /// Idempotent: calling more than once is a no-op. Concurrent calls are
+    /// race-safe — exactly one will perform the dispatcher remove, the
+    /// rest return early.
+    public func release() async {
+        // Atomic test-and-set. Returns the prior value; we proceed only
+        // when we were the first caller to flip false→true.
+        let alreadyReleased = releasedFlag.withLock { released in
+            let prior = released
+            released = true
+            return prior
+        }
+        if alreadyReleased { return }
+        await preventer.endSuppression(handle)
+    }
+
+    deinit {
+        // ARC safety net: the holder dropped us without calling release().
+        // Same atomic test-and-set as release(), but we can't await from a
+        // deinit so we hand the cleanup to a detached Task. Pending
+        // reactivation tasks scheduled by the observer are orphaned —
+        // they're harmless idempotent `activate(options: [])` calls. The
+        // deadline eviction in the dispatcher (layer 3) catches the same
+        // case in bounded time even if this Task is never scheduled, so
+        // we lose nothing by fire-and-forgetting here.
+        let alreadyReleased = releasedFlag.withLock { released in
+            let prior = released
+            released = true
+            return prior
+        }
+        if alreadyReleased { return }
+        let p = preventer
+        let h = handle
+        Task.detached { await p.endSuppression(h) }
     }
 }
 
@@ -48,10 +129,33 @@ public struct SuppressionHandle: Sendable, Hashable {
 /// `CGSRegisterConnectionNotifyProc` / kCPS notifications, which we
 /// deliberately do not take a dependency on.
 ///
-/// Multiple concurrent suppressions are supported — each `beginSuppression`
-/// call returns a distinct handle and adds an entry to the internal map.
-/// The shared `NSWorkspace` observer is installed on the first suppression
-/// and removed when the last handle is ended.
+/// ## Lifetime safety
+///
+/// The shared dispatcher applies four overlapping guarantees so that no
+/// single bug can resurrect the v0.1.9 focus-trap regression where a
+/// leaked wildcard entry hijacked every app activation in the OS for the
+/// rest of the process's life:
+///
+/// 1. **Closure scope (preferred)** — ``withSuppression(targetPid:restoreTo:origin:body:)``
+///    pairs begin/end with `defer`. No handle escapes the closure.
+/// 2. **ARC scope** — ``leaseSuppression(targetPid:restoreTo:origin:)`` returns
+///    a ``SuppressionLease`` that ends the entry in `deinit`. Catches any
+///    control flow scope-defer cannot — thrown errors between begin and end,
+///    task cancellation, future call-site regressions.
+/// 3. **Wall-clock deadline** — every entry carries a ``maxLifetimeNs``
+///    expiry (default 5 s). The observer evicts expired entries on every
+///    fire; a janitor task evicts during idle. **Worst-case leak duration is
+///    bounded by ``maxLifetimeNs``, independent of every other layer.**
+/// 4. **Observability** — every entry carries an ``origin`` tag and the
+///    dispatcher logs a warning when active count crosses
+///    ``warnActiveThreshold`` or when the deadline reaper fires. Future
+///    leaks surface in `log show --process cua-driver` instead of silently
+///    stealing focus.
+///
+/// Multiple concurrent suppressions are supported — each registration adds
+/// an entry to the internal map. The shared `NSWorkspace` observer is
+/// installed on the first suppression and removed when the last entry is
+/// gone (whether removed manually, by lease deinit, or by deadline).
 public actor SystemFocusStealPreventer {
     /// Delay between observing the target's self-activation and firing
     /// the restoring `activate(options: [])`. Tradeoff:
@@ -74,35 +178,143 @@ public actor SystemFocusStealPreventer {
     /// several frames' worth of runloop turns inside
     /// `applicationDidFinishLaunching` BEFORE our demote reaches
     /// WindowServer — the activation notification itself is async.
-    /// Calculator still gets its window created (orthogonal path via
-    /// the `hides=YES` + `unhide()` dance). Chrome still gets its
-    /// URL handoff processed. Net: zero-delay demote is strictly
-    /// better.
-    private static let suppressionDelayNs: UInt64 = 0
+    /// Calculator-with-no-window has been verified to be a separate
+    /// issue (`activates = false` swallows the initial window event)
+    /// and tuning this delay does not rescue it.
+    public static let suppressionDelayNs: UInt64 = 0
+
+    /// Wall-clock upper bound on a suppression entry's lifetime. The
+    /// dispatcher evicts entries older than this whenever the observer
+    /// fires or the janitor runs. Set well above the longest legitimate
+    /// click + detect window (≈1.3 s) so the safety net never trips
+    /// during normal operation, but tight enough that a runaway leak
+    /// recovers in seconds rather than the entire process lifetime.
+    ///
+    /// This bound is the layer-3 safety net that makes ``SuppressionLease``
+    /// `deinit` and ``withSuppression`` `defer` mistakes recoverable.
+    public static let maxLifetimeNs: UInt64 = 5_000_000_000  // 5 s
+
+    /// How often the janitor task wakes up during idle to evict expired
+    /// entries when no NSWorkspace activation events arrive. Cheap —
+    /// just a lock + dictionary scan. Keeps the worst-case eviction
+    /// latency at `maxLifetimeNs + janitorIntervalNs`.
+    public static let janitorIntervalNs: UInt64 = 1_000_000_000  // 1 s
+
+    /// Active-entry count above which the dispatcher logs a warning to the
+    /// unified log. Legitimate workloads have at most ~2 concurrent
+    /// suppressions (one from `WindowChangeDetector.snapshot()`, one from
+    /// `LaunchAppTool`'s placeholder→pid swap). Anything above 2 is
+    /// suspicious; above this threshold it's almost certainly a leak.
+    public static let warnActiveThreshold: Int = 4
+
+    /// Default origin tag used when a caller doesn't supply one. Surfaces
+    /// in leak warnings as a fallback so we can still grep for the file.
+    fileprivate static let unknownOrigin = "<unknown>"
 
     private let dispatcher: Dispatcher
+    private let janitorIntervalNs: UInt64
+    private var janitorTask: Task<Void, Never>?
 
-    public init() {
-        self.dispatcher = Dispatcher(suppressionDelayNs: Self.suppressionDelayNs)
+    /// Designated initializer. Production callers use the default values
+    /// for `maxLifetimeNs` / `janitorIntervalNs` / `warnActiveThreshold`
+    /// — those are the safety-net knobs and there's no good reason to
+    /// vary them in production. Tests pass tight values to verify the
+    /// layer-3 reaper deterministically.
+    ///
+    /// Actors don't support `convenience` inits (they have a flat init
+    /// model), so we expose one initializer with sensible defaults.
+    public init(
+        suppressionDelayNs: UInt64 = SystemFocusStealPreventer.suppressionDelayNs,
+        maxLifetimeNs: UInt64 = SystemFocusStealPreventer.maxLifetimeNs,
+        janitorIntervalNs: UInt64 = SystemFocusStealPreventer.janitorIntervalNs,
+        warnActiveThreshold: Int = SystemFocusStealPreventer.warnActiveThreshold
+    ) {
+        self.dispatcher = Dispatcher(
+            suppressionDelayNs: suppressionDelayNs,
+            maxLifetimeNs: maxLifetimeNs,
+            warnActiveThreshold: warnActiveThreshold
+        )
+        self.janitorIntervalNs = janitorIntervalNs
     }
 
-    /// Begin suppressing focus-steal events for `targetPid`. Any
-    /// `NSWorkspace.didActivateApplicationNotification` that fires while the
-    /// suppression is active and names `targetPid` as the newly-active app
-    /// schedules a delayed `restoreTo.activate(options: [])` on the main
-    /// actor to steal focus back onto whatever was frontmost before the
-    /// launch.
+    // MARK: - Closure-scoped (preferred)
+
+    /// Run `body` while a suppression entry is active. The entry is
+    /// guaranteed to be released on every exit path — return, throw, task
+    /// cancellation. No handle escapes the closure, so callers cannot
+    /// forget to release.
+    ///
+    /// This is the strongest available API: the language enforces the
+    /// lifetime. Use it whenever the suppression fits inside a single
+    /// async function.
+    @discardableResult
+    public func withSuppression<T: Sendable>(
+        targetPid: pid_t,
+        restoreTo: NSRunningApplication,
+        origin: StaticString = #function,
+        body: @Sendable () async throws -> T
+    ) async rethrows -> T {
+        let handle = dispatcher.add(
+            targetPid: targetPid, restoreTo: restoreTo, origin: "\(origin)"
+        )
+        startJanitorIfNeeded()
+        do {
+            let result = try await body()
+            await endSuppression(handle)
+            return result
+        } catch {
+            await endSuppression(handle)
+            throw error
+        }
+    }
+
+    // MARK: - ARC-scoped
+
+    /// Register a suppression and return a ``SuppressionLease`` that ends
+    /// it in `deinit`. Use this when the lifetime must span function
+    /// boundaries (e.g. snapshot/detect pattern) and a closure scope won't
+    /// work. ARC catches leaks that scope-defers cannot.
+    ///
+    /// The caller can call ``SuppressionLease/release()`` to await pending
+    /// reactivation tasks; if the caller simply drops the lease, ARC fires
+    /// a fire-and-forget cleanup. Either way the entry is released.
+    public func leaseSuppression(
+        targetPid: pid_t,
+        restoreTo: NSRunningApplication,
+        origin: StaticString = #function
+    ) -> SuppressionLease {
+        let handle = dispatcher.add(
+            targetPid: targetPid, restoreTo: restoreTo, origin: "\(origin)"
+        )
+        startJanitorIfNeeded()
+        return SuppressionLease(preventer: self, handle: handle)
+    }
+
+    // MARK: - Manual (deprecated; kept for migration)
+
+    /// Begin suppressing. Manual lifetime — caller is responsible for
+    /// matching ``endSuppression(_:)``. **Prefer ``withSuppression`` or
+    /// ``leaseSuppression`` over this manual API.** Direct begin/end pairs
+    /// are vulnerable to leaks across error and async boundaries; the
+    /// scoped APIs above make those leaks impossible.
     ///
     /// Returns a handle that must be passed to ``endSuppression(_:)`` to
     /// stop the suppression. Overlapping calls for different targets are
-    /// independent — each registers its own `(pid, restoreTo)` entry.
+    /// independent — each registers its own `(pid, restoreTo)` entry. The
+    /// underlying entry is also subject to the dispatcher's
+    /// ``maxLifetimeNs`` deadline, so a forgotten end will self-recover
+    /// in bounded time.
+    @available(*, deprecated, message: "Prefer withSuppression { … } (closure-scoped) or leaseSuppression() (ARC-scoped). Manual begin/end pairs are leak-prone across error and async boundaries.")
     @discardableResult
     public func beginSuppression(
         targetPid: pid_t,
-        restoreTo: NSRunningApplication
+        restoreTo: NSRunningApplication,
+        origin: StaticString = #function
     ) async -> SuppressionHandle {
-        let handle = SuppressionHandle()
-        dispatcher.add(handle: handle, targetPid: targetPid, restoreTo: restoreTo)
+        let handle = dispatcher.add(
+            targetPid: targetPid, restoreTo: restoreTo, origin: "\(origin)"
+        )
+        startJanitorIfNeeded()
         return handle
     }
 
@@ -120,6 +332,49 @@ public actor SystemFocusStealPreventer {
             _ = await task.value
         }
     }
+
+    // MARK: - Diagnostics
+
+    /// Number of currently-active suppression entries. Test/diagnostic-only.
+    public var activeCount: Int {
+        dispatcher.activeCount
+    }
+
+    // MARK: - Janitor
+
+    private func startJanitorIfNeeded() {
+        if janitorTask != nil { return }
+        let dispatcher = self.dispatcher
+        let interval = self.janitorIntervalNs
+        janitorTask = Task.detached(priority: .background) { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: interval)
+                let evicted = dispatcher.reapExpired()
+                for task in evicted { _ = await task.value }
+                // Idle shutdown: when the dispatcher has no entries and
+                // observer is torn down, stop the janitor.
+                if await self?.shouldStopJanitor() ?? true { break }
+            }
+            await self?.clearJanitor()
+        }
+    }
+
+    /// Test-only: force a reap pass without waiting for the janitor or
+    /// an `NSWorkspace` activation. Production code should never call
+    /// this — eviction is automatic. Exposed for unit tests so the
+    /// layer-3 deadline contract can be verified deterministically.
+    public func _forceReapForTesting() async {
+        let pending = dispatcher.reapExpired()
+        for task in pending { _ = await task.value }
+    }
+
+    private func shouldStopJanitor() -> Bool {
+        dispatcher.activeCount == 0
+    }
+
+    private func clearJanitor() {
+        janitorTask = nil
+    }
 }
 
 // MARK: - Dispatcher
@@ -134,27 +389,88 @@ private final class Dispatcher: @unchecked Sendable {
     private struct Entry {
         let targetPid: pid_t
         let restoreTo: NSRunningApplication
+        let origin: String
+        /// Wall-clock deadline (mach_absolute_time-style monotonic ns).
+        /// Layer-3 safety net: when the observer fires or the janitor
+        /// runs, any entry with `now > deadline` is force-evicted.
+        let deadline: UInt64
     }
 
     private let suppressionDelayNs: UInt64
+    private let maxLifetimeNs: UInt64
+    private let warnActiveThreshold: Int
+
     private let lock = NSLock()
     private var entries: [UUID: Entry] = [:]
     private var pendingRestoreTasks: [Task<Void, Never>] = []
     private var observer: NSObjectProtocol?
 
-    init(suppressionDelayNs: UInt64) {
+    /// Unified-log subsystem. Routed through `os.Logger` so the messages
+    /// appear in `log show --process cua-driver` and `log stream`. We
+    /// don't take a swift-log dependency — `os.Logger` is free, builds
+    /// into Console.app, and is the right tool for "operator wants to
+    /// see what the driver did last Tuesday" diagnostics.
+    private let logger = Logger(
+        subsystem: "io.trycua.cua-driver", category: "FocusStealPreventer"
+    )
+
+    init(suppressionDelayNs: UInt64, maxLifetimeNs: UInt64, warnActiveThreshold: Int) {
         self.suppressionDelayNs = suppressionDelayNs
+        self.maxLifetimeNs = maxLifetimeNs
+        self.warnActiveThreshold = warnActiveThreshold
     }
 
-    func add(handle: SuppressionHandle, targetPid: pid_t, restoreTo: NSRunningApplication) {
+    var activeCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return entries.count
+    }
+
+    /// Register a new entry and return its handle. Installs the shared
+    /// `NSWorkspace` observer if this is the first entry. Logs a warning
+    /// if the active count crosses the leak-suspicion threshold so future
+    /// regressions surface in the unified log instead of silently
+    /// stealing focus.
+    func add(
+        targetPid: pid_t, restoreTo: NSRunningApplication, origin: String
+    ) -> SuppressionHandle {
+        let handle = SuppressionHandle()
+        let deadline = monotonicNow() &+ maxLifetimeNs
+
         lock.lock()
-        entries[handle.id] = Entry(targetPid: targetPid, restoreTo: restoreTo)
+        entries[handle.id] = Entry(
+            targetPid: targetPid,
+            restoreTo: restoreTo,
+            origin: origin,
+            deadline: deadline
+        )
+        let count = entries.count
         let needsObserver = (observer == nil)
+        // Snapshot a description list while holding the lock so we can
+        // log without re-acquiring it.
+        let leakSuspect = count > warnActiveThreshold
+        let originList = leakSuspect ? entries.values.map(\.origin).sorted() : []
         lock.unlock()
 
         if needsObserver {
             installObserver()
         }
+
+        if leakSuspect {
+            // Surface, don't crash. A leak is a bug we want to fix; an
+            // assert in production breaks the user's automation. Log it
+            // loudly in the unified log instead — operators can grep for
+            // "FocusStealPreventer leak" and the origin list pinpoints
+            // the call sites holding the entries.
+            logger.warning(
+                """
+                FocusStealPreventer leak suspect: \(count, privacy: .public) active \
+                entries (threshold \(self.warnActiveThreshold, privacy: .public)). \
+                Origins: \(originList.joined(separator: ", "), privacy: .public)
+                """
+            )
+        }
+
+        return handle
     }
 
     /// Removes the entry for `handle` and returns any in-flight
@@ -179,6 +495,56 @@ private final class Dispatcher: @unchecked Sendable {
         if shouldRemoveObserver, let token {
             NSWorkspace.shared.notificationCenter.removeObserver(token)
         }
+        return pending
+    }
+
+    /// Layer-3 safety net: scan for entries past their deadline and force-
+    /// evict them. Returns any pending reactivation tasks that the caller
+    /// can drain.
+    ///
+    /// Called from two places: (1) the janitor task on a timer, (2) the
+    /// activation observer on every fire. The observer-side reap is what
+    /// makes a leaked wildcard entry stop hijacking activations *before*
+    /// the next user app-switch — even if the janitor is starved.
+    @discardableResult
+    func reapExpired() -> [Task<Void, Never>] {
+        let now = monotonicNow()
+
+        lock.lock()
+        var evicted: [(UUID, Entry)] = []
+        for (id, entry) in entries where now > entry.deadline {
+            evicted.append((id, entry))
+            entries.removeValue(forKey: id)
+        }
+        let shouldRemoveObserver = entries.isEmpty && !evicted.isEmpty
+        let token = observer
+        if shouldRemoveObserver {
+            observer = nil
+        }
+        let pending = shouldRemoveObserver ? pendingRestoreTasks : []
+        if shouldRemoveObserver {
+            pendingRestoreTasks = []
+        }
+        lock.unlock()
+
+        if shouldRemoveObserver, let token {
+            NSWorkspace.shared.notificationCenter.removeObserver(token)
+        }
+
+        for (_, entry) in evicted {
+            // Errors, not warnings: deadline reap means a higher-layer
+            // guarantee (closure defer / lease deinit) failed. Surface
+            // loudly so the next operator pass can find it.
+            logger.error(
+                """
+                FocusStealPreventer deadline reap: evicted entry origin=\
+                \(entry.origin, privacy: .public) targetPid=\
+                \(entry.targetPid, privacy: .public). This indicates a \
+                missing release path; investigate the named origin.
+                """
+            )
+        }
+
         return pending
     }
 
@@ -218,9 +584,27 @@ private final class Dispatcher: @unchecked Sendable {
 
         let activatedPid = app.processIdentifier
 
+        // Reap on every fire. Cheap (one dictionary scan) and bounds the
+        // worst-case leak duration to `maxLifetimeNs` — the leaked entry
+        // stops hijacking activations *before* this very fire schedules a
+        // restore task.
+        reapExpired()
+
         lock.lock()
+        // Match entries where:
+        //   - targetPid == activatedPid  (specific target suppression), OR
+        //   - targetPid == 0             (wildcard: suppress any activation that
+        //                                 isn't restoreTo — used by the side-effect
+        //                                 guard in WindowChangeDetector so that a
+        //                                 background click opening a new app, e.g.
+        //                                 UTM Gallery → Safari, is suppressed even
+        //                                 though we didn't know Safari's pid ahead
+        //                                 of time.)
         let restoreCandidates = entries.values
-            .filter { $0.targetPid == activatedPid }
+            .filter {
+                $0.targetPid == activatedPid ||
+                ($0.targetPid == 0 && activatedPid != $0.restoreTo.processIdentifier)
+            }
             .map { $0.restoreTo }
         lock.unlock()
 
@@ -244,4 +628,16 @@ private final class Dispatcher: @unchecked Sendable {
         pendingRestoreTasks.append(task)
         lock.unlock()
     }
+}
+
+// MARK: - Time
+
+/// Monotonic nanosecond clock for entry deadlines. Uses
+/// `clock_gettime(CLOCK_MONOTONIC_RAW)` so jumps in wall time (sleep,
+/// NTP slew) cannot accidentally expire entries early or extend leaks.
+@inline(__always)
+private func monotonicNow() -> UInt64 {
+    var ts = timespec()
+    clock_gettime(CLOCK_MONOTONIC_RAW, &ts)
+    return UInt64(ts.tv_sec) &* 1_000_000_000 &+ UInt64(ts.tv_nsec)
 }

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/Windows/WindowEnumerator.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverCore/Windows/WindowEnumerator.swift
@@ -50,10 +50,25 @@ public enum WindowEnumerator {
     /// callers that also need `bounds` (e.g. the auth-signed click recipe that
     /// computes a window-local point via `CGEventSetWindowLocation`) can
     /// read both off a single query.
+    ///
+    /// Uses `allWindows()` (not `visibleWindows()`) so that windows whose
+    /// `kCGWindowIsOnscreen` bit is momentarily false — which can happen for
+    /// the frontmost window itself when WindowServer considers it occluded —
+    /// are still eligible. Space membership via SkyLight SPIs is the primary
+    /// filter; `isOnScreen` is used as a fallback when SPIs are unavailable.
     public static func frontmostWindow(forPid pid: Int32) -> WindowInfo? {
-        let candidates = visibleWindows()
-            .filter { $0.pid == pid && $0.isOnScreen }
+        let currentSpace = SpaceMigrator.currentSpaceID()
+        let candidates = allWindows()
+            .filter { $0.pid == pid && $0.layer == 0 }
             .filter { $0.bounds.width > 1 && $0.bounds.height > 1 }
+            .filter { win in
+                if let currentSpace {
+                    // Prefer Space-based membership when SkyLight is available.
+                    let spaces = SpaceMigrator.spaceIDs(forWindowID: UInt32(win.id))
+                    return spaces?.contains(currentSpace) ?? win.isOnScreen
+                }
+                return win.isOnScreen
+            }
         return candidates.max(by: { $0.zIndex < $1.zIndex })
     }
 

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/CuaDriverMCPServer.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/CuaDriverMCPServer.swift
@@ -27,4 +27,183 @@ public enum CuaDriverMCPServer {
 
         return server
     }
+
+    /// Build an MCP Server whose `ListTools` / `CallTool` handlers forward
+    /// every request to a running `cua-driver serve` daemon over its Unix
+    /// domain socket. Used by the `mcp` subcommand's TCC-sidestep path:
+    /// when stdio MCP is spawned from an IDE terminal, the process inherits
+    /// the terminal's TCC responsibility chain so AX probes silently fail.
+    /// Proxying through the daemon — which runs under LaunchServices and is
+    /// correctly attributed to `com.wefonk.deepchat.computeruse` — gives MCP clients
+    /// identical behavior without requiring an external Python bridge.
+    ///
+    /// `claudeCodeComputerUseCompat` advertises the compat tool set in
+    /// `ListTools`, but every `CallTool` still hits the daemon. The daemon
+    /// always exposes the full native registry; the shim is purely a
+    /// client-side rename of `screenshot` and is implemented entirely by
+    /// the in-process MCP layer. When proxying, we therefore rewrite the
+    /// `screenshot` tool advertised to the client into its compat-mode
+    /// shape and translate inbound `screenshot` calls back into the
+    /// equivalent native daemon call.
+    public static func makeProxy(
+        serverName: String = "cua-driver",
+        version: String = CuaDriverCore.version,
+        socketPath: String,
+        claudeCodeComputerUseCompat: Bool = false
+    ) async throws -> Server {
+        let server = Server(
+            name: serverName,
+            version: version,
+            capabilities: Server.Capabilities(tools: .init(listChanged: false))
+        )
+
+        // Cache the tool list once at startup. Daemon registries are
+        // static — every connected client sees the same handlers — so a
+        // single fetch is enough for the life of the stdio MCP session.
+        // Fail fast on a missing/unhealthy daemon so the MCP client sees
+        // a clear startup error instead of a "successful" handshake that
+        // advertises zero tools and then errors on every `CallTool`.
+        let cachedToolList = try await fetchProxyToolList(
+            socketPath: socketPath,
+            claudeCodeComputerUseCompat: claudeCodeComputerUseCompat
+        )
+
+        await server.withMethodHandler(ListTools.self) { _ in
+            ListTools.Result(tools: cachedToolList)
+        }
+
+        await server.withMethodHandler(CallTool.self) { params in
+            let (name, args) = rewriteForProxy(
+                name: params.name,
+                arguments: params.arguments,
+                claudeCodeComputerUseCompat: claudeCodeComputerUseCompat
+            )
+            return try await forwardCallToDaemon(
+                name: name,
+                arguments: args,
+                socketPath: socketPath
+            )
+        }
+
+        return server
+    }
+
+    /// Translate `(name, arguments)` from the MCP client's view of the
+    /// compat tool surface into the native daemon registry's view.
+    ///
+    /// Compat-mode `screenshot` takes `{pid, window_id}` and returns a
+    /// JPEG; the daemon's native `screenshot` takes `{window_id, format,
+    /// quality}` and defaults to PNG. We map the former onto the latter
+    /// by dropping the unused `pid` and pinning `format: "jpeg",
+    /// quality: 85` to match the compat shim's output shape.
+    ///
+    /// Non-compat mode passes through unchanged.
+    private static func rewriteForProxy(
+        name: String,
+        arguments: [String: Value]?,
+        claudeCodeComputerUseCompat: Bool
+    ) -> (String, [String: Value]?) {
+        guard claudeCodeComputerUseCompat else { return (name, arguments) }
+        if name == "screenshot" {
+            var rewritten: [String: Value] = [:]
+            if let windowID = arguments?["window_id"] {
+                rewritten["window_id"] = windowID
+            }
+            rewritten["format"] = .string("jpeg")
+            rewritten["quality"] = .int(85)
+            return (name, rewritten)
+        }
+        return (name, arguments)
+    }
+
+    /// One-shot daemon `list` over the UDS, with the compat-mode rename
+    /// applied client-side. Throws a descriptive `MCPError.internalError`
+    /// if the daemon is unreachable, transport-failed, or returned an
+    /// unexpected envelope — surfacing the failure during `makeProxy`'s
+    /// init rather than producing a proxy that advertises zero tools and
+    /// errors on every subsequent `CallTool`.
+    private static func fetchProxyToolList(
+        socketPath: String,
+        claudeCodeComputerUseCompat: Bool
+    ) async throws -> [Tool] {
+        let request = DaemonRequest(method: "list")
+        let result = DaemonClient.sendRequest(request, socketPath: socketPath)
+        let tools: [Tool]
+        switch result {
+        case .noDaemon:
+            throw MCPError.internalError(
+                "cua-driver daemon not reachable on \(socketPath). "
+                    + "Start it with `open -n -g -a \"DeepChat Computer Use\" --args serve` and retry."
+            )
+        case .error(let message):
+            throw MCPError.internalError(
+                "cua-driver daemon transport error while listing tools on \(socketPath): \(message)"
+            )
+        case .ok(let response):
+            guard response.ok, case let .list(listed) = response.result else {
+                let reason = response.error ?? "daemon returned unexpected result kind for list"
+                throw MCPError.internalError(
+                    "cua-driver daemon refused tool list on \(socketPath): \(reason)"
+                )
+            }
+            tools = listed
+        }
+        if !claudeCodeComputerUseCompat {
+            return tools
+        }
+        // Compat mode: swap the native `screenshot` tool descriptor for
+        // the window-only shim's descriptor so MCP clients see the same
+        // schema they'd see in the in-process compat registry.
+        let compatHandlers = ClaudeCodeComputerUseCompatTools.all
+        let compatToolsByName = Dictionary(
+            uniqueKeysWithValues: compatHandlers.map { ($0.tool.name, $0.tool) }
+        )
+        return tools.map { tool in
+            compatToolsByName[tool.name] ?? tool
+        }
+    }
+
+    /// Forward a single `CallTool` invocation to the daemon and translate
+    /// the `DaemonResponse` back into an MCP `CallTool.Result` (or throw
+    /// `MCPError` on protocol-level failures).
+    ///
+    /// Tool-level errors — i.e. the tool ran but returned `isError: true`
+    /// — round-trip cleanly as part of the `.call` payload, so MCP clients
+    /// see exactly the same error envelope they would in the in-process
+    /// path. Only daemon-level failures (socket gone, decode error, unknown
+    /// tool) throw.
+    private static func forwardCallToDaemon(
+        name: String,
+        arguments: [String: Value]?,
+        socketPath: String
+    ) async throws -> CallTool.Result {
+        let request = DaemonRequest(method: "call", name: name, args: arguments)
+        // Match the daemon's own per-call read budget. AX-heavy tools
+        // (e.g. `screenshot`, `get_window_state`) regularly take a few
+        // seconds; the default 120s in `DaemonClient` is plenty.
+        let result = DaemonClient.sendRequest(request, socketPath: socketPath)
+        switch result {
+        case .noDaemon:
+            throw MCPError.internalError(
+                "cua-driver daemon not reachable on \(socketPath). "
+                    + "Start it with `open -n -g -a \"DeepChat Computer Use\" --args serve` and retry."
+            )
+        case .error(let message):
+            throw MCPError.internalError("daemon transport: \(message)")
+        case .ok(let response):
+            if !response.ok {
+                let reason = response.error ?? "daemon reported failure"
+                if response.exitCode == DaemonExit.usage {
+                    throw MCPError.invalidParams(reason)
+                }
+                throw MCPError.internalError(reason)
+            }
+            guard case let .call(callResult) = response.result else {
+                throw MCPError.internalError(
+                    "daemon returned unexpected result kind for call"
+                )
+            }
+            return callResult
+        }
+    }
 }

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/ToolRegistry.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/ToolRegistry.swift
@@ -52,12 +52,29 @@ public struct ToolRegistry: Sendable {
     ]
 
     public func call(_ name: String, arguments: [String: Value]?) async throws -> CallTool.Result {
-        guard let handler = handlers[name] else {
+        // Deprecated alias: type_text_chars → type_text. Kept for backwards
+        // compatibility with hermes-agent builds that still emit the old name.
+        // The alias is intentionally NOT registered in handlers so it never
+        // appears in tools/list — only legacy callers that already cached the
+        // old name will hit this path.
+        let effectiveName: String
+        if name == "type_text_chars" {
+            FileHandle.standardError.write(
+                Data(
+                    "[cua-driver] deprecated tool name 'type_text_chars' — use 'type_text' instead.\n"
+                        .utf8
+                ))
+            effectiveName = "type_text"
+        } else {
+            effectiveName = name
+        }
+
+        guard let handler = handlers[effectiveName] else {
             throw MCPError.invalidParams("Unknown tool: \(name)")
         }
         // Capture monotonic start time before any animation or side-effect
         // so the recorded span brackets the full action duration.
-        let actionStartNs: UInt64 = Self.actionToolNames.contains(name)
+        let actionStartNs: UInt64 = Self.actionToolNames.contains(effectiveName)
             ? clock_gettime_nsec_np(CLOCK_UPTIME_RAW) : 0
 
         let result = try await handler.invoke(arguments)
@@ -65,7 +82,7 @@ public struct ToolRegistry: Sendable {
         // Recording hook — runs AFTER the tool's invoke. Errors inside
         // the recorder are swallowed by the actor; the tool caller
         // never sees a recording-path failure.
-        if Self.actionToolNames.contains(name),
+        if Self.actionToolNames.contains(effectiveName),
            await RecordingSession.shared.isEnabled()
         {
             // Bind the shared engine lazily. `bindAppStateEngine` just
@@ -75,15 +92,15 @@ public struct ToolRegistry: Sendable {
             )
             let pid = extractPid(arguments)
             let clickPoint: CGPoint?
-            if Self.clickFamilyToolNames.contains(name) {
+            if Self.clickFamilyToolNames.contains(effectiveName) {
                 clickPoint = await resolveClickPoint(
-                    toolName: name, arguments: arguments
+                    toolName: effectiveName, arguments: arguments
                 )
             } else {
                 clickPoint = nil
             }
             await RecordingSession.shared.record(
-                toolName: name,
+                toolName: effectiveName,
                 arguments: snapshotArguments(arguments),
                 pid: pid,
                 clickPoint: clickPoint,

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/ClickTool.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/ClickTool.swift
@@ -252,6 +252,8 @@ public enum ClickTool {
         guard let axAction = axActionByName[actionName] else {
             return errorResult("Unknown action: \(actionName).")
         }
+        // Snapshot before the action so we can detect cross-app side-effects.
+        let snap = await WindowChangeDetector.snapshot()
         do {
             let element = try await AppStateRegistry.engine.lookup(
                 pid: pid,
@@ -345,6 +347,15 @@ public enum ClickTool {
             // period and arm the idle-hide timer. No-op when
             // disabled.
             await AgentCursor.shared.finishClick(pid: pid)
+            // Detect side-effects: new windows or foreground-app change triggered
+            // by this action (e.g. "Browse UTM Gallery" opens Safari, or
+            // "Open in UTM" hands off to UTM via a URL scheme).
+            let changes = await WindowChangeDetector.detectChanges(snapshot: snap)
+            if let origPid = snap.frontPid, changes.needsRestore {
+                await MainActor.run {
+                    WindowChangeDetector.reRaiseForeground(pid: origPid)
+                }
+            }
             var summary =
                 "✅ Performed \(axAction) on [\(index)] \(target.role ?? "?") \"\(target.title ?? "")\"."
             // For popup buttons (HTML <select> elements in Safari/WebKit):
@@ -392,7 +403,7 @@ public enum ClickTool {
                 summary += " if the expected state change didn't happen."
             }
             return CallTool.Result(
-                content: [.text(text: summary, annotations: nil, _meta: nil)]
+                content: [.text(text: summary + changes.resultSuffix, annotations: nil, _meta: nil)]
             )
         } catch AppStateError.noCachedState(let pid, let windowId) {
             return errorResult(noCachedStateMessage(pid: pid, windowId: windowId))
@@ -446,8 +457,11 @@ public enum ClickTool {
         fromZoom: Bool = false,
         debugImageOut: String? = nil
     ) async -> CallTool.Result {
+        // Snapshot before the action so we can detect cross-app side-effects
+        // (e.g. clicking "Open in UTM" in Safari fires a utm:// URL scheme
+        // that activates UTM and potentially opens a new window).
+        let snap = await WindowChangeDetector.snapshot()
         // Write the debug crosshair BEFORE any coordinate mangling —
-        // we want the saved image to reflect the exact (x, y) the
         // caller handed us, in the same resized space the caller
         // was reasoning in. The crosshair lands on the received
         // pixel; the caller compares against their own "intent"
@@ -540,10 +554,17 @@ public enum ClickTool {
             }
             await AgentCursor.shared.playClickPress()
             await AgentCursor.shared.finishClick(pid: pid)
+            // Detect side-effects: new windows or foreground change.
+            let changes = await WindowChangeDetector.detectChanges(snapshot: snap)
+            if let origPid = snap.frontPid, changes.needsRestore {
+                await MainActor.run {
+                    WindowChangeDetector.reRaiseForeground(pid: origPid)
+                }
+            }
             let clickWord = count == 2 ? "double-click" : (count == 3 ? "triple-click" : "click")
             let modSuffix = modifiers.isEmpty ? "" : " with \(modifiers.joined(separator: "+"))"
             return CallTool.Result(
-                content: [.text(text: "✅ Posted \(clickWord)\(modSuffix) to pid \(pid).", annotations: nil, _meta: nil)]
+                content: [.text(text: "✅ Posted \(clickWord)\(modSuffix) to pid \(pid)." + changes.resultSuffix, annotations: nil, _meta: nil)]
             )
         } catch let error as MouseInputError {
             return errorResult(error.description)

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/GetWindowStateTool.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/GetWindowStateTool.swift
@@ -74,6 +74,19 @@ public enum GetWindowStateTool {
                 Change with `cua-driver config set capture_mode <mode>` or
                 the `set_config` tool.
 
+                Screenshot capture failures behave differently per mode:
+                in `som`, they're non-fatal — the AX tree still ships in
+                the response and the summary line carries a hint, so
+                agents can keep doing element-indexed clicks against the
+                same window even when the screenshot is unavailable. In
+                `vision`, the screenshot IS the deliverable, so the same
+                failure returns `isError: true` with an actionable hint
+                (try another window, retry later, or switch to
+                `capture_mode: ax`). The macOS 26.4.x SCK regression
+                (SCStreamError -3801, "Could not start streaming") is
+                surfaced this way. Switching to `capture_mode: ax` skips
+                the capture attempt entirely on subsequent turns.
+
                 Requires Accessibility and Screen Recording permissions.
                 """,
             inputSchema: [
@@ -211,6 +224,13 @@ public enum GetWindowStateTool {
                 // race (window closed between validation and capture)
                 // leaves the snapshot without a screenshot; the structured
                 // response's `has_screenshot=false` surfaces the omission.
+                // A `.streamingFailed` (macOS 26.4 SCK regression) is
+                // handled differently per mode: in `som` the AX tree is
+                // still useful so we swallow it and emit a hint; in
+                // `vision` the screenshot IS the deliverable, so we
+                // return a hard error with the same actionable guidance
+                // as the standalone `screenshot` tool.
+                var captureHint: String? = nil
                 if captureMode != .ax {
                     do {
                         let shot = try await capture.captureWindow(
@@ -241,12 +261,52 @@ public enum GetWindowStateTool {
                     } catch CaptureError.windowNotFound {
                         // Window raced — swallow and emit a screenshot-less
                         // response.
+                    } catch CaptureError.streamingFailed(let msg) {
+                        if captureMode == .vision {
+                            // In `vision` mode the screenshot IS the
+                            // deliverable — there's no AX tree to fall
+                            // back to. Surface the same actionable hint
+                            // as the standalone `screenshot` tool.
+                            return errorResult(
+                                """
+                                ScreenCaptureKit refused this window: \(msg)
+
+                                This is a known macOS 26.4.x SCK regression that hits \
+                                specific windows on physical Macs. The legacy \
+                                CGWindowList fallback also returned no image.
+
+                                Workarounds:
+                                  • Try a different `window_id` on the same app — \
+                                often only one window is affected.
+                                  • For element-indexed clicks, switch to AX-only: \
+                                `cua-driver config set capture_mode ax` and re-call \
+                                `get_window_state` (no screenshot, AX tree only).
+                                  • Re-snapshot a moment later — the failure is \
+                                sometimes transient.
+                                """
+                            )
+                        }
+                        // `som` mode: AX snapshot is still useful for
+                        // element-indexed clicks, so we don't fail the
+                        // call. The hint nudges the caller toward
+                        // `capture_mode: ax` to skip the capture attempt
+                        // entirely on subsequent turns.
+                        captureHint = """
+                            ⚠️  Screenshot skipped: ScreenCaptureKit refused this \
+                            window (\(msg)). Known macOS 26.4 SCK regression. The \
+                            AX tree below is still valid; element-indexed clicks \
+                            work as usual. To suppress future capture attempts on \
+                            this app: `cua-driver config set capture_mode ax`.
+                            """
                     }
                 }
 
                 var textContent = buildSummary(
                     snapshot: snapshot, pid: pid, mode: captureMode
                 )
+                if let captureHint {
+                    textContent += "\n" + captureHint
+                }
                 if captureMode != .vision && !snapshot.treeMarkdown.isEmpty {
                     textContent += "\n\n" + snapshot.treeMarkdown
                 }

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/LaunchAppTool.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/LaunchAppTool.swift
@@ -3,7 +3,16 @@ import CuaDriverCore
 import Foundation
 import MCP
 
+/// MCP tool that launches a macOS app in the background without stealing
+/// focus from the current frontmost application. Pairs the LaunchServices
+/// `activates = false` flag with the layer-3 `SystemFocusStealPreventer` so
+/// targets that self-activate during `applicationDidFinishLaunching` are
+/// also kept off-front. Configures `WEBKIT_INSPECTOR_SERVER` and
+/// `--remote-debugging-port` for WKWebView / Electron remote inspection
+/// when the corresponding ports are supplied.
 public enum LaunchAppTool {
+    /// MCP `ToolHandler` registration. Wires the JSON schema, argument
+    /// parser, and the body that performs the launch.
     public static let handler = ToolHandler(
         tool: Tool(
             name: "launch_app",
@@ -43,6 +52,16 @@ public enum LaunchAppTool {
                 the background. Works with any app that implements
                 `application(_:open:)`; apps that ignore the delegate simply
                 launch without side effects.
+
+                ⚠️ BROWSER WINDOW REQUIREMENT: Browsers (Safari, Chrome,
+                Firefox, Arc, Brave, Edge) require at least one URL in
+                `urls` — without it NSWorkspace starts the process but
+                never creates a window, so subsequent `get_window_state`,
+                `click`, and `screenshot` calls will fail with "no window
+                found." Use `urls=["about:blank"]` for a blank window.
+                Example: `{"bundle_id": "com.apple.Safari", "urls":
+                ["about:blank"]}`. Electron apps also follow this contract
+                when their entry point depends on a URL argument.
 
                 Optional `electron_debugging_port` launches an Electron app
                 with `--remote-debugging-port=<N>`, activating its Chrome
@@ -186,19 +205,24 @@ public enum LaunchAppTool {
                     NSWorkspace.shared.frontmostApplication
                 }
 
-                // Arm the preventer speculatively with targetPid=0; we'll
-                // replace it below once we know the real pid. The preventer
-                // matches by pid on each activation notification, so a
-                // placeholder won't fire false positives.
-                var handle: SuppressionHandle?
-                if let priorFrontmost {
-                    handle =
+                // Arm the preventer speculatively with a placeholder
+                // (targetPid=0 wildcard) BEFORE launch returns, so any
+                // activation the target emits while `AppLauncher.launch`
+                // is still running gets caught. Lease form: if `launch`
+                // throws, ARC fires `deinit` on the lease and the entry
+                // is released. We never have to thread a manual cleanup
+                // through the catch path.
+                let placeholderLease: SuppressionLease? =
+                    if let priorFrontmost {
                         await AppStateRegistry.systemFocusStealPreventer
-                        .beginSuppression(
-                            targetPid: 0,  // placeholder; replaced after launch
-                            restoreTo: priorFrontmost
-                        )
-                }
+                            .leaseSuppression(
+                                targetPid: 0,  // placeholder; replaced after launch
+                                restoreTo: priorFrontmost,
+                                origin: "LaunchAppTool.placeholder"
+                            )
+                    } else {
+                        nil
+                    }
 
                 var additionalArguments: [String] = rawExtraArgs.compactMap { $0.stringValue }
                 if let port = electronDebuggingPort {
@@ -224,33 +248,37 @@ public enum LaunchAppTool {
                     createsNewApplicationInstance: createsNewInstance
                 )
 
-                // Replace the placeholder pid with the real one so any
-                // activation notification the target emits from now on is
-                // caught. Observed activations that fired DURING the launch
-                // (synchronous `open`) will have been seen by the observer
-                // but not matched (pid=0 mismatch), so they pass through —
-                // this fix covers the PROCESS-ORDERING race (target emits
-                // activation AFTER `open` returns) which is the common
-                // case on real machines; the intra-`open` case is handled
-                // by the target's own reflex running asynchronously.
+                // Crossfade from placeholder (wildcard) to pid-specific
+                // suppression with NO suppression-free window in between.
+                //
+                // Earlier ordering was `release placeholder → arm
+                // pid-specific`, which left a brief window where a target
+                // self-activation could slip through. The dispatcher
+                // permits multiple concurrent entries — during the
+                // overlap below, any activation is matched by both the
+                // placeholder wildcard ("anything not priorFrontmost")
+                // and the pid-specific entry ("exactly info.pid"); the
+                // first match restores `priorFrontmost`, which is what
+                // we want.
+                //
+                // 500ms is enough for applicationDidFinishLaunching plus
+                // any reflex NSApp.activate to fire and get suppressed.
                 let shouldSuppress =
                     priorFrontmost != nil
                     && priorFrontmost?.processIdentifier != info.pid
-                if shouldSuppress, let handle, let priorFrontmost {
+                if shouldSuppress, let priorFrontmost {
                     await AppStateRegistry.systemFocusStealPreventer
-                        .endSuppression(handle)
-                    let reArmedHandle =
-                        await AppStateRegistry.systemFocusStealPreventer
-                        .beginSuppression(
+                        .withSuppression(
                             targetPid: info.pid,
-                            restoreTo: priorFrontmost
-                        )
-                    // 500ms is enough for applicationDidFinishLaunching
-                    // plus any reflex NSApp.activate to fire and get
-                    // suppressed.
-                    try? await Task.sleep(nanoseconds: 500_000_000)
-                    await AppStateRegistry.systemFocusStealPreventer
-                        .endSuppression(reArmedHandle)
+                            restoreTo: priorFrontmost,
+                            origin: "LaunchAppTool.postLaunch"
+                        ) {
+                            // Pid-specific entry is now armed. NOW it's
+                            // safe to drop the placeholder — the
+                            // crossfade is complete.
+                            await placeholderLease?.release()
+                            try? await Task.sleep(nanoseconds: 500_000_000)
+                        }
 
                     // Belt-and-braces: if the target is STILL frontmost
                     // after the suppression window (intra-`open` synchronous
@@ -265,9 +293,15 @@ public enum LaunchAppTool {
                             _ = priorFrontmost.activate(options: [])
                         }
                     }
-                } else if let handle {
-                    await AppStateRegistry.systemFocusStealPreventer
-                        .endSuppression(handle)
+                } else {
+                    // No pid-specific phase needed (priorFrontmost was nil
+                    // or matches the launched pid). The placeholder has
+                    // done its job — catching any intra-launch activation
+                    // — and can be released now. ARC would also catch this
+                    // via deinit when `placeholderLease` goes out of scope,
+                    // but explicit release awaits any pending reactivation
+                    // Tasks before we leave the do-block.
+                    await placeholderLease?.release()
                 }
 
                 var summary = "✅ Launched \(info.name) (pid \(info.pid)) in background."

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/ListWindowsTool.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/ListWindowsTool.swift
@@ -107,6 +107,25 @@ public enum ListWindowsTool {
                     return info.pid == pid
                 }
 
+            // When a pid filter was specified but no windows matched, surface
+            // a loud warning so the caller knows the pid is wrong or the app
+            // has no windows yet — rather than silently returning an empty list.
+            if let pidFilter, windows.isEmpty {
+                let frontmost = WindowEnumerator.allWindows()
+                    .filter { $0.layer == 0 && $0.isOnScreen }
+                    .max(by: { $0.zIndex < $1.zIndex })
+                var warning =
+                    "⚠️ No windows found for pid \(pidFilter). "
+                    + "The pid may be wrong or the app may not have created a window yet."
+                if let front = frontmost {
+                    warning +=
+                        " The current frontmost app appears to be \"\(front.owner)\" (pid \(front.pid))."
+                }
+                return CallTool.Result(
+                    content: [.text(text: warning, annotations: nil, _meta: nil)]
+                )
+            }
+
             let currentSpaceID = SpaceMigrator.currentSpaceID()
             let records = windows.map { info -> Row in
                 let spaceIDs = SpaceMigrator.spaceIDs(forWindowID: UInt32(info.id))

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/ScreenshotTool.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/ScreenshotTool.swift
@@ -18,6 +18,14 @@ public enum ScreenshotTool {
 
                 Requires the Screen Recording TCC grant — call `check_permissions`
                 first if unsure.
+
+                On macOS 26.4.x, ScreenCaptureKit can refuse specific windows on
+                physical Macs (SCStreamError -3801, "Could not start streaming").
+                The driver retries once and falls back to the legacy
+                CGWindowList path before failing; if both refuse, the error
+                response includes a hint to try a different `window_id` or
+                switch to `capture_mode: ax` for `get_window_state` (the
+                element-indexed flow doesn't need pixels).
                 """,
             inputSchema: [
                 "type": "object",
@@ -105,6 +113,38 @@ public enum ScreenshotTool {
                                 `check_permissions` with {"prompt": true} to request it, \
                                 then allow cua-driver in System Settings → Privacy & \
                                 Security → Screen Recording.
+                                """,
+                            annotations: nil,
+                            _meta: nil
+                        )
+                    ],
+                    isError: true
+                )
+            } catch CaptureError.streamingFailed(let msg) {
+                // SCK streaming-start regression on macOS 26.4.x — the
+                // legacy CGWindowList fallback also refused this specific
+                // window. There's nothing we can do at the pixel layer;
+                // surface an actionable hint pointing at `get_window_state`
+                // (which can fall back to AX-only via `capture_mode: ax`)
+                // or trying a different window.
+                return CallTool.Result(
+                    content: [
+                        .text(
+                            text: """
+                                ScreenCaptureKit refused this window: \(msg)
+
+                                This is a known macOS 26.4.x SCK regression that hits \
+                                specific windows on physical Macs. The legacy \
+                                CGWindowList fallback also returned no image.
+
+                                Workarounds:
+                                  • Try a different `window_id` on the same app — \
+                                often only one window is affected.
+                                  • For element-indexed clicks, switch to AX-only: \
+                                `cua-driver config set capture_mode ax` and use \
+                                `get_window_state` (no screenshot, AX tree only).
+                                  • Re-snapshot a moment later — the failure is \
+                                sometimes transient.
                                 """,
                             annotations: nil,
                             _meta: nil

--- a/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/WindowChangeDetector.swift
+++ b/plugins/cua/vendor/cua-driver/source/Sources/CuaDriverServer/Tools/WindowChangeDetector.swift
@@ -1,0 +1,260 @@
+import AppKit
+import CuaDriverCore
+import Foundation
+
+/// Detects windows and foreground-app changes that happen as a side-effect
+/// of a click or other action, then re-raises the original foreground
+/// application so background agent actions never permanently displace the
+/// user's active context.
+///
+/// Usage (inside an `async` tool handler):
+///
+///     let snap = await WindowChangeDetector.snapshot()
+///     // … perform action …
+///     let changes = await WindowChangeDetector.detectChanges(snapshot: snap)
+///     if let pid = snap.frontPid, changes.needsRestore {
+///         await WindowChangeDetector.reRaiseForeground(pid: pid)
+///     }
+///     let suffix = changes.resultSuffix
+///
+public enum WindowChangeDetector {
+
+    // MARK: - Types
+
+    /// A lightweight record for a newly-appeared window.
+    public struct WindowEvent: Sendable {
+        /// CGWindowID of the window. Stable for the window's lifetime.
+        public let windowId: Int
+        /// Process id of the app that owns the window.
+        public let pid: Int32
+        /// Owning app's localized name (e.g. "Safari").
+        public let appName: String
+        /// Window title at the moment of detection. May be empty.
+        public let title: String
+    }
+
+    /// State captured before the action.
+    ///
+    /// Holds an ARC-managed ``SuppressionLease`` rather than a raw handle.
+    /// **This is the leak-proofing for the snapshot/detect pattern**: if a
+    /// caller drops the `Snapshot` without ever calling
+    /// ``WindowChangeDetector/detectChanges(snapshot:timeout:pollInterval:)``
+    /// (e.g. an early-return error path between snapshot and detect), the
+    /// lease's `deinit` releases the underlying entry. The cleanup happens
+    /// by the language, not by call-site discipline.
+    ///
+    /// `Snapshot` is a struct, so a copy retains the lease reference. The
+    /// final copy going out of scope is what fires deinit; explicit
+    /// `detectChanges` releases it earlier and turns deinit into a no-op.
+    public struct Snapshot: Sendable {
+        /// CGWindowIDs of all visible layer-0 windows at snapshot time.
+        public let windowIds: Set<Int>
+        /// PID of the frontmost application at snapshot time, or nil.
+        public let frontPid: Int32?
+        /// Wildcard suppression lease armed at snapshot time.
+        /// Active from `snapshot()` through `detectChanges()` so that any
+        /// app that self-activates as a side-effect of the action (e.g.
+        /// Safari opening from UTM Gallery) is blocked before the first
+        /// compositor frame, not just after we notice it in the poll loop.
+        ///
+        /// ARC-managed: dropping the Snapshot without calling
+        /// `detectChanges` is safe — `SuppressionLease.deinit` releases.
+        internal let suppressionLease: SuppressionLease?
+    }
+
+    /// What changed after the action.
+    public struct Changes: Sendable {
+        /// Windows that appeared after the action (new window IDs).
+        public let newWindows: [WindowEvent]
+        /// True when the frontmost app changed to a pid other than the
+        /// original frontmost pid.
+        public let foregroundChanged: Bool
+        /// True when we found evidence that the action triggered a cross-app
+        /// side-effect that required (or would have required) a foreground
+        /// restore. True when:
+        ///   - The OS-level frontmost app changed (detected before the
+        ///     wildcard suppressor could fire), OR
+        ///   - New windows appeared — even if foregroundChanged is false
+        ///     because the wildcard suppressor in snapshot() already blocked
+        ///     the steal before the poll loop could observe it.
+        public var needsRestore: Bool { foregroundChanged || !newWindows.isEmpty }
+
+        /// One-liner summary to append to a tool result, or empty string when
+        /// nothing interesting happened.
+        public var resultSuffix: String {
+            guard needsRestore else { return "" }
+
+            if !newWindows.isEmpty {
+                // Deduplicate by app name for a compact message.
+                let byApp = Dictionary(grouping: newWindows, by: { $0.appName })
+                let appSummaries = byApp.map { (app, wins) -> String in
+                    let titles = wins.compactMap {
+                        $0.title.isEmpty ? nil : "\"\($0.title)\""
+                    }
+                    return titles.isEmpty ? app : "\(app) (\(titles.joined(separator: ", ")))"
+                }.sorted()
+                return "\n\n🪟 Action opened new window(s): \(appSummaries.joined(separator: "; "))."
+            } else {
+                return "\n\n🔀 Action caused a different app to become frontmost."
+            }
+        }
+
+        /// Sentinel returned when the detection window elapses with no
+        /// new windows and no foreground change. Reused so callers can
+        /// `return .noChange` cheaply.
+        public static let noChange = Changes(newWindows: [], foregroundChanged: false)
+    }
+
+    // MARK: - Public API
+
+    /// Capture the current window set and frontmost pid, and arm the wildcard
+    /// focus-steal suppressor. Call this immediately before performing an action.
+    ///
+    /// The suppressor (targetPid = 0) blocks any app from stealing focus from
+    /// the current frontmost between `snapshot()` and `detectChanges()` — this
+    /// covers the window during which the AX action fires and any side-effect
+    /// app (e.g. Safari opening from UTM Gallery) would otherwise briefly
+    /// appear at the front before we notice it in the poll loop.
+    ///
+    /// Safe to call from any thread — CGWindowList and NSWorkspace are
+    /// both accessible off the main thread in a non-UI process.
+    public static func snapshot() async -> Snapshot {
+        let ids = currentWindowIds()
+        let frontPid = await MainActor.run {
+            NSWorkspace.shared.frontmostApplication?.processIdentifier
+        }
+
+        // Arm the wildcard suppressor immediately — before the action fires.
+        // Lease form: ARC releases on Snapshot drop even if detectChanges()
+        // is never called (early-return error path between snapshot and
+        // detect). origin tag surfaces in the unified log if a leak warning
+        // is ever triggered.
+        var lease: SuppressionLease?
+        if let pid = frontPid,
+           let restoreTo = NSRunningApplication(processIdentifier: pid)
+        {
+            lease = await AppStateRegistry.systemFocusStealPreventer
+                .leaseSuppression(
+                    targetPid: 0,
+                    restoreTo: restoreTo,
+                    origin: "WindowChangeDetector.snapshot"
+                )
+        }
+
+        return Snapshot(windowIds: ids, frontPid: frontPid, suppressionLease: lease)
+    }
+
+    /// Poll for up to `timeout` seconds for new windows or a foreground-app
+    /// change. Returns as soon as a change is detected or the timeout elapses.
+    ///
+    /// The wildcard suppressor that was armed in `snapshot()` stays active
+    /// for the entire detection window and is ended on return. This ensures
+    /// side-effect apps that activate after the poll loop starts are also
+    /// suppressed.
+    ///
+    /// - Parameters:
+    ///   - snapshot: The `Snapshot` captured before the action.
+    ///   - timeout: How long to wait for a side-effect. Default 0.3s — new
+    ///     windows triggered by a click appear within ~200ms on macOS; the
+    ///     extra 100ms gives the suppressor time to fire and settle.
+    ///   - pollInterval: Check interval in milliseconds. Default 50ms.
+    public static func detectChanges(
+        snapshot: Snapshot,
+        timeout: TimeInterval = 1.0,
+        pollInterval: Int = 50
+    ) async -> Changes {
+        // Single-exit refactor so the lease can be torn down with a
+        // direct `await` (not a detached Task) before returning. The
+        // earlier defer-with-Task.detached form let `detectChanges`
+        // return while the wildcard suppressor was still active —
+        // a stale lease bleeding into the next action's snapshot
+        // window. Awaiting in-line is the only way to make the
+        // detection boundary the lease teardown boundary.
+        //
+        // The lease's `deinit` safety net still applies if this call
+        // is somehow skipped (caller early-return between snapshot and
+        // detect): ARC fires deinit when the Snapshot copy goes out of
+        // scope and the entry is released. Belt + suspenders.
+        var result: Changes = .noChange
+        let deadline = Date().addingTimeInterval(timeout)
+        pollLoop: while Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(pollInterval))
+
+            // --- New windows ---
+            let current = currentWindowIds()
+            let newIds = current.subtracting(snapshot.windowIds)
+            var newEvents: [WindowEvent] = []
+            if !newIds.isEmpty {
+                // Resolve app names / titles from the live window list.
+                let allVisible = WindowEnumerator.visibleWindows().filter { $0.layer == 0 }
+                newEvents = allVisible
+                    .filter { newIds.contains($0.id) }
+                    .map { WindowEvent(
+                        windowId: $0.id,
+                        pid: $0.pid,
+                        appName: $0.owner,
+                        title: $0.name
+                    )}
+            }
+
+            // --- Foreground change ---
+            // With the wildcard suppressor armed we expect the frontmost app
+            // to remain stable. Track changes anyway so the result suffix can
+            // accurately describe what happened (the suppressor fires async
+            // and a very brief transient change may still be observed here).
+            let currentFront = await MainActor.run {
+                NSWorkspace.shared.frontmostApplication?.processIdentifier
+            }
+            let foregroundChanged: Bool
+            if let orig = snapshot.frontPid, let cur = currentFront {
+                foregroundChanged = cur != orig
+            } else {
+                foregroundChanged = false
+            }
+
+            if !newEvents.isEmpty || foregroundChanged {
+                result = Changes(
+                    newWindows: newEvents, foregroundChanged: foregroundChanged
+                )
+                break pollLoop
+            }
+        }
+
+        // Tear down the wildcard suppressor BEFORE returning. Direct
+        // `await` (not `Task { ... }`) so the dispatcher entry and any
+        // in-flight delayed reactivation Tasks are fully drained before
+        // the caller sees `result`. Without this, the next caller's
+        // snapshot()  could observe the stale wildcard still firing on
+        // the next NSWorkspace activation.
+        if let lease = snapshot.suppressionLease {
+            await lease.release()
+        }
+        return result
+    }
+
+    /// Re-activate the previously-frontmost application, sending its window
+    /// back to the front on the current Space without moving or resizing it.
+    ///
+    /// Uses `activate(options: [])` — the non-deprecated form on macOS 14+.
+    ///
+    /// Call this AFTER `detectChanges` as a belt-and-suspenders restore in
+    /// case the wildcard suppressor's async Task hasn't settled yet.
+    @MainActor
+    public static func reRaiseForeground(pid: Int32) {
+        NSRunningApplication(processIdentifier: pid)?
+            .activate(options: [])
+    }
+
+    // MARK: - Internal
+
+    /// CGWindowIDs of all currently-visible layer-0 windows.
+    /// Thread-safe — CGWindowListCopyWindowInfo is documented as callable
+    /// from any thread.
+    static func currentWindowIds() -> Set<Int> {
+        Set(
+            WindowEnumerator.visibleWindows()
+                .filter { $0.layer == 0 }
+                .map { $0.id }
+        )
+    }
+}

--- a/plugins/cua/vendor/cua-driver/source/Tests/FocusStealPreventerTests/FocusStealPreventerTests.swift
+++ b/plugins/cua/vendor/cua-driver/source/Tests/FocusStealPreventerTests/FocusStealPreventerTests.swift
@@ -1,0 +1,320 @@
+import AppKit
+import XCTest
+@testable import CuaDriverCore
+
+/// Unit tests for the four-layer leak-prevention design in
+/// ``SystemFocusStealPreventer``.
+///
+/// The contract under test is that **no caller error path can leave a
+/// suppression entry alive in the dispatcher for longer than
+/// ``SystemFocusStealPreventer/maxLifetimeNs``**, regardless of which
+/// API surface they used. Each test exercises one layer of the design:
+///
+/// 1. ``testWithSuppressionReleasesOnReturn`` /
+///    ``testWithSuppressionReleasesOnThrow`` — closure scope (compiler
+///    enforces release on every exit path).
+/// 2. ``testLeaseReleasesOnExplicitCall`` /
+///    ``testLeaseReleasesOnDeinit`` — ARC scope (deinit catches what
+///    scope-defer cannot).
+/// 3. ``testDeadlineReapsLeakedManualEntry`` — wall-clock deadline
+///    (the safety net under everything else).
+///
+/// We use `NSRunningApplication.current` for `restoreTo` so the tests
+/// don't depend on any external app being frontmost. The dispatcher
+/// just stores the reference — none of these tests fire the
+/// `NSWorkspace.didActivateApplicationNotification` observer.
+final class FocusStealPreventerTests: XCTestCase {
+
+    private var selfApp: NSRunningApplication { NSRunningApplication.current }
+
+    // MARK: - Layer 1: closure scope
+
+    func testWithSuppressionReleasesOnReturn() async {
+        let preventer = SystemFocusStealPreventer(suppressionDelayNs: 0)
+        let __count1 = await preventer.activeCount
+        XCTAssertEqual(__count1, 0)
+        await preventer.withSuppression(targetPid: 0, restoreTo: selfApp) {
+            let inside = await preventer.activeCount
+            XCTAssertEqual(inside, 1, "entry must be live during body")
+        }
+
+        let __count2 = await preventer.activeCount
+
+        XCTAssertEqual(__count2, 0,
+            "withSuppression must release on normal return"
+        )
+    }
+
+    func testWithSuppressionReleasesOnThrow() async {
+        struct BodyError: Error {}
+        let preventer = SystemFocusStealPreventer(suppressionDelayNs: 0)
+
+        do {
+            try await preventer.withSuppression(targetPid: 0, restoreTo: selfApp) {
+                throw BodyError()
+            }
+            XCTFail("expected throw")
+        } catch is BodyError {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+
+        let __count3 = await preventer.activeCount
+
+        XCTAssertEqual(__count3, 0,
+            "withSuppression must release on thrown error"
+        )
+    }
+
+    // MARK: - Layer 2: ARC scope (lease)
+
+    func testLeaseReleasesOnExplicitCall() async {
+        let preventer = SystemFocusStealPreventer(suppressionDelayNs: 0)
+        let lease = await preventer.leaseSuppression(targetPid: 0, restoreTo: selfApp)
+        let __count4 = await preventer.activeCount
+        XCTAssertEqual(__count4, 1)
+        await lease.release()
+        let __count5 = await preventer.activeCount
+        XCTAssertEqual(__count5, 0)
+    }
+
+    func testLeaseReleaseIsIdempotent() async {
+        let preventer = SystemFocusStealPreventer(suppressionDelayNs: 0)
+        let lease = await preventer.leaseSuppression(targetPid: 0, restoreTo: selfApp)
+
+        await lease.release()
+        await lease.release()  // second call must be a no-op
+
+        let __count6 = await preventer.activeCount
+
+        XCTAssertEqual(__count6, 0)
+    }
+
+    /// ARC fires `deinit` when the lease's last reference goes out of
+    /// scope. The deinit's cleanup is dispatched to a `Task.detached`,
+    /// so we have to poll for the active-count to drop. The poll
+    /// timeout (2 s) is generous compared to the dispatcher's release
+    /// latency (microseconds). If this test ever flakes, the design's
+    /// language-level guarantee has failed and the regression is
+    /// urgent.
+    func testLeaseReleasesOnDeinit() async throws {
+        let preventer = SystemFocusStealPreventer(suppressionDelayNs: 0)
+
+        // Scope the lease so it deinits at the end of this block.
+        do {
+            let lease = await preventer.leaseSuppression(targetPid: 0, restoreTo: selfApp)
+            let __count7 = await preventer.activeCount
+            XCTAssertEqual(__count7, 1)
+            _ = lease
+        }
+
+        try await waitForActiveCount(0, on: preventer, timeout: 2.0)
+    }
+
+    // MARK: - Layer 3: wall-clock deadline (the safety net)
+
+    /// **The crucial test.** Even when every higher layer fails — the
+    /// caller used the deprecated raw `beginSuppression`, threw away
+    /// the handle, and never called `endSuppression` — the dispatcher's
+    /// deadline reaper must evict the entry within `maxLifetimeNs`.
+    /// Anything else means the v0.1.9 focus-trap regression class is
+    /// still possible.
+    ///
+    /// Uses the test-seam initializer to set `maxLifetimeNs = 200 ms`
+    /// so the test runs fast. The eviction is triggered explicitly via
+    /// `_forceReapForTesting()`, which simulates the reap pass that
+    /// happens automatically inside the activation observer and the
+    /// janitor task. We don't rely on the janitor to prove the
+    /// contract — that would make the test wait the full janitor
+    /// interval and add CI flake risk.
+    func testDeadlineReapsLeakedManualEntry() async throws {
+        let testMaxLifetimeNs: UInt64 = 200_000_000  // 200 ms
+        let preventer = SystemFocusStealPreventer(
+            suppressionDelayNs: 0,
+            maxLifetimeNs: testMaxLifetimeNs,
+            janitorIntervalNs: 60_000_000_000,  // disable janitor influence
+            warnActiveThreshold: 1000
+        )
+
+        // Deprecated API on purpose: this test exists *because* the
+        // deprecated path remains a leak hazard for callers who haven't
+        // migrated. The deadline must protect them.
+        @available(*, deprecated)
+        func leakAnEntry() async {
+            _ = await preventer.beginSuppression(targetPid: 0, restoreTo: selfApp)
+        }
+        await leakAnEntry()
+        let __count8 = await preventer.activeCount
+        XCTAssertEqual(__count8, 1)
+        // Wait past the deadline.
+        try await Task.sleep(nanoseconds: testMaxLifetimeNs + 50_000_000)
+
+        // Trigger the observer-side reap path directly.
+        await preventer._forceReapForTesting()
+
+        let __count9 = await preventer.activeCount
+
+        XCTAssertEqual(__count9,
+            0,
+            "deadline reaper must evict expired entries even when the caller leaked the handle"
+        )
+    }
+
+    /// The deadline reaper must not evict still-live entries just because
+    /// they share a preventer with expired ones.
+    func testDeadlineReapsOnlyExpiredEntries() async throws {
+        let testMaxLifetimeNs: UInt64 = 200_000_000
+        let preventer = SystemFocusStealPreventer(
+            suppressionDelayNs: 0,
+            maxLifetimeNs: testMaxLifetimeNs,
+            janitorIntervalNs: 60_000_000_000,
+            warnActiveThreshold: 1000
+        )
+
+        @available(*, deprecated)
+        func makeOldHandle() async -> SuppressionHandle {
+            await preventer.beginSuppression(targetPid: 0, restoreTo: selfApp)
+        }
+        let oldHandle = await makeOldHandle()
+        // Wait so the first entry is past its deadline.
+        try await Task.sleep(nanoseconds: testMaxLifetimeNs + 50_000_000)
+        // Add a fresh entry — its deadline is `now + maxLifetimeNs`.
+        let freshLease = await preventer.leaseSuppression(targetPid: 0, restoreTo: selfApp)
+
+        await preventer._forceReapForTesting()
+
+        let __count10 = await preventer.activeCount
+
+        XCTAssertEqual(__count10, 1,
+            "fresh entry must survive a reap pass that evicts only the expired one"
+        )
+        // Cleanup.
+        await preventer.endSuppression(oldHandle)  // already evicted; idempotent
+        await freshLease.release()
+        let __count11 = await preventer.activeCount
+        XCTAssertEqual(__count11, 0)
+    }
+
+    // MARK: - Diagnostics
+
+    /// `endSuppression` of an already-evicted handle must be idempotent.
+    /// Existing call sites (and the deprecated migration window) depend
+    /// on this — a forgotten handle that gets reaped should not crash
+    /// the eventual end call.
+    func testEndSuppressionAfterDeadlineIsNoOp() async throws {
+        let testMaxLifetimeNs: UInt64 = 100_000_000
+        let preventer = SystemFocusStealPreventer(
+            suppressionDelayNs: 0,
+            maxLifetimeNs: testMaxLifetimeNs,
+            janitorIntervalNs: 60_000_000_000,
+            warnActiveThreshold: 1000
+        )
+
+        @available(*, deprecated)
+        func beginAndForget() async -> SuppressionHandle {
+            await preventer.beginSuppression(targetPid: 0, restoreTo: selfApp)
+        }
+        let handle = await beginAndForget()
+
+        try await Task.sleep(nanoseconds: testMaxLifetimeNs + 50_000_000)
+        await preventer._forceReapForTesting()
+        let __count12 = await preventer.activeCount
+        XCTAssertEqual(__count12, 0)
+        // Calling end on an already-reaped entry must not crash or
+        // resurrect anything.
+        await preventer.endSuppression(handle)
+        let __count13 = await preventer.activeCount
+        XCTAssertEqual(__count13, 0)
+    }
+
+    // MARK: - Concurrency invariants (regression tests for CR feedback)
+
+    /// Regression test for the Task-based defer that let `detectChanges`
+    /// return before the lease was actually torn down. A direct `await
+    /// lease.release()` must drain the dispatcher entry before the
+    /// caller proceeds — otherwise a stale wildcard suppressor could
+    /// bleed into the next caller's snapshot window.
+    ///
+    /// This test verifies the explicit `release()` semantics: the
+    /// post-await `activeCount` is observed by the same task that
+    /// awaited, with no scheduling gap that a `Task { await ... }`
+    /// detach would introduce.
+    func testExplicitReleaseDrainsBeforeReturning() async {
+        let preventer = SystemFocusStealPreventer(suppressionDelayNs: 0)
+        let lease = await preventer.leaseSuppression(targetPid: 0, restoreTo: selfApp)
+        let beforeRelease = await preventer.activeCount
+        XCTAssertEqual(beforeRelease, 1)
+
+        await lease.release()
+
+        // Crucial: the count is observed *immediately* after `release`
+        // returns, with no `try await Task.sleep` or polling. A
+        // detached release would not satisfy this assertion
+        // deterministically.
+        let immediatelyAfter = await preventer.activeCount
+        XCTAssertEqual(
+            immediatelyAfter, 0,
+            "explicit release() must drain the entry before returning, "
+            + "not hand cleanup to a detached Task"
+        )
+    }
+
+    /// Regression test for the LaunchAppTool placeholder→pid crossfade.
+    /// Two overlapping leases must coexist in the dispatcher (overlap is
+    /// the structural fix for the gap-window bug). The dispatcher's add
+    /// and remove must be independent so the crossfade has zero
+    /// suppression-free time.
+    func testCrossfadeOfTwoLeasesHasNoSuppressionGap() async {
+        let preventer = SystemFocusStealPreventer(suppressionDelayNs: 0)
+        let __c201 = await preventer.activeCount
+        XCTAssertEqual(__c201, 0)
+        // Phase 1: placeholder armed.
+        let placeholder = await preventer.leaseSuppression(targetPid: 0, restoreTo: selfApp)
+        let __c202 = await preventer.activeCount
+        XCTAssertEqual(__c202, 1)
+        // Phase 2: pid-specific armed BEFORE placeholder is released.
+        // This is the crossfade: both entries live concurrently.
+        let pidSpecific = await preventer.leaseSuppression(
+            targetPid: 1234, restoreTo: selfApp
+        )
+        let duringOverlap = await preventer.activeCount
+        XCTAssertEqual(
+            duringOverlap, 2,
+            "dispatcher must support two concurrent leases — this is "
+            + "what makes the LaunchAppTool crossfade leak-free"
+        )
+
+        // Phase 3: drop the placeholder; the pid-specific entry survives.
+        await placeholder.release()
+        let afterPlaceholderDrop = await preventer.activeCount
+        XCTAssertEqual(
+            afterPlaceholderDrop, 1,
+            "releasing the placeholder must not affect the pid-specific entry"
+        )
+
+        // Phase 4: drop the pid-specific entry. Done.
+        await pidSpecific.release()
+        let __c203 = await preventer.activeCount
+        XCTAssertEqual(__c203, 0)
+    }
+
+    // MARK: - Helpers
+
+    /// Poll `activeCount` until it reaches `expected` or `timeout`
+    /// elapses. Used for tests where cleanup happens on a detached
+    /// Task and there's no better signal.
+    private func waitForActiveCount(
+        _ expected: Int,
+        on preventer: SystemFocusStealPreventer,
+        timeout: TimeInterval
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await preventer.activeCount == expected { return }
+            try await Task.sleep(nanoseconds: 10_000_000)  // 10 ms
+        }
+        let final = await preventer.activeCount
+        XCTFail("activeCount never reached \(expected); final=\(final)")
+    }
+}

--- a/plugins/cua/vendor/cua-driver/source/Tests/integration/test_app_name_locale_fallback.py
+++ b/plugins/cua/vendor/cua-driver/source/Tests/integration/test_app_name_locale_fallback.py
@@ -1,0 +1,110 @@
+"""Integration test: app name resolution fallback (#1481).
+
+Verifies that launch_app accepts more than just the exact bundle-file name:
+
+  1. Bundle ID passed as `name` (e.g. "com.apple.calculator") resolves via
+     LaunchServices — callers don't need to use the `bundle_id` parameter.
+
+  2. Case-insensitive match on CFBundleName / display name works so
+     "calculator" and "CALCULATOR" both resolve to Calculator.app.
+
+  3. Exact name still works (regression guard).
+
+The JP-locale localizedName path ("計算機") cannot be exercised on an EN
+locale machine; that path is exercised by the same NSRunningApplication
+localizedName lookup and would pass on a JP-locale host.
+
+Run:
+    scripts/test.sh test_app_name_locale_fallback
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from driver_client import DriverClient, default_binary_path, reset_calculator
+
+CALCULATOR_BUNDLE = "com.apple.calculator"
+
+
+def _kill_calc() -> None:
+    subprocess.run(["pkill", "-x", "Calculator"], check=False)
+    time.sleep(0.4)
+
+
+class AppNameLocaleFallbackTests(unittest.TestCase):
+    """launch_app name= accepts bundle IDs and case-insensitive display names."""
+
+    def setUp(self) -> None:
+        reset_calculator()
+        self.client = DriverClient(default_binary_path()).__enter__()
+
+    def tearDown(self) -> None:
+        self.client.__exit__(None, None, None)
+        _kill_calc()
+
+    def _launch_by_name(self, name: str) -> dict:
+        result = self.client.call_tool("launch_app", {"name": name})
+        return result
+
+    def test_bundle_id_as_name_resolves(self) -> None:
+        """Bundle ID string passed as name= launches the correct app."""
+        result = self._launch_by_name(CALCULATOR_BUNDLE)
+        self.assertFalse(
+            result.get("isError"),
+            f"launch_app(name='{CALCULATOR_BUNDLE}') failed: {result}",
+        )
+        sc = result.get("structuredContent", {})
+        self.assertEqual(
+            sc.get("bundle_id"),
+            CALCULATOR_BUNDLE,
+            f"Unexpected bundle_id in response: {sc}",
+        )
+        self.assertGreater(sc.get("pid", 0), 0)
+
+    def test_case_insensitive_name_lowercase(self) -> None:
+        """Lowercase name= ('calculator') matches Calculator.app."""
+        result = self._launch_by_name("calculator")
+        self.assertFalse(
+            result.get("isError"),
+            f"launch_app(name='calculator') failed: {result}",
+        )
+        sc = result.get("structuredContent", {})
+        self.assertEqual(sc.get("bundle_id"), CALCULATOR_BUNDLE)
+
+    def test_case_insensitive_name_uppercase(self) -> None:
+        """All-caps name= ('CALCULATOR') matches Calculator.app."""
+        result = self._launch_by_name("CALCULATOR")
+        self.assertFalse(
+            result.get("isError"),
+            f"launch_app(name='CALCULATOR') failed: {result}",
+        )
+        sc = result.get("structuredContent", {})
+        self.assertEqual(sc.get("bundle_id"), CALCULATOR_BUNDLE)
+
+    def test_exact_name_still_works(self) -> None:
+        """Exact canonical name= ('Calculator') still works (regression guard)."""
+        result = self._launch_by_name("Calculator")
+        self.assertFalse(
+            result.get("isError"),
+            f"launch_app(name='Calculator') failed: {result}",
+        )
+        sc = result.get("structuredContent", {})
+        self.assertEqual(sc.get("bundle_id"), CALCULATOR_BUNDLE)
+
+    def test_unknown_name_returns_error(self) -> None:
+        """Completely unknown name returns isError (not a silent empty result)."""
+        result = self._launch_by_name("ThisAppDefinitelyDoesNotExist_xyzzy")
+        self.assertTrue(
+            result.get("isError"),
+            f"Expected isError for unknown app name, got: {result}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/cua/vendor/cua-driver/source/Tests/integration/test_click_opens_new_window.py
+++ b/plugins/cua/vendor/cua-driver/source/Tests/integration/test_click_opens_new_window.py
@@ -1,0 +1,275 @@
+"""Integration test: clicking a background app that triggers a cross-app side-effect.
+
+Scenario
+--------
+FocusMonitorApp is the simulated "user foreground window" — the thing the user
+is actively working on.  UTM is the background target the agent is operating.
+
+1. Launch FocusMonitorApp → it becomes frontmost (user's context).
+2. Launch UTM in the background via the driver (no focus steal).
+3. Click "Browse UTM Gallery" inside UTM (background).
+   - This causes macOS to open a Safari window and briefly make Safari active.
+   - WindowChangeDetector inside ClickTool must detect the side-effect and
+     re-raise the original foreground (FocusMonitorApp) before returning.
+4. Assert the click result text mentions:
+     a. 🪟  — new Safari window appeared
+     b. Safari — named in the notice
+     c. ↩️  — original foreground re-raised
+5. Assert FocusMonitorApp (not Safari) is still frontmost.
+6. Assert FocusMonitorApp's focus-loss counter is 0 (ux_guard: it never lost focus).
+
+Run
+---
+    python3 -m pytest libs/cua-driver/Tests/integration/test_click_opens_new_window.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from driver_client import (  # noqa: E402
+    DriverClient,
+    default_binary_path,
+    frontmost_bundle_id,
+)
+
+# ---------------------------------------------------------------------------
+# Paths / constants
+# ---------------------------------------------------------------------------
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(os.path.dirname(_THIS_DIR))
+_FOCUS_APP_DIR = os.path.join(_REPO_ROOT, "Tests", "FocusMonitorApp")
+_FOCUS_APP_BUNDLE = os.path.join(_FOCUS_APP_DIR, "FocusMonitorApp.app")
+_FOCUS_APP_EXE = os.path.join(
+    _FOCUS_APP_BUNDLE, "Contents", "MacOS", "FocusMonitorApp"
+)
+_LOSS_FILE = "/tmp/focus_monitor_losses.txt"
+
+_UTM_BUNDLE = "com.utmapp.UTM"
+_UTM_PATH = "/Applications/UTM.app"
+_SAFARI_BUNDLE = "com.apple.Safari"
+_FOCUS_MONITOR_BUNDLE = "com.trycua.FocusMonitorApp"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _tool_text(result: dict) -> str:
+    for item in result.get("content", []):
+        if item.get("type") == "text":
+            return item.get("text", "")
+    return ""
+
+
+def _build_focus_app() -> None:
+    if not os.path.exists(_FOCUS_APP_EXE):
+        subprocess.run([os.path.join(_FOCUS_APP_DIR, "build.sh")], check=True)
+
+
+def _launch_focus_app() -> tuple[subprocess.Popen, int]:
+    """Launch FocusMonitorApp; wait for FOCUS_PID= line; return (proc, pid)."""
+    proc = subprocess.Popen(
+        [_FOCUS_APP_EXE],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    for _ in range(40):
+        line = proc.stdout.readline().strip()
+        if line.startswith("FOCUS_PID="):
+            return proc, int(line.split("=", 1)[1])
+        time.sleep(0.1)
+    proc.terminate()
+    raise RuntimeError("FocusMonitorApp did not print FOCUS_PID= in time")
+
+
+def _read_focus_losses() -> int:
+    try:
+        with open(_LOSS_FILE) as f:
+            return int(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        return -1
+
+
+def _wait_for_window(
+    client: DriverClient, app_name_substr: str, timeout: float = 6.0
+) -> dict | None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        r = client.call_tool("list_windows", {"on_screen_only": True})
+        wins = (r.get("structuredContent") or {}).get("windows") or []
+        for w in wins:
+            if app_name_substr.lower() in w.get("app_name", "").lower():
+                return w
+        time.sleep(0.3)
+    return None
+
+
+def _kill(name: str) -> None:
+    subprocess.run(["pkill", "-x", name], check=False, capture_output=True)
+    time.sleep(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+class TestBrowseUTMGalleryUXGuard(unittest.TestCase):
+    """Clicking 'Browse UTM Gallery' in a backgrounded UTM must not steal focus.
+
+    FocusMonitorApp is frontmost throughout.  The click side-effect (Safari
+    opening) must be detected and the foreground must be restored, all without
+    FocusMonitorApp ever losing active status.
+    """
+
+    _focus_proc: subprocess.Popen
+    _focus_pid: int
+    _client: DriverClient
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not os.path.exists(_UTM_PATH):
+            raise unittest.SkipTest(f"UTM not installed at {_UTM_PATH}")
+
+        _build_focus_app()
+
+        # Clean slate: kill Safari and UTM so no stale windows interfere.
+        _kill("Safari")
+        _kill("UTM")
+
+        # Reset the focus-loss counter.
+        try:
+            os.remove(_LOSS_FILE)
+        except FileNotFoundError:
+            pass
+
+        # Start the driver client for setup.
+        cls._client = DriverClient(default_binary_path()).__enter__()
+
+        # Launch UTM in the background — launch_app does NOT steal focus.
+        r = cls._client.call_tool("launch_app", {"bundle_id": _UTM_BUNDLE})
+        sc = r.get("structuredContent") or {}
+        cls._utm_pid = sc.get("pid")
+        time.sleep(1.5)  # let UTM draw its welcome screen
+
+        # Launch FocusMonitorApp last so it is frontmost — this is the
+        # "user's active window" that must never be displaced.
+        cls._focus_proc, cls._focus_pid = _launch_focus_app()
+        time.sleep(0.5)  # let it settle as frontmost
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._focus_proc.terminate()
+        cls._client.__exit__(None, None, None)
+        _kill("Safari")
+        _kill("UTM")
+
+    # -----------------------------------------------------------------------
+
+    def test_browse_gallery_click_with_ux_guard(self) -> None:
+        """Full end-to-end: background UTM click opens Safari, foreground preserved."""
+        c = self._client
+
+        # Verify FocusMonitorApp is frontmost before the click.
+        front_before = frontmost_bundle_id(c)
+        self.assertEqual(
+            front_before, _FOCUS_MONITOR_BUNDLE,
+            f"Expected FocusMonitorApp to be frontmost before the click, "
+            f"got {front_before!r}",
+        )
+
+        losses_before = _read_focus_losses()
+
+        # Locate UTM's window.
+        utm_win = _wait_for_window(c, "UTM", timeout=5.0)
+        self.assertIsNotNone(utm_win, "UTM window not visible after launch")
+        utm_pid = utm_win["pid"]
+        window_id = utm_win["window_id"]
+
+        # Get the AX tree to find the "Browse UTM Gallery" button index.
+        ws = c.call_tool("get_window_state", {"pid": utm_pid, "window_id": window_id})
+        ws_text = _tool_text(ws)
+
+        gallery_idx: int | None = None
+        for line in ws_text.splitlines():
+            if "Browse" in line and "Gallery" in line:
+                m = re.search(r"\[(\d+)\]", line)
+                if m:
+                    gallery_idx = int(m.group(1))
+                    break
+
+        # Click the gallery button — by element index if found, pixel otherwise.
+        if gallery_idx is not None:
+            result = c.call_tool("click", {
+                "pid": utm_pid,
+                "window_id": window_id,
+                "element_index": gallery_idx,
+            })
+        else:
+            # Fallback: pixel click at the approximate "Browse UTM Gallery"
+            # button location in UTM's welcome screen.
+            b = utm_win["bounds"]
+            result = c.call_tool("click", {
+                "pid": utm_pid,
+                "window_id": window_id,
+                "x": b["width"] / 2.0,
+                "y": b["height"] * 0.35,
+            })
+
+        result_text = _tool_text(result)
+
+        # 1. Safari window must actually appear.
+        safari_win = _wait_for_window(c, "Safari", timeout=8.0)
+        self.assertIsNotNone(
+            safari_win,
+            f"Safari window did not appear after clicking Browse UTM Gallery.\n"
+            f"Click result: {result_text}",
+        )
+
+        # 2. Result must announce the new Safari window.
+        self.assertIn(
+            "🪟", result_text,
+            f"Expected 🪟 new-window notice in click result.\nGot: {result_text}",
+        )
+        self.assertIn(
+            "Safari", result_text,
+            f"Expected 'Safari' mentioned in new-window notice.\nGot: {result_text}",
+        )
+
+        # 4. FocusMonitorApp (not Safari, not UTM) must still be frontmost.
+        time.sleep(0.3)
+        front_after = frontmost_bundle_id(c)
+        self.assertEqual(
+            front_after, _FOCUS_MONITOR_BUNDLE,
+            f"Expected FocusMonitorApp to remain frontmost after re-raise, "
+            f"got {front_after!r}.\nClick result: {result_text}",
+        )
+
+        # 5. ux_guard: FocusMonitorApp may lose focus at most once during the
+        #    click sequence. The wildcard SystemFocusStealPreventer fires
+        #    reactively — it receives NSWorkspace.didActivateApplicationNotification
+        #    and immediately re-activates FocusMonitorApp, but the notification
+        #    itself is already one event after the activation, so exactly one
+        #    NSApplication.didResignActiveNotification is guaranteed for any
+        #    cross-app side-effect. More than one loss means the suppressor
+        #    is not firing or FocusMonitorApp lost focus for an unrelated reason.
+        losses_after = _read_focus_losses()
+        delta = losses_after - losses_before
+        self.assertLessEqual(
+            delta, 1,
+            f"FocusMonitorApp lost focus {delta} time(s) (max 1 allowed) "
+            f"during the click sequence — ux_guard violated.\n"
+            f"Click result: {result_text}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/cua/vendor/cua-driver/source/Tests/integration/test_hidden_app_capture.py
+++ b/plugins/cua/vendor/cua-driver/source/Tests/integration/test_hidden_app_capture.py
@@ -1,0 +1,151 @@
+"""Integration test: hidden-app launch → list_windows → screenshot capture.
+
+Verifies the contract documented in issue #1489 / #1486:
+
+  1. `launch_app` with a bundle that creates a window (Calculator) sets
+     is_on_screen=false when the window isn't shown on the current Space,
+     but `list_windows` (default, no on_screen_only filter) still surfaces
+     it and returns a valid window_id.
+
+  2. `screenshot` succeeds against that window_id even though
+     is_on_screen is false — ScreenCaptureKit captures the backing store
+     regardless of visibility.
+
+  3. The `list_windows(pid=...)` warning message is returned (not isError)
+     when the pid filter finds windows — exercises the non-empty path.
+
+Calculator is used as the test target because it reliably creates a window
+on launch_app and is guaranteed to be available on every macOS install.
+We terminate it at the end to leave the system clean.
+
+Run:
+    scripts/test.sh test_hidden_app_capture
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from driver_client import DriverClient, default_binary_path, reset_calculator
+
+
+CALCULATOR_BUNDLE = "com.apple.calculator"
+
+
+class HiddenAppCaptureTests(unittest.TestCase):
+    """Test that list_windows surfaces hidden windows and screenshot works."""
+
+    def setUp(self) -> None:
+        reset_calculator()
+        self.client = DriverClient(default_binary_path()).__enter__()
+
+    def tearDown(self) -> None:
+        self.client.__exit__(None, None, None)
+        # Kill Calculator so it doesn't linger between test runs.
+        subprocess.run(["pkill", "-x", "Calculator"], check=False)
+        time.sleep(0.3)
+
+    def test_hidden_window_appears_in_list_windows(self) -> None:
+        """launch_app → window appears in list_windows even if off-screen."""
+        result = self.client.call_tool(
+            "launch_app", {"bundle_id": CALCULATOR_BUNDLE}
+        )
+        self.assertFalse(
+            result.get("isError"), f"launch_app failed: {result}"
+        )
+        pid = result["structuredContent"]["pid"]
+        self.assertIsInstance(pid, int)
+        self.assertGreater(pid, 0)
+
+        # Give Calculator a moment to create its window.
+        time.sleep(1.0)
+
+        # list_windows (no filter) must include Calculator's window.
+        all_windows = self.client.call_tool("list_windows", {})[
+            "structuredContent"
+        ]["windows"]
+        calc_windows = [w for w in all_windows if w["pid"] == pid]
+        self.assertGreater(
+            len(calc_windows),
+            0,
+            f"Calculator (pid {pid}) window not found in list_windows",
+        )
+
+        # Every returned record must have the required fields.
+        required = {"window_id", "pid", "app_name", "bounds", "layer", "z_index", "is_on_screen"}
+        for w in calc_windows:
+            missing = required - set(w.keys())
+            self.assertFalse(missing, f"window record missing fields: {missing}")
+
+    def test_screenshot_succeeds_for_hidden_window(self) -> None:
+        """screenshot tool captures the backing store even when is_on_screen=false."""
+        result = self.client.call_tool(
+            "launch_app", {"bundle_id": CALCULATOR_BUNDLE}
+        )
+        self.assertFalse(result.get("isError"), f"launch_app failed: {result}")
+        pid = result["structuredContent"]["pid"]
+        time.sleep(1.0)
+
+        # Grab a window_id for Calculator.
+        windows_result = self.client.call_tool("list_windows", {"pid": pid})[
+            "structuredContent"
+        ]["windows"]
+        self.assertGreater(
+            len(windows_result), 0, "No windows found for Calculator"
+        )
+        window_id = windows_result[0]["window_id"]
+
+        # screenshot must succeed regardless of is_on_screen.
+        shot = self.client.call_tool("screenshot", {"window_id": window_id})
+        self.assertFalse(
+            shot.get("isError"),
+            f"screenshot failed for window_id {window_id}: {shot}",
+        )
+        # Result should contain an image content block.
+        content = shot.get("content", [])
+        has_image = any(c.get("type") == "image" for c in content)
+        has_text = any(c.get("type") == "text" for c in content)
+        self.assertTrue(
+            has_image or has_text,
+            f"screenshot returned no content blocks: {content}",
+        )
+
+    def test_list_windows_pid_filter_returns_warning_on_unknown_pid(self) -> None:
+        """list_windows with a nonexistent pid returns a warning, not an error."""
+        # Use a pid that is virtually guaranteed not to exist.
+        fake_pid = 99999
+        result = self.client.call_tool("list_windows", {"pid": fake_pid})
+        # Must NOT be isError — the tool surfaces a warning in the text body.
+        self.assertFalse(
+            result.get("isError"),
+            "list_windows should not set isError for empty pid filter results",
+        )
+        text_content = " ".join(
+            c.get("text", "") for c in result.get("content", []) if c.get("type") == "text"
+        )
+        self.assertIn(
+            "No windows found",
+            text_content,
+            f"Expected warning text in response, got: {text_content!r}",
+        )
+
+    def test_list_windows_pid_filter_includes_frontmost_hint(self) -> None:
+        """Warning message for empty pid filter includes the frontmost app name."""
+        fake_pid = 99999
+        result = self.client.call_tool("list_windows", {"pid": fake_pid})
+        text_content = " ".join(
+            c.get("text", "") for c in result.get("content", []) if c.get("type") == "text"
+        )
+        # The frontmost-app hint is conditional on having any on-screen window;
+        # on a normal macOS machine this is always true (Finder, at minimum).
+        # We just check the warning structure is present.
+        self.assertIn(str(fake_pid), text_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/cua/vendor/cua-driver/source/scripts/build/build-release-notarized.sh
+++ b/plugins/cua/vendor/cua-driver/source/scripts/build/build-release-notarized.sh
@@ -60,9 +60,16 @@ cd "$CUA_DRIVER_DIR"
 mkdir -p .release
 log "normal" "Ensuring .release directory exists and is accessible"
 
-# Build the release version
-log "essential" "Building release version..."
-swift build -c release --product cua-driver > /dev/null
+# Build or use a prebuilt binary (e.g. a pre-lipo'd universal binary from CI).
+# Set CUA_DRIVER_PREBUILT_BINARY to an absolute path to skip swift build entirely.
+if [ -n "${CUA_DRIVER_PREBUILT_BINARY:-}" ]; then
+    log "essential" "Using prebuilt binary: $CUA_DRIVER_PREBUILT_BINARY"
+    BUILT_BINARY="$CUA_DRIVER_PREBUILT_BINARY"
+else
+    log "essential" "Building release version..."
+    swift build -c release --product cua-driver > /dev/null
+    BUILT_BINARY=".build/release/cua-driver"
+fi
 
 # --- Assemble .app bundle ---
 log "essential" "Assembling .app bundle..."
@@ -73,7 +80,7 @@ mkdir -p "$APP_BUNDLE/Contents/MacOS"
 mkdir -p "$APP_BUNDLE/Contents/Resources"
 
 # Copy the binary into the bundle
-cp -f .build/release/cua-driver "$APP_BUNDLE/Contents/MacOS/cua-driver"
+cp -f "$BUILT_BINARY" "$APP_BUNDLE/Contents/MacOS/cua-driver"
 
 # Stamp and copy Info.plist — the source plist ships with a static
 # `CFBundleShortVersionString` for dev builds; substitute the release

--- a/plugins/cua/vendor/cua-driver/source/scripts/install.sh
+++ b/plugins/cua/vendor/cua-driver/source/scripts/install.sh
@@ -12,6 +12,13 @@
 #                        ~/.local/bin (e.g. /usr/local/bin — that target needs sudo)
 #   --no-modify-path     skip auto-appending an `export PATH=...` line to your
 #                        shell rc when ~/.local/bin is missing from PATH
+#   --experimental-rust  opt into the experimental cua-driver-rs (Rust port)
+#                        backend instead of the Swift binary. Delegates to
+#                        libs/cua-driver-rs/scripts/install.sh — see that
+#                        script for backend-specific env vars. Installs to a
+#                        separate bundle (CuaDriverRs.app) so the Swift
+#                        binary is left untouched. Also accepted as
+#                        --backend=rust.
 #
 # Env overrides:
 #   CUA_DRIVER_VERSION=0.1.0   pin a specific release tag
@@ -30,15 +37,96 @@ APP_DEST="/Applications/$APP_NAME"
 BIN_DIR="${CUA_DRIVER_BIN_DIR:-$HOME/.local/bin}"
 NO_MODIFY_PATH="${CUA_DRIVER_NO_MODIFY_PATH:-0}"
 
+# Rust-backend delegation target. Kept in sync with the canonical path on
+# main; --experimental-rust below either execs the on-disk copy (when this
+# script runs from a checked-out tree) or curls this URL and pipes it to
+# bash (the `curl ... | bash` install path).
+RUST_INSTALLER_URL="https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver-rs/scripts/install.sh"
+
 # Lightweight flag parsing (avoid getopt; macOS getopt is GNU-incompatible).
+#
+# Two-pass shape:
+#   1. Walk all argv and collect every unrecognised arg into FORWARDED_ARGS.
+#      That bucket is what we'd hand off to the Rust installer if the user
+#      opted in. Recognised Swift-only flags (--bin-dir, --no-modify-path)
+#      are consumed in this pass and applied to local state.
+#   2. If --experimental-rust (or --backend=rust) was seen anywhere in argv,
+#      exec into the Rust installer with FORWARDED_ARGS and never reach the
+#      Swift install path below.
+#
+# This lets the experimental flag appear at any position, lets `--` end
+# Swift-flag parsing without breaking forwarding, and keeps both installers'
+# argv shapes (--bin-dir, --no-modify-path) bit-compatible so the same
+# command works regardless of backend.
+USE_RUST_BACKEND=0
+FORWARDED_ARGS=()
+PASSTHROUGH=0
 while [[ $# -gt 0 ]]; do
+    if [[ "$PASSTHROUGH" == "1" ]]; then
+        FORWARDED_ARGS+=("$1"); shift; continue
+    fi
     case "$1" in
-        --bin-dir) BIN_DIR="$2"; shift 2 ;;
-        --bin-dir=*) BIN_DIR="${1#*=}"; shift ;;
-        --no-modify-path) NO_MODIFY_PATH=1; shift ;;
-        *) shift ;;
+        --experimental-rust) USE_RUST_BACKEND=1; shift ;;
+        --backend=rust)      USE_RUST_BACKEND=1; shift ;;
+        --backend=swift)     shift ;;                 # explicit default — no-op
+        --backend=*)
+            printf 'error: unknown backend %q; supported: swift, rust\n' "${1#*=}" >&2
+            exit 2
+            ;;
+        --bin-dir)
+            if [[ -z "${2:-}" || "${2:0:1}" == "-" ]]; then
+                printf 'error: --bin-dir requires a value\n' >&2
+                exit 2
+            fi
+            BIN_DIR="$2"; FORWARDED_ARGS+=("$1" "$2"); shift 2 ;;
+        --bin-dir=*)         BIN_DIR="${1#*=}"; FORWARDED_ARGS+=("$1"); shift ;;
+        --no-modify-path)    NO_MODIFY_PATH=1; FORWARDED_ARGS+=("$1"); shift ;;
+        --)                  PASSTHROUGH=1; shift ;;  # forward the rest verbatim
+        *)                   FORWARDED_ARGS+=("$1"); shift ;;
     esac
 done
+
+# --- Optional delegation to the experimental Rust backend ---------------
+#
+# If the user opted in with --experimental-rust / --backend=rust, hand the
+# rest of argv to cua-driver-rs/scripts/install.sh and exit. The Swift
+# install path below is never touched in this case, so the Swift binary
+# (if present) is left exactly as-is — users can roll back by deleting
+# /Applications/CuaDriverRs.app and re-running this script without the flag.
+if [[ "$USE_RUST_BACKEND" == "1" ]]; then
+    printf 'note: installing experimental Rust backend (cua-driver-rs). The Swift binary won'"'"'t be touched.\n' >&2
+
+    # Prefer the on-disk copy when this script is running from a checked-out
+    # tree (dev / CI). Falls back to curling the canonical URL for the
+    # `curl ... | bash` install path, where $BASH_SOURCE is unset / -.
+    LOCAL_RUST_INSTALLER=""
+    if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]}" != "-" && -f "${BASH_SOURCE[0]}" ]]; then
+        SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+        CANDIDATE="$SCRIPT_DIR/../../cua-driver-rs/scripts/install.sh"
+        if [[ -f "$CANDIDATE" ]]; then
+            LOCAL_RUST_INSTALLER="$CANDIDATE"
+        fi
+    fi
+
+    # macOS ships bash 3.2, which trips `set -u` when expanding an empty
+    # array via "${arr[@]}" — guard with the +alt-value pattern so the
+    # zero-arg case becomes a literal no-expansion.
+    if [[ -n "$LOCAL_RUST_INSTALLER" ]]; then
+        exec /bin/bash "$LOCAL_RUST_INSTALLER" ${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}
+    else
+        if ! command -v curl >/dev/null 2>&1; then
+            printf 'error: curl not found on PATH; cannot fetch %s\n' "$RUST_INSTALLER_URL" >&2
+            exit 1
+        fi
+        # `exec` so the Rust installer replaces this process — we don't want
+        # to fall through to the Swift install path on any error here.
+        RUST_INSTALLER_SCRIPT="$(curl -fsSL "$RUST_INSTALLER_URL")" || {
+            printf 'error: failed to download Rust installer from %s\n' "$RUST_INSTALLER_URL" >&2
+            exit 1
+        }
+        exec /bin/bash -c "$RUST_INSTALLER_SCRIPT" cua-driver-rs-install ${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}
+    fi
+fi
 
 BIN_LINK="$BIN_DIR/$BINARY_NAME"
 TMP_DIR=$(mktemp -d)
@@ -62,14 +150,32 @@ for cmd in curl tar; do
 done
 
 # --- Resolve release tag ------------------------------------------------
+#
+# Version is resolved in priority order:
+#   1. CUA_DRIVER_VERSION env var (explicit pin)
+#   2. BAKED_VERSION below (set automatically by CD after each release — no API call needed)
+#   3. GitHub Releases API (fallback; unauthenticated = 60 req/hr per IP)
+#
+# ~~~ BAKED_VERSION: auto-updated by CD workflow after each release — do not edit ~~~
+CUA_DRIVER_BAKED_VERSION="0.1.9"
+# ~~~ END_BAKED_VERSION ~~~
 
 if [[ -n "${CUA_DRIVER_VERSION:-}" ]]; then
     TAG="${TAG_PREFIX}${CUA_DRIVER_VERSION#v}"
     log "using version from CUA_DRIVER_VERSION: $TAG"
+elif [[ -n "${CUA_DRIVER_BAKED_VERSION:-}" ]]; then
+    TAG="${TAG_PREFIX}${CUA_DRIVER_BAKED_VERSION}"
+    log "latest release: $TAG"
 else
     log "resolving latest $TAG_PREFIX* release via GitHub API"
-    TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=40" \
+    # `grep -v cua-driver-rs` is defense-in-depth — the Rust port (cua-driver-rs)
+    # publishes to the same repo under tag prefix `cua-driver-rs-v*` and the
+    # current grep regex `cua-driver-v[^"]+` already excludes it (differs at
+    # position 11: 'r' vs 'v'), but the negation guards against any future
+    # regex tweak that might accidentally widen the match.
+    TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=100" \
         | grep -Eo '"tag_name":[[:space:]]*"'"${TAG_PREFIX}"'[^"]+"' \
+        | grep -v 'cua-driver-rs' \
         | sed -E 's/.*"'"${TAG_PREFIX}"'([0-9]+[.][0-9]+[.][0-9]+)"/\1/' \
         | sort -t. -k1,1nr -k2,2nr -k3,3nr \
         | head -n 1 \

--- a/plugins/cua/vendor/cua-driver/upstream.json
+++ b/plugins/cua/vendor/cua-driver/upstream.json
@@ -2,14 +2,14 @@
   "sourceKind": "deepchat-owned-fork",
   "upstreamRepo": "https://github.com/trycua/cua.git",
   "upstreamSubdir": "libs/cua-driver",
-  "tag": "cua-driver-v0.1.5",
-  "commit": "534304f56290b290a3799d4168d3bdf42287be26",
-  "version": "0.1.5",
-  "updatedAt": "2026-05-08",
+  "tag": "cua-driver-v0.2.0",
+  "commit": "d3f3b9325f49aa5302c15fb03f6b66bd1e688e27",
+  "version": "0.2.0",
+  "updatedAt": "2026-05-25",
   "forkPolicy": "Build from the DeepChat-maintained local source snapshot. Cherry-pick upstream fixes only when they directly improve the bundled DeepChat Computer Use helper.",
   "lastCherryPick": {
-    "sourceTag": "cua-driver-v0.1.5",
-    "sourceCommit": "534304f56290b290a3799d4168d3bdf42287be26",
-    "appliedAt": "2026-05-08"
+    "sourceTag": "cua-driver-v0.2.0",
+    "sourceCommit": "d3f3b9325f49aa5302c15fb03f6b66bd1e688e27",
+    "appliedAt": "2026-05-25"
   }
 }


### PR DESCRIPTION
## Summary
- sync vendored CUA Swift driver metadata and source to upstream cua-driver-v0.2.0
- preserve DeepChat helper identity, permission probe, update flow, and MCP-first behavior
- add SDD records for the sync

## Validation
- swift build --package-path plugins/cua/vendor/cua-driver/source --product cua-driver
- pnpm run format
- pnpm run i18n
- pnpm run lint
- git diff --check
- pnpm run plugin:cua:build:mac:arm64
- pnpm run plugin:validate -- --name cua --platform darwin --arch arm64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cleanup` command to remove stale installer artifacts.
  * Enhanced `mcp` command with daemon-proxy mode and socket override support.
  * Improved window capture with streaming failure retry and legacy fallback.
  * Added window change detection to track side-effects during tool operations.

* **Bug Fixes**
  * Improved focus suppression with leak-safe, ARC-scoped leases.
  * Enhanced app launching with case-insensitive name resolution.
  * Better handling of off-screen and hidden windows.

* **Tests**
  * Added focus suppression tests and integration tests for app launching, window capture, and side-effect detection.

* **Chores**
  * Updated to version 0.2.0 and upstream metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->