### PR TITLE
fix(upgrade): respect prerelease channel & guard downgrades

### DIFF
--- a/src/main/presenter/configPresenter/index.ts
+++ b/src/main/presenter/configPresenter/index.ts
@@ -438,7 +438,7 @@ export class ConfigPresenter implements IConfigPresenter {
         skillsPath: path.join(app.getPath('home'), '.deepchat', 'skills'),
         enableSkills: true,
         skillDraftSuggestionsEnabled: false,
-        updateChannel: 'stable', // Default to stable version
+        // updateChannel 不预填，首次由 getUpdateChannel() 根据当前应用版本号推断（避免 beta 安装包被默认推入 stable 渠道）
         appVersion: this.currentAppVersion,
         hooksNotifications: createDefaultHooksNotificationsConfig(),
         scheduledTasks: createDefaultScheduledTasksSettings()
@@ -2992,12 +2992,15 @@ export class ConfigPresenter implements IConfigPresenter {
 
   // 获取更新渠道
   getUpdateChannel(): string {
-    const raw = this.getSetting<string>('updateChannel') || 'stable'
-    const channel = raw === 'stable' || raw === 'beta' ? raw : 'beta'
-    if (channel !== raw) {
-      this.setSetting('updateChannel', channel)
+    const raw = this.getSetting<string>('updateChannel')
+    if (raw === 'stable' || raw === 'beta') {
+      return raw
     }
-    return channel
+    // 首次启动或值非法时，按当前应用版本号推断：含 -alpha/-beta/-rc/-canary 等预发后缀的安装包默认进入 beta 渠道
+    const isPrerelease = /-(?:alpha|beta|rc|canary)(?:[.-]\d+)?$/i.test(this.currentAppVersion)
+    const inferred = isPrerelease ? 'beta' : 'stable'
+    this.setSetting('updateChannel', inferred)
+    return inferred
   }
 
   // 设置更新渠道

--- a/src/main/presenter/upgradePresenter/index.ts
+++ b/src/main/presenter/upgradePresenter/index.ts
@@ -11,6 +11,7 @@ import { presenter } from '@/presenter'
 import { publishDeepchatEvent } from '@/routes/publishDeepchatEvent'
 import electronUpdater from 'electron-updater'
 import type { UpdateInfo } from 'electron-updater'
+import { compare } from 'compare-versions'
 import fs from 'fs'
 import path from 'path'
 
@@ -21,6 +22,11 @@ const GITHUB_REPO = 'deepchat'
 const OFFICIAL_DOWNLOAD_URL = 'https://deepchatai.cn/#/download'
 const UPDATE_CHANNEL_STABLE = 'stable'
 const UPDATE_CHANNEL_BETA = 'beta'
+const PRERELEASE_VERSION_REGEX = /-(?:alpha|beta|rc|canary)(?:[.-]\d+)?$/i
+
+const isPrereleaseVersion = (version: string): boolean => {
+  return PRERELEASE_VERSION_REGEX.test(version)
+}
 
 type ReleaseNoteItem = {
   version?: string | null
@@ -174,6 +180,41 @@ export class UpgradePresenter implements IUpgradePresenter {
     autoUpdater.on('update-available', (info) => {
       console.log('检测到新版本', info)
       this._lock = false
+
+      // 版本号兜底保护：electron-updater 在 channel 错配时可能把当前 beta 安装包"更新"成更旧的正式版。
+      // 严格按 semver 判定——只要远端版本 <= 当前版本就拒绝。这里不再单独以"channel 是否同源"为拒绝条件，
+      // 以免误伤"beta → 同版本号 stable 正式发布"这类合法的渠道收敛升级。
+      const currentVersion = app.getVersion()
+      const remoteVersion = info?.version || ''
+
+      let isDowngradeOrSame = false
+      try {
+        if (!remoteVersion) {
+          isDowngradeOrSame = true
+        } else if (compare(remoteVersion, currentVersion, '<=')) {
+          isDowngradeOrSame = true
+        }
+      } catch (e) {
+        console.warn('版本号对比失败，忽略此次更新提示', currentVersion, remoteVersion, e)
+        isDowngradeOrSame = true
+      }
+
+      if (isDowngradeOrSame) {
+        console.log('忽略降级或同版本的更新提示', {
+          current: currentVersion,
+          remote: remoteVersion
+        })
+        this._status = 'not-available'
+        this._error = null
+        this._progress = null
+        this._versionInfo = null
+        this.emitStatusChanged({
+          status: this._status,
+          type: this._lastCheckType
+        })
+        return
+      }
+
       this._versionInfo = toVersionInfo(info)
       this._error = null
       this._progress = null
@@ -245,6 +286,19 @@ export class UpgradePresenter implements IUpgradePresenter {
           // 删除标记文件
           fs.unlinkSync(this._updateMarkerPath)
           return
+        }
+
+        // 渠道一致性校验：marker 中的目标版本若与当前安装包不属于同一渠道（beta vs stable），
+        // 说明上次的"待完成更新"来自渠道错配，应直接丢弃而不是钉死为 previousUpdateFailed
+        const markerVersion = typeof updateInfo.version === 'string' ? updateInfo.version : ''
+        if (markerVersion) {
+          const markerIsPre = isPrereleaseVersion(markerVersion)
+          const currentIsPre = isPrereleaseVersion(currentVersion)
+          if (markerIsPre !== currentIsPre) {
+            console.log('忽略跨渠道的旧 update marker', { marker: markerVersion, currentVersion })
+            fs.unlinkSync(this._updateMarkerPath)
+            return
+          }
         }
 
         // 否则说明上次更新失败，标记为错误状态

--- a/test/main/presenter/upgradePresenter.test.ts
+++ b/test/main/presenter/upgradePresenter.test.ts
@@ -10,7 +10,8 @@ const {
   setApplicationQuittingMock,
   appQuitMock,
   appRelaunchMock,
-  appExitMock
+  appExitMock,
+  appGetVersionMock
 } = vi.hoisted(() => {
   const autoUpdaterState = {
     listeners: new Map<string, (...args: unknown[]) => void>(),
@@ -28,13 +29,15 @@ const {
     setApplicationQuittingMock: vi.fn(),
     appQuitMock: vi.fn(),
     appRelaunchMock: vi.fn(),
-    appExitMock: vi.fn()
+    appExitMock: vi.fn(),
+    appGetVersionMock: vi.fn(() => '1.0.0')
   }
 })
 
 vi.mock('electron', () => ({
   app: {
     getPath: vi.fn(() => '/tmp/deepchat-test'),
+    getVersion: appGetVersionMock,
     quit: appQuitMock,
     relaunch: appRelaunchMock,
     exit: appExitMock
@@ -100,6 +103,8 @@ describe('UpgradePresenter', () => {
     appQuitMock.mockReset()
     appRelaunchMock.mockReset()
     appExitMock.mockReset()
+    appGetVersionMock.mockReset()
+    appGetVersionMock.mockReturnValue('1.0.0')
     vi.mocked(electronUpdater.autoUpdater.checkForUpdates).mockReset()
   })
 
@@ -180,5 +185,60 @@ describe('UpgradePresenter', () => {
     await presenter.checkUpdate()
 
     expect(electronUpdater.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores cross-channel downgrades when current install is a prerelease', () => {
+    appGetVersionMock.mockReturnValue('1.0.5-beta.5')
+    const configPresenter = {
+      getUpdateChannel: vi.fn(() => 'stable'),
+      getPrivacyModeEnabled: vi.fn(() => false)
+    } as any
+
+    const presenter = new UpgradePresenter(configPresenter)
+    const handler = autoUpdaterState.listeners.get('update-available')
+    expect(handler).toBeDefined()
+
+    // 模拟 electron-updater 在 channel 错配下推送的旧正式版
+    handler!({ version: '1.0.4', releaseDate: '2026-05-01', releaseNotes: '' })
+
+    expect((presenter as any)._status).toBe('not-available')
+    expect((presenter as any)._versionInfo).toBeNull()
+    // 不应触发自动下载
+    expect(electronUpdater.autoUpdater.downloadUpdate).not.toHaveBeenCalled()
+  })
+
+  it('accepts in-channel upgrades from one beta to a newer beta', () => {
+    appGetVersionMock.mockReturnValue('1.0.5-beta.2')
+    const configPresenter = {
+      getUpdateChannel: vi.fn(() => 'beta'),
+      getPrivacyModeEnabled: vi.fn(() => false)
+    } as any
+
+    const presenter = new UpgradePresenter(configPresenter)
+    const handler = autoUpdaterState.listeners.get('update-available')
+    expect(handler).toBeDefined()
+
+    handler!({ version: '1.0.5-beta.5', releaseDate: '2026-05-15', releaseNotes: '' })
+
+    expect((presenter as any)._status).toBe('available')
+    expect((presenter as any)._versionInfo?.version).toBe('1.0.5-beta.5')
+  })
+
+  it('accepts beta to same-version stable release as a legitimate channel convergence', () => {
+    // beta 测试完成，1.0.5 正式版发布；用户从 1.0.5-beta.5 升级到 1.0.5 应被允许
+    appGetVersionMock.mockReturnValue('1.0.5-beta.5')
+    const configPresenter = {
+      getUpdateChannel: vi.fn(() => 'stable'),
+      getPrivacyModeEnabled: vi.fn(() => false)
+    } as any
+
+    const presenter = new UpgradePresenter(configPresenter)
+    const handler = autoUpdaterState.listeners.get('update-available')
+    expect(handler).toBeDefined()
+
+    handler!({ version: '1.0.5', releaseDate: '2026-06-01', releaseNotes: '' })
+
+    expect((presenter as any)._status).toBe('available')
+    expect((presenter as any)._versionInfo?.version).toBe('1.0.5')
   })
 })


### PR DESCRIPTION
## Summary

close #1691。Canary 安装包启动后会被自动"更新"到旧的正式版本，且后续切回内测渠道会被误判为"自动更新失败"。

### 根因
1. `configPresenter` 默认 `updateChannel = 'stable'`，导致 Canary 安装包首启时也按 stable 拉 `latest.yml`。
2. `electron-updater` 在 channel 错配时拿到的可能是版本号低于当前 beta 的旧正式版，但 `update-available` 没有做版本号兜底，直接进入自动下载安装。
3. 上一步若已写入 `auto_update_marker.json`，下次启动 `checkPendingUpdate` 会把渠道错配的 stale marker 当作"上次更新失败"，把 `_previousUpdateFailed` 钉死，后续切到 beta 拿到正确版本也只能提示手动下载。

### 改动
- `configPresenter.getUpdateChannel()`：移除硬编码默认 `stable`，首次按当前安装包版本号是否含 `-alpha/-beta/-rc/-canary` 等后缀推断默认渠道。
- `upgradePresenter` `update-available`：加 semver 兜底，远端版本 `<=` 当前版本直接拒绝（覆盖 issue 描述的 Canary 被推送旧正式版场景）。**不**以"channel 是否同源"作为独立拒绝条件，避免误伤 "beta → 同版本号 stable 正式发布" 这类合法的渠道收敛升级。
- `upgradePresenter` `checkPendingUpdate`：marker 中目标版本若与当前安装包不属于同一渠道（beta vs stable），直接丢弃 marker 而不是钉死 `_previousUpdateFailed`。
- 单元测试：新增 3 个用例覆盖跨渠道降级被拒、同渠道升级被放行、beta→同版本号 stable 收敛升级被放行。

## Test plan
- [x] `pnpm exec vitest run test/main/presenter/upgradePresenter.test.ts` (7/7 passed)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run format`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented the app from offering older versions as updates through improved version comparison checks
  * Fixed prerelease version validation to prevent incorrect channel downgrades
  * Enhanced update channel detection to properly identify beta and stable releases based on your current version

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ThinkInAIXYZ/deepchat/pull/1698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->