### PR TITLE
fix(floating-button): persist resting position across restarts

### DIFF
--- a/docs/issues/floating-button-position-persistence/plan.md
+++ b/docs/issues/floating-button-position-persistence/plan.md
@@ -1,0 +1,73 @@
+# Plan — Floating Button Position Persistence
+
+## Approach
+
+Stop persisting live window bounds via `electron-window-state` for the floating button.
+Instead persist the **logical resting position** — the snapped, fully-on-screen docked
+rectangle plus its dock side — through `configPresenter` (electron-store), and restore it
+on window creation, re-clamped to the current display.
+
+The presenter already computes the correct resting rectangle on drag end
+(`snapWidgetBoundsToEdge` → `snapped`), which is fully visible and edge-docked. That is
+exactly the value we persist, so the off-screen-reset problem disappears.
+
+## Data Model
+
+New shared type (`src/shared/types/floating-widget.ts`):
+
+```ts
+export type FloatingWidgetDockSide = 'left' | 'right'
+
+export interface FloatingButtonBounds {
+  x: number
+  y: number
+  dockSide: FloatingWidgetDockSide
+}
+```
+
+Stored under config key `floatingButtonBounds`. `x` is stored for completeness; on restore
+`x` is recomputed from `dockSide` + current work area so the widget always docks to an edge
+even after a resolution change. The meaningful restored values are `y` + `dockSide`.
+
+## Components & Changes
+
+- `src/shared/types/floating-widget.ts`: add `FloatingWidgetDockSide`, `FloatingButtonBounds`.
+- `src/main/presenter/floatingButtonPresenter/layout.ts`: re-use shared `FloatingWidgetDockSide`
+  (single source of truth; existing imports keep working via re-export).
+- `src/main/presenter/configPresenter/index.ts`: add `getFloatingButtonBounds()` /
+  `setFloatingButtonBounds(bounds)` using the generic `getSetting`/`setSetting`.
+- `src/shared/types/presenters/legacy.presenters.d.ts`: declare both methods on `IConfigPresenter`.
+- `src/main/presenter/floatingButtonPresenter/FloatingButtonWindow.ts`:
+  - Remove `electron-window-state` usage.
+  - Accept persisted bounds via constructor (`persistedBounds: FloatingButtonBounds | null`).
+  - `resolveInitialBounds()` restores from persisted bounds: pick nearest display, re-dock
+    `x` from `dockSide`, clamp `y` into work area; fall back to default placement otherwise.
+  - Prefer persisted `dockSide` for the initial `dockSide`.
+- `src/main/presenter/floatingButtonPresenter/index.ts`:
+  - On `createFloatingWindow()` read `configPresenter.getFloatingButtonBounds()` and pass it in.
+  - On `DRAG_END`, after computing `snapped`, persist
+    `{ x: snapped.x, y: snapped.y, dockSide: snapped.dockSide }`.
+
+## Event Flow
+
+- Save: renderer drag → `DRAG_END` IPC → presenter snaps → `configPresenter.setFloatingButtonBounds`.
+- Restore: app start → `createFloatingWindow` → `getFloatingButtonBounds` → `new FloatingButtonWindow(config, bounds)`
+  → `resolveInitialBounds`.
+
+## Compatibility
+
+- Backward compatible: missing `floatingButtonBounds` → default placement (first run / upgrade).
+- The stale `floating-button-window-state.json` file is simply no longer read; no migration needed.
+
+## Test Strategy
+
+- Unit (presenter, `test/main/presenter/floatingButtonPresenter/index.test.ts`):
+  - Extend the mock `configPresenter` with `getFloatingButtonBounds`/`setFloatingButtonBounds`.
+  - Assert `setFloatingButtonBounds` is called with the snapped docked bounds + dock side on `DRAG_END`.
+  - Assert `getFloatingButtonBounds` is read during initialization.
+- Existing layout/drag tests must continue to pass unchanged.
+
+## Risks
+
+- Low. Pure main-process change behind an existing persistence mechanism. No renderer/IPC
+  surface change, no new dependency, no data migration.

--- a/docs/issues/floating-button-position-persistence/spec.md
+++ b/docs/issues/floating-button-position-persistence/spec.md
@@ -1,0 +1,56 @@
+# Floating Button Position Persistence
+
+## User Need
+
+Users drag the floating button/widget to a comfortable spot on screen. After
+restarting DeepChat, the button should reappear where they last left it. Today it
+jumps back to the top-left corner of the primary display on every restart, which
+feels broken.
+
+## Goal
+
+Persist the floating button's resting position (vertical offset + docked edge) and
+restore it on the next launch, re-clamped to the current display's work area.
+
+## Root Cause
+
+The floating button previously relied on `electron-window-state` (`windowState.manage`)
+to persist its position from live window bounds. This fails for an edge-docked widget:
+
+- When idle/collapsed the widget rests in a **peeked** position with half of itself
+  off the screen edge (`getPeekedCollapsedBounds`). `electron-window-state` records this
+  off-screen rectangle.
+- On the next launch `electron-window-state.validateState()` →
+  `ensureWindowVisibleOnSomeDisplay()` sees `x + width > display.right`, treats the saved
+  bounds as "not visible on any display", and **resets state to `{ x: 0, y: 0 }`**. The
+  widget therefore snaps to the top-left corner.
+- Secondary: the floating window is removed with `BrowserWindow.destroy()` (it is
+  `closable: false`), which emits `closed` but not `close`. `electron-window-state`'s
+  `closedHandler` cancels the pending debounced state update and writes stale state, so
+  the final position before quit is unreliable even when it is on-screen.
+
+## Acceptance Criteria
+
+- After dragging the floating button and restarting the app, the button reappears on the
+  same docked edge (left/right) and at the same vertical position (within work-area
+  clamping).
+- The restored position is always fully visible on a connected display; it never resets
+  to the top-left corner.
+- If the saved display/resolution changed, the button re-docks to the saved edge of the
+  nearest current display and the vertical offset is clamped into the visible work area.
+- First run (no saved position) keeps the existing default placement (bottom-right with
+  configured offset).
+- Existing drag, hover-peek, expand/collapse, and snapping behavior is unchanged.
+
+## Constraints
+
+- Persist via the existing `configPresenter` settings store (electron-store), consistent
+  with other persisted settings; do not add a new dependency.
+- Position persistence is a main-process concern only — no renderer route/IPC changes.
+- Keep the stored shape minimal and forward-compatible.
+
+## Non-goals
+
+- Remembering the expanded panel size (it is derived from session count).
+- Multi-monitor "remember which exact monitor" beyond nearest-display restoration.
+- Changing the visual peek/snap/dock behavior.

--- a/docs/issues/floating-button-position-persistence/tasks.md
+++ b/docs/issues/floating-button-position-persistence/tasks.md
@@ -1,0 +1,13 @@
+# Tasks — Floating Button Position Persistence
+
+1. [x] Add shared types `FloatingWidgetDockSide` + `FloatingButtonBounds`
+       (`src/shared/types/floating-widget.ts`); re-use them in `layout.ts`.
+2. [x] Add `getFloatingButtonBounds` / `setFloatingButtonBounds` to `configPresenter`
+       and declare them on `IConfigPresenter`.
+3. [x] `FloatingButtonWindow`: drop `electron-window-state`, accept persisted bounds,
+       restore in `resolveInitialBounds` with work-area clamping.
+4. [x] `FloatingButtonPresenter`: read persisted bounds on create and pass them in;
+       persist snapped bounds on `DRAG_END`.
+5. [x] Update `index.test.ts` mock config; add a persistence test for `DRAG_END`.
+6. [x] Quality gates: `pnpm run format`, `pnpm run i18n`, `pnpm run lint`,
+       `pnpm run typecheck`, `pnpm test` (floating button suites).

--- a/src/main/presenter/configPresenter/index.ts
+++ b/src/main/presenter/configPresenter/index.ts
@@ -85,6 +85,7 @@ import type {
   DeepChatAgentConfig,
   UpdateDeepChatAgentInput
 } from '@shared/types/agent-interface'
+import type { FloatingButtonBounds } from '@shared/types/floating-widget'
 import {
   createDefaultHooksNotificationsConfig,
   normalizeHooksNotificationsConfig
@@ -2120,6 +2121,25 @@ export class ConfigPresenter implements IConfigPresenter {
     } catch (error) {
       console.error('Failed to directly call floatingButtonPresenter:', error)
     }
+  }
+
+  // Get persisted floating button resting position (docked, fully on-screen)
+  getFloatingButtonBounds(): FloatingButtonBounds | null {
+    const value = this.getSetting<FloatingButtonBounds>('floatingButtonBounds')
+    if (
+      !value ||
+      typeof value.x !== 'number' ||
+      typeof value.y !== 'number' ||
+      (value.dockSide !== 'left' && value.dockSide !== 'right')
+    ) {
+      return null
+    }
+    return value
+  }
+
+  // Persist floating button resting position so it survives restarts
+  setFloatingButtonBounds(bounds: FloatingButtonBounds): void {
+    this.setSetting('floatingButtonBounds', bounds)
   }
 
   // ===================== MCP configuration related methods =====================

--- a/src/main/presenter/floatingButtonPresenter/FloatingButtonWindow.ts
+++ b/src/main/presenter/floatingButtonPresenter/FloatingButtonWindow.ts
@@ -9,17 +9,18 @@ import {
   type FloatingWidgetDockSide,
   type WidgetRect
 } from './layout'
-import windowStateManager from 'electron-window-state'
+import type { FloatingButtonBounds } from '@shared/types/floating-widget'
 
 export class FloatingButtonWindow {
   private window: BrowserWindow | null = null
   private config: FloatingButtonConfig
   private state: FloatingButtonState
-  private windowState: ReturnType<typeof windowStateManager>
+  private persistedBounds: FloatingButtonBounds | null
   private dockSide: FloatingWidgetDockSide
 
-  constructor(config: FloatingButtonConfig) {
+  constructor(config: FloatingButtonConfig, persistedBounds: FloatingButtonBounds | null = null) {
     this.config = config
+    this.persistedBounds = persistedBounds
     this.state = {
       isVisible: false,
       bounds: {
@@ -29,12 +30,8 @@ export class FloatingButtonWindow {
         height: FLOATING_WIDGET_LAYOUT.collapsedIdle.height
       }
     }
-    this.dockSide = config.position.endsWith('left') ? 'left' : 'right'
-    this.windowState = windowStateManager({
-      file: 'floating-button-window-state.json',
-      defaultWidth: FLOATING_WIDGET_LAYOUT.collapsedIdle.width,
-      defaultHeight: FLOATING_WIDGET_LAYOUT.collapsedIdle.height
-    })
+    this.dockSide =
+      persistedBounds?.dockSide ?? (config.position.endsWith('left') ? 'left' : 'right')
   }
 
   public async create(): Promise<void> {
@@ -79,7 +76,6 @@ export class FloatingButtonWindow {
         }
       })
 
-      this.windowState.manage(this.window)
       this.window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
       this.window.setAlwaysOnTop(this.config.alwaysOnTop, 'floating')
       this.window.setOpacity(1)
@@ -192,19 +188,38 @@ export class FloatingButtonWindow {
   }
 
   private resolveInitialBounds(): WidgetRect {
-    const defaultPosition = this.getDefaultPosition()
     const width = FLOATING_WIDGET_LAYOUT.collapsedIdle.width
     const height = FLOATING_WIDGET_LAYOUT.collapsedIdle.height
-    const initialX = typeof this.windowState.x === 'number' ? this.windowState.x : defaultPosition.x
-    const initialY = typeof this.windowState.y === 'number' ? this.windowState.y : defaultPosition.y
-    const targetDisplay = screen.getDisplayNearestPoint({ x: initialX, y: initialY })
-    const { workArea } = targetDisplay
-    const x = Math.max(workArea.x, Math.min(initialX, workArea.x + workArea.width - width))
-    const y = Math.max(workArea.y, Math.min(initialY, workArea.y + workArea.height - height))
+
+    // Restore the last persisted resting position when available.
+    if (this.persistedBounds) {
+      const { x: savedX, y: savedY, dockSide } = this.persistedBounds
+      const { workArea } = screen.getDisplayNearestPoint({ x: savedX, y: savedY })
+      // Re-dock horizontally so the widget stays edge-aligned across resolution changes,
+      // and clamp the saved vertical offset into the current work area.
+      const x = dockSide === 'left' ? workArea.x : workArea.x + workArea.width - width
+      const y = Math.max(workArea.y, Math.min(savedY, workArea.y + workArea.height - height))
+
+      return {
+        x: Math.round(x),
+        y: Math.round(y),
+        width,
+        height
+      }
+    }
+
+    // First run / no saved position: fall back to the configured default placement.
+    const defaultPosition = this.getDefaultPosition()
+    const { workArea } = screen.getDisplayNearestPoint(defaultPosition)
+    const x = Math.max(workArea.x, Math.min(defaultPosition.x, workArea.x + workArea.width - width))
+    const y = Math.max(
+      workArea.y,
+      Math.min(defaultPosition.y, workArea.y + workArea.height - height)
+    )
 
     return {
-      x,
-      y,
+      x: Math.round(x),
+      y: Math.round(y),
       width,
       height
     }

--- a/src/main/presenter/floatingButtonPresenter/index.ts
+++ b/src/main/presenter/floatingButtonPresenter/index.ts
@@ -6,6 +6,7 @@ import {
   getWidgetSizeForSnapshot,
   repositionWidgetForResize,
   snapWidgetBoundsToEdge,
+  type FloatingWidgetDockSide,
   type WidgetRect
 } from './layout'
 import type { FloatingWidgetSnapshot } from '@shared/types/floating-widget'
@@ -197,7 +198,8 @@ export class FloatingButtonPresenter {
     this.registerIpcHandlers()
 
     if (!this.floatingWindow) {
-      this.floatingWindow = new FloatingButtonWindow(this.config)
+      const persistedBounds = this.configPresenter.getFloatingButtonBounds()
+      this.floatingWindow = new FloatingButtonWindow(this.config, persistedBounds)
       await this.floatingWindow.create()
     }
 
@@ -349,6 +351,7 @@ export class FloatingButtonPresenter {
       const snapped = snapWidgetBoundsToEdge(stableBounds, currentDisplay.workArea)
       this.floatingWindow.setDockSide(snapped.dockSide)
       this.floatingWindow.setBounds(snapped)
+      this.persistFloatingBounds(snapped)
       this.isDragging = false
       dragState = null
       this.floatingWindow.setOpacity(this.resolveWindowOpacity())
@@ -509,6 +512,18 @@ export class FloatingButtonPresenter {
 
     this.pendingLayoutSync = false
     this.applyWindowLayout()
+  }
+
+  private persistFloatingBounds(snapped: WidgetRect & { dockSide: FloatingWidgetDockSide }): void {
+    try {
+      this.configPresenter.setFloatingButtonBounds({
+        x: snapped.x,
+        y: snapped.y,
+        dockSide: snapped.dockSide
+      })
+    } catch (error) {
+      console.error('Failed to persist floating button bounds:', error)
+    }
   }
 
   private getSnapshotBounds(bounds: WidgetRect): WidgetRect {

--- a/src/main/presenter/floatingButtonPresenter/layout.ts
+++ b/src/main/presenter/floatingButtonPresenter/layout.ts
@@ -1,12 +1,13 @@
 import type { Agent, SessionWithState } from '@shared/types/agent-interface'
 import type {
+  FloatingWidgetDockSide,
   FloatingWidgetSessionAgent,
   FloatingWidgetSessionItem,
   FloatingWidgetSessionStatus,
   FloatingWidgetSnapshot
 } from '@shared/types/floating-widget'
 
-export type FloatingWidgetDockSide = 'left' | 'right'
+export type { FloatingWidgetDockSide }
 
 export interface WidgetRect {
   x: number

--- a/src/shared/types/floating-widget.ts
+++ b/src/shared/types/floating-widget.ts
@@ -23,3 +23,19 @@ export interface FloatingWidgetSnapshot {
   activeCount: number
   sessions: FloatingWidgetSessionItem[]
 }
+
+/** Edge the floating widget is docked to. */
+export type FloatingWidgetDockSide = 'left' | 'right'
+
+/**
+ * Persisted resting position of the floating button.
+ *
+ * Stored via configPresenter so the widget reappears where the user last left it.
+ * `x` is recorded for completeness; on restore it is recomputed from `dockSide` and
+ * the current display work area so the widget always re-docks to an edge.
+ */
+export interface FloatingButtonBounds {
+  x: number
+  y: number
+  dockSide: FloatingWidgetDockSide
+}

--- a/src/shared/types/presenters/legacy.presenters.d.ts
+++ b/src/shared/types/presenters/legacy.presenters.d.ts
@@ -4,6 +4,7 @@ import { MessageFile } from './chat'
 import { ShowResponse } from 'ollama'
 import { ShortcutKeySetting } from '@/presenter/configPresenter/shortcutKeySettings'
 import type { NewApiEndpointType } from '@shared/model'
+import type { FloatingButtonBounds } from '@shared/types/floating-widget'
 import { ApiEndpointType, ModelType } from '@shared/model'
 import type { ImageGenerationOptions } from '../../imageGenerationSettings'
 import type { VideoGenerationOptions } from '../../videoGenerationSettings'
@@ -583,6 +584,8 @@ export interface IConfigPresenter {
   // Floating button settings
   getFloatingButtonEnabled(): boolean
   setFloatingButtonEnabled(enabled: boolean): void
+  getFloatingButtonBounds(): FloatingButtonBounds | null
+  setFloatingButtonBounds(bounds: FloatingButtonBounds): void
   // Update channel settings
   getUpdateChannel(): string
   setUpdateChannel(channel: string): void

--- a/test/main/presenter/floatingButtonPresenter/index.test.ts
+++ b/test/main/presenter/floatingButtonPresenter/index.test.ts
@@ -193,7 +193,9 @@ describe('FloatingButtonPresenter drag layout sync', () => {
     ({
       getFloatingButtonEnabled: vi.fn(() => true),
       getLanguage: vi.fn(() => 'zh-CN'),
-      getCurrentThemeIsDark: vi.fn(async () => false)
+      getCurrentThemeIsDark: vi.fn(async () => false),
+      getFloatingButtonBounds: vi.fn(() => null),
+      setFloatingButtonBounds: vi.fn()
     }) as any
 
   const emitEvent = async (channel: string, payload?: unknown) => {
@@ -273,6 +275,31 @@ describe('FloatingButtonPresenter drag layout sync', () => {
       height: getCollapsedWidgetSize(0).height
     })
     expect(floatingWindowState.opacity).toBe(0.5)
+  })
+
+  it('restores the persisted resting position on initialization', async () => {
+    const configPresenter = createConfigPresenter()
+    floatingPresenter = new FloatingButtonPresenter(configPresenter)
+    await floatingPresenter.initialize()
+
+    expect(configPresenter.getFloatingButtonBounds).toHaveBeenCalled()
+  })
+
+  it('persists the docked resting position after a drag ends', async () => {
+    const configPresenter = createConfigPresenter()
+    floatingPresenter = new FloatingButtonPresenter(configPresenter)
+    await floatingPresenter.initialize()
+
+    await emitEvent(FLOATING_BUTTON_EVENTS.DRAG_START, { x: 100, y: 100 })
+    await emitEvent(FLOATING_BUTTON_EVENTS.DRAG_MOVE, { x: 220, y: 150 })
+    await emitEvent(FLOATING_BUTTON_EVENTS.DRAG_END)
+
+    // Snapped/docked bounds (fully on-screen), not the peeked idle position.
+    expect(configPresenter.setFloatingButtonBounds).toHaveBeenCalledWith({
+      x: electronState.workArea.x + electronState.workArea.width - getCollapsedWidgetSize(0).width,
+      y: 230,
+      dockSide: 'right'
+    })
   })
 
   it('loads all regular sessions without restricting the agent id', async () => {


### PR DESCRIPTION
## 背景

Closes #1714

悬浮按钮被拖动后，**重启应用不会记住位置**，每次都跳回主屏幕左上角。

## 根因

悬浮按钮通过 `electron-window-state` 持久化位置，它跟踪**实时窗口边界**。但按钮空闲时停靠在 peeked（半隐藏）状态，一半在屏幕外：

- `electron-window-state` 记录了这个屏幕外矩形；
- 下次启动时 `ensureWindowVisibleOnSomeDisplay()` 判定坐标不可见，**重置为 `{0,0}`**，按钮跳到左上角；
- 次要：悬浮窗用 `destroy()`（非 `close()`）销毁，只触发 `closed`，退出前位置捕获不可靠。

## 方案

不再用 `electron-window-state` 跟踪悬浮按钮的实时边界，改为持久化**逻辑停靠位置**（吸附后、完全可见的坐标 + dock 方向），通过本项目惯用的 `configPresenter`（electron-store）存储：

- **保存**：拖拽结束（`DRAG_END`）吸附到边缘后，保存 `snapped` 的 `{ x, y, dockSide }`（始终在屏幕内）。
- **恢复**：创建窗口时读取持久化位置，按当前显示器工作区重新吸附到保存的边缘并夹取纵向偏移，分辨率/显示器变化也能稳健恢复。
- 首次运行（无记录）保持原有默认位置（右下角 + 偏移）。

纯主进程改动，不涉及 renderer / IPC 路由，无新增依赖，无数据迁移（旧的 `floating-button-window-state.json` 不再读取即可）。

## 行为对比（BEFORE / AFTER）

```
BEFORE — 拖到右侧中部后重启
┌────────────────────────────┐      ┌────────────────────────────┐
│ ▮ ← 重启后跳回左上角        │      │                            │
│                            │      │                          ▮ │ ← 拖到这里
│                            │  →   │                            │
│                            │      │                            │
└────────────────────────────┘      └────────────────────────────┘
        重启后                              退出前

AFTER — 位置被记住
┌────────────────────────────┐      ┌────────────────────────────┐
│                            │      │                            │
│                          ▮ │      │                          ▮ │ ← 拖到这里
│                            │  →   │                            │
│                            │      │                            │
└────────────────────────────┘      └────────────────────────────┘
        重启后（同一边缘/高度）            退出前
```

## 改动文件

- `src/shared/types/floating-widget.ts`：新增 `FloatingWidgetDockSide`、`FloatingButtonBounds` 类型。
- `src/main/presenter/floatingButtonPresenter/layout.ts`：复用共享 `FloatingWidgetDockSide`（单一来源）。
- `src/main/presenter/configPresenter/index.ts` + `IConfigPresenter`：新增 `getFloatingButtonBounds` / `setFloatingButtonBounds`。
- `src/main/presenter/floatingButtonPresenter/FloatingButtonWindow.ts`：移除 `electron-window-state`，接收并恢复持久化位置。
- `src/main/presenter/floatingButtonPresenter/index.ts`：创建时读取、拖拽结束时保存。
- `docs/issues/floating-button-position-persistence/`：SDD spec/plan/tasks。

## 测试

- 新增：`DRAG_END` 后持久化吸附位置、初始化时读取持久化位置。
- `pnpm vitest run test/main/presenter/floatingButtonPresenter` → 11/11 通过。
- `pnpm run typecheck`、`pnpm run lint`、`pnpm run format`、`pnpm run i18n` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Floating button now remembers and restores its position after app restart
  * Restored position automatically adjusts to ensure full visibility on screen
  * Button repositions intelligently when display configuration changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->