### PR TITLE
fix(sidebar): expand on collapsed agent click

### DIFF
--- a/docs/archives/sidebar-collapsed-agent-expand/plan.md
+++ b/docs/archives/sidebar-collapsed-agent-expand/plan.md
@@ -1,0 +1,36 @@
+# Plan
+
+## Implementation approach
+
+Update `WindowSideBar.vue` so the existing `handleAgentSelect` path expands the shared sidebar store when invoked from a collapsed state. Keep the current Agent switch queue, active-session close, and selected-Agent toggle behavior intact.
+
+## Affected interfaces
+
+- Renderer component: `src/renderer/src/components/WindowSideBar.vue`
+- Shared sidebar store API already has `setCollapsed(value: boolean)` and needs no interface changes.
+- Component tests: `test/renderer/components/WindowSideBar.test.ts`
+
+## Data flow
+
+1. User clicks All Agents or Agent button in the left rail.
+2. `handleAgentSelect(id)` runs.
+3. If `collapsed` is true, call `sidebarStore.setCollapsed(false)`.
+4. Continue the existing queued Agent selection pipeline:
+   - derive current/next Agent id;
+   - close active session if needed;
+   - set selected Agent if the request is still current.
+5. The now-visible session column renders sessions filtered by `sidebarSelectedAgentId`.
+
+## Compatibility
+
+- Existing expanded-sidebar behavior is unchanged because `setCollapsed(false)` is only called when the sidebar is collapsed.
+- Existing Agent toggle semantics remain unchanged.
+- No migration or persistence changes.
+
+## Test strategy
+
+- Add a component test that starts the sidebar in collapsed mode, clicks an Agent button, and verifies:
+  - `setCollapsed(false)` was called;
+  - the sidebar expands to the full width class;
+  - the existing Agent selection action still runs.
+- Run the targeted WindowSideBar test suite, then repository-required format/i18n/lint checks.

--- a/docs/archives/sidebar-collapsed-agent-expand/spec.md
+++ b/docs/archives/sidebar-collapsed-agent-expand/spec.md
@@ -1,0 +1,37 @@
+# Sidebar Collapsed Agent Expand
+
+## User need
+
+When the sidebar is collapsed, clicking the Agent rail should provide visible feedback and access to the selected Agent's conversation list. The current behavior only switches the selected Agent while the session column remains hidden, making the click feel ineffective.
+
+## Goal
+
+In the first phase, clicking either the All Agents button or a specific Agent button while the sidebar is collapsed expands the sidebar and keeps the existing Agent selection behavior.
+
+## Acceptance criteria
+
+- When the sidebar is collapsed, clicking All Agents expands the sidebar.
+- When the sidebar is collapsed, clicking any Agent expands the sidebar.
+- Existing Agent selection semantics remain unchanged:
+  - selecting a different Agent closes the active session first and then selects that Agent;
+  - clicking the currently selected Agent toggles back to All Agents;
+  - expanded-sidebar Agent clicks behave the same as before.
+- Existing collapse/expand toggle button behavior remains unchanged.
+- Component coverage verifies the collapsed Agent click path.
+
+## Constraints
+
+- Keep the change renderer-local and focused on `WindowSideBar`.
+- Do not introduce a quick-list popover in this phase.
+- Avoid new user-facing strings unless required.
+- Preserve current session switching order and error handling.
+
+## Non-goals
+
+- Implementing a compact Agent quick list.
+- Redesigning sidebar layout or width.
+- Changing Agent/session data models or persistence.
+
+## Open questions
+
+None.

--- a/docs/archives/sidebar-collapsed-agent-expand/tasks.md
+++ b/docs/archives/sidebar-collapsed-agent-expand/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] Create SDD artifacts for the collapsed Agent click behavior.
+- [x] Expand the sidebar from `handleAgentSelect` when collapsed.
+- [x] Add component coverage for clicking an Agent while collapsed.
+- [x] Run targeted tests.
+- [x] Run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint`.

--- a/src/renderer/src/components/WindowSideBar.vue
+++ b/src/renderer/src/components/WindowSideBar.vue
@@ -738,6 +738,10 @@ const handleNewChat = () => {
 }
 
 const handleAgentSelect = async (id: string | null) => {
+  if (collapsed.value) {
+    sidebarStore.setCollapsed(false)
+  }
+
   const requestSeq = ++agentSwitchSeq
 
   agentSwitchQueue = agentSwitchQueue

--- a/test/renderer/components/WindowSideBar.test.ts
+++ b/test/renderer/components/WindowSideBar.test.ts
@@ -19,6 +19,7 @@ type SetupOptions = {
     enabled: boolean
     state: 'disabled' | 'stopped' | 'starting' | 'running' | 'backoff' | 'error'
   }
+  collapsed?: boolean
 }
 
 const TEST_TIMEOUT_MS = 20000
@@ -99,7 +100,7 @@ const setup = async (options: SetupOptions = {}) => {
     isDark: false
   })
   const sidebarStore = reactive({
-    collapsed: false,
+    collapsed: options.collapsed ?? false,
     toggleSidebar: vi.fn(() => {
       sidebarStore.collapsed = !sidebarStore.collapsed
     }),
@@ -310,6 +311,36 @@ describe('WindowSideBar agent switch', () => {
       await (wrapper.vm as any).handleAgentSelect('acp-a')
 
       expect(sessionStore.closeSession).toHaveBeenCalledTimes(1)
+      expect(agentStore.setSelectedAgent).toHaveBeenCalledWith('acp-a')
+      expect(operations).toEqual(['close', 'set:acp-a'])
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'expands the collapsed sidebar before applying selected agent',
+    async () => {
+      const { wrapper, operations, agentStore, sidebarStore } = await setup({
+        collapsed: true,
+        activeSession: {
+          id: 'session-deepchat',
+          agentId: 'deepchat'
+        },
+        enabledAgents: [
+          { id: 'deepchat', name: 'DeepChat', type: 'deepchat', enabled: true },
+          { id: 'acp-a', name: 'ACP A', type: 'acp', enabled: true }
+        ]
+      })
+
+      expect(wrapper.get('[data-testid="window-sidebar"]').classes()).toContain('w-12')
+
+      await wrapper
+        .get('[data-testid="sidebar-agent-button"][data-agent-id="acp-a"]')
+        .trigger('click')
+      await flushPromises()
+
+      expect(sidebarStore.setCollapsed).toHaveBeenCalledWith(false)
+      expect(wrapper.get('[data-testid="window-sidebar"]').classes()).toContain('w-[288px]')
       expect(agentStore.setSelectedAgent).toHaveBeenCalledWith('acp-a')
       expect(operations).toEqual(['close', 'set:acp-a'])
     },


### PR DESCRIPTION
## Summary
- Expand the sidebar when clicking All Agents or an Agent while collapsed.
- Preserve existing Agent switch behavior and active-session close flow.
- Add renderer component coverage for the collapsed Agent click path.
- Archive the completed SDD artifacts for this change.

Closes #1716

## UI Layout

BEFORE:
```text
Collapsed sidebar
┌────┐
│Agent icons only│  click switches Agent but session list stays hidden
└────┘
```

AFTER:
```text
Collapsed sidebar
┌────┐
│Agent icons│  click Agent
└────┘
   ↓
Expanded sidebar
┌────┬────────────────────┐
│Agent│ filtered sessions │
└────┴────────────────────┘
```

## Tests

- pnpm vitest run test/renderer/components/WindowSideBar.test.ts
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pre-commit typecheck hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The sidebar now automatically expands when you select an agent while it is in a collapsed state, improving workflow efficiency.

* **Tests**
  * Added test coverage for the sidebar expansion behavior when selecting agents from a collapsed state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->