### PR TITLE
fix: fix plan model style

### DIFF
--- a/src/renderer/src/pages/ChatPage.vue
+++ b/src/renderer/src/pages/ChatPage.vue
@@ -59,7 +59,7 @@
         class="chat-capture-hide sticky bottom-0 z-10 w-full px-6 pb-3 pt-3"
       >
         <div class="mx-auto flex w-full max-w-5xl min-w-0 flex-col items-center">
-          <div class="w-full">
+          <div class="relative w-full">
             <PendingInputLane
               :steer-items="pendingInputStore.steerItems"
               :queue-items="pendingInputStore.queueItems"
@@ -71,7 +71,9 @@
               @delete-queue="onPendingInputDelete"
               @resume-queue="onResumePendingQueue"
             />
-            <div class="relative">
+            <!-- Anchor the plan/question float to the outer .relative (which includes the queue lane)
+                 so bottom:calc(100%+0.75rem) lifts it above PendingInputLane instead of covering it. -->
+            <div>
               <div
                 v-if="latestPlanSnapshot || activePendingInteraction"
                 ref="planFloatLayer"


### PR DESCRIPTION
before: 
<img width="1720" height="446" alt="8d69066d-4749-4ace-9d09-b2fc95393c34" src="https://github.com/user-attachments/assets/8cb62cf2-fd1d-4c4c-b78c-b035ad60275b" />

after:
<img width="1508" height="634" alt="5fbd420e-128e-435b-aa15-111f8a28011f" src="https://github.com/user-attachments/assets/5d2306d8-74ff-43f1-a1cd-e70cfe8f0365" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed positioning of the floating plan/question layer to prevent it from covering the queue lane in the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->