### PR TITLE
feat(workspace): collapsible file tree sidebar

### DIFF
--- a/src/renderer/src/components/sidepanel/WorkspacePanel.vue
+++ b/src/renderer/src/components/sidepanel/WorkspacePanel.vue
@@ -1,133 +1,174 @@
 <template>
   <div class="flex h-full min-h-0 min-w-0 flex-1 overflow-hidden">
-    <aside class="flex h-full min-h-0 w-[224px] shrink-0 flex-col border-r bg-muted/20">
-      <div class="flex-1 overflow-auto py-2">
-        <section>
-          <button
-            class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium"
-            type="button"
-            @click="sidepanelStore.toggleSection(props.sessionId, 'files')"
-          >
-            <Icon icon="lucide:folder-tree" class="h-3.5 w-3.5 text-muted-foreground" />
-            <span class="flex-1 truncate">{{ t('chat.workspace.sections.files') }}</span>
-            <Icon
-              :icon="sessionState.sections.files ? 'lucide:chevron-down' : 'lucide:chevron-right'"
-              class="h-3.5 w-3.5 text-muted-foreground"
-            />
-          </button>
-          <div v-if="sessionState.sections.files" class="pb-2">
-            <div
-              v-if="!props.workspacePath"
-              class="mx-2 rounded-lg border border-dashed border-muted-foreground/30 px-3 py-4 text-center"
-              :class="{ 'border-primary bg-primary/5': isDragging }"
-              @dragenter.prevent="isDragging = true"
-              @dragover.prevent="handleDragOver"
-              @dragleave="handleDragLeave"
-              @drop.prevent="handleDrop"
-            >
-              <Icon icon="lucide:folder-plus" class="mx-auto mb-2 h-6 w-6 text-muted-foreground" />
-              <p class="mb-2 text-xs font-medium text-foreground">
-                {{ t('chat.workspace.files.noWorkspace.title') }}
-              </p>
-              <p class="mb-3 text-[11px] text-muted-foreground">
-                {{ t('chat.workspace.files.noWorkspace.description') }}
-              </p>
-              <Button variant="outline" size="sm" class="h-7 text-xs" @click="selectFolder">
-                <Icon icon="lucide:folder-open" class="mr-1.5 h-3.5 w-3.5" />
-                {{ t('chat.workspace.files.noWorkspace.button') }}
-              </Button>
-            </div>
-            <div v-else-if="loadingFiles" class="px-3 py-2 text-[11px] text-muted-foreground/70">
-              {{ t('chat.workspace.files.loading') }}
-            </div>
-            <WorkspaceFileNode
-              v-for="node in fileTree"
-              :key="node.path"
-              :node="node"
-              :depth="0"
-              @toggle="toggleNode"
-              @append-path="handleFileSelect"
-              @insert-path="handleInsertFileReference"
-            />
-          </div>
-        </section>
-
-        <section v-if="gitState">
-          <button
-            class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium"
-            type="button"
-            @click="sidepanelStore.toggleSection(props.sessionId, 'git')"
-          >
-            <Icon icon="lucide:git-branch" class="h-3.5 w-3.5 text-muted-foreground" />
-            <span class="flex-1 truncate">{{ t('chat.workspace.sections.git') }}</span>
-            <span class="text-[11px] text-muted-foreground">{{ gitState.changes.length }}</span>
-            <Icon
-              :icon="sessionState.sections.git ? 'lucide:chevron-down' : 'lucide:chevron-right'"
-              class="h-3.5 w-3.5 text-muted-foreground"
-            />
-          </button>
-          <div v-if="sessionState.sections.git" class="pb-2">
+    <aside
+      class="workspace-nav relative flex h-full min-h-0 shrink-0 flex-col overflow-hidden border-r bg-muted/20"
+      :class="{ 'workspace-nav--resizing': isNavResizing }"
+      :style="navStyle"
+    >
+      <div class="flex h-full min-h-0 shrink-0 flex-col" :style="{ width: expandedNavWidth }">
+        <button
+          class="flex w-full shrink-0 items-center gap-2 px-3 py-2 text-muted-foreground transition-colors hover:text-foreground"
+          type="button"
+          :title="navCollapsed ? t('chat.workspace.expand') : t('chat.workspace.collapse')"
+          @click="sidepanelStore.toggleNavCollapsed()"
+        >
+          <Icon
+            :icon="navCollapsed ? 'lucide:panel-left-open' : 'lucide:panel-left-close'"
+            class="h-3.5 w-3.5 shrink-0"
+          />
+        </button>
+        <div class="min-h-0 flex-1 overflow-auto pb-2">
+          <section>
             <button
-              v-for="change in gitState.changes"
-              :key="change.path"
-              class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors"
-              :class="
-                sessionState.selectedDiffPath === change.path
-                  ? 'bg-accent text-accent-foreground'
-                  : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
-              "
+              class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium"
               type="button"
-              @click="handleDiffSelect(change.path)"
+              @click="handleSectionClick('files')"
             >
-              <span class="w-4 shrink-0 text-center font-mono text-[11px]">
-                {{ formatGitFlag(change) }}
-              </span>
-              <span class="min-w-0 flex-1 truncate">{{ change.relativePath }}</span>
+              <Icon icon="lucide:folder-tree" class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span v-show="!navCollapsed" class="flex-1 truncate">{{
+                t('chat.workspace.sections.files')
+              }}</span>
+              <Icon
+                v-show="!navCollapsed"
+                :icon="sessionState.sections.files ? 'lucide:chevron-down' : 'lucide:chevron-right'"
+                class="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+              />
             </button>
-            <div
-              v-if="gitState.changes.length === 0"
-              class="px-3 py-2 text-[11px] text-muted-foreground/70"
-            >
-              {{ t('chat.workspace.git.clean') }}
+            <div v-if="!navCollapsed && sessionState.sections.files" class="pb-2">
+              <div
+                v-if="!props.workspacePath"
+                class="mx-2 rounded-lg border border-dashed border-muted-foreground/30 px-3 py-4 text-center"
+                :class="{ 'border-primary bg-primary/5': isDragging }"
+                @dragenter.prevent="isDragging = true"
+                @dragover.prevent="handleDragOver"
+                @dragleave="handleDragLeave"
+                @drop.prevent="handleDrop"
+              >
+                <Icon
+                  icon="lucide:folder-plus"
+                  class="mx-auto mb-2 h-6 w-6 text-muted-foreground"
+                />
+                <p class="mb-2 text-xs font-medium text-foreground">
+                  {{ t('chat.workspace.files.noWorkspace.title') }}
+                </p>
+                <p class="mb-3 text-[11px] text-muted-foreground">
+                  {{ t('chat.workspace.files.noWorkspace.description') }}
+                </p>
+                <Button variant="outline" size="sm" class="h-7 text-xs" @click="selectFolder">
+                  <Icon icon="lucide:folder-open" class="mr-1.5 h-3.5 w-3.5" />
+                  {{ t('chat.workspace.files.noWorkspace.button') }}
+                </Button>
+              </div>
+              <div v-else-if="loadingFiles" class="px-3 py-2 text-[11px] text-muted-foreground/70">
+                {{ t('chat.workspace.files.loading') }}
+              </div>
+              <WorkspaceFileNode
+                v-for="node in fileTree"
+                :key="node.path"
+                :node="node"
+                :depth="0"
+                @toggle="toggleNode"
+                @append-path="handleFileSelect"
+                @insert-path="handleInsertFileReference"
+              />
             </div>
-          </div>
-        </section>
+          </section>
 
-        <section v-if="artifactItems.length > 0">
-          <button
-            class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium"
-            type="button"
-            @click="sidepanelStore.toggleSection(props.sessionId, 'artifacts')"
-          >
-            <Icon icon="lucide:box" class="h-3.5 w-3.5 text-muted-foreground" />
-            <span class="flex-1 truncate">{{ t('chat.workspace.sections.artifacts') }}</span>
-            <span class="text-[11px] text-muted-foreground">{{ artifactItems.length }}</span>
-            <Icon
-              :icon="
-                sessionState.sections.artifacts ? 'lucide:chevron-down' : 'lucide:chevron-right'
-              "
-              class="h-3.5 w-3.5 text-muted-foreground"
-            />
-          </button>
-          <div v-if="sessionState.sections.artifacts" class="pb-2">
+          <section v-if="gitState">
             <button
-              v-for="item in artifactItems"
-              :key="item.key"
-              class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors"
-              :class="
-                isArtifactSelected(item)
-                  ? 'bg-accent text-accent-foreground'
-                  : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
-              "
+              class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium"
               type="button"
-              @click="handleArtifactSelect(item)"
+              @click="handleSectionClick('git')"
             >
-              <Icon :icon="getArtifactIcon(item.type)" class="h-3.5 w-3.5 shrink-0" />
-              <span class="min-w-0 flex-1 truncate">{{ item.title || item.identifier }}</span>
+              <Icon icon="lucide:git-branch" class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span v-show="!navCollapsed" class="flex-1 truncate">{{
+                t('chat.workspace.sections.git')
+              }}</span>
+              <span v-show="!navCollapsed" class="text-[11px] text-muted-foreground">{{
+                gitState.changes.length
+              }}</span>
+              <Icon
+                v-show="!navCollapsed"
+                :icon="sessionState.sections.git ? 'lucide:chevron-down' : 'lucide:chevron-right'"
+                class="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+              />
             </button>
-          </div>
-        </section>
+            <div v-if="!navCollapsed && sessionState.sections.git" class="pb-2">
+              <button
+                v-for="change in gitState.changes"
+                :key="change.path"
+                class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors"
+                :class="
+                  sessionState.selectedDiffPath === change.path
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
+                "
+                type="button"
+                @click="handleDiffSelect(change.path)"
+              >
+                <span class="w-4 shrink-0 text-center font-mono text-[11px]">
+                  {{ formatGitFlag(change) }}
+                </span>
+                <span class="min-w-0 flex-1 truncate">{{ change.relativePath }}</span>
+              </button>
+              <div
+                v-if="gitState.changes.length === 0"
+                class="px-3 py-2 text-[11px] text-muted-foreground/70"
+              >
+                {{ t('chat.workspace.git.clean') }}
+              </div>
+            </div>
+          </section>
+
+          <section v-if="artifactItems.length > 0">
+            <button
+              class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium"
+              type="button"
+              @click="handleSectionClick('artifacts')"
+            >
+              <Icon icon="lucide:box" class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span v-show="!navCollapsed" class="flex-1 truncate">{{
+                t('chat.workspace.sections.artifacts')
+              }}</span>
+              <span v-show="!navCollapsed" class="text-[11px] text-muted-foreground">{{
+                artifactItems.length
+              }}</span>
+              <Icon
+                v-show="!navCollapsed"
+                :icon="
+                  sessionState.sections.artifacts ? 'lucide:chevron-down' : 'lucide:chevron-right'
+                "
+                class="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+              />
+            </button>
+            <div v-if="!navCollapsed && sessionState.sections.artifacts" class="pb-2">
+              <button
+                v-for="item in artifactItems"
+                :key="item.key"
+                class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors"
+                :class="
+                  isArtifactSelected(item)
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
+                "
+                type="button"
+                @click="handleArtifactSelect(item)"
+              >
+                <Icon :icon="getArtifactIcon(item.type)" class="h-3.5 w-3.5 shrink-0" />
+                <span class="min-w-0 flex-1 truncate">{{ item.title || item.identifier }}</span>
+              </button>
+            </div>
+          </section>
+        </div>
       </div>
+
+      <button
+        v-if="!navCollapsed"
+        data-testid="workspace-nav-resize-handle"
+        class="absolute inset-y-0 right-0 z-10 w-1.5 cursor-col-resize"
+        type="button"
+        @mousedown="startNavResize"
+      ></button>
     </aside>
 
     <WorkspaceViewer
@@ -144,7 +185,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, toRef, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, toRef, watch } from 'vue'
 import { Icon } from '@iconify/vue'
 import { Button } from '@shadcn/components/ui/button'
 import { useI18n } from 'vue-i18n'
@@ -159,7 +200,7 @@ import { useArtifactStore } from '@/stores/artifact'
 import { useMessageStore } from '@/stores/ui/message'
 import { useSidepanelStore, type WorkspaceArtifactContext } from '@/stores/ui/sidepanel'
 import { useSessionStore } from '@/stores/ui/session'
-import type { WorkspaceGitFileChange } from '@shared/presenter'
+import type { WorkspaceGitFileChange, WorkspaceNavSection } from '@shared/presenter'
 
 const props = defineProps<{
   sessionId: string
@@ -303,6 +344,91 @@ watch(
   },
   { immediate: true }
 )
+
+// px-3 (12) + icon (14) + px-3 (12) so the leading icons sit centered in the collapsed rail
+const NAV_COLLAPSED_WIDTH = 38
+
+const navCollapsed = computed(() => sidepanelStore.navCollapsed)
+const isNavResizing = ref(false)
+
+const expandedNavWidth = computed(() => `${sidepanelStore.navWidth}px`)
+
+const navStyle = computed(() => ({
+  width: navCollapsed.value ? `${NAV_COLLAPSED_WIDTH}px` : expandedNavWidth.value
+}))
+
+const expandNavToSection = (section: WorkspaceNavSection) => {
+  sidepanelStore.setNavCollapsed(false)
+  const state = sidepanelStore.ensureSessionState(props.sessionId)
+  state.sections[section] = true
+}
+
+const handleSectionClick = (section: WorkspaceNavSection) => {
+  if (navCollapsed.value) {
+    expandNavToSection(section)
+    return
+  }
+  sidepanelStore.toggleSection(props.sessionId, section)
+}
+
+let navResizeCleanup: (() => void) | null = null
+let pendingNavWidth: number | null = null
+let navResizeFrame: number | null = null
+
+const applyPendingNavResize = () => {
+  navResizeFrame = null
+  if (pendingNavWidth === null) {
+    return
+  }
+  sidepanelStore.setNavWidth(pendingNavWidth)
+  pendingNavWidth = null
+}
+
+const stopNavResize = () => {
+  navResizeCleanup?.()
+  navResizeCleanup = null
+  if (navResizeFrame !== null) {
+    window.cancelAnimationFrame(navResizeFrame)
+    navResizeFrame = null
+  }
+  if (pendingNavWidth !== null) {
+    sidepanelStore.setNavWidth(pendingNavWidth)
+    pendingNavWidth = null
+  }
+}
+
+const startNavResize = (event: MouseEvent) => {
+  event.preventDefault()
+  stopNavResize()
+  isNavResizing.value = true
+
+  const startX = event.clientX
+  const startWidth = sidepanelStore.navWidth
+
+  const onMouseMove = (moveEvent: MouseEvent) => {
+    pendingNavWidth = startWidth + (moveEvent.clientX - startX)
+    if (navResizeFrame === null) {
+      navResizeFrame = window.requestAnimationFrame(applyPendingNavResize)
+    }
+  }
+
+  const onMouseUp = () => {
+    isNavResizing.value = false
+    stopNavResize()
+  }
+
+  window.addEventListener('mousemove', onMouseMove, { passive: true })
+  window.addEventListener('mouseup', onMouseUp, { once: true })
+  navResizeCleanup = () => {
+    window.removeEventListener('mousemove', onMouseMove)
+    window.removeEventListener('mouseup', onMouseUp)
+    isNavResizing.value = false
+  }
+}
+
+onBeforeUnmount(() => {
+  stopNavResize()
+})
 
 const handleFileSelect = (filePath: string) => {
   sidepanelStore.selectFile(props.sessionId, filePath, {
@@ -488,3 +614,22 @@ function getDroppedFilePath(file: File): string | null {
   return legacyPath || null
 }
 </script>
+
+<style scoped>
+.workspace-nav {
+  transition-duration: var(--dc-motion-default);
+  transition-property: width;
+  transition-timing-function: var(--dc-ease-out-express);
+  will-change: width;
+}
+
+.workspace-nav--resizing {
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-nav {
+    transition: none;
+  }
+}
+</style>

--- a/src/renderer/src/i18n/da-DK/chat.json
+++ b/src/renderer/src/i18n/da-DK/chat.json
@@ -190,6 +190,7 @@
   },
   "workspace": {
     "collapse": "tæt",
+    "expand": "Udvid",
     "sections": {
       "files": "Filer",
       "git": "Git",

--- a/src/renderer/src/i18n/de-DE/chat.json
+++ b/src/renderer/src/i18n/de-DE/chat.json
@@ -228,6 +228,7 @@
   "workspace": {
     "title": "Arbeitsbereich",
     "collapse": "Einklappen",
+    "expand": "Erweitern",
     "sections": {
       "files": "Dateien",
       "git": "Git",

--- a/src/renderer/src/i18n/en-US/chat.json
+++ b/src/renderer/src/i18n/en-US/chat.json
@@ -247,6 +247,7 @@
   "workspace": {
     "title": "Workspace",
     "collapse": "Collapse",
+    "expand": "Expand",
     "sections": {
       "files": "Files",
       "git": "Git",

--- a/src/renderer/src/i18n/es-ES/chat.json
+++ b/src/renderer/src/i18n/es-ES/chat.json
@@ -228,6 +228,7 @@
   "workspace": {
     "title": "Espacio de trabajo",
     "collapse": "Contraer",
+    "expand": "Expandir",
     "sections": {
       "files": "Archivos",
       "git": "Git",

--- a/src/renderer/src/i18n/fa-IR/chat.json
+++ b/src/renderer/src/i18n/fa-IR/chat.json
@@ -190,6 +190,7 @@
   },
   "workspace": {
     "collapse": "بستن",
+    "expand": "گسترش",
     "sections": {
       "files": "فایل‌ها",
       "git": "Git",

--- a/src/renderer/src/i18n/fr-FR/chat.json
+++ b/src/renderer/src/i18n/fr-FR/chat.json
@@ -190,6 +190,7 @@
   },
   "workspace": {
     "collapse": "fermer",
+    "expand": "Développer",
     "sections": {
       "files": "Fichiers",
       "git": "Git",

--- a/src/renderer/src/i18n/he-IL/chat.json
+++ b/src/renderer/src/i18n/he-IL/chat.json
@@ -190,6 +190,7 @@
   },
   "workspace": {
     "collapse": "לִסְגוֹר",
+    "expand": "הרחב",
     "sections": {
       "files": "קבצים",
       "git": "Git",

--- a/src/renderer/src/i18n/id-ID/chat.json
+++ b/src/renderer/src/i18n/id-ID/chat.json
@@ -228,6 +228,7 @@
   "workspace": {
     "title": "ruang kerja",
     "collapse": "dekat",
+    "expand": "Perluas",
     "sections": {
       "files": "Mengajukan",
       "git": "Git",

--- a/src/renderer/src/i18n/it-IT/chat.json
+++ b/src/renderer/src/i18n/it-IT/chat.json
@@ -228,6 +228,7 @@
   "workspace": {
     "title": "Workspace",
     "collapse": "Comprimi",
+    "expand": "Espandi",
     "sections": {
       "files": "File",
       "git": "Git",

--- a/src/renderer/src/i18n/ja-JP/chat.json
+++ b/src/renderer/src/i18n/ja-JP/chat.json
@@ -190,6 +190,7 @@
   },
   "workspace": {
     "collapse": "近い",
+    "expand": "展開",
     "sections": {
       "files": "ファイル",
       "git": "Git",

--- a/src/renderer/src/i18n/ko-KR/chat.json
+++ b/src/renderer/src/i18n/ko-KR/chat.json
@@ -190,6 +190,7 @@
   },
   "workspace": {
     "collapse": "닫다",
+    "expand": "펼치기",
     "sections": {
       "files": "파일",
       "git": "Git",

--- a/src/renderer/src/i18n/ms-MY/chat.json
+++ b/src/renderer/src/i18n/ms-MY/chat.json
@@ -228,6 +228,7 @@
   "workspace": {
     "title": "ruang kerja",
     "collapse": "dekat",
+    "expand": "Kembangkan",
     "sections": {
       "files": "dokumen",
       "git": "Git",

--- a/src/renderer/src/i18n/pl-PL/chat.json
+++ b/src/renderer/src/i18n/pl-PL/chat.json
@@ -228,6 +228,7 @@
   "workspace": {
     "title": "Obszar roboczy",
     "collapse": "Zwiń",
+    "expand": "Rozwiń",
     "sections": {
       "files": "Pliki",
       "git": "Git",

--- a/src/renderer/src/i18n/pt-BR/chat.json
+++ b/src/renderer/src/i18n/pt-BR/chat.json
@@ -190,6 +190,7 @@
   },
   "workspace": {
     "collapse": "fechar",
+    "expand": "Expandir",
     "sections": {
       "files": "Arquivos",
       "git": "Git",

--- a/src/renderer/src/i18n/ru-RU/chat.json
+++ b/src/renderer/src/i18n/ru-RU/chat.json
@@ -190,6 +190,7 @@
   },
   "workspace": {
     "collapse": "закрывать",
+    "expand": "Развернуть",
     "sections": {
       "files": "Файлы",
       "git": "Git",

--- a/src/renderer/src/i18n/tr-TR/chat.json
+++ b/src/renderer/src/i18n/tr-TR/chat.json
@@ -228,6 +228,7 @@
   "workspace": {
     "title": "Çalışma alanı",
     "collapse": "Yıkılmak",
+    "expand": "Genişlet",
     "sections": {
       "files": "Dosyalar",
       "git": "Git",

--- a/src/renderer/src/i18n/vi-VN/chat.json
+++ b/src/renderer/src/i18n/vi-VN/chat.json
@@ -228,6 +228,7 @@
   "workspace": {
     "title": "Không gian làm việc",
     "collapse": "Thu gọn",
+    "expand": "Mở rộng",
     "sections": {
       "files": "Tập tin",
       "git": "Git",

--- a/src/renderer/src/i18n/zh-CN/chat.json
+++ b/src/renderer/src/i18n/zh-CN/chat.json
@@ -247,6 +247,7 @@
   "workspace": {
     "title": "工作区",
     "collapse": "收起",
+    "expand": "展开",
     "sections": {
       "files": "文件",
       "git": "Git",

--- a/src/renderer/src/i18n/zh-HK/chat.json
+++ b/src/renderer/src/i18n/zh-HK/chat.json
@@ -198,6 +198,7 @@
   },
   "workspace": {
     "collapse": "收起",
+    "expand": "展開",
     "sections": {
       "files": "文件",
       "git": "Git",

--- a/src/renderer/src/i18n/zh-TW/chat.json
+++ b/src/renderer/src/i18n/zh-TW/chat.json
@@ -198,6 +198,7 @@
   },
   "workspace": {
     "collapse": "收起",
+    "expand": "展開",
     "sections": {
       "files": "檔案",
       "git": "Git",

--- a/src/renderer/src/stores/ui/sidepanel.ts
+++ b/src/renderer/src/stores/ui/sidepanel.ts
@@ -56,6 +56,35 @@ export const useSidepanelStore = defineStore('sidepanel', () => {
     return clampWidth(Number(width.value))
   })
 
+  const NAV_MIN_WIDTH = 160
+  const NAV_MAX_WIDTH = 360
+  const NAV_DEFAULT_WIDTH = 200
+
+  const clampNavWidth = (nextWidth: number) => {
+    const widthValue = Number(nextWidth)
+    if (!Number.isFinite(widthValue)) {
+      return NAV_DEFAULT_WIDTH
+    }
+    return Math.min(NAV_MAX_WIDTH, Math.max(NAV_MIN_WIDTH, Math.round(widthValue)))
+  }
+
+  const navCollapsed = useStorage('workspace-nav-collapsed', false)
+  const navWidthStorage = useStorage('workspace-nav-width', NAV_DEFAULT_WIDTH)
+
+  const navWidth = computed(() => clampNavWidth(Number(navWidthStorage.value)))
+
+  const setNavWidth = (nextWidth: number) => {
+    navWidthStorage.value = clampNavWidth(nextWidth)
+  }
+
+  const setNavCollapsed = (collapsed: boolean) => {
+    navCollapsed.value = collapsed
+  }
+
+  const toggleNavCollapsed = () => {
+    navCollapsed.value = !navCollapsed.value
+  }
+
   if (typeof window !== 'undefined') {
     const handleResize = () => {
       viewportWidth.value = window.innerWidth
@@ -195,6 +224,11 @@ export const useSidepanelStore = defineStore('sidepanel', () => {
     open,
     activeTab,
     width: normalizedWidth,
+    navCollapsed,
+    navWidth,
+    setNavWidth,
+    setNavCollapsed,
+    toggleNavCollapsed,
     sessionStates,
     ensureSessionState,
     getSessionState,


### PR DESCRIPTION

https://github.com/user-attachments/assets/9d311126-7833-426f-903c-4d030997d1ce



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace navigation sidebar now supports a collapsible layout with a resizable width adjustment via mouse drag
  * Navigation collapse/expand state is persisted across sessions
  * Added "Expand" workspace button label translations across all supported languages (16+ locales)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->