### PR TITLE
fix(renderer): use capabilities for temperature UI

### DIFF
--- a/docs/issues/remove-gpt5-temperature-hardcode/plan.md
+++ b/docs/issues/remove-gpt5-temperature-hardcode/plan.md
@@ -1,0 +1,19 @@
+# Remove GPT-5 Temperature Hardcode Plan
+
+## Implementation
+
+- Extend `useModelCapabilities` to expose `supportsTemperatureControl`, using
+  `supportsTemperatureControl` first and `temperatureCapability` as the fallback.
+- Remove `isGPT5Model` from `useModelTypeDetection` and stop passing it through `ChatConfig`.
+- Update `useChatConfigFields` to show temperature unless `supportsTemperatureControl` is exactly
+  `false`.
+
+## Test Strategy
+
+- Update model type detection tests to cover only type and provider detection plus reasoning loading.
+- Add focused `useChatConfigFields` tests for unsupported, supported, and unknown temperature
+  capability states.
+
+## Compatibility
+
+- Capability `null` preserves the previous default-visible behavior for unknown and custom models.

--- a/docs/issues/remove-gpt5-temperature-hardcode/spec.md
+++ b/docs/issues/remove-gpt5-temperature-hardcode/spec.md
@@ -1,0 +1,26 @@
+# Remove GPT-5 Temperature Hardcode
+
+## User Story
+
+As a user configuring chat generation settings, I want temperature controls to follow model
+capability metadata instead of frontend model-name matching, so supported models keep their controls
+and unsupported models hide them consistently.
+
+## Acceptance Criteria
+
+- ChatConfig hides the temperature slider only when model capabilities explicitly report
+  temperature control as unsupported.
+- GPT-5-like model IDs do not automatically hide temperature when capabilities report support.
+- Missing or unavailable capability data keeps the existing conservative behavior and shows
+  temperature.
+
+## Non-goals
+
+- Do not change backend request filtering.
+- Do not update provider model database contents.
+- Do not introduce OpenAI-specific frontend special cases.
+
+## Constraints
+
+- Reuse the existing `models.getCapabilities` surface.
+- Keep the change scoped to renderer configuration UI behavior.

--- a/docs/issues/remove-gpt5-temperature-hardcode/tasks.md
+++ b/docs/issues/remove-gpt5-temperature-hardcode/tasks.md
@@ -1,0 +1,7 @@
+# Remove GPT-5 Temperature Hardcode Tasks
+
+- [x] Add SDD records.
+- [x] Expose temperature support from `useModelCapabilities`.
+- [x] Replace GPT-5 string matching in ChatConfig field generation.
+- [x] Update and add renderer composable tests.
+- [x] Run targeted tests and project checks.

--- a/src/renderer/src/components/ChatConfig.vue
+++ b/src/renderer/src/components/ChatConfig.vue
@@ -110,7 +110,6 @@ const { sliderFields, inputFields, selectFields } = useChatConfigFields({
   providerId: toRef(props, 'providerId'),
 
   // Composables
-  isImageGenerationModel: modelTypeDetection.isImageGenerationModel,
   supportsTemperatureControl: capabilities.supportsTemperatureControl,
   showThinkingBudget: thinkingBudget.showThinkingBudget,
   thinkingBudgetError: thinkingBudget.validationError,

--- a/src/renderer/src/components/ChatConfig.vue
+++ b/src/renderer/src/components/ChatConfig.vue
@@ -110,8 +110,8 @@ const { sliderFields, inputFields, selectFields } = useChatConfigFields({
   providerId: toRef(props, 'providerId'),
 
   // Composables
-  isGPT5Model: modelTypeDetection.isGPT5Model,
   isImageGenerationModel: modelTypeDetection.isImageGenerationModel,
+  supportsTemperatureControl: capabilities.supportsTemperatureControl,
   showThinkingBudget: thinkingBudget.showThinkingBudget,
   thinkingBudgetError: thinkingBudget.validationError,
   budgetRange: capabilities.budgetRange,

--- a/src/renderer/src/composables/useChatConfigFields.ts
+++ b/src/renderer/src/composables/useChatConfigFields.ts
@@ -31,7 +31,6 @@ export interface UseChatConfigFieldsOptions {
   providerId: Ref<string | undefined>
 
   // Composables
-  isImageGenerationModel: ComputedRef<boolean>
   supportsTemperatureControl: Ref<boolean | null>
   showThinkingBudget: ComputedRef<boolean>
   thinkingBudgetError: ComputedRef<string>

--- a/src/renderer/src/composables/useChatConfigFields.ts
+++ b/src/renderer/src/composables/useChatConfigFields.ts
@@ -31,8 +31,8 @@ export interface UseChatConfigFieldsOptions {
   providerId: Ref<string | undefined>
 
   // Composables
-  isGPT5Model: ComputedRef<boolean>
   isImageGenerationModel: ComputedRef<boolean>
+  supportsTemperatureControl: Ref<boolean | null>
   showThinkingBudget: ComputedRef<boolean>
   thinkingBudgetError: ComputedRef<string>
   budgetRange: Ref<{ min?: number; max?: number; default?: number } | null>
@@ -62,8 +62,8 @@ export function useChatConfigFields(options: UseChatConfigFieldsOptions) {
   const sliderFields = computed<SliderFieldConfig[]>(() => {
     const fields: SliderFieldConfig[] = []
 
-    // Temperature (hidden for GPT-5)
-    if (!options.isGPT5Model.value) {
+    // Temperature is hidden only when model capabilities explicitly disable it.
+    if (options.supportsTemperatureControl.value !== false) {
       fields.push({
         key: 'temperature',
         type: 'slider',

--- a/src/renderer/src/composables/useModelCapabilities.ts
+++ b/src/renderer/src/composables/useModelCapabilities.ts
@@ -17,6 +17,7 @@ export interface ModelCapabilities {
     forced?: boolean
     strategy?: 'turbo' | 'max'
   } | null
+  supportsTemperatureControl: boolean | null
 }
 
 export interface UseModelCapabilitiesOptions {
@@ -40,6 +41,7 @@ export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
     default?: number
   } | null>(null)
   const capabilitySupportsSearch = ref<boolean | null>(null)
+  const capabilitySupportsTemperatureControl = ref<boolean | null>(null)
   const capabilitySearchDefaults = ref<{
     default?: boolean
     forced?: boolean
@@ -53,6 +55,7 @@ export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
     capabilitySupportsReasoning.value = null
     capabilityBudgetRange.value = null
     capabilitySupportsSearch.value = null
+    capabilitySupportsTemperatureControl.value = null
     capabilitySearchDefaults.value = null
   }
 
@@ -69,11 +72,13 @@ export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
 
     isLoading.value = true
     try {
-      const [sr, br, ss, sd] = await Promise.all([
+      const [sr, br, ss, sd, stc, tc] = await Promise.all([
         modelClient.supportsReasoningCapability(currentProviderId, currentModelId),
         modelClient.getThinkingBudgetRange(currentProviderId, currentModelId),
         modelClient.supportsSearchCapability(currentProviderId, currentModelId),
-        modelClient.getSearchDefaults(currentProviderId, currentModelId)
+        modelClient.getSearchDefaults(currentProviderId, currentModelId),
+        modelClient.supportsTemperatureControl(currentProviderId, currentModelId),
+        modelClient.getTemperatureCapability(currentProviderId, currentModelId)
       ])
 
       if (currentRequestId !== requestId) return
@@ -82,6 +87,8 @@ export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
       capabilityBudgetRange.value = br || {}
       capabilitySupportsSearch.value = typeof ss === 'boolean' ? ss : null
       capabilitySearchDefaults.value = sd || {}
+      capabilitySupportsTemperatureControl.value =
+        typeof stc === 'boolean' ? stc : typeof tc === 'boolean' ? tc : null
     } catch (error) {
       if (currentRequestId !== requestId) return
 
@@ -104,6 +111,7 @@ export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
     budgetRange: capabilityBudgetRange,
     supportsSearch: capabilitySupportsSearch,
     searchDefaults: capabilitySearchDefaults,
+    supportsTemperatureControl: capabilitySupportsTemperatureControl,
     isLoading,
     // Methods
     refresh: fetchCapabilities

--- a/src/renderer/src/composables/useModelTypeDetection.ts
+++ b/src/renderer/src/composables/useModelTypeDetection.ts
@@ -17,7 +17,6 @@ export interface UseModelTypeDetectionReturn {
   isImageGenerationModel: ComputedRef<boolean>
   isVideoGenerationModel: ComputedRef<boolean>
   isTtsModel: ComputedRef<boolean>
-  isGPT5Model: ComputedRef<boolean>
   isGeminiProvider: ComputedRef<boolean>
   modelReasoning: Ref<boolean>
 }
@@ -60,15 +59,6 @@ export function useModelTypeDetection(
   })
 
   /**
-   * Checks if current model is GPT-5 series
-   * GPT-5 models have special UI requirements (no temperature slider)
-   */
-  const isGPT5Model = computed(() => {
-    const id = modelId.value?.toLowerCase() || ''
-    return id.includes('gpt-5')
-  })
-
-  /**
    * Checks if current provider is Gemini
    * Gemini has special thinking budget rules (-1 for unlimited)
    */
@@ -106,7 +96,6 @@ export function useModelTypeDetection(
     isImageGenerationModel,
     isVideoGenerationModel,
     isTtsModel,
-    isGPT5Model,
     isGeminiProvider,
     modelReasoning
   }

--- a/test/renderer/composables/useChatConfigFields.test.ts
+++ b/test/renderer/composables/useChatConfigFields.test.ts
@@ -1,0 +1,48 @@
+import { computed, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import { useChatConfigFields } from '@/composables/useChatConfigFields'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key })
+}))
+
+function createFields(supportsTemperatureControl: boolean | null) {
+  return useChatConfigFields({
+    temperature: ref(0.7),
+    contextLength: ref(4096),
+    maxTokens: ref(1024),
+    contextLengthLimit: ref(undefined),
+    maxTokensLimit: ref(undefined),
+    thinkingBudget: ref(undefined),
+    reasoningEffort: ref(undefined),
+    verbosity: ref(undefined),
+    providerId: ref('openai'),
+    isImageGenerationModel: computed(() => false),
+    supportsTemperatureControl: ref(supportsTemperatureControl),
+    showThinkingBudget: computed(() => false),
+    thinkingBudgetError: computed(() => ''),
+    budgetRange: ref(null),
+    formatSize: (size: number) => String(size),
+    emit: vi.fn()
+  })
+}
+
+describe('useChatConfigFields', () => {
+  it('hides temperature when capabilities explicitly disable temperature control', () => {
+    const { sliderFields } = createFields(false)
+
+    expect(sliderFields.value.some((field) => field.key === 'temperature')).toBe(false)
+  })
+
+  it('shows temperature when capabilities support temperature control', () => {
+    const { sliderFields } = createFields(true)
+
+    expect(sliderFields.value.some((field) => field.key === 'temperature')).toBe(true)
+  })
+
+  it('shows temperature while temperature capability is unknown', () => {
+    const { sliderFields } = createFields(null)
+
+    expect(sliderFields.value.some((field) => field.key === 'temperature')).toBe(true)
+  })
+})

--- a/test/renderer/composables/useChatConfigFields.test.ts
+++ b/test/renderer/composables/useChatConfigFields.test.ts
@@ -17,7 +17,6 @@ function createFields(supportsTemperatureControl: boolean | null) {
     reasoningEffort: ref(undefined),
     verbosity: ref(undefined),
     providerId: ref('openai'),
-    isImageGenerationModel: computed(() => false),
     supportsTemperatureControl: ref(supportsTemperatureControl),
     showThinkingBudget: computed(() => false),
     thinkingBudgetError: computed(() => ''),

--- a/test/renderer/composables/useModelCapabilities.test.ts
+++ b/test/renderer/composables/useModelCapabilities.test.ts
@@ -4,7 +4,9 @@ const modelClient = vi.hoisted(() => ({
   supportsReasoningCapability: vi.fn(),
   getThinkingBudgetRange: vi.fn(),
   supportsSearchCapability: vi.fn(),
-  getSearchDefaults: vi.fn()
+  getSearchDefaults: vi.fn(),
+  supportsTemperatureControl: vi.fn(),
+  getTemperatureCapability: vi.fn()
 }))
 
 vi.mock('@api/ModelClient', () => ({
@@ -38,6 +40,8 @@ describe('useModelCapabilities', () => {
       forced: false,
       strategy: 'turbo'
     })
+    modelClient.supportsTemperatureControl.mockResolvedValue(false)
+    modelClient.getTemperatureCapability.mockResolvedValue(true)
 
     const api = useModelCapabilities({ providerId, modelId })
     // initial immediate fetch occurs - wait for isLoading to become false
@@ -46,12 +50,30 @@ describe('useModelCapabilities', () => {
     expect(api.budgetRange.value?.max).toBe(200)
     expect(api.supportsSearch.value).toBe(true)
     expect(api.searchDefaults.value?.strategy).toBe('turbo')
+    expect(api.supportsTemperatureControl.value).toBe(false)
 
     // reset path
     providerId.value = undefined
     await vi.waitFor(() => expect(api.isLoading.value).toBe(false))
     expect(api.supportsReasoning.value).toBeNull()
     expect(api.budgetRange.value).toBeNull()
+    expect(api.supportsTemperatureControl.value).toBeNull()
+  })
+
+  it('falls back to temperatureCapability when supportsTemperatureControl is missing', async () => {
+    const providerId = ref<string | undefined>('openai')
+    const modelId = ref<string | undefined>('gpt-5-chat-latest')
+    modelClient.supportsReasoningCapability.mockResolvedValue(false)
+    modelClient.getThinkingBudgetRange.mockResolvedValue(null)
+    modelClient.supportsSearchCapability.mockResolvedValue(false)
+    modelClient.getSearchDefaults.mockResolvedValue(null)
+    modelClient.supportsTemperatureControl.mockResolvedValue(null)
+    modelClient.getTemperatureCapability.mockResolvedValue(true)
+
+    const api = useModelCapabilities({ providerId, modelId })
+
+    await vi.waitFor(() => expect(api.isLoading.value).toBe(false))
+    expect(api.supportsTemperatureControl.value).toBe(true)
   })
 
   it('ignores stale capability responses after model changes', async () => {
@@ -61,13 +83,17 @@ describe('useModelCapabilities', () => {
       supportsReasoning: deferred<boolean>(),
       budgetRange: deferred<{ min: number; max: number }>(),
       supportsSearch: deferred<boolean>(),
-      searchDefaults: deferred<{ strategy: 'turbo' | 'max' }>()
+      searchDefaults: deferred<{ strategy: 'turbo' | 'max' }>(),
+      supportsTemperatureControl: deferred<boolean>(),
+      temperatureCapability: deferred<boolean>()
     }
     const newResponse = {
       supportsReasoning: deferred<boolean>(),
       budgetRange: deferred<{ min: number; max: number }>(),
       supportsSearch: deferred<boolean>(),
-      searchDefaults: deferred<{ strategy: 'turbo' | 'max' }>()
+      searchDefaults: deferred<{ strategy: 'turbo' | 'max' }>(),
+      supportsTemperatureControl: deferred<boolean>(),
+      temperatureCapability: deferred<boolean>()
     }
 
     modelClient.supportsReasoningCapability.mockImplementation((_provider, model) =>
@@ -84,6 +110,16 @@ describe('useModelCapabilities', () => {
     modelClient.getSearchDefaults.mockImplementation((_provider, model) =>
       model === 'gpt-old' ? oldResponse.searchDefaults.promise : newResponse.searchDefaults.promise
     )
+    modelClient.supportsTemperatureControl.mockImplementation((_provider, model) =>
+      model === 'gpt-old'
+        ? oldResponse.supportsTemperatureControl.promise
+        : newResponse.supportsTemperatureControl.promise
+    )
+    modelClient.getTemperatureCapability.mockImplementation((_provider, model) =>
+      model === 'gpt-old'
+        ? oldResponse.temperatureCapability.promise
+        : newResponse.temperatureCapability.promise
+    )
 
     const api = useModelCapabilities({ providerId, modelId })
     await vi.waitFor(() => expect(modelClient.supportsReasoningCapability).toHaveBeenCalledTimes(1))
@@ -95,21 +131,27 @@ describe('useModelCapabilities', () => {
     newResponse.budgetRange.resolve({ min: 10, max: 20 })
     newResponse.supportsSearch.resolve(false)
     newResponse.searchDefaults.resolve({ strategy: 'max' })
+    newResponse.supportsTemperatureControl.resolve(false)
+    newResponse.temperatureCapability.resolve(true)
 
     await vi.waitFor(() => expect(api.budgetRange.value?.max).toBe(20))
     expect(api.supportsReasoning.value).toBe(false)
     expect(api.supportsSearch.value).toBe(false)
     expect(api.searchDefaults.value?.strategy).toBe('max')
+    expect(api.supportsTemperatureControl.value).toBe(false)
 
     oldResponse.supportsReasoning.resolve(true)
     oldResponse.budgetRange.resolve({ min: 100, max: 200 })
     oldResponse.supportsSearch.resolve(true)
     oldResponse.searchDefaults.resolve({ strategy: 'turbo' })
+    oldResponse.supportsTemperatureControl.resolve(true)
+    oldResponse.temperatureCapability.resolve(true)
     await Promise.resolve()
 
     expect(api.budgetRange.value?.max).toBe(20)
     expect(api.supportsReasoning.value).toBe(false)
     expect(api.supportsSearch.value).toBe(false)
     expect(api.searchDefaults.value?.strategy).toBe('max')
+    expect(api.supportsTemperatureControl.value).toBe(false)
   })
 })

--- a/test/renderer/composables/useModelTypeDetection.test.ts
+++ b/test/renderer/composables/useModelTypeDetection.test.ts
@@ -26,7 +26,7 @@ describe('useModelTypeDetection', () => {
   })
 
   it('detects provider/model type and loads reasoning flag', async () => {
-    const modelId = ref<string | undefined>('gpt-5-pro')
+    const modelId = ref<string | undefined>('gemini-pro')
     const providerId = ref<string | undefined>('gemini')
     const modelType = ref<'chat' | 'imageGeneration' | 'embedding' | 'rerank' | undefined>(
       'imageGeneration'
@@ -34,7 +34,6 @@ describe('useModelTypeDetection', () => {
 
     const api = useModelTypeDetection({ modelId, providerId, modelType })
     expect(api.isImageGenerationModel.value).toBe(true)
-    expect(api.isGPT5Model.value).toBe(true)
     expect(api.isGeminiProvider.value).toBe(true)
 
     await Promise.resolve()


### PR DESCRIPTION
Remove the hardcoded temperature judgment for GPT-5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Temperature slider visibility now follows each model's reported temperature-support capability instead of name-based rules, so compatible models show the control and incompatible ones hide it.

* **Documentation**
  * Added planning, spec, and task docs describing the change.

* **Tests**
  * Added/updated unit tests to validate temperature-capability behavior and fallback logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->