### PR TITLE
fix(renderer): honor provider-db budget sentinels

### DIFF
--- a/src/renderer/src/components/ChatConfig.vue
+++ b/src/renderer/src/components/ChatConfig.vue
@@ -78,8 +78,7 @@ const thinkingBudget = useThinkingBudget({
   thinkingBudget: toRef(props, 'thinkingBudget'),
   budgetRange: capabilities.budgetRange,
   modelReasoning: modelTypeDetection.modelReasoning,
-  supportsReasoning: capabilities.supportsReasoning,
-  isGeminiProvider: modelTypeDetection.isGeminiProvider
+  supportsReasoning: capabilities.supportsReasoning
 })
 
 // === Utility Functions ===

--- a/src/renderer/src/composables/useChatConfigFields.ts
+++ b/src/renderer/src/composables/useChatConfigFields.ts
@@ -18,6 +18,29 @@ import {
   type Verbosity
 } from '@shared/types/model-db'
 
+const getThinkingBudgetInputBounds = (
+  budgetRange: ThinkingBudgetRange | null
+): { min?: number; max?: number } => {
+  const bounds: { min?: number; max?: number } = {
+    min: budgetRange?.min,
+    max: budgetRange?.max
+  }
+  const sentinels = [budgetRange?.auto, budgetRange?.off].filter(
+    (value): value is number => typeof value === 'number'
+  )
+
+  for (const sentinel of sentinels) {
+    if (typeof bounds.min === 'number' && sentinel < bounds.min) {
+      bounds.min = sentinel
+    }
+    if (typeof bounds.max === 'number' && sentinel > bounds.max) {
+      bounds.max = sentinel
+    }
+  }
+
+  return bounds
+}
+
 // === Interfaces ===
 export interface UseChatConfigFieldsOptions {
   // Props
@@ -120,6 +143,8 @@ export function useChatConfigFields(options: UseChatConfigFieldsOptions) {
 
     // Thinking Budget
     if (options.showThinkingBudget.value) {
+      const thinkingBudgetInputBounds = getThinkingBudgetInputBounds(options.budgetRange.value)
+
       fields.push({
         key: 'thinkingBudget',
         type: 'input',
@@ -127,8 +152,8 @@ export function useChatConfigFields(options: UseChatConfigFieldsOptions) {
         label: t('settings.model.modelConfig.thinkingBudget.label'),
         description: t('settings.model.modelConfig.thinkingBudget.description'),
         inputType: 'number',
-        min: options.budgetRange.value?.min,
-        max: options.budgetRange.value?.max,
+        min: thinkingBudgetInputBounds.min,
+        max: thinkingBudgetInputBounds.max,
         step: 128,
         placeholder: t('settings.model.modelConfig.thinkingBudget.placeholder'),
         getValue: () => options.thinkingBudget.value,

--- a/src/renderer/src/composables/useChatConfigFields.ts
+++ b/src/renderer/src/composables/useChatConfigFields.ts
@@ -10,6 +10,7 @@ import type {
   SelectOption,
   FieldConfig
 } from '@/components/ChatConfig/types'
+import type { ThinkingBudgetRange } from '@/composables/useThinkingBudget'
 import {
   DEFAULT_REASONING_EFFORT_OPTIONS as FALLBACK_REASONING_EFFORT_OPTIONS,
   isReasoningEffort,
@@ -34,7 +35,7 @@ export interface UseChatConfigFieldsOptions {
   supportsTemperatureControl: Ref<boolean | null>
   showThinkingBudget: ComputedRef<boolean>
   thinkingBudgetError: ComputedRef<string>
-  budgetRange: Ref<{ min?: number; max?: number; default?: number } | null>
+  budgetRange: Ref<ThinkingBudgetRange | null>
 
   // Utils
   formatSize: (size: number) => string

--- a/src/renderer/src/composables/useModelCapabilities.ts
+++ b/src/renderer/src/composables/useModelCapabilities.ts
@@ -2,15 +2,29 @@
 import { ref, watch, type Ref } from 'vue'
 
 import { createModelClient } from '@api/ModelClient'
+import type { ReasoningPortrait } from '@shared/types/model-db'
+import type { ThinkingBudgetRange } from './useThinkingBudget'
+
+const normalizeBudgetRange = (
+  budget: ReasoningPortrait['budget'] | ThinkingBudgetRange | null | undefined
+): ThinkingBudgetRange | null => {
+  if (!budget) return null
+
+  const range: ThinkingBudgetRange = {}
+  if (typeof budget.min === 'number') range.min = budget.min
+  if (typeof budget.max === 'number') range.max = budget.max
+  if (typeof budget.default === 'number') range.default = budget.default
+  if (typeof budget.auto === 'number') range.auto = budget.auto
+  if (typeof budget.off === 'number') range.off = budget.off
+  if (typeof budget.unit === 'string') range.unit = budget.unit
+
+  return Object.keys(range).length > 0 ? range : null
+}
 
 // === Interfaces ===
 export interface ModelCapabilities {
   supportsReasoning: boolean | null
-  budgetRange: {
-    min?: number
-    max?: number
-    default?: number
-  } | null
+  budgetRange: ThinkingBudgetRange | null
   supportsSearch: boolean | null
   searchDefaults: {
     default?: boolean
@@ -35,11 +49,7 @@ export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
 
   // === Local State ===
   const capabilitySupportsReasoning = ref<boolean | null>(null)
-  const capabilityBudgetRange = ref<{
-    min?: number
-    max?: number
-    default?: number
-  } | null>(null)
+  const capabilityBudgetRange = ref<ThinkingBudgetRange | null>(null)
   const capabilitySupportsSearch = ref<boolean | null>(null)
   const capabilitySupportsTemperatureControl = ref<boolean | null>(null)
   const capabilitySearchDefaults = ref<{
@@ -72,23 +82,25 @@ export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
 
     isLoading.value = true
     try {
-      const [sr, br, ss, sd, stc, tc] = await Promise.all([
-        modelClient.supportsReasoningCapability(currentProviderId, currentModelId),
-        modelClient.getThinkingBudgetRange(currentProviderId, currentModelId),
-        modelClient.supportsSearchCapability(currentProviderId, currentModelId),
-        modelClient.getSearchDefaults(currentProviderId, currentModelId),
-        modelClient.supportsTemperatureControl(currentProviderId, currentModelId),
-        modelClient.getTemperatureCapability(currentProviderId, currentModelId)
-      ])
+      const capabilities = await modelClient.getCapabilities(currentProviderId, currentModelId)
 
       if (currentRequestId !== requestId) return
 
-      capabilitySupportsReasoning.value = typeof sr === 'boolean' ? sr : null
-      capabilityBudgetRange.value = br || {}
-      capabilitySupportsSearch.value = typeof ss === 'boolean' ? ss : null
-      capabilitySearchDefaults.value = sd || {}
+      capabilitySupportsReasoning.value =
+        typeof capabilities.supportsReasoning === 'boolean' ? capabilities.supportsReasoning : null
+      capabilityBudgetRange.value =
+        normalizeBudgetRange(capabilities.reasoningPortrait?.budget) ??
+        normalizeBudgetRange(capabilities.thinkingBudgetRange) ??
+        {}
+      capabilitySupportsSearch.value =
+        typeof capabilities.supportsSearch === 'boolean' ? capabilities.supportsSearch : null
+      capabilitySearchDefaults.value = capabilities.searchDefaults || {}
       capabilitySupportsTemperatureControl.value =
-        typeof stc === 'boolean' ? stc : typeof tc === 'boolean' ? tc : null
+        typeof capabilities.supportsTemperatureControl === 'boolean'
+          ? capabilities.supportsTemperatureControl
+          : typeof capabilities.temperatureCapability === 'boolean'
+            ? capabilities.temperatureCapability
+            : null
     } catch (error) {
       if (currentRequestId !== requestId) return
 

--- a/src/renderer/src/composables/useModelCapabilities.ts
+++ b/src/renderer/src/composables/useModelCapabilities.ts
@@ -21,6 +21,20 @@ const normalizeBudgetRange = (
   return Object.keys(range).length > 0 ? range : null
 }
 
+const mergeBudgetRanges = (
+  base: ReasoningPortrait['budget'] | ThinkingBudgetRange | null | undefined,
+  overlay: ReasoningPortrait['budget'] | ThinkingBudgetRange | null | undefined
+): ThinkingBudgetRange | null => {
+  const normalizedBase = normalizeBudgetRange(base) ?? {}
+  const normalizedOverlay = normalizeBudgetRange(overlay) ?? {}
+  const merged = {
+    ...normalizedBase,
+    ...normalizedOverlay
+  }
+
+  return Object.keys(merged).length > 0 ? merged : null
+}
+
 // === Interfaces ===
 export interface ModelCapabilities {
   supportsReasoning: boolean | null
@@ -89,9 +103,10 @@ export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
       capabilitySupportsReasoning.value =
         typeof capabilities.supportsReasoning === 'boolean' ? capabilities.supportsReasoning : null
       capabilityBudgetRange.value =
-        normalizeBudgetRange(capabilities.reasoningPortrait?.budget) ??
-        normalizeBudgetRange(capabilities.thinkingBudgetRange) ??
-        {}
+        mergeBudgetRanges(
+          capabilities.thinkingBudgetRange,
+          capabilities.reasoningPortrait?.budget
+        ) ?? {}
       capabilitySupportsSearch.value =
         typeof capabilities.supportsSearch === 'boolean' ? capabilities.supportsSearch : null
       capabilitySearchDefaults.value = capabilities.searchDefaults || {}

--- a/src/renderer/src/composables/useModelCapabilities.ts
+++ b/src/renderer/src/composables/useModelCapabilities.ts
@@ -102,11 +102,10 @@ export function useModelCapabilities(options: UseModelCapabilitiesOptions) {
 
       capabilitySupportsReasoning.value =
         typeof capabilities.supportsReasoning === 'boolean' ? capabilities.supportsReasoning : null
-      capabilityBudgetRange.value =
-        mergeBudgetRanges(
-          capabilities.thinkingBudgetRange,
-          capabilities.reasoningPortrait?.budget
-        ) ?? {}
+      capabilityBudgetRange.value = mergeBudgetRanges(
+        capabilities.thinkingBudgetRange,
+        capabilities.reasoningPortrait?.budget
+      )
       capabilitySupportsSearch.value =
         typeof capabilities.supportsSearch === 'boolean' ? capabilities.supportsSearch : null
       capabilitySearchDefaults.value = capabilities.searchDefaults || {}

--- a/src/renderer/src/composables/useModelTypeDetection.ts
+++ b/src/renderer/src/composables/useModelTypeDetection.ts
@@ -17,7 +17,6 @@ export interface UseModelTypeDetectionReturn {
   isImageGenerationModel: ComputedRef<boolean>
   isVideoGenerationModel: ComputedRef<boolean>
   isTtsModel: ComputedRef<boolean>
-  isGeminiProvider: ComputedRef<boolean>
   modelReasoning: Ref<boolean>
 }
 
@@ -58,12 +57,6 @@ export function useModelTypeDetection(
     return modelType.value === 'tts'
   })
 
-  /**
-   * Checks if current provider is Gemini
-   * Gemini has special thinking budget rules (-1 for unlimited)
-   */
-  const isGeminiProvider = computed(() => providerId.value?.toLowerCase() === 'gemini')
-
   // === Internal Methods ===
   const fetchModelReasoning = async () => {
     const currentRequestId = ++requestId
@@ -96,7 +89,6 @@ export function useModelTypeDetection(
     isImageGenerationModel,
     isVideoGenerationModel,
     isTtsModel,
-    isGeminiProvider,
     modelReasoning
   }
 }

--- a/src/renderer/src/composables/useThinkingBudget.ts
+++ b/src/renderer/src/composables/useThinkingBudget.ts
@@ -9,6 +9,9 @@ export interface ThinkingBudgetRange {
   min?: number
   max?: number
   default?: number
+  auto?: number
+  off?: number
+  unit?: string
 }
 
 export interface UseThinkingBudgetOptions {
@@ -16,7 +19,6 @@ export interface UseThinkingBudgetOptions {
   budgetRange: Ref<ThinkingBudgetRange | null>
   modelReasoning: Ref<boolean>
   supportsReasoning: Ref<boolean | null>
-  isGeminiProvider: ComputedRef<boolean>
 }
 
 export interface UseThinkingBudgetReturn {
@@ -29,8 +31,7 @@ export interface UseThinkingBudgetReturn {
  * Handles budget range validation, display logic, and error messages
  */
 export function useThinkingBudget(options: UseThinkingBudgetOptions): UseThinkingBudgetReturn {
-  const { thinkingBudget, budgetRange, modelReasoning, supportsReasoning, isGeminiProvider } =
-    options
+  const { thinkingBudget, budgetRange, modelReasoning, supportsReasoning } = options
   const { t } = useI18n()
 
   // === Computed Properties ===
@@ -46,13 +47,14 @@ export function useThinkingBudget(options: UseThinkingBudgetOptions): UseThinkin
       !!budgetRange.value &&
       (budgetRange.value.min !== undefined ||
         budgetRange.value.max !== undefined ||
-        budgetRange.value.default !== undefined)
+        budgetRange.value.default !== undefined ||
+        budgetRange.value.auto !== undefined ||
+        budgetRange.value.off !== undefined)
     )
   })
 
   /**
    * Validates thinking budget value and returns error message if invalid
-   * Handles special case for Gemini provider (-1 value)
    */
   const validationError = computed(() => {
     const value = thinkingBudget.value
@@ -62,8 +64,11 @@ export function useThinkingBudget(options: UseThinkingBudgetOptions): UseThinkin
       return ''
     }
 
-    // Gemini special case: -1 is valid (unlimited)
-    if (isGeminiProvider.value && value === -1) {
+    const isProviderDbSentinel =
+      (typeof range.auto === 'number' && value === range.auto) ||
+      (typeof range.off === 'number' && value === range.off)
+
+    if (isProviderDbSentinel) {
       return ''
     }
 

--- a/test/renderer/composables/useChatConfigFields.test.ts
+++ b/test/renderer/composables/useChatConfigFields.test.ts
@@ -1,26 +1,34 @@
 import { computed, ref } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
 import { useChatConfigFields } from '@/composables/useChatConfigFields'
+import type { ThinkingBudgetRange } from '@/composables/useThinkingBudget'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: (key: string) => key })
 }))
 
-function createFields(supportsTemperatureControl: boolean | null) {
+function createFields(
+  supportsTemperatureControl: boolean | null,
+  options: {
+    showThinkingBudget?: boolean
+    thinkingBudget?: number
+    budgetRange?: ThinkingBudgetRange | null
+  } = {}
+) {
   return useChatConfigFields({
     temperature: ref(0.7),
     contextLength: ref(4096),
     maxTokens: ref(1024),
     contextLengthLimit: ref(undefined),
     maxTokensLimit: ref(undefined),
-    thinkingBudget: ref(undefined),
+    thinkingBudget: ref(options.thinkingBudget),
     reasoningEffort: ref(undefined),
     verbosity: ref(undefined),
     providerId: ref('openai'),
     supportsTemperatureControl: ref(supportsTemperatureControl),
-    showThinkingBudget: computed(() => false),
+    showThinkingBudget: computed(() => options.showThinkingBudget ?? false),
     thinkingBudgetError: computed(() => ''),
-    budgetRange: ref(null),
+    budgetRange: ref(options.budgetRange ?? null),
     formatSize: (size: number) => String(size),
     emit: vi.fn()
   })
@@ -43,5 +51,29 @@ describe('useChatConfigFields', () => {
     const { sliderFields } = createFields(null)
 
     expect(sliderFields.value.some((field) => field.key === 'temperature')).toBe(true)
+  })
+
+  it('expands thinking budget input bounds to include sentinels', () => {
+    const autoFields = createFields(true, {
+      showThinkingBudget: true,
+      budgetRange: { min: 128, max: 24576, auto: -1, unit: 'tokens' }
+    })
+    const autoBudgetField = autoFields.inputFields.value.find(
+      (field) => field.key === 'thinkingBudget'
+    )
+
+    expect(autoBudgetField?.min).toBe(-1)
+    expect(autoBudgetField?.max).toBe(24576)
+
+    const offFields = createFields(true, {
+      showThinkingBudget: true,
+      budgetRange: { min: 512, max: 24576, off: 0, unit: 'tokens' }
+    })
+    const offBudgetField = offFields.inputFields.value.find(
+      (field) => field.key === 'thinkingBudget'
+    )
+
+    expect(offBudgetField?.min).toBe(0)
+    expect(offBudgetField?.max).toBe(24576)
   })
 })

--- a/test/renderer/composables/useModelCapabilities.test.ts
+++ b/test/renderer/composables/useModelCapabilities.test.ts
@@ -84,6 +84,26 @@ describe('useModelCapabilities', () => {
     expect(api.supportsTemperatureControl.value).toBe(true)
   })
 
+  it('keeps budget range null when capabilities have no budget metadata', async () => {
+    const providerId = ref<string | undefined>('openai')
+    const modelId = ref<string | undefined>('gpt-4o')
+    modelClient.getCapabilities.mockResolvedValue({
+      supportsAudioInput: false,
+      supportsReasoning: false,
+      reasoningPortrait: null,
+      thinkingBudgetRange: null,
+      supportsSearch: false,
+      searchDefaults: null,
+      supportsTemperatureControl: true,
+      temperatureCapability: true
+    })
+
+    const api = useModelCapabilities({ providerId, modelId })
+
+    await vi.waitFor(() => expect(api.isLoading.value).toBe(false))
+    expect(api.budgetRange.value).toBeNull()
+  })
+
   it('merges thinking budget range with reasoning portrait sentinels', async () => {
     const providerId = ref<string | undefined>('openrouter')
     const modelId = ref<string | undefined>('google/gemini-2.5-flash')

--- a/test/renderer/composables/useModelCapabilities.test.ts
+++ b/test/renderer/composables/useModelCapabilities.test.ts
@@ -1,12 +1,7 @@
 import { ref } from 'vue'
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 const modelClient = vi.hoisted(() => ({
-  supportsReasoningCapability: vi.fn(),
-  getThinkingBudgetRange: vi.fn(),
-  supportsSearchCapability: vi.fn(),
-  getSearchDefaults: vi.fn(),
-  supportsTemperatureControl: vi.fn(),
-  getTemperatureCapability: vi.fn()
+  getCapabilities: vi.fn()
 }))
 
 vi.mock('@api/ModelClient', () => ({
@@ -32,22 +27,31 @@ describe('useModelCapabilities', () => {
   it('fetches capabilities and resets when ids missing', async () => {
     const providerId = ref<string | undefined>('openai')
     const modelId = ref<string | undefined>('gpt-4')
-    modelClient.supportsReasoningCapability.mockResolvedValue(true)
-    modelClient.getThinkingBudgetRange.mockResolvedValue({ min: 100, max: 200 })
-    modelClient.supportsSearchCapability.mockResolvedValue(true)
-    modelClient.getSearchDefaults.mockResolvedValue({
-      default: true,
-      forced: false,
-      strategy: 'turbo'
+    modelClient.getCapabilities.mockResolvedValue({
+      supportsAudioInput: false,
+      supportsReasoning: true,
+      reasoningPortrait: {
+        budget: { min: 100, max: 200, default: -1, auto: -1, off: 0, unit: 'tokens' }
+      },
+      thinkingBudgetRange: { min: 100, max: 200 },
+      supportsSearch: true,
+      searchDefaults: {
+        default: true,
+        forced: false,
+        strategy: 'turbo'
+      },
+      supportsTemperatureControl: false,
+      temperatureCapability: true
     })
-    modelClient.supportsTemperatureControl.mockResolvedValue(false)
-    modelClient.getTemperatureCapability.mockResolvedValue(true)
 
     const api = useModelCapabilities({ providerId, modelId })
     // initial immediate fetch occurs - wait for isLoading to become false
     await vi.waitFor(() => expect(api.isLoading.value).toBe(false))
     expect(api.supportsReasoning.value).toBe(true)
     expect(api.budgetRange.value?.max).toBe(200)
+    expect(api.budgetRange.value?.auto).toBe(-1)
+    expect(api.budgetRange.value?.off).toBe(0)
+    expect(api.budgetRange.value?.unit).toBe('tokens')
     expect(api.supportsSearch.value).toBe(true)
     expect(api.searchDefaults.value?.strategy).toBe('turbo')
     expect(api.supportsTemperatureControl.value).toBe(false)
@@ -63,12 +67,16 @@ describe('useModelCapabilities', () => {
   it('falls back to temperatureCapability when supportsTemperatureControl is missing', async () => {
     const providerId = ref<string | undefined>('openai')
     const modelId = ref<string | undefined>('gpt-5-chat-latest')
-    modelClient.supportsReasoningCapability.mockResolvedValue(false)
-    modelClient.getThinkingBudgetRange.mockResolvedValue(null)
-    modelClient.supportsSearchCapability.mockResolvedValue(false)
-    modelClient.getSearchDefaults.mockResolvedValue(null)
-    modelClient.supportsTemperatureControl.mockResolvedValue(null)
-    modelClient.getTemperatureCapability.mockResolvedValue(true)
+    modelClient.getCapabilities.mockResolvedValue({
+      supportsAudioInput: false,
+      supportsReasoning: false,
+      reasoningPortrait: null,
+      thinkingBudgetRange: null,
+      supportsSearch: false,
+      searchDefaults: null,
+      supportsTemperatureControl: null,
+      temperatureCapability: true
+    })
 
     const api = useModelCapabilities({ providerId, modelId })
 
@@ -80,59 +88,50 @@ describe('useModelCapabilities', () => {
     const providerId = ref<string | undefined>('openai')
     const modelId = ref<string | undefined>('gpt-old')
     const oldResponse = {
-      supportsReasoning: deferred<boolean>(),
-      budgetRange: deferred<{ min: number; max: number }>(),
-      supportsSearch: deferred<boolean>(),
-      searchDefaults: deferred<{ strategy: 'turbo' | 'max' }>(),
-      supportsTemperatureControl: deferred<boolean>(),
-      temperatureCapability: deferred<boolean>()
+      capabilities: deferred<{
+        supportsAudioInput: boolean
+        supportsReasoning: boolean
+        reasoningPortrait: { budget: { min: number; max: number } } | null
+        thinkingBudgetRange: { min: number; max: number } | null
+        supportsSearch: boolean
+        searchDefaults: { strategy: 'turbo' | 'max' }
+        supportsTemperatureControl: boolean
+        temperatureCapability: boolean
+      }>()
     }
     const newResponse = {
-      supportsReasoning: deferred<boolean>(),
-      budgetRange: deferred<{ min: number; max: number }>(),
-      supportsSearch: deferred<boolean>(),
-      searchDefaults: deferred<{ strategy: 'turbo' | 'max' }>(),
-      supportsTemperatureControl: deferred<boolean>(),
-      temperatureCapability: deferred<boolean>()
+      capabilities: deferred<{
+        supportsAudioInput: boolean
+        supportsReasoning: boolean
+        reasoningPortrait: { budget: { min: number; max: number } } | null
+        thinkingBudgetRange: { min: number; max: number } | null
+        supportsSearch: boolean
+        searchDefaults: { strategy: 'turbo' | 'max' }
+        supportsTemperatureControl: boolean
+        temperatureCapability: boolean
+      }>()
     }
 
-    modelClient.supportsReasoningCapability.mockImplementation((_provider, model) =>
-      model === 'gpt-old'
-        ? oldResponse.supportsReasoning.promise
-        : newResponse.supportsReasoning.promise
-    )
-    modelClient.getThinkingBudgetRange.mockImplementation((_provider, model) =>
-      model === 'gpt-old' ? oldResponse.budgetRange.promise : newResponse.budgetRange.promise
-    )
-    modelClient.supportsSearchCapability.mockImplementation((_provider, model) =>
-      model === 'gpt-old' ? oldResponse.supportsSearch.promise : newResponse.supportsSearch.promise
-    )
-    modelClient.getSearchDefaults.mockImplementation((_provider, model) =>
-      model === 'gpt-old' ? oldResponse.searchDefaults.promise : newResponse.searchDefaults.promise
-    )
-    modelClient.supportsTemperatureControl.mockImplementation((_provider, model) =>
-      model === 'gpt-old'
-        ? oldResponse.supportsTemperatureControl.promise
-        : newResponse.supportsTemperatureControl.promise
-    )
-    modelClient.getTemperatureCapability.mockImplementation((_provider, model) =>
-      model === 'gpt-old'
-        ? oldResponse.temperatureCapability.promise
-        : newResponse.temperatureCapability.promise
+    modelClient.getCapabilities.mockImplementation((_provider, model) =>
+      model === 'gpt-old' ? oldResponse.capabilities.promise : newResponse.capabilities.promise
     )
 
     const api = useModelCapabilities({ providerId, modelId })
-    await vi.waitFor(() => expect(modelClient.supportsReasoningCapability).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(modelClient.getCapabilities).toHaveBeenCalledTimes(1))
 
     modelId.value = 'gpt-new'
-    await vi.waitFor(() => expect(modelClient.supportsReasoningCapability).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(modelClient.getCapabilities).toHaveBeenCalledTimes(2))
 
-    newResponse.supportsReasoning.resolve(false)
-    newResponse.budgetRange.resolve({ min: 10, max: 20 })
-    newResponse.supportsSearch.resolve(false)
-    newResponse.searchDefaults.resolve({ strategy: 'max' })
-    newResponse.supportsTemperatureControl.resolve(false)
-    newResponse.temperatureCapability.resolve(true)
+    newResponse.capabilities.resolve({
+      supportsAudioInput: false,
+      supportsReasoning: false,
+      reasoningPortrait: { budget: { min: 10, max: 20 } },
+      thinkingBudgetRange: null,
+      supportsSearch: false,
+      searchDefaults: { strategy: 'max' },
+      supportsTemperatureControl: false,
+      temperatureCapability: true
+    })
 
     await vi.waitFor(() => expect(api.budgetRange.value?.max).toBe(20))
     expect(api.supportsReasoning.value).toBe(false)
@@ -140,12 +139,16 @@ describe('useModelCapabilities', () => {
     expect(api.searchDefaults.value?.strategy).toBe('max')
     expect(api.supportsTemperatureControl.value).toBe(false)
 
-    oldResponse.supportsReasoning.resolve(true)
-    oldResponse.budgetRange.resolve({ min: 100, max: 200 })
-    oldResponse.supportsSearch.resolve(true)
-    oldResponse.searchDefaults.resolve({ strategy: 'turbo' })
-    oldResponse.supportsTemperatureControl.resolve(true)
-    oldResponse.temperatureCapability.resolve(true)
+    oldResponse.capabilities.resolve({
+      supportsAudioInput: false,
+      supportsReasoning: true,
+      reasoningPortrait: { budget: { min: 100, max: 200 } },
+      thinkingBudgetRange: null,
+      supportsSearch: true,
+      searchDefaults: { strategy: 'turbo' },
+      supportsTemperatureControl: true,
+      temperatureCapability: true
+    })
     await Promise.resolve()
 
     expect(api.budgetRange.value?.max).toBe(20)

--- a/test/renderer/composables/useModelCapabilities.test.ts
+++ b/test/renderer/composables/useModelCapabilities.test.ts
@@ -84,6 +84,35 @@ describe('useModelCapabilities', () => {
     expect(api.supportsTemperatureControl.value).toBe(true)
   })
 
+  it('merges thinking budget range with reasoning portrait sentinels', async () => {
+    const providerId = ref<string | undefined>('openrouter')
+    const modelId = ref<string | undefined>('google/gemini-2.5-flash')
+    modelClient.getCapabilities.mockResolvedValue({
+      supportsAudioInput: false,
+      supportsReasoning: true,
+      reasoningPortrait: {
+        budget: { auto: -1, off: 0, unit: 'tokens' }
+      },
+      thinkingBudgetRange: { min: 128, max: 24576, default: 1024 },
+      supportsSearch: false,
+      searchDefaults: null,
+      supportsTemperatureControl: true,
+      temperatureCapability: true
+    })
+
+    const api = useModelCapabilities({ providerId, modelId })
+
+    await vi.waitFor(() => expect(api.isLoading.value).toBe(false))
+    expect(api.budgetRange.value).toEqual({
+      min: 128,
+      max: 24576,
+      default: 1024,
+      auto: -1,
+      off: 0,
+      unit: 'tokens'
+    })
+  })
+
   it('ignores stale capability responses after model changes', async () => {
     const providerId = ref<string | undefined>('openai')
     const modelId = ref<string | undefined>('gpt-old')

--- a/test/renderer/composables/useModelTypeDetection.test.ts
+++ b/test/renderer/composables/useModelTypeDetection.test.ts
@@ -34,7 +34,6 @@ describe('useModelTypeDetection', () => {
 
     const api = useModelTypeDetection({ modelId, providerId, modelType })
     expect(api.isImageGenerationModel.value).toBe(true)
-    expect(api.isGeminiProvider.value).toBe(true)
 
     await Promise.resolve()
     expect(api.modelReasoning.value).toBe(true)

--- a/test/renderer/composables/useThinkingBudget.test.ts
+++ b/test/renderer/composables/useThinkingBudget.test.ts
@@ -1,6 +1,6 @@
-import { ref, computed } from 'vue'
-import { describe, it, expect } from 'vitest'
-import { useThinkingBudget } from '@/composables/useThinkingBudget'
+import { ref } from 'vue'
+import { describe, it, expect, vi } from 'vitest'
+import { useThinkingBudget, type ThinkingBudgetRange } from '@/composables/useThinkingBudget'
 
 // mock i18n -> return the key so we can assert on it
 vi.mock('vue-i18n', () => ({
@@ -10,20 +10,18 @@ vi.mock('vue-i18n', () => ({
 describe('useThinkingBudget', () => {
   it('computes showThinkingBudget only when reasoning supported and range provided', () => {
     const thinkingBudget = ref<number | undefined>(undefined)
-    const budgetRange = ref<{ min?: number; max?: number; default?: number } | null>({
+    const budgetRange = ref<ThinkingBudgetRange | null>({
       min: 256,
       max: 4096
     })
     const modelReasoning = ref(true)
     const supportsReasoning = ref<boolean | null>(true)
-    const isGeminiProvider = computed(() => false)
 
     const api = useThinkingBudget({
       thinkingBudget,
       budgetRange,
       modelReasoning,
-      supportsReasoning,
-      isGeminiProvider
+      supportsReasoning
     })
     expect(api.showThinkingBudget.value).toBe(true)
 
@@ -33,24 +31,25 @@ describe('useThinkingBudget', () => {
     supportsReasoning.value = true
     budgetRange.value = null
     expect(api.showThinkingBudget.value).toBe(false)
+
+    budgetRange.value = { auto: -1 }
+    expect(api.showThinkingBudget.value).toBe(true)
   })
 
-  it('validates range and returns translation keys; allows -1 for Gemini', () => {
+  it('validates ranges and allows provider-db budget sentinels', () => {
     const thinkingBudget = ref<number | undefined>(128)
-    const budgetRange = ref<{ min?: number; max?: number; default?: number } | null>({
+    const budgetRange = ref<ThinkingBudgetRange | null>({
       min: 256,
       max: 1024
     })
     const modelReasoning = ref(true)
     const supportsReasoning = ref<boolean | null>(true)
-    const isGeminiProvider = computed(() => false)
 
     const api = useThinkingBudget({
       thinkingBudget,
       budgetRange,
       modelReasoning,
-      supportsReasoning,
-      isGeminiProvider
+      supportsReasoning
     })
     expect(api.validationError.value).toBe(
       'settings.model.modelConfig.thinkingBudget.validation.minValue'
@@ -64,14 +63,16 @@ describe('useThinkingBudget', () => {
     thinkingBudget.value = 512
     expect(api.validationError.value).toBe('')
 
-    // Gemini special case
-    const gemApi = useThinkingBudget({
-      thinkingBudget: ref(-1),
-      budgetRange,
-      modelReasoning,
-      supportsReasoning,
-      isGeminiProvider: computed(() => true)
-    })
-    expect(gemApi.validationError.value).toBe('')
+    thinkingBudget.value = -1
+    expect(api.validationError.value).toBe(
+      'settings.model.modelConfig.thinkingBudget.validation.minValue'
+    )
+
+    budgetRange.value = { min: 0, max: 24576, default: -1, auto: -1, off: 0, unit: 'tokens' }
+    expect(api.validationError.value).toBe('')
+
+    budgetRange.value = { min: 512, max: 24576, off: 0 }
+    thinkingBudget.value = 0
+    expect(api.validationError.value).toBe('')
   })
 })


### PR DESCRIPTION
Use reasoningPortrait.budget auto/off values for thinking budget validation instead of checking the Gemini provider id.
Preserve auto/off/unit in renderer capability state and update composable tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified capability retrieval and simplified model-type detection; removed a provider-specific flag.
  * Redesigned thinking-budget semantics: added auto/off/unit sentinels, normalized/merged ranges, and adaptive input bounds.

* **Tests**
  * Updated and expanded tests to cover consolidated capability payloads, budget sentinel behavior, range merging, and adjusted model-type assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->