### PR TITLE
feat(chat): collapse turn activity

### DIFF
--- a/docs/features/automatic-turn-activity-collapse/plan.md
+++ b/docs/features/automatic-turn-activity-collapse/plan.md
@@ -211,10 +211,18 @@ Omit count segments when the count is `0`:
 
 ## Duration Formatting
 
-Add a local formatter in the grouping helper or a small companion file:
+Add a local formatter in the grouping helper or a small companion file. Keep the formatter pure and
+pass localized unit labels from `MessageBlockActivityGroup.vue`:
 
 ```typescript
-formatActivityDuration(durationMs: number, locale: string): string
+type ActivityDurationLabels = {
+  day: string
+  hour: string
+  minute: string
+  second: string
+}
+
+formatActivityDuration(durationMs: number, labels: ActivityDurationLabels): string
 ```
 
 Implementation detail:
@@ -222,8 +230,9 @@ Implementation detail:
 - Clamp non-finite values to `0`.
 - `totalSeconds = Math.max(0, Math.floor(durationMs / 1000))`.
 - Compute days/hours/minutes/seconds.
-- For Chinese, concatenate non-zero units and include seconds when all larger units are zero.
-- For English, use compact units: `d`, `h`, `m`, `s`.
+- Concatenate non-zero units and include seconds when all larger units are zero.
+- Use localized unit labels from `chat.activityCollapse.duration.*`.
+- Unit labels may include spacing when the locale needs spaces between duration segments.
 
 Avoid `Intl.DurationFormat` for now because support varies and would add fallback complexity.
 

--- a/docs/features/automatic-turn-activity-collapse/plan.md
+++ b/docs/features/automatic-turn-activity-collapse/plan.md
@@ -1,0 +1,336 @@
+# Plan
+
+## Approach
+
+Implement a render-only activity grouping layer inside assistant message rendering:
+
+1. Expose assistant `updatedAt` on `DisplayMessage`.
+2. Add a small pure helper that turns assistant blocks into render items.
+3. Add a compact `MessageBlockActivityGroup.vue` component that renders the title and, when expanded,
+   delegates to the existing reasoning/tool-call block components.
+4. Update `MessageItemAssistant.vue` to render grouped items only when the turn is settled.
+5. Add localized title strings and duration formatter output.
+6. Cover the helper and component behavior with renderer tests.
+
+No main-process, preload, IPC, route, database, or shared event contract changes are planned for the
+first increment.
+
+Persistence decision:
+
+- Do not persist derived activity groups.
+- Do not persist per-group expanded/collapsed state.
+- Keep the default state collapsed each time a completed assistant message group is mounted.
+- Use renderer computation first; add only an in-memory cache if profiling shows a real bottleneck.
+
+## Affected Files
+
+Expected renderer files:
+
+- `src/renderer/src/components/chat/messageListItems.ts`
+- `src/renderer/src/pages/ChatPage.vue`
+- `src/renderer/src/components/message/MessageItemAssistant.vue`
+- `src/renderer/src/components/message/MessageBlockActivityGroup.vue`
+- `src/renderer/src/components/message/messageActivityGroups.ts`
+- `src/renderer/src/i18n/*/chat.json`
+
+Expected tests:
+
+- `test/renderer/components/message/MessageItemAssistant.test.ts`
+- `test/renderer/components/message/MessageBlockActivityGroup.test.ts`
+- `test/renderer/components/message/messageActivityGroups.test.ts`
+
+## Display Model
+
+Add `updatedAt` to the renderer-only `DisplayMessageBase`.
+
+```typescript
+type DisplayMessageBase = {
+  id: string
+  timestamp: number
+  updatedAt: number
+  // existing fields...
+}
+```
+
+Populate it in:
+
+- `toDisplayMessage(record)`: `updatedAt: record.updatedAt`
+- `toStreamingMessage(...)`: `updatedAt: Date.now()` for type completeness, though streaming messages
+  must not be auto-grouped.
+
+## Render Item Model
+
+Keep the persisted `DisplayAssistantMessageBlock[]` unchanged. Add only a local UI render model.
+
+```typescript
+type AssistantRenderItem =
+  | {
+      kind: 'block'
+      key: string
+      block: DisplayAssistantMessageBlock
+    }
+  | {
+      kind: 'activity-group'
+      key: string
+      blocks: DisplayAssistantMessageBlock[]
+      startedAt: number
+      endedAt: number
+      durationMs: number
+      reasoningCount: number
+      toolCallCount: number
+    }
+```
+
+This is not written to message content and is not sent over IPC.
+
+## Performance Model
+
+The grouping helper is an O(n) pass over the assistant block array, where n is the number of blocks in
+one assistant message. This is expected to be cheaper than markdown rendering, tool-call detail
+rendering, syntax highlighting, and media previews.
+
+Renderer computation is preferred over persistence because the renderer already needs the block array
+to decide which existing component to render. Persisting grouping state would not remove the need to
+parse/render the message content, but would add:
+
+- storage reads/writes for every manual toggle if UI state is persisted,
+- schema or settings-key lifecycle concerns,
+- stale synthetic ids after retry/regeneration/import,
+- cleanup work when messages are deleted,
+- extra compatibility surface for exports and variants.
+
+Implementation should keep the helper pure and easy to memoize. If needed, cache render items in
+memory by:
+
+```text
+messageId + content reference/hash + updatedAt + status + shouldGroupActivity
+```
+
+Do not add disk persistence as a performance optimization without measured renderer cost.
+
+## Grouping Helper
+
+Create a pure helper near message components:
+
+```typescript
+buildAssistantRenderItems({
+  blocks,
+  messageId,
+  messageUpdatedAt,
+  shouldGroup,
+  isInternalToolCall
+}): AssistantRenderItem[]
+```
+
+Rules:
+
+- `shouldGroup === false`: every visible block returns as `kind: 'block'`.
+- A block is activity when it matches the spec's collapsible activity definition.
+- A block is groupable only when its status is not `loading` or `pending`.
+- Consecutive groupable activity blocks are buffered.
+- Any non-groupable visible block flushes the buffer before itself.
+- Internal hidden tool calls are skipped exactly as they are today.
+
+Keying:
+
+- Use stable block ids/tool call ids when present.
+- Fall back to `messageId:index`.
+- Group key can be `activity:${messageId}:${firstIndex}:${lastIndex}`.
+
+## Turn Settled Gate
+
+In `MessageItemAssistant.vue`, compute:
+
+```typescript
+const shouldGroupActivity = computed(() => {
+  if (resolvedIsInGeneratingThread.value) return false
+  if (currentMessage.value.status === 'pending') return false
+  return true
+})
+```
+
+If implementation finds paused user-interaction turns have `status: pending` even after stream end,
+do not broaden the first increment. Keep pending turns ungrouped unless a reliable existing signal
+already distinguishes inactive pending from active streaming.
+
+This keeps the behavior strict and avoids hiding activity while the turn is still live.
+
+## Activity Group Component
+
+`MessageBlockActivityGroup.vue` props:
+
+```typescript
+defineProps<{
+  blocks: DisplayAssistantMessageBlock[]
+  messageId: string
+  threadId: string
+  usage: DisplayMessageUsage
+  startedAt: number
+  endedAt: number
+  reasoningCount: number
+  toolCallCount: number
+}>()
+```
+
+State:
+
+- `isExpanded = false` by default.
+- Local state only; no config setting and no message metadata write.
+- Toggling emits `toggle-collapse` so `MessageItemAssistant` can reuse the existing
+  `variantChanged` notification path.
+
+Rendering:
+
+- Title row mirrors `ThinkContent` text size/color/chevron.
+- The title row is a real button with reset button styles.
+- Expanded children render in a flat `flex flex-col gap-1.5` container with no added left padding.
+- Reasoning blocks use `MessageBlockThink`.
+- Tool-call blocks use `MessageBlockToolCall`.
+- Artifact thinking can reuse the same visual pattern as reasoning if the codebase already renders
+  it through `MessageBlockThink`; otherwise keep it as an explicit non-goal for the first
+  implementation pass.
+
+## Title Text
+
+Recommended Chinese title:
+
+```text
+已经工作了 {duration} · {reasoningCount} 段思考 · {toolCallCount} 次工具调用
+```
+
+Recommended English title:
+
+```text
+Worked for {duration} · {reasoningCount} thought(s) · {toolCallCount} tool call(s)
+```
+
+Omit count segments when the count is `0`:
+
+- reasoning only: `已经工作了 12秒 · 1 段思考`
+- tool calls only: `已经工作了 12秒 · 2 次工具调用`
+
+## Duration Formatting
+
+Add a local formatter in the grouping helper or a small companion file:
+
+```typescript
+formatActivityDuration(durationMs: number, locale: string): string
+```
+
+Implementation detail:
+
+- Clamp non-finite values to `0`.
+- `totalSeconds = Math.max(0, Math.floor(durationMs / 1000))`.
+- Compute days/hours/minutes/seconds.
+- For Chinese, concatenate non-zero units and include seconds when all larger units are zero.
+- For English, use compact units: `d`, `h`, `m`, `s`.
+
+Avoid `Intl.DurationFormat` for now because support varies and would add fallback complexity.
+
+## Styling
+
+Use the current reasoning header as the visual reference:
+
+- `text-xs`
+- `leading-4`
+- muted foreground color consistent with `ThinkContent`
+- `lucide:chevron-right` when collapsed
+- `lucide:chevron-down` when expanded
+- no border/card wrapper
+- no additional content indentation
+- `self-start` width title, not full-width panel
+
+ASCII layout target:
+
+```text
+Assistant row
+  icon | message column
+       | info line
+       | > Worked for 1m 12s · 1 thought · 2 tool calls
+       | visible answer text
+```
+
+Expanded target:
+
+```text
+Assistant row
+  icon | message column
+       | v Worked for 1m 12s · 1 thought · 2 tool calls
+       | Thinking for 18s
+       | [tool] shell_command
+       | [tool] read_file
+       | visible answer text
+```
+
+## Compatibility
+
+- Existing persisted messages render unchanged except for the new collapsed presentation.
+- Export, context building, compaction, and model input are unaffected because stored blocks are not
+  changed.
+- Copy behavior remains based on `currentContent`.
+- Existing reasoning global setting `think_collapse` remains scoped to individual reasoning content
+  when a group is expanded. The group's default collapsed state is independent.
+- Manual activity-group expansion is intentionally not remembered across reloads in the first
+  increment.
+- Search and trace behavior are unaffected.
+
+## Risks
+
+1. **Duration overcounts separate groups in the same message.**
+   - Mitigation: first increment uses the only reliable end timestamp available in the current display
+     model, the final assistant message `updatedAt`. Do not add backend block update timestamps unless
+     the UX proves this is misleading.
+2. **Pending paused turns may remain long.**
+   - Mitigation: keep first increment strict. If needed later, add a reliable settled-state signal
+     rather than guessing from block shapes.
+3. **Rendering logic duplication.**
+   - Mitigation: group component renders only the narrow set of groupable block types.
+4. **Layout shift after reload.**
+   - Mitigation: collapse only after stream completion reload; this is expected and solves transcript
+     length. Keep scrolling behavior covered by existing message-list auto-scroll tests if affected.
+5. **Repeated renderer grouping work.**
+   - Mitigation: keep grouping pure and O(n). Add in-memory memoization only if profiling shows the
+     helper is material compared with existing block rendering.
+
+## Test Strategy
+
+Unit tests:
+
+- Group consecutive reasoning/tool-call blocks after a settled turn.
+- Split groups around `content` blocks.
+- Skip grouping when `shouldGroup` is false.
+- Skip `loading` and `pending` activity blocks.
+- Preserve internal hidden tool-call behavior.
+- Format duration for seconds, minutes, hours, and days.
+- Verify grouping helper remains deterministic so in-memory memoization is safe if added later.
+
+Component tests:
+
+- `MessageItemAssistant` renders `MessageBlockActivityGroup` for final messages.
+- `MessageItemAssistant` renders raw `MessageBlockThink` / `MessageBlockToolCall` while pending.
+- `MessageBlockActivityGroup` starts collapsed.
+- Clicking title expands and shows child reasoning/tool-call stubs.
+- Clicking again collapses.
+- Remounting a group returns it to the default collapsed state.
+- Title includes duration and counts.
+
+Manual QA:
+
+- Long agent turn with multiple tool calls.
+- Turn with only final text and no activity.
+- Turn with reasoning only.
+- Turn with tool calls only.
+- Error final message.
+- Dark mode.
+- Narrow chat width.
+
+Quality gates after implementation:
+
+```text
+pnpm run format
+pnpm run i18n
+pnpm run lint
+pnpm run typecheck
+pnpm test -- MessageItemAssistant
+pnpm test -- MessageBlockActivityGroup
+```

--- a/docs/features/automatic-turn-activity-collapse/spec.md
+++ b/docs/features/automatic-turn-activity-collapse/spec.md
@@ -1,0 +1,284 @@
+# Automatic Turn Activity Collapse
+
+## User Need
+
+DeepChat agent turns can include multiple reasoning sections and tool calls before the final answer.
+When every intermediate block remains expanded, one assistant turn becomes too long to scan and the
+final conclusion is pushed far down the transcript.
+
+Users need completed thinking/tool activity to collapse automatically after the turn settles, while
+keeping the final text answer visible and preserving the current message layout.
+
+## Goal
+
+After an assistant turn is complete, automatically group completed reasoning and visible tool-call
+blocks into a compact collapsible title row. The title should reuse the visual language of the
+current reasoning-content header, show how long the grouped work took, and expand/collapse on click.
+
+The grouping is a renderer-only presentation transform over the existing assistant message blocks.
+It must not create a new persisted message type, database table, or backend transport contract unless
+implementation proves the renderer cannot compute the required state reliably.
+
+## Current Structure Summary
+
+- Chat messages are loaded in `ChatPage.vue` from `ChatMessageRecord` into `DisplayMessage`.
+- Assistant content is stored as a JSON array of `AssistantMessageBlock`.
+- `MessageItemAssistant.vue` renders assistant blocks in order:
+  - `content` through `MessageBlockContent`
+  - `reasoning_content` through `MessageBlockThink`
+  - `tool_call` through `MessageBlockToolCall`
+  - other block types through their existing block components
+- Streaming updates apply blocks inline while the assistant message is pending, then stream end reloads
+  the persisted message.
+- Reasoning UI uses `ThinkContent.vue`, whose title row is compact text plus a chevron/ellipsis.
+
+## UX Requirements
+
+1. During streaming, keep the current layout and do not auto-collapse new blocks.
+2. After the turn settles, collapse completed reasoning/tool-call activity by default.
+3. Keep regular assistant text content visible by default.
+4. Clicking the activity title toggles the grouped activity open/closed.
+5. The activity title must not introduce a new indentation level for the expanded blocks.
+6. The expanded content must reuse existing reasoning/tool-call block rendering.
+7. Pending user actions, errors, media, plans, and normal text content must remain visible unless they
+   already have their own existing collapsed behavior.
+8. Internal tool calls that are already hidden, such as internal `update_plan`, must stay hidden.
+9. Copy behavior must continue to use the original assistant content array, so existing
+   `copyWithCotEnabled` behavior remains unchanged.
+10. The feature should not add a user setting in the first increment.
+
+## Collapsible Activity Definition
+
+The first increment treats these completed block types as collapsible activity:
+
+- `reasoning_content` with non-empty `content`
+- `artifact-thinking` with non-empty `content`
+- visible `tool_call` blocks, excluding current internal tool calls
+
+The first increment does not auto-collapse:
+
+- `content`
+- `plan`
+- `action`
+- `error`
+- `search`
+- `image`
+- `audio`
+- `video`
+- any block with `status` still `loading` or `pending`
+
+## Grouping Rules
+
+1. Build render groups only when the assistant turn is settled.
+2. Preserve the original block order.
+3. Consecutive collapsible activity blocks become one activity group.
+4. A visible non-activity block flushes the current activity group before rendering that block.
+5. If the final blocks are collapsible activity and the turn is settled, render them as the final
+   activity group.
+6. If a group contains only one collapsible block, still collapse it automatically after turn end.
+
+## Settled Turn Definition
+
+A turn is considered settled when the renderer is no longer receiving stream updates for that
+assistant message and the persisted message has been reloaded after stream completion or failure.
+
+Implementation should prefer existing signals:
+
+- `chat.stream.completed` / `chat.stream.failed` already trigger `loadMessages`.
+- Persisted `ChatMessageRecord.updatedAt` is available after reload.
+- `MessageItemAssistant` already receives message status and generating-thread state.
+
+The feature must not collapse blocks while the current assistant message is actively streaming.
+
+## Persistence Decision
+
+The first increment must not persist either the derived activity groups or each group's expanded /
+collapsed UI state.
+
+Keep these concepts separate:
+
+- Stored assistant blocks: existing source of truth, unchanged.
+- Derived activity groups: renderer-only, rebuilt from the block array.
+- Expanded/collapsed state: local component state, default collapsed after the group is mounted.
+
+Reasons:
+
+1. Grouping is a cheap linear pass over blocks that are already parsed for rendering.
+2. Persisting derived groups would duplicate source data and introduce invalidation rules when a
+   message is edited, retried, regenerated, imported, or rendered as a variant.
+3. Persisting per-group UI state would require stable synthetic group ids and storage cleanup for
+   deleted messages, without improving the main goal of reducing long completed turns.
+4. A stored state could make old long turns unexpectedly expanded on later visits, weakening the
+   default compact transcript behavior.
+
+If profiling later shows grouping is expensive, prefer an in-memory renderer cache keyed by message
+id, content identity, `updatedAt`, status, and the grouping gate. Do not add disk persistence for
+performance unless measurements show the renderer pass is a bottleneck.
+
+## Duration Display
+
+The collapsed title shows the duration from the grouped work's first creation timestamp to the
+containing assistant message's final update timestamp.
+
+Start timestamp:
+
+- Use the first folded block's `timestamp`.
+
+End timestamp:
+
+- Use the containing assistant message's `updatedAt` after it is exposed to the display message.
+- Clamp to the start timestamp if malformed or earlier than start.
+
+Formatting:
+
+- Use whole seconds.
+- Omit leading zero units.
+- Always include seconds when duration is under one minute.
+- Maximum display granularity is days, hours, minutes, seconds.
+
+Examples:
+
+- `已经工作了 8秒`
+- `已经工作了 3分钟12秒`
+- `已经工作了 2小时4分钟9秒`
+- `已经工作了 1天3小时10分钟2秒`
+
+English equivalent:
+
+- `Worked for 8s`
+- `Worked for 3m 12s`
+- `Worked for 2h 4m 9s`
+- `Worked for 1d 3h 10m 2s`
+
+## ASCII UI
+
+Before:
+
+```text
+Assistant  GPT-5  10:20
+
+Thinking for 18s                 v
+Reasoning text...
+More reasoning text...
+
+[tool] shell_command  pnpm run lint
+  params...
+  response...
+
+[tool] read_file  MessageItemAssistant.vue
+  params...
+  response...
+
+Final answer starts here...
+```
+
+After, collapsed:
+
+```text
+Assistant  GPT-5  10:20
+
+> 已经工作了 2分钟13秒 · 1 段思考 · 2 次工具调用
+
+Final answer starts here...
+```
+
+After, expanded:
+
+```text
+Assistant  GPT-5  10:20
+
+v 已经工作了 2分钟13秒 · 1 段思考 · 2 次工具调用
+Thinking for 18s                 v
+Reasoning text...
+More reasoning text...
+
+[tool] shell_command  pnpm run lint
+  params...
+  response...
+
+[tool] read_file  MessageItemAssistant.vue
+  params...
+  response...
+
+Final answer starts here...
+```
+
+No extra indentation:
+
+```text
+v 已经工作了 2分钟13秒 · 1 段思考 · 2 次工具调用
+Thinking for 18s
+[tool] shell_command
+Final answer starts here
+^ same left edge
+```
+
+Multiple activity phases in one turn:
+
+```text
+Assistant  GPT-5  10:20
+
+> 已经工作了 42秒 · 1 段思考 · 1 次工具调用
+
+I found the relevant file and will adjust the renderer grouping.
+
+> 已经工作了 1分钟9秒 · 1 段思考 · 2 次工具调用
+
+The implementation is complete.
+```
+
+## Accessibility
+
+1. The title row is a `button`.
+2. It exposes `aria-expanded`.
+3. It has an accessible label that includes the duration and whether it expands or collapses the
+   activity group.
+4. Keyboard activation uses native button behavior.
+5. The focus ring should match existing button/focus styling.
+
+## Acceptance Criteria
+
+1. Completed assistant messages with reasoning/tool-call blocks show collapsed activity groups by
+   default.
+2. Active streaming messages continue to show reasoning/tool-call progress as they do today.
+3. Clicking a collapsed group expands it and shows the original reasoning/tool-call components in the
+   original order.
+4. Clicking an expanded group collapses it again.
+5. The expanded content aligns with the group title and does not shift right compared with the
+   collapsed title.
+6. The final assistant text content remains visible without an extra click.
+7. Duration text is computed from the first folded block timestamp to the assistant message
+   `updatedAt`, formatted up to days/hours/minutes/seconds.
+8. Existing hidden internal tool calls remain hidden.
+9. Existing message copy behavior is unchanged.
+10. Grouping and expanded/collapsed UI state are not persisted in the first increment.
+11. Tests cover grouping, duration formatting, default collapsed state after turn completion, and no
+    grouping during active streaming.
+
+## Non-goals
+
+- No backend compaction or summarization of reasoning/tool results.
+- No deletion or mutation of stored assistant blocks.
+- No persistent per-user collapse preference.
+- No persisted per-message or per-group expansion state.
+- No new database table or migration.
+- No auto-collapse for pending permission/question cards.
+- No visual redesign of tool-call details.
+
+## Constraints
+
+- Keep the change focused in renderer message rendering.
+- Follow Vue 3 Composition API and existing Tailwind utility style.
+- Use existing i18n files for user-facing text.
+- Do not duplicate large message rendering logic unless extracted into a small local helper.
+- Avoid adding broad fallback heuristics for malformed historical data; clamp invalid duration and
+  render original blocks if grouping cannot be computed.
+
+## Open Questions
+
+Resolved: the first increment should be renderer-only and should not persist synthetic activity
+blocks.
+
+Resolved: grouping should happen only after a turn settles, not during streaming.
+
+Resolved: the group title should not create an indentation wrapper around expanded content.

--- a/docs/features/automatic-turn-activity-collapse/spec.md
+++ b/docs/features/automatic-turn-activity-collapse/spec.md
@@ -135,6 +135,7 @@ Formatting:
 - Omit leading zero units.
 - Always include seconds when duration is under one minute.
 - Maximum display granularity is days, hours, minutes, seconds.
+- Unit labels must come from i18n, not hardcoded locale checks.
 
 Examples:
 

--- a/docs/features/automatic-turn-activity-collapse/tasks.md
+++ b/docs/features/automatic-turn-activity-collapse/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+- [x] Inspect current assistant message rendering, reasoning header, tool-call block, stream end flow,
+      and display message conversion.
+- [x] Write SDD spec with UX requirements, grouping rules, duration rules, ASCII UI, and acceptance
+      criteria.
+- [x] Write implementation plan with affected files, render-only data model, component plan, and test
+      strategy.
+- [x] Document persistence and performance decision: renderer-derived grouping, local-only expansion
+      state, no disk persistence in the first increment.
+- [x] Add `updatedAt` to renderer display message types and conversion.
+- [x] Add pure activity grouping and duration formatting helper.
+- [x] Add `MessageBlockActivityGroup.vue`.
+- [x] Update `MessageItemAssistant.vue` to render grouped activity after settled turns.
+- [x] Add i18n keys for activity group title and duration units.
+- [x] Add renderer unit/component tests.
+- [x] Run `pnpm run format`.
+- [x] Run `pnpm run i18n`.
+- [x] Run `pnpm run lint`.
+- [x] Run focused renderer tests.
+- [x] Run `pnpm run typecheck` if the touched type surface is broader than expected.

--- a/src/renderer/src/components/chat/messageListItems.ts
+++ b/src/renderer/src/components/chat/messageListItems.ts
@@ -160,6 +160,7 @@ type DisplayMessageBase = {
   id: string
   role: 'user' | 'assistant'
   timestamp: number
+  updatedAt: number
   avatar: string
   name: string
   model_name: string

--- a/src/renderer/src/components/message/MessageBlockActivityGroup.vue
+++ b/src/renderer/src/components/message/MessageBlockActivityGroup.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="flex flex-col w-full gap-1.5" data-testid="activity-group">
+    <button
+      type="button"
+      data-testid="activity-group-toggle"
+      class="inline-flex max-w-full min-w-0 items-center gap-[10px] self-start text-xs leading-4 text-[rgba(37,37,37,0.5)] dark:text-white/50 select-none rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      :aria-expanded="isExpanded"
+      :aria-label="toggleLabel"
+      @click="toggleExpanded"
+    >
+      <Icon
+        :icon="isExpanded ? 'lucide:chevron-down' : 'lucide:chevron-right'"
+        class="w-[14px] h-[14px] shrink-0 text-[rgba(37,37,37,0.5)] dark:text-white/50"
+      />
+      <span class="min-w-0 truncate">
+        {{ titleText }}
+      </span>
+    </button>
+
+    <div v-show="isExpanded" class="flex flex-col w-full gap-1.5" data-testid="activity-group-body">
+      <template v-for="(block, index) in blocks" :key="buildActivityBlockKey(block, index)">
+        <MessageBlockThink
+          v-if="
+            (block.type === 'reasoning_content' || block.type === 'artifact-thinking') &&
+            block.content
+          "
+          :block="block"
+          :usage="usage"
+          @toggle-collapse="handleChildCollapseToggle"
+        />
+        <MessageBlockToolCall
+          v-else-if="block.type === 'tool_call'"
+          :block="block"
+          :message-id="messageId"
+          :thread-id="threadId"
+        />
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Icon } from '@iconify/vue'
+import { useI18n } from 'vue-i18n'
+import type {
+  DisplayAssistantMessageBlock,
+  DisplayMessageUsage
+} from '@/components/chat/messageListItems'
+import { formatActivityDuration } from './messageActivityGroups'
+import MessageBlockThink from './MessageBlockThink.vue'
+import MessageBlockToolCall from './MessageBlockToolCall.vue'
+
+const props = defineProps<{
+  blocks: DisplayAssistantMessageBlock[]
+  messageId: string
+  threadId: string
+  usage: DisplayMessageUsage
+  durationMs: number
+  reasoningCount: number
+  toolCallCount: number
+}>()
+
+const emit = defineEmits<{
+  'toggle-collapse': [isCollapsed: boolean]
+}>()
+
+const { t, locale } = useI18n()
+const isExpanded = ref(false)
+
+const currentLocale = computed(() => {
+  const value = typeof locale === 'string' ? locale : locale.value
+  return value || 'en-US'
+})
+
+const durationText = computed(() => formatActivityDuration(props.durationMs, currentLocale.value))
+
+const countSegments = computed(() => {
+  const segments: string[] = []
+  if (props.reasoningCount > 0) {
+    segments.push(t('chat.activityCollapse.reasoningCount', { count: props.reasoningCount }))
+  }
+  if (props.toolCallCount > 0) {
+    segments.push(t('chat.activityCollapse.toolCallCount', { count: props.toolCallCount }))
+  }
+  return segments
+})
+
+const titleText = computed(() =>
+  [t('chat.activityCollapse.workedFor', { duration: durationText.value }), ...countSegments.value]
+    .filter(Boolean)
+    .join(' · ')
+)
+
+const toggleLabel = computed(() =>
+  isExpanded.value
+    ? t('chat.activityCollapse.collapseLabel', { title: titleText.value })
+    : t('chat.activityCollapse.expandLabel', { title: titleText.value })
+)
+
+const toggleExpanded = () => {
+  isExpanded.value = !isExpanded.value
+  emit('toggle-collapse', !isExpanded.value)
+}
+
+const handleChildCollapseToggle = (isCollapsed: boolean) => {
+  emit('toggle-collapse', isCollapsed)
+}
+
+const buildActivityBlockKey = (block: DisplayAssistantMessageBlock, index: number): string =>
+  block.id ?? block.tool_call?.id ?? `${block.type}:${block.timestamp}:${index}`
+</script>

--- a/src/renderer/src/components/message/MessageBlockActivityGroup.vue
+++ b/src/renderer/src/components/message/MessageBlockActivityGroup.vue
@@ -65,15 +65,17 @@ const emit = defineEmits<{
   'toggle-collapse': [isCollapsed: boolean]
 }>()
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
 const isExpanded = ref(false)
 
-const currentLocale = computed(() => {
-  const value = typeof locale === 'string' ? locale : locale.value
-  return value || 'en-US'
-})
+const durationLabels = computed(() => ({
+  day: t('chat.activityCollapse.duration.day'),
+  hour: t('chat.activityCollapse.duration.hour'),
+  minute: t('chat.activityCollapse.duration.minute'),
+  second: t('chat.activityCollapse.duration.second')
+}))
 
-const durationText = computed(() => formatActivityDuration(props.durationMs, currentLocale.value))
+const durationText = computed(() => formatActivityDuration(props.durationMs, durationLabels.value))
 
 const countSegments = computed(() => {
   const segments: string[] = []

--- a/src/renderer/src/components/message/MessageItemAssistant.vue
+++ b/src/renderer/src/components/message/MessageItemAssistant.vue
@@ -37,59 +37,76 @@
             class="size-3 text-muted-foreground"
           />
           <div v-else class="flex flex-col w-full gap-1.5" data-message-content="true">
-            <template v-for="(block, idx) in currentContent" :key="`${message.id}-${idx}`">
+            <template v-for="item in currentRenderItems" :key="item.key">
+              <MessageBlockActivityGroup
+                v-if="item.kind === 'activity-group'"
+                :blocks="item.blocks"
+                :message-id="currentMessage.id"
+                :thread-id="currentThreadId"
+                :usage="currentMessage.usage"
+                :duration-ms="item.durationMs"
+                :reasoning-count="item.reasoningCount"
+                :tool-call-count="item.toolCallCount"
+                @toggle-collapse="handleCollapseToggle"
+              />
               <MessageBlockContent
-                v-if="block.type === 'content'"
-                :block="block"
+                v-else-if="item.block.type === 'content'"
+                :block="item.block"
                 :message-id="currentMessage.id"
                 :thread-id="currentThreadId"
                 :is-search-result="isSearchResult"
               />
               <MessageBlockThink
-                v-else-if="block.type === 'reasoning_content' && block.content"
-                :block="block"
-                :usage="message.usage"
+                v-else-if="
+                  (item.block.type === 'reasoning_content' ||
+                    item.block.type === 'artifact-thinking') &&
+                  item.block.content
+                "
+                :block="item.block"
+                :usage="currentMessage.usage"
                 @toggle-collapse="handleCollapseToggle"
               />
-              <MessageBlockPlan v-else-if="block.type === 'plan'" :block="block" />
+              <MessageBlockPlan v-else-if="item.block.type === 'plan'" :block="item.block" />
               <MessageBlockToolCall
-                v-else-if="block.type === 'tool_call' && !isInternalToolCall(block)"
-                :block="block"
+                v-else-if="item.block.type === 'tool_call' && !isInternalToolCall(item.block)"
+                :block="item.block"
                 :message-id="currentMessage.id"
                 :thread-id="currentThreadId"
               />
               <MessageBlockQuestionRequest
-                v-else-if="block.type === 'action' && block.action_type === 'question_request'"
-                :block="block"
+                v-else-if="
+                  item.block.type === 'action' && item.block.action_type === 'question_request'
+                "
+                :block="item.block"
               />
               <MessageBlockAction
-                v-else-if="block.type === 'action'"
+                v-else-if="item.block.type === 'action'"
                 :message-id="currentMessage.id"
                 :conversation-id="currentThreadId"
-                :block="block"
+                :block="item.block"
                 :is-read-only="isReadOnly"
                 @continue="handleBlockContinue"
                 @switch-provider="handleBlockSwitchProvider"
               />
               <MessageBlockAudio
-                v-else-if="isAudioBlock(block)"
-                :block="block"
+                v-else-if="isAudioBlock(item.block)"
+                :block="item.block"
                 :message-id="currentMessage.id"
                 :thread-id="currentThreadId"
               />
               <MessageBlockVideo
-                v-else-if="isVideoBlock(block)"
-                :block="block"
+                v-else-if="isVideoBlock(item.block)"
+                :block="item.block"
                 :message-id="currentMessage.id"
                 :thread-id="currentThreadId"
               />
               <MessageBlockImage
-                v-else-if="block.type === 'image'"
-                :block="block"
+                v-else-if="item.block.type === 'image'"
+                :block="item.block"
                 :message-id="currentMessage.id"
                 :thread-id="currentThreadId"
               />
-              <MessageBlockError v-else-if="block.type === 'error'" :block="block" />
+              <MessageBlockError v-else-if="item.block.type === 'error'" :block="item.block" />
             </template>
           </div>
           <MessageToolbar
@@ -193,6 +210,8 @@ import MessageBlockImage from './MessageBlockImage.vue'
 import MessageBlockAudio from './MessageBlockAudio.vue'
 import MessageBlockVideo from './MessageBlockVideo.vue'
 import MessageBlockPlan from './MessageBlockPlan.vue'
+import MessageBlockActivityGroup from './MessageBlockActivityGroup.vue'
+import { buildAssistantRenderItems } from './messageActivityGroups'
 
 import {
   Dialog,
@@ -362,6 +381,21 @@ const currentContent = computed(() => {
   const variant = allVariants.value[currentVariantIndex.value - 1]
   return (variant?.content || props.message.content) as DisplayAssistantMessageBlock[]
 })
+
+const shouldGroupActivity = computed(() => {
+  if (resolvedIsInGeneratingThread.value) return false
+  return currentMessage.value.status !== 'pending'
+})
+
+const currentRenderItems = computed(() =>
+  buildAssistantRenderItems({
+    blocks: currentContent.value,
+    messageId: currentMessage.value.id,
+    messageUpdatedAt: currentMessage.value.updatedAt,
+    shouldGroup: shouldGroupActivity.value,
+    isInternalToolCall
+  })
+)
 
 // 监听 allVariants 长度变化，用于新变体生成时的自动切换和持久化
 watch(

--- a/src/renderer/src/components/message/messageActivityGroups.ts
+++ b/src/renderer/src/components/message/messageActivityGroups.ts
@@ -25,6 +25,13 @@ export type BuildAssistantRenderItemsOptions = {
   isInternalToolCall?: (block: DisplayAssistantMessageBlock) => boolean
 }
 
+export type ActivityDurationLabels = {
+  day: string
+  hour: string
+  minute: string
+  second: string
+}
+
 type BufferedActivityBlock = {
   block: DisplayAssistantMessageBlock
   index: number
@@ -154,7 +161,10 @@ export const buildAssistantRenderItems = ({
   return items
 }
 
-export const formatActivityDuration = (durationMs: number, locale: string): string => {
+export const formatActivityDuration = (
+  durationMs: number,
+  labels: ActivityDurationLabels
+): string => {
   const safeDurationMs = Number.isFinite(durationMs) ? Math.max(0, durationMs) : 0
   let remainingSeconds = Math.floor(safeDurationMs / 1000)
   const days = Math.floor(remainingSeconds / 86_400)
@@ -164,24 +174,11 @@ export const formatActivityDuration = (durationMs: number, locale: string): stri
   const minutes = Math.floor(remainingSeconds / 60)
   const seconds = remainingSeconds % 60
 
-  const isChineseLocale =
-    locale.toLowerCase().startsWith('zh') || locale.toLowerCase().startsWith('yue')
-
-  if (isChineseLocale) {
-    const parts = [
-      days > 0 ? `${days}天` : '',
-      hours > 0 ? `${hours}小时` : '',
-      minutes > 0 ? `${minutes}分钟` : '',
-      seconds > 0 || (days === 0 && hours === 0 && minutes === 0) ? `${seconds}秒` : ''
-    ]
-    return parts.filter(Boolean).join('')
-  }
-
   const parts = [
-    days > 0 ? `${days}d` : '',
-    hours > 0 ? `${hours}h` : '',
-    minutes > 0 ? `${minutes}m` : '',
-    seconds > 0 || (days === 0 && hours === 0 && minutes === 0) ? `${seconds}s` : ''
+    days > 0 ? `${days}${labels.day}` : '',
+    hours > 0 ? `${hours}${labels.hour}` : '',
+    minutes > 0 ? `${minutes}${labels.minute}` : '',
+    seconds > 0 || (days === 0 && hours === 0 && minutes === 0) ? `${seconds}${labels.second}` : ''
   ]
-  return parts.filter(Boolean).join(' ')
+  return parts.filter(Boolean).join('').trimEnd()
 }

--- a/src/renderer/src/components/message/messageActivityGroups.ts
+++ b/src/renderer/src/components/message/messageActivityGroups.ts
@@ -1,0 +1,187 @@
+import type { DisplayAssistantMessageBlock } from '@/components/chat/messageListItems'
+
+export type AssistantRenderItem =
+  | {
+      kind: 'block'
+      key: string
+      block: DisplayAssistantMessageBlock
+    }
+  | {
+      kind: 'activity-group'
+      key: string
+      blocks: DisplayAssistantMessageBlock[]
+      startedAt: number
+      endedAt: number
+      durationMs: number
+      reasoningCount: number
+      toolCallCount: number
+    }
+
+export type BuildAssistantRenderItemsOptions = {
+  blocks: DisplayAssistantMessageBlock[]
+  messageId: string
+  messageUpdatedAt: number
+  shouldGroup: boolean
+  isInternalToolCall?: (block: DisplayAssistantMessageBlock) => boolean
+}
+
+type BufferedActivityBlock = {
+  block: DisplayAssistantMessageBlock
+  index: number
+}
+
+const ACTIVITY_BLOCK_TYPES = new Set<DisplayAssistantMessageBlock['type']>([
+  'reasoning_content',
+  'artifact-thinking',
+  'tool_call'
+])
+
+const isFiniteTimestamp = (value: number): boolean => Number.isFinite(value) && value >= 0
+
+const normalizeTimestamp = (value: number, fallback: number): number =>
+  isFiniteTimestamp(value) ? value : fallback
+
+const isReasoningActivityBlock = (block: DisplayAssistantMessageBlock): boolean =>
+  (block.type === 'reasoning_content' || block.type === 'artifact-thinking') &&
+  typeof block.content === 'string' &&
+  block.content.trim().length > 0
+
+export const isCompletedActivityBlock = (block: DisplayAssistantMessageBlock): boolean => {
+  if (!ACTIVITY_BLOCK_TYPES.has(block.type)) {
+    return false
+  }
+
+  if (block.status === 'loading' || block.status === 'pending') {
+    return false
+  }
+
+  if (block.type === 'tool_call') {
+    return true
+  }
+
+  return isReasoningActivityBlock(block)
+}
+
+const buildBlockKey = (
+  block: DisplayAssistantMessageBlock,
+  messageId: string,
+  index: number
+): string => {
+  const stableId = block.id ?? block.tool_call?.id
+  return stableId ? `${messageId}:${stableId}` : `${messageId}:${index}`
+}
+
+const buildGroupKey = (messageId: string, buffer: BufferedActivityBlock[]): string => {
+  const first = buffer[0]?.index ?? 0
+  const last = buffer[buffer.length - 1]?.index ?? first
+  return `activity:${messageId}:${first}:${last}`
+}
+
+const countReasoningBlocks = (blocks: DisplayAssistantMessageBlock[]): number =>
+  blocks.filter((block) => block.type === 'reasoning_content' || block.type === 'artifact-thinking')
+    .length
+
+const countToolCallBlocks = (blocks: DisplayAssistantMessageBlock[]): number =>
+  blocks.filter((block) => block.type === 'tool_call').length
+
+const buildActivityGroupItem = (
+  messageId: string,
+  messageUpdatedAt: number,
+  buffer: BufferedActivityBlock[]
+): AssistantRenderItem | null => {
+  const firstBlock = buffer[0]?.block
+  if (!firstBlock) {
+    return null
+  }
+
+  const startedAt = normalizeTimestamp(firstBlock.timestamp, messageUpdatedAt)
+  const endedAt = Math.max(startedAt, normalizeTimestamp(messageUpdatedAt, startedAt))
+  const blocks = buffer.map((item) => item.block)
+
+  return {
+    kind: 'activity-group',
+    key: buildGroupKey(messageId, buffer),
+    blocks,
+    startedAt,
+    endedAt,
+    durationMs: endedAt - startedAt,
+    reasoningCount: countReasoningBlocks(blocks),
+    toolCallCount: countToolCallBlocks(blocks)
+  }
+}
+
+export const buildAssistantRenderItems = ({
+  blocks,
+  messageId,
+  messageUpdatedAt,
+  shouldGroup,
+  isInternalToolCall
+}: BuildAssistantRenderItemsOptions): AssistantRenderItem[] => {
+  const items: AssistantRenderItem[] = []
+  let activityBuffer: BufferedActivityBlock[] = []
+
+  const flushActivityBuffer = () => {
+    if (activityBuffer.length === 0) {
+      return
+    }
+
+    const group = buildActivityGroupItem(messageId, messageUpdatedAt, activityBuffer)
+    if (group) {
+      items.push(group)
+    }
+    activityBuffer = []
+  }
+
+  blocks.forEach((block, index) => {
+    if (block.type === 'tool_call' && isInternalToolCall?.(block)) {
+      return
+    }
+
+    if (shouldGroup && isCompletedActivityBlock(block)) {
+      activityBuffer.push({ block, index })
+      return
+    }
+
+    flushActivityBuffer()
+    items.push({
+      kind: 'block',
+      key: buildBlockKey(block, messageId, index),
+      block
+    })
+  })
+
+  flushActivityBuffer()
+  return items
+}
+
+export const formatActivityDuration = (durationMs: number, locale: string): string => {
+  const safeDurationMs = Number.isFinite(durationMs) ? Math.max(0, durationMs) : 0
+  let remainingSeconds = Math.floor(safeDurationMs / 1000)
+  const days = Math.floor(remainingSeconds / 86_400)
+  remainingSeconds %= 86_400
+  const hours = Math.floor(remainingSeconds / 3_600)
+  remainingSeconds %= 3_600
+  const minutes = Math.floor(remainingSeconds / 60)
+  const seconds = remainingSeconds % 60
+
+  const isChineseLocale =
+    locale.toLowerCase().startsWith('zh') || locale.toLowerCase().startsWith('yue')
+
+  if (isChineseLocale) {
+    const parts = [
+      days > 0 ? `${days}天` : '',
+      hours > 0 ? `${hours}小时` : '',
+      minutes > 0 ? `${minutes}分钟` : '',
+      seconds > 0 || (days === 0 && hours === 0 && minutes === 0) ? `${seconds}秒` : ''
+    ]
+    return parts.filter(Boolean).join('')
+  }
+
+  const parts = [
+    days > 0 ? `${days}d` : '',
+    hours > 0 ? `${hours}h` : '',
+    minutes > 0 ? `${minutes}m` : '',
+    seconds > 0 || (days === 0 && hours === 0 && minutes === 0) ? `${seconds}s` : ''
+  ]
+  return parts.filter(Boolean).join(' ')
+}

--- a/src/renderer/src/i18n/da-DK/chat.json
+++ b/src/renderer/src/i18n/da-DK/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "Arbejdet i {duration}",
+    "reasoningCount": "{count} tanke(r)",
+    "toolCallCount": "{count} værktøjskald",
+    "expandLabel": "Udvid {title}",
+    "collapseLabel": "Skjul {title}",
+    "duration": {
+      "day": "d ",
+      "hour": "t ",
+      "minute": "min ",
+      "second": "s"
+    }
   }
 }

--- a/src/renderer/src/i18n/da-DK/chat.json
+++ b/src/renderer/src/i18n/da-DK/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Skill-kladden er kasseret.",
       "failed": "Kunne ikke håndtere skill-kladden: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/de-DE/chat.json
+++ b/src/renderer/src/i18n/de-DE/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "Gearbeitet für {duration}",
+    "reasoningCount": "{count} Gedanke(n)",
+    "toolCallCount": "{count} Werkzeugaufruf(e)",
+    "expandLabel": "Erweitern {title}",
+    "collapseLabel": "Einklappen {title}",
+    "duration": {
+      "day": "T ",
+      "hour": "Std. ",
+      "minute": "Min. ",
+      "second": "Sek."
+    }
   }
 }

--- a/src/renderer/src/i18n/de-DE/chat.json
+++ b/src/renderer/src/i18n/de-DE/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Skill-Entwurf verworfen.",
       "failed": "Skill-Entwurf konnte nicht verarbeitet werden: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/en-US/chat.json
+++ b/src/renderer/src/i18n/en-US/chat.json
@@ -410,6 +410,12 @@
     "reasoningCount": "{count} thought(s)",
     "toolCallCount": "{count} tool call(s)",
     "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "collapseLabel": "Collapse {title}",
+    "duration": {
+      "day": "d ",
+      "hour": "h ",
+      "minute": "m ",
+      "second": "s"
+    }
   }
 }

--- a/src/renderer/src/i18n/en-US/chat.json
+++ b/src/renderer/src/i18n/en-US/chat.json
@@ -404,5 +404,12 @@
       "description": "Everything is ready. Type your first message here to finish the onboarding flow.",
       "caption": "The spotlight stays on the input box until you send your first message."
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/es-ES/chat.json
+++ b/src/renderer/src/i18n/es-ES/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Borrador de skill descartado.",
       "failed": "No se pudo gestionar el borrador de skill: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/es-ES/chat.json
+++ b/src/renderer/src/i18n/es-ES/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "Trabajó durante {duration}",
+    "reasoningCount": "{count} pensamiento(s)",
+    "toolCallCount": "{count} llamada(s) a herramienta",
+    "expandLabel": "Expandir {title}",
+    "collapseLabel": "Contraer {title}",
+    "duration": {
+      "day": "d ",
+      "hour": "h ",
+      "minute": "min ",
+      "second": "s"
+    }
   }
 }

--- a/src/renderer/src/i18n/fa-IR/chat.json
+++ b/src/renderer/src/i18n/fa-IR/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "به مدت {duration} کار کرده است",
+    "reasoningCount": "{count} مورد تفکر",
+    "toolCallCount": "{count} فراخوانی ابزار",
+    "expandLabel": "گسترش {title}",
+    "collapseLabel": "جمع کردن {title}",
+    "duration": {
+      "day": " روز ",
+      "hour": " ساعت ",
+      "minute": " دقیقه ",
+      "second": " ثانیه"
+    }
   }
 }

--- a/src/renderer/src/i18n/fa-IR/chat.json
+++ b/src/renderer/src/i18n/fa-IR/chat.json
@@ -404,5 +404,12 @@
       "discarded": "پیش‌نویس مهارت دور انداخته شد.",
       "failed": "رسیدگی به پیش‌نویس مهارت ناموفق بود: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/fr-FR/chat.json
+++ b/src/renderer/src/i18n/fr-FR/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "A travaillé pendant {duration}",
+    "reasoningCount": "{count} réflexion(s)",
+    "toolCallCount": "{count} appel(s) d'outil",
+    "expandLabel": "Développer {title}",
+    "collapseLabel": "Réduire {title}",
+    "duration": {
+      "day": "j ",
+      "hour": "h ",
+      "minute": "min ",
+      "second": "s"
+    }
   }
 }

--- a/src/renderer/src/i18n/fr-FR/chat.json
+++ b/src/renderer/src/i18n/fr-FR/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Brouillon de compétence ignoré.",
       "failed": "Impossible de traiter le brouillon de compétence : {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/he-IL/chat.json
+++ b/src/renderer/src/i18n/he-IL/chat.json
@@ -404,5 +404,12 @@
       "discarded": "טיוטת המיומנות נמחקה.",
       "failed": "הטיפול בטיוטת המיומנות נכשל: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/he-IL/chat.json
+++ b/src/renderer/src/i18n/he-IL/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "עבד במשך {duration}",
+    "reasoningCount": "{count} מחשבות",
+    "toolCallCount": "{count} קריאות כלי",
+    "expandLabel": "הרחב את {title}",
+    "collapseLabel": "כווץ את {title}",
+    "duration": {
+      "day": " יום ",
+      "hour": " שעה ",
+      "minute": " דק׳ ",
+      "second": " שנ׳"
+    }
   }
 }

--- a/src/renderer/src/i18n/id-ID/chat.json
+++ b/src/renderer/src/i18n/id-ID/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "Bekerja selama {duration}",
+    "reasoningCount": "{count} pemikiran",
+    "toolCallCount": "{count} panggilan alat",
+    "expandLabel": "Perluas {title}",
+    "collapseLabel": "Ciutkan {title}",
+    "duration": {
+      "day": "h ",
+      "hour": "j ",
+      "minute": "m ",
+      "second": "d"
+    }
   }
 }

--- a/src/renderer/src/i18n/id-ID/chat.json
+++ b/src/renderer/src/i18n/id-ID/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Draf skill dibuang.",
       "failed": "Gagal menangani draf skill: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/it-IT/chat.json
+++ b/src/renderer/src/i18n/it-IT/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "Ha lavorato per {duration}",
+    "reasoningCount": "{count} ragionamento/i",
+    "toolCallCount": "{count} chiamata/e strumento",
+    "expandLabel": "Espandi {title}",
+    "collapseLabel": "Comprimi {title}",
+    "duration": {
+      "day": "g ",
+      "hour": "h ",
+      "minute": "min ",
+      "second": "s"
+    }
   }
 }

--- a/src/renderer/src/i18n/it-IT/chat.json
+++ b/src/renderer/src/i18n/it-IT/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Bozza di skill scartata.",
       "failed": "Impossibile gestire la bozza di skill: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/ja-JP/chat.json
+++ b/src/renderer/src/i18n/ja-JP/chat.json
@@ -404,5 +404,12 @@
       "discarded": "スキルドラフトを破棄しました。",
       "failed": "スキルドラフトの処理に失敗しました: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/ja-JP/chat.json
+++ b/src/renderer/src/i18n/ja-JP/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "{duration} 作業しました",
+    "reasoningCount": "{count} 件の思考",
+    "toolCallCount": "{count} 件のツール呼び出し",
+    "expandLabel": "{title} を展開",
+    "collapseLabel": "{title} を折りたたむ",
+    "duration": {
+      "day": "日",
+      "hour": "時間",
+      "minute": "分",
+      "second": "秒"
+    }
   }
 }

--- a/src/renderer/src/i18n/ko-KR/chat.json
+++ b/src/renderer/src/i18n/ko-KR/chat.json
@@ -404,5 +404,12 @@
       "discarded": "스킬 초안을 버렸습니다.",
       "failed": "스킬 초안 처리에 실패했습니다: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/ko-KR/chat.json
+++ b/src/renderer/src/i18n/ko-KR/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "{duration} 동안 작업함",
+    "reasoningCount": "{count}개 사고",
+    "toolCallCount": "{count}개 도구 호출",
+    "expandLabel": "{title} 펼치기",
+    "collapseLabel": "{title} 접기",
+    "duration": {
+      "day": "일",
+      "hour": "시간",
+      "minute": "분",
+      "second": "초"
+    }
   }
 }

--- a/src/renderer/src/i18n/ms-MY/chat.json
+++ b/src/renderer/src/i18n/ms-MY/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Draf skill telah dibuang.",
       "failed": "Gagal mengendalikan draf skill: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/ms-MY/chat.json
+++ b/src/renderer/src/i18n/ms-MY/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "Bekerja selama {duration}",
+    "reasoningCount": "{count} pemikiran",
+    "toolCallCount": "{count} panggilan alat",
+    "expandLabel": "Kembangkan {title}",
+    "collapseLabel": "Runtuhkan {title}",
+    "duration": {
+      "day": "h ",
+      "hour": "j ",
+      "minute": "m ",
+      "second": "s"
+    }
   }
 }

--- a/src/renderer/src/i18n/pl-PL/chat.json
+++ b/src/renderer/src/i18n/pl-PL/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Odrzucono szkic umiejętności.",
       "failed": "Nie udało się obsłużyć szkicu umiejętności: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/pl-PL/chat.json
+++ b/src/renderer/src/i18n/pl-PL/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "Pracowano przez {duration}",
+    "reasoningCount": "{count} rozumowanie(a)",
+    "toolCallCount": "{count} wywołanie(a) narzędzia",
+    "expandLabel": "Rozwiń {title}",
+    "collapseLabel": "Zwiń {title}",
+    "duration": {
+      "day": "d ",
+      "hour": "godz. ",
+      "minute": "min ",
+      "second": "s"
+    }
   }
 }

--- a/src/renderer/src/i18n/pt-BR/chat.json
+++ b/src/renderer/src/i18n/pt-BR/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Rascunho de skill descartado.",
       "failed": "Falha ao lidar com o rascunho de skill: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/pt-BR/chat.json
+++ b/src/renderer/src/i18n/pt-BR/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "Trabalhou por {duration}",
+    "reasoningCount": "{count} raciocínio(s)",
+    "toolCallCount": "{count} chamada(s) de ferramenta",
+    "expandLabel": "Expandir {title}",
+    "collapseLabel": "Recolher {title}",
+    "duration": {
+      "day": "d ",
+      "hour": "h ",
+      "minute": "min ",
+      "second": "s"
+    }
   }
 }

--- a/src/renderer/src/i18n/ru-RU/chat.json
+++ b/src/renderer/src/i18n/ru-RU/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "Работал(а) {duration}",
+    "reasoningCount": "{count} рассуждение(й)",
+    "toolCallCount": "{count} вызов(ов) инструмента",
+    "expandLabel": "Развернуть {title}",
+    "collapseLabel": "Свернуть {title}",
+    "duration": {
+      "day": "д ",
+      "hour": "ч ",
+      "minute": "мин ",
+      "second": "с"
+    }
   }
 }

--- a/src/renderer/src/i18n/ru-RU/chat.json
+++ b/src/renderer/src/i18n/ru-RU/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Черновик навыка отброшен.",
       "failed": "Не удалось обработать черновик навыка: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/tr-TR/chat.json
+++ b/src/renderer/src/i18n/tr-TR/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "{duration} boyunca çalıştı",
+    "reasoningCount": "{count} düşünce",
+    "toolCallCount": "{count} araç çağrısı",
+    "expandLabel": "{title} öğesini genişlet",
+    "collapseLabel": "{title} öğesini daralt",
+    "duration": {
+      "day": "g ",
+      "hour": "sa ",
+      "minute": "dk ",
+      "second": "sn"
+    }
   }
 }

--- a/src/renderer/src/i18n/tr-TR/chat.json
+++ b/src/renderer/src/i18n/tr-TR/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Skill taslağından vazgeçildi.",
       "failed": "Skill taslağı işlenemedi: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/vi-VN/chat.json
+++ b/src/renderer/src/i18n/vi-VN/chat.json
@@ -406,10 +406,16 @@
     }
   },
   "activityCollapse": {
-    "workedFor": "Worked for {duration}",
-    "reasoningCount": "{count} thought(s)",
-    "toolCallCount": "{count} tool call(s)",
-    "expandLabel": "Expand {title}",
-    "collapseLabel": "Collapse {title}"
+    "workedFor": "Hoạt động trong {duration}",
+    "reasoningCount": "{count} suy nghĩ",
+    "toolCallCount": "{count} lần gọi công cụ",
+    "expandLabel": "Mở rộng {title}",
+    "collapseLabel": "Thu gọn {title}",
+    "duration": {
+      "day": "ng ",
+      "hour": "g ",
+      "minute": "p ",
+      "second": "gi"
+    }
   }
 }

--- a/src/renderer/src/i18n/vi-VN/chat.json
+++ b/src/renderer/src/i18n/vi-VN/chat.json
@@ -404,5 +404,12 @@
       "discarded": "Đã loại bỏ bản nháp kỹ năng.",
       "failed": "Không thể xử lý bản nháp kỹ năng: {error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "Worked for {duration}",
+    "reasoningCount": "{count} thought(s)",
+    "toolCallCount": "{count} tool call(s)",
+    "expandLabel": "Expand {title}",
+    "collapseLabel": "Collapse {title}"
   }
 }

--- a/src/renderer/src/i18n/zh-CN/chat.json
+++ b/src/renderer/src/i18n/zh-CN/chat.json
@@ -410,6 +410,12 @@
     "reasoningCount": "{count} 段思考",
     "toolCallCount": "{count} 次工具调用",
     "expandLabel": "展开 {title}",
-    "collapseLabel": "收起 {title}"
+    "collapseLabel": "收起 {title}",
+    "duration": {
+      "day": "天",
+      "hour": "小时",
+      "minute": "分钟",
+      "second": "秒"
+    }
   }
 }

--- a/src/renderer/src/i18n/zh-CN/chat.json
+++ b/src/renderer/src/i18n/zh-CN/chat.json
@@ -404,5 +404,12 @@
       "description": "现在已经准备好了，在这里发送第一条消息即可完成引导。",
       "caption": "聚光会一直停留在输入框，直到你真正发出第一条消息。"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "已经工作了 {duration}",
+    "reasoningCount": "{count} 段思考",
+    "toolCallCount": "{count} 次工具调用",
+    "expandLabel": "展开 {title}",
+    "collapseLabel": "收起 {title}"
   }
 }

--- a/src/renderer/src/i18n/zh-HK/chat.json
+++ b/src/renderer/src/i18n/zh-HK/chat.json
@@ -404,5 +404,12 @@
       "discarded": "已丟棄技能草稿。",
       "failed": "處理技能草稿失敗：{error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "已經工作了 {duration}",
+    "reasoningCount": "{count} 段思考",
+    "toolCallCount": "{count} 次工具呼叫",
+    "expandLabel": "展開 {title}",
+    "collapseLabel": "收起 {title}"
   }
 }

--- a/src/renderer/src/i18n/zh-HK/chat.json
+++ b/src/renderer/src/i18n/zh-HK/chat.json
@@ -410,6 +410,12 @@
     "reasoningCount": "{count} 段思考",
     "toolCallCount": "{count} 次工具呼叫",
     "expandLabel": "展開 {title}",
-    "collapseLabel": "收起 {title}"
+    "collapseLabel": "收起 {title}",
+    "duration": {
+      "day": "天",
+      "hour": "小時",
+      "minute": "分鐘",
+      "second": "秒"
+    }
   }
 }

--- a/src/renderer/src/i18n/zh-TW/chat.json
+++ b/src/renderer/src/i18n/zh-TW/chat.json
@@ -404,5 +404,12 @@
       "discarded": "已捨棄技能草稿。",
       "failed": "處理技能草稿失敗：{error}"
     }
+  },
+  "activityCollapse": {
+    "workedFor": "已經工作了 {duration}",
+    "reasoningCount": "{count} 段思考",
+    "toolCallCount": "{count} 次工具呼叫",
+    "expandLabel": "展開 {title}",
+    "collapseLabel": "收起 {title}"
   }
 }

--- a/src/renderer/src/i18n/zh-TW/chat.json
+++ b/src/renderer/src/i18n/zh-TW/chat.json
@@ -410,6 +410,12 @@
     "reasoningCount": "{count} 段思考",
     "toolCallCount": "{count} 次工具呼叫",
     "expandLabel": "展開 {title}",
-    "collapseLabel": "收起 {title}"
+    "collapseLabel": "收合 {title}",
+    "duration": {
+      "day": "天",
+      "hour": "小時",
+      "minute": "分鐘",
+      "second": "秒"
+    }
   }
 }

--- a/src/renderer/src/pages/ChatPage.vue
+++ b/src/renderer/src/pages/ChatPage.vue
@@ -556,6 +556,7 @@ function toDisplayMessage(record: ChatMessageRecord): DisplayMessage {
   const baseMessage = {
     id: record.id,
     timestamp: record.createdAt,
+    updatedAt: record.updatedAt,
     avatar: '',
     name: record.role === 'user' ? 'You' : 'Assistant',
     model_name: modelName,
@@ -604,11 +605,13 @@ function toStreamingMessage(
   messageId?: string | null
 ): DisplayMessage {
   const modelId = sessionStore.activeSession?.modelId ?? ''
+  const now = Date.now()
   return {
     id: messageId ? `__streaming__:${messageId}` : '__streaming__',
     content: blocks as DisplayAssistantMessageBlock[],
     role: 'assistant',
-    timestamp: Date.now(),
+    timestamp: now,
+    updatedAt: now,
     avatar: '',
     name: 'Assistant',
     model_name: resolveAssistantModelName(modelId),

--- a/test/renderer/components/MessageList.test.ts
+++ b/test/renderer/components/MessageList.test.ts
@@ -89,6 +89,7 @@ function createMessage(id: string, role: 'user' | 'assistant', orderSeq: number)
           }
         : [],
     timestamp: orderSeq,
+    updatedAt: orderSeq,
     avatar: '',
     name: role === 'user' ? 'You' : 'Assistant',
     model_name: '',

--- a/test/renderer/components/message/MessageBlockActivityGroup.test.ts
+++ b/test/renderer/components/message/MessageBlockActivityGroup.test.ts
@@ -1,0 +1,153 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import MessageBlockActivityGroup from '@/components/message/MessageBlockActivityGroup.vue'
+import type {
+  DisplayAssistantMessageBlock,
+  DisplayMessageUsage
+} from '@/components/chat/messageListItems'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    locale: {
+      value: 'en-US'
+    },
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (key === 'chat.activityCollapse.workedFor') {
+        return `Worked for ${params?.duration}`
+      }
+      if (key === 'chat.activityCollapse.reasoningCount') {
+        return `${params?.count} thought(s)`
+      }
+      if (key === 'chat.activityCollapse.toolCallCount') {
+        return `${params?.count} tool call(s)`
+      }
+      if (key === 'chat.activityCollapse.expandLabel') {
+        return `Expand ${params?.title}`
+      }
+      if (key === 'chat.activityCollapse.collapseLabel') {
+        return `Collapse ${params?.title}`
+      }
+      return key
+    }
+  })
+}))
+
+const usage: DisplayMessageUsage = {
+  context_usage: 0,
+  tokens_per_second: 0,
+  total_tokens: 0,
+  generation_time: 0,
+  first_token_time: 0,
+  reasoning_start_time: 0,
+  reasoning_end_time: 0,
+  input_tokens: 0,
+  output_tokens: 0
+}
+
+const blocks: DisplayAssistantMessageBlock[] = [
+  {
+    type: 'reasoning_content',
+    content: 'thinking',
+    status: 'success',
+    timestamp: 1_000
+  },
+  {
+    type: 'tool_call',
+    status: 'success',
+    timestamp: 2_000,
+    tool_call: {
+      id: 'tc1',
+      name: 'shell_command'
+    }
+  }
+]
+
+const mountGroup = () =>
+  mount(MessageBlockActivityGroup, {
+    props: {
+      blocks,
+      messageId: 'm1',
+      threadId: 's1',
+      usage,
+      durationMs: 65_000,
+      reasoningCount: 1,
+      toolCallCount: 1
+    },
+    global: {
+      stubs: {
+        Icon: defineComponent({
+          name: 'Icon',
+          template: '<span data-testid="icon" />'
+        }),
+        MessageBlockThink: defineComponent({
+          name: 'MessageBlockThink',
+          props: {
+            block: {
+              type: Object,
+              required: true
+            }
+          },
+          template: '<div data-testid="think-block">{{ block.content }}</div>'
+        }),
+        MessageBlockToolCall: defineComponent({
+          name: 'MessageBlockToolCall',
+          props: {
+            block: {
+              type: Object,
+              required: true
+            }
+          },
+          template: '<div data-testid="tool-block">{{ block.tool_call?.name }}</div>'
+        })
+      }
+    }
+  })
+
+describe('MessageBlockActivityGroup', () => {
+  it('starts collapsed with duration and activity counts in the title', () => {
+    const wrapper = mountGroup()
+
+    expect(wrapper.get('[data-testid="activity-group-toggle"]').text()).toContain(
+      'Worked for 1m 5s · 1 thought(s) · 1 tool call(s)'
+    )
+    expect(wrapper.get('[data-testid="activity-group-toggle"]').attributes('aria-expanded')).toBe(
+      'false'
+    )
+    expect(wrapper.get('[data-testid="activity-group-body"]').isVisible()).toBe(false)
+  })
+
+  it('toggles expanded state and shows the original activity blocks', async () => {
+    const wrapper = mountGroup()
+
+    await wrapper.get('[data-testid="activity-group-toggle"]').trigger('click')
+
+    expect(wrapper.get('[data-testid="activity-group-toggle"]').attributes('aria-expanded')).toBe(
+      'true'
+    )
+    expect(wrapper.get('[data-testid="activity-group-body"]').isVisible()).toBe(true)
+    expect(wrapper.find('[data-testid="think-block"]').text()).toBe('thinking')
+    expect(wrapper.find('[data-testid="tool-block"]').text()).toBe('shell_command')
+
+    await wrapper.get('[data-testid="activity-group-toggle"]').trigger('click')
+
+    expect(wrapper.get('[data-testid="activity-group-toggle"]').attributes('aria-expanded')).toBe(
+      'false'
+    )
+  })
+
+  it('does not persist expanded state across remounts', async () => {
+    const wrapper = mountGroup()
+    await wrapper.get('[data-testid="activity-group-toggle"]').trigger('click')
+    expect(wrapper.get('[data-testid="activity-group-toggle"]').attributes('aria-expanded')).toBe(
+      'true'
+    )
+
+    wrapper.unmount()
+    const remounted = mountGroup()
+
+    expect(remounted.get('[data-testid="activity-group-toggle"]').attributes('aria-expanded')).toBe(
+      'false'
+    )
+  })
+})

--- a/test/renderer/components/message/MessageBlockActivityGroup.test.ts
+++ b/test/renderer/components/message/MessageBlockActivityGroup.test.ts
@@ -9,9 +9,6 @@ import type {
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    locale: {
-      value: 'en-US'
-    },
     t: (key: string, params?: Record<string, unknown>) => {
       if (key === 'chat.activityCollapse.workedFor') {
         return `Worked for ${params?.duration}`
@@ -27,6 +24,18 @@ vi.mock('vue-i18n', () => ({
       }
       if (key === 'chat.activityCollapse.collapseLabel') {
         return `Collapse ${params?.title}`
+      }
+      if (key === 'chat.activityCollapse.duration.day') {
+        return 'd '
+      }
+      if (key === 'chat.activityCollapse.duration.hour') {
+        return 'h '
+      }
+      if (key === 'chat.activityCollapse.duration.minute') {
+        return 'm '
+      }
+      if (key === 'chat.activityCollapse.duration.second') {
+        return 's'
       }
       return key
     }

--- a/test/renderer/components/message/MessageItemAssistant.test.ts
+++ b/test/renderer/components/message/MessageItemAssistant.test.ts
@@ -100,6 +100,7 @@ const createMessage = (
   id: 'm1',
   role: 'assistant',
   timestamp: 1,
+  updatedAt: 1,
   avatar: '',
   name: 'Assistant',
   model_name: 'GPT-4',
@@ -137,6 +138,29 @@ const createVideoLikeImageBlock = (
   ...overrides
 })
 
+const createThinkingBlock = (
+  overrides: Partial<DisplayAssistantMessageBlock> = {}
+): DisplayAssistantMessageBlock => ({
+  type: 'reasoning_content',
+  content: 'thinking',
+  status: 'success',
+  timestamp: 1,
+  ...overrides
+})
+
+const createToolCallBlock = (
+  overrides: Partial<DisplayAssistantMessageBlock> = {}
+): DisplayAssistantMessageBlock => ({
+  type: 'tool_call',
+  status: 'success',
+  timestamp: 2,
+  tool_call: {
+    id: 'tc1',
+    name: 'read_file'
+  },
+  ...overrides
+})
+
 describe('MessageItemAssistant', () => {
   const global = {
     stubs: {
@@ -161,7 +185,18 @@ describe('MessageItemAssistant', () => {
         template: '<div data-testid="video-block" />'
       }),
       MessageBlockAudio: componentStub('MessageBlockAudio'),
-      MessageBlockPlan: componentStub('MessageBlockPlan')
+      MessageBlockPlan: componentStub('MessageBlockPlan'),
+      MessageBlockActivityGroup: defineComponent({
+        name: 'MessageBlockActivityGroup',
+        props: {
+          blocks: {
+            type: Array,
+            required: true
+          }
+        },
+        template:
+          '<div data-testid="activity-group" :data-block-count="String(blocks.length)">activity</div>'
+      })
     }
   }
 
@@ -223,5 +258,36 @@ describe('MessageItemAssistant', () => {
     })
 
     expect(wrapper.find('[data-testid="video-block"]').exists()).toBe(false)
+  })
+
+  it('groups completed assistant activity blocks after the turn is settled', () => {
+    const wrapper = mount(MessageItemAssistant, {
+      props: {
+        message: createMessage('sent', [createThinkingBlock(), createToolCallBlock()]),
+        isCapturingImage: false,
+        isInGeneratingThread: false
+      },
+      global
+    })
+
+    expect(wrapper.find('[data-testid="activity-group"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="activity-group"]').attributes('data-block-count')).toBe('2')
+    expect(wrapper.findComponent({ name: 'MessageBlockThink' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'MessageBlockToolCall' }).exists()).toBe(false)
+  })
+
+  it('does not group activity while the assistant message is pending', () => {
+    const wrapper = mount(MessageItemAssistant, {
+      props: {
+        message: createMessage('pending', [createThinkingBlock(), createToolCallBlock()]),
+        isCapturingImage: false,
+        isInGeneratingThread: true
+      },
+      global
+    })
+
+    expect(wrapper.find('[data-testid="activity-group"]').exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'MessageBlockThink' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'MessageBlockToolCall' }).exists()).toBe(true)
   })
 })

--- a/test/renderer/components/message/MessageItemAssistant.test.ts
+++ b/test/renderer/components/message/MessageItemAssistant.test.ts
@@ -290,4 +290,60 @@ describe('MessageItemAssistant', () => {
     expect(wrapper.findComponent({ name: 'MessageBlockThink' }).exists()).toBe(true)
     expect(wrapper.findComponent({ name: 'MessageBlockToolCall' }).exists()).toBe(true)
   })
+
+  it('does not group sent activity while the thread is still generating', () => {
+    const wrapper = mount(MessageItemAssistant, {
+      props: {
+        message: createMessage('sent', [createThinkingBlock(), createToolCallBlock()]),
+        isCapturingImage: false,
+        isInGeneratingThread: true
+      },
+      global
+    })
+
+    expect(wrapper.find('[data-testid="activity-group"]').exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'MessageBlockThink' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'MessageBlockToolCall' }).exists()).toBe(true)
+  })
+
+  it('does not group pending activity when the thread is idle', () => {
+    const wrapper = mount(MessageItemAssistant, {
+      props: {
+        message: createMessage('pending', [createThinkingBlock(), createToolCallBlock()]),
+        isCapturingImage: false,
+        isInGeneratingThread: false
+      },
+      global
+    })
+
+    expect(wrapper.find('[data-testid="activity-group"]').exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'MessageBlockThink' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'MessageBlockToolCall' }).exists()).toBe(true)
+  })
+
+  it('excludes internal tool calls from activity groups', () => {
+    const wrapper = mount(MessageItemAssistant, {
+      props: {
+        message: createMessage('sent', [
+          createThinkingBlock(),
+          createToolCallBlock({
+            extra: {
+              internalTool: true
+            },
+            tool_call: {
+              id: 'tc-plan',
+              name: 'update_plan'
+            }
+          })
+        ]),
+        isCapturingImage: false,
+        isInGeneratingThread: false
+      },
+      global
+    })
+
+    expect(wrapper.find('[data-testid="activity-group"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="activity-group"]').attributes('data-block-count')).toBe('1')
+    expect(wrapper.findComponent({ name: 'MessageBlockToolCall' }).exists()).toBe(false)
+  })
 })

--- a/test/renderer/components/message/messageActivityGroups.test.ts
+++ b/test/renderer/components/message/messageActivityGroups.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import type { DisplayAssistantMessageBlock } from '@/components/chat/messageListItems'
+import {
+  buildAssistantRenderItems,
+  formatActivityDuration
+} from '@/components/message/messageActivityGroups'
+
+const createBlock = (
+  type: DisplayAssistantMessageBlock['type'],
+  overrides: Partial<DisplayAssistantMessageBlock> = {}
+): DisplayAssistantMessageBlock => ({
+  type,
+  status: 'success',
+  timestamp: 1_000,
+  ...overrides
+})
+
+describe('messageActivityGroups', () => {
+  it('groups consecutive completed reasoning and tool-call blocks', () => {
+    const items = buildAssistantRenderItems({
+      messageId: 'm1',
+      messageUpdatedAt: 70_000,
+      shouldGroup: true,
+      blocks: [
+        createBlock('reasoning_content', { content: 'thinking', timestamp: 10_000 }),
+        createBlock('tool_call', {
+          timestamp: 20_000,
+          tool_call: {
+            id: 'tc1',
+            name: 'read_file'
+          }
+        })
+      ]
+    })
+
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      kind: 'activity-group',
+      startedAt: 10_000,
+      endedAt: 70_000,
+      durationMs: 60_000,
+      reasoningCount: 1,
+      toolCallCount: 1
+    })
+  })
+
+  it('splits activity groups around visible content blocks', () => {
+    const items = buildAssistantRenderItems({
+      messageId: 'm1',
+      messageUpdatedAt: 12_000,
+      shouldGroup: true,
+      blocks: [
+        createBlock('reasoning_content', { content: 'first' }),
+        createBlock('content', { content: 'answer' }),
+        createBlock('tool_call', {
+          tool_call: {
+            id: 'tc1',
+            name: 'shell'
+          }
+        })
+      ]
+    })
+
+    expect(items.map((item) => item.kind)).toEqual(['activity-group', 'block', 'activity-group'])
+  })
+
+  it('does not group when the turn is not settled', () => {
+    const items = buildAssistantRenderItems({
+      messageId: 'm1',
+      messageUpdatedAt: 12_000,
+      shouldGroup: false,
+      blocks: [
+        createBlock('reasoning_content', { content: 'thinking' }),
+        createBlock('tool_call', {
+          tool_call: {
+            id: 'tc1',
+            name: 'shell'
+          }
+        })
+      ]
+    })
+
+    expect(items.map((item) => item.kind)).toEqual(['block', 'block'])
+  })
+
+  it('does not group pending or loading activity blocks', () => {
+    const items = buildAssistantRenderItems({
+      messageId: 'm1',
+      messageUpdatedAt: 12_000,
+      shouldGroup: true,
+      blocks: [
+        createBlock('reasoning_content', { content: 'thinking', status: 'loading' }),
+        createBlock('tool_call', {
+          status: 'pending',
+          tool_call: {
+            id: 'tc1',
+            name: 'shell'
+          }
+        })
+      ]
+    })
+
+    expect(items.map((item) => item.kind)).toEqual(['block', 'block'])
+  })
+
+  it('skips internal hidden tool calls', () => {
+    const items = buildAssistantRenderItems({
+      messageId: 'm1',
+      messageUpdatedAt: 12_000,
+      shouldGroup: true,
+      isInternalToolCall: (block) =>
+        block.tool_call?.name === 'update_plan' && block.extra?.internalTool === true,
+      blocks: [
+        createBlock('tool_call', {
+          extra: {
+            internalTool: true
+          },
+          tool_call: {
+            id: 'tc1',
+            name: 'update_plan'
+          }
+        }),
+        createBlock('content', { content: 'visible' })
+      ]
+    })
+
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      kind: 'block',
+      block: {
+        type: 'content'
+      }
+    })
+  })
+
+  it('formats duration up to days, hours, minutes, and seconds', () => {
+    expect(formatActivityDuration(8_900, 'zh-CN')).toBe('8秒')
+    expect(formatActivityDuration(192_000, 'zh-CN')).toBe('3分钟12秒')
+    expect(formatActivityDuration(7_449_000, 'zh-CN')).toBe('2小时4分钟9秒')
+    expect(formatActivityDuration(97_802_000, 'zh-CN')).toBe('1天3小时10分钟2秒')
+
+    expect(formatActivityDuration(192_000, 'en-US')).toBe('3m 12s')
+  })
+})

--- a/test/renderer/components/message/messageActivityGroups.test.ts
+++ b/test/renderer/components/message/messageActivityGroups.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { DisplayAssistantMessageBlock } from '@/components/chat/messageListItems'
 import {
+  type ActivityDurationLabels,
   buildAssistantRenderItems,
   formatActivityDuration
 } from '@/components/message/messageActivityGroups'
@@ -14,6 +15,20 @@ const createBlock = (
   timestamp: 1_000,
   ...overrides
 })
+
+const zhDurationLabels: ActivityDurationLabels = {
+  day: '天',
+  hour: '小时',
+  minute: '分钟',
+  second: '秒'
+}
+
+const enDurationLabels: ActivityDurationLabels = {
+  day: 'd ',
+  hour: 'h ',
+  minute: 'm ',
+  second: 's'
+}
 
 describe('messageActivityGroups', () => {
   it('groups consecutive completed reasoning and tool-call blocks', () => {
@@ -134,11 +149,11 @@ describe('messageActivityGroups', () => {
   })
 
   it('formats duration up to days, hours, minutes, and seconds', () => {
-    expect(formatActivityDuration(8_900, 'zh-CN')).toBe('8秒')
-    expect(formatActivityDuration(192_000, 'zh-CN')).toBe('3分钟12秒')
-    expect(formatActivityDuration(7_449_000, 'zh-CN')).toBe('2小时4分钟9秒')
-    expect(formatActivityDuration(97_802_000, 'zh-CN')).toBe('1天3小时10分钟2秒')
+    expect(formatActivityDuration(8_900, zhDurationLabels)).toBe('8秒')
+    expect(formatActivityDuration(192_000, zhDurationLabels)).toBe('3分钟12秒')
+    expect(formatActivityDuration(7_449_000, zhDurationLabels)).toBe('2小时4分钟9秒')
+    expect(formatActivityDuration(97_802_000, zhDurationLabels)).toBe('1天3小时10分钟2秒')
 
-    expect(formatActivityDuration(192_000, 'en-US')).toBe('3m 12s')
+    expect(formatActivityDuration(192_000, enDurationLabels)).toBe('3m 12s')
   })
 })


### PR DESCRIPTION
## Summary
- Add renderer-only grouping for completed reasoning and tool-call activity blocks.
- Add a collapsible activity title with worked duration and activity counts while keeping final answer text visible.
- Document SDD plan and persistence decision for local-only collapse state.

## Tests
- pnpm run i18n
- pnpm run format
- pnpm run lint
- pnpm run typecheck
- pnpm exec vitest --config vitest.config.renderer.ts test/renderer/components/message/messageActivityGroups.test.ts test/renderer/components/message/MessageBlockActivityGroup.test.ts test/renderer/components/message/MessageItemAssistant.test.ts test/renderer/components/MessageList.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant responses automatically group/collapse completed reasoning and tool interactions into expandable activity summaries showing duration and counts.

* **Documentation**
  * Added plan, spec, and task docs describing UX, behavior, duration rules, accessibility, and tests.

* **Localization**
  * Added activity-collapse UI strings for many locales.

* **Tests**
  * Added unit and component tests for grouping, duration formatting, accessibility, and i18n.

* **Chores**
  * Message objects now include an updated timestamp used by rendering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->