### PR TITLE
feat(sidebar): add chat number shortcuts

### DIFF
--- a/docs/features/sidebar-chat-number-shortcuts/plan.md
+++ b/docs/features/sidebar-chat-number-shortcuts/plan.md
@@ -12,7 +12,7 @@
 - Detect platform with existing renderer device information, preferring `useDeviceVersion()` or the
   same `createDeviceClient().getDeviceInfo()` source used by existing components.
 - On macOS, handle `event.metaKey`; on Windows/Linux, handle `event.altKey`.
-- Start a 2 second timer when the platform modifier is pressed by itself.
+- Start a 0.5 second timer when the platform modifier is pressed by itself.
 - Show `showShortcutBadges` when the timer completes and the modifier is still down.
 - Clear the timer and hide badges on modifier release, blur, visibility change, unmount, or sidebar
   collapse.
@@ -59,7 +59,7 @@
   - missing index does nothing;
   - editable focused elements suppress switching.
 - Cover long-press behavior with fake timers:
-  - badges show after 2 seconds;
+  - badges show after 0.5 seconds;
   - badges hide on modifier release;
   - delete button is not rendered/clickable while the badge is visible.
 - Cover hover separation:
@@ -107,7 +107,7 @@ collapse state, and pin/unpin changes.
 ```text
 Window keydown
   -> detect platform modifier
-  -> if modifier-only, start 2s badge timer
+  -> if modifier-only, start 0.5s badge timer
   -> if modifier+digit, recompute visibleShortcutRows
   -> select target session through sessionStore.selectSession()
 
@@ -143,5 +143,5 @@ Window keyup / blur / visibility hidden / unmount
 - Targeted renderer tests for the sidebar shortcut behavior
 - Manual check on macOS and Windows/Linux-equivalent platform mocks:
   - press `Command+2` / `Alt+2`;
-  - hold modifier for 2 seconds;
+  - hold modifier for 0.5 seconds;
   - search/filter/collapse, then verify badge numbers recalculate.

--- a/docs/features/sidebar-chat-number-shortcuts/plan.md
+++ b/docs/features/sidebar-chat-number-shortcuts/plan.md
@@ -1,0 +1,147 @@
+# Implementation Plan — Sidebar Chat Number Shortcuts
+
+## Touch Points
+
+### Sidebar container — `src/renderer/src/components/WindowSideBar.vue`
+
+- Compute a `numberedShortcutSessions` array from the same renderer state used by the visible list:
+  `pinnedSessions` when expanded, followed by each non-collapsed `filteredGroups[].sessions`.
+- Limit numbering to the first 10 sessions and map row indexes to shortcut labels:
+  `1..9`, then `0`.
+- Register window-level `keydown` / `keyup` listeners while the sidebar is mounted.
+- Detect platform with existing renderer device information, preferring `useDeviceVersion()` or the
+  same `createDeviceClient().getDeviceInfo()` source used by existing components.
+- On macOS, handle `event.metaKey`; on Windows/Linux, handle `event.altKey`.
+- Start a 2 second timer when the platform modifier is pressed by itself.
+- Show `showShortcutBadges` when the timer completes and the modifier is still down.
+- Clear the timer and hide badges on modifier release, blur, visibility change, unmount, or sidebar
+  collapse.
+- Ignore shortcut handling when focus is inside editable UI or when modal/overlay focus owns the
+  keyboard.
+- On number shortcut, recompute the current mapping synchronously and call
+  `sessionStore.selectSession(target.id)` when a target exists.
+
+### Sidebar item — `src/renderer/src/components/WindowSideBarSessionItem.vue`
+
+- Add optional props:
+  - `shortcutBadgeLabel?: string | null`
+  - `shortcutBadgeVisible?: boolean`
+- Render the badge inside the existing `.right-button` area.
+- When the badge is visible, hide/disable the delete button in that same area so the badge covers
+  the hover delete affordance.
+- Keep badge visibility controlled only by the explicit `shortcutBadgeVisible` prop. Do not make
+  shortcut badges appear through `.session-item:hover`, `group-hover`, or `focus-within` selectors.
+- Keep the existing hover delete trigger intact for the normal state; the long-press overlay should
+  replace what is rendered in the right slot, not alter the row's hover state machine.
+- Add ARIA/tooltip text using i18n, e.g. "Switch to this chat with {shortcut}".
+- Keep row width stable; the badge must not shift the chat title or resize the row.
+
+### i18n — `src/renderer/src/i18n/*/thread.json`
+
+- Add labels under `thread.actions` or a sidebar-oriented namespace:
+  - `switchWithShortcut`
+  - `shortcutBadge`
+- Include at least English and Chinese source strings in the implementation increment, then run
+  `pnpm run i18n` to synchronize locale files according to the repository workflow.
+
+### Tests
+
+- Add renderer unit coverage near the sidebar tests. If no direct sidebar suite exists, add
+  `test/renderer/components/WindowSideBar*.test.ts` with Vue Test Utils.
+- Cover visible-row mapping:
+  - pinned expanded rows before grouped rows;
+  - collapsed pinned/group sections excluded;
+  - search-filtered rows excluded;
+  - `0` maps to the tenth row.
+- Cover keyboard behavior:
+  - macOS uses `metaKey`;
+  - Windows/Linux uses `altKey`;
+  - missing index does nothing;
+  - editable focused elements suppress switching.
+- Cover long-press behavior with fake timers:
+  - badges show after 2 seconds;
+  - badges hide on modifier release;
+  - delete button is not rendered/clickable while the badge is visible.
+- Cover hover separation:
+  - hovering a row without long-press does not render a shortcut badge;
+  - long-press renders badges even when no row is hovered;
+  - after long-press ends, hover delete behavior still works.
+
+## Shortcut Mapping
+
+The mapping is intentionally not stored. It is derived from current computed values each time:
+
+```text
+visibleShortcutRows =
+  expanded pinned sessions
+  + expanded grouped sessions in rendered group order
+
+keys:
+  1 -> visibleShortcutRows[0]
+  2 -> visibleShortcutRows[1]
+  ...
+  9 -> visibleShortcutRows[8]
+  0 -> visibleShortcutRows[9]
+```
+
+This keeps behavior aligned with sidebar search, agent filtering, lazy-loaded sessions, group
+collapse state, and pin/unpin changes.
+
+## Decisions
+
+- **Renderer-only shortcut.** The feature depends on current sidebar presentation state, so global
+  Electron accelerators or main-process presenters would be the wrong source of truth.
+- **Visible rows only.** Group headers are not selectable chats, and collapsed/filtered/unloaded
+  sessions are not part of the user's current visual list.
+- **`0` means tenth.** This matches common numbered shortcut conventions and keeps the first ten rows
+  addressable.
+- **Badges replace delete affordance.** The screenshot shows the shortcut label in the right-side
+  action slot; using the existing delete slot avoids adding another competing control.
+- **Hover and shortcut states stay separate.** Hover remains responsible for delete affordance
+  visibility; modifier long-press is the only trigger for shortcut badge visibility.
+- **No settings surface in first increment.** The requested shortcut is fixed and discoverable via
+  long-press, keeping the change small.
+
+## Event Flow
+
+```text
+Window keydown
+  -> detect platform modifier
+  -> if modifier-only, start 2s badge timer
+  -> if modifier+digit, recompute visibleShortcutRows
+  -> select target session through sessionStore.selectSession()
+
+Window keyup / blur / visibility hidden / unmount
+  -> cancel badge timer
+  -> hide badges
+```
+
+## Compatibility
+
+- Existing session activation, route updates, message clearing, and selected agent sync remain
+  delegated to `sessionStore.selectSession()`.
+- Existing pin/unpin animation and delete dialog behavior are unchanged.
+- The shortcut should not conflict with `Command+F` chat search because it listens only for digits.
+- The long-press overlay should respect reduced-motion preferences by avoiding nonessential
+  animation.
+
+## Risks And Mitigations
+
+- **Alt conflicts on Windows/Linux:** handle only `Alt+digit` and modifier-only hold. Avoid
+  preventing default for unrelated Alt combinations.
+- **Input focus conflicts:** suppress the shortcut in editable elements and active overlays.
+- **Stale timer state:** clear timers on keyup, blur, visibility change, unmount, and sidebar
+  collapse.
+- **Layout regression:** keep badge rendering inside the current right action slot and verify desktop
+  plus narrow sidebar widths.
+
+## Validation
+
+- `pnpm run format`
+- `pnpm run i18n`
+- `pnpm run lint`
+- Targeted renderer tests for the sidebar shortcut behavior
+- Manual check on macOS and Windows/Linux-equivalent platform mocks:
+  - press `Command+2` / `Alt+2`;
+  - hold modifier for 2 seconds;
+  - search/filter/collapse, then verify badge numbers recalculate.

--- a/docs/features/sidebar-chat-number-shortcuts/spec.md
+++ b/docs/features/sidebar-chat-number-shortcuts/spec.md
@@ -15,7 +15,7 @@ Add renderer-local number shortcuts for the current left sidebar chat list:
 - `1` maps to the first currently displayed chat row, `2` to the second, and so on.
 - `0` maps to the tenth currently displayed chat row.
 - The mapping is recalculated from the current renderer state every time the shortcut is pressed.
-- Holding the platform modifier for 2 seconds shows shortcut badges on the first ten displayed chat
+- Holding the platform modifier for 0.5 seconds shows shortcut badges on the first ten displayed chat
   rows, matching the provided screenshot style.
 
 ## Acceptance Criteria
@@ -34,7 +34,7 @@ Add renderer-local number shortcuts for the current left sidebar chat list:
 5. If the requested index has no current chat row, the shortcut is ignored without UI noise.
 6. The shortcut handler does not fire while typing in inputs, textareas, contenteditable editors, or
    active command/search overlays.
-7. Holding only the platform modifier for 2 seconds shows number badges for at most ten displayed
+7. Holding only the platform modifier for 0.5 seconds shows number badges for at most ten displayed
    chat rows. Releasing the modifier hides them immediately.
 8. While the badge overlay is visible, it occupies the same right-side area as the hover delete
    button so the delete button is visually covered and cannot be clicked.
@@ -67,7 +67,7 @@ Hover row before this feature:
 +------------------------------------------------+
 ```
 
-Modifier held for 2 seconds:
+Modifier held for 0.5 seconds:
 
 ```text
 +------------------------------------------------+
@@ -106,8 +106,8 @@ Collapsed and filtered rows do not receive numbers:
 - No stored preference, migration, menu item, global Electron accelerator, or main-process presenter
   change is needed for the first increment.
 - The implementation should stay inside existing sidebar boundaries and reuse the session store.
-- Badge visuals should follow the current sidebar item styling: compact pill, muted surface,
-  right-aligned, no layout jump.
+- Badge visuals should follow the current sidebar item styling: compact pill, right-aligned, no
+  layout jump, with the same default surface as the pin/delete action buttons.
 - Badge display state must be driven by the modifier long-press state, not by CSS `:hover`,
   `group-hover`, or row focus selectors.
 - Do not change session sorting, grouping, pagination, pinning, deletion, or agent filter behavior.

--- a/docs/features/sidebar-chat-number-shortcuts/spec.md
+++ b/docs/features/sidebar-chat-number-shortcuts/spec.md
@@ -1,0 +1,127 @@
+# Sidebar Chat Number Shortcuts
+
+## User Need
+
+Users with many chats in the left sidebar need a fast way to switch between the currently visible
+chat rows without moving the pointer. The shortcut should be discoverable in the same place where
+the action will happen, so users can learn the mapping while looking at the sidebar.
+
+## Goal
+
+Add renderer-local number shortcuts for the current left sidebar chat list:
+
+- macOS: `Command+1` through `Command+9`, plus `Command+0`.
+- Windows/Linux: `Alt+1` through `Alt+9`, plus `Alt+0`.
+- `1` maps to the first currently displayed chat row, `2` to the second, and so on.
+- `0` maps to the tenth currently displayed chat row.
+- The mapping is recalculated from the current renderer state every time the shortcut is pressed.
+- Holding the platform modifier for 2 seconds shows shortcut badges on the first ten displayed chat
+  rows, matching the provided screenshot style.
+
+## Acceptance Criteria
+
+1. Pressing `Command+N` on macOS or `Alt+N` on Windows/Linux selects the Nth chat in the left
+   sidebar's current displayed order.
+2. `N=1..9` selects rows 1 through 9; `N=0` selects row 10.
+3. The displayed order is derived only from the renderer's current sidebar state:
+   - pinned chats first when the pinned section is expanded;
+   - grouped chats in the same order as `filteredGroups`;
+   - collapsed sections, filtered-out search results, empty group headers, and unloaded pages are
+     excluded;
+   - hidden pin-flight placeholders are excluded.
+4. Shortcut selection calls the existing `sessionStore.selectSession(session.id)` path and does not
+   add main-process IPC or persisted shortcut settings.
+5. If the requested index has no current chat row, the shortcut is ignored without UI noise.
+6. The shortcut handler does not fire while typing in inputs, textareas, contenteditable editors, or
+   active command/search overlays.
+7. Holding only the platform modifier for 2 seconds shows number badges for at most ten displayed
+   chat rows. Releasing the modifier hides them immediately.
+8. While the badge overlay is visible, it occupies the same right-side area as the hover delete
+   button so the delete button is visually covered and cannot be clicked.
+9. Badge visibility is independent from row hover/focus state:
+   - hovering a row never starts or reveals shortcut badges;
+   - long-pressing the platform modifier never forces the row into its hover visual state;
+   - when badges are hidden, existing hover delete behavior remains unchanged.
+10. The overlay labels use `⌘1..⌘9`, `⌘0` on macOS and `Alt+1..Alt+9`, `Alt+0` on Windows/Linux.
+11. The overlay updates from current renderer state when sidebar search, agent filter, pinned state,
+    collapse state, or session list data changes.
+12. The sidebar collapsed state does not expose hidden chat shortcuts. If the sidebar is collapsed,
+    shortcut switching and badge rendering are disabled.
+13. All user-facing tooltip/ARIA text uses vue-i18n keys.
+
+## ASCII UI
+
+Default row, no hover:
+
+```text
++------------------------------------------------+
+|  [pin space]  Chat title text              ... |
++------------------------------------------------+
+```
+
+Hover row before this feature:
+
+```text
++------------------------------------------------+
+|  [pin]       Chat title text              [del]|
++------------------------------------------------+
+```
+
+Modifier held for 2 seconds:
+
+```text
++------------------------------------------------+
+|  [pin]       Chat title text              [⌘1] |
+|  [pin]       Another title                [⌘2] |
+|  [pin]       Third title                  [⌘3] |
+|  ...                                           |
+|  [pin]       Tenth title                  [⌘0] |
++------------------------------------------------+
+```
+
+Windows/Linux badge labels:
+
+```text
++------------------------------------------------+
+|  [pin]       Chat title text             [Alt+1]|
+|  [pin]       Another title               [Alt+2]|
++------------------------------------------------+
+```
+
+Collapsed and filtered rows do not receive numbers:
+
+```text
++------------------------------------------------+
+|  Pinned                                [closed]|
+|  Today                                  [open] |
+|    Visible chat A                         [⌘1]|
+|    Visible chat B                         [⌘2]|
+|  Older                                 [closed]|
++------------------------------------------------+
+```
+
+## Constraints
+
+- This is a renderer-only feature driven by the sidebar's current computed state.
+- No stored preference, migration, menu item, global Electron accelerator, or main-process presenter
+  change is needed for the first increment.
+- The implementation should stay inside existing sidebar boundaries and reuse the session store.
+- Badge visuals should follow the current sidebar item styling: compact pill, muted surface,
+  right-aligned, no layout jump.
+- Badge display state must be driven by the modifier long-press state, not by CSS `:hover`,
+  `group-hover`, or row focus selectors.
+- Do not change session sorting, grouping, pagination, pinning, deletion, or agent filter behavior.
+
+## Non-goals
+
+- No configurable keybinding UI in settings.
+- No shortcuts for group headers, settings, remote controls, new chat, or non-chat sidebar items.
+- No switching to sessions that are not currently loaded in the renderer.
+- No mouse-only tutorial or onboarding modal.
+- No changes to chat input shortcuts.
+
+## Business Value
+
+The feature reduces navigation friction for keyboard-heavy users and makes the shortcut self-teaching
+through the sidebar badge overlay, while keeping the implementation local to the renderer and low
+risk for session persistence.

--- a/docs/features/sidebar-chat-number-shortcuts/tasks.md
+++ b/docs/features/sidebar-chat-number-shortcuts/tasks.md
@@ -1,0 +1,17 @@
+# Tasks — Sidebar Chat Number Shortcuts
+
+- [ ] Sidebar mapping: derive first ten visible chat sessions from expanded pinned and grouped
+      renderer state.
+- [ ] Platform handling: detect macOS vs Windows/Linux and build display labels (`⌘N` vs `Alt+N`).
+- [ ] Keyboard runtime: add mounted window listeners for digit switching and 2 second modifier hold.
+- [ ] Focus guards: suppress shortcuts in editable fields and active keyboard-owning overlays.
+- [ ] Badge rendering: add sidebar item props and render right-slot shortcut badges over the delete
+      button.
+- [ ] State separation: keep shortcut badge visibility independent from row hover/focus delete
+      triggers.
+- [ ] i18n: add shortcut badge aria/tooltip strings and synchronize locale files.
+- [ ] Tests: cover mapping, platform modifiers, focus suppression, long-press timer, and delete
+      button replacement, including hover/long-press separation.
+- [ ] Quality gates: run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint`.
+- [ ] Manual QA: verify desktop behavior for normal, searched, collapsed, pinned, and less-than-ten
+      chat lists.

--- a/docs/features/sidebar-chat-number-shortcuts/tasks.md
+++ b/docs/features/sidebar-chat-number-shortcuts/tasks.md
@@ -1,17 +1,17 @@
 # Tasks — Sidebar Chat Number Shortcuts
 
-- [ ] Sidebar mapping: derive first ten visible chat sessions from expanded pinned and grouped
+- [x] Sidebar mapping: derive first ten visible chat sessions from expanded pinned and grouped
       renderer state.
-- [ ] Platform handling: detect macOS vs Windows/Linux and build display labels (`⌘N` vs `Alt+N`).
-- [ ] Keyboard runtime: add mounted window listeners for digit switching and 2 second modifier hold.
-- [ ] Focus guards: suppress shortcuts in editable fields and active keyboard-owning overlays.
-- [ ] Badge rendering: add sidebar item props and render right-slot shortcut badges over the delete
+- [x] Platform handling: detect macOS vs Windows/Linux and build display labels (`⌘N` vs `Alt+N`).
+- [x] Keyboard runtime: add mounted window listeners for digit switching and 0.5 second modifier hold.
+- [x] Focus guards: suppress shortcuts in editable fields and active keyboard-owning overlays.
+- [x] Badge rendering: add sidebar item props and render right-slot shortcut badges over the delete
       button.
-- [ ] State separation: keep shortcut badge visibility independent from row hover/focus delete
+- [x] State separation: keep shortcut badge visibility independent from row hover/focus delete
       triggers.
-- [ ] i18n: add shortcut badge aria/tooltip strings and synchronize locale files.
-- [ ] Tests: cover mapping, platform modifiers, focus suppression, long-press timer, and delete
+- [x] i18n: add shortcut badge aria/tooltip strings and synchronize locale files.
+- [x] Tests: cover mapping, platform modifiers, focus suppression, long-press timer, and delete
       button replacement, including hover/long-press separation.
-- [ ] Quality gates: run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint`.
+- [x] Quality gates: run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint`.
 - [ ] Manual QA: verify desktop behavior for normal, searched, collapsed, pinned, and less-than-ten
       chat lists.

--- a/src/renderer/src/components/WindowSideBar.vue
+++ b/src/renderer/src/components/WindowSideBar.vue
@@ -304,6 +304,8 @@
                 :force-pin-docked="pinDockedSessionId === session.id"
                 :pin-feedback-mode="pinFeedbackSessionId === session.id ? pinFeedbackMode : null"
                 :search-query="sessionSearchQuery"
+                :shortcut-badge-label="getShortcutBadgeLabelForSession(session.id)"
+                :shortcut-badge-visible="hasShortcutBadgeForSession(session.id)"
                 @select="handleSessionClick"
                 @toggle-pin="handleTogglePin"
                 @delete="openDeleteDialog"
@@ -341,6 +343,8 @@
                 :force-pin-docked="pinDockedSessionId === session.id"
                 :pin-feedback-mode="pinFeedbackSessionId === session.id ? pinFeedbackMode : null"
                 :search-query="sessionSearchQuery"
+                :shortcut-badge-label="getShortcutBadgeLabelForSession(session.id)"
+                :shortcut-badge-visible="hasShortcutBadgeForSession(session.id)"
                 @select="handleSessionClick"
                 @toggle-pin="handleTogglePin"
                 @delete="openDeleteDialog"
@@ -398,6 +402,7 @@ import {
 } from '@shadcn/components/ui/dialog'
 import { createSettingsClient } from '@api/SettingsClient'
 import { createRemoteControlRuntime } from '@api/RemoteControlRuntime'
+import { createDeviceClient } from '@api/DeviceClient'
 import { useAgentStore } from '@/stores/ui/agent'
 import { useSessionStore, type SessionGroup, type UISession } from '@/stores/ui/session'
 import { useSpotlightStore } from '@/stores/ui/spotlight'
@@ -422,10 +427,13 @@ const PIN_FEEDBACK_DURATION_MS: Record<PinFeedbackMode, number> = {
 const PIN_FLIGHT_DURATION_MS = 460
 const PIN_TARGET_SETTLE_MAX_FRAMES = 10
 const PIN_TARGET_SETTLE_EPSILON_PX = 0.5
+const SIDEBAR_SHORTCUT_BADGE_DELAY_MS = 500
+const SIDEBAR_SHORTCUT_MAX_ROWS = 10
 const getPinFeedbackMode = (nextPinned: boolean): PinFeedbackMode =>
   nextPinned ? 'pinning' : 'unpinning'
 
 type SessionItemRegion = 'pinned' | 'grouped'
+type ShortcutPlatform = 'mac' | 'other'
 type SessionItemRect = {
   left: number
   top: number
@@ -435,6 +443,7 @@ type SessionItemRect = {
 
 const settingsClient = createSettingsClient()
 const remoteControlRuntime = createRemoteControlRuntime()
+const deviceClient = createDeviceClient()
 const { t } = useI18n()
 const agentStore = useAgentStore()
 const sessionStore = useSessionStore()
@@ -533,6 +542,12 @@ let agentSwitchQueue: Promise<void> = Promise.resolve()
 let remoteControlStatusTimer: ReturnType<typeof setInterval> | null = null
 let pinFeedbackTimer: number | null = null
 let sessionListScrollFrame: number | null = null
+let shortcutBadgeTimer: number | null = null
+const shortcutPlatform = ref<ShortcutPlatform>(
+  navigator.platform.toLowerCase().includes('mac') ? 'mac' : 'other'
+)
+const shortcutModifierDown = ref(false)
+const showShortcutBadges = ref(false)
 const sidebarSelectedAgentId = computed(() => {
   const activeSessionAgentId = sessionStore.activeSession?.agentId?.trim()
   if (sessionStore.hasActiveSession && activeSessionAgentId) {
@@ -675,6 +690,53 @@ const getGroupLabel = (group: SessionGroup) => (group.labelKey ? t(group.labelKe
 
 const isGroupCollapsed = (group: SessionGroup) =>
   collapsedGroupIds.value.has(getGroupIdentifier(group))
+
+const visibleShortcutSessions = computed<UISession[]>(() => {
+  if (collapsed.value) {
+    return []
+  }
+
+  const sessions: UISession[] = []
+
+  if (!isPinnedSectionCollapsed.value) {
+    sessions.push(...pinnedSessions.value)
+  }
+
+  for (const group of filteredGroups.value) {
+    if (!isGroupCollapsed(group)) {
+      sessions.push(...group.sessions)
+    }
+  }
+
+  return sessions
+    .filter((session) => session.id !== pinFlightSessionId.value)
+    .slice(0, SIDEBAR_SHORTCUT_MAX_ROWS)
+})
+
+const getShortcutDigitForIndex = (index: number) => (index === 9 ? '0' : String(index + 1))
+
+const getShortcutIndexForDigit = (digit: string) => (digit === '0' ? 9 : Number(digit) - 1)
+
+const getShortcutBadgeLabelForIndex = (index: number) => {
+  const digit = getShortcutDigitForIndex(index)
+  return shortcutPlatform.value === 'mac' ? `⌘${digit}` : `Alt+${digit}`
+}
+
+const shortcutBadgeLabelBySessionId = computed(() => {
+  const labels = new Map<string, string>()
+
+  visibleShortcutSessions.value.forEach((session, index) => {
+    labels.set(session.id, getShortcutBadgeLabelForIndex(index))
+  })
+
+  return labels
+})
+
+const getShortcutBadgeLabelForSession = (sessionId: string) =>
+  shortcutBadgeLabelBySessionId.value.get(sessionId) ?? null
+
+const hasShortcutBadgeForSession = (sessionId: string) =>
+  showShortcutBadges.value && shortcutBadgeLabelBySessionId.value.has(sessionId)
 
 const togglePinnedSection = () => {
   isPinnedSectionCollapsed.value = !isPinnedSectionCollapsed.value
@@ -828,6 +890,156 @@ const handleAgentSelect = async (id: string | null) => {
 const handleSessionClick = (session: { id: string }) => {
   void sessionStore.selectSession(session.id)
 }
+
+const loadShortcutPlatform = async () => {
+  try {
+    const deviceInfo = await deviceClient.getDeviceInfo()
+    shortcutPlatform.value = deviceInfo.platform === 'darwin' ? 'mac' : 'other'
+  } catch (error) {
+    console.warn('[WindowSideBar] Failed to resolve shortcut platform:', error)
+  }
+}
+
+const isEditableShortcutTarget = (target: EventTarget | null) => {
+  const element = target instanceof HTMLElement ? target : null
+  if (!element) {
+    return false
+  }
+
+  return Boolean(
+    element.closest('input, textarea, select, [contenteditable]:not([contenteditable="false"])')
+  )
+}
+
+const hasKeyboardOwningOverlay = () =>
+  spotlightStore.open ||
+  deleteDialogOpen.value ||
+  document.querySelector('.chat-search-bar') !== null ||
+  document.querySelector('[role="dialog"][aria-modal="true"]') !== null
+
+const shouldIgnoreSidebarShortcutEvent = (event: KeyboardEvent) =>
+  collapsed.value || isEditableShortcutTarget(event.target) || hasKeyboardOwningOverlay()
+
+const getPlatformModifierKey = () => (shortcutPlatform.value === 'mac' ? 'Meta' : 'Alt')
+
+const isPlatformModifierPressed = (event: KeyboardEvent) =>
+  shortcutPlatform.value === 'mac' ? event.metaKey : event.altKey
+
+const isPlatformModifierOnlyKeydown = (event: KeyboardEvent) => {
+  if (event.repeat || shouldIgnoreSidebarShortcutEvent(event)) {
+    return false
+  }
+
+  if (shortcutPlatform.value === 'mac') {
+    return (
+      event.key === 'Meta' && event.metaKey && !event.altKey && !event.ctrlKey && !event.shiftKey
+    )
+  }
+
+  return event.key === 'Alt' && event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey
+}
+
+const isSidebarShortcutDigitEvent = (event: KeyboardEvent) => {
+  if (!/^[0-9]$/.test(event.key) || shouldIgnoreSidebarShortcutEvent(event)) {
+    return false
+  }
+
+  if (shortcutPlatform.value === 'mac') {
+    return event.metaKey && !event.altKey && !event.ctrlKey && !event.shiftKey
+  }
+
+  return event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey
+}
+
+const clearShortcutBadgeTimer = () => {
+  if (shortcutBadgeTimer !== null) {
+    window.clearTimeout(shortcutBadgeTimer)
+    shortcutBadgeTimer = null
+  }
+}
+
+const hideShortcutBadges = () => {
+  clearShortcutBadgeTimer()
+  shortcutModifierDown.value = false
+  showShortcutBadges.value = false
+}
+
+const startShortcutBadgeTimer = () => {
+  if (shortcutBadgeTimer !== null || showShortcutBadges.value) {
+    return
+  }
+
+  shortcutModifierDown.value = true
+  shortcutBadgeTimer = window.setTimeout(() => {
+    shortcutBadgeTimer = null
+
+    if (
+      shortcutModifierDown.value &&
+      !collapsed.value &&
+      !hasKeyboardOwningOverlay() &&
+      visibleShortcutSessions.value.length > 0
+    ) {
+      showShortcutBadges.value = true
+    }
+  }, SIDEBAR_SHORTCUT_BADGE_DELAY_MS)
+}
+
+const selectShortcutSession = (digit: string) => {
+  const shortcutIndex = getShortcutIndexForDigit(digit)
+  const targetSession = visibleShortcutSessions.value[shortcutIndex]
+
+  if (targetSession) {
+    void sessionStore.selectSession(targetSession.id)
+  }
+}
+
+const handleWindowShortcutKeydown = (event: KeyboardEvent) => {
+  if (isPlatformModifierOnlyKeydown(event)) {
+    if (shortcutPlatform.value !== 'mac') {
+      event.preventDefault()
+    }
+    startShortcutBadgeTimer()
+    return
+  }
+
+  if (shortcutBadgeTimer !== null && event.key !== getPlatformModifierKey()) {
+    clearShortcutBadgeTimer()
+  }
+
+  if (!isSidebarShortcutDigitEvent(event)) {
+    return
+  }
+
+  event.preventDefault()
+  event.stopPropagation()
+  selectShortcutSession(event.key)
+}
+
+const handleWindowShortcutKeyup = (event: KeyboardEvent) => {
+  const modifierKey = getPlatformModifierKey()
+  if (event.key === modifierKey || !isPlatformModifierPressed(event)) {
+    if (shortcutPlatform.value !== 'mac' && event.key === modifierKey) {
+      event.preventDefault()
+    }
+    hideShortcutBadges()
+  }
+}
+
+const handleWindowShortcutBlur = () => {
+  hideShortcutBadges()
+}
+
+const handleDocumentVisibilityChange = () => {
+  if (document.visibilityState === 'hidden') {
+    hideShortcutBadges()
+  }
+}
+
+watch(collapsed, (isCollapsed) => {
+  if (isCollapsed) {
+    hideShortcutBadges()
+  }
+})
 
 const openDeleteDialog = (session: UISession) => {
   deleteTargetSession.value = session
@@ -1157,6 +1369,12 @@ const handleDeleteConfirm = async () => {
 }
 
 onMounted(() => {
+  void loadShortcutPlatform()
+  window.addEventListener('keydown', handleWindowShortcutKeydown)
+  window.addEventListener('keyup', handleWindowShortcutKeyup)
+  window.addEventListener('blur', handleWindowShortcutBlur)
+  document.addEventListener('visibilitychange', handleDocumentVisibilityChange)
+
   void refreshRemoteControlStatus()
   remoteControlStatusTimer = setInterval(() => {
     void refreshRemoteControlStatus()
@@ -1164,6 +1382,11 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  window.removeEventListener('keydown', handleWindowShortcutKeydown)
+  window.removeEventListener('keyup', handleWindowShortcutKeyup)
+  window.removeEventListener('blur', handleWindowShortcutBlur)
+  document.removeEventListener('visibilitychange', handleDocumentVisibilityChange)
+
   if (remoteControlStatusTimer) {
     clearInterval(remoteControlStatusTimer)
     remoteControlStatusTimer = null
@@ -1177,6 +1400,7 @@ onUnmounted(() => {
   pinFlightSessionId.value = null
   pinDockedSessionId.value = null
   clearPinFeedback()
+  hideShortcutBadges()
 })
 </script>
 

--- a/src/renderer/src/components/WindowSideBar.vue
+++ b/src/renderer/src/components/WindowSideBar.vue
@@ -940,7 +940,7 @@ const isPlatformModifierOnlyKeydown = (event: KeyboardEvent) => {
 }
 
 const isSidebarShortcutDigitEvent = (event: KeyboardEvent) => {
-  if (!/^[0-9]$/.test(event.key) || shouldIgnoreSidebarShortcutEvent(event)) {
+  if (event.repeat || !/^[0-9]$/.test(event.key) || shouldIgnoreSidebarShortcutEvent(event)) {
     return false
   }
 

--- a/src/renderer/src/components/WindowSideBarSessionItem.vue
+++ b/src/renderer/src/components/WindowSideBarSessionItem.vue
@@ -25,6 +25,8 @@ const props = defineProps<{
   forcePinDocked?: boolean
   pinFeedbackMode?: PinFeedbackMode | null
   searchQuery?: string
+  shortcutBadgeLabel?: string | null
+  shortcutBadgeVisible?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -41,6 +43,15 @@ const pinActionLabel = computed(() =>
 )
 
 const deleteActionLabel = computed(() => t('thread.actions.delete'))
+
+const shortcutBadgeTitle = computed(() => {
+  const shortcut = props.shortcutBadgeLabel
+  if (!shortcut) {
+    return ''
+  }
+
+  return t('thread.actions.switchWithShortcut', { shortcut })
+})
 
 const isWorking = computed(() => session.value.status === 'working')
 
@@ -164,8 +175,21 @@ const titleSegments = computed(() => {
       </span>
     </div>
 
-    <span class="right-button flex items-center">
+    <span
+      class="right-button flex items-center"
+      :data-shortcut-badge-visible="shortcutBadgeVisible ? 'true' : undefined"
+    >
+      <span
+        v-if="shortcutBadgeVisible && shortcutBadgeLabel"
+        data-testid="sidebar-session-shortcut-badge"
+        class="shortcut-badge"
+        :title="shortcutBadgeTitle"
+        :aria-label="shortcutBadgeTitle"
+      >
+        {{ shortcutBadgeLabel }}
+      </span>
       <button
+        v-else
         type="button"
         class="session-action-button right-button__action flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive/30"
         :title="deleteActionLabel"
@@ -487,6 +511,34 @@ const titleSegments = computed(() => {
   transition-delay: 0s;
 }
 
+.right-button[data-shortcut-badge-visible='true'] {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, -50%, 0) scale(1);
+  transition-delay: 0s;
+}
+
+.shortcut-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  height: 1.5rem;
+  padding: 0 0.45rem;
+  border: 1px solid var(--action-border);
+  border-radius: 999px;
+  background-color: var(--action-surface);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--foreground) 6%, transparent),
+    var(--action-shadow);
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
 @keyframes session-loading-sheen {
   from {
     -webkit-mask-position: -26% 0;
@@ -600,6 +652,7 @@ const titleSegments = computed(() => {
   .session-item::after,
   .session-content,
   .session-action-button,
+  .shortcut-badge,
   .pin-button::before,
   .pin-button__icon,
   .right-button {

--- a/src/renderer/src/i18n/da-DK/thread.json
+++ b/src/renderer/src/i18n/da-DK/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Omdøb",
     "delete": "Slet",
+    "switchWithShortcut": "Skift til denne chat med {shortcut}",
     "cleanMessages": "Ryd beskeder",
     "pin": "Fastgør",
     "unpin": "Frigør",

--- a/src/renderer/src/i18n/de-DE/thread.json
+++ b/src/renderer/src/i18n/de-DE/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Umbenennen",
     "delete": "Löschen",
+    "switchWithShortcut": "Mit {shortcut} zu diesem Chat wechseln",
     "cleanMessages": "Nachrichten leeren",
     "pin": "Anheften",
     "unpin": "Lösen",

--- a/src/renderer/src/i18n/en-US/thread.json
+++ b/src/renderer/src/i18n/en-US/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Rename",
     "delete": "Delete",
+    "switchWithShortcut": "Switch to this chat with {shortcut}",
     "cleanMessages": "Clear Messages",
     "pin": "Pin",
     "unpin": "Unpin",

--- a/src/renderer/src/i18n/es-ES/thread.json
+++ b/src/renderer/src/i18n/es-ES/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Cambiar nombre",
     "delete": "Eliminar",
+    "switchWithShortcut": "Cambiar a este chat con {shortcut}",
     "cleanMessages": "Borrar mensajes",
     "pin": "Alfiler",
     "unpin": "Desanclar",

--- a/src/renderer/src/i18n/fa-IR/thread.json
+++ b/src/renderer/src/i18n/fa-IR/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "ویرایش نام",
     "delete": "پاک کردن",
+    "switchWithShortcut": "با {shortcut} به این گفتگو بروید",
     "cleanMessages": "پاک کردن پیام‌ها",
     "pin": "سنجاق کردن",
     "unpin": "برداشتن سنجاق",

--- a/src/renderer/src/i18n/fr-FR/thread.json
+++ b/src/renderer/src/i18n/fr-FR/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Renommer",
     "delete": "Supprimer",
+    "switchWithShortcut": "Passer à cette discussion avec {shortcut}",
     "cleanMessages": "Nettoyer les messages",
     "pin": "Épingler",
     "unpin": "Détacher",

--- a/src/renderer/src/i18n/he-IL/thread.json
+++ b/src/renderer/src/i18n/he-IL/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "שנה שם",
     "delete": "מחק",
+    "switchWithShortcut": "עבור לצ'אט הזה עם {shortcut}",
     "cleanMessages": "נקה הודעות",
     "pin": "נעץ",
     "unpin": "בטל נעיצה",

--- a/src/renderer/src/i18n/id-ID/thread.json
+++ b/src/renderer/src/i18n/id-ID/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Ganti nama",
     "delete": "Hapus",
+    "switchWithShortcut": "Beralih ke obrolan ini dengan {shortcut}",
     "cleanMessages": "Hapus pesan",
     "pin": "sematkan ke atas",
     "unpin": "Lepas sematan",

--- a/src/renderer/src/i18n/it-IT/thread.json
+++ b/src/renderer/src/i18n/it-IT/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Rinomina",
     "delete": "Elimina",
+    "switchWithShortcut": "Passa a questa chat con {shortcut}",
     "cleanMessages": "Cancella messaggi",
     "pin": "Fissa",
     "unpin": "Rimuovi fissaggio",

--- a/src/renderer/src/i18n/ja-JP/thread.json
+++ b/src/renderer/src/i18n/ja-JP/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "名前を変更",
     "delete": "削除",
+    "switchWithShortcut": "{shortcut}でこのチャットに切り替え",
     "cleanMessages": "メッセージをクリア",
     "pin": "ピン留めする",
     "unpin": "ピン留めを外す",

--- a/src/renderer/src/i18n/ko-KR/thread.json
+++ b/src/renderer/src/i18n/ko-KR/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "이름 변경",
     "delete": "삭제",
+    "switchWithShortcut": "{shortcut}로 이 채팅으로 전환",
     "cleanMessages": "메시지 정리",
     "pin": "고정하기",
     "unpin": "고정 해제",

--- a/src/renderer/src/i18n/ms-MY/thread.json
+++ b/src/renderer/src/i18n/ms-MY/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Namakan semula",
     "delete": "padam",
+    "switchWithShortcut": "Beralih ke sembang ini dengan {shortcut}",
     "cleanMessages": "Kosongkan mesej",
     "pin": "pin ke atas",
     "unpin": "Nyahsemat",

--- a/src/renderer/src/i18n/pl-PL/thread.json
+++ b/src/renderer/src/i18n/pl-PL/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Zmień nazwę",
     "delete": "Usuń",
+    "switchWithShortcut": "Przełącz na ten czat za pomocą {shortcut}",
     "cleanMessages": "Wyczyść Wiadomości",
     "pin": "Przypnij",
     "unpin": "Odepnij",

--- a/src/renderer/src/i18n/pt-BR/thread.json
+++ b/src/renderer/src/i18n/pt-BR/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Renomear",
     "delete": "Excluir",
+    "switchWithShortcut": "Mudar para este chat com {shortcut}",
     "cleanMessages": "Limpar Mensagens",
     "pin": "Fixar",
     "unpin": "Desafixar",

--- a/src/renderer/src/i18n/ru-RU/thread.json
+++ b/src/renderer/src/i18n/ru-RU/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Переименовать",
     "delete": "Удалить",
+    "switchWithShortcut": "Переключиться на этот чат с помощью {shortcut}",
     "cleanMessages": "Очистить сообщения",
     "pin": "Закрепить",
     "unpin": "Открепить",

--- a/src/renderer/src/i18n/tr-TR/thread.json
+++ b/src/renderer/src/i18n/tr-TR/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Yeniden isimlendirmek",
     "delete": "Silmek",
+    "switchWithShortcut": "{shortcut} ile bu sohbete geç",
     "cleanMessages": "Mesajları Temizle",
     "pin": "Sabitle",
     "unpin": "Sabitlemeyi kaldır",

--- a/src/renderer/src/i18n/vi-VN/thread.json
+++ b/src/renderer/src/i18n/vi-VN/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "Đổi tên",
     "delete": "Xóa",
+    "switchWithShortcut": "Chuyển sang cuộc trò chuyện này bằng {shortcut}",
     "cleanMessages": "Xóa tin nhắn",
     "pin": "Ghim",
     "unpin": "Bỏ ghim",

--- a/src/renderer/src/i18n/zh-CN/thread.json
+++ b/src/renderer/src/i18n/zh-CN/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "重命名",
     "delete": "删除",
+    "switchWithShortcut": "使用 {shortcut} 切换到此会话",
     "cleanMessages": "清空消息",
     "pin": "置顶",
     "unpin": "取消置顶",

--- a/src/renderer/src/i18n/zh-HK/thread.json
+++ b/src/renderer/src/i18n/zh-HK/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "重命名",
     "delete": "刪除",
+    "switchWithShortcut": "使用 {shortcut} 切換到此會話",
     "cleanMessages": "清空消息",
     "pin": "置頂",
     "unpin": "取消置頂",

--- a/src/renderer/src/i18n/zh-TW/thread.json
+++ b/src/renderer/src/i18n/zh-TW/thread.json
@@ -2,6 +2,7 @@
   "actions": {
     "rename": "重新命名",
     "delete": "刪除",
+    "switchWithShortcut": "使用 {shortcut} 切換到此對話",
     "cleanMessages": "清除訊息",
     "pin": "置頂",
     "unpin": "取消置頂",

--- a/test/renderer/components/WindowSideBar.test.ts
+++ b/test/renderer/components/WindowSideBar.test.ts
@@ -20,6 +20,7 @@ type SetupOptions = {
     state: 'disabled' | 'stopped' | 'starting' | 'running' | 'backoff' | 'error'
   }
   collapsed?: boolean
+  platform?: 'darwin' | 'win32' | 'linux'
 }
 
 const TEST_TIMEOUT_MS = 20000
@@ -36,6 +37,32 @@ const createDomRect = (left: number, top: number, width: number, height: number)
     bottom: top + height,
     toJSON: () => ({})
   }) as DOMRect
+
+const dispatchWindowKeydown = (
+  key: string,
+  modifiers: Partial<Pick<KeyboardEventInit, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>> = {}
+) =>
+  window.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...modifiers
+    })
+  )
+
+const dispatchWindowKeyup = (
+  key: string,
+  modifiers: Partial<Pick<KeyboardEventInit, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>> = {}
+) =>
+  window.dispatchEvent(
+    new KeyboardEvent('keyup', {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...modifiers
+    })
+  )
 
 afterEach(() => {
   vi.clearAllTimers()
@@ -119,6 +146,13 @@ const setup = async (options: SetupOptions = {}) => {
   })
   const settingsClient = {
     openSettings: vi.fn().mockResolvedValue({ windowId: 99 })
+  }
+  const deviceClient = {
+    getDeviceInfo: vi.fn().mockResolvedValue({
+      platform: options.platform ?? 'darwin',
+      osVersion: '',
+      osVersionMetadata: []
+    })
   }
   const remoteControlRuntime = {
     listRemoteChannels: vi.fn(async () => [
@@ -214,6 +248,9 @@ const setup = async (options: SetupOptions = {}) => {
   vi.doMock('@api/SettingsClient', () => ({
     createSettingsClient: vi.fn(() => settingsClient)
   }))
+  vi.doMock('@api/DeviceClient', () => ({
+    createDeviceClient: vi.fn(() => deviceClient)
+  }))
   vi.doMock('@api/RemoteControlRuntime', () => ({
     createRemoteControlRuntime: vi.fn(() => remoteControlRuntime)
   }))
@@ -295,6 +332,7 @@ const setup = async (options: SetupOptions = {}) => {
     agentStore,
     sessionStore,
     settingsClient,
+    deviceClient,
     remoteControlRuntime,
     spotlightStore,
     pageRouterStore,
@@ -508,6 +546,381 @@ describe('WindowSideBar agent switch', () => {
 
       expect(wrapper.text()).toContain('Alpha Session')
       expect(wrapper.text()).not.toContain('Beta Session')
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'selects visible sidebar sessions with macOS number shortcuts',
+    async () => {
+      const groupedSessions = Array.from({ length: 9 }, (_, index) => ({
+        id: `group-${index + 1}`,
+        title: `Group Session ${index + 1}`,
+        status: 'none'
+      }))
+      const { sessionStore } = await setup({
+        pinnedSessions: [
+          {
+            id: 'pinned-1',
+            title: 'Pinned Session',
+            status: 'none'
+          }
+        ],
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: groupedSessions
+          }
+        ]
+      })
+
+      dispatchWindowKeydown('2', { metaKey: true })
+      await flushPromises()
+
+      expect(sessionStore.selectSession).toHaveBeenLastCalledWith('group-1')
+
+      dispatchWindowKeydown('0', { metaKey: true })
+      await flushPromises()
+
+      expect(sessionStore.selectSession).toHaveBeenLastCalledWith('group-9')
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'uses Alt as the sidebar number shortcut modifier on Windows and Linux',
+    async () => {
+      const { sessionStore } = await setup({
+        platform: 'win32',
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              {
+                id: 'group-1',
+                title: 'Group Session 1',
+                status: 'none'
+              },
+              {
+                id: 'group-2',
+                title: 'Group Session 2',
+                status: 'none'
+              }
+            ]
+          }
+        ]
+      })
+
+      dispatchWindowKeydown('2', { altKey: true })
+      await flushPromises()
+
+      expect(sessionStore.selectSession).toHaveBeenLastCalledWith('group-2')
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'excludes collapsed groups from sidebar shortcut mapping',
+    async () => {
+      const { wrapper, sessionStore } = await setup({
+        pinnedSessions: [
+          {
+            id: 'pinned-1',
+            title: 'Pinned Session',
+            status: 'none'
+          }
+        ],
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              {
+                id: 'group-1',
+                title: 'Group Session 1',
+                status: 'none'
+              }
+            ]
+          }
+        ]
+      })
+
+      await wrapper.find('[data-group-id="common.time.today"]').trigger('click')
+      await wrapper.vm.$nextTick()
+      sessionStore.selectSession.mockClear()
+
+      dispatchWindowKeydown('2', { metaKey: true })
+      await flushPromises()
+
+      expect(sessionStore.selectSession).not.toHaveBeenCalled()
+
+      dispatchWindowKeydown('1', { metaKey: true })
+      await flushPromises()
+
+      expect(sessionStore.selectSession).toHaveBeenLastCalledWith('pinned-1')
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'excludes collapsed pinned sessions from sidebar shortcut mapping',
+    async () => {
+      const { wrapper, sessionStore } = await setup({
+        pinnedSessions: [
+          {
+            id: 'pinned-1',
+            title: 'Pinned Session',
+            status: 'none'
+          }
+        ],
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              {
+                id: 'group-1',
+                title: 'Group Session 1',
+                status: 'none'
+              }
+            ]
+          }
+        ]
+      })
+
+      await wrapper.find('[data-group-id="__pinned__"]').trigger('click')
+      await wrapper.vm.$nextTick()
+      sessionStore.selectSession.mockClear()
+
+      dispatchWindowKeydown('1', { metaKey: true })
+      await flushPromises()
+
+      expect(sessionStore.selectSession).toHaveBeenLastCalledWith('group-1')
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'disables sidebar number shortcuts while the sidebar is collapsed',
+    async () => {
+      const { wrapper, sessionStore } = await setup({
+        collapsed: true,
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              {
+                id: 'group-1',
+                title: 'Group Session 1',
+                status: 'none'
+              }
+            ]
+          }
+        ]
+      })
+
+      dispatchWindowKeydown('1', { metaKey: true })
+      await flushPromises()
+
+      expect(sessionStore.selectSession).not.toHaveBeenCalled()
+
+      dispatchWindowKeydown('Meta', { metaKey: true })
+      vi.advanceTimersByTime(500)
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('[data-testid="sidebar-session-shortcut-badge"]').exists()).toBe(false)
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'suppresses sidebar number shortcuts for editable targets',
+    async () => {
+      const { wrapper, sessionStore } = await setup({
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              {
+                id: 'group-1',
+                title: 'Group Session 1',
+                status: 'none'
+              }
+            ]
+          }
+        ]
+      })
+      const event = new KeyboardEvent('keydown', {
+        key: '1',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true
+      })
+
+      Object.defineProperty(event, 'target', {
+        value: wrapper.find('input').element
+      })
+
+      ;(wrapper.vm as any).handleWindowShortcutKeydown(event)
+      await flushPromises()
+
+      expect(sessionStore.selectSession).not.toHaveBeenCalled()
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'suppresses sidebar number shortcuts while keyboard-owning overlays are open',
+    async () => {
+      const { wrapper, sessionStore, spotlightStore } = await setup({
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              {
+                id: 'group-1',
+                title: 'Group Session 1',
+                status: 'none'
+              }
+            ]
+          }
+        ]
+      })
+
+      spotlightStore.open = true
+
+      dispatchWindowKeydown('1', { metaKey: true })
+      await flushPromises()
+
+      expect(sessionStore.selectSession).not.toHaveBeenCalled()
+
+      dispatchWindowKeydown('Meta', { metaKey: true })
+      vi.advanceTimersByTime(500)
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('[data-testid="sidebar-session-shortcut-badge"]').exists()).toBe(false)
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'shows shortcut badges only after a modifier long press and hides them on release',
+    async () => {
+      const { wrapper } = await setup({
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              {
+                id: 'group-1',
+                title: 'Group Session 1',
+                status: 'none'
+              },
+              {
+                id: 'group-2',
+                title: 'Group Session 2',
+                status: 'none'
+              }
+            ]
+          }
+        ]
+      })
+
+      dispatchWindowKeydown('Meta', { metaKey: true })
+      vi.advanceTimersByTime(499)
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('[data-testid="sidebar-session-shortcut-badge"]').exists()).toBe(false)
+
+      vi.advanceTimersByTime(1)
+      await wrapper.vm.$nextTick()
+
+      const badges = wrapper.findAll('[data-testid="sidebar-session-shortcut-badge"]')
+      expect(badges.map((badge) => badge.text())).toEqual(['⌘1', '⌘2'])
+      expect(wrapper.find('[aria-label="thread.actions.delete"]').exists()).toBe(false)
+
+      dispatchWindowKeyup('Meta')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('[data-testid="sidebar-session-shortcut-badge"]').exists()).toBe(false)
+      expect(wrapper.find('[aria-label="thread.actions.delete"]').exists()).toBe(true)
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'does not show shortcut badges after a number shortcut cancels the pending hold',
+    async () => {
+      const { wrapper, sessionStore } = await setup({
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              {
+                id: 'group-1',
+                title: 'Group Session 1',
+                status: 'none'
+              }
+            ]
+          }
+        ]
+      })
+
+      dispatchWindowKeydown('Meta', { metaKey: true })
+      dispatchWindowKeydown('1', { metaKey: true })
+      await flushPromises()
+
+      expect(sessionStore.selectSession).toHaveBeenLastCalledWith('group-1')
+
+      vi.advanceTimersByTime(500)
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('[data-testid="sidebar-session-shortcut-badge"]').exists()).toBe(false)
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'removes sidebar shortcut listeners when the component unmounts',
+    async () => {
+      const { wrapper, sessionStore } = await setup({
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              {
+                id: 'group-1',
+                title: 'Group Session 1',
+                status: 'none'
+              }
+            ]
+          }
+        ]
+      })
+
+      wrapper.unmount()
+      dispatchWindowKeydown('1', { metaKey: true })
+      await flushPromises()
+
+      expect(sessionStore.selectSession).not.toHaveBeenCalled()
     },
     TEST_TIMEOUT_MS
   )

--- a/test/renderer/components/WindowSideBar.test.ts
+++ b/test/renderer/components/WindowSideBar.test.ts
@@ -40,7 +40,9 @@ const createDomRect = (left: number, top: number, width: number, height: number)
 
 const dispatchWindowKeydown = (
   key: string,
-  modifiers: Partial<Pick<KeyboardEventInit, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>> = {}
+  modifiers: Partial<
+    Pick<KeyboardEventInit, 'altKey' | 'ctrlKey' | 'metaKey' | 'repeat' | 'shiftKey'>
+  > = {}
 ) =>
   window.dispatchEvent(
     new KeyboardEvent('keydown', {
@@ -53,7 +55,9 @@ const dispatchWindowKeydown = (
 
 const dispatchWindowKeyup = (
   key: string,
-  modifiers: Partial<Pick<KeyboardEventInit, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>> = {}
+  modifiers: Partial<
+    Pick<KeyboardEventInit, 'altKey' | 'ctrlKey' | 'metaKey' | 'repeat' | 'shiftKey'>
+  > = {}
 ) =>
   window.dispatchEvent(
     new KeyboardEvent('keyup', {
@@ -64,7 +68,31 @@ const dispatchWindowKeyup = (
     })
   )
 
+const mountedWrappers: Array<{ unmount: () => void }> = []
+
+const trackMountedWrapper = <T extends { unmount: () => void }>(wrapper: T): T => {
+  let mounted = true
+  const originalUnmount = wrapper.unmount.bind(wrapper)
+
+  wrapper.unmount = () => {
+    if (!mounted) {
+      return
+    }
+
+    mounted = false
+    const wrapperIndex = mountedWrappers.indexOf(wrapper)
+    if (wrapperIndex !== -1) {
+      mountedWrappers.splice(wrapperIndex, 1)
+    }
+    originalUnmount()
+  }
+
+  mountedWrappers.push(wrapper)
+  return wrapper
+}
+
 afterEach(() => {
+  mountedWrappers.splice(0).forEach((wrapper) => wrapper.unmount())
   vi.clearAllTimers()
   vi.useRealTimers()
   vi.unstubAllGlobals()
@@ -297,32 +325,34 @@ const setup = async (options: SetupOptions = {}) => {
   })
 
   const WindowSideBar = (await import('@/components/WindowSideBar.vue')).default
-  const wrapper = mount(WindowSideBar, {
-    global: {
-      stubs: {
-        TooltipProvider: passthrough,
-        Tooltip: passthrough,
-        TooltipContent: passthrough,
-        TooltipTrigger: passthrough,
-        ContextMenu: passthrough,
-        ContextMenuTrigger: passthrough,
-        ContextMenuContent: passthrough,
-        ContextMenuSeparator: passthrough,
-        ContextMenuItem: contextMenuItemStub,
-        Dialog: dialogStub,
-        DialogContent: passthrough,
-        DialogDescription: passthrough,
-        DialogFooter: passthrough,
-        DialogHeader: passthrough,
-        DialogTitle: passthrough,
-        Button: buttonStub,
-        Input: inputStub,
-        AgentAvatar: true,
-        Icon: true,
-        ModelIcon: true
+  const wrapper = trackMountedWrapper(
+    mount(WindowSideBar, {
+      global: {
+        stubs: {
+          TooltipProvider: passthrough,
+          Tooltip: passthrough,
+          TooltipContent: passthrough,
+          TooltipTrigger: passthrough,
+          ContextMenu: passthrough,
+          ContextMenuTrigger: passthrough,
+          ContextMenuContent: passthrough,
+          ContextMenuSeparator: passthrough,
+          ContextMenuItem: contextMenuItemStub,
+          Dialog: dialogStub,
+          DialogContent: passthrough,
+          DialogDescription: passthrough,
+          DialogFooter: passthrough,
+          DialogHeader: passthrough,
+          DialogTitle: passthrough,
+          Button: buttonStub,
+          Input: inputStub,
+          AgentAvatar: true,
+          Icon: true,
+          ModelIcon: true
+        }
       }
-    }
-  })
+    })
+  )
 
   await flushPromises()
 
@@ -619,6 +649,34 @@ describe('WindowSideBar agent switch', () => {
       await flushPromises()
 
       expect(sessionStore.selectSession).toHaveBeenLastCalledWith('group-2')
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'ignores repeated sidebar number shortcut keydown events',
+    async () => {
+      const { sessionStore } = await setup({
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              {
+                id: 'group-1',
+                title: 'Group Session 1',
+                status: 'none'
+              }
+            ]
+          }
+        ]
+      })
+
+      dispatchWindowKeydown('1', { metaKey: true, repeat: true })
+      await flushPromises()
+
+      expect(sessionStore.selectSession).not.toHaveBeenCalled()
     },
     TEST_TIMEOUT_MS
   )

--- a/test/renderer/components/WindowSideBarSessionItem.test.ts
+++ b/test/renderer/components/WindowSideBarSessionItem.test.ts
@@ -24,6 +24,8 @@ const mountComponent = async (options?: {
   heroHidden?: boolean
   pinFeedbackMode?: 'pinning' | 'unpinning' | null
   searchQuery?: string
+  shortcutBadgeLabel?: string | null
+  shortcutBadgeVisible?: boolean
 }) => {
   vi.resetModules()
 
@@ -43,7 +45,9 @@ const mountComponent = async (options?: {
       region: options?.isPinned ? 'pinned' : 'grouped',
       heroHidden: options?.heroHidden ?? false,
       pinFeedbackMode: options?.pinFeedbackMode ?? null,
-      searchQuery: options?.searchQuery ?? ''
+      searchQuery: options?.searchQuery ?? '',
+      shortcutBadgeLabel: options?.shortcutBadgeLabel ?? null,
+      shortcutBadgeVisible: options?.shortcutBadgeVisible ?? false
     },
     global: {
       stubs: {
@@ -135,5 +139,32 @@ describe('WindowSideBarSessionItem', () => {
     const highlight = wrapper.find('.session-title__highlight')
     expect(highlight.exists()).toBe(true)
     expect(highlight.text()).toBe('Title')
+  }, 10000)
+
+  it('renders shortcut badges independently from the delete action', async () => {
+    const badgeWrapper = await mountComponent({
+      shortcutBadgeLabel: '⌘2',
+      shortcutBadgeVisible: true
+    })
+
+    const badge = badgeWrapper.find('[data-testid="sidebar-session-shortcut-badge"]')
+
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('⌘2')
+    expect(badge.attributes('aria-label')).toBe('thread.actions.switchWithShortcut')
+    expect(badgeWrapper.find('[aria-label="thread.actions.delete"]').exists()).toBe(false)
+    expect(badgeWrapper.find('.right-button').attributes('data-shortcut-badge-visible')).toBe(
+      'true'
+    )
+
+    const normalWrapper = await mountComponent({
+      shortcutBadgeLabel: '⌘2',
+      shortcutBadgeVisible: false
+    })
+
+    expect(normalWrapper.find('[data-testid="sidebar-session-shortcut-badge"]').exists()).toBe(
+      false
+    )
+    expect(normalWrapper.find('[aria-label="thread.actions.delete"]').exists()).toBe(true)
   }, 10000)
 })

--- a/test/renderer/components/WindowSideBarSessionItem.test.ts
+++ b/test/renderer/components/WindowSideBarSessionItem.test.ts
@@ -166,5 +166,8 @@ describe('WindowSideBarSessionItem', () => {
       false
     )
     expect(normalWrapper.find('[aria-label="thread.actions.delete"]').exists()).toBe(true)
+    expect(
+      normalWrapper.find('.right-button').attributes('data-shortcut-badge-visible')
+    ).toBeUndefined()
   }, 10000)
 })


### PR DESCRIPTION
## Summary
- add Cmd/Alt + number shortcuts for switching the first ten visible sidebar chats
- show shortcut badges after a 0.5s platform-modifier hold without coupling to hover state
- add localized shortcut tooltip text and renderer tests for mapping, focus guards, overlays, and cleanup

## Tests
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck
- pnpm exec vitest --config vitest.config.renderer.ts test/renderer/components/WindowSideBar.test.ts test/renderer/components/WindowSideBarSessionItem.test.ts

## UI Structure
Before:
```text
+--------------------------------------+
| Chat title                      [del]|
+--------------------------------------+
```

After holding Cmd/Alt for 0.5s:
```text
+--------------------------------------+
| Chat title                       [⌘1]|
| Next chat                         [⌘2]|
+--------------------------------------+
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts to quickly switch between sidebar chats using platform-specific modifiers (⌘ on macOS, Alt on Windows/Linux) with number keys 1–9 and 0 for the 10th chat
  * Added visual shortcut badges on sidebar items indicating available keyboard shortcuts
  * Updated translations across 18 languages to support the new feature
<!-- end of auto-generated comment: release notes by coderabbit.ai -->