### PR TITLE
fix: macOS app foreground identity

### DIFF
--- a/docs/issues/mac-app-name-identity/plan.md
+++ b/docs/issues/mac-app-name-identity/plan.md
@@ -1,0 +1,15 @@
+# macOS App Name Identity Plan
+
+## Implementation
+
+- Update the main-process startup path in `src/main/appMain.ts` to set the Electron application name to
+  `DeepChat` before the app creates windows or menus.
+- Ensure the macOS process advertises itself as a regular foreground app and reveals its Dock identity
+  before startup windows attempt to take focus.
+- Keep the change scoped to startup identity only, avoiding any unrelated menu, dock, or window policy
+  changes unless verification shows they are required.
+
+## Validation
+
+- Run a node-side typecheck or equivalent narrow validation for the touched startup file.
+- Run repository-required format, i18n, and lint checks before handoff.

--- a/docs/issues/mac-app-name-identity/spec.md
+++ b/docs/issues/mac-app-name-identity/spec.md
@@ -1,0 +1,20 @@
+# macOS App Name Identity Spec
+
+## Goal
+
+On macOS, DeepChat should identify itself as the active application when its window is focused,
+so the menu bar shows DeepChat instead of Finder or the generic Electron host identity.
+
+## Acceptance Criteria
+
+- DeepChat sets its user-visible application name during main-process startup before windows are created.
+- DeepChat declares a regular foreground macOS activation policy before startup windows are shown.
+- When a DeepChat window becomes the active foreground app on macOS, the menu bar app label resolves to
+  DeepChat rather than Finder.
+- The change does not alter Windows or Linux startup behavior.
+
+## Non-Goals
+
+- No app icon, bundle identifier, or code-signing changes.
+- No renderer UI changes.
+- No shortcut or menu structure refactor.

--- a/docs/issues/mac-app-name-identity/tasks.md
+++ b/docs/issues/mac-app-name-identity/tasks.md
@@ -1,0 +1,6 @@
+# macOS App Name Identity Tasks
+
+- [x] Document the bug, implementation scope, and validation plan.
+- [x] Set the macOS-visible app name during main-process startup.
+- [x] Run focused validation for the startup change.
+- [x] Run required format, i18n, and lint checks.

--- a/src/main/appMain.ts
+++ b/src/main/appMain.ts
@@ -13,14 +13,27 @@ import {
   storeStartupDeepLink
 } from './lib/startupDeepLink'
 import { isInsecureTlsAllowed } from './lib/insecureTls'
+import { activateAppOnMac, ensureRegularAppOnMac } from './lib/activateApp'
 
 let appStarted = false
+const APP_NAME = 'DeepChat'
 
 export function startApp(): void {
   if (appStarted) {
     return
   }
   appStarted = true
+
+  app.setName(APP_NAME)
+  if (process.platform === 'darwin') {
+    if (app.isReady()) {
+      ensureRegularAppOnMac()
+    } else {
+      app.once('ready', () => {
+        ensureRegularAppOnMac()
+      })
+    }
+  }
 
   registerWorkspacePreviewSchemes()
 
@@ -105,6 +118,7 @@ export function startApp(): void {
     }
     targetWindow.show()
     targetWindow.focus()
+    activateAppOnMac()
   }
 
   const routeIncomingDeeplink = (url: string, source: string) => {
@@ -157,6 +171,7 @@ export function startApp(): void {
 
   // Start the lifecycle management system instead of using app.whenReady()
   app.whenReady().then(async () => {
+    ensureRegularAppOnMac()
     // Set app user model id for windows
     electronApp.setAppUserModelId('com.wefonk.deepchat')
     try {

--- a/src/main/lib/activateApp.ts
+++ b/src/main/lib/activateApp.ts
@@ -1,0 +1,19 @@
+import { app } from 'electron'
+
+export function ensureRegularAppOnMac(): void {
+  if (process.platform !== 'darwin') {
+    return
+  }
+
+  app.setActivationPolicy('regular')
+  app.dock?.show()
+}
+
+export function activateAppOnMac(): void {
+  if (process.platform !== 'darwin') {
+    return
+  }
+
+  ensureRegularAppOnMac()
+  app.focus({ steal: true })
+}

--- a/src/main/presenter/lifecyclePresenter/SplashWindowManager.ts
+++ b/src/main/presenter/lifecyclePresenter/SplashWindowManager.ts
@@ -27,6 +27,7 @@ import {
   type DatabaseUnlockRequestPayload,
   type DatabaseUnlockReason
 } from '@shared/contracts/databaseSecurity'
+import { activateAppOnMac } from '@/lib/activateApp'
 
 type SplashActivityStatus = 'running' | 'completed' | 'failed'
 
@@ -483,6 +484,7 @@ export class SplashWindowManager implements ISplashWindowManager {
     }
     this.splashWindow.show()
     this.splashWindow.focus()
+    activateAppOnMac()
   }
 
   private markSplashLoaded(): void {

--- a/src/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.ts
+++ b/src/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.ts
@@ -45,6 +45,9 @@ export const eventListenerSetupHook: LifecycleHook = {
         if (!targetWindow.isDestroyed()) {
           targetWindow.show()
           targetWindow.focus() // Ensure window gets focus
+          // macOS: transparent windows may not properly activate the app,
+          // causing the global menu bar to not update.
+          app.focus()
         } else {
           console.warn(
             'eventListenerSetupHook: App activated but target window is destroyed, creating new window.'

--- a/src/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.ts
+++ b/src/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.ts
@@ -11,6 +11,7 @@ import { WINDOW_EVENTS, TRAY_EVENTS, FLOATING_BUTTON_EVENTS, SETTINGS_EVENTS } f
 import { handleShowHiddenWindow } from '@/utils'
 import { presenter } from '@/presenter'
 import { LifecyclePhase } from '@shared/lifecycle'
+import { activateAppOnMac } from '@/lib/activateApp'
 
 export const eventListenerSetupHook: LifecycleHook = {
   name: 'event-listener-setup',
@@ -45,9 +46,7 @@ export const eventListenerSetupHook: LifecycleHook = {
         if (!targetWindow.isDestroyed()) {
           targetWindow.show()
           targetWindow.focus() // Ensure window gets focus
-          // macOS: transparent windows may not properly activate the app,
-          // causing the global menu bar to not update.
-          app.focus()
+          activateAppOnMac()
         } else {
           console.warn(
             'eventListenerSetupHook: App activated but target window is destroyed, creating new window.'

--- a/src/main/presenter/windowPresenter/index.ts
+++ b/src/main/presenter/windowPresenter/index.ts
@@ -1,5 +1,6 @@
 // src\main\presenter\windowPresenter\index.ts
 import {
+  app,
   BrowserWindow,
   shell,
   nativeImage,
@@ -357,6 +358,11 @@ export class WindowPresenter implements IWindowPresenter {
     targetWindow.show()
     if (shouldFocus) {
       targetWindow.focus() // Bring to foreground
+      // macOS: transparent windows may not properly activate the app,
+      // causing the global menu bar to not update.
+      if (process.platform === 'darwin') {
+        app.focus()
+      }
     }
     // 触发恢复逻辑以确保活动标签页可见且位置正确
     this.handleWindowRestore(targetWindow.id).catch((error) => {
@@ -699,6 +705,12 @@ export class WindowPresenter implements IWindowPresenter {
       if (!appWindow.isDestroyed()) {
         appWindow.show()
         appWindow.focus()
+        // macOS: transparent windows may not properly activate the app,
+        // causing the global menu bar to not update. Explicitly call app.focus()
+        // to ensure macOS recognizes DeepChat as the active application.
+        if (process.platform === 'darwin') {
+          app.focus()
+        }
         eventBus.sendToMain(WINDOW_EVENTS.WINDOW_CREATED, {
           windowId,
           isMainWindow: windowId === this.mainWindowId

--- a/src/main/presenter/windowPresenter/index.ts
+++ b/src/main/presenter/windowPresenter/index.ts
@@ -1,6 +1,5 @@
 // src\main\presenter\windowPresenter\index.ts
 import {
-  app,
   BrowserWindow,
   shell,
   nativeImage,
@@ -36,6 +35,7 @@ import { FloatingChatWindow } from './FloatingChatWindow' // Floating chat windo
 import type { ProviderInstallPreview } from '@shared/providerDeeplink'
 import { StartupWorkloadCoordinator } from '../startupWorkloadCoordinator'
 import { openExternalUrl } from '@/lib/externalUrl'
+import { activateAppOnMac } from '@/lib/activateApp'
 
 type PendingSettingsMessage = {
   channel: string
@@ -358,11 +358,7 @@ export class WindowPresenter implements IWindowPresenter {
     targetWindow.show()
     if (shouldFocus) {
       targetWindow.focus() // Bring to foreground
-      // macOS: transparent windows may not properly activate the app,
-      // causing the global menu bar to not update.
-      if (process.platform === 'darwin') {
-        app.focus()
-      }
+      activateAppOnMac()
     }
     // 触发恢复逻辑以确保活动标签页可见且位置正确
     this.handleWindowRestore(targetWindow.id).catch((error) => {
@@ -535,6 +531,7 @@ export class WindowPresenter implements IWindowPresenter {
     if (switchToTarget) {
       targetWindow.show()
       targetWindow.focus()
+      activateAppOnMac()
     }
 
     return true
@@ -705,12 +702,7 @@ export class WindowPresenter implements IWindowPresenter {
       if (!appWindow.isDestroyed()) {
         appWindow.show()
         appWindow.focus()
-        // macOS: transparent windows may not properly activate the app,
-        // causing the global menu bar to not update. Explicitly call app.focus()
-        // to ensure macOS recognizes DeepChat as the active application.
-        if (process.platform === 'darwin') {
-          app.focus()
-        }
+        activateAppOnMac()
         eventBus.sendToMain(WINDOW_EVENTS.WINDOW_CREATED, {
           windowId,
           isMainWindow: windowId === this.mainWindowId
@@ -1243,6 +1235,7 @@ export class WindowPresenter implements IWindowPresenter {
       console.log('Settings window already exists, showing and focusing.')
       this.settingsWindow.show()
       this.settingsWindow.focus()
+      activateAppOnMac()
       if (navigation) {
         if (this.settingsWindowReady) {
           this.sendToWindow(this.settingsWindow.id, SETTINGS_EVENTS.NAVIGATE, navigation)
@@ -1419,6 +1412,7 @@ export class WindowPresenter implements IWindowPresenter {
 
     mainWindow.show()
     mainWindow.focus()
+    activateAppOnMac()
     return true
   }
 


### PR DESCRIPTION
## Summary
Fix the macOS app identity path so DeepChat becomes the active foreground app instead of leaving the menu bar attached to the previously focused application.

## What changed
- set the app name during startup
- add a shared macOS activation helper that forces regular activation policy and Dock identity
- reuse that helper across startup, splash, main window, settings window, and Dock activation paths
- add SDD notes for the issue scope and validation plan

## Validation
- `pnpm run typecheck:node`
- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- pre-commit hook also ran `pnpm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS app now correctly displays "DeepChat" in the menu bar when active and appears in the Dock.

* **Documentation**
  * Added implementation plan, specification, and task checklist for the macOS app name identity feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->