### PR TITLE
feat: adapt dify new retrieval_model schema

### DIFF
--- a/src/main/presenter/mcpPresenter/inMemoryServers/difyKnowledgeServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/difyKnowledgeServer.ts
@@ -216,24 +216,31 @@ export class DifyKnowledgeServer {
 
     try {
       const url = `${config.endpoint.replace(/\/$/, '')}/datasets/${config.datasetId}/retrieve`
+
+      // Dify 新版 API 把检索配置统一收进了 retrieval_model 对象，且要求：
+      // 1. search_method 为必填项（缺失会导致参数校验失败）；
+      // 2. reranking_enable / score_threshold_enabled 必须是布尔值，旧版传 null 已不再被接受。
+      // 这里默认走 semantic_search 且关闭 rerank —— 不依赖数据集是否配置了 Rerank 模型，
+      // 对任意数据集都可用；阈值过滤维持原有「不过滤」行为，保证检索结果集与改动前一致。
+      const retrievalModel = {
+        search_method: 'semantic_search',
+        reranking_enable: false,
+        top_k: topK,
+        score_threshold_enabled: false,
+        score_threshold: null
+      }
+
       console.log('performDifyKnowledgeSearch request', url, {
         query,
-        retrieval_model: {
-          top_k: topK,
-          score_threshold: scoreThreshold
-        }
+        score_threshold: scoreThreshold,
+        retrieval_model: retrievalModel
       })
 
       const response = await axios.post<DifySearchResponse>(
         url,
         {
           query,
-          retrieval_model: {
-            top_k: topK,
-            score_threshold: scoreThreshold,
-            reranking_enable: null, // 下面这两个字段即使为空也必须要有，否则接口无法请求
-            score_threshold_enabled: null
-          }
+          retrieval_model: retrievalModel
         },
         {
           headers: {


### PR DESCRIPTION
## 背景 / Background

Closes #1744

Dify 新版检索 API 把检索配置统一收进了 `retrieval_model` 对象，并对其字段做了校验收紧：

- `search_method` 变为**必填**（缺失会导致参数校验失败）；
- `reranking_enable` / `score_threshold_enabled` 必须是**布尔值**，旧版传 `null` 已不再被接受。

`dify_knowledge_search` 工具当前发出的请求体仍缺少 `search_method`、且这两个开关传的是 `null`，因此在新版 Dify 上检索直接报错。

## 改动 / Changes

仅修改 `difyKnowledgeServer.ts` 中 `performDifyKnowledgeSearch` 构造请求体的部分（私有方法，无外部调用方）：

- 新增 `search_method: 'semantic_search'` —— 语义检索不依赖数据集是否配置 Rerank 模型，对任意数据集都可用；
- `reranking_enable` / `score_threshold_enabled` 改为布尔值，避免 `null` 被新版接口拒绝。

请求体由：

```json
{
  "query": "...",
  "retrieval_model": {
    "top_k": 5,
    "score_threshold": 0.2,
    "reranking_enable": null,
    "score_threshold_enabled": null
  }
}
```

改为：

```json
{
  "query": "...",
  "retrieval_model": {
    "search_method": "semantic_search",
    "reranking_enable": false,
    "top_k": 5,
    "score_threshold_enabled": false,
    "score_threshold": null
  }
}
```

## 兼容性 / Compatibility

- 工具入参（`query` / `topK` / `scoreThreshold`）、schema、工具注册逻辑**均未改动**，对调用方零侵入。
- 阈值过滤保持原有「不过滤」行为（改动前 `score_threshold_enabled` 为 `null`，Dify 本就未启用阈值），因此检索结果集与改动前一致，唯一区别是新版 Dify 上由 400 报错变为正常返回。
- 未选用截图建议的 `hybrid_search` + `reranking_enable: true`，因其要求数据集已配置 Rerank 模型，否则反而会让部分用户报错。如需混合检索，可作为后续「每知识库可配置检索方式」的增强项。

## 测试 / Test

- `pnpm run format`、`pnpm run lint`：通过（0 warning / 0 error）
- `pnpm run typecheck:node` / `typecheck:web`：通过（pre-commit 钩子自动执行）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Dify knowledge search integration to use the latest API retrieval model format with semantic search, ensuring continued compatibility and optimal search performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->