### PR TITLE
fix(agent): load FFF from unpacked app

### DIFF
--- a/docs/issues/fff-packaged-native-loading/plan.md
+++ b/docs/issues/fff-packaged-native-loading/plan.md
@@ -1,0 +1,22 @@
+# FFF Packaged Native Loading Plan
+
+## Approach
+
+- Detect the packaged FFF entry at
+  `process.resourcesPath/app.asar.unpacked/node_modules/@ff-labs/fff-node/dist/src/index.js`.
+- Make the default `FffSearchService` module loader import that file URL when present.
+- Fall back to the bare `@ff-labs/fff-node` import for dev, tests, and unpackaged runs.
+- Leave explicit test-injected `moduleLoader` behavior unchanged.
+
+## Validation
+
+- Add a focused unit test that sets a temporary `process.resourcesPath` and verifies the
+  default loader uses the unpacked FFF entry.
+- Run focused FFF service tests.
+- Run required project checks after implementation.
+
+## Risks
+
+- A malformed unpacked package would fail during import. That failure remains wrapped by
+  `FffSearchUnavailableError` through the existing loader error path.
+- Dynamic file URL imports are cached by URL, so tests use unique temp directories.

--- a/docs/issues/fff-packaged-native-loading/spec.md
+++ b/docs/issues/fff-packaged-native-loading/spec.md
@@ -1,0 +1,32 @@
+# FFF Packaged Native Loading
+
+## Problem
+
+Packaged DeepChat can show `Error: FFF native library is not available` when agent `glob`
+or `grep` runs. The packaged app contains `@ff-labs/fff-node`, `ffi-rs`, and the platform
+native packages under `app.asar.unpacked`, but the main process resolves
+`@ff-labs/fff-node` from `app.asar`.
+
+`@ff-labs/fff-node` resolves its platform library with `createRequire()` from its package
+root. When that root is inside `app.asar`, the manually copied `@ff-labs/fff-bin-*`
+package in `app.asar.unpacked` is outside the module resolution tree and `findBinary()`
+returns `null`.
+
+## Acceptance Criteria
+
+- Packaged agent `glob` and `grep` load FFF from `app.asar.unpacked` when the unpacked
+  package exists.
+- Development and test environments keep using the normal `@ff-labs/fff-node` import.
+- FFF native availability failures still surface as `FffSearchUnavailableError`.
+- The fix stays scoped to FFF loading and packaging behavior.
+
+## Non-Goals
+
+- Replacing FFF search behavior.
+- Changing tool schemas or renderer UI.
+- Reworking Electron Builder packaging for all native dependencies.
+
+## Constraints
+
+- Keep `@ff-labs/fff-node` isolated behind `FffSearchService`.
+- Avoid depending on Electron imports in this low-level service.

--- a/docs/issues/fff-packaged-native-loading/tasks.md
+++ b/docs/issues/fff-packaged-native-loading/tasks.md
@@ -1,0 +1,6 @@
+# FFF Packaged Native Loading Tasks
+
+- [x] Reproduce the packaged ASAR vs unpacked FFF availability difference.
+- [x] Add packaged FFF module resolution in `FffSearchService`.
+- [x] Cover the packaged loader path with a focused unit test.
+- [x] Run focused tests and required checks.

--- a/src/main/lib/agentRuntime/fffSearchService.ts
+++ b/src/main/lib/agentRuntime/fffSearchService.ts
@@ -1,5 +1,7 @@
 import path from 'path'
+import { existsSync } from 'node:fs'
 import { readFile } from 'fs/promises'
+import { pathToFileURL } from 'url'
 import type { FileFinderApi, FileItem, GrepMatch, GrepMode, Result, Score } from '@ff-labs/fff-node'
 
 export type FffFileSearchHit = {
@@ -77,9 +79,43 @@ const MAX_FIND_LIMIT = 200
 const MAX_GREP_LIMIT = 200
 const MAX_GLOB_LIMIT = 1000
 const MAX_CONTEXT_LINES = 5
+const PACKAGED_FFF_NODE_ENTRY = path.join(
+  'app.asar.unpacked',
+  'node_modules',
+  '@ff-labs',
+  'fff-node',
+  'dist',
+  'src',
+  'index.js'
+)
 const GLOB_PATTERN = /[*?[{]/
 const WHITESPACE_PATTERN = /\s/
 const REGEX_INTENT_PATTERN = /(^|[^\\])(?:\||\(\?|\[[^\]]+\]|\.\*|\.\+|\\[bBdDsSwW]|\^|\$)/
+
+const getProcessResourcesPath = (): string | undefined => {
+  const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
+  return typeof resourcesPath === 'string' ? resourcesPath : undefined
+}
+
+const resolvePackagedFffNodeEntry = (
+  resourcesPath: string | undefined = getProcessResourcesPath()
+): string | null => {
+  if (!resourcesPath) {
+    return null
+  }
+
+  const candidate = path.join(resourcesPath, PACKAGED_FFF_NODE_ENTRY)
+  return existsSync(candidate) ? candidate : null
+}
+
+const loadFffModule = async (): Promise<FffModule> => {
+  const packagedEntry = resolvePackagedFffNodeEntry()
+  if (packagedEntry) {
+    return (await import(pathToFileURL(packagedEntry).href)) as FffModule
+  }
+
+  return import('@ff-labs/fff-node')
+}
 
 const clampInt = (value: number | undefined, fallback: number, max: number): number => {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
@@ -261,7 +297,7 @@ export class FffSearchService {
   private readonly finders = new Map<string, Promise<FinderHandle>>()
 
   constructor(options: FffSearchServiceOptions = {}) {
-    this.moduleLoader = options.moduleLoader ?? (() => import('@ff-labs/fff-node'))
+    this.moduleLoader = options.moduleLoader ?? loadFffModule
     this.scanTimeoutMs = options.scanTimeoutMs ?? DEFAULT_SCAN_TIMEOUT_MS
     this.maxCachedFinders = options.maxCachedFinders ?? DEFAULT_MAX_CACHED_FINDERS
     this.now = options.now ?? (() => Date.now())

--- a/test/main/lib/agentRuntime/fffSearchService.test.ts
+++ b/test/main/lib/agentRuntime/fffSearchService.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { existsSync } from 'fs'
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
@@ -90,6 +91,93 @@ function createMockModule(overrides: Record<string, unknown> = {}) {
 }
 
 describe('FffSearchService', () => {
+  it('loads the packaged FFF module from app.asar.unpacked when available', async () => {
+    const resourcesPath = await fs.mkdtemp(path.join(os.tmpdir(), 'fff-packaged-resources-'))
+    const moduleRoot = path.join(
+      resourcesPath,
+      'app.asar.unpacked',
+      'node_modules',
+      '@ff-labs',
+      'fff-node'
+    )
+    const entryPath = path.join(moduleRoot, 'dist', 'src', 'index.js')
+    const originalResourcesPath = Object.getOwnPropertyDescriptor(process, 'resourcesPath')
+
+    await fs.mkdir(path.dirname(entryPath), { recursive: true })
+    await fs.writeFile(path.join(moduleRoot, 'package.json'), '{"type":"module"}', 'utf8')
+    await fs.writeFile(
+      entryPath,
+      `
+export const FileFinder = {
+  isAvailable() {
+    return true
+  },
+  create() {
+    return {
+      ok: true,
+      value: {
+        isDestroyed: false,
+        destroy() {},
+        waitForScan() {
+          return Promise.resolve({ ok: true, value: true })
+        },
+        fileSearch() {
+          return {
+            ok: true,
+            value: {
+              items: [
+                {
+                  relativePath: 'packaged.ts',
+                  fileName: 'packaged.ts',
+                  size: 1,
+                  modified: 1,
+                  accessFrecencyScore: 0,
+                  modificationFrecencyScore: 0,
+                  totalFrecencyScore: 0,
+                  gitStatus: 'clean'
+                }
+              ],
+              scores: [{ total: 999 }],
+              totalMatched: 1,
+              totalFiles: 1
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`,
+      'utf8'
+    )
+    vi.mocked(existsSync).mockImplementation((candidate) => String(candidate) === entryPath)
+
+    Object.defineProperty(process, 'resourcesPath', {
+      value: resourcesPath,
+      writable: true,
+      configurable: true
+    })
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = resourcesPath
+
+    const service = new FffSearchService()
+    try {
+      const hits = await service.findFiles('packaged', {
+        workspaceRoot: resourcesPath,
+        maxResults: 1
+      })
+
+      expect(hits).toEqual([{ path: 'packaged.ts', score: 999 }])
+    } finally {
+      service.destroyAll()
+      if (originalResourcesPath) {
+        Object.defineProperty(process, 'resourcesPath', originalResourcesPath)
+      } else {
+        delete (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
+      }
+      await fs.rm(resourcesPath, { recursive: true, force: true })
+    }
+  })
+
   it('maps file search results into DeepChat JSON shape', async () => {
     const mock = createMockModule()
     const service = new FffSearchService({


### PR DESCRIPTION
## Summary
- load packaged FFF from app.asar.unpacked before falling back to bare @ff-labs/fff-node imports
- add a packaged loader regression test
- document the issue in SDD notes

## Validation
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck
- pnpm vitest --config vitest.config.ts test/main/lib/agentRuntime/fffSearchService.test.ts
- pnpm exec electron-vite build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * FFF native library loading now works reliably in packaged Electron builds, automatically falling back to development paths when needed.

* **Documentation**
  * Added comprehensive documentation detailing the packaged FFF loading strategy, implementation approach, acceptance criteria, and task checklist.

* **Tests**
  * Added focused test coverage for the packaged FFF module loading functionality in various environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->