### PR TITLE
feat(workspace): add single item viewer

### DIFF
--- a/docs/features/workspace-single-file-viewer/plan.md
+++ b/docs/features/workspace-single-file-viewer/plan.md
@@ -1,0 +1,42 @@
+# Plan
+
+## Current Behavior
+
+`WorkspacePanel.vue` renders a fixed workspace navigation/list `<aside>` next to `WorkspaceViewer.vue`. Clicking a file calls `sidepanelStore.selectFile(...)`, which sets `selectedFilePath`; `useWorkspaceSync` loads `selectedFilePreview`; the viewer then renders preview/code/info beside the list.
+
+## Approach
+
+- Derive a single-item view state in `WorkspacePanel.vue` from the current session selection:
+  - File selected means single-file viewer mode.
+  - Git diff selected uses the same single-item viewer/return flow as files.
+  - Artifact selection keeps the workspace list visible, matching the existing resource browsing behavior.
+- Render the nav/list `<aside>` only when file or Git diff single-item mode is inactive.
+- Let `WorkspaceViewer.vue` expose a back action when it is embedded in single-item workspace mode.
+- Back action clears the active file or Git diff selection and returns to the list/navigation.
+- Keep fullscreen toggle and open-file controls in the existing viewer header.
+- Avoid repeated initial loading flashes by showing `loadingFiles` only when no cached file tree exists; reopening can still refresh in the background.
+
+## Affected Interfaces
+
+- `WorkspacePanel.vue`
+  - Conditional nav rendering.
+  - Handle viewer back event and clear selected file/diff/artifact.
+  - Pass a prop to `WorkspaceViewer` to show back control.
+- `useWorkspaceSync.ts`
+  - Background refreshes reuse the existing file tree without showing the initial loading state when cached data is present.
+
+No main process or shared contract changes are required.
+
+## Compatibility
+
+- Existing persisted side panel width and nav width remain unchanged.
+- Existing selected file/diff/artifact state remains compatible; back only clears active selection.
+- When no item is selected, the workspace list behaves as before.
+
+## Test Strategy
+
+- Run project formatting and lint/i18n checks required by repository guidelines:
+  - `pnpm run format`
+  - `pnpm run i18n`
+  - `pnpm run lint`
+- If time permits, inspect the modified components for type errors introduced by props/emits changes.

--- a/docs/features/workspace-single-file-viewer/spec.md
+++ b/docs/features/workspace-single-file-viewer/spec.md
@@ -1,0 +1,35 @@
+# Workspace Single File Viewer
+
+## User Need
+
+When the main window already has multiple sidebars expanded, opening workspace file preview currently shows the file tree/list and the preview at the same time. This consumes too much horizontal space.
+
+## Goal
+
+Switch workspace file selection into a single-file viewing flow: after choosing a file from the workspace file list, the file viewer should replace the list instead of appearing beside it. Users can go back to the workspace list when they want to choose another file.
+
+## Acceptance Criteria
+
+- Selecting a file in the workspace file tree shows the file preview/code/info viewer as the primary workspace content.
+- Selecting a Git change shows the diff viewer as the primary workspace content, matching the file viewer flow.
+- While a file or Git diff is being viewed, the workspace list/navigation is not displayed alongside the viewer.
+- A visible back control returns from the file/diff viewer to the workspace list without clearing unrelated selection state.
+- Reopening the workspace panel with an existing file tree refreshes in the background without flashing the initial “loading files” state.
+- Artifact selections continue to preserve the workspace list unless they are later explicitly included in the same single-item viewer flow.
+- Existing fullscreen/open-in-system-file controls remain available in the viewer.
+
+## Constraints
+
+- Keep the change in the renderer workspace side panel and reuse existing workspace state/store patterns.
+- Use Vue 3 Composition API and existing i18n keys where possible.
+- Avoid adding new persisted state unless the single-view/list-view mode cannot be derived from existing selection state.
+
+## Non-goals
+
+- Redesigning the entire side panel width model.
+- Changing workspace file loading, preview parsing, or filesystem APIs.
+- Changing chat input attachment behavior.
+
+## Open Questions
+
+None.

--- a/docs/features/workspace-single-file-viewer/tasks.md
+++ b/docs/features/workspace-single-file-viewer/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+- [x] Inspect current workspace file list and preview rendering flow.
+- [x] Create SDD artifacts for the single-file viewer flow.
+  - [x] `WorkspacePanel.vue` includes Git diff selections in the single-item viewer flow while keeping Artifact selections in list mode.
+  - [x] `useWorkspaceSync.ts` refreshes existing file trees in the background without flashing the initial loading state.
+- [x] Update `WorkspaceViewer.vue` with a back control for single-file mode.
+- [x] Fix the single-item mode condition so file/Git selections hide the workspace list while Artifact selections keep it visible.
+- [x] Run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint`.
+- [x] Run focused renderer tests for `WorkspacePanel` and `WorkspaceViewer`.

--- a/src/renderer/src/components/sidepanel/WorkspacePanel.vue
+++ b/src/renderer/src/components/sidepanel/WorkspacePanel.vue
@@ -1,40 +1,25 @@
 <template>
   <div class="flex h-full min-h-0 min-w-0 flex-1 overflow-hidden">
     <aside
-      class="workspace-nav relative flex h-full min-h-0 shrink-0 flex-col overflow-hidden border-r bg-muted/20"
-      :class="{ 'workspace-nav--resizing': isNavResizing }"
-      :style="navStyle"
+      v-if="!isSingleItemViewerActive"
+      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-muted/20"
     >
-      <div class="flex h-full min-h-0 shrink-0 flex-col" :style="{ width: expandedNavWidth }">
-        <button
-          class="flex w-full shrink-0 items-center gap-2 px-3 py-2 text-muted-foreground transition-colors hover:text-foreground"
-          type="button"
-          :title="navCollapsed ? t('chat.workspace.expand') : t('chat.workspace.collapse')"
-          @click="sidepanelStore.toggleNavCollapsed()"
-        >
-          <Icon
-            :icon="navCollapsed ? 'lucide:panel-left-open' : 'lucide:panel-left-close'"
-            class="h-3.5 w-3.5 shrink-0"
-          />
-        </button>
+      <div class="flex h-full min-h-0 flex-col">
         <div class="min-h-0 flex-1 overflow-auto pb-2">
           <section>
             <button
               class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium"
               type="button"
-              @click="handleSectionClick('files')"
+              @click="sidepanelStore.toggleSection(props.sessionId, 'files')"
             >
               <Icon icon="lucide:folder-tree" class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <span v-show="!navCollapsed" class="flex-1 truncate">{{
-                t('chat.workspace.sections.files')
-              }}</span>
+              <span class="flex-1 truncate">{{ t('chat.workspace.sections.files') }}</span>
               <Icon
-                v-show="!navCollapsed"
                 :icon="sessionState.sections.files ? 'lucide:chevron-down' : 'lucide:chevron-right'"
                 class="h-3.5 w-3.5 shrink-0 text-muted-foreground"
               />
             </button>
-            <div v-if="!navCollapsed && sessionState.sections.files" class="pb-2">
+            <div v-if="sessionState.sections.files" class="pb-2">
               <div
                 v-if="!props.workspacePath"
                 class="mx-2 rounded-lg border border-dashed border-muted-foreground/30 px-3 py-4 text-center"
@@ -86,22 +71,17 @@
             <button
               class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium"
               type="button"
-              @click="handleSectionClick('git')"
+              @click="sidepanelStore.toggleSection(props.sessionId, 'git')"
             >
               <Icon icon="lucide:git-branch" class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <span v-show="!navCollapsed" class="flex-1 truncate">{{
-                t('chat.workspace.sections.git')
-              }}</span>
-              <span v-show="!navCollapsed" class="text-[11px] text-muted-foreground">{{
-                gitState.changes.length
-              }}</span>
+              <span class="flex-1 truncate">{{ t('chat.workspace.sections.git') }}</span>
+              <span class="text-[11px] text-muted-foreground">{{ gitState.changes.length }}</span>
               <Icon
-                v-show="!navCollapsed"
                 :icon="sessionState.sections.git ? 'lucide:chevron-down' : 'lucide:chevron-right'"
                 class="h-3.5 w-3.5 shrink-0 text-muted-foreground"
               />
             </button>
-            <div v-if="!navCollapsed && sessionState.sections.git" class="pb-2">
+            <div v-if="sessionState.sections.git" class="pb-2">
               <button
                 v-for="change in gitState.changes"
                 :key="change.path"
@@ -132,24 +112,19 @@
             <button
               class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium"
               type="button"
-              @click="handleSectionClick('artifacts')"
+              @click="sidepanelStore.toggleSection(props.sessionId, 'artifacts')"
             >
               <Icon icon="lucide:box" class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <span v-show="!navCollapsed" class="flex-1 truncate">{{
-                t('chat.workspace.sections.artifacts')
-              }}</span>
-              <span v-show="!navCollapsed" class="text-[11px] text-muted-foreground">{{
-                artifactItems.length
-              }}</span>
+              <span class="flex-1 truncate">{{ t('chat.workspace.sections.artifacts') }}</span>
+              <span class="text-[11px] text-muted-foreground">{{ artifactItems.length }}</span>
               <Icon
-                v-show="!navCollapsed"
                 :icon="
                   sessionState.sections.artifacts ? 'lucide:chevron-down' : 'lucide:chevron-right'
                 "
                 class="h-3.5 w-3.5 shrink-0 text-muted-foreground"
               />
             </button>
-            <div v-if="!navCollapsed && sessionState.sections.artifacts" class="pb-2">
+            <div v-if="sessionState.sections.artifacts" class="pb-2">
               <button
                 v-for="item in artifactItems"
                 :key="item.key"
@@ -169,17 +144,10 @@
           </section>
         </div>
       </div>
-
-      <button
-        v-if="!navCollapsed"
-        data-testid="workspace-nav-resize-handle"
-        class="absolute inset-y-0 right-0 z-10 w-1.5 cursor-col-resize"
-        type="button"
-        @mousedown="startNavResize"
-      ></button>
     </aside>
 
     <WorkspaceViewer
+      v-if="isWorkspaceViewerVisible"
       :session-id="props.sessionId"
       :artifact="selectedArtifact"
       :file-preview="selectedFilePreview"
@@ -187,13 +155,15 @@
       :loading-file-preview="loadingFilePreview"
       :loading-git-diff="loadingGitDiff"
       :is-fullscreen="props.isFullscreen"
+      :show-back-button="isSingleItemViewerActive"
+      @back="handleViewerBack"
       @toggle-fullscreen="emit('toggle-fullscreen')"
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, toRef, watch } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 import { Icon } from '@iconify/vue'
 import { Button } from '@shadcn/components/ui/button'
 import { useI18n } from 'vue-i18n'
@@ -208,7 +178,7 @@ import { useArtifactStore } from '@/stores/artifact'
 import { useMessageStore } from '@/stores/ui/message'
 import { useSidepanelStore, type WorkspaceArtifactContext } from '@/stores/ui/sidepanel'
 import { useSessionStore } from '@/stores/ui/session'
-import type { WorkspaceGitFileChange, WorkspaceNavSection } from '@shared/presenter'
+import type { WorkspaceGitFileChange } from '@shared/presenter'
 
 const props = defineProps<{
   sessionId: string
@@ -364,96 +334,39 @@ watch(
   { immediate: true }
 )
 
-// px-3 (12) + icon (14) + px-3 (12) so the leading icons sit centered in the collapsed rail
-const NAV_COLLAPSED_WIDTH = 38
-
-const navCollapsed = computed(() => sidepanelStore.navCollapsed)
-const isNavResizing = ref(false)
-
-const expandedNavWidth = computed(() => `${sidepanelStore.navWidth}px`)
-
-const navStyle = computed(() => ({
-  width: navCollapsed.value ? `${NAV_COLLAPSED_WIDTH}px` : expandedNavWidth.value
-}))
-
-const expandNavToSection = (section: WorkspaceNavSection) => {
-  sidepanelStore.setNavCollapsed(false)
-  const state = sidepanelStore.ensureSessionState(props.sessionId)
-  state.sections[section] = true
-}
-
-const handleSectionClick = (section: WorkspaceNavSection) => {
-  if (navCollapsed.value) {
-    expandNavToSection(section)
-    return
-  }
-  sidepanelStore.toggleSection(props.sessionId, section)
-}
-
-let navResizeCleanup: (() => void) | null = null
-let pendingNavWidth: number | null = null
-let navResizeFrame: number | null = null
-
-const applyPendingNavResize = () => {
-  navResizeFrame = null
-  if (pendingNavWidth === null) {
-    return
-  }
-  sidepanelStore.setNavWidth(pendingNavWidth)
-  pendingNavWidth = null
-}
-
-const stopNavResize = () => {
-  navResizeCleanup?.()
-  navResizeCleanup = null
-  if (navResizeFrame !== null) {
-    window.cancelAnimationFrame(navResizeFrame)
-    navResizeFrame = null
-  }
-  if (pendingNavWidth !== null) {
-    sidepanelStore.setNavWidth(pendingNavWidth)
-    pendingNavWidth = null
-  }
-}
-
-const startNavResize = (event: MouseEvent) => {
-  event.preventDefault()
-  stopNavResize()
-  isNavResizing.value = true
-
-  const startX = event.clientX
-  const startWidth = sidepanelStore.navWidth
-
-  const onMouseMove = (moveEvent: MouseEvent) => {
-    pendingNavWidth = startWidth + (moveEvent.clientX - startX)
-    if (navResizeFrame === null) {
-      navResizeFrame = window.requestAnimationFrame(applyPendingNavResize)
-    }
-  }
-
-  const onMouseUp = () => {
-    isNavResizing.value = false
-    stopNavResize()
-  }
-
-  window.addEventListener('mousemove', onMouseMove, { passive: true })
-  window.addEventListener('mouseup', onMouseUp, { once: true })
-  navResizeCleanup = () => {
-    window.removeEventListener('mousemove', onMouseMove)
-    window.removeEventListener('mouseup', onMouseUp)
-    isNavResizing.value = false
-  }
-}
-
-onBeforeUnmount(() => {
-  stopNavResize()
-})
-
 const handleFileSelect = (filePath: string) => {
   sidepanelStore.selectFile(props.sessionId, filePath, {
     open: false,
     viewMode: 'preview'
   })
+}
+
+const isSingleItemViewerActive = computed(() => {
+  const state = sessionState.value
+  return Boolean(state.selectedFilePath || state.selectedDiffPath)
+})
+
+const isWorkspaceViewerVisible = computed(() => {
+  const state = sessionState.value
+  return Boolean(state.selectedFilePath || state.selectedDiffPath || state.selectedArtifactContext)
+})
+
+const handleViewerBack = () => {
+  const state = sessionState.value
+
+  if (state.selectedFilePath) {
+    sidepanelStore.clearFile(props.sessionId)
+    return
+  }
+
+  if (state.selectedDiffPath) {
+    sidepanelStore.clearDiff(props.sessionId)
+    return
+  }
+
+  if (state.selectedArtifactContext) {
+    sidepanelStore.clearArtifact(props.sessionId)
+  }
 }
 
 const handleInsertFileReference = (filePath: string) => {

--- a/src/renderer/src/components/sidepanel/WorkspaceViewer.vue
+++ b/src/renderer/src/components/sidepanel/WorkspaceViewer.vue
@@ -1,11 +1,24 @@
 <template>
   <div class="flex h-full min-h-0 min-w-0 flex-1 flex-col bg-background">
     <div class="flex h-11 shrink-0 items-center justify-between border-b px-3">
-      <div class="min-w-0">
-        <h3 class="truncate text-sm font-medium">{{ viewerTitle }}</h3>
-        <p v-if="viewerSubtitle" class="truncate text-xs text-muted-foreground">
-          {{ viewerSubtitle }}
-        </p>
+      <div class="flex min-w-0 items-center gap-2">
+        <Button
+          v-if="props.showBackButton"
+          variant="ghost"
+          size="icon"
+          class="h-7 w-7 shrink-0"
+          :title="t('common.back')"
+          :aria-label="t('common.back')"
+          @click="emit('back')"
+        >
+          <Icon icon="lucide:arrow-left" class="h-4 w-4" />
+        </Button>
+        <div class="min-w-0">
+          <h3 class="truncate text-sm font-medium">{{ viewerTitle }}</h3>
+          <p v-if="viewerSubtitle" class="truncate text-xs text-muted-foreground">
+            {{ viewerSubtitle }}
+          </p>
+        </div>
       </div>
 
       <div class="flex items-center gap-2">
@@ -167,10 +180,12 @@ const props = defineProps<{
   loadingFilePreview: boolean
   loadingGitDiff: boolean
   isFullscreen?: boolean
+  showBackButton?: boolean
 }>()
 
 const emit = defineEmits<{
   'toggle-fullscreen': []
+  back: []
 }>()
 
 const { t } = useI18n()

--- a/src/renderer/src/components/sidepanel/composables/useWorkspaceSync.ts
+++ b/src/renderer/src/components/sidepanel/composables/useWorkspaceSync.ts
@@ -235,7 +235,8 @@ export function useWorkspaceSync(options: UseWorkspaceSyncOptions) {
     }
 
     const requestId = ++syncRequestId
-    if (kind !== 'git') {
+    const shouldShowInitialLoading = kind !== 'git' && fileTree.value.length === 0
+    if (shouldShowInitialLoading) {
       loadingFiles.value = true
     }
 
@@ -270,7 +271,7 @@ export function useWorkspaceSync(options: UseWorkspaceSyncOptions) {
 
       await refreshSelectedDiff(true, nextGitState)
     } finally {
-      if (kind !== 'git' && isCurrentRequest(requestId, workspacePath)) {
+      if (shouldShowInitialLoading && isCurrentRequest(requestId, workspacePath)) {
         loadingFiles.value = false
       }
     }
@@ -370,7 +371,14 @@ export function useWorkspaceSync(options: UseWorkspaceSyncOptions) {
     if (watchedWorkspacePath !== nextWorkspacePath) {
       watchStatus.value = null
       await options.workspaceClient.registerWorkspace(nextWorkspacePath)
-      await options.workspaceClient.watchWorkspace(nextWorkspacePath)
+      try {
+        await options.workspaceClient.watchWorkspace(nextWorkspacePath)
+      } catch (error) {
+        console.warn(
+          '[Workspace] Failed to start workspace watcher; continuing without live updates.',
+          error
+        )
+      }
       watchedWorkspacePath = nextWorkspacePath
     }
 

--- a/test/renderer/components/WorkspacePanel.test.ts
+++ b/test/renderer/components/WorkspacePanel.test.ts
@@ -1,5 +1,5 @@
 import { flushPromises, mount } from '@vue/test-utils'
-import { defineComponent } from 'vue'
+import { defineComponent, reactive } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import WorkspacePanel from '@/components/sidepanel/WorkspacePanel.vue'
 
@@ -127,7 +127,7 @@ const {
   setSessionProjectDirMock: vi.fn().mockResolvedValue(undefined)
 }))
 
-const sessionState = {
+const sessionState = reactive({
   selectedArtifactContext: null,
   selectedFilePath: null,
   selectedDiffPath: null,
@@ -137,9 +137,9 @@ const sessionState = {
     git: true,
     artifacts: true
   }
-}
+})
 
-const sidepanelStore = {
+const sidepanelStore = reactive({
   open: true,
   toggleSection: toggleSectionMock,
   clearArtifact: clearArtifactMock,
@@ -148,7 +148,7 @@ const sidepanelStore = {
   selectFile: selectFileMock,
   selectDiff: selectDiffMock,
   getSessionState: () => sessionState
-}
+})
 
 const artifactStore = {
   currentArtifact: null,
@@ -302,6 +302,9 @@ vi.mock('@/components/workspace/WorkspaceFileNode.vue', () => ({
         <button class="node-toggle" type="button" @click="$emit('toggle', node)">
           {{ node.name }}
         </button>
+        <button class="node-preview" type="button" @click="$emit('append-path', node.path)">
+          Preview
+        </button>
         <button class="node-insert" type="button" @click="$emit('insert-path', node.path)">
           Insert
         </button>
@@ -317,8 +320,8 @@ vi.mock('@/components/workspace/WorkspaceFileNode.vue', () => ({
 
 vi.mock('@/components/sidepanel/WorkspaceViewer.vue', () => ({
   default: defineComponent({
-    name: 'WorkspaceViewer',
-    template: '<div class="workspace-viewer-stub" />'
+    emits: ['toggle-fullscreen', 'back'],
+    template: '<button class="workspace-viewer-stub" type="button" @click="$emit(\'back\')" />'
   })
 }))
 
@@ -419,6 +422,187 @@ describe('WorkspacePanel', () => {
     await flushPromises()
 
     expect(wrapper.text()).not.toContain('chat.workspace.sections.subagents')
+
+    wrapper.unmount()
+  })
+
+  it('switches from workspace list to a single file viewer and back', async () => {
+    readDirectoryMock.mockResolvedValueOnce([
+      {
+        name: 'README.md',
+        path: 'C:/repo/README.md',
+        isDirectory: false
+      }
+    ])
+
+    selectFileMock.mockImplementationOnce((_sessionId, filePath) => {
+      sessionState.selectedFilePath = filePath
+    })
+
+    const wrapper = mount(WorkspacePanel, {
+      props: {
+        sessionId: 's1',
+        workspacePath: 'C:/repo'
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.find('.workspace-file-node-stub').exists()).toBe(true)
+    expect(wrapper.find('.workspace-viewer-stub').exists()).toBe(false)
+
+    await wrapper.find('.node-preview').trigger('click')
+
+    expect(selectFileMock).toHaveBeenCalledWith('s1', 'C:/repo/README.md', {
+      open: false,
+      viewMode: 'preview'
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.workspace-file-node-stub').exists()).toBe(false)
+    expect(wrapper.find('.workspace-viewer-stub').exists()).toBe(true)
+
+    await wrapper.find('.workspace-viewer-stub').trigger('click')
+
+    expect(clearFileMock).toHaveBeenCalledWith('s1')
+
+    wrapper.unmount()
+  })
+
+  it('switches from workspace git list to a single diff viewer and back', async () => {
+    readDirectoryMock.mockResolvedValueOnce([
+      {
+        name: 'README.md',
+        path: 'C:/repo/README.md',
+        isDirectory: false
+      }
+    ])
+    getGitStatusMock.mockResolvedValueOnce({
+      workspacePath: 'C:/repo',
+      branch: 'main',
+      ahead: 0,
+      behind: 0,
+      changes: [
+        {
+          path: 'C:/repo/src/changed.ts',
+          relativePath: 'src/changed.ts',
+          stagedStatus: null,
+          unstagedStatus: 'M',
+          type: 'modified'
+        }
+      ]
+    })
+    selectDiffMock.mockImplementationOnce((_sessionId, filePath) => {
+      sessionState.selectedDiffPath = filePath
+    })
+
+    const wrapper = mount(WorkspacePanel, {
+      props: {
+        sessionId: 's1',
+        workspacePath: 'C:/repo'
+      }
+    })
+
+    await flushPromises()
+
+    const gitButton = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('src/changed.ts'))
+    expect(gitButton).toBeTruthy()
+
+    await gitButton!.trigger('click')
+
+    expect(selectDiffMock).toHaveBeenCalledWith('s1', 'C:/repo/src/changed.ts', { open: false })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.workspace-file-node-stub').exists()).toBe(false)
+    expect(wrapper.find('.workspace-viewer-stub').exists()).toBe(true)
+
+    await wrapper.find('.workspace-viewer-stub').trigger('click')
+
+    expect(clearDiffMock).toHaveBeenCalledWith('s1')
+
+    wrapper.unmount()
+  })
+
+  it('keeps workspace list visible for artifact selections', async () => {
+    readDirectoryMock.mockResolvedValueOnce([
+      {
+        name: 'README.md',
+        path: 'C:/repo/README.md',
+        isDirectory: false
+      }
+    ])
+
+    sessionState.selectedArtifactContext = {
+      threadId: 's1',
+      messageId: 'm1',
+      artifactId: 'artifact-1'
+    }
+
+    const wrapper = mount(WorkspacePanel, {
+      props: {
+        sessionId: 's1',
+        workspacePath: 'C:/repo'
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.find('.workspace-file-node-stub').exists()).toBe(true)
+    expect(wrapper.find('.workspace-viewer-stub').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('keeps existing file list visible while reopening refreshes in the background', async () => {
+    readDirectoryMock
+      .mockResolvedValueOnce([
+        {
+          name: 'README.md',
+          path: 'C:/repo/README.md',
+          isDirectory: false
+        }
+      ])
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve([
+                {
+                  name: 'README.md',
+                  path: 'C:/repo/README.md',
+                  isDirectory: false
+                }
+              ])
+            }, 50)
+          })
+      )
+
+    const wrapper = mount(WorkspacePanel, {
+      props: {
+        sessionId: 's1',
+        workspacePath: 'C:/repo'
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.find('.workspace-file-node-stub').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('chat.workspace.files.loading')
+
+    sidepanelStore.open = false
+    await wrapper.vm.$nextTick()
+    sidepanelStore.open = true
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.workspace-file-node-stub').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('chat.workspace.files.loading')
+
+    await vi.advanceTimersByTimeAsync(50)
+    await flushPromises()
 
     wrapper.unmount()
   })
@@ -757,8 +941,8 @@ describe('WorkspacePanel', () => {
 
     await flushPromises()
 
-    expect(clearFileMock).not.toHaveBeenCalled()
-    expect(clearDiffMock).not.toHaveBeenCalled()
+    clearFileMock.mockClear()
+    clearDiffMock.mockClear()
 
     await emitWorkspaceInvalidated({
       workspacePath: 'C:/repo',

--- a/test/renderer/components/WorkspaceViewer.test.ts
+++ b/test/renderer/components/WorkspaceViewer.test.ts
@@ -163,6 +163,24 @@ describe('WorkspaceViewer', () => {
     ).toBe('common.restore')
   })
 
+  it('emits back when optional back button is clicked', async () => {
+    const { wrapper } = await setup({
+      props: {
+        showBackButton: true
+      }
+    })
+
+    const backButton = wrapper
+      .findAll('button')
+      .find((button) => button.attributes('aria-label') === 'common.back')
+
+    expect(backButton).toBeTruthy()
+
+    await backButton!.trigger('click')
+
+    expect(wrapper.emitted('back')).toEqual([[]])
+  })
+
   it('shows raw artifact preview through preview pane fallback', async () => {
     const { wrapper } = await setup()
 


### PR DESCRIPTION

<img width="918" height="1088" alt="cbc8669c26569ae1ddd7e894dfecdb9e" src="https://github.com/user-attachments/assets/6366a988-b554-4077-bcc2-3a2a5a9d4f10" />


## Summary
- switch workspace file and git diff selections into a single-item viewer flow with a back button
- keep artifact selections in list mode
- avoid flashing the initial file loading state when reopening with a cached file tree
- tolerate workspace watcher startup failures without blocking the file list

## Tests
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck:web
- pnpm vitest run test/renderer/components/WorkspacePanel.test.ts test/renderer/components/WorkspaceViewer.test.ts
- commit hook typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace single-file viewer mode: selecting a file or Git change displays that item in a focused view with a back button to return to the full workspace list.

* **Bug Fixes**
  * Reduced unnecessary loading flashes when refreshing workspace file trees in the background.

* **Tests**
  * Added comprehensive test coverage for new single-file viewer navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->