### PR TITLE
perf(chat): lazy render collapsed activity

### DIFF
--- a/docs/issues/long-message-collapse-scroll-jank/spec.md
+++ b/docs/issues/long-message-collapse-scroll-jank/spec.md
@@ -1,0 +1,66 @@
+# Long Message Collapse Scroll Jank
+
+## Problem
+
+Long assistant messages can contain many collapsible blocks, such as thinking, tool call, action, or
+activity blocks. When a generated response is very long and many blocks are collapsed or expanded,
+the chat viewport can become slow and visibly jitter while the user scrolls or while auto-follow is
+trying to keep the latest response visible.
+
+## User Need
+
+As a user reading a long generated conversation, I need scrolling to stay smooth and stable even
+when the message contains many collapsible sections, so I can review content without the viewport
+lagging or jumping.
+
+## Goals
+
+- Upgrade `markstream-vue` to the current npm `latest` release before investigating renderer
+  behavior.
+- Identify whether the jitter comes from Markdown rendering, collapsible block transitions,
+  message-height measurement, auto-scroll retry logic, or the message windowing layer.
+- Keep the chat message layout and existing collapsed/expanded affordances unchanged unless a
+  behavior change is required for stability.
+- Prefer a scoped renderer-side fix over broader scrolling rewrites.
+
+## Acceptance Criteria
+
+- `markstream-vue` resolves to the current npm `latest` release in `package.json` and the local
+  pnpm install state. `pnpm-lock.yaml` is intentionally ignored by this repository.
+- Long assistant messages with many collapsible blocks can be scrolled without repeated forced
+  bottom jumps when the user is not at the bottom.
+- Collapsing or expanding one block adjusts scroll position predictably and does not trigger a
+  feedback loop between measurement and auto-scroll.
+- Existing chat auto-follow behavior still works while a response is generating and the user stays
+  near the bottom.
+- No new user-facing strings or settings are introduced.
+
+## Non-goals
+
+- Redesign the chat message UI.
+- Replace the chat message windowing implementation.
+- Replace `markstream-vue`.
+- Add a new virtualization dependency.
+
+## Constraints
+
+- Use existing Vue 3, Pinia, Tailwind, and renderer composable patterns.
+- Keep changes focused on dependency resolution and the smallest root-cause fix.
+- Do not patch `node_modules`.
+
+## Root Cause
+
+Collapsed message activity still mounted heavy hidden content:
+
+- `ThinkContent` used `v-show`, so collapsed thinking blocks still instantiated
+  `markstream-vue`'s `NodeRenderer` whenever content existed.
+- `MessageBlockActivityGroup` started collapsed, but still rendered every grouped
+  `MessageBlockThink` and `MessageBlockToolCall` inside a zero-height grid.
+- Long settled assistant messages with many completed reasoning/tool blocks therefore kept large
+  hidden DOM and Markdown renderer work in the visible message row.
+- Those hidden children also interacted with row `ResizeObserver` measurement; when heights changed
+  during expansion/collapse, `ChatPage` could repeatedly run bottom-follow or anchor-restore logic
+  while the user was scrolling.
+
+The first fix is to avoid mounting collapsed body content until the user expands it, and to unmount
+it again after the collapse transition.

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "katex": "^0.16.47",
     "lint-staged": "^16.4.0",
     "lucide-vue-next": "^0.544.0",
-    "markstream-vue": "1.0.3-beta.3",
+    "markstream-vue": "1.0.3",
     "mermaid": "^11.15.0",
     "minimatch": "^10.2.5",
     "monaco-editor": "^0.55.1",

--- a/src/renderer/src/components/message/MessageBlockActivityGroup.vue
+++ b/src/renderer/src/components/message/MessageBlockActivityGroup.vue
@@ -30,6 +30,7 @@
       data-testid="activity-group-body-shell"
     >
       <div
+        v-if="shouldRenderBody"
         class="min-h-0 flex flex-col w-full gap-1.5 overflow-hidden"
         data-testid="activity-group-body"
       >
@@ -56,7 +57,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, ref } from 'vue'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
 import type {
@@ -83,6 +84,26 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const isExpanded = ref(false)
+const shouldRenderBody = ref(false)
+const BODY_UNMOUNT_DELAY_MS = 260
+let bodyUnmountTimer: number | null = null
+
+const cancelBodyUnmount = () => {
+  if (bodyUnmountTimer !== null) {
+    window.clearTimeout(bodyUnmountTimer)
+    bodyUnmountTimer = null
+  }
+}
+
+const scheduleBodyUnmount = () => {
+  cancelBodyUnmount()
+  bodyUnmountTimer = window.setTimeout(() => {
+    bodyUnmountTimer = null
+    if (!isExpanded.value) {
+      shouldRenderBody.value = false
+    }
+  }, BODY_UNMOUNT_DELAY_MS)
+}
 
 const durationLabels = computed(() => ({
   day: t('chat.activityCollapse.duration.day'),
@@ -117,7 +138,16 @@ const toggleLabel = computed(() =>
 )
 
 const toggleExpanded = () => {
-  isExpanded.value = !isExpanded.value
+  if (!isExpanded.value) {
+    cancelBodyUnmount()
+    shouldRenderBody.value = true
+    isExpanded.value = true
+    emit('toggle-collapse', false)
+    return
+  }
+
+  isExpanded.value = false
+  scheduleBodyUnmount()
   emit('toggle-collapse', !isExpanded.value)
 }
 
@@ -127,4 +157,8 @@ const handleChildCollapseToggle = (isCollapsed: boolean) => {
 
 const buildActivityBlockKey = (block: DisplayAssistantMessageBlock, index: number): string =>
   block.id ?? block.tool_call?.id ?? `${block.type}:${block.timestamp}:${index}`
+
+onBeforeUnmount(() => {
+  cancelBodyUnmount()
+})
 </script>

--- a/src/renderer/src/components/think-content/ThinkContent.vue
+++ b/src/renderer/src/components/think-content/ThinkContent.vue
@@ -26,7 +26,7 @@
       />
     </div>
 
-    <div v-show="expanded" class="w-full relative">
+    <div v-if="expanded" class="w-full relative">
       <NodeRenderer
         v-if="sanitizedContent"
         class="think-prose w-full max-w-full"

--- a/test/renderer/components/message/MessageBlockActivityGroup.test.ts
+++ b/test/renderer/components/message/MessageBlockActivityGroup.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import MessageBlockActivityGroup from '@/components/message/MessageBlockActivityGroup.vue'
 import type {
   DisplayAssistantMessageBlock,
@@ -114,6 +114,10 @@ const mountGroup = () =>
   })
 
 describe('MessageBlockActivityGroup', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('starts collapsed with duration and activity counts in the title', () => {
     const wrapper = mountGroup()
 
@@ -132,11 +136,12 @@ describe('MessageBlockActivityGroup', () => {
     expect(wrapper.get('[data-testid="activity-group-body-shell"]').classes()).toContain(
       'grid-rows-[0fr]'
     )
-    expect(wrapper.find('[data-testid="think-block"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="tool-block"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="think-block"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="tool-block"]').exists()).toBe(false)
   })
 
   it('toggles expanded state and shows the original activity blocks', async () => {
+    vi.useFakeTimers()
     const wrapper = mountGroup()
 
     await wrapper.get('[data-testid="activity-group-toggle"]').trigger('click')
@@ -167,6 +172,17 @@ describe('MessageBlockActivityGroup', () => {
     expect(
       wrapper.get('[data-testid="activity-group-body-shell"]').attributes('inert')
     ).toBeDefined()
+
+    expect(wrapper.find('[data-testid="think-block"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="tool-block"]').exists()).toBe(true)
+
+    vi.runAllTimers()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="think-block"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="tool-block"]').exists()).toBe(false)
+
+    vi.useRealTimers()
   })
 
   it('does not persist expanded state across remounts', async () => {


### PR DESCRIPTION
## Summary
- Upgrade `markstream-vue` to the npm `latest` release (`1.0.3`).
- Lazy-render collapsed assistant activity groups and thinking Markdown so long settled messages do not keep heavy hidden renderers mounted.
- Add an SDD issue spec documenting the root cause and regression contract.

## UI Layout

Before:

```text
Assistant message
  activity group (collapsed)
    hidden zero-height body still mounted
      MessageBlockThink -> ThinkContent -> NodeRenderer
      MessageBlockToolCall
      MessageBlockToolCall
      ...many hidden activity blocks
```

After:

```text
Assistant message
  activity group (collapsed)
    summary trigger only

  activity group (expanded)
    mounted body
      MessageBlockThink
      MessageBlockToolCall
      MessageBlockToolCall
```

## Root Cause
- Collapsed `ThinkContent` used `v-show`, keeping `markstream-vue` NodeRenderer instances alive while hidden.
- Collapsed `MessageBlockActivityGroup` rendered all grouped child blocks inside a zero-height grid.
- Long messages with many completed reasoning/tool blocks therefore kept a large hidden DOM/rendering workload, which also interacted with row height measurement during scroll.

## Verification
- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec vitest --config vitest.config.renderer.ts test/renderer/components/message/MessageBlockActivityGroup.test.ts test/renderer/components/message/MessageBlockThink.test.ts test/renderer/components/think-content/ThinkContentStyle.test.ts test/renderer/components/message/MessageItemAssistant.test.ts`

## Notes
- `pnpm-lock.yaml` is intentionally ignored by this repository, so the committed dependency change is in `package.json`; local pnpm resolution confirms `markstream-vue@1.0.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scrolling jank and unexpected scroll jumps when collapsing long messages containing multiple expandable content blocks. Improved overall performance when expanding and collapsing nested sections.

* **Chores**
  * Updated core dependency to the stable release for improved reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->