### PR TITLE
feat(provider): add API key providers

### DIFF
--- a/docs/features/basic-api-key-providers/plan.md
+++ b/docs/features/basic-api-key-providers/plan.md
@@ -1,0 +1,38 @@
+# Basic API Key Providers Plan
+
+## Provider Mapping
+
+| Provider ID | Runtime | Model Source | Provider DB Source | Check Model |
+| --- | --- | --- | --- | --- |
+| `nvidia` | OpenAI-compatible | provider-db | `nvidia` | `microsoft/phi-4-mini-instruct` |
+| `huggingface` | OpenAI-compatible | provider-db | `huggingface` | `Qwen/Qwen3-Coder-Next` |
+| `moonshot-ai` | OpenAI-compatible | provider-db | `moonshot-ai` | `kimi-k2-0905-preview` |
+| `stepfun` | OpenAI-compatible | provider-db | `stepfun` | `step-3.5-flash` |
+| `upstage` | OpenAI-compatible | provider-db | `upstage` | `solar-mini` |
+| `alibaba-token-plan` | OpenAI-compatible | provider-db | `alibaba-token-plan` | `deepseek-v4-flash` |
+| `alibaba-token-plan-cn` | OpenAI-compatible | provider-db | `alibaba-token-plan-cn` | `deepseek-v4-flash` |
+| `minimax-global` | Anthropic-compatible | provider-db | `minimax` | `MiniMax-M2.1` |
+
+## Implementation
+
+- Add built-in entries in `src/main/presenter/configPresenter/providers.ts`.
+- Add provider-db alias only when the built-in provider ID differs from provider-db source ID.
+- Add provider registry definitions for runtime, model source, credential strategy, and check model.
+- Add new provider IDs to the provider-db backed allowlist.
+- Extend `ModelIcon.vue` with icon imports and mappings for providers not currently represented.
+- Add focused tests for provider registry mapping, provider-db backed detection, provider-db model
+  mapping, and icon resolution.
+
+## Compatibility
+
+- Existing `minimax` remains unchanged for current users.
+- New `minimax-global` points at `https://api.minimax.io/anthropic` and reads model metadata from
+  provider-db source `minimax`.
+- Alibaba token plan entries are separate from existing DashScope.
+
+## Validation
+
+- Run focused tests for provider registry/model mapping and icons.
+- Run `pnpm run format`.
+- Run `pnpm run i18n`.
+- Run `pnpm run lint`.

--- a/docs/features/basic-api-key-providers/spec.md
+++ b/docs/features/basic-api-key-providers/spec.md
@@ -1,0 +1,51 @@
+# Basic API Key Providers
+
+## User Need
+
+DeepChat should expose more built-in API-key providers that already have public provider-db model
+metadata and can run through existing OpenAI-compatible or Anthropic-compatible transports.
+
+## Goal
+
+Add a first batch of low-complexity providers:
+
+- NVIDIA
+- Hugging Face
+- Moonshot AI global
+- StepFun
+- Upstage
+- Alibaba Token Plan global
+- Alibaba Token Plan China
+- MiniMax global
+
+## Acceptance Criteria
+
+- Each provider appears in the built-in provider list with a default base URL, docs links, API-key
+  link, model link, and disabled default state.
+- OpenAI-compatible providers use the existing `openai-compatible` runtime.
+- MiniMax global uses the existing Anthropic runtime.
+- Provider model lists come from provider-db metadata where available.
+- Provider-db backed model refresh recognizes the new built-in providers.
+- Provider icons resolve through existing llm-icon assets without adding new image files.
+- Connection checks use existing API-key handling and a small generate-text request.
+- No special provider class, renderer-side provider execution, dynamic SDK install, or provider
+  runtime manifest is added.
+- Existing built-in MiniMax behavior remains compatible.
+
+## Constraints
+
+- Follow the current explicit provider registration pattern.
+- Keep technical identifiers and code comments in English.
+- Do not add `ProviderRuntimeDefinition` or generated runtime files.
+- Do not change OAuth, Bedrock, Vertex, Azure, or local-provider behavior.
+
+## Non-Goals
+
+- Full parity with all provider-db or models.dev providers.
+- New native SDK support for Cohere, Perplexity, AI21, or other non-selected providers.
+- Credential migration for existing providers.
+- Changing existing MiniMax users from the current `minimax` provider ID.
+
+## Open Questions
+
+None.

--- a/docs/features/basic-api-key-providers/tasks.md
+++ b/docs/features/basic-api-key-providers/tasks.md
@@ -1,0 +1,9 @@
+# Basic API Key Providers Tasks
+
+- [x] Add SDD artifacts for the provider batch.
+- [x] Add built-in provider entries.
+- [x] Register provider runtime definitions and provider-db aliases.
+- [x] Mark new provider-db backed provider IDs.
+- [x] Add icon mappings for new provider IDs.
+- [x] Add focused tests.
+- [x] Run formatting, i18n, lint, and focused tests.

--- a/src/main/presenter/configPresenter/providerId.ts
+++ b/src/main/presenter/configPresenter/providerId.ts
@@ -8,7 +8,8 @@ const PROVIDER_ID_ALIASES: Record<string, string> = {
   'azure-openai': 'azure',
   'aws-bedrock': 'amazon-bedrock',
   ppio: 'ppinfra',
-  fireworks: 'fireworks-ai'
+  fireworks: 'fireworks-ai',
+  'minimax-global': 'minimax'
 }
 
 export const resolveProviderId = (providerId: string | undefined): string | undefined => {

--- a/src/main/presenter/configPresenter/providers.ts
+++ b/src/main/presenter/configPresenter/providers.ts
@@ -353,6 +353,36 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
     }
   },
   {
+    id: 'nvidia',
+    name: 'NVIDIA',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://integrate.api.nvidia.com/v1',
+    enable: false,
+    websites: {
+      official: 'https://build.nvidia.com/',
+      apiKey: 'https://build.nvidia.com/settings/api-keys',
+      docs: 'https://docs.api.nvidia.com/nim/',
+      models: 'https://build.nvidia.com/explore/discover',
+      defaultBaseUrl: 'https://integrate.api.nvidia.com/v1'
+    }
+  },
+  {
+    id: 'huggingface',
+    name: 'Hugging Face',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://router.huggingface.co/v1',
+    enable: false,
+    websites: {
+      official: 'https://huggingface.co/',
+      apiKey: 'https://huggingface.co/settings/tokens',
+      docs: 'https://huggingface.co/docs/inference-providers',
+      models: 'https://huggingface.co/inference/models',
+      defaultBaseUrl: 'https://router.huggingface.co/v1'
+    }
+  },
+  {
     id: 'vercel-ai-gateway',
     name: 'Vercel AI Gateway',
     apiType: 'vercel-ai-gateway',
@@ -474,6 +504,21 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
     }
   },
   {
+    id: 'minimax-global',
+    name: 'MiniMax Global',
+    apiType: 'anthropic',
+    apiKey: '',
+    baseUrl: 'https://api.minimax.io/anthropic/v1',
+    enable: false,
+    websites: {
+      official: 'https://www.minimax.io/',
+      apiKey: 'https://platform.minimax.io/user-center/basic-information/interface-key',
+      docs: 'https://platform.minimax.io/docs/api-reference/text-anthropic-api',
+      models: 'https://platform.minimax.io/docs/api-reference/models/anthropic/list-models',
+      defaultBaseUrl: 'https://api.minimax.io/anthropic/v1'
+    }
+  },
+  {
     id: 'fireworks',
     name: 'Fireworks',
     apiType: 'fireworks',
@@ -516,6 +561,21 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
       docs: 'https://platform.moonshot.cn/docs/',
       models: 'https://platform.moonshot.cn/docs/intro#%E6%A8%A1%E5%9E%8B%E5%88%97%E8%A1%A8',
       defaultBaseUrl: 'https://api.moonshot.cn/v1'
+    }
+  },
+  {
+    id: 'moonshot-ai',
+    name: 'Moonshot AI',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://api.moonshot.ai/v1',
+    enable: false,
+    websites: {
+      official: 'https://www.moonshot.ai/',
+      apiKey: 'https://platform.kimi.ai/console/api-keys',
+      docs: 'https://platform.moonshot.ai/docs/api/chat',
+      models: 'https://platform.moonshot.ai/docs/models',
+      defaultBaseUrl: 'https://api.moonshot.ai/v1'
     }
   },
   {
@@ -564,6 +624,36 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
     }
   },
   {
+    id: 'alibaba-token-plan',
+    name: 'Alibaba Token Plan',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1',
+    enable: false,
+    websites: {
+      official: 'https://www.alibabacloud.com/product/modelstudio',
+      apiKey: 'https://modelstudio.console.alibabacloud.com/',
+      docs: 'https://www.alibabacloud.com/help/en/model-studio/token-plan-overview',
+      models: 'https://www.alibabacloud.com/help/en/model-studio/token-plan-overview',
+      defaultBaseUrl: 'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1'
+    }
+  },
+  {
+    id: 'alibaba-token-plan-cn',
+    name: 'Alibaba Token Plan (China)',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
+    enable: false,
+    websites: {
+      official: 'https://www.aliyun.com/product/bailian',
+      apiKey: 'https://bailian.console.aliyun.com/?apiKey=1#/api-key',
+      docs: 'https://www.alibabacloud.com/help/zh/model-studio/token-plan-overview',
+      models: 'https://www.alibabacloud.com/help/zh/model-studio/token-plan-overview',
+      defaultBaseUrl: 'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1'
+    }
+  },
+  {
     id: 'lmstudio',
     name: 'LM Studio',
     apiType: 'lmstudio',
@@ -578,21 +668,21 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
       defaultBaseUrl: 'http://127.0.0.1:1234/v1'
     }
   },
-  // {
-  //   id: 'stepfun',
-  //   name: 'StepFun',
-  //   apiType: 'stepfun',
-  //   apiKey: '',
-  //   baseUrl: 'https://api.stepfun.com',
-  //   enable: false,
-  //   websites: {
-  //     official: 'https://platform.stepfun.com/',
-  //     apiKey: 'https://platform.stepfun.com/interface-key',
-  //     docs: 'https://platform.stepfun.com/docs/overview/concept',
-  //     models: 'https://platform.stepfun.com/docs/llm/text',
-  //     defaultBaseUrl: 'https://api.stepfun.com'
-  //   }
-  // }
+  {
+    id: 'stepfun',
+    name: 'StepFun',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://api.stepfun.com/v1',
+    enable: false,
+    websites: {
+      official: 'https://platform.stepfun.com/',
+      apiKey: 'https://platform.stepfun.com/interface-key',
+      docs: 'https://platform.stepfun.com/docs/zh/overview/concept',
+      models: 'https://platform.stepfun.com/docs/zh/llm/text',
+      defaultBaseUrl: 'https://api.stepfun.com/v1'
+    }
+  },
 
   {
     id: 'groq',
@@ -639,6 +729,21 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
       docs: 'https://docs.x.ai/',
       models: 'https://docs.x.ai/docs#getting-started',
       defaultBaseUrl: 'https://api.x.ai/v1'
+    }
+  },
+  {
+    id: 'upstage',
+    name: 'Upstage',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://api.upstage.ai/v1/solar',
+    enable: false,
+    websites: {
+      official: 'https://www.upstage.ai/',
+      apiKey: 'https://console.upstage.ai/api-keys?api=chat',
+      docs: 'https://developers.upstage.ai/docs/apis/chat',
+      models: 'https://developers.upstage.ai/docs/getting-started/models',
+      defaultBaseUrl: 'https://api.upstage.ai/v1/solar'
     }
   },
   // {
@@ -731,21 +836,6 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
       defaultBaseUrl: 'https://api.hunyuan.cloud.tencent.com/v1'
     }
   },
-  // {
-  //   id: 'nvidia',
-  //   name: 'NVIDIA',
-  //   apiType: 'nvidia',
-  //   apiKey: '',
-  //   baseUrl: 'https://integrate.api.nvidia.com',
-  //   enable: false,
-  //   websites: {
-  //     official: 'https://build.nvidia.com/explore/discover',
-  //     apiKey: 'https://build.nvidia.com/meta/llama-3_1-405b-instruct',
-  //     docs: 'https://docs.api.nvidia.com/nim/reference/llm-apis',
-  //     models: 'https://build.nvidia.com/nim',
-  //     defaultBaseUrl: 'https://integrate.api.nvidia.com'
-  //   }
-  // },
   {
     id: 'azure-openai',
     name: 'Azure OpenAI',

--- a/src/main/presenter/llmProviderPresenter/providerRegistry.ts
+++ b/src/main/presenter/llmProviderPresenter/providerRegistry.ts
@@ -129,6 +129,36 @@ const PROVIDER_ID_REGISTRY = new Map<string, AiSdkProviderDefinition>([
     })
   ],
   [
+    'alibaba-token-plan',
+    createDefinition({
+      ...ENGLISH_SUMMARY_OPENAI,
+      modelSource: 'provider-db',
+      providerDbSourceId: 'alibaba-token-plan',
+      providerDbGroup: 'Token Plan',
+      checkStrategy: 'generate-text',
+      credentialStrategy: 'api-key',
+      checkModelId: 'deepseek-v4-flash',
+      checkPrompt: 'Hello',
+      checkTemperature: 0.2,
+      checkMaxTokens: 16
+    })
+  ],
+  [
+    'alibaba-token-plan-cn',
+    createDefinition({
+      ...CHINESE_SUMMARY_OPENAI,
+      modelSource: 'provider-db',
+      providerDbSourceId: 'alibaba-token-plan-cn',
+      providerDbGroup: 'Token Plan',
+      checkStrategy: 'generate-text',
+      credentialStrategy: 'api-key',
+      checkModelId: 'deepseek-v4-flash',
+      checkPrompt: 'Hello',
+      checkTemperature: 0.2,
+      checkMaxTokens: 16
+    })
+  ],
+  [
     'anthropic',
     createDefinition({
       runtimeKind: 'anthropic',
@@ -235,6 +265,21 @@ const PROVIDER_ID_REGISTRY = new Map<string, AiSdkProviderDefinition>([
     })
   ],
   [
+    'huggingface',
+    createDefinition({
+      ...OPENAI_BASE,
+      modelSource: 'provider-db',
+      providerDbSourceId: 'huggingface',
+      providerDbGroup: 'default',
+      checkStrategy: 'generate-text',
+      credentialStrategy: 'api-key',
+      checkModelId: 'Qwen/Qwen3-Coder-Next',
+      checkPrompt: 'Hello',
+      checkTemperature: 0.2,
+      checkMaxTokens: 16
+    })
+  ],
+  [
     'jiekou',
     createDefinition({
       ...OPENAI_BASE
@@ -299,6 +344,25 @@ const PROVIDER_ID_REGISTRY = new Map<string, AiSdkProviderDefinition>([
     })
   ],
   [
+    'minimax-global',
+    createDefinition({
+      runtimeKind: 'anthropic',
+      behaviorPreset: 'anthropic',
+      modelSource: 'provider-db',
+      providerDbSourceId: 'minimax',
+      providerDbGroup: 'default',
+      checkStrategy: 'generate-text',
+      credentialStrategy: 'api-key',
+      keyStatusStrategy: 'none',
+      routeStrategy: 'none',
+      embeddingStrategy: 'none',
+      checkModelId: 'MiniMax-M2.1',
+      checkPrompt: 'Hello',
+      checkTemperature: 0.2,
+      checkMaxTokens: 16
+    })
+  ],
+  [
     'modelscope',
     createDefinition({
       ...TITLE_SUMMARY_OPENAI,
@@ -313,6 +377,36 @@ const PROVIDER_ID_REGISTRY = new Map<string, AiSdkProviderDefinition>([
       modelSource: 'new-api',
       routeStrategy: 'new-api',
       embeddingStrategy: 'new-api'
+    })
+  ],
+  [
+    'moonshot-ai',
+    createDefinition({
+      ...OPENAI_BASE,
+      modelSource: 'provider-db',
+      providerDbSourceId: 'moonshot-ai',
+      providerDbGroup: 'default',
+      checkStrategy: 'generate-text',
+      credentialStrategy: 'api-key',
+      checkModelId: 'kimi-k2-0905-preview',
+      checkPrompt: 'Hello',
+      checkTemperature: 0.2,
+      checkMaxTokens: 16
+    })
+  ],
+  [
+    'nvidia',
+    createDefinition({
+      ...OPENAI_BASE,
+      modelSource: 'provider-db',
+      providerDbSourceId: 'nvidia',
+      providerDbGroup: 'default',
+      checkStrategy: 'generate-text',
+      credentialStrategy: 'api-key',
+      checkModelId: 'microsoft/phi-4-mini-instruct',
+      checkPrompt: 'Hello',
+      checkTemperature: 0.2,
+      checkMaxTokens: 16
     })
   ],
   [
@@ -379,6 +473,21 @@ const PROVIDER_ID_REGISTRY = new Map<string, AiSdkProviderDefinition>([
     })
   ],
   [
+    'stepfun',
+    createDefinition({
+      ...CHINESE_SUMMARY_OPENAI,
+      modelSource: 'provider-db',
+      providerDbSourceId: 'stepfun',
+      providerDbGroup: 'default',
+      checkStrategy: 'generate-text',
+      credentialStrategy: 'api-key',
+      checkModelId: 'step-3.5-flash',
+      checkPrompt: 'Hello',
+      checkTemperature: 0.2,
+      checkMaxTokens: 16
+    })
+  ],
+  [
     'together',
     createDefinition({
       ...CHINESE_SUMMARY_OPENAI,
@@ -392,6 +501,21 @@ const PROVIDER_ID_REGISTRY = new Map<string, AiSdkProviderDefinition>([
       modelSource: 'tokenflux',
       checkStrategy: 'key-status',
       keyStatusStrategy: 'tokenflux'
+    })
+  ],
+  [
+    'upstage',
+    createDefinition({
+      ...OPENAI_BASE,
+      modelSource: 'provider-db',
+      providerDbSourceId: 'upstage',
+      providerDbGroup: 'default',
+      checkStrategy: 'generate-text',
+      credentialStrategy: 'api-key',
+      checkModelId: 'solar-mini',
+      checkPrompt: 'Hello',
+      checkTemperature: 0.2,
+      checkMaxTokens: 16
     })
   ],
   [

--- a/src/renderer/src/components/icons/ModelIcon.vue
+++ b/src/renderer/src/components/icons/ModelIcon.vue
@@ -61,6 +61,8 @@ import googleColorIcon from '@/assets/llm-icons/google-color.svg?url'
 import qiniuIcon from '@/assets/llm-icons/qiniu.svg?url'
 import grokColorIcon from '@/assets/llm-icons/grok.svg?url'
 import groqColorIcon from '@/assets/llm-icons/groq.svg?url'
+import nvidiaColorIcon from '@/assets/llm-icons/nvidia-color.svg?url'
+import huggingfaceColorIcon from '@/assets/llm-icons/huggingface-color.svg?url'
 import hunyuanColorIcon from '@/assets/llm-icons/hunyuan-color.svg?url'
 import dashscopeColorIcon from '@/assets/llm-icons/alibabacloud-color.svg?url'
 import aihubmixColorIcon from '@/assets/llm-icons/aihubmix.png?url'
@@ -95,11 +97,16 @@ const icons = {
   'new-api': newApiColorIcon,
   modelscope: modelscopeColorIcon,
   '302ai': _302aiIcon,
+  'alibaba-token-plan': dashscopeColorIcon,
+  'alibaba-token-plan-cn': dashscopeColorIcon,
+  alibaba: dashscopeColorIcon,
   aihubmix: aihubmixColorIcon,
   dashscope: dashscopeColorIcon,
   hunyuan: hunyuanColorIcon,
   grok: grokColorIcon,
   groq: groqColorIcon,
+  nvidia: nvidiaColorIcon,
+  huggingface: huggingfaceColorIcon,
   qiniu: qiniuIcon,
   gemma: googleColorIcon,
   claude: claudeColorIcon,
@@ -110,6 +117,7 @@ const icons = {
   openai: openaiColorIcon,
   ollama: ollamaColorIcon,
   doubao: doubaoColorIcon,
+  'minimax-global': minimaxColorIcon,
   minimax: minimaxColorIcon,
   mistral: mistralColorIcon,
   fireworks: fireworksColorIcon,

--- a/src/shared/providerDbCatalog.ts
+++ b/src/shared/providerDbCatalog.ts
@@ -1,9 +1,17 @@
 const PROVIDER_DB_BACKED_PROVIDER_IDS = new Set([
+  'alibaba-token-plan',
+  'alibaba-token-plan-cn',
   'doubao',
+  'huggingface',
+  'minimax-global',
   'zhipu',
   'minimax',
   'mistral',
+  'moonshot-ai',
+  'nvidia',
   'o3fan',
+  'stepfun',
+  'upstage',
   'kimi-for-coding',
   'openai-codex'
 ])

--- a/test/main/presenter/configPresenter/defaultProviders.test.ts
+++ b/test/main/presenter/configPresenter/defaultProviders.test.ts
@@ -34,4 +34,49 @@ describe('DEFAULT_PROVIDERS', () => {
       })
     )
   })
+
+  it('includes the basic API-key provider batch as disabled built-ins', () => {
+    const providersById = new Map(DEFAULT_PROVIDERS.map((provider) => [provider.id, provider]))
+
+    expect(providersById.get('nvidia')).toMatchObject({
+      apiType: 'openai-completions',
+      baseUrl: 'https://integrate.api.nvidia.com/v1',
+      enable: false
+    })
+    expect(providersById.get('huggingface')).toMatchObject({
+      apiType: 'openai-completions',
+      baseUrl: 'https://router.huggingface.co/v1',
+      enable: false
+    })
+    expect(providersById.get('moonshot-ai')).toMatchObject({
+      apiType: 'openai-completions',
+      baseUrl: 'https://api.moonshot.ai/v1',
+      enable: false
+    })
+    expect(providersById.get('stepfun')).toMatchObject({
+      apiType: 'openai-completions',
+      baseUrl: 'https://api.stepfun.com/v1',
+      enable: false
+    })
+    expect(providersById.get('upstage')).toMatchObject({
+      apiType: 'openai-completions',
+      baseUrl: 'https://api.upstage.ai/v1/solar',
+      enable: false
+    })
+    expect(providersById.get('alibaba-token-plan')).toMatchObject({
+      apiType: 'openai-completions',
+      baseUrl: 'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1',
+      enable: false
+    })
+    expect(providersById.get('alibaba-token-plan-cn')).toMatchObject({
+      apiType: 'openai-completions',
+      baseUrl: 'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
+      enable: false
+    })
+    expect(providersById.get('minimax-global')).toMatchObject({
+      apiType: 'anthropic',
+      baseUrl: 'https://api.minimax.io/anthropic/v1',
+      enable: false
+    })
+  })
 })

--- a/test/main/presenter/llmProviderPresenter/basicApiKeyProviders.test.ts
+++ b/test/main/presenter/llmProviderPresenter/basicApiKeyProviders.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IConfigPresenter, LLM_PROVIDER } from '../../../../src/shared/presenter'
+import { AiSdkProvider } from '../../../../src/main/presenter/llmProviderPresenter/providers/aiSdkProvider'
+import { resolveAiSdkProviderDefinition } from '../../../../src/main/presenter/llmProviderPresenter/providerRegistry'
+
+const { mockGetProvider, mockRunAiSdkGenerateText } = vi.hoisted(() => ({
+  mockGetProvider: vi.fn(),
+  mockRunAiSdkGenerateText: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getName: vi.fn(() => 'DeepChat'),
+    getVersion: vi.fn(() => '0.0.0-test'),
+    getPath: vi.fn(() => '/mock/path'),
+    isReady: vi.fn(() => true),
+    on: vi.fn()
+  }
+}))
+
+vi.mock('@shared/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    verbose: vi.fn(),
+    silly: vi.fn(),
+    log: vi.fn()
+  }
+}))
+
+vi.mock('@/eventbus', () => ({
+  eventBus: {
+    on: vi.fn(),
+    sendToMain: vi.fn(),
+    emit: vi.fn(),
+    send: vi.fn()
+  }
+}))
+
+vi.mock('@/events', () => ({
+  CONFIG_EVENTS: {
+    MODEL_LIST_CHANGED: 'MODEL_LIST_CHANGED'
+  },
+  PROVIDER_DB_EVENTS: {
+    LOADED: 'LOADED',
+    UPDATED: 'UPDATED'
+  },
+  NOTIFICATION_EVENTS: {
+    SHOW_ERROR: 'SHOW_ERROR'
+  }
+}))
+
+vi.mock('../../../../src/main/presenter/proxyConfig', () => ({
+  proxyConfig: {
+    getProxyUrl: vi.fn().mockReturnValue(null)
+  }
+}))
+
+vi.mock('../../../../src/main/presenter/configPresenter/providerDbLoader', () => ({
+  providerDbLoader: {
+    getDb: vi.fn().mockReturnValue(null),
+    getProvider: mockGetProvider,
+    getModel: vi.fn()
+  }
+}))
+
+vi.mock('../../../../src/main/presenter/llmProviderPresenter/aiSdk', () => ({
+  runAiSdkCoreStream: vi.fn(),
+  runAiSdkDimensions: vi.fn(),
+  runAiSdkEmbeddings: vi.fn(),
+  runAiSdkGenerateText: mockRunAiSdkGenerateText
+}))
+
+const createProvider = (overrides: Partial<LLM_PROVIDER>): LLM_PROVIDER => ({
+  id: 'nvidia',
+  name: 'NVIDIA',
+  apiType: 'openai-completions',
+  apiKey: 'test-key',
+  baseUrl: 'https://integrate.api.nvidia.com/v1',
+  enable: false,
+  ...overrides
+})
+
+const createConfigPresenter = (): IConfigPresenter =>
+  ({
+    getProviderModels: vi.fn().mockReturnValue([]),
+    getCustomModels: vi.fn().mockReturnValue([]),
+    getModelConfig: vi.fn().mockReturnValue(undefined),
+    getSetting: vi.fn().mockReturnValue(undefined),
+    setProviderModels: vi.fn(),
+    getModelStatus: vi.fn().mockReturnValue(true),
+    setModelConfig: vi.fn(),
+    hasUserModelConfig: vi.fn().mockReturnValue(false)
+  }) as unknown as IConfigPresenter
+
+describe('basic API-key provider registrations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRunAiSdkGenerateText.mockResolvedValue({ content: 'ok' })
+  })
+
+  it('resolves OpenAI-compatible providers through provider-db backed definitions', () => {
+    const expectations = [
+      ['nvidia', 'nvidia', 'microsoft/phi-4-mini-instruct'],
+      ['huggingface', 'huggingface', 'Qwen/Qwen3-Coder-Next'],
+      ['moonshot-ai', 'moonshot-ai', 'kimi-k2-0905-preview'],
+      ['stepfun', 'stepfun', 'step-3.5-flash'],
+      ['upstage', 'upstage', 'solar-mini'],
+      ['alibaba-token-plan', 'alibaba-token-plan', 'deepseek-v4-flash'],
+      ['alibaba-token-plan-cn', 'alibaba-token-plan-cn', 'deepseek-v4-flash']
+    ] as const
+
+    for (const [providerId, sourceId, checkModelId] of expectations) {
+      expect(
+        resolveAiSdkProviderDefinition(
+          createProvider({
+            id: providerId
+          })
+        )
+      ).toMatchObject({
+        runtimeKind: 'openai-compatible',
+        modelSource: 'provider-db',
+        providerDbSourceId: sourceId,
+        checkStrategy: 'generate-text',
+        credentialStrategy: 'api-key',
+        checkModelId
+      })
+    }
+  })
+
+  it('resolves MiniMax global through the Anthropic-compatible runtime', () => {
+    expect(
+      resolveAiSdkProviderDefinition(
+        createProvider({
+          id: 'minimax-global',
+          name: 'MiniMax Global',
+          apiType: 'anthropic',
+          baseUrl: 'https://api.minimax.io/anthropic/v1'
+        })
+      )
+    ).toMatchObject({
+      runtimeKind: 'anthropic',
+      behaviorPreset: 'anthropic',
+      modelSource: 'provider-db',
+      providerDbSourceId: 'minimax',
+      checkStrategy: 'generate-text',
+      credentialStrategy: 'api-key',
+      checkModelId: 'MiniMax-M2.1'
+    })
+  })
+
+  it('maps provider DB metadata into built-in provider models', async () => {
+    mockGetProvider.mockReturnValue({
+      id: 'nvidia',
+      name: 'NVIDIA',
+      models: [
+        {
+          id: 'microsoft/phi-4-mini-instruct',
+          display_name: 'Phi-4 Mini',
+          tool_call: true,
+          reasoning: {
+            supported: false
+          },
+          modalities: {
+            input: ['text'],
+            output: ['text']
+          },
+          limit: {
+            context: 131072,
+            output: 8192
+          }
+        }
+      ]
+    })
+
+    const provider = new AiSdkProvider(createProvider({}), createConfigPresenter())
+    const models = await provider.fetchModels()
+
+    expect(mockGetProvider).toHaveBeenCalledWith('nvidia')
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: 'microsoft/phi-4-mini-instruct',
+        name: 'Phi-4 Mini',
+        group: 'default',
+        providerId: 'nvidia',
+        functionCall: true,
+        reasoning: false,
+        contextLength: 131072,
+        maxTokens: 8192
+      })
+    ])
+  })
+
+  it('uses the configured check model for MiniMax global', async () => {
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: 'minimax-global',
+        name: 'MiniMax Global',
+        apiType: 'anthropic',
+        baseUrl: 'https://api.minimax.io/anthropic/v1'
+      }),
+      createConfigPresenter()
+    )
+    ;(provider as any).isInitialized = true
+
+    await expect(provider.check()).resolves.toEqual({
+      isOk: true,
+      errorMsg: null
+    })
+    expect(mockRunAiSdkGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerKind: 'anthropic',
+        provider: expect.objectContaining({
+          id: 'minimax-global',
+          baseUrl: 'https://api.minimax.io/anthropic/v1'
+        })
+      }),
+      [{ role: 'user', content: 'Hello' }],
+      'MiniMax-M2.1',
+      expect.any(Object),
+      0.2,
+      16
+    )
+  })
+})

--- a/test/main/shared/providerDbCatalog.test.ts
+++ b/test/main/shared/providerDbCatalog.test.ts
@@ -15,4 +15,19 @@ describe('provider DB catalog', () => {
     expect(isProviderDbBackedProvider('kimi-for-coding')).toBe(true)
     expect(isProviderDbBackedProvider(' KIMI-FOR-CODING ')).toBe(true)
   })
+
+  it('treats the basic API-key provider batch as provider DB-backed', () => {
+    for (const providerId of [
+      'alibaba-token-plan',
+      'alibaba-token-plan-cn',
+      'huggingface',
+      'minimax-global',
+      'moonshot-ai',
+      'nvidia',
+      'stepfun',
+      'upstage'
+    ]) {
+      expect(isProviderDbBackedProvider(providerId)).toBe(true)
+    }
+  })
 })

--- a/test/renderer/components/ModelIcon.test.ts
+++ b/test/renderer/components/ModelIcon.test.ts
@@ -73,4 +73,31 @@ describe('ModelIcon', () => {
     expect(image.attributes('alt')).toBe('kimi-for-coding')
     expect(image.attributes('src')).toBe(kimiIcon)
   })
+
+  it('resolves the basic API-key provider icons', async () => {
+    const ModelIcon = (await import('@/components/icons/ModelIcon.vue')).default
+    const nvidiaIcon = (await import('@/assets/llm-icons/nvidia-color.svg?url')).default
+    const huggingFaceIcon = (await import('@/assets/llm-icons/huggingface-color.svg?url')).default
+    const alibabaIcon = (await import('@/assets/llm-icons/alibabacloud-color.svg?url')).default
+
+    const nvidia = mount(ModelIcon, {
+      props: {
+        modelId: 'nvidia'
+      }
+    })
+    const huggingface = mount(ModelIcon, {
+      props: {
+        modelId: 'huggingface'
+      }
+    })
+    const alibabaTokenPlan = mount(ModelIcon, {
+      props: {
+        modelId: 'alibaba-token-plan'
+      }
+    })
+
+    expect(nvidia.get('img').attributes('src')).toBe(nvidiaIcon)
+    expect(huggingface.get('img').attributes('src')).toBe(huggingFaceIcon)
+    expect(alibabaTokenPlan.get('img').attributes('src')).toBe(alibabaIcon)
+  })
 })


### PR DESCRIPTION
## Summary
- Add built-in API-key providers for NVIDIA, Hugging Face, Moonshot AI global, StepFun, Upstage, Alibaba Token Plan global/CN, and MiniMax Global.
- Register the new providers against existing OpenAI-compatible or Anthropic-compatible runtime definitions with provider-db model metadata.
- Add provider-db refresh allowlist entries, provider-db aliasing for MiniMax Global, icon mappings, SDD docs, and focused tests.

## UI Layout
BEFORE:
```text
Provider settings
├─ Existing built-in providers
├─ MiniMax (existing)
└─ Custom provider entry
```

AFTER:
```text
Provider settings
├─ Existing built-in providers
├─ NVIDIA
├─ Hugging Face
├─ Moonshot AI
├─ StepFun
├─ Upstage
├─ Alibaba Token Plan
├─ Alibaba Token Plan (China)
├─ MiniMax (existing)
├─ MiniMax Global
└─ Custom provider entry
```

## Tests
- pnpm run format
- pnpm exec vitest run test/main/presenter/configPresenter/defaultProviders.test.ts test/main/shared/providerDbCatalog.test.ts test/main/presenter/llmProviderPresenter/basicApiKeyProviders.test.ts test/renderer/components/ModelIcon.test.ts
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in support for 8 new AI providers with API key authentication: NVIDIA, Hugging Face, Moonshot AI, StepFun, Upstage, Alibaba Token Plan (China and Global), and MiniMax Global. All are configured as disabled by default.

* **Documentation**
  * Added specification and implementation documentation for the Basic API Key Providers feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->