### PR TITLE
fix(plugin): stop MCP servers on quit

### DIFF
--- a/docs/issues/plugin-shutdown-lifecycle/plan.md
+++ b/docs/issues/plugin-shutdown-lifecycle/plan.md
@@ -1,0 +1,40 @@
+# Plugin Shutdown Lifecycle Plan
+
+## Design
+
+Add a public `PluginPresenter.shutdown()` method for app-exit cleanup. It will:
+
+- inspect configured MCP servers;
+- select servers with `ownerPluginId` or `source === 'plugin'`;
+- stop only the running plugin-owned servers through `IMCPPresenter.stopServer()`;
+- close plugin settings windows;
+- clear in-memory plugin tool policies for installed plugins;
+- avoid `disableByOwner()` because shutdown must not remove config, resources, skills, or enabled
+  installation records.
+
+Add `IMCPPresenter.shutdown()` and `McpPresenter.shutdown()` as a general final cleanup pass for all
+remaining running MCP clients after plugin shutdown.
+
+Make MCP stdio disconnect await transport cleanup. For stdio transports, use the existing
+`terminateProcessTree()` helper against the SDK transport's child process when available, then call
+`transport.close()` to clear SDK buffers. This matches the stronger process-tree behavior already used
+by exec cleanup.
+
+Update `Presenter.destroy()` order:
+
+1. `pluginPresenter.shutdown()`
+2. `mcpPresenter.shutdown()`
+3. existing presenter cleanup
+
+## Test Strategy
+
+- PluginPresenter test: shutdown stops running plugin-owned MCP servers, skips regular servers, and
+  does not remove MCP server config.
+- McpPresenter test: shutdown stops all running clients and continues after individual failures.
+- McpClient test: disconnect awaits stdio transport close and invokes process-tree termination for
+  stdio child processes.
+
+## Compatibility
+
+Saved plugin installation and MCP config state are preserved across shutdown. On next app launch,
+enabled plugins will activate using existing startup behavior.

--- a/docs/issues/plugin-shutdown-lifecycle/spec.md
+++ b/docs/issues/plugin-shutdown-lifecycle/spec.md
@@ -1,0 +1,34 @@
+# Plugin Shutdown Lifecycle
+
+## Problem
+
+Plugin-owned MCP servers can launch long-running helper processes such as the CUA driver. Disabling a
+plugin stops its managed MCP server, but application shutdown currently does not run a plugin-specific
+shutdown lifecycle before the main process exits.
+
+## Goal
+
+When DeepChat quits, enabled plugin runtime resources must be explicitly shut down so helper
+processes owned by plugin MCP servers do not survive the app.
+
+## Acceptance Criteria
+
+- App shutdown invokes a PluginPresenter lifecycle method before the presenter tears down shared
+  infrastructure.
+- The plugin shutdown lifecycle stops every running MCP server whose config is owned by a plugin.
+- Shutdown does not persistently disable plugins or remove their saved MCP server config.
+- MCP stdio disconnect waits for transport close and terminates the spawned process tree when a child
+  process is available.
+- Failures to stop one plugin-owned server are logged and do not block cleanup of the remaining
+  plugin-owned servers.
+
+## Non-Goals
+
+- No UI changes.
+- No plugin manifest schema changes.
+- No CUA-specific special cases.
+- No change to user plugin enablement state.
+
+## Open Questions
+
+None.

--- a/docs/issues/plugin-shutdown-lifecycle/tasks.md
+++ b/docs/issues/plugin-shutdown-lifecycle/tasks.md
@@ -1,0 +1,8 @@
+# Plugin Shutdown Lifecycle Tasks
+
+- [x] Inspect plugin/MCP shutdown gaps.
+- [x] Define SDD spec and implementation plan.
+- [x] Add plugin shutdown lifecycle.
+- [x] Add MCP presenter shutdown and awaitable MCP client cleanup.
+- [x] Add focused tests for plugin shutdown and MCP shutdown.
+- [x] Run formatting, i18n, lint, and targeted tests.

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -893,8 +893,18 @@ export class Presenter implements IPresenter {
 
   // 在应用退出时进行清理，关闭数据库连接
   async destroy(): Promise<void> {
-    await this.pluginPresenter.shutdown()
-    await this.mcpPresenter.shutdown()
+    try {
+      await this.pluginPresenter.shutdown()
+    } catch (error) {
+      console.error('PluginPresenter.shutdown failed during presenter destroy:', error)
+    }
+
+    try {
+      await this.mcpPresenter.shutdown()
+    } catch (error) {
+      console.error('McpPresenter.shutdown failed during presenter destroy:', error)
+    }
+
     await this.destroyRemoteControl()
     this.floatingButtonPresenter.destroy() // 销毁悬浮按钮
     this.tabPresenter.destroy()

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -893,6 +893,8 @@ export class Presenter implements IPresenter {
 
   // 在应用退出时进行清理，关闭数据库连接
   async destroy(): Promise<void> {
+    await this.pluginPresenter.shutdown()
+    await this.mcpPresenter.shutdown()
     await this.destroyRemoteControl()
     this.floatingButtonPresenter.destroy() // 销毁悬浮按钮
     this.tabPresenter.destroy()

--- a/src/main/presenter/mcpPresenter/index.ts
+++ b/src/main/presenter/mcpPresenter/index.ts
@@ -169,6 +169,17 @@ export class McpPresenter implements IMCPPresenter {
     }
   }
 
+  async shutdown(): Promise<void> {
+    const runningClients = await this.serverManager.getRunningClients()
+    for (const client of runningClients) {
+      try {
+        await this.stopServer(client.serverName)
+      } catch (error) {
+        console.error(`[MCP] Failed to stop server ${client.serverName} during shutdown:`, error)
+      }
+    }
+  }
+
   // =============== McpRouter marketplace APIs ===============
   async listMcpRouterServers(
     page: number,

--- a/src/main/presenter/mcpPresenter/mcpClient.ts
+++ b/src/main/presenter/mcpPresenter/mcpClient.ts
@@ -549,11 +549,15 @@ export class McpClient {
   }
 
   private async closeTransport(transport: Transport): Promise<void> {
-    if (transport instanceof StdioClientTransport) {
-      const child = (transport as unknown as StdioClientTransportProcessAccess)._process
-      if (child) {
-        await terminateProcessTree(child, { graceMs: 2000 })
+    try {
+      if (transport instanceof StdioClientTransport) {
+        const child = (transport as unknown as StdioClientTransportProcessAccess)._process
+        if (child) {
+          await terminateProcessTree(child, { graceMs: 2000 })
+        }
       }
+    } catch (error) {
+      console.error(`Failed to terminate MCP stdio process tree for ${this.serverName}:`, error)
     }
 
     await transport.close()

--- a/src/main/presenter/mcpPresenter/mcpClient.ts
+++ b/src/main/presenter/mcpPresenter/mcpClient.ts
@@ -4,6 +4,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { type Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import type { ChildProcess } from 'node:child_process'
 import {
   ToolListChangedNotificationSchema,
   PromptListChangedNotificationSchema,
@@ -25,6 +26,7 @@ import { app } from 'electron'
 import { getInMemoryServer } from './inMemoryServers/builder'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { RuntimeHelper } from '@/lib/runtimeHelper'
+import { terminateProcessTree } from '@/lib/agentRuntime/processTree'
 import {
   PromptListEntry,
   ToolCallResult,
@@ -43,6 +45,10 @@ const ALLOWED_SAMPLING_IMAGE_MIME_TYPES = new Set([
   'image/gif',
   'image/webp'
 ])
+
+type StdioClientTransportProcessAccess = {
+  _process?: ChildProcess
+}
 
 // TODO: resources 和 prompts 的类型,Notifactions 的类型 https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/examples/client/simpleStreamableHttp.ts
 // Simple OAuth provider for handling Bearer Token
@@ -488,7 +494,7 @@ export class McpClient {
       }
 
       // 清理资源
-      this.cleanupResources()
+      await this.cleanupResources()
 
       console.error(`Failed to connect to MCP server ${this.serverName}:`, error)
 
@@ -514,7 +520,7 @@ export class McpClient {
   }
 
   // 清理资源
-  private cleanupResources(): void {
+  private async cleanupResources(): Promise<void> {
     // 清除超时定时器
     if (this.connectionTimeout) {
       clearTimeout(this.connectionTimeout)
@@ -522,9 +528,11 @@ export class McpClient {
     }
 
     // 关闭transport
-    if (this.transport) {
+    const transport = this.transport
+    this.transport = null
+    if (transport) {
       try {
-        this.transport.close()
+        await this.closeTransport(transport)
       } catch (error) {
         console.error(`Failed to close MCP transport:`, error)
       }
@@ -532,13 +540,23 @@ export class McpClient {
 
     // 重置状态
     this.client = null
-    this.transport = null
     this.isConnected = false
 
     // 清空缓存
     this.cachedTools = null
     this.cachedPrompts = null
     this.cachedResources = null
+  }
+
+  private async closeTransport(transport: Transport): Promise<void> {
+    if (transport instanceof StdioClientTransport) {
+      const child = (transport as unknown as StdioClientTransportProcessAccess)._process
+      if (child) {
+        await terminateProcessTree(child, { graceMs: 2000 })
+      }
+    }
+
+    await transport.close()
   }
 
   // Register notification handlers
@@ -920,7 +938,7 @@ export class McpClient {
 
       try {
         // Clean up current connection
-        this.cleanupResources()
+        await this.cleanupResources()
 
         // Clear all caches to ensure fresh data after reconnection
         this.cachedTools = null
@@ -952,7 +970,7 @@ export class McpClient {
   // Internal disconnect with custom reason
   private async internalDisconnect(reason?: string): Promise<void> {
     // Clean up all resources
-    this.cleanupResources()
+    await this.cleanupResources()
 
     const logMessage = reason
       ? `MCP service ${this.serverName} has been stopped due to ${reason}`

--- a/src/main/presenter/pluginPresenter/index.ts
+++ b/src/main/presenter/pluginPresenter/index.ts
@@ -129,6 +129,40 @@ export class PluginPresenter {
     }
   }
 
+  async shutdown(): Promise<void> {
+    const pluginIds = new Set(this.getInstallations().map((installation) => installation.pluginId))
+    const servers = await this.configPresenter.getMcpServers()
+
+    for (const [serverName, serverConfig] of Object.entries(servers)) {
+      if (!this.isPluginOwnedServerConfig(serverConfig)) {
+        continue
+      }
+
+      const ownerPluginId = this.getServerOwnerPluginId(serverConfig)
+      if (ownerPluginId) {
+        pluginIds.add(ownerPluginId)
+      }
+
+      try {
+        if (await this.mcpPresenter.isServerRunning(serverName)) {
+          await this.mcpPresenter.stopServer(serverName)
+        }
+      } catch (error) {
+        console.warn('[PluginHost] Failed to stop plugin-owned MCP server during shutdown:', {
+          pluginId: ownerPluginId,
+          serverName,
+          error
+        })
+      }
+    }
+
+    for (const pluginId of pluginIds) {
+      unregisterPluginToolPolicies(pluginId)
+    }
+
+    this.closeAllPluginSettingsWindows()
+  }
+
   async listPlugins(): Promise<PluginListItem[]> {
     await this.loadOfficialPlugins()
     return await Promise.all(
@@ -289,10 +323,7 @@ export class PluginPresenter {
   private async disableByOwner(pluginId: string): Promise<void> {
     const servers = await this.configPresenter.getMcpServers()
     for (const [serverName, serverConfig] of Object.entries(servers)) {
-      if (
-        serverConfig.ownerPluginId === pluginId ||
-        (serverConfig.source === 'plugin' && serverConfig.sourceId === pluginId)
-      ) {
+      if (this.isServerOwnedByPlugin(serverConfig, pluginId)) {
         try {
           if (await this.mcpPresenter.isServerRunning(serverName)) {
             await this.mcpPresenter.stopServer(serverName)
@@ -312,6 +343,24 @@ export class PluginPresenter {
     unregisterPluginToolPolicies(pluginId)
     this.closePluginSettingsWindow(pluginId)
     this.removeResourceRecordsByOwner(pluginId)
+  }
+
+  private isPluginOwnedServerConfig(serverConfig: MCPServerConfig): boolean {
+    return Boolean(serverConfig.ownerPluginId || serverConfig.source === 'plugin')
+  }
+
+  private isServerOwnedByPlugin(serverConfig: MCPServerConfig, pluginId: string): boolean {
+    return (
+      serverConfig.ownerPluginId === pluginId ||
+      (serverConfig.source === 'plugin' && serverConfig.sourceId === pluginId)
+    )
+  }
+
+  private getServerOwnerPluginId(serverConfig: MCPServerConfig): string | undefined {
+    return (
+      serverConfig.ownerPluginId ||
+      (serverConfig.source === 'plugin' ? serverConfig.sourceId : undefined)
+    )
   }
 
   private async removePersistedInstallation(pluginId: string): Promise<void> {
@@ -477,6 +526,12 @@ export class PluginPresenter {
       settingsWindow.close()
     }
     this.settingsWindows.delete(pluginId)
+  }
+
+  private closeAllPluginSettingsWindows(): void {
+    for (const pluginId of Array.from(this.settingsWindows.keys())) {
+      this.closePluginSettingsWindow(pluginId)
+    }
   }
 
   private registerToolPolicies(plugin: ResolvedOfficialPlugin): void {

--- a/src/shared/types/presenters/core.presenter.d.ts
+++ b/src/shared/types/presenters/core.presenter.d.ts
@@ -1757,6 +1757,7 @@ export interface MCPResourceContent {
 
 export interface IMCPPresenter {
   initialize(): Promise<void>
+  shutdown(): Promise<void>
   isReady(): boolean
   getMcpServers(): Promise<Record<string, MCPServerConfig>>
   getMcpClients(): Promise<McpClient[]>

--- a/test/main/presenter/mcpClient.test.ts
+++ b/test/main/presenter/mcpClient.test.ts
@@ -8,6 +8,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 
 const fsExistsSyncMock = vi.hoisted(() => vi.fn())
+const terminateProcessTreeMock = vi.hoisted(() => vi.fn().mockResolvedValue(true))
 
 // Mock electron modules
 vi.mock('electron', () => ({
@@ -88,6 +89,10 @@ vi.mock('@/routes/publishDeepchatEvent', () => ({
 
 vi.mock('../../../src/main/presenter/mcpPresenter/inMemoryServers/builder', () => ({
   getInMemoryServer: vi.fn()
+}))
+
+vi.mock('../../../src/main/lib/agentRuntime/processTree', () => ({
+  terminateProcessTree: terminateProcessTreeMock
 }))
 
 // Mock MCP SDK modules
@@ -408,6 +413,37 @@ describe('McpClient Runtime Command Processing Tests', () => {
       const pathEnv =
         transportOptions.env.PATH ?? transportOptions.env.Path ?? transportOptions.env.path
       expect(pathEnv).toContain('/custom/bin')
+    })
+
+    it('awaits process-tree cleanup before closing stdio transport on disconnect', async () => {
+      const order: string[] = []
+      const child = { pid: 123, exitCode: null, signalCode: null }
+      const closeMock = vi.fn(async () => {
+        order.push('transport-close')
+      })
+      terminateProcessTreeMock.mockImplementationOnce(async () => {
+        order.push('process-tree')
+        return true
+      })
+      vi.mocked(StdioClientTransport).mockImplementationOnce(function (this: any) {
+        this.stderr = {
+          on: vi.fn()
+        }
+        this.close = closeMock
+        this._process = child
+      } as any)
+      const client = new McpClient('test', {
+        type: 'stdio',
+        command: 'node',
+        args: ['server.js']
+      })
+
+      await client.connect()
+      await client.disconnect()
+
+      expect(terminateProcessTreeMock).toHaveBeenCalledWith(child, { graceMs: 2000 })
+      expect(closeMock).toHaveBeenCalledTimes(1)
+      expect(order).toEqual(['process-tree', 'transport-close'])
     })
   })
 

--- a/test/main/presenter/mcpClient.test.ts
+++ b/test/main/presenter/mcpClient.test.ts
@@ -445,6 +445,37 @@ describe('McpClient Runtime Command Processing Tests', () => {
       expect(closeMock).toHaveBeenCalledTimes(1)
       expect(order).toEqual(['process-tree', 'transport-close'])
     })
+
+    it('closes stdio transport even when process-tree cleanup fails', async () => {
+      const child = { pid: 456, exitCode: null, signalCode: null }
+      const cleanupError = new Error('cleanup failed')
+      const closeMock = vi.fn().mockResolvedValue(undefined)
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      terminateProcessTreeMock.mockRejectedValueOnce(cleanupError)
+      vi.mocked(StdioClientTransport).mockImplementationOnce(function (this: any) {
+        this.stderr = {
+          on: vi.fn()
+        }
+        this.close = closeMock
+        this._process = child
+      } as any)
+      const client = new McpClient('test', {
+        type: 'stdio',
+        command: 'node',
+        args: ['server.js']
+      })
+
+      await client.connect()
+      await client.disconnect()
+
+      expect(terminateProcessTreeMock).toHaveBeenCalledWith(child, { graceMs: 2000 })
+      expect(closeMock).toHaveBeenCalledTimes(1)
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to terminate MCP stdio process tree for test:',
+        cleanupError
+      )
+      consoleErrorSpy.mockRestore()
+    })
   })
 
   describe('Unsupported MCP capabilities', () => {

--- a/test/main/presenter/mcpPresenter.test.ts
+++ b/test/main/presenter/mcpPresenter.test.ts
@@ -223,6 +223,30 @@ describe('McpPresenter#setMcpServerEnabled', () => {
     expect(stopSpy).toHaveBeenCalledWith('regular')
   })
 
+  it('stops all running clients during shutdown and continues after stop failures', async () => {
+    const configPresenter = createConfigPresenter(true)
+    const presenter = new McpPresenter(configPresenter)
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    ;(presenter as any).serverManager = {
+      getRunningClients: serverManagerMocks.getRunningClients,
+      stopServer: serverManagerMocks.stopServer
+    }
+    serverManagerMocks.getRunningClients.mockResolvedValue([
+      { serverName: 'first' },
+      { serverName: 'second' }
+    ])
+    serverManagerMocks.stopServer
+      .mockRejectedValueOnce(new Error('first failed'))
+      .mockResolvedValueOnce(undefined)
+
+    await presenter.shutdown()
+
+    expect(serverManagerMocks.stopServer).toHaveBeenCalledTimes(2)
+    expect(serverManagerMocks.stopServer).toHaveBeenCalledWith('first')
+    expect(serverManagerMocks.stopServer).toHaveBeenCalledWith('second')
+    consoleErrorSpy.mockRestore()
+  })
+
   it('keeps plugin-owned tool definitions available when MCP is globally disabled', async () => {
     const configPresenter = createConfigPresenter(false, false, {
       regular: { enabled: true },

--- a/test/main/presenter/pluginPresenter.test.ts
+++ b/test/main/presenter/pluginPresenter.test.ts
@@ -947,6 +947,14 @@ describe('PluginPresenter', () => {
     expect(presenter.__mocks.mcpPresenter.stopServer).toHaveBeenCalledWith('plugin-first')
     expect(presenter.__mocks.mcpPresenter.stopServer).toHaveBeenCalledWith('plugin-second')
     expect(presenter.__mocks.configPresenter.removeMcpServer).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[PluginHost] Failed to stop plugin-owned MCP server during shutdown:',
+      expect.objectContaining({
+        pluginId: 'com.deepchat.plugins.first',
+        serverName: 'plugin-first',
+        error: expect.any(Error)
+      })
+    )
     consoleWarnSpy.mockRestore()
   })
 

--- a/test/main/presenter/pluginPresenter.test.ts
+++ b/test/main/presenter/pluginPresenter.test.ts
@@ -886,6 +886,70 @@ describe('PluginPresenter', () => {
     expect(presenter.__mocks.mcpPresenter.startServer).toHaveBeenCalledWith('fixture-runtime')
   })
 
+  it('shuts down running plugin-owned MCP servers without removing saved config', async () => {
+    const presenter = await createPluginPresenter('darwin')
+    await presenter.__mocks.configPresenter.addMcpServer('regular-server', {
+      source: 'manual'
+    })
+    await presenter.__mocks.configPresenter.addMcpServer('plugin-running', {
+      source: 'plugin',
+      sourceId: 'com.deepchat.plugins.fixture',
+      ownerPluginId: 'com.deepchat.plugins.fixture'
+    })
+    await presenter.__mocks.configPresenter.addMcpServer('plugin-stopped', {
+      source: 'plugin',
+      sourceId: 'com.deepchat.plugins.other',
+      ownerPluginId: 'com.deepchat.plugins.other'
+    })
+    presenter.__mocks.mcpPresenter.isServerRunning.mockImplementation(
+      async (serverName: string) => serverName !== 'plugin-stopped'
+    )
+
+    await presenter.shutdown()
+
+    expect(presenter.__mocks.mcpPresenter.stopServer).toHaveBeenCalledTimes(1)
+    expect(presenter.__mocks.mcpPresenter.stopServer).toHaveBeenCalledWith('plugin-running')
+    expect(presenter.__mocks.configPresenter.removeMcpServer).not.toHaveBeenCalled()
+    expect(await presenter.__mocks.configPresenter.getMcpServers()).toMatchObject({
+      'regular-server': {
+        source: 'manual'
+      },
+      'plugin-running': {
+        source: 'plugin',
+        ownerPluginId: 'com.deepchat.plugins.fixture'
+      },
+      'plugin-stopped': {
+        source: 'plugin',
+        ownerPluginId: 'com.deepchat.plugins.other'
+      }
+    })
+  })
+
+  it('continues plugin shutdown when one plugin-owned MCP server fails to stop', async () => {
+    const presenter = await createPluginPresenter('darwin')
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    await presenter.__mocks.configPresenter.addMcpServer('plugin-first', {
+      source: 'plugin',
+      sourceId: 'com.deepchat.plugins.first'
+    })
+    await presenter.__mocks.configPresenter.addMcpServer('plugin-second', {
+      source: 'plugin',
+      sourceId: 'com.deepchat.plugins.second'
+    })
+    presenter.__mocks.mcpPresenter.isServerRunning.mockResolvedValue(true)
+    presenter.__mocks.mcpPresenter.stopServer
+      .mockRejectedValueOnce(new Error('first failed'))
+      .mockResolvedValueOnce(undefined)
+
+    await presenter.shutdown()
+
+    expect(presenter.__mocks.mcpPresenter.stopServer).toHaveBeenCalledTimes(2)
+    expect(presenter.__mocks.mcpPresenter.stopServer).toHaveBeenCalledWith('plugin-first')
+    expect(presenter.__mocks.mcpPresenter.stopServer).toHaveBeenCalledWith('plugin-second')
+    expect(presenter.__mocks.configPresenter.removeMcpServer).not.toHaveBeenCalled()
+    consoleWarnSpy.mockRestore()
+  })
+
   it('declares the CUA internal tool server with cross-platform helper context', async () => {
     const manifest = JSON.parse(await readFile('plugins/cua/plugin.json', 'utf8'))
     const mcpConfig = JSON.parse(await readFile('plugins/cua/mcp/cua-driver.json', 'utf8'))


### PR DESCRIPTION
## Summary
- add a plugin shutdown lifecycle before presenter teardown
- stop plugin-owned MCP servers on app quit without disabling plugins or deleting config
- make MCP stdio cleanup await transport close and terminate spawned process trees for helpers such as CUA driver

## Tests
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck
- pnpm exec vitest run test/main/presenter/mcpPresenter.test.ts test/main/presenter/mcpClient.test.ts
- pnpm exec vitest run test/main/presenter/pluginPresenter.test.ts -t "shuts down running plugin-owned MCP servers|continues plugin shutdown"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved application shutdown to reliably stop plugin-owned helper connections and terminate related spawned processes.
  * Preserved saved MCP server configuration and plugin/install state across restarts.

* **Improvements**
  * Made disconnect/shutdown cleanup more robust by waiting for transport cleanup and closing process trees when available.

* **Tests**
  * Added unit tests covering plugin and MCP shutdown behavior, including failure handling and cleanup order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->