### PR TITLE
fix(skills): handle reinstall locked folders

### DIFF
--- a/docs/issues/skill-reinstall-windows-eperm/plan.md
+++ b/docs/issues/skill-reinstall-windows-eperm/plan.md
@@ -1,0 +1,38 @@
+# Skill Reinstall Windows EPERM Plan
+
+## Scope
+
+- `src/main/presenter/skillPresenter/index.ts`
+- `src/main/presenter/skillPresenter/skillExecutionService.ts`
+- Shared skill result typing in `src/shared/types/skill.ts`
+- Focused Vitest coverage under `test/main/presenter/skillPresenter`
+
+## Approach
+
+1. Add a structured install error code for locked target folders.
+2. Split replacement handling in `installFromDirectory`:
+   - valid existing skill folder: keep the current timestamped backup rename behavior.
+   - stale residue folder without `SKILL.md`: remove the residue and copy the new skill normally.
+3. Wrap replacement filesystem failures so Windows `EPERM`, `EBUSY`, and related access errors are
+   reported as a locked-folder result with the target path.
+4. Move uninstall cache/event updates after successful filesystem removal.
+5. Change skill execution working-directory fallback away from the skill root by creating a
+   per-conversation session directory when no valid conversation workdir exists. Keep `SKILL_ROOT`
+   and absolute script paths unchanged so scripts can still locate bundled resources.
+
+## Compatibility
+
+- Existing route names and payload shapes remain unchanged except for an additional optional
+  `errorCode` literal.
+- Existing overwrite backups are preserved for valid installed skills.
+- Stale-folder reinstall is a behavioral tightening for the delete/reinstall case, not a migration.
+
+## Test Strategy
+
+- Unit-test `installFromFolder` with an overwrite target that lacks `SKILL.md`; assert residue
+  removal and no backup rename.
+- Unit-test `installFromFolder` when replacement rename throws `EPERM`; assert
+  `errorCode: 'target_locked'`.
+- Unit-test `uninstallSkill` when removal throws; assert caches/events are not updated as success.
+- Unit-test `SkillExecutionService` fallback cwd resolves to a session directory rather than the
+  skill root.

--- a/docs/issues/skill-reinstall-windows-eperm/plan.md
+++ b/docs/issues/skill-reinstall-windows-eperm/plan.md
@@ -19,6 +19,8 @@
 5. Change skill execution working-directory fallback away from the skill root by creating a
    per-conversation session directory when no valid conversation workdir exists. Keep `SKILL_ROOT`
    and absolute script paths unchanged so scripts can still locate bundled resources.
+6. Keep the uninstall not-found path in sync with normal local cleanup for safe skill names, so an
+   externally removed folder cannot leave stale extension sidecars or cached metadata behind.
 
 ## Compatibility
 
@@ -34,5 +36,7 @@
 - Unit-test `installFromFolder` when replacement rename throws `EPERM`; assert
   `errorCode: 'target_locked'`.
 - Unit-test `uninstallSkill` when removal throws; assert caches/events are not updated as success.
+- Unit-test `uninstallSkill` when the directory is already gone; assert stale cache and sidecar
+  state is cleared without publishing a successful uninstall event.
 - Unit-test `SkillExecutionService` fallback cwd resolves to a session directory rather than the
   skill root.

--- a/docs/issues/skill-reinstall-windows-eperm/spec.md
+++ b/docs/issues/skill-reinstall-windows-eperm/spec.md
@@ -1,0 +1,38 @@
+# Skill Reinstall Windows EPERM
+
+## User Story
+
+When a user deletes a skill and immediately imports the same skill again on Windows, DeepChat
+should reinstall it normally when the old skill folder is only a stale residue. If the folder is
+still locked by another process, DeepChat should report a clear locked-folder error instead of a
+raw `EPERM: operation not permitted, rename ... .backup-*` message.
+
+## Problem
+
+Skill installation treats every existing target directory as an overwrite conflict. With overwrite
+enabled, the installer renames the existing directory to a timestamped backup before copying the
+new skill. On Windows, renaming a directory fails with `EPERM` when any child file or process keeps
+the directory open. A deleted or partially deleted skill may also disappear from discovery because
+`SKILL.md` is gone while the root folder still remains on disk, causing the next import to look
+like a confusing overwrite failure.
+
+## Acceptance Criteria
+
+- Reinstalling a skill succeeds without creating a backup when the target directory exists but no
+  valid `SKILL.md` remains.
+- Overwriting a valid installed skill continues to preserve the previous folder through the existing
+  backup behavior.
+- Windows `EPERM` or `EBUSY` failures while replacing a skill return a structured locked-folder
+  error instead of a raw rename stack message.
+- Skill uninstall does not publish a successful uninstall or clear caches before the target folder
+  is actually removed.
+- Skill script execution should avoid using the skill root as the process working directory when a
+  safer session directory is available or creatable.
+- Tests cover stale-folder reinstall, locked-folder error mapping, uninstall failure ordering, and
+  skill script working-directory fallback.
+
+## Non-Goals
+
+- Removing backup behavior for intentional overwrites of valid installed skills.
+- Adding a new user-facing installation mode.
+- Changing skill metadata discovery semantics for valid skills.

--- a/docs/issues/skill-reinstall-windows-eperm/spec.md
+++ b/docs/issues/skill-reinstall-windows-eperm/spec.md
@@ -26,6 +26,8 @@ like a confusing overwrite failure.
   error instead of a raw rename stack message.
 - Skill uninstall does not publish a successful uninstall or clear caches before the target folder
   is actually removed.
+- Skill uninstall clears stale sidecar and cache state when the skill folder was already removed
+  outside DeepChat.
 - Skill script execution should avoid using the skill root as the process working directory when a
   safer session directory is available or creatable.
 - Tests cover stale-folder reinstall, locked-folder error mapping, uninstall failure ordering, and

--- a/docs/issues/skill-reinstall-windows-eperm/tasks.md
+++ b/docs/issues/skill-reinstall-windows-eperm/tasks.md
@@ -5,6 +5,7 @@
 - [x] Implement stale-residue replacement without backup rename.
 - [x] Preserve backup behavior for valid overwrites.
 - [x] Move uninstall success side effects after filesystem removal.
+- [x] Keep not-found uninstall cleanup in sync with local sidecar/cache cleanup.
 - [x] Avoid skill-root cwd fallback for skill script execution.
 - [x] Add focused presenter and execution-service tests.
 - [x] Run format, i18n, lint, and focused tests.

--- a/docs/issues/skill-reinstall-windows-eperm/tasks.md
+++ b/docs/issues/skill-reinstall-windows-eperm/tasks.md
@@ -1,0 +1,11 @@
+# Skill Reinstall Windows EPERM Tasks
+
+- [x] Document the issue, replacement rules, and test strategy.
+- [x] Add structured locked-folder install result support.
+- [x] Implement stale-residue replacement without backup rename.
+- [x] Preserve backup behavior for valid overwrites.
+- [x] Move uninstall success side effects after filesystem removal.
+- [x] Avoid skill-root cwd fallback for skill script execution.
+- [x] Add focused presenter and execution-service tests.
+- [x] Run format, i18n, lint, and focused tests.
+- [x] Create the GitHub issue for public tracking.

--- a/src/main/presenter/skillPresenter/index.ts
+++ b/src/main/presenter/skillPresenter/index.ts
@@ -1553,6 +1553,7 @@ export class SkillPresenter implements ISkillPresenter {
       const skillDir = path.join(this.skillsDir, name)
 
       if (!fs.existsSync(skillDir)) {
+        this.cleanupUninstalledSkillState(name)
         return { success: false, error: `Skill "${name}" not found`, errorCode: 'not_found' }
       }
 
@@ -1561,17 +1562,7 @@ export class SkillPresenter implements ISkillPresenter {
         return this.createTargetLockedFailure(name, skillDir, 'remove')
       }
 
-      try {
-        this.deleteSkillExtension(name)
-      } catch (error) {
-        logger.warn('[SkillPresenter] Failed to delete skill sidecar after uninstall', {
-          name,
-          error
-        })
-      }
-
-      this.metadataCache.delete(name)
-      this.contentCache.delete(name)
+      this.cleanupUninstalledSkillState(name)
 
       publishDeepchatEvent('skills.catalog.changed', {
         reason: 'uninstalled',
@@ -1588,6 +1579,26 @@ export class SkillPresenter implements ISkillPresenter {
         error
       )
     }
+  }
+
+  private cleanupUninstalledSkillState(name: string): void {
+    if (this.isSafeSkillName(name)) {
+      try {
+        this.deleteSkillExtension(name)
+      } catch (error) {
+        logger.warn('[SkillPresenter] Failed to delete skill sidecar after uninstall', {
+          name,
+          error
+        })
+      }
+    }
+
+    this.metadataCache.delete(name)
+    this.contentCache.delete(name)
+  }
+
+  private isSafeSkillName(name: string): boolean {
+    return SKILL_NAME_PATTERN.test(name) && !name.includes('/') && !name.includes('\\')
   }
 
   /**

--- a/src/main/presenter/skillPresenter/index.ts
+++ b/src/main/presenter/skillPresenter/index.ts
@@ -1318,7 +1318,10 @@ export class SkillPresenter implements ISkillPresenter {
             existingSkillName: skillName
           }
         }
-        this.backupExistingSkill(skillName)
+        const replaceResult = this.prepareExistingSkillTargetForInstall(skillName, resolvedTarget)
+        if (replaceResult) {
+          return replaceResult
+        }
         this.metadataCache.delete(skillName)
         this.contentCache.delete(skillName)
       }
@@ -1346,6 +1349,26 @@ export class SkillPresenter implements ISkillPresenter {
     }
   }
 
+  private prepareExistingSkillTargetForInstall(
+    skillName: string,
+    targetDir: string
+  ): SkillInstallResult | null {
+    try {
+      const existingSkillPath = path.join(targetDir, 'SKILL.md')
+      if (fs.existsSync(existingSkillPath)) {
+        this.backupExistingSkill(skillName)
+      } else {
+        fs.rmSync(targetDir, { recursive: true, force: true })
+        if (fs.existsSync(targetDir)) {
+          return this.createTargetLockedFailure(skillName, targetDir, 'replace')
+        }
+      }
+      return null
+    } catch (error) {
+      return this.createTargetOperationFailure(skillName, targetDir, 'replace', error)
+    }
+  }
+
   private backupExistingSkill(skillName: string): string {
     const sourceDir = path.join(this.skillsDir, skillName)
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
@@ -1357,6 +1380,46 @@ export class SkillPresenter implements ISkillPresenter {
     }
     fs.renameSync(sourceDir, backupDir)
     return backupDir
+  }
+
+  private createTargetLockedFailure(
+    skillName: string,
+    targetPath: string,
+    operation: 'replace' | 'remove'
+  ): SkillInstallResult {
+    const verb = operation === 'remove' ? 'removed' : 'replaced'
+    return {
+      success: false,
+      error: `Skill "${skillName}" cannot be ${verb} because its folder is in use: ${targetPath}`,
+      errorCode: 'target_locked',
+      skillName,
+      targetPath
+    }
+  }
+
+  private createTargetOperationFailure(
+    skillName: string,
+    targetPath: string,
+    operation: 'replace' | 'remove',
+    error: unknown
+  ): SkillInstallResult {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    if (this.isFileSystemLockError(error)) {
+      return this.createTargetLockedFailure(skillName, targetPath, operation)
+    }
+
+    return {
+      success: false,
+      error: errorMsg,
+      errorCode: 'io_error',
+      skillName,
+      targetPath
+    }
+  }
+
+  private isFileSystemLockError(error: unknown): boolean {
+    const code = (error as { code?: unknown } | null)?.code
+    return code === 'EPERM' || code === 'EBUSY' || code === 'EACCES' || code === 'ENOTEMPTY'
   }
 
   private extractZipToDirectory(zipPath: string, targetDir: string): void {
@@ -1490,16 +1553,25 @@ export class SkillPresenter implements ISkillPresenter {
       const skillDir = path.join(this.skillsDir, name)
 
       if (!fs.existsSync(skillDir)) {
-        return { success: false, error: `Skill "${name}" not found` }
+        return { success: false, error: `Skill "${name}" not found`, errorCode: 'not_found' }
       }
 
-      // Remove from caches
+      fs.rmSync(skillDir, { recursive: true, force: true })
+      if (fs.existsSync(skillDir)) {
+        return this.createTargetLockedFailure(name, skillDir, 'remove')
+      }
+
+      try {
+        this.deleteSkillExtension(name)
+      } catch (error) {
+        logger.warn('[SkillPresenter] Failed to delete skill sidecar after uninstall', {
+          name,
+          error
+        })
+      }
+
       this.metadataCache.delete(name)
       this.contentCache.delete(name)
-
-      // Delete the directory
-      fs.rmSync(skillDir, { recursive: true, force: true })
-      this.deleteSkillExtension(name)
 
       publishDeepchatEvent('skills.catalog.changed', {
         reason: 'uninstalled',
@@ -1509,8 +1581,12 @@ export class SkillPresenter implements ISkillPresenter {
 
       return { success: true, skillName: name }
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error)
-      return { success: false, error: errorMsg }
+      return this.createTargetOperationFailure(
+        name,
+        path.join(this.skillsDir, name),
+        'remove',
+        error
+      )
     }
   }
 

--- a/src/main/presenter/skillPresenter/skillExecutionService.ts
+++ b/src/main/presenter/skillPresenter/skillExecutionService.ts
@@ -178,7 +178,7 @@ export class SkillExecutionService {
   private async resolveExecutionCwd(conversationId: string, skillRoot: string): Promise<string> {
     const normalizedSkillRoot = path.resolve(skillRoot)
     if (!this.resolveConversationWorkdir) {
-      return normalizedSkillRoot
+      return this.resolveFallbackExecutionCwd(conversationId, normalizedSkillRoot)
     }
 
     try {
@@ -191,22 +191,16 @@ export class SkillExecutionService {
           if (stat.isDirectory()) {
             return resolvedPath
           }
-          logger.warn(
-            '[SkillExecutionService] Conversation workdir is not a directory, falling back to skill root',
-            {
-              conversationId,
-              invalidWorkdir: resolvedPath
-            }
-          )
+          logger.warn('[SkillExecutionService] Conversation workdir is not a directory', {
+            conversationId,
+            invalidWorkdir: resolvedPath
+          })
         } catch (error) {
-          logger.warn(
-            '[SkillExecutionService] Conversation workdir is invalid, falling back to skill root',
-            {
-              conversationId,
-              invalidWorkdir: resolvedPath,
-              error
-            }
-          )
+          logger.warn('[SkillExecutionService] Conversation workdir is invalid', {
+            conversationId,
+            invalidWorkdir: resolvedPath,
+            error
+          })
         }
       }
     } catch (error) {
@@ -216,14 +210,35 @@ export class SkillExecutionService {
       })
     }
 
-    logger.warn(
-      '[SkillExecutionService] Missing conversation workdir, falling back to skill root',
-      {
-        conversationId,
-        skillRoot: normalizedSkillRoot
-      }
-    )
-    return normalizedSkillRoot
+    logger.warn('[SkillExecutionService] Missing conversation workdir, using session directory', {
+      conversationId,
+      skillRoot: normalizedSkillRoot
+    })
+    return this.resolveFallbackExecutionCwd(conversationId, normalizedSkillRoot)
+  }
+
+  private resolveFallbackExecutionCwd(conversationId: string, skillRoot: string): string {
+    const sessionDir = resolveSessionDir(conversationId)
+    if (!sessionDir) {
+      return skillRoot
+    }
+
+    try {
+      fs.mkdirSync(sessionDir, { recursive: true })
+      return sessionDir
+    } catch (error) {
+      logger.warn(
+        '[SkillExecutionService] Failed to create session directory, falling back to skill root',
+        {
+          conversationId,
+          sessionDir,
+          skillRoot,
+          error
+        }
+      )
+    }
+
+    return skillRoot
   }
 
   private resolveRequestedScript(

--- a/src/renderer/settings/components/skills/SkillInstallDialog.vue
+++ b/src/renderer/settings/components/skills/SkillInstallDialog.vue
@@ -164,6 +164,7 @@ import { useToast } from '@/components/use-toast'
 import { useSkillsStore } from '@/stores/skillsStore'
 import { createDeviceClient } from '@api/DeviceClient'
 import { createFileClient } from '@api/FileClient'
+import type { SkillInstallResult } from '@shared/types/skill'
 
 const props = defineProps<{
   open: boolean
@@ -349,7 +350,7 @@ const tryInstallFromUrl = async (url: string, overwrite = false) => {
 
 // Common result handling
 const handleInstallResult = (
-  result: { success: boolean; error?: string; skillName?: string },
+  result: SkillInstallResult,
   retryWithOverwrite: () => Promise<void>
 ) => {
   if (result.success) {
@@ -359,8 +360,8 @@ const handleInstallResult = (
     })
     emit('installed')
     isOpen.value = false
-  } else if (result.error?.includes('already exists')) {
-    const skillName = result.error.match(/"([^"]+)"/)?.[1] || ''
+  } else if (result.errorCode === 'conflict') {
+    const skillName = result.existingSkillName || result.error?.match(/"([^"]+)"/)?.[1] || ''
     conflictSkillName.value = skillName
     pendingInstallAction.value = retryWithOverwrite
     conflictDialogOpen.value = true

--- a/src/shared/types/skill.ts
+++ b/src/shared/types/skill.ts
@@ -78,9 +78,10 @@ export interface SkillScriptDescriptor {
 export interface SkillInstallResult {
   success: boolean
   error?: string
-  errorCode?: 'conflict' | 'invalid_skill' | 'not_found' | 'io_error'
+  errorCode?: 'conflict' | 'invalid_skill' | 'not_found' | 'io_error' | 'target_locked'
   skillName?: string
   existingSkillName?: string
+  targetPath?: string
 }
 
 /**

--- a/test/main/presenter/skillPresenter/skillExecutionService.test.ts
+++ b/test/main/presenter/skillPresenter/skillExecutionService.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events'
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ISkillPresenter } from '../../../../src/shared/types/skill'
@@ -57,6 +58,7 @@ describe('SkillExecutionService', () => {
     vi.clearAllMocks()
     vi.mocked(shellEnvHelper.getUserShell).mockReturnValue({ shell: '/bin/zsh', args: ['-c'] })
     vi.spyOn(fs, 'existsSync').mockReturnValue(false)
+    vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined)
     vi.mocked(fs.promises.stat).mockResolvedValue({
       isDirectory: () => true
     } as never)
@@ -134,7 +136,7 @@ describe('SkillExecutionService', () => {
     expect(plan.args).toEqual(['run', '/skills/ocr/scripts/run.py', '--lang', 'en'])
   })
 
-  it('falls back to skill root cwd when the session workdir is unavailable', async () => {
+  it('uses a session cwd when the conversation workdir is unavailable', async () => {
     resolveConversationWorkdir.mockResolvedValueOnce(null)
     vi.spyOn(service as never, 'resolveRuntimeCommand' as never).mockResolvedValue({
       command: 'uv',
@@ -149,13 +151,36 @@ describe('SkillExecutionService', () => {
       'conv-1'
     )
 
-    expect(plan.cwd).toBe(resolvePath('/skills/ocr'))
+    const sessionDir = path.resolve(os.homedir(), '.deepchat', 'sessions', 'conv-1')
+    expect(plan.cwd).toBe(sessionDir)
+    expect(fs.mkdirSync).toHaveBeenCalledWith(sessionDir, { recursive: true })
   })
 
-  it('falls back to skill root cwd when the resolved session workdir is not a directory', async () => {
+  it('uses a session cwd when the resolved conversation workdir is not a directory', async () => {
     vi.mocked(fs.promises.stat).mockResolvedValueOnce({
       isDirectory: () => false
     } as never)
+    vi.spyOn(service as never, 'resolveRuntimeCommand' as never).mockResolvedValue({
+      command: 'uv',
+      mode: 'uv'
+    })
+
+    const plan = await (service as never).buildSpawnPlan(
+      {
+        skill: 'ocr',
+        script: 'scripts/run.py'
+      },
+      'conv-1'
+    )
+
+    expect(plan.cwd).toBe(path.resolve(os.homedir(), '.deepchat', 'sessions', 'conv-1'))
+  })
+
+  it('falls back to skill root cwd when a session cwd cannot be created', async () => {
+    resolveConversationWorkdir.mockResolvedValueOnce(null)
+    vi.mocked(fs.mkdirSync).mockImplementationOnce(() => {
+      throw new Error('mkdir failed')
+    })
     vi.spyOn(service as never, 'resolveRuntimeCommand' as never).mockResolvedValue({
       command: 'uv',
       mode: 'uv'

--- a/test/main/presenter/skillPresenter/skillPresenter.test.ts
+++ b/test/main/presenter/skillPresenter/skillPresenter.test.ts
@@ -1594,13 +1594,37 @@ describe('SkillPresenter', () => {
   })
 
   describe('uninstallSkill', () => {
-    it('should fail if skill does not exist', async () => {
-      ;(fs.existsSync as Mock).mockReturnValue(false)
+    it('should clean stale local state when skill directory no longer exists', async () => {
+      const sidecarPath = `${DEFAULT_SKILLS_DIR}/.deepchat-meta/nonexistent.json`
+      ;(skillPresenter as any).metadataCache.set(
+        'nonexistent',
+        createSkillMetadata('nonexistent', 'nonexistent')
+      )
+      ;(skillPresenter as any).contentCache.set('nonexistent', {
+        name: 'nonexistent',
+        content: 'content'
+      })
+      ;(fs.existsSync as Mock).mockImplementation((target: string) => target === sidecarPath)
+      publishDeepchatEventMock.mockClear()
 
       const result = await skillPresenter.uninstallSkill('nonexistent')
 
       expect(result.success).toBe(false)
       expect(result.error).toContain('not found')
+      expect(result.errorCode).toBe('not_found')
+      expect(fs.rmSync).toHaveBeenCalledWith(sidecarPath, { force: true })
+      expect((skillPresenter as any).metadataCache.has('nonexistent')).toBe(false)
+      expect((skillPresenter as any).contentCache.has('nonexistent')).toBe(false)
+      expect(publishDeepchatEventMock).not.toHaveBeenCalled()
+    })
+
+    it('should not remove sidecar paths for invalid missing skill names', async () => {
+      ;(fs.existsSync as Mock).mockReturnValue(false)
+
+      const result = await skillPresenter.uninstallSkill('../outside')
+
+      expect(result.errorCode).toBe('not_found')
+      expect(fs.rmSync).not.toHaveBeenCalled()
     })
 
     it('should successfully uninstall a skill', async () => {

--- a/test/main/presenter/skillPresenter/skillPresenter.test.ts
+++ b/test/main/presenter/skillPresenter/skillPresenter.test.ts
@@ -1457,6 +1457,64 @@ describe('SkillPresenter', () => {
       expect(result.error).toContain('already exists')
     })
 
+    it('should reinstall over stale residue without backup rename', async () => {
+      const targetDir = `${DEFAULT_SKILLS_DIR}/reloaded-skill`
+      let removed = false
+      ;(fs.existsSync as Mock).mockImplementation((target: string) => {
+        if (target === '/source/reloaded' || target === '/source/reloaded/SKILL.md') return true
+        if (target === targetDir) return !removed
+        if (target === `${targetDir}/SKILL.md`) return false
+        return true
+      })
+      ;(fs.rmSync as Mock).mockImplementation((target: string) => {
+        if (target === targetDir) {
+          removed = true
+        }
+      })
+      ;(fs.readFileSync as Mock).mockReturnValue('test')
+      ;(fs.readdirSync as Mock).mockReturnValue([])
+      ;(matter as unknown as Mock).mockReturnValue({
+        data: { name: 'reloaded-skill', description: 'Reloaded skill' },
+        content: '# Content'
+      })
+
+      const result = await skillPresenter.installFromFolder('/source/reloaded', { overwrite: true })
+
+      expect(result).toEqual({ success: true, skillName: 'reloaded-skill' })
+      expect(fs.rmSync).toHaveBeenCalledWith(targetDir, { recursive: true, force: true })
+      expect(fs.renameSync).not.toHaveBeenCalled()
+    })
+
+    it('should return target_locked when overwrite backup rename is denied', async () => {
+      const targetDir = `${DEFAULT_SKILLS_DIR}/locked-skill`
+      const lockError = Object.assign(new Error('EPERM: operation not permitted, rename'), {
+        code: 'EPERM'
+      })
+      ;(fs.existsSync as Mock).mockImplementation((target: string) => {
+        if (target === '/source/locked' || target === '/source/locked/SKILL.md') return true
+        if (target === targetDir || target === `${targetDir}/SKILL.md`) return true
+        return false
+      })
+      ;(fs.readFileSync as Mock).mockReturnValue('test')
+      ;(matter as unknown as Mock).mockReturnValue({
+        data: { name: 'locked-skill', description: 'Locked skill' },
+        content: '# Content'
+      })
+      ;(fs.renameSync as Mock).mockImplementation(() => {
+        throw lockError
+      })
+
+      const result = await skillPresenter.installFromFolder('/source/locked', { overwrite: true })
+
+      expect(result).toMatchObject({
+        success: false,
+        errorCode: 'target_locked',
+        skillName: 'locked-skill',
+        targetPath: targetDir
+      })
+      expect(fs.rmSync).not.toHaveBeenCalledWith(targetDir, { recursive: true, force: true })
+    })
+
     it('should successfully install a valid skill', async () => {
       // Mock path functions first
       ;(path.resolve as Mock).mockImplementation((p: string) => {
@@ -1546,8 +1604,17 @@ describe('SkillPresenter', () => {
     })
 
     it('should successfully uninstall a skill', async () => {
-      ;(fs.existsSync as Mock).mockReturnValue(true)
-      ;(fs.rmSync as Mock).mockReturnValue(undefined)
+      const skillDir = `${DEFAULT_SKILLS_DIR}/test-skill`
+      let removed = false
+      ;(fs.existsSync as Mock).mockImplementation((target: string) => {
+        if (target === skillDir) return !removed
+        return true
+      })
+      ;(fs.rmSync as Mock).mockImplementation((target: string) => {
+        if (target === skillDir) {
+          removed = true
+        }
+      })
 
       const result = await skillPresenter.uninstallSkill('test-skill')
 
@@ -1562,6 +1629,38 @@ describe('SkillPresenter', () => {
           version: expect.any(Number)
         })
       )
+    })
+
+    it('should not clear caches or publish success when uninstall cannot remove the folder', async () => {
+      const skillDir = `${DEFAULT_SKILLS_DIR}/locked-skill`
+      const lockError = Object.assign(new Error('EPERM: operation not permitted, rmdir'), {
+        code: 'EPERM'
+      })
+      ;(skillPresenter as any).metadataCache.set(
+        'locked-skill',
+        createSkillMetadata('locked-skill', 'locked-skill')
+      )
+      ;(skillPresenter as any).contentCache.set('locked-skill', {
+        name: 'locked-skill',
+        content: 'content'
+      })
+      ;(fs.existsSync as Mock).mockImplementation((target: string) => target === skillDir)
+      ;(fs.rmSync as Mock).mockImplementation(() => {
+        throw lockError
+      })
+      publishDeepchatEventMock.mockClear()
+
+      const result = await skillPresenter.uninstallSkill('locked-skill')
+
+      expect(result).toMatchObject({
+        success: false,
+        errorCode: 'target_locked',
+        skillName: 'locked-skill',
+        targetPath: skillDir
+      })
+      expect((skillPresenter as any).metadataCache.has('locked-skill')).toBe(true)
+      expect((skillPresenter as any).contentCache.has('locked-skill')).toBe(true)
+      expect(publishDeepchatEventMock).not.toHaveBeenCalled()
     })
   })
 
@@ -1843,7 +1942,17 @@ describe('SkillPresenter', () => {
     })
 
     it('should remove sidecar config when uninstalling a skill', async () => {
-      ;(fs.existsSync as Mock).mockReturnValue(true)
+      const skillDir = `${DEFAULT_SKILLS_DIR}/test-skill`
+      let removed = false
+      ;(fs.existsSync as Mock).mockImplementation((target: string) => {
+        if (target === skillDir) return !removed
+        return true
+      })
+      ;(fs.rmSync as Mock).mockImplementation((target: string) => {
+        if (target === skillDir) {
+          removed = true
+        }
+      })
 
       await skillPresenter.uninstallSkill('test-skill')
 


### PR DESCRIPTION
## Summary

- Treat same-name skill folders without `SKILL.md` as stale residues during overwrite reinstall, removing them before copying the new skill instead of creating a `.backup-*` folder.
- Preserve timestamped backup behavior for valid existing skills and map locked-folder filesystem failures to `errorCode: 'target_locked'` with `targetPath`.
- Move uninstall cache/event updates after successful folder removal and avoid using the skill root as the fallback cwd for skill scripts when a session directory can be created.
- Add SDD issue docs and focused presenter/execution-service regression coverage.

## UI State

Before:

```text
Import same skill after delete
└─ overwrite
   └─ raw EPERM rename ... .backup-* error
```

After:

```text
Import same skill after delete
├─ stale folder without SKILL.md -> reinstall normally
└─ locked folder -> target_locked result with targetPath
```

## Validation

- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test -- test/main/presenter/skillPresenter/skillPresenter.test.ts test/main/presenter/skillPresenter/skillExecutionService.test.ts`

Closes #1803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill installs now recognize and surface a clearer “target locked” state when Windows blocks replacement.
  * Skill scripts now run using a session-based working directory when the conversation workspace is unavailable.

* **Bug Fixes**
  * Uninstall now reports success only after the skill folder is confirmed removed.
  * Replacement logic preserves the previous valid-backup behavior while correctly handling stale residue and missing `SKILL.md`.

* **Tests**
  * Expanded coverage for locked-folder, stale overwrite, cwd fallback, and uninstall success/failure ordering.

* **Documentation**
  * Added detailed EPERM/EBUSY handling plans and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->