### PR TITLE
build(deps): bump markstream-vue

### DIFF
--- a/docs/issues/markstream-vue-1-0-4-upgrade/plan.md
+++ b/docs/issues/markstream-vue-1-0-4-upgrade/plan.md
@@ -1,0 +1,19 @@
+# Plan
+
+## Approach
+Treat the existing `package.json` edit as a focused dependency maintenance fix and keep the SDD record minimal.
+
+## Affected files
+- `package.json`
+- `docs/issues/markstream-vue-1-0-4-upgrade/spec.md`
+- `docs/issues/markstream-vue-1-0-4-upgrade/plan.md`
+- `docs/issues/markstream-vue-1-0-4-upgrade/tasks.md`
+
+## Compatibility
+A patch-level dependency bump should preserve the existing public interface while picking up upstream fixes.
+
+## Validation
+Run:
+- `pnpm run format`
+- `pnpm run i18n`
+- `pnpm run lint`

--- a/docs/issues/markstream-vue-1-0-4-upgrade/spec.md
+++ b/docs/issues/markstream-vue-1-0-4-upgrade/spec.md
@@ -1,0 +1,23 @@
+# Markstream Vue 1.0.4 Upgrade
+
+## User need
+Keep the renderer dependency aligned with the required upstream package version so the workspace can be committed and reviewed cleanly.
+
+## Goal
+Record and ship the `markstream-vue` dependency bump from `1.0.3` to `1.0.4` in `package.json`.
+
+## Acceptance criteria
+- `package.json` declares `markstream-vue` at `1.0.4`.
+- The change is documented as a small issue-level maintenance update.
+- Validation covers formatting, i18n, and lint commands required by the repository workflow.
+
+## Constraints
+- Keep the change limited to the dependency version bump already present in the workspace.
+- Do not alter unrelated dependencies or application code.
+
+## Non-goals
+- Refactoring markdown rendering code.
+- Introducing new renderer behavior.
+
+## Open questions
+- None.

--- a/docs/issues/markstream-vue-1-0-4-upgrade/tasks.md
+++ b/docs/issues/markstream-vue-1-0-4-upgrade/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+1. Record the dependency bump in issue-scoped SDD docs.
+2. Validate the workspace with format, i18n, and lint.
+3. Commit the package version change and SDD docs.
+4. Push the branch and create a merge request.

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "katex": "^0.16.47",
     "lint-staged": "^16.4.0",
     "lucide-vue-next": "^0.544.0",
-    "markstream-vue": "1.0.3",
+    "markstream-vue": "1.0.4",
     "mermaid": "^11.15.0",
     "minimatch": "^10.2.5",
     "monaco-editor": "^0.55.1",


### PR DESCRIPTION
## Summary\n- bump markstream-vue from 1.0.3 to 1.0.4 in package.json\n- run format, i18n check, lint, and commit-time typecheck\n\n## Validation\n- pnpm run format\n- pnpm run i18n\n- pnpm run lint\n- pnpm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the `markstream-vue` dependency to version 1.0.4 for improved stability and compatibility.
* **Documentation**
  * Added issue-scoped documentation covering the upgrade plan, specification, and validation/maintenance tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->