### PR TITLE
fix(sidebar): load full conversation history (#1762)

### DIFF
--- a/docs/issues/sidebar-history-pagination-stuck/plan.md
+++ b/docs/issues/sidebar-history-pagination-stuck/plan.md
@@ -1,80 +1,59 @@
-# 实施计划：侧边栏历史会话分页加载卡死
+# Plan
 
-## 目标
+## Current data flow
 
-修复 #1762：让侧边栏能持续加载并展示全部 regular 历史会话。核心两改 + 一项次要增强。
+1. Renderer calls `sessionClient.listLightweight({ limit: 30, cursor, includeSubagents: false })` from the session store.
+2. Main presenter delegates to `NewSessionManager.listPage` and SQLite `new_sessions` cursor pagination ordered by `updated_at DESC, id DESC`.
+3. Store maps rows to `UISession`, merges pages, and exposes `sessions`, `hasMore`, and `nextCursor`.
+4. `WindowSideBar.vue` derives pinned sessions and grouped sessions from the loaded `sessions` array, then applies agent filter and local title search.
+5. Pagination is triggered by scroll-near-bottom and by an auto-fill loop for non-overflowing content.
 
-## 方案概述
+## Failure modes
 
-### 改动 1 — 分页不再携带子代理会话（页槽修正）
+- The existing auto-fill watcher observes raw session count, `hasMore`, loading state, and selected agent, but not all rendered-height inputs. Group mode changes, collapsed/expanded groups, search text, pinned collapse, and project metadata ordering can drastically alter visible height without changing `sessions.length`.
+- The scroll check only runs on actual scroll events. If content shrinks below the viewport after grouping/filtering, no scroll event fires.
+- Agent filtering is applied after the global page is fetched. A specific agent or All agents visible state may be too short even while the global cursor has more rows.
+- The current loop stops when `sessions.length` does not increase. If the fetched page is deduped because of prioritized sessions or cursor overlap, it can stop even while `hasMore` remains true.
+- Confirmed runtime root cause: `nextCursor.value` is a Pinia/Vue reactive object. Passing it directly through the IPC bridge for `sessionClient.listLightweight()` can fail structured clone with `An object could not be cloned`, leaving the renderer at the first 30 rows while `hasMore` remains true.
 
-**文件**：`src/renderer/src/stores/ui/session.ts`
+## Implementation approach
 
-将 `loadSessionPage` 中两处分页请求的 `includeSubagents: true` 改为 `false`
-（`:512` 首屏、`:551` 翻页）。
+1. Extend `WindowSideBar.vue` pagination fill triggers to observe rendered list drivers:
+   - `filteredGroups` shape / visible session ids
+   - `pinnedSessions` ids
+   - `collapsedGroupIds` and pinned section collapsed state
+   - `sessionStore.groupMode`
+   - `normalizedSessionSearchQuery`
+   - sidebar collapsed state
+2. Add a `ResizeObserver` on the session list container so height changes re-run the fill check.
+3. After group expand/collapse and pinned expand/collapse, schedule a post-render fill check.
+4. Harden `ensureSessionListFilled`:
+   - keep the max-round guard
+   - stop on missing cursor, no `hasMore`, active loading, drag, collapsed sidebar, or errors
+   - treat `hasMore`/cursor progress as the primary signal, not only `sessions.length`
+5. Clone the pagination cursor into a plain object before sending it over IPC so Vue/Pinia proxies do not hit structured clone errors.
+6. Keep backend pagination unchanged unless tests reveal cursor/filtering bugs.
 
-- 后端 `newSessions.ts:240` 在 `includeSubagents !== true` 时自动加
-  `WHERE session_kind = 'regular'`，使一页 30 条全部为 regular 会话。
-- `nextCursor` / `hasMore`（`sessionManager.ts:107-113`、`newSessions.ts:262`）随之只基于
-  regular 会话计算，语义与显示层一致。
-- 影响面已核实安全（见 spec「影响面评估」）。
+## Affected files
 
-### 改动 2 — 加载后自动填充视口（根治"无滚动条→不加载"）
-
-**文件**：`src/renderer/src/components/WindowSideBar.vue`
-
-新增 `ensureSessionListFilled()`：在首屏加载完成、列表渲染更新（`nextTick`）后，检测
-`scrollHeight <= clientHeight && sessionStore.hasMore && !sessionStore.loadingMore`，
-若成立则 `await sessionStore.loadNextPage()` 并循环复检，直到视口被填满或 `hasMore = false`。
-
-触发时机：
-- `onMounted` 首屏 `fetchSessions` 之后；
-- `watch(filteredGroups / pinnedSessions)` 或 `watch(sessionStore.sessions.length)` 变化后
-  （会话列表内容变化、agent 切换过滤后内容变矮时复检）。
-
-防护：
-- 用一个 `isFilling` 本地标志避免并发重入；
-- 设置最大循环轮数上限（如 `hasMore` 为真但连续加载无新增时退出）防止异常死循环；
-- 复用现有 `performSessionListScrollCheck` 的 96px 阈值常量，逻辑保持一致。
-
-### 改动 3（次要）— 侧边栏搜索接入后端 FTS
-
-**文件**：`src/renderer/src/components/WindowSideBar.vue`（+ 可能 `session.ts` / `SessionClient`）
-
-当前 `matchesSessionSearch` 仅前端过滤。增强为：搜索关键词非空时，调用已有
-`sessionClient.searchHistory(query)`（FTS 直查 DB），将命中的历史会话合并进可显示集合。
-
-- 优先复用 `spotlight.ts:305` 已验证的 `searchHistory` 调用方式。
-- 加 debounce，避免逐字符请求。
-- 若本增强工作量偏大，可拆为独立后续 PR，先合入改动 1+2 即可让"滚动加载"恢复正常。
-
-## 涉及模块
-
-| 层 | 文件 | 改动 |
-|---|---|---|
-| Renderer Store | `src/renderer/src/stores/ui/session.ts` | `includeSubagents: false` ×2 |
-| Renderer 组件 | `src/renderer/src/components/WindowSideBar.vue` | 视口自动填充；（次要）搜索接 FTS |
-| Renderer Client | `src/renderer/api/SessionClient.ts` | （次要）如需暴露 searchHistory |
-
-主进程 / DB / 契约层**无需改动**（透传逻辑已正确）。
-
-## 测试策略
-
-- `test/renderer/stores/sessionStore.test.ts`
-  - 断言 `loadSessionPage` 发出的请求 `includeSubagents === false`。
-  - 断言翻页 cursor 推进、`hasMore` 收敛、`sessions` 累积去重。
+- `src/renderer/src/components/WindowSideBar.vue`
 - `test/renderer/components/WindowSideBar.test.ts`
-  - 模拟 `scrollHeight <= clientHeight && hasMore` 场景，断言 `loadNextPage` 被自动调用
-    直到 `hasMore = false`。
-  - 模拟首屏已填满视口（`scrollHeight > clientHeight`）时，不应额外自动加载。
-- 回归：`pnpm test:renderer` 全绿。
+- Potentially `src/renderer/src/stores/ui/session.ts` and store tests if cursor/dedupe behavior needs a small guard.
 
-## 兼容性 / 风险
+## Test strategy
 
-- 分页协议、存储数据、契约类型均不变，无数据迁移。
-- 风险点：自动填充循环若与 cursor 异常叠加可能多拉数据 → 用 `isFilling` 标志 + 轮数上限兜底。
-- 性能：改动 1 减少传输的无关子代理会话，整体更优。
+- Add/adjust renderer component tests for:
+  - auto-fill after a group collapses and visible content no longer fills the viewport
+  - auto-fill after switching to All agents or an agent filter with too few visible items
+  - auto-fill after search filters the visible list down while more pages exist
+  - no extra fetch when `hasMore` is false or a page is already loading
+- Keep existing store tests for `includeSubagents: false` and cursor propagation.
 
-## 质量门禁
+## Validation
 
-实现后执行：`pnpm run format && pnpm run i18n && pnpm run lint && pnpm run typecheck && pnpm test:renderer`
+Run at minimum:
+
+- `pnpm vitest run test/renderer/components/WindowSideBar.test.ts`
+- `pnpm run format`
+- `pnpm run i18n`
+- `pnpm run lint`

--- a/docs/issues/sidebar-history-pagination-stuck/spec.md
+++ b/docs/issues/sidebar-history-pagination-stuck/spec.md
@@ -1,71 +1,50 @@
-# 侧边栏历史会话分页加载卡死
+# Sidebar history pagination remains stuck
 
-> Issue: [#1762](https://github.com/ThinkInAIXYZ/deepchat/issues/1762) `[BUG] 对话历史无法加载`
-> 环境: Windows 11 / DeepChat v1.0.6-beta.5
+## User need
 
-## 背景
+Users with many persisted conversations must be able to browse and search older conversations from the sidebar. The database can contain complete history, but the sidebar currently exposes only the already-loaded subset when pagination does not continue.
 
-用户的数据库中存在 100+ 个 regular 会话（已用数据库修复功能确认数据完整、schema 正常），
-但侧边栏只显示最近十几个会话，滚动到底部不触发"加载更多"，侧边栏搜索也找不到未加载的旧会话。
-用户进一步反馈：在同一个 agent 下新建几个对话后，更早的旧对话也会从侧边栏消失。
+## Problem statement
 
-## 根因
+Issue [#1762](https://github.com/ThinkInAIXYZ/deepchat/issues/1762) reports that historical conversations cannot be loaded even though the database is complete. A prior fix added viewport auto-fill for the case where the first regular-session page does not create a scrollbar. The problem still appears to persist when sidebar height, project/date grouping, collapsed groups, and the All agents view affect the rendered list height and scrollability.
 
-侧边栏分页存在两个相互叠加的缺陷：
+Current behavior to re-check:
 
-1. **页槽被子代理会话浪费**
-   侧边栏首屏与翻页请求 `listLightweight` 时传入 `includeSubagents: true`
-   (`src/renderer/src/stores/ui/session.ts:512`、`:551`)，使后端一页 30 条结果里混入
-   `session_kind = 'subagent'` 的会话；但显示层只渲染 regular 会话
-   (`isRegularSession`，`session.ts:918`/`:930`)。一页 30 条里被子代理占用的名额会被直接过滤掉，
-   导致界面可见的 regular 会话远少于 30。
+- Sidebar pulls lightweight conversation pages from SQLite.
+- Renderer appends pages only when the sidebar scroll container reaches the bottom or auto-fill decides the rendered viewport is not filled.
+- Grouping and collapsed groups can make the rendered content much shorter than the loaded data set.
+- All agents is a UI-level filter over already-loaded sessions, not an independent complete fetch scope.
+- Search is currently local to loaded sidebar sessions, so older database rows cannot be found until pagination reaches them.
+- Runtime comparison showed DB had 52 regular non-draft sessions while the renderer stayed at 30 with `hasMore=true`; `loadNextPage()` failed because Pinia's reactive cursor proxy could not be cloned over IPC.
 
-2. **首屏未填满视口 → 无滚动条 → 永不触发加载更多**
-   `performSessionListScrollCheck` 仅在 `scroll` 事件中调用
-   (`src/renderer/src/components/WindowSideBar.vue:1102-1125`)。当首屏可见 regular 会话过少、
-   列表内容高度 < 容器高度时，不存在可滚动空间，`scroll` 事件永不触发，
-   `loadNextPage()` 永远不会被调用。缺少"加载后检测视口是否填满、未满则继续加载"的自动填充逻辑。
+## Goals
 
-此外，侧边栏搜索 (`WindowSideBar.vue` `matchesSessionSearch`) 仅在已加载的 `sessions.value`
-内存数组中按标题过滤，未接入后端 FTS 搜索，因此未加载的旧会话搜不到。
+1. Ensure sidebar pagination continues until the user can reach older regular conversations.
+2. Make bottom loading robust when rendered height changes because of grouping, collapsed groups, pinning, All agents/agent filter changes, and search filtering.
+3. Keep All agents capable of eventually loading the complete regular-session history rather than stopping at the visible subset.
+4. Preserve the existing lightweight-session paging API and avoid loading message bodies for sidebar browsing.
 
-## 用户故事
+## Acceptance criteria
 
-- 作为用户，当我有上百个历史会话时，**滚动侧边栏应能持续加载更早的会话**，直到全部可见。
-- 作为用户，**首屏应尽量填满可视区域**，而不是只显示十几条后就停住、且没有滚动条。
-- 作为用户，在侧边栏搜索框输入关键词时，**应能命中未加载到前端的历史会话**（次要目标）。
+- Initial sidebar load continues fetching when visible content does not overflow the list container and `hasMore` remains true.
+- Toggling group mode, expanding/collapsing groups, switching All agents vs a specific agent, changing search text, pinning/unpinning, or resizing the sidebar re-runs the pagination fill check.
+- Scrolling near the bottom still requests the next page exactly once per pending page and keeps using the current cursor.
+- All agents view does not become stuck with `hasMore=true` and no further page requests when visible groups are shorter than the viewport.
+- Tests cover the stuck cases caused by collapsed/filtered/grouped visible content, not only the first-page-no-scroll case.
 
-## 验收标准
+## Constraints
 
-1. 数据库有 100+ regular 会话时，侧边栏首屏加载后内容高度应填满（或超过）列表容器高度，
-   存在可滚动空间。
-2. 滚动到列表底部（距底 ≤ 96px）时触发 `loadNextPage`，可持续翻页直到 `hasMore = false`，
-   最终能展示数据库中的全部 regular 会话。
-3. 当首屏返回的 regular 会话不足以填满视口、且 `hasMore = true` 时，应自动继续加载下一页，
-   直到填满视口或无更多数据，无需用户手动滚动。
-4. 侧边栏分页请求不再因子代理会话占用页槽而减少可见 regular 会话数量。
-5. （次要）侧边栏搜索能命中数据库中未加载到前端的会话标题。
-6. 现有 Vitest 套件（`test/main/**`、`test/renderer/**`）全部通过；新增针对分页/自动填充的回归用例。
+- Sidebar list should keep using lightweight session records only.
+- Subagent sessions must not consume visible sidebar page slots unless explicitly requested elsewhere.
+- Do not introduce unbounded eager loading; keep guardrails against cursor stalls or repeated empty pages.
+- Avoid changing database schema for this issue.
 
-## 非目标
+## Non-goals
 
-- 不改动子代理会话本身的存储、级联删除、agent 迁移等业务逻辑
-  （主进程 4 处 `includeSubagents: true` 走 `.list()`，与本修复无关，保持不变）。
-- 不重构 cursor 分页协议（`updatedAt + id` 游标语义保持不变）。
-- 不改变会话分组（time / project）与置顶逻辑。
+- Full global message search redesign.
+- Reworking project group ordering UX.
+- Changing how conversations are stored.
 
-## 约束
+## Open questions
 
-- 遵循 typed route / `renderer/api/*Client` 现有路径，不引入 legacy presenter 调用。
-- 用户可见文案使用 i18n key。
-- 兼容性：分页协议与已存储数据均不变，纯前端/查询行为修正，无数据迁移。
-
-## 影响面评估（已核实）
-
-- `isRegularSession`：仅 `session.ts` 3 处，全部用于侧边栏显示过滤，证明 store 无需子代理数据。
-- `includeSubagents: true`：侧边栏分页 2 处需改；主进程 4 处（agent 迁移/删除/级联删/子会话判断）
-  走 `.list()`，独立且必须保留；DB/契约/类型层为透传，改前端传 `false` 后 DB 正确启用
-  `WHERE session_kind = 'regular'`。
-- 其它 renderer 消费方（`spotlight.ts` 自身已 `.filter(sessionKind !== 'subagent')`）不依赖
-  侧边栏 store 包含子代理会话。
-- 现有测试无断言依赖侧边栏 `listLightweight` 携带子代理，改动安全。
+None for implementation. The intended behavior is: sidebar pagination should be driven by the rendered visible list and user filter changes, and should continue safely while `hasMore` is true and the viewport/bottom condition requires more rows.

--- a/docs/issues/sidebar-history-pagination-stuck/tasks.md
+++ b/docs/issues/sidebar-history-pagination-stuck/tasks.md
@@ -1,34 +1,11 @@
-# 任务拆分：侧边栏历史会话分页加载卡死
+# Tasks
 
-按提交粒度排序，每项可独立 review。
-
-## T1 — 分页停止携带子代理会话（核心，最小修复）
-- [ ] `src/renderer/src/stores/ui/session.ts:512`、`:551` 将 `includeSubagents: true` 改为 `false`
-- [ ] `test/renderer/stores/sessionStore.test.ts` 增断言：分页请求 `includeSubagents === false`，
-      翻页 cursor 推进与 `hasMore` 收敛正确
-- 提交：`fix(session): exclude subagents from sidebar pagination`
-
-## T2 — 侧边栏列表加载后自动填充视口（核心）
-- [ ] `WindowSideBar.vue` 新增 `ensureSessionListFilled()`：
-      `scrollHeight <= clientHeight && hasMore && !loadingMore` 时循环 `loadNextPage()`
-- [ ] 加 `isFilling` 重入防护与轮数上限
-- [ ] 在 `onMounted` 首屏加载后、以及会话列表/agent 过滤变化的 `watch` 中触发复检
-- [ ] `test/renderer/components/WindowSideBar.test.ts` 增用例：
-      - 未填满视口 + `hasMore` → 自动持续加载至 `hasMore=false`
-      - 已填满视口 → 不额外自动加载
-- 提交：`fix(sidebar): auto-fill session list viewport to resume pagination`
-
-## T3 — （次要）侧边栏搜索接入后端 FTS
-- [ ] 搜索关键词非空时调用 `sessionClient.searchHistory(query)`，合并命中会话
-- [ ] 加 debounce
-- [ ] 如需要，`SessionClient.ts` 暴露 `searchHistory`
-- [ ] 增搜索命中未加载会话的用例
-- 提交：`feat(sidebar): search history via backend FTS`
-- 备注：可拆为独立后续 PR，不阻塞 T1+T2 合入
-
-## T4 — 质量门禁与收尾
-- [ ] `pnpm run format && pnpm run i18n && pnpm run lint && pnpm run typecheck`
-- [ ] `pnpm test:renderer`（必要时 `pnpm test`）
-- [ ] PR 描述附 BEFORE/AFTER 行为说明，`Closes #1762`，base 分支 `dev`
-- [ ] 实现完成后按 SDD 保留策略：删除本目录 `plan.md` / `tasks.md`，
-      `spec.md` 作为回归契约保留（两周后若无价值再清理）
+- [x] Re-state issue #1762 after the previous fix and capture the updated failure modes.
+- [x] Inspect current sidebar pagination, grouping, and lightweight session data flow.
+- [x] Add tests that reproduce pagination getting stuck when rendered content changes without a scroll event.
+- [x] Update sidebar pagination triggers so visible-height changes schedule auto-fill checks.
+- [x] Harden the auto-fill loop against cursor stalls without stopping on harmless dedupe.
+- [x] Compare the live renderer state with the local database session list.
+- [x] Clone the next-page cursor before sending it through IPC.
+- [x] Run focused tests.
+- [ ] Run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint`.

--- a/src/renderer/src/components/WindowSideBar.vue
+++ b/src/renderer/src/components/WindowSideBar.vue
@@ -624,6 +624,8 @@ let agentSwitchQueue: Promise<void> = Promise.resolve()
 let remoteControlStatusTimer: ReturnType<typeof setInterval> | null = null
 let pinFeedbackTimer: number | null = null
 let sessionListScrollFrame: number | null = null
+let sessionListFillFrame: number | null = null
+let sessionListResizeObserver: ResizeObserver | null = null
 let shortcutBadgeTimer: number | null = null
 const shortcutPlatform = ref<ShortcutPlatform>(
   navigator.platform.toLowerCase().includes('mac') ? 'mac' : 'other'
@@ -913,8 +915,20 @@ const getShortcutBadgeLabelForSession = (sessionId: string) =>
 const hasShortcutBadgeForSession = (sessionId: string) =>
   showShortcutBadges.value && shortcutBadgeLabelBySessionId.value.has(sessionId)
 
+const scheduleSessionListFillCheck = () => {
+  if (sessionListFillFrame !== null) {
+    return
+  }
+
+  sessionListFillFrame = window.requestAnimationFrame(() => {
+    sessionListFillFrame = null
+    void ensureSessionListFilled()
+  })
+}
+
 const togglePinnedSection = () => {
   isPinnedSectionCollapsed.value = !isPinnedSectionCollapsed.value
+  scheduleSessionListFillCheck()
 }
 
 const toggleGroup = (group: SessionGroup) => {
@@ -928,6 +942,7 @@ const toggleGroup = (group: SessionGroup) => {
   }
 
   collapsedGroupIds.value = nextCollapsedGroupIds
+  scheduleSessionListFillCheck()
 }
 
 const isProjectGroupReorderTarget = (group: SessionGroup) => isActiveProjectDirectoryGroup(group)
@@ -1438,7 +1453,7 @@ const handleSessionListScroll = () => {
 // 这里在加载/过滤变化后主动检测视口是否被填满，未满且仍有更多数据时继续加载。
 let isFillingSessionList = false
 const ensureSessionListFilled = async () => {
-  if (isFillingSessionList || isProjectGroupDragging.value) {
+  if (isFillingSessionList || isProjectGroupDragging.value || collapsed.value) {
     return
   }
   isFillingSessionList = true
@@ -1451,6 +1466,7 @@ const ensureSessionListFilled = async () => {
       if (
         !listElement ||
         isProjectGroupDragging.value ||
+        collapsed.value ||
         !sessionStore.hasMore ||
         sessionStore.loadingMore ||
         sessionStore.loading
@@ -1462,9 +1478,13 @@ const ensureSessionListFilled = async () => {
         return
       }
       const beforeCount = sessionStore.sessions.length
+      const beforeHasMore = sessionStore.hasMore
       await sessionStore.loadNextPage()
-      // 没有新增会话说明已到底或加载失败，停止以防空转。
-      if (sessionStore.sessions.length <= beforeCount) {
+      if (
+        beforeHasMore === sessionStore.hasMore &&
+        sessionStore.hasMore &&
+        sessionStore.sessions.length <= beforeCount
+      ) {
         return
       }
     }
@@ -1473,17 +1493,32 @@ const ensureSessionListFilled = async () => {
   }
 }
 
-// 会话列表内容或 agent 过滤变化后，若视口未被填满则继续加载，
-// 保证「滚动加载更多」在首屏内容过少时也能启动（issue #1762）。
+const visibleSessionFingerprint = computed(() =>
+  [
+    isPinnedSectionCollapsed.value ? 'pinned:collapsed' : 'pinned:expanded',
+    ...pinnedSessions.value.map((session) => `pinned:${session.id}`),
+    ...filteredGroups.value.flatMap((group) => [
+      `group:${getGroupIdentifier(group)}:${isGroupCollapsed(group) ? 'collapsed' : 'expanded'}`,
+      ...(!isGroupCollapsed(group) ? group.sessions.map((session) => session.id) : [])
+    ])
+  ].join('|')
+)
+
+// 会话列表内容、过滤、分组折叠或容器高度变化后，若视口未被填满则继续加载，
+// 保证「滚动加载更多」在首屏内容过少或可见内容被过滤/折叠后也能启动（issue #1762）。
 watch(
   [
     () => sessionStore.sessions.length,
     () => sessionStore.hasMore,
     () => sessionStore.loading,
-    sidebarSelectedAgentId
+    () => sessionStore.groupMode,
+    sidebarSelectedAgentId,
+    normalizedSessionSearchQuery,
+    visibleSessionFingerprint,
+    collapsed
   ],
   () => {
-    void ensureSessionListFilled()
+    scheduleSessionListFillCheck()
   },
   { immediate: true }
 )
@@ -1740,6 +1775,16 @@ onMounted(() => {
   window.addEventListener('blur', handleWindowShortcutBlur)
   document.addEventListener('visibilitychange', handleDocumentVisibilityChange)
 
+  if (typeof ResizeObserver !== 'undefined') {
+    sessionListResizeObserver = new ResizeObserver(() => {
+      scheduleSessionListFillCheck()
+    })
+    if (sessionListRef.value) {
+      sessionListResizeObserver.observe(sessionListRef.value)
+    }
+  }
+
+  scheduleSessionListFillCheck()
   void refreshRemoteControlStatus()
   remoteControlStatusTimer = setInterval(() => {
     void refreshRemoteControlStatus()
@@ -1760,6 +1805,16 @@ onUnmounted(() => {
   if (sessionListScrollFrame !== null) {
     window.cancelAnimationFrame(sessionListScrollFrame)
     sessionListScrollFrame = null
+  }
+
+  if (sessionListFillFrame !== null) {
+    window.cancelAnimationFrame(sessionListFillFrame)
+    sessionListFillFrame = null
+  }
+
+  if (sessionListResizeObserver) {
+    sessionListResizeObserver.disconnect()
+    sessionListResizeObserver = null
   }
 
   pinFlightSessionId.value = null

--- a/src/renderer/src/stores/ui/session.ts
+++ b/src/renderer/src/stores/ui/session.ts
@@ -250,6 +250,12 @@ function mergeSessions(current: UISession[], updates: UISession[]): UISession[] 
   return sortSessions(Array.from(next.values()))
 }
 
+function cloneSessionPageCursor(
+  cursor: { updatedAt: number; id: string } | null
+): { updatedAt: number; id: string } | null {
+  return cursor ? { updatedAt: cursor.updatedAt, id: cursor.id } : null
+}
+
 export const useSessionStore = defineStore('session', () => {
   const sessionClient = createSessionClient()
   const chatClient = createChatClient()
@@ -549,7 +555,7 @@ export const useSessionStore = defineStore('session', () => {
     try {
       const result = await sessionClient.listLightweight({
         limit: DEFAULT_SESSION_PAGE_SIZE,
-        cursor: nextCursor.value,
+        cursor: cloneSessionPageCursor(nextCursor.value),
         // 与首屏一致：仅分页 regular 会话，避免子代理会话占用页槽。
         includeSubagents: false
       })

--- a/test/renderer/components/WindowSideBar.test.ts
+++ b/test/renderer/components/WindowSideBar.test.ts
@@ -77,6 +77,29 @@ const dispatchWindowKeyup = (
     })
   )
 
+const flushSidebarFillFrame = async () => {
+  vi.advanceTimersByTime(16)
+  await flushPromises()
+}
+
+const setSidebarListSize = (
+  wrapper: { get: (selector: string) => { element: Element } },
+  sizes: {
+    scrollHeight: number
+    clientHeight: number
+  }
+) => {
+  const listElement = wrapper.get('.session-list').element
+  Object.defineProperty(listElement, 'scrollHeight', {
+    configurable: true,
+    value: sizes.scrollHeight
+  })
+  Object.defineProperty(listElement, 'clientHeight', {
+    configurable: true,
+    value: sizes.clientHeight
+  })
+}
+
 const mountedWrappers: Array<{ unmount: () => void }> = []
 
 const trackMountedWrapper = <T extends { unmount: () => void }>(wrapper: T): T => {
@@ -1669,7 +1692,7 @@ describe('WindowSideBar viewport auto-fill', () => {
         ]
       })
 
-      await flushPromises()
+      await flushSidebarFillFrame()
 
       // jsdom 下 scrollHeight/clientHeight 均为 0（未填满视口），
       // 自动填充应持续翻页直到 hasMore 收敛为 false。
@@ -1694,9 +1717,82 @@ describe('WindowSideBar viewport auto-fill', () => {
         hasMore: false
       })
 
-      await flushPromises()
+      await flushSidebarFillFrame()
 
       expect(sessionStore.loadNextPage).not.toHaveBeenCalled()
+
+      wrapper.unmount()
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'rechecks pagination after a group collapse makes the visible list too short',
+    async () => {
+      const { wrapper, sessionStore } = await setup({
+        hasMore: true,
+        sessions: [{ id: 'session-1' }, { id: 'session-2' }],
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              { id: 'session-1', title: 'Alpha', status: 'none' },
+              { id: 'session-2', title: 'Bravo', status: 'none' }
+            ]
+          }
+        ],
+        nextPages: [{ items: [{ id: 'session-3' }], hasMore: false }]
+      })
+      setSidebarListSize(wrapper, { scrollHeight: 240, clientHeight: 120 })
+      await flushSidebarFillFrame()
+      expect(sessionStore.loadNextPage).not.toHaveBeenCalled()
+
+      await wrapper.get('[data-group-id="common.time.today"]').trigger('click')
+      setSidebarListSize(wrapper, { scrollHeight: 80, clientHeight: 120 })
+      await flushSidebarFillFrame()
+
+      expect(sessionStore.loadNextPage).toHaveBeenCalledTimes(1)
+      expect(sessionStore.sessions.map((session) => session.id)).toEqual([
+        'session-1',
+        'session-2',
+        'session-3'
+      ])
+
+      wrapper.unmount()
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it(
+    'rechecks pagination when local search filters visible sessions below the viewport',
+    async () => {
+      const { wrapper, sessionStore } = await setup({
+        hasMore: true,
+        sessions: [{ id: 'session-1' }, { id: 'session-2' }],
+        groups: [
+          {
+            id: 'common.time.today',
+            label: 'common.time.today',
+            labelKey: 'common.time.today',
+            sessions: [
+              { id: 'session-1', title: 'Alpha', status: 'none' },
+              { id: 'session-2', title: 'Bravo', status: 'none' }
+            ]
+          }
+        ],
+        nextPages: [{ items: [{ id: 'session-3' }], hasMore: false }]
+      })
+      setSidebarListSize(wrapper, { scrollHeight: 240, clientHeight: 120 })
+      await flushSidebarFillFrame()
+      expect(sessionStore.loadNextPage).not.toHaveBeenCalled()
+
+      await wrapper.get('[data-testid="window-sidebar-search"] input').setValue('missing older')
+      setSidebarListSize(wrapper, { scrollHeight: 60, clientHeight: 120 })
+      await flushSidebarFillFrame()
+
+      expect(sessionStore.loadNextPage).toHaveBeenCalledTimes(1)
 
       wrapper.unmount()
     },

--- a/test/renderer/stores/sessionStore.test.ts
+++ b/test/renderer/stores/sessionStore.test.ts
@@ -1021,10 +1021,13 @@ describe('sessionStore pagination', () => {
     })
     await store.fetchSessions()
 
-    sessionClient.listLightweight.mockResolvedValueOnce({
-      items: [createSession({ id: 'session-b', title: 'Bravo', updatedAt: 20 })],
-      hasMore: false,
-      nextCursor: null
+    sessionClient.listLightweight.mockImplementationOnce(async (input: { cursor?: unknown }) => {
+      structuredClone(input.cursor)
+      return {
+        items: [createSession({ id: 'session-b', title: 'Bravo', updatedAt: 20 })],
+        hasMore: false,
+        nextCursor: null
+      }
     })
     await store.loadNextPage()
 
@@ -1033,6 +1036,7 @@ describe('sessionStore pagination', () => {
       includeSubagents: false,
       cursor: { updatedAt: 30, id: 'session-a' }
     })
+    expect(lastCall.cursor).not.toBe(store.nextCursor?.value)
     expect(store.hasMore.value).toBe(false)
     expect(store.sessions.value.map((session: { id: string }) => session.id)).toEqual([
       'session-a',


### PR DESCRIPTION
## Summary

修复侧边栏历史会话无法加载完整的问题 (#1762, #1800)。

## Root cause

通过对比本地数据库与运行中的 renderer 状态定位到真实根因：

- 数据库 `new_sessions` regular 非 draft 会话：**52 条**
- 运行中 Pinia `session.sessions.length`：只有 **30 条**，且 `hasMore=true`
- 手动调用 `sessionStore.loadNextPage()` 失败：
  `Failed to load more sessions: Error: An object could not be cloned.`

`nextCursor.value` 是 Vue/Pinia reactive proxy，直接通过 IPC bridge 传给 `sessionClient.listLightweight()` 时 structured clone 失败，导致第二页及之后的请求全部失败，侧边栏只能停留在第一页 30 条。

## Changes

- `src/renderer/src/stores/ui/session.ts`
  - 新增 `cloneSessionPageCursor()`，在 `loadNextPage` 请求前把 reactive cursor 克隆为 plain object，避免 IPC structured clone 失败。
- `src/renderer/src/components/WindowSideBar.vue`
  - 扩展自动补拉 watcher，覆盖 group mode、分组折叠、pinned 折叠、搜索过滤、All agents/agent 切换、sidebar collapsed 等可见高度变化来源。
  - group/pinned 折叠展开后主动触发补拉检查。
  - 新增 `ResizeObserver` 监听列表容器高度变化。
  - 加固 `ensureSessionListFilled`，在 collapsed/loading/dragging/hasMore=false 时安全退出。
- 测试：`test/renderer/stores/sessionStore.test.ts`、`test/renderer/components/WindowSideBar.test.ts`
  - 验证下一页 cursor 传入的是克隆对象而非 store 内部引用。
  - 覆盖分组折叠后、搜索过滤后可见列表变短仍能继续分页的场景。

## Verification

- 本地 dev + CDP 实测：reload 后 `session.sessions.length = 52`，`hasMore = false`，DOM 会话项 = 52，与数据库一致。
- `pnpm vitest run test/renderer/stores/sessionStore.test.ts test/renderer/components/WindowSideBar.test.ts` → 70 passed。
- `pnpm run format` / `pnpm run i18n` / `pnpm run lint` / `pnpm run typecheck` 均通过。

Closes #1762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar session pagination so it continues loading when the visible list changes due to grouping, collapsing, or search filtering.
  * Fixed an issue where loading could stall after the first page by ensuring pagination state is passed safely and progress is tracked more reliably.
* **Tests**
  * Added and updated renderer tests to cover auto-fill behavior after layout and filter changes.
* **Documentation**
  * Rewrote the related issue notes, plan, and task checklist in English with updated acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->