### PR TITLE
fix(sqlite): repair fresh schema bootstrap

### DIFF
--- a/docs/issues/sqlite-fresh-schema-bootstrap/plan.md
+++ b/docs/issues/sqlite-fresh-schema-bootstrap/plan.md
@@ -1,0 +1,49 @@
+# SQLite Fresh Schema Bootstrap Plan
+
+## Approach
+
+- Remove the `NewSessionsTable.createTable()` override so new `new_sessions` tables use
+  `BaseTable.createTable()` and the table's latest create SQL.
+- Simplify `DeepChatSessionsTable.createTable()` to keep only the downgrade guard, then create with
+  latest SQL.
+- Keep `SQLitePresenter.migrate()` fresh fast-path unchanged; latest table creation makes the
+  fast-path safe.
+- Extend `DatabaseInitializer.initialize()` to run advisory startup schema checks after basic
+  connectivity and before returning the presenter.
+- Store fresh-install table metadata in the schema catalog, then derive the startup schema catalog
+  from that metadata instead of private denylists.
+- Treat the startup catalog as the single boot-time actionability boundary. The full catalog remains
+  the settings/manual repair boundary.
+
+## Startup Flow
+
+- Construct `SQLitePresenter`.
+- Validate the connection with the existing empty transaction.
+- Run `diagnoseSchema(getStartupSchemaCatalog())`; full catalog diagnosis may still include optional
+  legacy tables in explicit settings/database repair.
+- Continue startup if diagnosis itself fails.
+- If startup repairable issues exist and no repair has been attempted, close the presenter, call
+  `repairSQLiteDatabaseFile()` with the startup catalog, and retry initialization.
+- If construction fails with a classified schema error, use the same startup catalog for the guarded
+  repair retry so boot-time repair stays scoped to fresh-owned tables.
+- If repairable startup issues remain after one repair attempt, log a warning and continue startup.
+- If only manual issues remain, log a warning and continue startup.
+- Reuse the existing `repairAttempted` guard for both construction-time schema errors and
+  diagnosis-time schema drift.
+
+## Compatibility
+
+- Existing historical migration tests remain valid.
+- Already affected databases can be repaired because the startup schema catalog contains repair SQL
+  for the gated `new_sessions` and `deepchat_sessions` columns.
+- Future fields still require updates to latest create SQL, migration SQL, and repair catalog.
+
+## Test Strategy
+
+- Update SQLite integration tests to assert startup-actionable fresh DB schema health and latest
+  gated columns.
+- Add mocked `DatabaseInitializer` tests for diagnosis-driven repair, diagnosis failure,
+  post-repair residual drift, manual-only issues, and healthy startup no-op behavior.
+- Add pure Node tests for fresh-install schema metadata and static guards tying optional legacy
+  tables to catalog definitions and the `initTables()` fresh creation path.
+- Run available targeted tests plus project format, i18n, and lint commands.

--- a/docs/issues/sqlite-fresh-schema-bootstrap/spec.md
+++ b/docs/issues/sqlite-fresh-schema-bootstrap/spec.md
@@ -1,0 +1,50 @@
+# SQLite Fresh Schema Bootstrap
+
+## User Need
+
+Fresh DeepChat installs must create a usable `agent.db` schema on first launch. Existing beta
+databases that were stamped to the latest schema version while missing columns must repair
+automatically during startup.
+
+## Goal
+
+- Fresh `agent.db` creation uses latest schema for active tables.
+- Startup detects repairable schema drift before session creation reaches SQLite writes.
+- Repairable missing tables, columns, and indexes are repaired through the existing database repair
+  service for tables created on fresh install.
+- Startup schema diagnosis is advisory: diagnosis failures, manual schema issues, and repair
+  residuals are logged but do not block opening the app.
+
+## Acceptance Criteria
+
+- A new `agent.db` contains the latest `new_sessions` and `deepchat_sessions` columns immediately
+  after initialization.
+- Fresh startup does not diagnose or auto-repair missing optional legacy conversation tables.
+- A database with latest `schema_versions` but missing `new_sessions.is_draft` is repaired during
+  `DatabaseInitializer.initialize()`.
+- Startup repair attempts are guarded so one initialization call does not create duplicate backups
+  for the same schema drift.
+- Startup health is defined as no startup-actionable schema issues in the fresh-install catalog, not
+  full catalog health; optional legacy conversation tables can remain absent on clean new-stack DBs.
+- If startup diagnosis fails or a one-shot startup repair leaves residual drift, initialization
+  continues so existing in-app repair affordances can still surface later runtime errors.
+- No IPC, route, renderer API, or data model contract changes are required.
+
+## Constraints
+
+- Keep `migrate()` fresh fast-path so new installs do not run historical `ALTER TABLE` steps.
+- Do not solve the native SQLite ABI issue that can skip `sqlitePresenter.test.ts` in some local
+  Vitest environments.
+- Do not add automatic synthesized repair SQL in this change.
+- Keep explicit settings/database repair on the full schema catalog; startup repair intentionally
+  uses the filtered fresh-install catalog.
+
+## Non-Goals
+
+- Changing legacy `conversations` bootstrap behavior.
+- Replacing the existing schema repair service.
+- Adding user-facing settings or prompts.
+
+## Open Questions
+
+None.

--- a/docs/issues/sqlite-fresh-schema-bootstrap/tasks.md
+++ b/docs/issues/sqlite-fresh-schema-bootstrap/tasks.md
@@ -1,0 +1,10 @@
+# SQLite Fresh Schema Bootstrap Tasks
+
+- [x] Document the issue and implementation plan.
+- [x] Make fresh `new_sessions` and `deepchat_sessions` creation use latest schema.
+- [x] Add startup schema diagnosis and guarded repair in `DatabaseInitializer`.
+- [x] Add focused regression tests.
+- [x] Run formatting, i18n, lint, and targeted checks.
+- [x] Make startup schema diagnosis advisory and non-blocking.
+- [x] Scope startup diagnosis and repair through schema catalog fresh-install metadata.
+- [x] Add startup schema catalog guard comments and pure Node drift tests.

--- a/src/main/presenter/lifecyclePresenter/DatabaseInitializer.ts
+++ b/src/main/presenter/lifecyclePresenter/DatabaseInitializer.ts
@@ -1,4 +1,5 @@
 import logger from '@shared/logger'
+import type { DatabaseSchemaDiagnosis, DatabaseSchemaIssue } from '@shared/presenter'
 import { app } from 'electron'
 import path from 'path'
 import {
@@ -6,7 +7,9 @@ import {
   repairSQLiteDatabaseFile,
   SQLitePresenter
 } from '@/presenter/sqlitePresenter'
+import { getStartupSchemaCatalog } from '@/presenter/sqlitePresenter/schemaCatalog'
 import { classifySchemaError } from '@/presenter/sqlitePresenter/schemaErrorClassifier'
+import type { SchemaTableSpec } from '@/presenter/sqlitePresenter/schemaTypes'
 
 /**
  * Database initialization interface
@@ -51,6 +54,41 @@ export class DatabaseInitializer implements IDatabaseInitializer {
             throw new Error('Database connection validation failed')
           }
 
+          // Startup checks use the fresh-install catalog so automatic repair does not create
+          // retired legacy conversation tables. Manual settings repair still uses the full catalog.
+          const startupDiagnosis = await this.diagnoseStartupSchema()
+          if (!startupDiagnosis) {
+            logger.info('DatabaseInitializer: Database initialization completed successfully')
+            return this.database
+          }
+
+          const { catalog, diagnosis } = startupDiagnosis
+          if (diagnosis.repairableIssues.length > 0) {
+            if (repairAttempted) {
+              console.warn(
+                `DatabaseInitializer: Startup schema repair left repairable issues; continuing initialization: ${this.formatSchemaIssues(
+                  diagnosis.repairableIssues
+                )}`
+              )
+              this.warnManualSchemaIssues(diagnosis)
+              logger.info('DatabaseInitializer: Database initialization completed successfully')
+              return this.database
+            }
+
+            repairAttempted = true
+            console.warn(
+              `DatabaseInitializer: Attempting one-off schema repair for ${this.formatSchemaIssues(
+                diagnosis.repairableIssues
+              )}`
+            )
+            this.database.close()
+            this.database = undefined
+            repairSQLiteDatabaseFile(this.dbPath, this.password, { catalog })
+            continue
+          }
+
+          this.warnManualSchemaIssues(diagnosis)
+
           logger.info('DatabaseInitializer: Database initialization completed successfully')
           return this.database
         } catch (error) {
@@ -69,7 +107,11 @@ export class DatabaseInitializer implements IDatabaseInitializer {
           console.warn(
             `DatabaseInitializer: Attempting one-off schema repair for ${classified.dedupeKey}`
           )
-          repairSQLiteDatabaseFile(this.dbPath, this.password)
+          // Construction-time schema failures use the same startup catalog for the same reason:
+          // keep boot-time repair scoped to tables that fresh initialization owns.
+          repairSQLiteDatabaseFile(this.dbPath, this.password, {
+            catalog: getStartupSchemaCatalog()
+          })
         }
       }
     } catch (error) {
@@ -113,5 +155,47 @@ export class DatabaseInitializer implements IDatabaseInitializer {
       console.error('DatabaseInitializer: Connection validation failed:', error)
       return false
     }
+  }
+
+  private formatSchemaIssues(issues: DatabaseSchemaIssue[]): string {
+    return issues
+      .map((issue) => `${issue.kind}:${issue.table}.${issue.name}`)
+      .slice(0, 8)
+      .join(', ')
+  }
+
+  private async diagnoseStartupSchema(): Promise<{
+    catalog: SchemaTableSpec[]
+    diagnosis: DatabaseSchemaDiagnosis
+  } | null> {
+    if (!this.database) {
+      return null
+    }
+
+    try {
+      const catalog = getStartupSchemaCatalog()
+      return {
+        catalog,
+        diagnosis: await this.database.diagnoseSchema(catalog)
+      }
+    } catch (error) {
+      console.warn(
+        'DatabaseInitializer: Startup schema diagnosis failed; continuing startup:',
+        error
+      )
+      return null
+    }
+  }
+
+  private warnManualSchemaIssues(diagnosis: DatabaseSchemaDiagnosis): void {
+    if (diagnosis.manualIssues.length === 0) {
+      return
+    }
+
+    console.warn(
+      `DatabaseInitializer: Manual database schema action may be required: ${this.formatSchemaIssues(
+        diagnosis.manualIssues
+      )}`
+    )
   }
 }

--- a/src/main/presenter/lifecyclePresenter/DatabaseInitializer.ts
+++ b/src/main/presenter/lifecyclePresenter/DatabaseInitializer.ts
@@ -71,7 +71,9 @@ export class DatabaseInitializer implements IDatabaseInitializer {
                 )}`
               )
               this.warnManualSchemaIssues(diagnosis)
-              logger.info('DatabaseInitializer: Database initialization completed successfully')
+              logger.info(
+                'DatabaseInitializer: Database initialization continued with residual startup schema issues'
+              )
               return this.database
             }
 

--- a/src/main/presenter/sqlitePresenter/index.ts
+++ b/src/main/presenter/sqlitePresenter/index.ts
@@ -43,6 +43,7 @@ import { NewSessionActiveSkillsTable } from './tables/newSessionActiveSkills'
 import { NewSessionDisabledAgentToolsTable } from './tables/newSessionDisabledAgentTools'
 import { SettingsActivityTable } from './tables/settingsActivity'
 import { DatabaseRepairService, SchemaInspector } from './schemaRepair'
+import type { SchemaTableSpec } from './schemaTypes'
 import type { SettingsActivityInput, SettingsActivityRecord } from '@shared/contracts/routes'
 import { configureSQLiteConnection } from './connectionConfig'
 import { LegacyChatImportService } from '../agentSessionPresenter/legacyImportService'
@@ -85,11 +86,17 @@ export function openSQLiteDatabase(dbPath: string, password?: string): Database.
   return db
 }
 
-export function repairSQLiteDatabaseFile(dbPath: string, password?: string): DatabaseRepairReport {
+export function repairSQLiteDatabaseFile(
+  dbPath: string,
+  password?: string,
+  options?: {
+    catalog?: SchemaTableSpec[]
+  }
+): DatabaseRepairReport {
   const db = openSQLiteDatabase(dbPath, password)
 
   try {
-    return new DatabaseRepairService(db, dbPath).repair()
+    return new DatabaseRepairService(db, dbPath, options?.catalog).repair()
   } finally {
     db.close()
   }
@@ -279,8 +286,8 @@ export class SQLitePresenter implements ISQLitePresenter {
     this.reopen()
   }
 
-  public async diagnoseSchema(): Promise<DatabaseSchemaDiagnosis> {
-    return new SchemaInspector(this.db).diagnose()
+  public async diagnoseSchema(catalog?: SchemaTableSpec[]): Promise<DatabaseSchemaDiagnosis> {
+    return new SchemaInspector(this.db, catalog).diagnose()
   }
 
   public async repairSchema(): Promise<DatabaseRepairReport> {

--- a/src/main/presenter/sqlitePresenter/index.ts
+++ b/src/main/presenter/sqlitePresenter/index.ts
@@ -42,6 +42,7 @@ import { ConfigTables } from './tables/configTables'
 import { NewSessionActiveSkillsTable } from './tables/newSessionActiveSkills'
 import { NewSessionDisabledAgentToolsTable } from './tables/newSessionDisabledAgentTools'
 import { SettingsActivityTable } from './tables/settingsActivity'
+import type { BaseTable } from './tables/baseTable'
 import { DatabaseRepairService, SchemaInspector } from './schemaRepair'
 import type { SchemaTableSpec } from './schemaTypes'
 import type { SettingsActivityInput, SettingsActivityRecord } from '@shared/contracts/routes'
@@ -281,6 +282,13 @@ export class SQLitePresenter implements ISQLitePresenter {
     return this.password
   }
 
+  public getLatestSchemaVersion(): number {
+    return this.getMigrationTables().reduce((maxVersion, table) => {
+      const tableMaxVersion = table.getLatestVersion()
+      return Math.max(maxVersion, tableMaxVersion)
+    }, 0)
+  }
+
   public reopenWithPassword(password?: string): void {
     this.password = password
     this.reopen()
@@ -472,10 +480,8 @@ export class SQLitePresenter implements ISQLitePresenter {
     this.currentVersion = result?.version || 0
   }
 
-  private migrate() {
-    // 获取所有表的迁移脚本
-    const migrations = new Map<number, string[]>()
-    const tables = [
+  private getMigrationTables(): BaseTable[] {
+    return [
       this.acpSessionsTable,
       this.newEnvironmentsTable,
       this.newEnvironmentPreferencesTable,
@@ -503,12 +509,15 @@ export class SQLitePresenter implements ISQLitePresenter {
       this.newSessionDisabledAgentToolsTable,
       this.settingsActivityTable
     ]
+  }
+
+  private migrate() {
+    // 获取所有表的迁移脚本
+    const migrations = new Map<number, string[]>()
+    const tables = this.getMigrationTables()
 
     // 获取最新的迁移版本
-    const latestVersion = tables.reduce((maxVersion, table) => {
-      const tableMaxVersion = table.getLatestVersion?.() || 0
-      return Math.max(maxVersion, tableMaxVersion)
-    }, 0)
+    const latestVersion = this.getLatestSchemaVersion()
 
     if (!this.databaseFileExistedBeforeOpen && this.currentVersion === 0 && latestVersion > 0) {
       this.db

--- a/src/main/presenter/sqlitePresenter/schemaCatalog.ts
+++ b/src/main/presenter/sqlitePresenter/schemaCatalog.ts
@@ -30,10 +30,14 @@ import { NewSessionDisabledAgentToolsTable } from './tables/newSessionDisabledAg
 import { SettingsActivityTable } from './tables/settingsActivity'
 import type { BaseTable } from './tables/baseTable'
 import type { SchemaTableSpec } from './schemaTypes'
+import { isSchemaTableCreatedOnFreshInstall } from './schemaCatalogMetadata'
 
 interface CatalogDefinition {
   name: string
   createTable: (db: Database.Database) => BaseTable
+  // Per-table override for exceptional cases. When omitted, schemaCatalogMetadata.ts decides
+  // whether the table belongs to the fresh startup catalog.
+  createdOnFreshInstall?: boolean
   repairableColumns?: Record<string, string>
   typeCheckedColumns?: string[]
   afterRepair?: (db: Database.Database) => void
@@ -286,6 +290,10 @@ export function getSchemaCatalog(): SchemaTableSpec[] {
       return {
         name: definition.name,
         createSql,
+        // Explicit catalog definitions win; otherwise the shared metadata supplies the startup
+        // diagnosis/repair default.
+        createdOnFreshInstall:
+          definition.createdOnFreshInstall ?? isSchemaTableCreatedOnFreshInstall(definition.name),
         columns: columns.map((column) => ({
           name: column.name,
           declaredType: normalizeDeclaredType(column.type),
@@ -304,4 +312,8 @@ export function getSchemaCatalog(): SchemaTableSpec[] {
   } finally {
     catalogDb.close()
   }
+}
+
+export function getStartupSchemaCatalog(): SchemaTableSpec[] {
+  return getSchemaCatalog().filter((table) => table.createdOnFreshInstall)
 }

--- a/src/main/presenter/sqlitePresenter/schemaCatalogMetadata.ts
+++ b/src/main/presenter/sqlitePresenter/schemaCatalogMetadata.ts
@@ -1,0 +1,20 @@
+// These catalog tables still exist for legacy/manual repair, but fresh new-stack startup does not
+// create them in SQLitePresenter.initTables(). Keep this list in sync with that fresh create path so
+// startup diagnosis and repair do not materialize retired legacy tables automatically.
+export const SCHEMA_TABLES_NOT_CREATED_ON_FRESH_INSTALL = [
+  'conversations',
+  'messages',
+  'message_attachments'
+] as const
+
+const schemaTablesNotCreatedOnFreshInstall = new Set<string>(
+  SCHEMA_TABLES_NOT_CREATED_ON_FRESH_INSTALL
+)
+
+export function isSchemaTableCreatedOnFreshInstall(tableName: string): boolean {
+  return !schemaTablesNotCreatedOnFreshInstall.has(tableName)
+}
+
+export function getSchemaTablesNotCreatedOnFreshInstall(): string[] {
+  return [...SCHEMA_TABLES_NOT_CREATED_ON_FRESH_INSTALL]
+}

--- a/src/main/presenter/sqlitePresenter/schemaTypes.ts
+++ b/src/main/presenter/sqlitePresenter/schemaTypes.ts
@@ -15,6 +15,7 @@ export interface SchemaIndexSpec {
 export interface SchemaTableSpec {
   name: string
   createSql: string
+  createdOnFreshInstall: boolean
   columns: SchemaColumnSpec[]
   indexes: SchemaIndexSpec[]
   afterRepair?: (db: Database.Database) => void

--- a/src/main/presenter/sqlitePresenter/tables/deepchatSessions.ts
+++ b/src/main/presenter/sqlitePresenter/tables/deepchatSessions.ts
@@ -87,7 +87,7 @@ export class DeepChatSessionsTable extends BaseTable {
       throw new Error(message)
     }
 
-    this.db.exec(this.getCreateTableSQLForVersion(recordedVersion))
+    this.db.exec(this.getCreateTableSQL())
   }
 
   private getCreateTableSQLForVersion(version: number): string {

--- a/src/main/presenter/sqlitePresenter/tables/newSessions.ts
+++ b/src/main/presenter/sqlitePresenter/tables/newSessions.ts
@@ -37,14 +37,6 @@ export class NewSessionsTable extends BaseTable {
     return this.getCreateTableSQLForVersion(this.getLatestVersion())
   }
 
-  override createTable(): void {
-    if (this.tableExists()) {
-      return
-    }
-
-    this.db.exec(this.getCreateTableSQLForVersion(this.getRecordedSchemaVersion()))
-  }
-
   private getCreateTableSQLForVersion(version: number): string {
     const columns = [
       'id TEXT PRIMARY KEY',

--- a/test/main/presenter/lifecyclePresenter/DatabaseInitializer.test.ts
+++ b/test/main/presenter/lifecyclePresenter/DatabaseInitializer.test.ts
@@ -1,5 +1,77 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const startupSchemaCatalog = [
+  {
+    name: 'new_sessions'
+  },
+  {
+    name: 'deepchat_sessions'
+  }
+]
+
+const healthyDiagnosis = {
+  checkedAt: 1,
+  isHealthy: true,
+  issues: [],
+  repairableIssues: [],
+  manualIssues: []
+}
+
+const missingDraftIssue = {
+  kind: 'missing_column',
+  table: 'new_sessions',
+  name: 'is_draft',
+  repairable: true,
+  message: 'Missing column "new_sessions.is_draft".',
+  expectedType: 'INTEGER',
+  actualType: null
+}
+
+async function createInitializerWithMocks(input: {
+  SQLitePresenter: ReturnType<typeof vi.fn>
+  repairSQLiteDatabaseFile?: ReturnType<typeof vi.fn>
+  isDestructiveDatabaseError?: ReturnType<typeof vi.fn>
+  classifySchemaError?: ReturnType<typeof vi.fn>
+  getStartupSchemaCatalog?: ReturnType<typeof vi.fn>
+}) {
+  const repairSQLiteDatabaseFile = input.repairSQLiteDatabaseFile ?? vi.fn()
+  const isDestructiveDatabaseError =
+    input.isDestructiveDatabaseError ?? vi.fn().mockReturnValue(false)
+  const classifySchemaError = input.classifySchemaError ?? vi.fn().mockReturnValue(null)
+  const getStartupSchemaCatalog =
+    input.getStartupSchemaCatalog ?? vi.fn().mockReturnValue(startupSchemaCatalog)
+
+  vi.doMock('electron', () => ({
+    app: {
+      getPath: vi.fn().mockReturnValue('C:/Users/test/AppData/Roaming/DeepChat')
+    }
+  }))
+  vi.doMock('@/presenter/sqlitePresenter', () => ({
+    SQLitePresenter: input.SQLitePresenter,
+    repairSQLiteDatabaseFile,
+    isDestructiveDatabaseError
+  }))
+  vi.doMock('@/presenter/sqlitePresenter/schemaCatalog', () => ({
+    getStartupSchemaCatalog
+  }))
+  vi.doMock('@/presenter/sqlitePresenter/schemaErrorClassifier', () => ({
+    classifySchemaError
+  }))
+
+  const { DatabaseInitializer } =
+    await import('../../../../src/main/presenter/lifecyclePresenter/DatabaseInitializer')
+
+  return {
+    initializer: new DatabaseInitializer({
+      dbPath: 'C:/tmp/deepchat-agent.db'
+    }),
+    repairSQLiteDatabaseFile,
+    isDestructiveDatabaseError,
+    classifySchemaError,
+    getStartupSchemaCatalog
+  }
+}
+
 describe('DatabaseInitializer', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -8,6 +80,7 @@ describe('DatabaseInitializer', () => {
   it('attempts one schema repair and retries initialization for repairable schema errors', async () => {
     const presenterInstance = {
       runTransaction: vi.fn().mockResolvedValue(undefined),
+      diagnoseSchema: vi.fn().mockResolvedValue(healthyDiagnosis),
       close: vi.fn()
     }
 
@@ -17,38 +90,167 @@ describe('DatabaseInitializer', () => {
         throw new Error('table deepchat_sessions has no column named reasoning_visibility')
       })
       .mockImplementationOnce(() => presenterInstance)
-    const repairSQLiteDatabaseFile = vi.fn()
-    const isDestructiveDatabaseError = vi.fn().mockReturnValue(false)
     const classifySchemaError = vi.fn().mockReturnValue({
       reason: 'missing-column',
       dedupeKey: 'missing-column:reasoning_visibility'
     })
 
-    vi.doMock('electron', () => ({
-      app: {
-        getPath: vi.fn().mockReturnValue('C:/Users/test/AppData/Roaming/DeepChat')
-      }
-    }))
-    vi.doMock('@/presenter/sqlitePresenter', () => ({
+    const { initializer, repairSQLiteDatabaseFile } = await createInitializerWithMocks({
       SQLitePresenter,
-      repairSQLiteDatabaseFile,
-      isDestructiveDatabaseError
-    }))
-    vi.doMock('@/presenter/sqlitePresenter/schemaErrorClassifier', () => ({
       classifySchemaError
-    }))
-
-    const { DatabaseInitializer } =
-      await import('../../../../src/main/presenter/lifecyclePresenter/DatabaseInitializer')
-
-    const initializer = new DatabaseInitializer({
-      dbPath: 'C:/tmp/deepchat-agent.db'
     })
     const result = await initializer.initialize()
 
     expect(SQLitePresenter).toHaveBeenCalledTimes(2)
     expect(repairSQLiteDatabaseFile).toHaveBeenCalledTimes(1)
-    expect(repairSQLiteDatabaseFile).toHaveBeenCalledWith('C:/tmp/deepchat-agent.db', undefined)
+    expect(repairSQLiteDatabaseFile).toHaveBeenCalledWith('C:/tmp/deepchat-agent.db', undefined, {
+      catalog: startupSchemaCatalog
+    })
+    expect(presenterInstance.diagnoseSchema).toHaveBeenCalledWith(startupSchemaCatalog)
+    expect(result).toBe(presenterInstance)
+  })
+
+  it('does not repair healthy schema after successful initialization', async () => {
+    const presenterInstance = {
+      runTransaction: vi.fn().mockResolvedValue(undefined),
+      diagnoseSchema: vi.fn().mockResolvedValue(healthyDiagnosis),
+      close: vi.fn()
+    }
+
+    const SQLitePresenter = vi.fn().mockImplementation(() => presenterInstance)
+    const { initializer, repairSQLiteDatabaseFile } = await createInitializerWithMocks({
+      SQLitePresenter
+    })
+    const result = await initializer.initialize()
+
+    expect(SQLitePresenter).toHaveBeenCalledTimes(1)
+    expect(presenterInstance.diagnoseSchema).toHaveBeenCalledWith(startupSchemaCatalog)
+    expect(repairSQLiteDatabaseFile).not.toHaveBeenCalled()
+    expect(result).toBe(presenterInstance)
+  })
+
+  it('continues startup when schema diagnosis fails', async () => {
+    const presenterInstance = {
+      runTransaction: vi.fn().mockResolvedValue(undefined),
+      diagnoseSchema: vi.fn().mockRejectedValue(new Error('database is locked')),
+      close: vi.fn()
+    }
+
+    const SQLitePresenter = vi.fn().mockImplementation(() => presenterInstance)
+    const { initializer, repairSQLiteDatabaseFile } = await createInitializerWithMocks({
+      SQLitePresenter
+    })
+    const result = await initializer.initialize()
+
+    expect(SQLitePresenter).toHaveBeenCalledTimes(1)
+    expect(repairSQLiteDatabaseFile).not.toHaveBeenCalled()
+    expect(presenterInstance.close).not.toHaveBeenCalled()
+    expect(result).toBe(presenterInstance)
+  })
+
+  it('repairs diagnosed schema drift and retries initialization', async () => {
+    const driftedPresenter = {
+      runTransaction: vi.fn().mockResolvedValue(undefined),
+      diagnoseSchema: vi.fn().mockResolvedValue({
+        checkedAt: 1,
+        isHealthy: false,
+        issues: [missingDraftIssue],
+        repairableIssues: [missingDraftIssue],
+        manualIssues: []
+      }),
+      close: vi.fn()
+    }
+    const repairedPresenter = {
+      runTransaction: vi.fn().mockResolvedValue(undefined),
+      diagnoseSchema: vi.fn().mockResolvedValue(healthyDiagnosis),
+      close: vi.fn()
+    }
+
+    const SQLitePresenter = vi
+      .fn()
+      .mockImplementationOnce(() => driftedPresenter)
+      .mockImplementationOnce(() => repairedPresenter)
+
+    const { initializer, repairSQLiteDatabaseFile } = await createInitializerWithMocks({
+      SQLitePresenter
+    })
+    const result = await initializer.initialize()
+
+    expect(SQLitePresenter).toHaveBeenCalledTimes(2)
+    expect(driftedPresenter.diagnoseSchema).toHaveBeenCalledWith(startupSchemaCatalog)
+    expect(driftedPresenter.close).toHaveBeenCalledTimes(1)
+    expect(repairSQLiteDatabaseFile).toHaveBeenCalledTimes(1)
+    expect(repairSQLiteDatabaseFile).toHaveBeenCalledWith('C:/tmp/deepchat-agent.db', undefined, {
+      catalog: startupSchemaCatalog
+    })
+    expect(result).toBe(repairedPresenter)
+  })
+
+  it('continues startup if repairable schema drift remains after one repair attempt', async () => {
+    const driftDiagnosis = {
+      checkedAt: 1,
+      isHealthy: false,
+      issues: [missingDraftIssue],
+      repairableIssues: [missingDraftIssue],
+      manualIssues: []
+    }
+    const driftedPresenter = {
+      runTransaction: vi.fn().mockResolvedValue(undefined),
+      diagnoseSchema: vi.fn().mockResolvedValue(driftDiagnosis),
+      close: vi.fn()
+    }
+    const stillDriftedPresenter = {
+      runTransaction: vi.fn().mockResolvedValue(undefined),
+      diagnoseSchema: vi.fn().mockResolvedValue(driftDiagnosis),
+      close: vi.fn()
+    }
+
+    const SQLitePresenter = vi
+      .fn()
+      .mockImplementationOnce(() => driftedPresenter)
+      .mockImplementationOnce(() => stillDriftedPresenter)
+
+    const { initializer, repairSQLiteDatabaseFile } = await createInitializerWithMocks({
+      SQLitePresenter
+    })
+    const result = await initializer.initialize()
+
+    expect(SQLitePresenter).toHaveBeenCalledTimes(2)
+    expect(repairSQLiteDatabaseFile).toHaveBeenCalledTimes(1)
+    expect(stillDriftedPresenter.close).not.toHaveBeenCalled()
+    expect(result).toBe(stillDriftedPresenter)
+  })
+
+  it('allows manual schema issues without automatic repair', async () => {
+    const manualIssue = {
+      kind: 'column_type_mismatch',
+      table: 'new_sessions',
+      name: 'session_kind',
+      repairable: false,
+      message: 'Column "new_sessions.session_kind" has unexpected type.',
+      expectedType: 'TEXT',
+      actualType: 'INTEGER'
+    }
+    const presenterInstance = {
+      runTransaction: vi.fn().mockResolvedValue(undefined),
+      diagnoseSchema: vi.fn().mockResolvedValue({
+        checkedAt: 1,
+        isHealthy: false,
+        issues: [manualIssue],
+        repairableIssues: [],
+        manualIssues: [manualIssue]
+      }),
+      close: vi.fn()
+    }
+
+    const SQLitePresenter = vi.fn().mockImplementation(() => presenterInstance)
+    const { initializer, repairSQLiteDatabaseFile } = await createInitializerWithMocks({
+      SQLitePresenter
+    })
+    const result = await initializer.initialize()
+
+    expect(SQLitePresenter).toHaveBeenCalledTimes(1)
+    expect(repairSQLiteDatabaseFile).not.toHaveBeenCalled()
     expect(result).toBe(presenterInstance)
   })
 
@@ -56,32 +258,16 @@ describe('DatabaseInitializer', () => {
     const SQLitePresenter = vi.fn().mockImplementation(() => {
       throw new Error('database disk image is malformed')
     })
-    const repairSQLiteDatabaseFile = vi.fn()
     const isDestructiveDatabaseError = vi.fn().mockReturnValue(true)
     const classifySchemaError = vi.fn().mockReturnValue({
       reason: 'missing-table',
       dedupeKey: 'missing-table:deepchat_sessions'
     })
 
-    vi.doMock('electron', () => ({
-      app: {
-        getPath: vi.fn().mockReturnValue('C:/Users/test/AppData/Roaming/DeepChat')
-      }
-    }))
-    vi.doMock('@/presenter/sqlitePresenter', () => ({
+    const { initializer, repairSQLiteDatabaseFile } = await createInitializerWithMocks({
       SQLitePresenter,
-      repairSQLiteDatabaseFile,
-      isDestructiveDatabaseError
-    }))
-    vi.doMock('@/presenter/sqlitePresenter/schemaErrorClassifier', () => ({
+      isDestructiveDatabaseError,
       classifySchemaError
-    }))
-
-    const { DatabaseInitializer } =
-      await import('../../../../src/main/presenter/lifecyclePresenter/DatabaseInitializer')
-
-    const initializer = new DatabaseInitializer({
-      dbPath: 'C:/tmp/deepchat-agent.db'
     })
 
     await expect(initializer.initialize()).rejects.toThrow('database disk image is malformed')

--- a/test/main/presenter/sqlitePresenter.test.ts
+++ b/test/main/presenter/sqlitePresenter.test.ts
@@ -12,8 +12,14 @@ const sqliteModule = await import('better-sqlite3-multiple-ciphers').catch(() =>
 const sqlitePresenterModule = sqliteModule
   ? await import('../../../src/main/presenter/sqlitePresenter').catch(() => null)
   : null
+const schemaCatalogModule = sqliteModule
+  ? await import('../../../src/main/presenter/sqlitePresenter/schemaCatalog').catch(() => null)
+  : null
 const Database = sqliteModule?.default
 const SQLitePresenter = sqlitePresenterModule?.SQLitePresenter
+const getStartupSchemaCatalog = schemaCatalogModule?.getStartupSchemaCatalog
+const sqliteSkipReason = 'skipped: better-sqlite3-multiple-ciphers is unavailable'
+const requireNativeSqlite = process.env.DEEPCHAT_REQUIRE_NATIVE_SQLITE === '1'
 let sqliteAvailable = false
 if (Database) {
   try {
@@ -26,7 +32,20 @@ if (Database) {
 }
 const DatabaseCtor = Database!
 const SQLitePresenterCtor = SQLitePresenter!
-const describeIfSqlite = sqliteAvailable && SQLitePresenter ? describe : describe.skip
+const sqliteHarnessAvailable = sqliteAvailable && SQLitePresenter && getStartupSchemaCatalog
+const sqliteHarnessSkipReason = sqliteAvailable
+  ? 'skipped: SQLitePresenter startup schema catalog is unavailable'
+  : sqliteSkipReason
+const describeIfSqlite = sqliteHarnessAvailable
+  ? describe
+  : requireNativeSqlite
+    ? (name: string, _suite: () => void) =>
+        describe(name, () => {
+          it('requires native SQLite support', () => {
+            throw new Error(sqliteHarnessSkipReason)
+          })
+        })
+    : describe.skip
 
 describeIfSqlite('SQLitePresenter legacy schema bootstrap', () => {
   const tempDirs: string[] = []
@@ -131,19 +150,29 @@ describeIfSqlite('SQLitePresenter legacy schema bootstrap', () => {
     checkDb.close()
   })
 
-  it('creates fresh new_sessions tables with disabled_agent_tools column', async () => {
+  it('creates fresh session tables with latest schema columns', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-sqlite-presenter-'))
     tempDirs.push(tempDir)
 
     const dbPath = path.join(tempDir, 'agent.db')
     const presenter = new SQLitePresenterCtor(dbPath)
+    const diagnosis = await presenter.diagnoseSchema()
     presenter.close()
+
+    const startupSchemaTableNames = new Set(getStartupSchemaCatalog!().map((table) => table.name))
+    expect(diagnosis.issues.filter((issue) => startupSchemaTableNames.has(issue.table))).toEqual([])
 
     const checkDb = new DatabaseCtor(dbPath)
     const newSessionColumns = checkDb.prepare('PRAGMA table_info(new_sessions)').all() as Array<{
       name: string
     }>
     const columnNames = new Set(newSessionColumns.map((column) => column.name))
+    const deepchatSessionColumns = checkDb
+      .prepare('PRAGMA table_info(deepchat_sessions)')
+      .all() as Array<{
+      name: string
+    }>
+    const deepchatColumnNames = new Set(deepchatSessionColumns.map((column) => column.name))
     const environmentColumns = checkDb
       .prepare('PRAGMA table_info(new_environments)')
       .all() as Array<{
@@ -154,12 +183,27 @@ describeIfSqlite('SQLitePresenter legacy schema bootstrap', () => {
     expect(columnNames.has('is_draft')).toBe(true)
     expect(columnNames.has('active_skills')).toBe(true)
     expect(columnNames.has('disabled_agent_tools')).toBe(true)
+    expect(columnNames.has('subagent_enabled')).toBe(true)
+    expect(columnNames.has('session_kind')).toBe(true)
+    expect(columnNames.has('parent_session_id')).toBe(true)
+    expect(columnNames.has('subagent_meta_json')).toBe(true)
+    expect(deepchatColumnNames.has('system_prompt')).toBe(true)
+    expect(deepchatColumnNames.has('summary_text')).toBe(true)
+    expect(deepchatColumnNames.has('summary_cursor_order_seq')).toBe(true)
+    expect(deepchatColumnNames.has('force_interleaved_thinking_compat')).toBe(true)
+    expect(deepchatColumnNames.has('reasoning_visibility')).toBe(true)
+    expect(deepchatColumnNames.has('timeout_ms')).toBe(true)
+    expect(deepchatColumnNames.has('image_generation_options_json')).toBe(true)
+    expect(deepchatColumnNames.has('video_generation_options_json')).toBe(true)
+    expect(deepchatColumnNames.has('top_p')).toBe(true)
+    expect(deepchatColumnNames.has('memory_cursor_order_seq')).toBe(true)
     expect(environmentColumnNames).toEqual(new Set(['path', 'session_count', 'last_used_at']))
 
     const versions = checkDb
       .prepare('SELECT version FROM schema_versions ORDER BY version ASC')
       .all() as Array<{ version: number }>
-    expect(versions.map((row) => row.version)).toEqual(expect.arrayContaining([11, 15, 16, 17]))
+    expect(versions).toHaveLength(1)
+    expect(versions[0].version).toBeGreaterThan(0)
     checkDb.close()
   })
 

--- a/test/main/presenter/sqlitePresenter.test.ts
+++ b/test/main/presenter/sqlitePresenter.test.ts
@@ -156,11 +156,11 @@ describeIfSqlite('SQLitePresenter legacy schema bootstrap', () => {
 
     const dbPath = path.join(tempDir, 'agent.db')
     const presenter = new SQLitePresenterCtor(dbPath)
-    const diagnosis = await presenter.diagnoseSchema()
+    const diagnosis = await presenter.diagnoseSchema(getStartupSchemaCatalog!())
+    const latestSchemaVersion = presenter.getLatestSchemaVersion()
     presenter.close()
 
-    const startupSchemaTableNames = new Set(getStartupSchemaCatalog!().map((table) => table.name))
-    expect(diagnosis.issues.filter((issue) => startupSchemaTableNames.has(issue.table))).toEqual([])
+    expect(diagnosis.issues).toEqual([])
 
     const checkDb = new DatabaseCtor(dbPath)
     const newSessionColumns = checkDb.prepare('PRAGMA table_info(new_sessions)').all() as Array<{
@@ -202,8 +202,7 @@ describeIfSqlite('SQLitePresenter legacy schema bootstrap', () => {
     const versions = checkDb
       .prepare('SELECT version FROM schema_versions ORDER BY version ASC')
       .all() as Array<{ version: number }>
-    expect(versions).toHaveLength(1)
-    expect(versions[0].version).toBeGreaterThan(0)
+    expect(versions).toEqual([{ version: latestSchemaVersion }])
     checkDb.close()
   })
 

--- a/test/main/presenter/sqlitePresenter/schemaCatalogMetadata.test.ts
+++ b/test/main/presenter/sqlitePresenter/schemaCatalogMetadata.test.ts
@@ -1,0 +1,73 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  getSchemaTablesNotCreatedOnFreshInstall,
+  isSchemaTableCreatedOnFreshInstall
+} from '@/presenter/sqlitePresenter/schemaCatalogMetadata'
+
+const fs = await vi.importActual<typeof import('fs')>('fs')
+const sourceDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../src/main/presenter/sqlitePresenter'
+)
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.join(sourceDir, relativePath), 'utf8')
+}
+
+function readInitTablesSource(): string {
+  const source = readSource('index.ts')
+  const start = source.indexOf('  private initTables()')
+  const end = source.indexOf('  private initVersionTable()', start)
+
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+
+  return source.slice(start, end)
+}
+
+describe('schema catalog fresh install metadata', () => {
+  const tablesNotCreatedOnFreshInstall = getSchemaTablesNotCreatedOnFreshInstall()
+
+  it('excludes only retired legacy conversation tables from fresh startup schema checks', () => {
+    expect(tablesNotCreatedOnFreshInstall).toEqual([
+      'conversations',
+      'messages',
+      'message_attachments'
+    ])
+
+    for (const tableName of tablesNotCreatedOnFreshInstall) {
+      expect(isSchemaTableCreatedOnFreshInstall(tableName)).toBe(false)
+    }
+  })
+
+  it('keeps active session tables in fresh startup schema checks', () => {
+    expect(isSchemaTableCreatedOnFreshInstall('new_sessions')).toBe(true)
+    expect(isSchemaTableCreatedOnFreshInstall('deepchat_sessions')).toBe(true)
+  })
+
+  it('keeps excluded tables present in the full schema catalog definitions', () => {
+    const catalogSource = readSource('schemaCatalog.ts')
+
+    for (const tableName of tablesNotCreatedOnFreshInstall) {
+      expect(catalogSource).toContain(`name: '${tableName}'`)
+    }
+  })
+
+  it('keeps excluded tables out of the fresh initTables creation path', () => {
+    const initTablesSource = readInitTablesSource()
+    const excludedCreateCalls = [
+      'this.conversationsTable.createTable()',
+      'this.messagesTable.createTable()',
+      'this.messageAttachmentsTable.createTable()'
+    ]
+
+    for (const createCall of excludedCreateCalls) {
+      expect(initTablesSource).not.toContain(createCall)
+    }
+
+    expect(initTablesSource).toContain('this.newSessionsTable.createTable()')
+    expect(initTablesSource).toContain('this.deepchatSessionsTable.createTable()')
+  })
+})

--- a/test/main/presenter/sqlitePresenter/schemaRepair.test.ts
+++ b/test/main/presenter/sqlitePresenter/schemaRepair.test.ts
@@ -56,6 +56,7 @@ describe('SchemaInspector table snapshot quoting', () => {
       {
         name: tableName,
         createSql: '',
+        createdOnFreshInstall: true,
         columns: [
           {
             name: 'id',
@@ -118,6 +119,7 @@ describe('SchemaInspector table snapshot quoting', () => {
       {
         name: tableName,
         createSql: '',
+        createdOnFreshInstall: true,
         columns: [
           {
             name: 'id',


### PR DESCRIPTION
Fixes fresh `agent.db` bootstrap on new DeepChat installs.

Previously, fresh startup could create `new_sessions` / `deepchat_sessions` from an empty recorded schema version, then stamp `schema_versions` to latest via the fresh fast-path. The database looked migrated but was missing latest columns such as `new_sessions.is_draft`, causing session creation to fail with `table new_sessions has no column named is_draft`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved first-launch SQLite schema bootstrap and startup schema diagnosis/repair for supported drift.
* **Bug Fixes**
  * Fresh session tables now use the latest schema SQL on clean installs.
  * Repair is scoped to fresh-install relevant tables, avoids repeated repair attempts, and surfaces warnings when only manual fixes remain.
* **Documentation**
  * Added a SQLite “fresh schema bootstrap” plan, specification, and task checklist.
* **Tests**
  * Updated/added coverage for fresh-install schema creation, startup diagnosis, and repair behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->