### PR TITLE
fix(new-api): separate responses endpoint option

### DIFF
--- a/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
@@ -220,6 +220,51 @@ const getNewApiPreferredCapabilityProviderIds = (
   return providerIds
 }
 
+const isOpenAiFamilyNewApiModel = (modelId: string, ownedBy?: string): boolean => {
+  const normalizedOwner = ownedBy?.trim().toLowerCase() ?? ''
+  if (normalizedOwner.includes('openai')) {
+    return true
+  }
+
+  const normalizedModelId = modelId.trim().toLowerCase()
+  return /^(?:gpt-|chatgpt-|o[1-9](?:[.-]|$))/.test(normalizedModelId)
+}
+
+const isNewApiResponsesIncompatibleModelId = (modelId: string): boolean => {
+  const normalizedModelId = modelId.trim().toLowerCase()
+  return (
+    normalizedModelId.startsWith('tts-') ||
+    normalizedModelId.startsWith('whisper-') ||
+    normalizedModelId.startsWith('audio-') ||
+    normalizedModelId.includes('speech') ||
+    normalizedModelId.includes('transcribe')
+  )
+}
+
+const resolveNewApiSelectableEndpointTypes = (
+  supportedEndpointTypes: NewApiEndpointType[],
+  modelId: string,
+  normalizedRawType: string,
+  ownedBy?: string
+): NewApiEndpointType[] | undefined => {
+  if (
+    !supportedEndpointTypes.includes('openai') ||
+    supportedEndpointTypes.includes('openai-response') ||
+    normalizedRawType !== ModelType.Chat ||
+    !isOpenAiFamilyNewApiModel(modelId, ownedBy) ||
+    isNewApiResponsesIncompatibleModelId(modelId)
+  ) {
+    return undefined
+  }
+
+  const openaiIndex = supportedEndpointTypes.indexOf('openai')
+  return [
+    ...supportedEndpointTypes.slice(0, openaiIndex + 1),
+    'openai-response',
+    ...supportedEndpointTypes.slice(openaiIndex + 1)
+  ]
+}
+
 export function normalizeExtractedImageText(content: string): string {
   const normalized = content
     .replace(/\r\n/g, '\n')
@@ -1898,7 +1943,7 @@ export class AiSdkProvider extends BaseLLMProvider {
           typeof rawModel.owned_by === 'string' && rawModel.owned_by.trim().length > 0
             ? rawModel.owned_by.trim()
             : undefined
-        const supportedEndpointTypes = Array.isArray(rawModel.supported_endpoint_types)
+        const rawSupportedEndpointTypes = Array.isArray(rawModel.supported_endpoint_types)
           ? rawModel.supported_endpoint_types.filter(isNewApiEndpointType)
           : []
 
@@ -1909,12 +1954,12 @@ export class AiSdkProvider extends BaseLLMProvider {
           normalizedRawType === 'imagegeneration' ||
           normalizedRawType === 'image-generation' ||
           normalizedRawType === 'image' ||
-          supportedEndpointTypes.includes('image-generation')
+          rawSupportedEndpointTypes.includes('image-generation')
             ? ModelType.ImageGeneration
             : normalizedRawType === 'videogeneration' ||
                 normalizedRawType === 'video-generation' ||
                 normalizedRawType === 'video' ||
-                supportedEndpointTypes.includes('video-generation')
+                rawSupportedEndpointTypes.includes('video-generation')
               ? ModelType.VideoGeneration
               : normalizedRawType === 'tts' ||
                   normalizedRawType === 'audio-speech' ||
@@ -1927,6 +1972,13 @@ export class AiSdkProvider extends BaseLLMProvider {
                   : normalizedRawType === 'rerank' || normalizedModelId.includes('rerank')
                     ? ModelType.Rerank
                     : undefined
+        const supportedEndpointTypes = rawSupportedEndpointTypes
+        const selectableEndpointTypes = resolveNewApiSelectableEndpointTypes(
+          rawSupportedEndpointTypes,
+          rawModel.id,
+          normalizedRawType,
+          ownedBy
+        )
 
         const contextLengthCandidate = [
           rawModel.context_length,
@@ -1998,6 +2050,7 @@ export class AiSdkProvider extends BaseLLMProvider {
           providerId: this.provider.id,
           isCustom: false,
           supportedEndpointTypes,
+          ...(selectableEndpointTypes ? { selectableEndpointTypes } : {}),
           endpointType: defaultEndpointType,
           ownedBy,
           ...(capabilityVision !== undefined ? { vision: capabilityVision } : {}),

--- a/src/renderer/settings/components/ProviderModelList.vue
+++ b/src/renderer/settings/components/ProviderModelList.vue
@@ -717,6 +717,7 @@ type VirtualModelListItem =
       maxTokens: RENDERER_MODEL_META['maxTokens']
       isCustom: boolean
       supportedEndpointTypes: RENDERER_MODEL_META['supportedEndpointTypes']
+      selectableEndpointTypes: RENDERER_MODEL_META['selectableEndpointTypes']
       endpointType: RENDERER_MODEL_META['endpointType']
     }
 
@@ -795,6 +796,7 @@ const createModelItem = (model: RENDERER_MODEL_META) =>
       maxTokens: model.maxTokens,
       isCustom: model.isCustom ?? false,
       supportedEndpointTypes: model.supportedEndpointTypes,
+      selectableEndpointTypes: model.selectableEndpointTypes,
       endpointType: model.endpointType
     }),
     (item) => {
@@ -814,6 +816,7 @@ const createModelItem = (model: RENDERER_MODEL_META) =>
       item.maxTokens = model.maxTokens
       item.isCustom = model.isCustom ?? false
       item.supportedEndpointTypes = model.supportedEndpointTypes
+      item.selectableEndpointTypes = model.selectableEndpointTypes
       item.endpointType = model.endpointType
     }
   )
@@ -941,6 +944,7 @@ const toRendererModel = (item: VirtualModelItem): RENDERER_MODEL_META => ({
   enableSearch: item.enableSearch,
   type: item.typeValue,
   supportedEndpointTypes: item.supportedEndpointTypes,
+  selectableEndpointTypes: item.selectableEndpointTypes,
   endpointType: item.endpointType
 })
 

--- a/src/renderer/src/components/settings/ModelConfigDialog.vue
+++ b/src/renderer/src/components/settings/ModelConfigDialog.vue
@@ -1067,6 +1067,14 @@ const syncCapabilityProviderId = () => {
 }
 
 const availableEndpointTypes = computed<NewApiEndpointType[]>(() => {
+  const selectableEndpointTypes = providerModelMeta.value?.selectableEndpointTypes
+  if (Array.isArray(selectableEndpointTypes) && selectableEndpointTypes.length > 0) {
+    const normalizedEndpointTypes = selectableEndpointTypes.filter(isNewApiEndpointType)
+    if (normalizedEndpointTypes.length > 0) {
+      return normalizedEndpointTypes
+    }
+  }
+
   const supportedEndpointTypes = providerModelMeta.value?.supportedEndpointTypes
   if (Array.isArray(supportedEndpointTypes) && supportedEndpointTypes.length > 0) {
     const normalizedEndpointTypes = supportedEndpointTypes.filter(isNewApiEndpointType)

--- a/src/renderer/src/stores/modelStore.ts
+++ b/src/renderer/src/stores/modelStore.ts
@@ -275,6 +275,7 @@ export const useModelStore = defineStore('model', () => {
     enableSearch: (model as RENDERER_MODEL_META).enableSearch ?? false,
     type: resolveRendererModelType(model),
     supportedEndpointTypes: model.supportedEndpointTypes,
+    selectableEndpointTypes: model.selectableEndpointTypes,
     endpointType: model.endpointType,
     ownedBy: model.ownedBy
   })
@@ -301,6 +302,7 @@ export const useModelStore = defineStore('model', () => {
     enableSearch: (model as RENDERER_MODEL_META).enableSearch ?? false,
     type: resolveRendererModelType(model),
     supportedEndpointTypes: model.supportedEndpointTypes,
+    selectableEndpointTypes: model.selectableEndpointTypes,
     endpointType: model.endpointType,
     ownedBy: model.ownedBy
   })
@@ -662,6 +664,7 @@ export const useModelStore = defineStore('model', () => {
         reasoning: meta.reasoning || false,
         type: (meta.type || ModelType.Chat) as ModelType,
         supportedEndpointTypes: meta.supportedEndpointTypes,
+        selectableEndpointTypes: meta.selectableEndpointTypes,
         endpointType: meta.endpointType,
         ownedBy: meta.ownedBy
       })
@@ -726,6 +729,8 @@ export const useModelStore = defineStore('model', () => {
             }),
             supportedEndpointTypes:
               model.supportedEndpointTypes ?? fallback?.supportedEndpointTypes,
+            selectableEndpointTypes:
+              model.selectableEndpointTypes ?? fallback?.selectableEndpointTypes,
             endpointType: model.endpointType ?? fallback?.endpointType,
             ownedBy: model.ownedBy ?? fallback?.ownedBy
           }

--- a/src/shared/contracts/common.ts
+++ b/src/shared/contracts/common.ts
@@ -202,6 +202,7 @@ export const ProviderModelSummarySchema = z.object({
   maxTokens: z.number().int().optional(),
   description: z.string().optional(),
   supportedEndpointTypes: z.array(z.enum(NEW_API_ENDPOINT_TYPES)).optional(),
+  selectableEndpointTypes: z.array(z.enum(NEW_API_ENDPOINT_TYPES)).optional(),
   endpointType: z.enum(NEW_API_ENDPOINT_TYPES).optional(),
   ownedBy: z.string().optional()
 })

--- a/src/shared/types/presenters/core.presenter.d.ts
+++ b/src/shared/types/presenters/core.presenter.d.ts
@@ -757,6 +757,7 @@ export type RENDERER_MODEL_META = {
   maxTokens?: number
   description?: string
   supportedEndpointTypes?: NewApiEndpointType[]
+  selectableEndpointTypes?: NewApiEndpointType[]
   endpointType?: NewApiEndpointType
   ownedBy?: string
 }
@@ -775,6 +776,7 @@ export type MODEL_META = {
   maxTokens?: number
   description?: string
   supportedEndpointTypes?: NewApiEndpointType[]
+  selectableEndpointTypes?: NewApiEndpointType[]
   endpointType?: NewApiEndpointType
   ownedBy?: string
 }

--- a/src/shared/types/presenters/llmprovider.presenter.d.ts
+++ b/src/shared/types/presenters/llmprovider.presenter.d.ts
@@ -28,6 +28,7 @@ export type RENDERER_MODEL_META = {
   maxTokens?: number
   description?: string
   supportedEndpointTypes?: NewApiEndpointType[]
+  selectableEndpointTypes?: NewApiEndpointType[]
   endpointType?: NewApiEndpointType
   ownedBy?: string
 }
@@ -48,6 +49,7 @@ export type MODEL_META = {
   maxTokens?: number
   description?: string
   supportedEndpointTypes?: NewApiEndpointType[]
+  selectableEndpointTypes?: NewApiEndpointType[]
   endpointType?: NewApiEndpointType
   ownedBy?: string
 }

--- a/test/main/presenter/llmProviderPresenter/newApiProvider.test.ts
+++ b/test/main/presenter/llmProviderPresenter/newApiProvider.test.ts
@@ -480,6 +480,234 @@ describe('NewApiProvider capability routing', () => {
     )
   })
 
+  it('exposes responses as a selectable option for openai-only chat models while keeping completions as default', async () => {
+    vi.spyOn(modelCapabilities, 'findCapabilityModelMatch').mockReturnValue(undefined)
+    vi.spyOn(modelCapabilities, 'supportsReasoning').mockReturnValue(false)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [
+            {
+              id: 'gpt-5.5',
+              object: 'model',
+              owned_by: 'openai',
+              supported_endpoint_types: ['openai'],
+              type: 'chat'
+            }
+          ]
+        })
+      })
+    )
+
+    const configPresenter = createConfigPresenter()
+    const provider = new AiSdkProvider(createProvider(), configPresenter)
+    const models = await (provider as any).fetchProviderModels()
+
+    expect(models[0]).toMatchObject({
+      id: 'gpt-5.5',
+      supportedEndpointTypes: ['openai'],
+      selectableEndpointTypes: ['openai', 'openai-response'],
+      endpointType: 'openai'
+    })
+    expect(configPresenter.setModelConfig).toHaveBeenCalledWith(
+      'gpt-5.5',
+      'new-api',
+      expect.objectContaining({
+        endpointType: 'openai',
+        apiEndpoint: ApiEndpointType.Chat
+      }),
+      { source: 'provider' }
+    )
+
+    const runtimeProvider = new AiSdkProvider(
+      createProvider(),
+      createConfigPresenter(
+        {},
+        {
+          'new-api': models
+        }
+      )
+    )
+    const routeDecision = (runtimeProvider as any).resolveRouteDecision('gpt-5.5')
+    const selectedProvider = (runtimeProvider as any).getRuntimeProvider(
+      routeDecision
+    ) as LLM_PROVIDER
+
+    expect(routeDecision.endpointType).toBe('openai')
+    expect(selectedProvider.apiType).toBe('openai-completions')
+  })
+
+  it('uses responses when an openai-only NewAPI model is manually configured for responses', () => {
+    const provider = new AiSdkProvider(
+      createProvider(),
+      createConfigPresenter(
+        {
+          'gpt-5.5': {
+            endpointType: 'openai-response'
+          }
+        },
+        {
+          'new-api': [
+            {
+              id: 'gpt-5.5',
+              name: 'GPT-5.5',
+              group: 'openai',
+              providerId: 'new-api',
+              isCustom: false,
+              supportedEndpointTypes: ['openai'],
+              selectableEndpointTypes: ['openai', 'openai-response'],
+              endpointType: 'openai',
+              ownedBy: 'openai',
+              type: ModelType.Chat
+            }
+          ]
+        }
+      )
+    )
+    const routeDecision = (provider as any).resolveRouteDecision('gpt-5.5')
+    const runtimeProvider = (provider as any).getRuntimeProvider(routeDecision) as LLM_PROVIDER
+
+    expect(routeDecision.endpointType).toBe('openai-response')
+    expect(runtimeProvider.apiType).toBe('openai-responses')
+  })
+
+  it('does not add responses as an option for openai-only non-chat models', async () => {
+    vi.spyOn(modelCapabilities, 'findCapabilityModelMatch').mockReturnValue(undefined)
+    vi.spyOn(modelCapabilities, 'supportsReasoning').mockReturnValue(false)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [
+            {
+              id: 'text-embedding-3-large',
+              object: 'model',
+              owned_by: 'openai',
+              supported_endpoint_types: ['openai'],
+              type: 'embedding'
+            }
+          ]
+        })
+      })
+    )
+
+    const provider = new AiSdkProvider(createProvider(), createConfigPresenter())
+    const models = await (provider as any).fetchProviderModels()
+
+    expect(models[0]).toMatchObject({
+      id: 'text-embedding-3-large',
+      type: ModelType.Embedding,
+      supportedEndpointTypes: ['openai'],
+      endpointType: 'openai'
+    })
+    expect(models[0].selectableEndpointTypes).toBeUndefined()
+  })
+
+  it('does not expose responses for openai-only models without an explicit chat type', async () => {
+    vi.spyOn(modelCapabilities, 'findCapabilityModelMatch').mockReturnValue(undefined)
+    vi.spyOn(modelCapabilities, 'supportsReasoning').mockReturnValue(false)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [
+            {
+              id: 'gpt-5.5',
+              object: 'model',
+              owned_by: 'openai',
+              supported_endpoint_types: ['openai']
+            }
+          ]
+        })
+      })
+    )
+
+    const provider = new AiSdkProvider(createProvider(), createConfigPresenter())
+    const models = await (provider as any).fetchProviderModels()
+
+    expect(models[0]).toMatchObject({
+      id: 'gpt-5.5',
+      supportedEndpointTypes: ['openai'],
+      endpointType: 'openai'
+    })
+    expect(models[0].selectableEndpointTypes).toBeUndefined()
+  })
+
+  it('does not expose responses for openai-only audio models', async () => {
+    vi.spyOn(modelCapabilities, 'findCapabilityModelMatch').mockReturnValue(undefined)
+    vi.spyOn(modelCapabilities, 'supportsReasoning').mockReturnValue(false)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [
+            {
+              id: 'tts-1',
+              object: 'model',
+              owned_by: 'openai',
+              supported_endpoint_types: ['openai'],
+              type: 'chat'
+            }
+          ]
+        })
+      })
+    )
+
+    const provider = new AiSdkProvider(createProvider(), createConfigPresenter())
+    const models = await (provider as any).fetchProviderModels()
+
+    expect(models[0]).toMatchObject({
+      id: 'tts-1',
+      supportedEndpointTypes: ['openai'],
+      endpointType: 'openai'
+    })
+    expect(models[0].selectableEndpointTypes).toBeUndefined()
+  })
+
+  it('does not expose responses for non-OpenAI relay chat models', async () => {
+    vi.spyOn(modelCapabilities, 'findCapabilityModelMatch').mockReturnValue(undefined)
+    vi.spyOn(modelCapabilities, 'supportsReasoning').mockReturnValue(false)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [
+            {
+              id: 'qwen3.7-max',
+              object: 'model',
+              owned_by: 'alibaba',
+              supported_endpoint_types: ['openai'],
+              type: 'chat'
+            },
+            {
+              id: 'deepseek-chat',
+              object: 'model',
+              owned_by: 'deepseek',
+              supported_endpoint_types: ['openai'],
+              type: 'chat'
+            }
+          ]
+        })
+      })
+    )
+
+    const provider = new AiSdkProvider(createProvider(), createConfigPresenter())
+    const models = await (provider as any).fetchProviderModels()
+
+    expect(models).toHaveLength(2)
+    for (const model of models) {
+      expect(model.supportedEndpointTypes).toEqual(['openai'])
+      expect(model.endpointType).toBe('openai')
+      expect(model.selectableEndpointTypes).toBeUndefined()
+    }
+  })
+
   it('does not overwrite user-owned model configs during provider refresh', async () => {
     vi.stubGlobal(
       'fetch',

--- a/test/renderer/components/ModelConfigDialog.test.ts
+++ b/test/renderer/components/ModelConfigDialog.test.ts
@@ -697,6 +697,32 @@ describe('ModelConfigDialog OpenAI image generation settings', () => {
 })
 
 describe('ModelConfigDialog new-api endpoint normalization', () => {
+  it('uses selectable endpoint types without mutating supported endpoint types', async () => {
+    const { wrapper } = await setup({
+      providerId: 'new-api',
+      modelId: 'gpt-5.5',
+      modelName: 'GPT-5.5',
+      providerApiType: 'new-api',
+      providerModels: [
+        {
+          id: 'gpt-5.5',
+          name: 'GPT-5.5',
+          type: ModelType.Chat,
+          supportedEndpointTypes: ['openai'],
+          selectableEndpointTypes: ['openai', 'openai-response'],
+          endpointType: 'openai'
+        }
+      ],
+      modelConfig: {
+        endpointType: undefined
+      }
+    })
+
+    expect((wrapper.vm as any).providerModelMeta.supportedEndpointTypes).toEqual(['openai'])
+    expect((wrapper.vm as any).availableEndpointTypes).toEqual(['openai', 'openai-response'])
+    expect((wrapper.vm as any).config.endpointType).toBe('openai')
+  })
+
   it('restores chat routing and provider model type when switching away from image-generation', async () => {
     const { wrapper, modelConfigStore } = await setup({
       providerId: 'new-api',


### PR DESCRIPTION
Keep supportedEndpointTypes as upstream-declared metadata and expose synthetic openai-response choices through selectableEndpointTypes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for more flexible endpoint selection for compatible models, including an additional selectable response option where available.
  * Model settings now surface eligible endpoint choices more accurately in the configuration dialog.
* **Bug Fixes**
  * Improved handling of special model types so speech, transcription, and other non-chat models are no longer shown with inappropriate endpoint options.
  * Preserved the currently selected endpoint when opening model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->