### PR TITLE
feat(agent-plan): persist plan blocks in history

### DIFF
--- a/docs/architecture/agent-plan-task-refactor/acp-plan-reachability.md
+++ b/docs/architecture/agent-plan-task-refactor/acp-plan-reachability.md
@@ -1,0 +1,24 @@
+# ACP Plan Reachability Audit
+
+## Summary
+
+- Subsystem A (`llmProviderPresenter/providers/acpProvider.ts`) is the active ACP provider stream
+  path. It calls `AcpContentMapper.map(notification)` and pushes `mapped.events` into the provider
+  `EventQueue`.
+- Subsystem A previously dropped `mapped.blocks`. This refactor adds an internal `LLMCoreStreamEvent`
+  `type:'plan'` variant and accumulator handling that upserts the same shared `type:'plan'` block
+  shape, so active ACP provider streams can persist plan blocks without inventing an IPC channel.
+- Subsystem B (`acpClientPresenter/mapper/AcpEventMapper.ts`) maps `mapped.blocks` to
+  `content.block` and `mapped.planEntries` to `plan.updated`, but repo grep finds no
+  `mapSessionUpdate` call site. It is instantiated by `acpClientPresenter/index.ts`, but not proven
+  live end-to-end.
+- `MessageBlockPlan` remains the single renderer. `AcpContentMapper.handlePlanUpdate` now uses the
+  shared plan-block builder, so ACP subsystem A, ACP subsystem B, and the agent-runtime path produce
+  the same `type:'plan'` block shape.
+
+## Decision For This Refactor
+
+- Do not delete `MessageBlockPlan`.
+- Keep the new internal `plan` stream event scoped to provider-to-accumulator transport.
+- Keep subsystem B's block-capable mapper on the shared builder shape.
+- Do not add a public IPC channel or a dedicated plan table for ACP plans.

--- a/docs/architecture/agent-plan-task-refactor/plan.md
+++ b/docs/architecture/agent-plan-task-refactor/plan.md
@@ -1,0 +1,300 @@
+# Agent Plan / `update_plan` Task — Plan (v4)
+
+> Active planning doc. Delete after implementation; fold durable facts into
+> `docs/architecture/agent-system.md` or `tool-system.md`. v4 broadens the terminal marker to cover
+> **every** turn-exit incl. the abort-exception early return (AD6), threads `max_steps` via
+> `StreamState`, and clarifies that ACP and agent-runtime share one block-builder helper, not one
+> entry point (AD2).
+
+## Involved modules
+
+| Layer | File | Role today |
+| --- | --- | --- |
+| Backend tool | `src/main/presenter/toolPresenter/agentTools/agentPlanTool.ts` | `update_plan` def, `states` Map, snapshot/revision |
+| Tool wiring | `src/main/presenter/toolPresenter/agentTools/agentToolManager.ts` | agent-mode gating (`isAgentMode`, :373), tool-call routing |
+| Prompt | `src/main/presenter/toolPresenter/index.ts` | `buildProgressPrompt` (:641-657) |
+| Runtime | `src/main/presenter/agentRuntimePresenter/dispatch.ts` | `markInternalPlanToolCallBlock` (:371), `publishPlanUpdated` (:385), `agent_plan` branch (:916), `finalize` (:1475) / `finalizeError` (:1489) |
+| Runtime loop / finalize | `src/main/presenter/agentRuntimePresenter/process.ts` | `while(true)` loop (:327), `MAX_TOOL_CALLS` break→`finalize` (:404), `finalizeError` calls (:95,440,504,512,538), **abort-exception early return (:527-535, bypasses finalize)** |
+| Error finalize | `src/main/presenter/agentRuntimePresenter/messageStore.ts` | `buildTerminalErrorBlocks` (:39) flips block `status`→`error` only — does **not** touch `plan_entries[*].status`; interrupted recovery (:615) |
+| Runtime lifecycle | `src/main/presenter/agentRuntimePresenter/index.ts` | `destroySession` (:528-554), cancel/abort |
+| Runtime state | `src/main/presenter/agentRuntimePresenter/types.ts` | `StreamState` — add `planTerminalReason` |
+| ACP (subsystem A) | `llmProviderPresenter/acp/acpContentMapper.ts`, `providers/acpProvider.ts`, `aiSdk/.../accumulator.ts` | builds `type:'plan'` block; `acpProvider` drops `mapped.blocks` |
+| ACP (subsystem B) | `acpClientPresenter/mapper/AcpEventMapper.ts` (instantiated at `acpClientPresenter/index.ts:18`) | maps `mapped.blocks`→`content.block`, `mapped.planEntries`→`plan.updated`; **`mapSessionUpdate` has no found call site** |
+| Shared types | `src/shared/types/agent-plan.ts`, `src/shared/contracts/events/chat.events.ts`, `src/shared/contracts/acp.ts` | `AgentPlanStepStatus`, snapshot/item, event payloads |
+| Store | `src/renderer/src/stores/ui/agentPlan.ts` | in-memory `snapshots`, persisted `collapsedBySession`, revision gate (:12) |
+| UI (live) | `src/renderer/src/components/chat/AgentProgressFloat.vue` | the float in the screenshot |
+| UI (persisted) | `src/renderer/src/components/message/MessageBlockPlan.vue` | `type:'plan'` renderer (`MessageItemAssistant.vue:69`); spins on `in_progress` (:139) |
+| Wiring | `src/renderer/src/pages/ChatPage.vue` | `onPlanUpdated` (:1860), dismiss (:999), stop/retry/continue (:1736/1746/1797) |
+| i18n | `src/renderer/src/i18n/*/chat.json` (`chat.workspace.plan.*`) | labels incl. dead `failed`/`skipped` |
+
+## Architecture decisions
+
+### AD1 — Single persisted representation = the `type:'plan'` block (D1, D4)
+The persisted, in-history plan is a `type:'plan'` block rendered by `MessageBlockPlan.vue`. The live
+`AgentProgressFloat` is a transient overlay during active generation; on reload it rehydrates from
+the latest persisted plan block of the conversation. The hidden `update_plan` tool-call block stays
+transport/provenance only (`extra.internalTool=true`, not double-rendered).
+
+The agent-runtime path **projects each `update_plan` snapshot into a persisted `type:'plan'`
+block**. This intentionally changes the contract asserted by `dispatch.test.ts:299` ("does not
+insert plan blocks"); that test is rewritten to assert the upsert behavior.
+
+**Upsert identity & position.** There is **at most one `type:'plan'` block per assistant message**.
+The producer locates it by scanning the current turn's block stream (`state.blocks`) for a
+`type:'plan'` block: if present it mutates that block in place; otherwise it inserts one
+**immediately after the first (hidden) `update_plan` tool-call block** of the turn, then mutates that
+same block in place for every later revision. Later revisions never move or duplicate it. Identity is
+"the lone `type:'plan'` block within the active message" — **not** a `toolCallId` (which differs per
+`update_plan` call) and **not** `messageId` lookups across the store. Because each turn (including
+retry/continue) builds a fresh `state.blocks` for a new assistant message, a new turn yields a new
+plan block — there is no cross-turn / cross-message overwrite.
+
+Why not "rehydrate the float from the hidden tool-call params" (rejected D4 alternative): it keeps
+two renderers interpreting different sources and leaves `MessageBlockPlan` half-dead. One
+`type:'plan'` block consumed by one renderer is the lower-divergence design and gives the ACP path a
+home (AD2).
+
+### AD2 — Converge ACP and agent-runtime on one block shape + one builder (D2), after an audit
+`AcpContentMapper.handlePlanUpdate` already builds a `type:'plan'` block. The agent-runtime
+`update_plan` path and the ACP plan-notification path are **necessarily two entry points** — that is
+fine. The constraint is: both must call **one shared plan-block construction/normalization helper**
+that produces **one `type:'plan'` block shape**, rendered by the **single `MessageBlockPlan`**
+renderer. Different entry points, one builder, one shape, one renderer.
+
+The audit (T1) establishes which ACP subsystem is live end-to-end:
+- If subsystem B (`AcpEventMapper` → `content.block`) is the real path, ensure a `content.block`
+  carrying a `type:'plan'` block reaches the persisted message stream and renders via
+  `MessageBlockPlan`.
+- If subsystem A (`acpProvider`) is the real path, it currently drops `mapped.blocks`; wire the
+  `type:'plan'` block through (and add a `'plan'` accumulator case if the persisted stream is rebuilt
+  there).
+Either way the **renderer stays `MessageBlockPlan`** and both paths share the builder helper. No
+deletion.
+
+### AD3 — Store models server-state and view-state separately, baseline per-turn (C1)
+- `snapshots[sessionId]` is pure server-state for the **current turn's** live overlay. Add
+  `beginTurn(sessionId)` that resets the baseline (clears the live snapshot) — called from
+  submit/steer/retry/continue. The revision gate then only orders within-turn updates.
+- Replace the boolean collapse map with per-session view-state `{ collapsed, dismissedRevision }`
+  (persisted). `dismiss` sets `dismissedRevision = current.revision` (sticky) instead of deleting.
+- `freezeActive(sessionId)` (for `onStop`): set the live overlay's terminal indicator so the spinner
+  stops immediately. This is the **live mirror** of the persisted terminal marker (AD6); the source
+  of truth for reload is the stamped block, not this call.
+- Float visibility = `snapshot exists && revision > dismissedRevision && entries.length > 0`.
+  Default `collapsed=false` on first appearance (AC19); auto-collapse (not delete) when
+  `completedCount === total` (AC6).
+- `purge(sessionId)` removes the live snapshot + persisted view-state key (on conversation delete /
+  `destroySession`).
+
+### AD4 — One shared status presentation module (AC13)
+`src/renderer/src/composables/useAgentPlanStatus.ts` exports `STATUS_ICON`, `STATUS_ICON_CLASS`,
+`STATUS_BADGE_CLASS`, `entryAriaLabel(t, status, step)`, and a `resolveStepPresentation(status,
+{ terminal })` helper that returns a **non-spinning** interrupted indicator for `in_progress` when
+the plan is terminal (AD6). Both renderers import it; the completed-step decision is made once (mute
+icon, keep text at `text-foreground` for AA — AC17). `MessageBlockPlan`'s ad-hoc `normalizeStatus`/
+`done`→`completed` tolerance moves here as a shared `normalizePlanEntry`.
+
+### AD5 — Status enum single source (AC12)
+In a shared runtime-capable module: `export const agentPlanStepStatusSchema = z.enum(['pending',
+'in_progress','completed'])`, `agentPlanItemSchema = z.object({ step, status })`,
+`type AgentPlanStepStatus = z.infer<...>`. `agentPlanTool.ts` and `chat.events.ts` import these.
+Remove `failed`/`skipped` i18n (AC21). The step-status enum stays three values (see AD6 for the
+block-level terminal marker).
+
+### AD6 — Persistable terminal marker for abnormal/error termination (AC4)
+The step-status enum is unchanged (AD5). To represent a turn that ended while a step was still
+`in_progress`, add a **block/snapshot-level** field `terminalReason?: 'aborted' | 'max_steps' |
+'error'`, persisted into the `type:'plan'` block `extra` (e.g. `plan_terminal_reason`) — additive, no
+enum change (C3).
+
+**Crucial: cover every turn-exit, not just `finalizeError`/`finalize`.** Three exits can leave an
+open `in_progress` step:
+1. `finalizeError` (`dispatch.ts:1489`) — the error/cancel chokepoint reached from user cancel
+   (`process.ts:95`), tool terminal error (`:440`), context-window error (`:504`), no-model-response
+   (`:512`), a **non-abort** uncaught exception (`:538`), plus interrupted-session recovery
+   (`messageStore.ts:615`). Its `buildTerminalErrorBlocks` (`messageStore.ts:39`) only flips block
+   `status`→`error`; it does **not** touch `extra.plan_entries[*].status`.
+2. The normal `finalize` (`dispatch.ts:1475`) after the `MAX_TOOL_CALLS` `break` (`process.ts:404`).
+3. **The abort-exception early-return branch (`process.ts:527-535`)** — when `abortSignal.aborted ||
+   isAbortError(err)`, the catch `return`s `{status:'aborted'}` **without calling `finalize` or
+   `finalizeError`**. Easy to miss; would leave the plan spinning on reload.
+
+Without handling all three, a persisted plan block keeps its `in_progress` entry and **reloads
+spinning** — violating "no step spins after its turn ended".
+
+Implementation: add `state.planTerminalReason?: 'aborted' | 'max_steps' | 'error'` to `StreamState`
+(`types.ts`); set it `= 'max_steps'` immediately before the `break` at `process.ts:404`. Introduce
+one **idempotent** helper `stampPlanTerminalIfOpen(state, io, reason)` that finds the latest
+`type:'plan'` block and, if any entry is still `in_progress` (and not already stamped), sets
+`extra.plan_terminal_reason` and emits one final `chat.plan.updated`. Call it from: `finalize`
+(reason = `state.planTerminalReason`, i.e. `max_steps`), `finalizeError` (reason `aborted` for
+USER_CANCELED, else `error`), **and the abort-exception catch branch before its `return`** (reason
+`aborted`). Idempotency makes a redundant call (e.g. an outer cancel path also invoking
+`finalizeUserCanceledErrorIfNeeded`, `process.ts:90`) harmless. The shared presentation (AD4) renders
+an `in_progress` step as a **static, non-spinning interrupted indicator** whenever `terminalReason`
+is set. Normal, well-closed completion needs no marker (R7). `freezeActive` mirrors this in the store
+for instant live feedback before persistence round-trips.
+
+**Persistence boundary (so reload, not just live, is fixed).** DB writes happen only in the finalize
+family — `finalize` → `updateAssistantContent` (`dispatch.ts:1449`) / `finalizeAssistantMessage`
+(`:1475`); `finalizeError` → `setMessageError` (`:1504`). Streaming itself only flushes to the
+renderer (`flushBlocksToRenderer`, no DB write). Therefore: (a) at `finalize`/`finalizeError`, call
+`stampPlanTerminalIfOpen` **before** the messageStore write so the stamp is persisted; (b) the
+abort-exception early-return branch (`process.ts:527-535`) runs **no** finalize and **no** DB write —
+after stamping it must itself persist (`messageStore.updateAssistantContent(io.messageId,
+state.blocks)` + `flushBlocksToRenderer`) before returning. Without (b), "live not spinning" is fixed
+but **"reload not spinning" is not**.
+
+Sequencing note: in Increment 1 (pre-persistence) `freezeActive` only stops the **live** spinner —
+acceptable because there is no persisted plan block yet to reload. The persistable stamp + reload
+non-spin lands in Increment 2, after the `type:'plan'` block exists (T5).
+
+## Event & data flow (target)
+
+```
+update_plan(call)
+  → AgentPlanTool: validate, build snapshot (revision = within-turn monotonic)
+  → onProgress(agent_plan)                              [single transport; drop toolResult.snapshot]
+  → dispatch.applyProgressUpdate (agent_plan, allowProgressUpdates):
+        • upsert THE type:'plan' block of this turn (the lone one in state.blocks)        [NEW]
+            plan_entries / plan_explanation / plan_revision / plan_updated_at
+            (inserted right after the first hidden update_plan tool-call block)
+        • keep update_plan tool-call block extra.internalTool=true (provenance, hidden)
+        • publishDeepchatEvent('chat.plan.updated', payload)                              (live)
+  → ChatPage.onPlanUpdated → agentPlanStore.applySnapshot
+
+turn start (submit/steer/retry/continue):
+  → agentPlanStore.beginTurn(sessionId)                 [NEW: reset per-turn baseline → 0]
+
+any turn-exit with an open in_progress step → stampPlanTerminalIfOpen(state, io, reason) [NEW, idempotent]
+  • finalizeError (stop / tool-error / context-window / no-response / non-abort exception / interrupted) → error | aborted
+  • finalize after MAX_TOOL_CALLS break (state.planTerminalReason='max_steps' set before break) → max_steps
+  • abort-exception catch branch (process.ts:527-535) BEFORE its early return → aborted
+      (no finalize on this path → must also persist: updateAssistantContent + flushBlocksToRenderer)
+  → stamps latest type:'plan' block extra.plan_terminal_reason + one final chat.plan.updated
+      (at finalize/finalizeError: stamp BEFORE the messageStore write so the stamp is persisted)
+  → agentPlanStore.freezeActive(sessionId)              [live mirror; non-spinning indicator]
+
+session load / reopen / switch:
+  → from loaded messages, take the latest type:'plan' block → agentPlanStore.applySnapshot [NEW]
+    (history always renders inline via MessageBlockPlan; float overlay optional)
+
+destroySession(sessionId) / conversation delete:
+  → planTool.clearState(sessionId)  AND  agentPlanStore.purge(sessionId)                 [NEW]
+```
+
+ACP path converges on the same `type:'plan'` block via the shared builder (AD2) after the audit.
+
+## Compatibility & migration
+
+- `type:'plan'` blocks and `block.extra` plan fields (`plan_entries`, `plan_terminal_reason`, …) are
+  additive; pre-change conversations have no plan block → rehydrate to "no plan" (C3).
+- `collapsedBySession` localStorage (`agent-plan-collapsed`) gains a richer value shape. Per C4 /
+  project preference (no compat shims unless required), the decision is to **rename the key** to
+  `agent-plan-view-state` and one-time-prune the legacy `agent-plan-collapsed` key on first read,
+  rather than ship a legacy-boolean translation shim.
+- **Backward-compatible typed-event extension** (not "no change"): `chat.plan.updated` gains an
+  optional `terminalReason`. Update the event-contract zod payload in `chat.events.ts:47-57` (add
+  `terminalReason: z.enum(['aborted','max_steps','error']).optional()`); `AgentPlanViewSnapshot =
+  DeepchatEventPayload<'chat.plan.updated'>` (`agentPlan.ts:6`) then derives the new field
+  automatically, and the contract's `defineEventContract` test must be updated. No route/IPC channel
+  change. If `AgentPlanViewSnapshot` is later re-expressed as `AgentPlanSnapshot + messageId`, that
+  is type-only.
+
+## Test strategy
+
+- **Main (Vitest):**
+  - `dispatch.test.ts:299` rewritten: `applyProgressUpdate` upserts the single `type:'plan'` block
+    of the turn (idempotent across revisions, never duplicated) and still publishes the event.
+  - abnormal/error termination: `finalizeError` (cancel, tool error, context-window, no-response,
+    non-abort exception), the `MAX_TOOL_CALLS` `finalize`, AND the **abort-exception early-return
+    branch** (plan written, then provider throws `AbortError`) each stamp `plan_terminal_reason`
+    (`aborted`/`max_steps`/`error`) on the latest plan block when a step is open and emit a final
+    event; for the abort-exception branch assert the stamp is **persisted to messageStore** (a
+    reload sees the non-spinning state), not just emitted. Assert no `in_progress` entry survives
+    unstamped after any such ending, and the helper is idempotent.
+  - `agentPlanTool`: clearState wiring; missing-`toolCallId` behavior; revision monotonic within turn.
+  - subagent path leaves no orphan state.
+  - ACP: per audit outcome, a `type:'plan'` block is produced/renderable through the live path via
+    the shared builder.
+- **Renderer (Vitest + VTU):**
+  - store: per-turn `beginTurn` baseline (the **C1 guard**: clear → next `revision=1` must render),
+    `dismiss` sticky, `freezeActive`, `purge`, auto-collapse.
+  - presentation: `in_progress` with `terminalReason` set renders **without** `animate-spin` (live
+    float and inline block); completed-step uses `text-foreground` (not 50%-alpha muted); steps
+    container has `aria-live`.
+  - `AgentProgressFloat`: stop/retry/complete transitions leave no spinning `in_progress`; badge
+    i18n renders per-locale (`en`, `ja`) without concatenation artifacts.
+  - rehydration: a loaded conversation with a persisted plan block shows the plan (and a frozen one
+    does not spin); switching sessions isolates plans.
+
+## Review follow-up fixes
+
+The post-implementation review found one real live-path regression and several missing regression
+tests. These are implemented as a follow-up to this same architecture goal.
+
+- Live terminal updates keep the existing tool revision, but `agentPlanStore.applySnapshot` must
+  accept a same-revision snapshot when it adds or changes `terminalReason`; otherwise the live float
+  can keep spinning until reload even though the persisted inline block is correct.
+- `dismiss` is sticky for the whole active turn, not just the current revision. `beginTurn` resets
+  the dismissed flag.
+- Store read paths (`isVisible`, `isCollapsed`) are pure and do not create persisted view-state keys.
+- Rehydration scans loaded messages from newest to oldest and stops at the first persisted plan
+  block.
+- Follow-up tests cover the subagent/no-progress path, process-level `max_steps` and abort-exception
+  wiring, same-revision terminal updates, sticky dismiss, pure getters, and session switch
+  rehydration isolation.
+
+## Second review follow-up fixes
+
+The second review found a real queue-path regression in the first follow-up: `dismiss` became
+session-scoped while `beginTurn` is only called by renderer user handlers. Main-process automatic
+pending-queue drain starts a new assistant turn without calling `beginTurn`, so the previous turn's
+dismissed state can hide the next turn's live float.
+
+- `dismiss` is keyed to the current snapshot `messageId`, so it remains sticky for the active turn
+  but cannot leak into a later auto-drained turn.
+- `agentPlanStore.applySnapshot` treats a changed `messageId` as a new turn boundary and accepts the
+  snapshot even when its revision is lower than the previous turn's last revision. Within the same
+  `messageId`, revision monotonicity remains intact and only same-revision terminal reason changes
+  are accepted.
+- Main exposes a narrow `clearAgentPlanState(sessionId)` path and calls it after creating a new
+  assistant message. This resets backend `update_plan` revision state for user-initiated turns and
+  main auto-drained queue turns without clearing tool mappings.
+- Tests cover the no-`beginTurn` auto-queue-visible store path, same-revision non-terminal drops,
+  direct plan-state reset wiring, auto-queue reset calls, and direct persisted-plan rehydration
+  helper behavior.
+
+## Third review follow-up fixes
+
+The third review found no functional blocker, but it identified two test guards that were still too
+weak and two renderer view-state edge cases.
+
+- `finalizeError` tests must capture the `setMessageError` write-time blocks with `structuredClone`
+  and assert the persisted plan block already has `plan_terminal_reason: 'error'`.
+- Renderer store tests must assert the actual `useStorage` value shape so `purge(sessionId)` cannot
+  become a no-op while tests stay green.
+- `agentPlanStore.applySnapshot` resets collapsed state when a changed `messageId` establishes a new
+  live turn, so auto-drained queue turns appear expanded even when the previous turn was dismissed.
+- Auto-collapse runs only when the same message transitions from not-all-completed to all-completed;
+  rehydration or repeated completed snapshots must not override a user's manual expansion.
+
+## Risks
+
+- **AD1 contract change** (`dispatch.test.ts:299`) is deliberate but touches a persisted-block
+  invariant; keep it isolated to one PR with the rewritten test + a rehydration test. The upsert
+  identity ("lone `type:'plan'` block in `state.blocks`") must be covered so revisions never
+  duplicate the block.
+- **C1 guard** (fresh-`revision=1`-dropped) is the highest-risk regression; the store test must
+  reproduce "beginTurn → revision 1 → renders".
+- **AD6 main-side stamping** must hook **every** turn-exit: `finalizeError`, the `MAX_TOOL_CALLS`
+  `finalize`, AND the **abort-exception early-return branch (`process.ts:527-535`) which bypasses
+  both** — or a reloaded plan still spins. Three traps: (1) `buildTerminalErrorBlocks` not touching
+  `plan_entries` status; (2) the abort branch returning before any finalize; (3) **DB writes living
+  only in the finalize family** — so the abort branch must persist (`updateAssistantContent` + flush)
+  after stamping, else "live" is fixed but "reload" is not. Cover each trigger (cancel,
+  abort-exception, tool-error, exception, max-steps) in tests **including a reload/persistence
+  assertion**; make the helper idempotent.
+- **AD2 audit** may reveal subsystems A/B are both partially wired; resolve to one before touching
+  the hot path. Audit is its own task (T1), output recorded in this folder.
+- Scope: R6 items are independent low-risk cleanups — separate commits so R1/R2 stay reviewable.

--- a/docs/architecture/agent-plan-task-refactor/spec.md
+++ b/docs/architecture/agent-plan-task-refactor/spec.md
@@ -1,0 +1,218 @@
+# Agent Plan / `update_plan` Task — Refactor Spec
+
+> Status: **proposal, decisions resolved (v4)** — incorporates four review rounds. No code change yet.
+> Derived from a full review of the `update_plan` task feature (backend tool → agent runtime →
+> renderer float + inline block). v4 hard-resolves D4, covers the terminal marker across **every**
+> turn-exit (incl. the abort-exception early return), threads `max_steps` via `StreamState`, defines
+> the plan-block upsert identity, and tightens the ACP-reachability and one-builder wording.
+
+## Problem
+
+The "计划 / Progress Checklist" task surface (the floating `AgentProgressFloat` shown during a
+multi-step agent turn) is functionally a port of Codex's `update_plan` tool, but it shipped with two
+disconnected plan representations and a cluster of lifecycle bugs that make a finished or aborted
+plan look stuck.
+
+1. **Two disconnected plan representations.**
+   - **Live path (DeepChat agent mode):** `update_plan` tool → `onProgress(agent_plan)` →
+     `chat.plan.updated` event → `agentPlan` Pinia store → `AgentProgressFloat.vue`. The store is
+     **in-memory only and not rehydrated on reload**. The agent-runtime path **deliberately does not
+     persist a plan block** — `test/main/.../dispatch.test.ts:299` asserts "publishes plan update
+     events without inserting plan blocks into messages", and the `update_plan` tool-call block is
+     hidden inline via `isInternalToolCall` (`MessageItemAssistant.vue:71`).
+   - **Persisted/ACP path:** `AcpContentMapper.handlePlanUpdate` builds a `type:'plan'` block with
+     `extra.plan_entries` (`acpContentMapper.ts:245`); `MessageBlockPlan.vue` renders `type:'plan'`
+     blocks (`MessageItemAssistant.vue:69`).
+   - **Correction vs. the original review:** the original review called the inline/ACP path
+     "entirely dead". That is **not established**. The main `acpProvider.handleSessionUpdate`
+     forwards only `mapped.events` (drops `mapped.blocks`), but a second mapper —
+     `acpClientPresenter/mapper/AcpEventMapper.ts:21-27` — maps `mapped.blocks`→`content.block` and
+     `mapped.planEntries`→`plan.updated`. `AcpEventMapper` **is instantiated**
+     (`acpClientPresenter/index.ts:18`), but **no call site for its `mapSessionUpdate` was found** in
+     repo grep. There are two parallel ACP subsystems and end-to-end reachability is genuinely
+     ambiguous. **A reachability audit is required before any deletion** (see R5).
+
+2. **Lifecycle / stale-state bugs (live path).** The float can show a finished or aborted plan
+   indefinitely:
+   - Disappears entirely after app reload / reopening a conversation (store is in-memory only).
+   - Re-shows a stale plan on conversation switch (the `sessionId` watcher never touches the plan
+     store; `ChatPage.vue:782`).
+   - `onStop` / `onMessageRetry` / `onMessageEditSave` / `onMessageContinue` never reset the store
+     (`ChatPage.vue:1736,1746,1797`), so an aborted or regenerated turn leaves the last
+     `in_progress` step **spinning forever** (`MessageBlockPlan.vue:139` / `AgentProgressFloat.vue`
+     `animate-spin`).
+   - An all-completed plan never auto-collapses; `dismiss` is not sticky.
+
+3. **Backend state hygiene.** `AgentPlanTool` keeps a process-lifetime `states` Map used only as a
+   `revision++` counter (`agentPlanTool.ts:55,94`). `getState`/`clearState` have **zero production
+   callers**; the Map is never cleared on `destroySession`, and a subagent's `update_plan` pollutes
+   it with orphan keys that no UI reads. The renderer's monotonic revision gate
+   (`agentPlan.ts:12`) silently depends on this Map never being cleared.
+
+4. **No single source of truth.** Status→presentation mapping is hand-copied across
+   `AgentProgressFloat.vue` and `MessageBlockPlan.vue` and has **already drifted** (completed step is
+   emerald in one, muted in the other). The status enum is hand-written in three places (TS union,
+   tool zod schema, event-contract zod schema).
+
+5. **UX / i18n / a11y gaps.** The inline badge concatenates a standalone status word into a counter
+   (`2/5 完了しました` in ja), completed-step text fails WCAG AA contrast, there is no `aria-live`
+   region, the float defaults to collapsed on first appearance, and there are two redundant collapse
+   controls. `status.failed` / `status.skipped` i18n keys are unreachable (enum has only three
+   values).
+
+## Current trigger conditions (verified — not changing)
+
+The task fires **only** when all of these hold; firing itself is **model-decided** (no code
+threshold):
+
+- Chat mode is DeepChat-native `agent` (`agentToolManager.getAllToolDefinitions`: `isAgentMode`
+  gate, line 373). Plain chat and **ACP agent mode do not expose `update_plan`**.
+- The tool is in the tool list, which injects the `## Progress Checklist Tool` system-prompt block
+  (`toolPresenter.buildProgressPrompt`, lines 641-657).
+- The model chooses to call it mid-turn inside the agent `while(true)` loop (`process.ts:327`).
+  There is **no turn-end event** that finalizes or clears the plan — the root cause behind the
+  stale-float bugs.
+
+## Resolved decisions
+
+- **D1 — One persisted representation: the `type:'plan'` block.** `MessageBlockPlan.vue` (rendering
+  `type:'plan'` blocks) is the **single visible, persisted plan renderer**. The live
+  `AgentProgressFloat` is a **transient overlay during active generation**, rehydrated from the same
+  persisted plan snapshot. The hidden `update_plan` tool-call block stays **transport/provenance
+  only**. The agent-runtime path therefore **projects each plan update into a persisted
+  `type:'plan'` block** (this intentionally changes the `dispatch.test.ts:299` contract — that test
+  is rewritten, not worked around).
+- **D2 — ACP plans render through the same `type:'plan'` block.** Both the agent-runtime
+  `update_plan` path and the ACP path converge on `type:'plan'` blocks rendered by
+  `MessageBlockPlan.vue`, which is **kept and hardened, never deleted**. Exact ACP wiring depends on
+  the reachability audit (R5/T1).
+- **D3 — Increment ordering.** The cheap terminal-state fixes (R2) and prompt closure (R7) ship
+  **first and independently of persistence**. Persistence/rehydration (R1) is the second increment.
+  Safe because, once R1 lands, "reload shows last state" is satisfied by the **persisted block**, not
+  the live store — so resetting the live store on stop/switch (R2) no longer conflicts with R1.
+- **D4 — Accepted (hard decision): agent-mode history shows an inline `type:'plan'` block.**
+  DeepChat agent-mode turns now render an inline plan checklist block in message history (previously
+  only the ephemeral float showed). The float is the live overlay during generation and rehydrates
+  from the same persisted snapshot; the inline block is the persisted history record. The rejected
+  alternative was float-only history rehydrated from hidden tool-call params, which keeps two
+  divergent renderers. **This is settled — not deferred to implementation.**
+
+## User stories
+
+- **U1** When a turn finishes or is stopped, the checklist reflects a terminal state — no step is
+  left spinning as if work were still running, **including after reload**.
+- **U2** When I reopen a conversation or reload the app, I still see the plan the agent produced for
+  that conversation, in its last state.
+- **U3** When switching conversations, each conversation shows its own plan (or none), never a stale
+  plan bled in from another conversation or a previous turn.
+- **U4** When I dismiss the float, it stays dismissed for the current turn.
+- **U5** As a screen-reader / keyboard user, plan progress changes are announced, the disclosure
+  control is unambiguous, and completed steps are legible (AA contrast).
+- **U6** As a translator, every shipped plan string is reachable and reads naturally in my locale.
+
+## Requirements & acceptance criteria
+
+### R1 — One plan model, persisted + rehydrated (U2, U3; D1)
+- Each plan update is persisted as a `type:'plan'` block on the assistant message (single block per
+  turn — see plan.md AD1 for the upsert identity). The live float rehydrates from the persisted plan
+  on session load / reopen.
+- AC1: After reload, reopening a conversation that ran a plan shows its last plan state (inline block
+  always; float overlay optional).
+- AC2: Switching A→B→A shows A's own last plan (or none), never B's or a stale turn's.
+- AC3: The live store baseline is **per-turn** (Constraint C1) — rehydration and new turns never
+  silently drop a fresh plan.
+
+### R2 — Terminal-state correctness (U1, U4)
+- AC4: On **any** turn exit that leaves a step `in_progress` — user `onStop`, a provider **abort
+  raised as an exception (the early-return catch branch)**, tool terminal error, context-window
+  error, no-model-response, a non-abort uncaught exception, interrupted-session recovery, or
+  `MAX_TOOL_CALLS` exhaustion — the agent runtime stamps the persisted `type:'plan'` block with a
+  terminal marker (`terminalReason: 'aborted' | 'max_steps' | 'error'`, additive — see C3 / plan.md
+  AD6) and emits a final `chat.plan.updated`. Both the live float and the reloaded inline block then
+  render the once-`in_progress` step **without a spinner** (a static interrupted indicator). Normal
+  completion is covered by R7 (the model marks steps complete). **No step spins after its turn ended
+  — on every error/abort path, including the abort-exception early return and after reload.**
+- AC5: A new turn (`onMessageRetry` / `onMessageEditSave` / `onMessageContinue`, matching
+  `onSubmit`/`onSteer`) **rebaselines** the live overlay (resets the per-turn baseline) rather than
+  blanket-deleting persisted data.
+- AC6: An all-completed plan auto-collapses (does not auto-delete) instead of lingering expanded.
+- AC7: `dismiss` is sticky for the current turn (a trailing higher-revision update does not re-pop).
+
+### R3 — Backend state hygiene
+- AC8: `AgentPlanTool.states` is bounded — cleared on `destroySession`. Because the live baseline is
+  per-turn (C1), backend revision may stay process-local and even reset on restart without risk.
+- AC9: Dead surface removed or wired: drop `rawData.toolResult.snapshot` (only `onProgress` is
+  consumed); remove `getState`/`clearState` unless wired by AC8.
+- AC10: A subagent `update_plan` no longer pollutes the parent's plan state with an orphan key.
+- AC11: A missing `toolCallId` no longer returns silent success with no UI effect (error or logged
+  drop).
+
+### R4 — Single source of truth for shape & presentation
+- AC12: `AgentPlanStepStatus` and the plan-item shape are defined once (zod as source, `z.infer`);
+  tool schema and event contract import it.
+- AC13: Status→icon/color/badge mapping, the frozen/terminal rendering, and the aria-label live in
+  one shared composable used by both renderers; completed-step styling is identical across surfaces.
+
+### R5 — Audit + converge the inline/ACP pipeline (D1, D2)
+- AC14: Before any change, a reachability audit documents whether/how the `type:'plan'` block is
+  produced and rendered today across **both** ACP subsystems (`acpProvider` and
+  `acpClientPresenter`/`AcpEventMapper`). No `MessageBlockPlan` deletion.
+- AC15: After convergence, agent-runtime and ACP may keep **separate entry points**, but both call
+  **one shared plan-block construction/normalization helper** producing **one `type:'plan'` block
+  shape**, rendered by the **single `MessageBlockPlan`** renderer; no second, divergent builder or
+  renderer remains.
+
+### R6 — UX / i18n / a11y
+- AC16: The completed counter uses one parameterized/pluralizable i18n message
+  (`{completed}/{total}` localized), not a concatenated status word; float and inline block present
+  the count consistently.
+- AC17: Completed-step text meets WCAG AA (≥4.5:1) — mute the icon and/or strike-through, keep text
+  at `text-foreground`.
+- AC18: The steps container exposes `aria-live="polite"` (`role="status"`); the disclosure control
+  is a single unambiguous control (`aria-expanded` + `aria-controls`), no duplicate tab stop.
+- AC19: The float defaults to expanded on first appearance.
+- AC20: `collapsedBySession` (and any persisted view-state) is pruned on conversation deletion.
+- AC21: Unreachable i18n keys (`status.failed`, `status.skipped`) are removed unless the enum is
+  extended to produce them.
+
+### R7 — Prompt closure discipline (cheap, high ROI; borrowed from Codex)
+- AC22: `buildProgressPrompt` instructs the model to reconcile every step before finishing and never
+  end a turn with a dangling `in_progress` step. This is the minimal mitigation for the "stuck
+  spinner" symptom under normal completion, independent of R1/R2.
+
+## Non-goals
+
+- No new heavyweight planning concept (no `PLANS.md` / ExecPlans, no Plan Mode).
+- No change to **when** the task triggers (model-decided, agent-mode-only stays).
+- No step-status enum extension (`blocked`/`cancelled`) in this goal — abnormal termination uses the
+  additive block-level `terminalReason` instead (AD6). Model-emitted closure stays the three values.
+- No cross-session "global task board"; plan stays scoped to its conversation.
+- No new dedicated DB table for plans — persistence rides the existing message/block store.
+
+## Constraints
+
+- **C1 — Revision baseline is per-turn (resolves the silent-drop hazard).** The renderer store drops
+  snapshots with `revision <= current` (`agentPlan.ts:12`); backend revision comes from a
+  process-local Map (`agentPlanTool.ts:94`) that resets on restart. To remove the coupling: **reset
+  the live store baseline to 0 at the start of every turn** (submit/steer/retry/continue). Revision
+  then only orders updates **within a single turn** (dispatch is sequential, so monotonic by
+  construction). Backend clearing and restart-reset become harmless. No "reset both ends from one
+  signal" handshake is needed.
+- **C2 — Agent-mode gating unchanged.** `update_plan` stays `agent`-mode only.
+- **C3 — Stored-data contract.** `type:'plan'` blocks and any `block.extra` plan fields
+  (`plan_entries`, `plan_terminal_reason`, …) are additive; conversations persisted before this
+  change have no plan block and rehydrate to "no plan".
+- **C4 — Minimal complexity.** Reuse the existing message-block + typed-event machinery; no new store
+  or channel. Per project preference (no compatibility shims unless explicitly required), the
+  storage-key migration is a clean rename + one-time prune, not a legacy-value translation layer.
+
+## Success criteria
+
+- No state can leave the float **or the reloaded inline block** showing a spinning `in_progress`
+  after its turn ended (tests for stop/retry/complete transitions, live and post-reload).
+- Plan survives reload and conversation switch with correct per-conversation isolation (AC1–AC3),
+  and a fresh `revision = 1` plan after restart is never dropped (C1 guard test).
+- Status enum and status→presentation logic each exist exactly once (grep shows a single source).
+- One persisted plan-block producer feeds one renderer; the ACP reachability audit is recorded.
+- `pnpm run format && pnpm run i18n && pnpm run lint && pnpm run typecheck` clean; new renderer/main
+  tests cover the lifecycle transitions, the per-turn baseline, the terminal marker, and rehydration.

--- a/docs/architecture/agent-plan-task-refactor/tasks.md
+++ b/docs/architecture/agent-plan-task-refactor/tasks.md
@@ -1,0 +1,161 @@
+# Agent Plan / `update_plan` Task — Tasks (v4)
+
+> Implemented. Decisions D1–D4 are hard-resolved in `spec.md` (D4: agent-mode history
+> shows an inline `type:'plan'` block — settled). Ordered so the cheap terminal-state wins ship
+> before the persistence refactor. Each task is one reviewable commit/PR.
+
+## Increment 0 — De-risk (must precede Increment 2)
+
+- [x] **T1 — ACP reachability audit (R5/AC14).** Trace both ACP subsystems end-to-end: does a
+      `type:'plan'` block today reach the persisted message stream and render via `MessageBlockPlan`?
+      Cover subsystem A (`acpProvider.handleSessionUpdate`, which drops `mapped.blocks`) vs subsystem
+      B (`AcpEventMapper`, instantiated at `acpClientPresenter/index.ts:18` but whose
+      `mapSessionUpdate` has **no found call site**). Record findings in
+      `acp-plan-reachability.md`. Output decides AD2 wiring (T8). **No deletion of `MessageBlockPlan`.**
+
+## Increment 1 — Stop the "stuck spinner" (no persistence, immediate value)
+
+- [x] **T2 — Prompt closure discipline (R7/AC22).** Extend `buildProgressPrompt`: reconcile every
+      step before finishing, never end a turn with a dangling `in_progress`. Mirrors Codex's
+      plan-closure rule. (+ prompt snapshot test.)
+- [x] **T3 — Per-turn baseline + live freeze/rebaseline transitions (R2/AC4 live, AC5; C1).** In the
+      store add `beginTurn(sessionId)` (reset baseline → 0) and `freezeActive(sessionId)` (stops the
+      **live** spinner). Wire `beginTurn` into `onSubmit`/`onSteer`/`onMessageRetry`/
+      `onMessageEditSave`/`onMessageContinue`; wire `freezeActive` into `onStop`. **No blanket
+      delete.** Scope: this only fixes the live in-session spinner; the persistable terminal marker
+      (reload) is T6. (+ renderer test: stop mid-plan → live float no longer spins; retry → clean
+      overlay.)
+- [x] **T4 — Auto-collapse + sticky dismiss + default-expanded (R2/AC6,AC7; AC19).** View-state
+      `{ collapsed, dismissedRevision }`; default `collapsed=false` first appearance; auto-collapse
+      when all complete; `dismiss` sets `dismissedRevision`. (+ store test.)
+
+## Increment 2 — Persisted plan block + terminal state + rehydration (depends on T1; D1/D2/D4)
+
+- [x] **T5 — Upsert THE `type:'plan'` block per turn (R1/AD1).** In `dispatch.applyProgressUpdate`,
+      upsert the single `type:'plan'` block of the turn — locate the lone `type:'plan'` block in
+      `state.blocks`, mutate in place, else insert it **immediately after the first (hidden)
+      `update_plan` tool-call block**; carry
+      `plan_entries/plan_explanation/plan_revision/plan_updated_at`; keep the tool-call block
+      `internalTool=true`. **Rewrite `dispatch.test.ts:299`** to assert the upsert (idempotent across
+      revisions, never duplicated) + event. (+ test.)
+- [x] **T6 — Persistable terminal marker on every turn-exit (R2/AC4 reload; AD6).** Add
+      `state.planTerminalReason?: 'aborted'|'max_steps'|'error'` to `StreamState` (`types.ts`); set
+      it `= 'max_steps'` right before the `break` at `process.ts:404`. Add an **idempotent** helper
+      `stampPlanTerminalIfOpen(state, io, reason)` that stamps `plan_terminal_reason` onto the latest
+      `type:'plan'` block (only when a step is still `in_progress`) and emits one final
+      `chat.plan.updated`. Call it from **all three exits**: `finalizeError` (`dispatch.ts:1489` —
+      covers cancel `process.ts:95`, tool error `:440`, context-window `:504`, no-response `:512`,
+      non-abort exception `:538`, interrupted recovery `messageStore.ts:615`), the `finalize`
+      (`:1475`) after `MAX_TOOL_CALLS`, **and the abort-exception catch branch (`process.ts:527-535`)
+      before its early `return`** (reason `aborted`). **Persistence boundary:** DB writes live only
+      in the finalize family (`updateAssistantContent` :1449 / `finalizeAssistantMessage` :1475 /
+      `setMessageError` :1504), so call the helper **before** those writes in `finalize`/
+      `finalizeError`, and in the abort-exception branch **persist after stamping**
+      (`messageStore.updateAssistantContent` + `flushBlocksToRenderer`) since it has no finalize.
+      (`buildTerminalErrorBlocks` flips block status only — never rely on it for entry status.)
+      **Extend the event contract** `chat.events.ts:47-57`
+      with optional `terminalReason: z.enum(['aborted','max_steps','error'])` (+ update the
+      `defineEventContract` test; `AgentPlanViewSnapshot` derives it). Render `in_progress`
+      **without** `animate-spin` when terminal — directly in `MessageBlockPlan.vue` +
+      `AgentProgressFloat.vue` for now (consolidated into the composable by T13). (+ main tests:
+      cancel / **abort-exception (plan written → provider throws `AbortError` → `aborted`,
+      asserted persisted to messageStore, not just emitted)** / tool-error / exception / max-steps;
+      + renderer test: reload after an error/abort ending → no spin.)
+- [x] **T7 — Rehydrate live float from persisted block on load/switch (R1/AC1–AC3; C1).** On
+      `loadMessages` / sessionId switch, take the latest `type:'plan'` block and
+      `agentPlanStore.applySnapshot`; rely on `beginTurn` (T3) so a subsequent live turn rebaselines
+      cleanly. Per-conversation isolation. (+ renderer rehydration + switch-isolation tests, incl.
+      the C1 guard.)
+- [x] **T8 — Converge ACP onto the same block (R5/AC15; AD2).** Per T1's outcome, fix the ACP
+      producer/transport so its `type:'plan'` block renders via `MessageBlockPlan`; remove the
+      divergent/dead branch (producer side only — renderer stays). (+ test for the live ACP path.)
+
+## Increment 3 — Backend hygiene
+
+- [x] **T9 — Bound `states` + purge renderer (R3/AC8).** Wire `planTool.clearState(sessionId)` into
+      `destroySession` and `agentPlanStore.purge` on conversation delete. Backend revision may stay
+      process-local (safe under C1). (+ main test.)
+- [x] **T10 — Remove dead surface (R3/AC9).** Drop `rawData.toolResult.snapshot` (only `onProgress`
+      consumed); remove `getState`/`clearState` if T9 leaves them unused. Document `onProgress` as
+      sole transport.
+- [x] **T11 — Subagent orphan-key + missing-`toolCallId` (R3/AC10,AC11).** Stop subagent
+      `update_plan` from polluting the parent `states` Map; treat a missing `toolCallId` as an error
+      or logged drop, not silent success. (+ main tests.)
+
+## Increment 4 — Contracts & DRY
+
+- [x] **T12 — Status enum single source (R4/AC12; AD5).** `agentPlanStepStatusSchema` /
+      `agentPlanItemSchema` once in shared; import in tool schema + event contract; remove
+      re-declarations and the unreachable `failed`/`skipped` i18n (AC21).
+- [x] **T13 — Shared status presentation composable (R4/AC13; AD4).** Extract
+      `useAgentPlanStatus.ts` (+ `normalizePlanEntry` + `resolveStepPresentation` incl. the terminal
+      non-spin rule from T6); both renderers consume it; unify completed styling.
+
+## Increment 5 — UX / i18n / a11y polish (independent, low-risk)
+
+- [x] **T14 — Parameterized completed counter (R6/AC16).** One pluralizable
+      `chat.workspace.plan.completedCount` across locales; float + inline badge consistent.
+      (+ per-locale render test.)
+- [x] **T15 — Contrast + a11y (R6/AC17,AC18).** Completed-step text at `text-foreground` (mute icon
+      only); `aria-live="polite"`/`role="status"`; single disclosure control with `aria-expanded` +
+      `aria-controls`; drop the redundant chevron tab stop.
+- [x] **T16 — Prune persisted view-state (R6/AC20).** GC the renamed `agent-plan-view-state` key on
+      conversation deletion (same flow as T9); one-time prune the legacy `agent-plan-collapsed` key.
+
+## Increment 6 — Review follow-up fixes
+
+- [x] **T17 — Accept same-revision terminal updates.** Keep terminal stamps on the existing plan
+      revision, but let `agentPlanStore.applySnapshot` accept a same-revision snapshot that adds or
+      changes `terminalReason`, so the live float does not keep spinning after `max_steps`/error.
+- [x] **T18 — Make dismiss turn-sticky and store getters pure.** Replace revision-based dismiss
+      gating with a turn-scoped `dismissed` flag reset by `beginTurn`; make `isVisible` and
+      `isCollapsed` pure reads that do not create localStorage entries.
+- [x] **T19 — Tighten rehydration.** Rename the store clear API to `clearSnapshot`, update
+      `ChatPage`, and scan loaded messages from newest to oldest, stopping at the first persisted
+      `type:'plan'` block.
+- [x] **T20 — Backend cleanup.** Reduce `AgentPlanState` to the revision value that remains in use
+      and share the canonical `update_plan` tool-name constant with the shared block helper.
+- [x] **T21 — Add runtime regression tests.** Cover subagent/no-progress isolation, process-level
+      `MAX_TOOL_CALLS` terminal stamping, abort-exception persistence, and terminal-stamp
+      idempotency with cloned messageStore write assertions.
+- [x] **T22 — Add renderer regression tests.** Cover same-revision terminal acceptance, backend
+      terminal reason overriding optimistic freeze, sticky dismiss through later revisions, pure
+      getters, and session switch rehydration isolation.
+
+## Increment 7 — Second review follow-up fixes
+
+- [x] **T23 — Make dismiss message-scoped.** Store the dismissed `messageId` instead of a
+      session-level boolean; keep dismiss sticky for the current turn and allow the next auto-drained
+      turn to show its live float without requiring renderer `beginTurn`.
+- [x] **T24 — Treat changed `messageId` as a new live plan turn.** Let `agentPlanStore.applySnapshot`
+      accept a lower/equal revision when `messageId` changes, while preserving same-message revision
+      monotonicity and same-revision terminal-only updates.
+- [x] **T25 — Reset backend plan state at new assistant turn creation.** Add
+      `clearAgentPlanState(sessionId)` as a narrow ToolPresenter method and call it after
+      `createAssistantMessage`, covering user sends and main auto-drained queue turns without
+      clearing tool mappings.
+- [x] **T26 — Add second-review regression tests.** Cover no-`beginTurn` next-message visibility,
+      same-revision non-terminal drops, narrow clear-state wiring, auto-queue reset calls, and direct
+      `snapshotFromAgentPlanBlock` hydration behavior.
+
+## Increment 8 — Third review follow-up fixes
+
+- [x] **T27 — Strengthen error stamp persistence guard.** Capture `setMessageError` blocks at call
+      time and assert ordinary `finalizeError` writes already include `plan_terminal_reason: 'error'`.
+- [x] **T28 — Strengthen renderer purge view-state guard.** Make `agentPlanStore` tests assert the
+      real `useStorage` value shape so `purge(sessionId)` must delete persisted view-state.
+- [x] **T29 — Keep new-message live plans expanded.** Reset collapsed state when `applySnapshot`
+      accepts a changed `messageId`, covering main auto-drained queue turns that do not call
+      `beginTurn`.
+- [x] **T30 — Make auto-collapse transition-only.** Auto-collapse only when the same message moves
+      from not-all-completed to all-completed, not during rehydration or repeated completed updates.
+
+## Sequencing notes
+
+- **T1 first** — resolves the only remaining ambiguity (ACP reachability) and unblocks T5/T8.
+- Increment 1 (T2–T4) ships independently, no persistence, fixes the most visible **live** symptom;
+  safe before T5 because freezing/rebaselining the live overlay does not touch persisted history.
+- T5 carries a deliberate test-contract change; T6 (terminal marker) and T7 (rehydration) must land
+  with it so reload never shows a spinning or vanished plan. T7 must include the C1 guard test.
+- Increments 3–5 are cleanup; interleave once Increment 2's contracts are settled. T13 absorbs the
+  inline terminal-render added directly in T6.

--- a/src/main/presenter/agentRuntimePresenter/accumulator.ts
+++ b/src/main/presenter/agentRuntimePresenter/accumulator.ts
@@ -2,6 +2,7 @@ import type { AssistantMessageBlock } from '@shared/types/agent-interface'
 import type { LLMCoreStreamEvent } from '@shared/types/core/llm-events'
 import type { ChatMessageProviderOptions } from '@shared/types/core/chat-message'
 import type { StreamState } from './types'
+import { upsertAgentPlanBlock } from '@shared/chat/agentPlanBlock'
 
 export function finalizeTrailingPendingNarrativeBlocks(blocks: AssistantMessageBlock[]): void {
   const last = blocks[blocks.length - 1]
@@ -104,6 +105,19 @@ export function accumulate(state: StreamState, event: LLMCoreStreamEvent): void 
       }
       const reasoningTime = block.reasoning_time as { start: number; end: number }
       updateReasoningMetadata(state, reasoningTime.start, reasoningTime.end)
+      state.dirty = true
+      break
+    }
+    case 'plan': {
+      finalizeTrailingPendingNarrativeBlocks(state.blocks)
+      upsertAgentPlanBlock(state.blocks, {
+        sessionId: '',
+        plan: event.plan,
+        ...(event.explanation ? { explanation: event.explanation } : {}),
+        revision: event.revision ?? 1,
+        updatedAt: event.updatedAt ?? new Date().toISOString(),
+        ...(event.terminalReason ? { terminalReason: event.terminalReason } : {})
+      })
       state.dirty = true
       break
     }

--- a/src/main/presenter/agentRuntimePresenter/dispatch.ts
+++ b/src/main/presenter/agentRuntimePresenter/dispatch.ts
@@ -10,7 +10,11 @@ import type { SearchResult } from '@shared/types/core/search'
 import type { IToolPresenter } from '@shared/types/presenters/tool.presenter'
 import type { AgentToolProgressUpdate } from '@shared/types/presenters/tool.presenter'
 import type { AssistantMessageBlock, PermissionMode } from '@shared/types/agent-interface'
-import type { AgentPlanSnapshot } from '@shared/types/agent-plan'
+import type { AgentPlanSnapshot, AgentPlanTerminalReason } from '@shared/types/agent-plan'
+import {
+  stampLatestAgentPlanBlockTerminal,
+  upsertAgentPlanBlock
+} from '@shared/chat/agentPlanBlock'
 import { parseQuestionToolArgs, QUESTION_TOOL_NAME } from '../../lib/agentRuntime/questionTool'
 import { UPDATE_PLAN_TOOL_NAME } from '../toolPresenter/agentTools/agentPlanTool'
 import type {
@@ -123,6 +127,7 @@ type PermissionRequestLike = {
 type RendererFlushHandle = Pick<EchoHandle, 'flush' | 'schedule' | 'rescheduleRenderer'>
 
 const PARALLEL_READ_ONLY_AGENT_TOOLS = new Set(['read'])
+const USER_CANCELED_GENERATION_ERROR = 'common.error.userCanceledGeneration'
 
 function extractTextFromBlocks(blocks: AssistantMessageBlock[]): string {
   return blocks
@@ -390,8 +395,31 @@ function publishPlanUpdated(io: IoParams, snapshot: AgentPlanSnapshot): void {
     plan: snapshot.plan,
     ...(snapshot.explanation ? { explanation: snapshot.explanation } : {}),
     revision: snapshot.revision,
-    updatedAt: snapshot.updatedAt
+    updatedAt: snapshot.updatedAt,
+    ...(snapshot.terminalReason ? { terminalReason: snapshot.terminalReason } : {})
   })
+}
+
+function stampPlanTerminalIfOpen(
+  state: StreamState,
+  io: IoParams,
+  reason: AgentPlanTerminalReason | undefined
+): boolean {
+  if (!reason) {
+    return false
+  }
+
+  const stamped = stampLatestAgentPlanBlockTerminal(state.blocks, reason)
+  if (!stamped) {
+    return false
+  }
+
+  publishPlanUpdated(io, {
+    ...stamped,
+    sessionId: io.sessionId,
+    messageId: io.messageId
+  })
+  return true
 }
 
 function extractSubagentToolState(rawData: MCPToolResponse): {
@@ -920,6 +948,7 @@ async function runToolCall(params: {
         allowProgressUpdates
       ) {
         markInternalPlanToolCallBlock(state.blocks, completedToolCall.id)
+        upsertAgentPlanBlock(state.blocks, update.snapshot, { toolCallId: completedToolCall.id })
         publishPlanUpdated(io, update.snapshot)
         state.dirty = true
         scheduleRendererFlush(state, rendererFlushHandle)
@@ -1460,6 +1489,7 @@ export function finalize(state: StreamState, io: IoParams): void {
   for (const block of state.blocks) {
     if (block.status === 'pending') block.status = 'success'
   }
+  stampPlanTerminalIfOpen(state, io, state.planTerminalReason)
 
   const endTime = Date.now()
   state.metadata.generationTime = endTime - state.startTime
@@ -1489,6 +1519,11 @@ export function finalize(state: StreamState, io: IoParams): void {
 export function finalizeError(state: StreamState, io: IoParams, error: unknown): void {
   const errorMessage = error instanceof Error ? error.message : String(error)
   state.blocks = buildTerminalErrorBlocks(state.blocks, errorMessage)
+  stampPlanTerminalIfOpen(
+    state,
+    io,
+    errorMessage === USER_CANCELED_GENERATION_ERROR ? 'aborted' : 'error'
+  )
 
   const endTime = Date.now()
   state.metadata.generationTime = endTime - state.startTime
@@ -1510,4 +1545,13 @@ export function finalizeError(state: StreamState, io: IoParams, error: unknown):
     failedAt: Date.now(),
     error: errorMessage
   })
+}
+
+export function persistAbortExceptionPlanState(state: StreamState, io: IoParams): void {
+  if (!stampPlanTerminalIfOpen(state, io, 'aborted')) {
+    return
+  }
+
+  io.messageStore.updateAssistantContent(io.messageId, state.blocks)
+  flushBlocksToRenderer(io, state.blocks)
 }

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -1036,6 +1036,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
 
       const assistantOrderSeq = this.messageStore.getNextOrderSeq(sessionId)
       assistantMessageId = this.messageStore.createAssistantMessage(sessionId, assistantOrderSeq)
+      this.toolPresenter?.clearAgentPlanState?.(sessionId)
       this.throwIfAbortRequested(preStreamAbortSignal)
 
       if (context?.pendingQueueItemId && pendingInputSource === 'send') {

--- a/src/main/presenter/agentRuntimePresenter/process.ts
+++ b/src/main/presenter/agentRuntimePresenter/process.ts
@@ -11,7 +11,13 @@ import type {
 import { createState } from './types'
 import { accumulate, finalizeTrailingPendingNarrativeBlocks } from './accumulator'
 import { startEcho } from './echo'
-import { executeTools, finalize, finalizeError, finalizePaused } from './dispatch'
+import {
+  executeTools,
+  finalize,
+  finalizeError,
+  finalizePaused,
+  persistAbortExceptionPlanState
+} from './dispatch'
 
 const MAX_TOOL_CALLS = 128
 const UNKNOWN_CONTEXT_LIMIT = Number.MAX_SAFE_INTEGER
@@ -405,6 +411,7 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
         logger.info(
           `[ProcessStream] max tool calls reached (${toolCallCount + state.completedToolCalls.length} > ${MAX_TOOL_CALLS}), stopping`
         )
+        state.planTerminalReason = 'max_steps'
         break
       }
 
@@ -527,6 +534,7 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
   } catch (err) {
     if (io.abortSignal.aborted || isAbortError(err)) {
       logger.info(`[ProcessStream] aborted via exception after ${eventCount} events`)
+      persistAbortExceptionPlanState(state, io)
       return {
         status: 'aborted' as const,
         stopReason: 'user_stop',

--- a/src/main/presenter/agentRuntimePresenter/types.ts
+++ b/src/main/presenter/agentRuntimePresenter/types.ts
@@ -11,6 +11,7 @@ import type { ModelConfig } from '@shared/presenter'
 import type { IToolPresenter } from '@shared/types/presenters/tool.presenter'
 import type { DeepChatMessageStore } from './messageStore'
 import type { ToolOutputGuard } from './toolOutputGuard'
+import type { AgentPlanTerminalReason } from '@shared/types/agent-plan'
 
 export interface InterleavedReasoningConfig {
   preserveReasoningContent: boolean
@@ -48,6 +49,7 @@ export interface StreamState {
   completedToolCalls: ToolCallResult[]
   pendingInteractions?: PendingToolInteraction[]
   stopReason: 'complete' | 'tool_use' | 'error' | 'abort' | 'max_tokens'
+  planTerminalReason?: AgentPlanTerminalReason
   dirty: boolean
 }
 

--- a/src/main/presenter/llmProviderPresenter/acp/acpContentMapper.ts
+++ b/src/main/presenter/llmProviderPresenter/acp/acpContentMapper.ts
@@ -1,13 +1,14 @@
 import type * as schema from '@agentclientprotocol/sdk/dist/schema/index.js'
 import type { AcpConfigState } from '@shared/presenter'
 import type { AssistantMessageBlock } from '@shared/chat'
+import { createAgentPlanBlock, normalizeAgentPlanStatus } from '@shared/chat/agentPlanBlock'
 import { createStreamEvent, type LLMCoreStreamEvent } from '@shared/types/core/llm-events'
 import { normalizeAcpConfigState } from './acpConfigState'
 
 export interface PlanEntry {
-  content: string
+  step: string
   priority?: string | null
-  status?: string | null
+  status: 'pending' | 'in_progress' | 'completed'
 }
 
 export interface MappedContent {
@@ -235,17 +236,19 @@ export class AcpContentMapper {
 
     // Store structured plan entries
     payload.planEntries = entries.map((entry) => ({
-      content: entry.content,
+      step: entry.content,
       priority: entry.priority ?? null,
-      status: entry.status ?? null
+      status: normalizeAgentPlanStatus(entry.status)
     }))
 
-    // Create dedicated plan block
-    payload.events.push(createStreamEvent.reasoning('')) // Empty event for plan
+    const updatedAt = new Date().toISOString()
+    payload.events.push(createStreamEvent.plan(payload.planEntries, { revision: 1, updatedAt }))
     payload.blocks.push(
-      this.createBlock('plan', '', {
-        extra: { plan_entries: payload.planEntries }
-      })
+      createAgentPlanBlock({
+        plan: payload.planEntries,
+        revision: 1,
+        updatedAt
+      }) as AssistantMessageBlock
     )
   }
 

--- a/src/main/presenter/toolPresenter/agentTools/agentPlanTool.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentPlanTool.ts
@@ -2,27 +2,23 @@ import { z } from 'zod'
 import { zodToJsonSchema } from 'zod-to-json-schema'
 import type { MCPToolDefinition } from '@shared/presenter'
 import type { AgentToolProgressUpdate } from '@shared/types/presenters/tool.presenter'
-import type { AgentPlanState, AgentPlanSnapshot, UpdatePlanArgs } from '@shared/types/agent-plan'
+import {
+  UPDATE_PLAN_TOOL_NAME,
+  agentPlanItemSchema,
+  type AgentPlanState,
+  type AgentPlanSnapshot,
+  type UpdatePlanArgs
+} from '@shared/types/agent-plan'
 
-export const UPDATE_PLAN_TOOL_NAME = 'update_plan'
+export { UPDATE_PLAN_TOOL_NAME }
 export const AGENT_CORE_TOOL_SERVER_NAME = 'agent-core'
 
 const MAX_PLAN_ITEMS = 12
 
-const planItemSchema = z
-  .object({
-    step: z
-      .string()
-      .transform((value) => value.trim())
-      .refine((value) => value.length > 0, 'step must be a non-empty string'),
-    status: z.enum(['pending', 'in_progress', 'completed'])
-  })
-  .strict()
-
 export const updatePlanToolArgsSchema = z
   .object({
     explanation: z.string().optional(),
-    plan: z.array(planItemSchema).max(MAX_PLAN_ITEMS)
+    plan: z.array(agentPlanItemSchema).max(MAX_PLAN_ITEMS)
   })
   .strict()
   .superRefine((value, context) => {
@@ -91,13 +87,17 @@ export class AgentPlanTool {
     }
 
     const normalizedArgs = this.normalizeArgs(validationResult.data)
+    const toolCallId = options?.toolCallId?.trim() || undefined
+    if (!toolCallId) {
+      throw new Error('update_plan requires a tool call ID')
+    }
+
     const previous = this.states.get(sessionId)
     const revision = (previous?.revision ?? 0) + 1
     const updatedAt = new Date().toISOString()
-    const toolCallId = options?.toolCallId?.trim() || undefined
     const snapshot: AgentPlanSnapshot = {
       sessionId,
-      ...(toolCallId ? { toolCallId } : {}),
+      toolCallId,
       ...(normalizedArgs.explanation ? { explanation: normalizedArgs.explanation } : {}),
       plan: normalizedArgs.plan,
       revision,
@@ -105,40 +105,23 @@ export class AgentPlanTool {
     }
 
     this.states.set(sessionId, {
-      current: normalizedArgs,
-      revision,
-      updatedAt
+      revision
     })
 
-    if (toolCallId) {
-      options?.onProgress?.({
-        kind: 'agent_plan',
-        toolCallId,
-        snapshot
-      })
-    }
+    options?.onProgress?.({
+      kind: 'agent_plan',
+      toolCallId,
+      snapshot
+    })
 
     return {
       content: '{}',
       rawData: {
         content: '{}',
         isError: false,
-        toolResult: {
-          kind: 'agent_plan',
-          snapshot
-        }
+        toolResult: { kind: 'agent_plan' }
       }
     }
-  }
-
-  getState(conversationId: string): AgentPlanState {
-    return (
-      this.states.get(conversationId) ?? {
-        current: null,
-        revision: 0,
-        updatedAt: null
-      }
-    )
   }
 
   clearState(conversationId: string): void {

--- a/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
@@ -892,6 +892,10 @@ export class AgentToolManager {
     }
   }
 
+  public clearPlanState(conversationId: string): void {
+    this.planTool?.clearState(conversationId)
+  }
+
   private async callFileSystemTool(
     toolName: string,
     args: Record<string, unknown>,

--- a/src/main/presenter/toolPresenter/index.ts
+++ b/src/main/presenter/toolPresenter/index.ts
@@ -79,6 +79,7 @@ export interface IToolPresenter {
     options?: { permissionMode?: PermissionMode }
   ): Promise<PreCheckedPermissionResult | null>
   clearConversationToolMapping?(conversationId: string): void
+  clearAgentPlanState?(conversationId: string): void
   buildToolSystemPrompt(context: {
     conversationId?: string
     toolDefinitions?: MCPToolDefinition[]
@@ -238,6 +239,16 @@ export class ToolPresenter implements IToolPresenter {
     }
 
     this.conversationMappers.delete(normalizedConversationId)
+    this.clearAgentPlanState(normalizedConversationId)
+  }
+
+  clearAgentPlanState(conversationId: string): void {
+    const normalizedConversationId = conversationId.trim()
+    if (!normalizedConversationId) {
+      return
+    }
+
+    this.agentToolManager?.clearPlanState(normalizedConversationId)
   }
 
   /**
@@ -652,6 +663,7 @@ export class ToolPresenter implements IToolPresenter {
       'Keep the checklist current as work progresses.',
       'At most one step may be in_progress at a time.',
       'When a step completes, update the checklist immediately and move the next active step to in_progress in the same call.',
+      'Before ending the turn, reconcile the checklist so no step remains in_progress.',
       'Use explanation only when the plan changes materially or progress would otherwise be unclear.'
     ].join('\n')
   }

--- a/src/renderer/src/components/chat/AgentProgressFloat.vue
+++ b/src/renderer/src/components/chat/AgentProgressFloat.vue
@@ -17,6 +17,7 @@
         class="agent-progress-trigger group flex min-w-0 flex-1 items-center gap-2.5 rounded-2xl px-2 py-1.5 text-left transition-all duration-200 hover:bg-foreground/[0.035] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
         data-testid="agent-progress-float-trigger"
         :aria-expanded="!collapsed"
+        :aria-controls="panelId"
         :aria-label="t('chat.workspace.plan.section')"
         @click="emit('toggle-collapse')"
       >
@@ -34,7 +35,12 @@
             <span
               class="shrink-0 rounded-full border border-border/70 bg-background/70 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground dark:bg-background/60"
             >
-              {{ completedCount }}/{{ entries.length }}
+              {{
+                t('chat.workspace.plan.completedCount', {
+                  completed: completedCount,
+                  total: entries.length
+                })
+              }}
             </span>
           </span>
 
@@ -50,15 +56,6 @@
       <div class="flex shrink-0 items-center gap-1">
         <button
           type="button"
-          class="agent-progress-action inline-flex h-7 w-7 items-center justify-center text-muted-foreground"
-          :aria-label="collapsed ? t('common.expand') : t('common.collapse')"
-          @click="emit('toggle-collapse')"
-        >
-          <Icon :icon="collapsed ? 'lucide:chevron-down' : 'lucide:chevron-up'" class="h-3 w-3" />
-        </button>
-
-        <button
-          type="button"
           class="agent-progress-action inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground"
           :aria-label="t('common.close')"
           @click="emit('dismiss')"
@@ -70,25 +67,29 @@
 
     <Transition name="agent-progress-panel">
       <div
+        :id="panelId"
         v-show="!collapsed"
         class="agent-progress-panel relative border-t border-border/60 px-3 pb-3 pt-2.5"
         data-testid="agent-progress-float-body"
+        role="status"
+        aria-live="polite"
       >
         <div class="space-y-2">
           <div
             v-for="(entry, index) in entries"
             :key="`${entry.status}-${index}-${entry.step}`"
             class="agent-progress-item flex items-center gap-2.5 rounded-2xl px-2.5 py-1 text-[13px] leading-5"
+            :class="resolveStepPresentation(entry.status, { terminal: isTerminal }).textClass"
             :aria-label="getEntryAriaLabel(entry)"
           >
             <span
               class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border"
-              :class="getStatusBadgeClass(entry.status)"
+              :class="resolveStepPresentation(entry.status, { terminal: isTerminal }).badgeClass"
             >
               <Icon
-                :icon="getStatusIcon(entry.status)"
+                :icon="resolveStepPresentation(entry.status, { terminal: isTerminal }).icon"
                 class="h-3 w-3 shrink-0"
-                :class="getStatusIconClass(entry.status)"
+                :class="resolveStepPresentation(entry.status, { terminal: isTerminal }).iconClass"
                 aria-hidden="true"
               />
             </span>
@@ -104,8 +105,9 @@
 import { computed } from 'vue'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
-import type { AgentPlanItem, AgentPlanStepStatus } from '@shared/types/agent-plan'
+import type { AgentPlanItem } from '@shared/types/agent-plan'
 import type { AgentPlanViewSnapshot } from '@/stores/ui/agentPlan'
+import { entryAriaLabel, resolveStepPresentation } from '@/composables/useAgentPlanStatus'
 
 const props = defineProps<{
   snapshot: AgentPlanViewSnapshot | null
@@ -128,29 +130,11 @@ const completedCount = computed(
   () => entries.value.filter((entry) => entry.status === 'completed').length
 )
 
-const getStatusIcon = (status: AgentPlanStepStatus): string => {
-  if (status === 'completed') return 'lucide:circle-check'
-  if (status === 'in_progress') return 'lucide:loader-circle'
-  return 'lucide:circle'
-}
-
-const getStatusIconClass = (status: AgentPlanStepStatus): string => {
-  if (status === 'completed') return 'text-emerald-600 dark:text-emerald-400'
-  if (status === 'in_progress') return 'animate-spin text-primary'
-  return 'text-muted-foreground'
-}
-
-const getStatusBadgeClass = (status: AgentPlanStepStatus): string => {
-  if (status === 'completed') return 'border-emerald-500/20 bg-emerald-500/10'
-  if (status === 'in_progress') return 'border-primary/25 bg-primary/10'
-  return 'border-border/70'
-}
+const isTerminal = computed(() => Boolean(props.snapshot?.terminalReason))
+const panelId = computed(() => `agent-progress-panel-${props.snapshot?.messageId ?? 'current'}`)
 
 const getEntryAriaLabel = (entry: AgentPlanItem): string =>
-  t('chat.workspace.plan.itemAriaLabel', {
-    status: t(`chat.workspace.plan.status.${entry.status}`),
-    step: entry.step
-  })
+  entryAriaLabel(t, entry, { terminal: isTerminal.value })
 </script>
 
 <style scoped>

--- a/src/renderer/src/components/chat/messageListItems.ts
+++ b/src/renderer/src/components/chat/messageListItems.ts
@@ -1,5 +1,5 @@
 import type { MessageFile } from '@shared/types/agent-interface'
-import type { AgentPlanDisplayItem } from '@shared/types/agent-plan'
+import type { AgentPlanDisplayItem, AgentPlanTerminalReason } from '@shared/types/agent-plan'
 import type { ToolCallImagePreview } from '@shared/types/core/mcp'
 
 export type DisplayMessageUsage = {
@@ -83,6 +83,7 @@ export type DisplayAssistantMessageExtra = Record<string, string | number | obje
   plan_explanation?: string
   plan_revision?: number
   plan_updated_at?: string
+  plan_terminal_reason?: AgentPlanTerminalReason
   subagentProgress?: string
   subagentFinal?: string
 }

--- a/src/renderer/src/components/message/MessageBlockPlan.vue
+++ b/src/renderer/src/components/message/MessageBlockPlan.vue
@@ -4,7 +4,12 @@
       <Icon icon="lucide:list-checks" class="h-4 w-4 text-primary" />
       <span class="text-sm font-medium">{{ t('chat.workspace.plan.section') }}</span>
       <span class="text-xs text-muted-foreground">
-        {{ completedCount }}/{{ totalCount }} {{ t('chat.workspace.plan.status.completed') }}
+        {{
+          t('chat.workspace.plan.completedCount', {
+            completed: completedCount,
+            total: totalCount
+          })
+        }}
       </span>
     </div>
 
@@ -22,22 +27,22 @@
       {{ explanation }}
     </p>
 
-    <div v-if="entries.length > 0" class="mt-3 space-y-2">
+    <div v-if="entries.length > 0" class="mt-3 space-y-2" role="status" aria-live="polite">
       <div
         v-for="(entry, index) in entries"
-        :key="`${entry.status}-${index}-${entry.label}`"
+        :key="`${entry.status}-${index}-${entry.step}`"
         class="grid grid-cols-[1rem_minmax(0,1fr)] gap-2 text-sm leading-5"
-        :class="entry.status === 'completed' ? 'text-muted-foreground' : 'text-foreground'"
+        :class="resolveStepPresentation(entry.status, { terminal: isTerminal }).textClass"
         :aria-label="getEntryAriaLabel(entry)"
       >
         <Icon
-          :icon="getStatusIcon(entry.status)"
+          :icon="resolveStepPresentation(entry.status, { terminal: isTerminal }).icon"
           class="mt-0.5 h-4 w-4 shrink-0"
-          :class="getStatusIconClass(entry.status)"
+          :class="resolveStepPresentation(entry.status, { terminal: isTerminal }).iconClass"
           aria-hidden="true"
         />
         <span class="min-w-0 whitespace-pre-wrap break-words">
-          {{ entry.label }}
+          {{ entry.step }}
         </span>
       </div>
     </div>
@@ -55,13 +60,14 @@
 import { computed } from 'vue'
 import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
-import type { AgentPlanStepStatus } from '@shared/types/agent-plan'
 import type { DisplayAssistantMessageBlock } from '@/components/chat/messageListItems'
-
-type NormalizedPlanEntry = {
-  label: string
-  status: AgentPlanStepStatus
-}
+import { normalizeAgentPlanTerminalReason } from '@shared/types/agent-plan-block'
+import {
+  entryAriaLabel,
+  normalizePlanEntry,
+  resolveStepPresentation,
+  type NormalizedAgentPlanEntry
+} from '@/composables/useAgentPlanStatus'
 
 const props = defineProps<{
   block: DisplayAssistantMessageBlock
@@ -69,43 +75,15 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
-
-const normalizeStatus = (value: unknown): AgentPlanStepStatus => {
-  if (value === 'completed' || value === 'done') {
-    return 'completed'
-  }
-  if (value === 'in_progress') {
-    return 'in_progress'
-  }
-  return 'pending'
-}
-
-const entries = computed<NormalizedPlanEntry[]>(() => {
+const entries = computed<NormalizedAgentPlanEntry[]>(() => {
   const rawEntries = props.block.extra?.plan_entries
   if (!Array.isArray(rawEntries)) {
     return []
   }
 
-  return rawEntries
-    .map((entry) => {
-      if (!isRecord(entry)) {
-        return null
-      }
-
-      const rawLabel = typeof entry.step === 'string' ? entry.step : entry.content
-      const label = typeof rawLabel === 'string' ? rawLabel.trim() : ''
-      if (!label) {
-        return null
-      }
-
-      return {
-        label,
-        status: normalizeStatus(entry.status)
-      }
-    })
-    .filter((entry): entry is NormalizedPlanEntry => entry !== null)
+  return rawEntries.map(normalizePlanEntry).filter((entry): entry is NormalizedAgentPlanEntry => {
+    return entry !== null
+  })
 })
 
 const explanation = computed(() => {
@@ -128,21 +106,10 @@ const progressPercent = computed(() => {
   return Math.round((completedCount.value / totalCount.value) * 100)
 })
 
-const getStatusIcon = (status: AgentPlanStepStatus): string => {
-  if (status === 'completed') return 'lucide:circle-check'
-  if (status === 'in_progress') return 'lucide:loader-circle'
-  return 'lucide:circle'
-}
+const isTerminal = computed(() =>
+  Boolean(normalizeAgentPlanTerminalReason(props.block.extra?.plan_terminal_reason))
+)
 
-const getStatusIconClass = (status: AgentPlanStepStatus): string => {
-  if (status === 'completed') return 'text-muted-foreground'
-  if (status === 'in_progress') return 'animate-spin text-primary'
-  return 'text-muted-foreground/80'
-}
-
-const getEntryAriaLabel = (entry: NormalizedPlanEntry): string =>
-  t('chat.workspace.plan.itemAriaLabel', {
-    status: t(`chat.workspace.plan.status.${entry.status}`),
-    step: entry.label
-  })
+const getEntryAriaLabel = (entry: NormalizedAgentPlanEntry): string =>
+  entryAriaLabel(t, entry, { terminal: isTerminal.value })
 </script>

--- a/src/renderer/src/composables/useAgentPlanStatus.ts
+++ b/src/renderer/src/composables/useAgentPlanStatus.ts
@@ -1,0 +1,89 @@
+import {
+  normalizeAgentPlanStatus,
+  normalizeAgentPlanEntry as normalizeSharedAgentPlanEntry
+} from '@shared/types/agent-plan-block'
+import type {
+  AgentPlanDisplayItem,
+  AgentPlanItem,
+  AgentPlanStepStatus
+} from '@shared/types/agent-plan'
+
+type Translate = (key: string, params?: Record<string, unknown>) => string
+
+export type AgentPlanStepPresentation = {
+  icon: string
+  iconClass: string
+  badgeClass: string
+  textClass: string
+}
+
+export type NormalizedAgentPlanEntry = AgentPlanItem & {
+  priority?: string | null
+}
+
+export function normalizePlanEntry(value: unknown): NormalizedAgentPlanEntry | null {
+  const entry = normalizeSharedAgentPlanEntry(value) as AgentPlanDisplayItem | null
+  if (!entry?.step) {
+    return null
+  }
+
+  return {
+    step: entry.step,
+    status: normalizeAgentPlanStatus(entry.status),
+    ...(entry.priority ? { priority: entry.priority } : {})
+  }
+}
+
+export function resolveStepPresentation(
+  status: AgentPlanStepStatus,
+  options: { terminal?: boolean } = {}
+): AgentPlanStepPresentation {
+  if (status === 'completed') {
+    return {
+      icon: 'lucide:circle-check',
+      iconClass: 'text-muted-foreground',
+      badgeClass: 'border-border/70 bg-muted/45',
+      textClass: 'text-foreground'
+    }
+  }
+
+  if (status === 'in_progress' && options.terminal) {
+    return {
+      icon: 'lucide:circle-pause',
+      iconClass: 'text-muted-foreground',
+      badgeClass: 'border-border/70 bg-muted/45',
+      textClass: 'text-foreground'
+    }
+  }
+
+  if (status === 'in_progress') {
+    return {
+      icon: 'lucide:loader-circle',
+      iconClass: 'animate-spin text-primary',
+      badgeClass: 'border-primary/25 bg-primary/10',
+      textClass: 'text-foreground'
+    }
+  }
+
+  return {
+    icon: 'lucide:circle',
+    iconClass: 'text-muted-foreground',
+    badgeClass: 'border-border/70',
+    textClass: 'text-foreground'
+  }
+}
+
+export function entryAriaLabel(
+  t: Translate,
+  entry: Pick<AgentPlanItem, 'step' | 'status'>,
+  options: { terminal?: boolean } = {}
+): string {
+  const statusKey =
+    entry.status === 'in_progress' && options.terminal
+      ? 'chat.workspace.plan.status.interrupted'
+      : `chat.workspace.plan.status.${entry.status}`
+  return t('chat.workspace.plan.itemAriaLabel', {
+    status: t(statusKey),
+    step: entry.step
+  })
+}

--- a/src/renderer/src/i18n/da-DK/chat.json
+++ b/src/renderer/src/i18n/da-DK/chat.json
@@ -234,11 +234,11 @@
       "itemAriaLabel": "{status}: {step}",
       "status": {
         "completed": "Afsluttet",
-        "failed": "Mislykket",
         "in_progress": "i gang",
         "pending": "Indtil",
-        "skipped": "sprunget over"
-      }
+        "interrupted": "Afbrudt"
+      },
+      "completedCount": "{completed}/{total} fuldført"
     },
     "terminal": {
       "empty": "Ingen output endnu",

--- a/src/renderer/src/i18n/de-DE/chat.json
+++ b/src/renderer/src/i18n/de-DE/chat.json
@@ -245,9 +245,9 @@
         "pending": "Ausstehend",
         "in_progress": "In Bearbeitung",
         "completed": "Abgeschlossen",
-        "failed": "Fehlgeschlagen",
-        "skipped": "Übersprungen"
-      }
+        "interrupted": "Unterbrochen"
+      },
+      "completedCount": "{completed}/{total} abgeschlossen"
     },
     "files": {
       "section": "Dateien",

--- a/src/renderer/src/i18n/en-US/chat.json
+++ b/src/renderer/src/i18n/en-US/chat.json
@@ -264,9 +264,9 @@
         "pending": "Pending",
         "in_progress": "In Progress",
         "completed": "Completed",
-        "failed": "Failed",
-        "skipped": "Skipped"
-      }
+        "interrupted": "Interrupted"
+      },
+      "completedCount": "{completed}/{total} completed"
     },
     "files": {
       "section": "Files",

--- a/src/renderer/src/i18n/es-ES/chat.json
+++ b/src/renderer/src/i18n/es-ES/chat.json
@@ -245,9 +245,9 @@
         "pending": "Pendiente",
         "in_progress": "En curso",
         "completed": "Completado",
-        "failed": "Fallido",
-        "skipped": "Omitido"
-      }
+        "interrupted": "Interrumpido"
+      },
+      "completedCount": "{completed}/{total} completados"
     },
     "files": {
       "section": "Archivos",

--- a/src/renderer/src/i18n/fa-IR/chat.json
+++ b/src/renderer/src/i18n/fa-IR/chat.json
@@ -234,11 +234,11 @@
       "itemAriaLabel": "{status}: {step}",
       "status": {
         "completed": "تکمیل شد",
-        "failed": "شکست بخورد",
         "in_progress": "در حال انجام است",
         "pending": "در انتظار",
-        "skipped": "پرش کرد"
-      }
+        "interrupted": "قطع شد"
+      },
+      "completedCount": "{completed}/{total} تکمیل شد"
     },
     "terminal": {
       "empty": "هنوز خروجی وجود ندارد",

--- a/src/renderer/src/i18n/fr-FR/chat.json
+++ b/src/renderer/src/i18n/fr-FR/chat.json
@@ -234,11 +234,11 @@
       "itemAriaLabel": "{status}: {step}",
       "status": {
         "completed": "Complété",
-        "failed": "échouer",
         "in_progress": "en cours",
         "pending": "En attente",
-        "skipped": "ignoré"
-      }
+        "interrupted": "Interrompu"
+      },
+      "completedCount": "{completed}/{total} terminés"
     },
     "terminal": {
       "empty": "Pas encore de sortie",

--- a/src/renderer/src/i18n/he-IL/chat.json
+++ b/src/renderer/src/i18n/he-IL/chat.json
@@ -234,11 +234,11 @@
       "itemAriaLabel": "{status}: {step}",
       "status": {
         "completed": "הושלם",
-        "failed": "לְהִכָּשֵׁל",
         "in_progress": "בתהליך",
         "pending": "תָלוּי וְעוֹמֵד",
-        "skipped": "דילג"
-      }
+        "interrupted": "הופסק"
+      },
+      "completedCount": "{completed}/{total} הושלמו"
     },
     "terminal": {
       "empty": "עדיין אין פלט",

--- a/src/renderer/src/i18n/id-ID/chat.json
+++ b/src/renderer/src/i18n/id-ID/chat.json
@@ -245,9 +245,9 @@
         "pending": "Tertunda",
         "in_progress": "Sedang berlangsung",
         "completed": "Selesai",
-        "failed": "gagal",
-        "skipped": "dilewati"
-      }
+        "interrupted": "Terinterupsi"
+      },
+      "completedCount": "{completed}/{total} selesai"
     },
     "files": {
       "section": "Mengajukan",

--- a/src/renderer/src/i18n/it-IT/chat.json
+++ b/src/renderer/src/i18n/it-IT/chat.json
@@ -245,9 +245,9 @@
         "pending": "Da fare",
         "in_progress": "In corso",
         "completed": "Completato",
-        "failed": "Non riuscito",
-        "skipped": "Saltato"
-      }
+        "interrupted": "Interrotto"
+      },
+      "completedCount": "{completed}/{total} completati"
     },
     "files": {
       "section": "File",

--- a/src/renderer/src/i18n/ja-JP/chat.json
+++ b/src/renderer/src/i18n/ja-JP/chat.json
@@ -234,11 +234,11 @@
       "itemAriaLabel": "{status}: {step}",
       "status": {
         "completed": "完了しました",
-        "failed": "失敗",
         "in_progress": "進行中",
         "pending": "保留中",
-        "skipped": "スキップしました"
-      }
+        "interrupted": "中断しました"
+      },
+      "completedCount": "{completed}/{total} 完了"
     },
     "terminal": {
       "empty": "まだ出力はありません",

--- a/src/renderer/src/i18n/ko-KR/chat.json
+++ b/src/renderer/src/i18n/ko-KR/chat.json
@@ -234,11 +234,11 @@
       "itemAriaLabel": "{status}: {step}",
       "status": {
         "completed": "완전한",
-        "failed": "실패하다",
         "in_progress": "진행 중",
         "pending": "보류 중",
-        "skipped": "건너뛰었습니다"
-      }
+        "interrupted": "중단됨"
+      },
+      "completedCount": "{completed}/{total} 완료"
     },
     "terminal": {
       "empty": "아직 출력이 없습니다",

--- a/src/renderer/src/i18n/ms-MY/chat.json
+++ b/src/renderer/src/i18n/ms-MY/chat.json
@@ -245,9 +245,9 @@
         "pending": "Belum selesai",
         "in_progress": "sedang berjalan",
         "completed": "Selesai",
-        "failed": "gagal",
-        "skipped": "dilangkau"
-      }
+        "interrupted": "Terganggu"
+      },
+      "completedCount": "{completed}/{total} selesai"
     },
     "files": {
       "section": "dokumen",

--- a/src/renderer/src/i18n/pl-PL/chat.json
+++ b/src/renderer/src/i18n/pl-PL/chat.json
@@ -245,9 +245,9 @@
         "pending": "Oczekujące",
         "in_progress": "W toku",
         "completed": "Ukończono",
-        "failed": "Nie udało się",
-        "skipped": "Pominięte"
-      }
+        "interrupted": "Przerwano"
+      },
+      "completedCount": "{completed}/{total} ukończono"
     },
     "files": {
       "section": "Pliki",

--- a/src/renderer/src/i18n/pt-BR/chat.json
+++ b/src/renderer/src/i18n/pt-BR/chat.json
@@ -234,11 +234,11 @@
       "itemAriaLabel": "{status}: {step}",
       "status": {
         "completed": "Concluído",
-        "failed": "falhar",
         "in_progress": "em andamento",
         "pending": "Pendente",
-        "skipped": "ignorado"
-      }
+        "interrupted": "Interrompido"
+      },
+      "completedCount": "{completed}/{total} concluídos"
     },
     "terminal": {
       "empty": "Nenhuma saída ainda",

--- a/src/renderer/src/i18n/ru-RU/chat.json
+++ b/src/renderer/src/i18n/ru-RU/chat.json
@@ -234,11 +234,11 @@
       "itemAriaLabel": "{status}: {step}",
       "status": {
         "completed": "Завершенный",
-        "failed": "неудача",
         "in_progress": "в ходе выполнения",
         "pending": "В ожидании",
-        "skipped": "пропущен"
-      }
+        "interrupted": "Прервано"
+      },
+      "completedCount": "{completed}/{total} завершено"
     },
     "terminal": {
       "empty": "Выходных данных пока нет",

--- a/src/renderer/src/i18n/tr-TR/chat.json
+++ b/src/renderer/src/i18n/tr-TR/chat.json
@@ -245,9 +245,9 @@
         "pending": "Askıda olması",
         "in_progress": "Devam etmekte",
         "completed": "Tamamlanmış",
-        "failed": "Arızalı",
-        "skipped": "Atlandı"
-      }
+        "interrupted": "Kesintiye uğradı"
+      },
+      "completedCount": "{completed}/{total} tamamlandı"
     },
     "files": {
       "section": "Dosyalar",

--- a/src/renderer/src/i18n/vi-VN/chat.json
+++ b/src/renderer/src/i18n/vi-VN/chat.json
@@ -245,9 +245,9 @@
         "pending": "Đang chờ xử lý",
         "in_progress": "Đang tiến hành",
         "completed": "Đã hoàn thành",
-        "failed": "thất bại",
-        "skipped": "Đã bỏ qua"
-      }
+        "interrupted": "Đã gián đoạn"
+      },
+      "completedCount": "{completed}/{total} đã hoàn thành"
     },
     "files": {
       "section": "Tập tin",

--- a/src/renderer/src/i18n/zh-CN/chat.json
+++ b/src/renderer/src/i18n/zh-CN/chat.json
@@ -264,9 +264,9 @@
         "pending": "待处理",
         "in_progress": "进行中",
         "completed": "已完成",
-        "failed": "失败",
-        "skipped": "已跳过"
-      }
+        "interrupted": "已中断"
+      },
+      "completedCount": "{completed}/{total} 已完成"
     },
     "files": {
       "section": "文件",

--- a/src/renderer/src/i18n/zh-HK/chat.json
+++ b/src/renderer/src/i18n/zh-HK/chat.json
@@ -242,11 +242,11 @@
       "itemAriaLabel": "{status}：{step}",
       "status": {
         "completed": "已完成",
-        "failed": "失敗",
         "in_progress": "進行中",
         "pending": "待處理",
-        "skipped": "已跳過"
-      }
+        "interrupted": "已中斷"
+      },
+      "completedCount": "{completed}/{total} 已完成"
     },
     "terminal": {
       "empty": "暫無輸出",

--- a/src/renderer/src/i18n/zh-TW/chat.json
+++ b/src/renderer/src/i18n/zh-TW/chat.json
@@ -242,11 +242,11 @@
       "itemAriaLabel": "{status}：{step}",
       "status": {
         "completed": "已完成",
-        "failed": "失敗",
         "in_progress": "進行中",
         "pending": "待處理",
-        "skipped": "已跳過"
-      }
+        "interrupted": "已中斷"
+      },
+      "completedCount": "{completed}/{total} 已完成"
     },
     "terminal": {
       "empty": "暫無輸出",

--- a/src/renderer/src/pages/ChatPage.vue
+++ b/src/renderer/src/pages/ChatPage.vue
@@ -220,6 +220,7 @@ import type {
   MessageMetadata,
   ToolInteractionResponse
 } from '@shared/types/agent-interface'
+import { snapshotFromAgentPlanBlock } from '@shared/types/agent-plan-block'
 
 const props = defineProps<{
   sessionId: string
@@ -264,6 +265,41 @@ const applyRestoredSessionSummary = (session: unknown) => {
   if (typeof applyRestoredSession === 'function') {
     applyRestoredSession(session)
   }
+}
+
+function rehydrateAgentPlanFromMessages(sessionId: string): void {
+  let latestSnapshot: ReturnType<typeof snapshotFromAgentPlanBlock> = null
+  for (let messageIndex = messageStore.messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
+    const message = messageStore.messages[messageIndex]
+    if (message.role !== 'assistant') {
+      continue
+    }
+
+    const blocks = messageStore.getAssistantMessageBlocks(message)
+    for (let blockIndex = blocks.length - 1; blockIndex >= 0; blockIndex -= 1) {
+      const block = blocks[blockIndex]
+      const snapshot = snapshotFromAgentPlanBlock(sessionId, message.id, block)
+      if (snapshot) {
+        latestSnapshot = snapshot
+        break
+      }
+    }
+
+    if (latestSnapshot) {
+      break
+    }
+  }
+
+  agentPlanStore.clearSnapshot(sessionId)
+  if (latestSnapshot) {
+    agentPlanStore.applySnapshot(latestSnapshot)
+  }
+}
+
+async function loadMessagesAndRehydrate(sessionId: string, count?: number) {
+  const restoredSession = await messageStore.loadMessages(sessionId, count)
+  rehydrateAgentPlanFromMessages(sessionId)
+  return restoredSession
 }
 
 // --- Auto-scroll ---
@@ -799,7 +835,7 @@ watch(
 
         console.info(`[Startup][Renderer] ChatPage restoring session ${id}`)
         const [restoredSession] = await Promise.all([
-          messageStore.loadMessages(id, INITIAL_MESSAGE_RESTORE_COUNT),
+          loadMessagesAndRehydrate(id, INITIAL_MESSAGE_RESTORE_COUNT),
           pendingInputStore.loadPendingInputs(id)
         ])
 
@@ -977,6 +1013,10 @@ const ephemeralRateLimitBlock = computed<DisplayAssistantMessageBlock | null>(()
 })
 
 const latestPlanSnapshot = computed(() => {
+  if (!agentPlanStore.isVisible(props.sessionId)) {
+    return null
+  }
+
   const snapshot = agentPlanStore.snapshots[props.sessionId]
   if (!snapshot || snapshot.plan.length === 0) {
     return null
@@ -997,8 +1037,7 @@ const messageSearchRootStyle = computed(() => {
 })
 
 function onDismissPlanFloat() {
-  agentPlanStore.setCollapsed(props.sessionId, true)
-  agentPlanStore.clear(props.sessionId)
+  agentPlanStore.dismiss(props.sessionId)
   planFloatReservedHeight.value = 0
 }
 
@@ -1590,7 +1629,7 @@ async function onSubmit() {
   if (isGenerating.value) {
     await pendingInputStore.queueInput(props.sessionId, { text, files })
   } else {
-    agentPlanStore.clear(props.sessionId)
+    agentPlanStore.beginTurn(props.sessionId)
     await chatClient.sendMessage(props.sessionId, { text, files })
   }
   message.value = ''
@@ -1613,7 +1652,7 @@ async function onCommandSubmit(command: string) {
   if (isGenerating.value) {
     await pendingInputStore.queueInput(props.sessionId, { text, files })
   } else {
-    agentPlanStore.clear(props.sessionId)
+    agentPlanStore.beginTurn(props.sessionId)
     await chatClient.sendMessage(props.sessionId, { text, files })
   }
   attachedFiles.value = []
@@ -1633,7 +1672,7 @@ async function handleManualCompactionCommand(text: string): Promise<boolean> {
 
   try {
     const result = await sessionClient.compactSession(props.sessionId)
-    applyRestoredSessionSummary(await messageStore.loadMessages(props.sessionId))
+    applyRestoredSessionSummary(await loadMessagesAndRehydrate(props.sessionId))
     if (!result.compacted) {
       toast({
         title: t('chat.compaction.noopTitle'),
@@ -1676,7 +1715,7 @@ async function onSteer() {
   if (await handleManualCompactionCommand(text)) {
     return
   }
-  agentPlanStore.clear(props.sessionId)
+  agentPlanStore.beginTurn(props.sessionId)
   await chatClient.steerActiveTurn(props.sessionId, { text, files })
   message.value = ''
   attachedFiles.value = []
@@ -1722,7 +1761,7 @@ async function onToolInteractionRespond(response: ToolInteractionResponse) {
       toolCallId: interaction.toolCallId,
       response
     })
-    applyRestoredSessionSummary(await messageStore.loadMessages(props.sessionId))
+    applyRestoredSessionSummary(await loadMessagesAndRehydrate(props.sessionId))
     if (result.handledInline) {
       return
     }
@@ -1737,6 +1776,7 @@ async function onStop() {
   if (isReadOnlySession.value) return
   if (!isGenerating.value) return
   try {
+    agentPlanStore.freezeActive(props.sessionId)
     await chatClient.stopStream({ sessionId: props.sessionId })
   } catch (error) {
     console.error('[ChatPage] cancel generation failed:', error)
@@ -1748,11 +1788,12 @@ async function onMessageRetry(messageId: string) {
   if (!messageId) return
   if (activePendingInteraction.value || isHandlingInteraction.value) return
   try {
+    agentPlanStore.beginTurn(props.sessionId)
     messageStore.clearStreamingState()
     await sessionClient.retryMessage(props.sessionId, messageId)
   } catch (error) {
     console.error('[ChatPage] retry message failed:', error)
-    applyRestoredSessionSummary(await messageStore.loadMessages(props.sessionId))
+    applyRestoredSessionSummary(await loadMessagesAndRehydrate(props.sessionId))
   }
 }
 
@@ -1762,7 +1803,7 @@ async function onMessageDelete(messageId: string) {
   try {
     messageStore.clearStreamingState()
     await sessionClient.deleteMessage(props.sessionId, messageId)
-    applyRestoredSessionSummary(await messageStore.loadMessages(props.sessionId))
+    applyRestoredSessionSummary(await loadMessagesAndRehydrate(props.sessionId))
   } catch (error) {
     console.error('[ChatPage] delete message failed:', error)
   }
@@ -1798,11 +1839,12 @@ async function onMessageContinue(_conversationId: string, messageId: string) {
   if (isReadOnlySession.value) return
   if (!messageId) return
   try {
+    agentPlanStore.beginTurn(props.sessionId)
     messageStore.clearStreamingState()
     await sessionClient.retryMessage(props.sessionId, messageId)
   } catch (error) {
     console.error('[ChatPage] continue message failed:', error)
-    applyRestoredSessionSummary(await messageStore.loadMessages(props.sessionId))
+    applyRestoredSessionSummary(await loadMessagesAndRehydrate(props.sessionId))
   }
 }
 
@@ -1840,7 +1882,7 @@ async function onPendingInputSteer(itemId: string) {
   if (activePendingInteraction.value || isHandlingInteraction.value) return
   try {
     await pendingInputStore.steerPendingInput(props.sessionId, itemId)
-    agentPlanStore.clear(props.sessionId)
+    agentPlanStore.beginTurn(props.sessionId)
   } catch (error) {
     console.error('[ChatPage] steer queued input failed:', error)
     toast({

--- a/src/renderer/src/stores/ui/agentPlan.ts
+++ b/src/renderer/src/stores/ui/agentPlan.ts
@@ -2,16 +2,85 @@ import { defineStore } from 'pinia'
 import { useStorage } from '@vueuse/core'
 import { ref } from 'vue'
 import type { DeepchatEventPayload } from '@shared/contracts/events'
+import type { AgentPlanTerminalReason } from '@shared/types/agent-plan'
 
 export type AgentPlanViewSnapshot = DeepchatEventPayload<'chat.plan.updated'>
 
+export type AgentPlanViewState = {
+  collapsed: boolean
+  dismissedMessageId?: string
+}
+
+type AgentPlanViewStatePatch = Omit<Partial<AgentPlanViewState>, 'dismissedMessageId'> & {
+  dismissedMessageId?: string | null
+}
+
+const VIEW_STATE_STORAGE_KEY = 'agent-plan-view-state'
+const LEGACY_COLLAPSED_STORAGE_KEY = 'agent-plan-collapsed'
+
+const defaultViewState = (): AgentPlanViewState => ({
+  collapsed: false
+})
+
+const hasOpenStep = (snapshot: AgentPlanViewSnapshot): boolean =>
+  snapshot.plan.some((entry) => entry.status === 'in_progress')
+
+const isAllCompleted = (snapshot: AgentPlanViewSnapshot): boolean =>
+  snapshot.plan.length > 0 && snapshot.plan.every((entry) => entry.status === 'completed')
+
 export const useAgentPlanStore = defineStore('agentPlan', () => {
   const snapshots = ref<Record<string, AgentPlanViewSnapshot>>({})
-  const collapsedBySession = useStorage<Record<string, boolean>>('agent-plan-collapsed', {})
+  const viewStateBySession = useStorage<Record<string, AgentPlanViewState>>(
+    VIEW_STATE_STORAGE_KEY,
+    {}
+  )
+
+  globalThis.localStorage?.removeItem(LEGACY_COLLAPSED_STORAGE_KEY)
+
+  const readViewState = (sessionId: string): AgentPlanViewState => {
+    const current = viewStateBySession.value[sessionId]
+    if (!current) {
+      return defaultViewState()
+    }
+
+    return {
+      collapsed: typeof current.collapsed === 'boolean' ? current.collapsed : false,
+      ...(typeof current.dismissedMessageId === 'string' && current.dismissedMessageId
+        ? { dismissedMessageId: current.dismissedMessageId }
+        : {})
+    }
+  }
+
+  const setViewState = (sessionId: string, patch: AgentPlanViewStatePatch): void => {
+    const current = readViewState(sessionId)
+    const nextDismissedMessageId = Object.prototype.hasOwnProperty.call(patch, 'dismissedMessageId')
+      ? patch.dismissedMessageId || undefined
+      : current.dismissedMessageId
+    const nextState: AgentPlanViewState = {
+      collapsed: typeof patch.collapsed === 'boolean' ? patch.collapsed : current.collapsed,
+      ...(nextDismissedMessageId ? { dismissedMessageId: nextDismissedMessageId } : {})
+    }
+    viewStateBySession.value = {
+      ...viewStateBySession.value,
+      [sessionId]: nextState
+    }
+  }
 
   const applySnapshot = (snapshot: AgentPlanViewSnapshot): void => {
     const current = snapshots.value[snapshot.sessionId]
-    if (current && current.revision >= snapshot.revision) {
+    const isNewMessage = Boolean(current && current.messageId !== snapshot.messageId)
+    const shouldAutoCollapse =
+      current !== undefined && !isNewMessage && !isAllCompleted(current) && isAllCompleted(snapshot)
+    const terminalChanged =
+      !isNewMessage &&
+      Boolean(snapshot.terminalReason) &&
+      snapshot.terminalReason !== current?.terminalReason
+    if (
+      current &&
+      !isNewMessage &&
+      (current.revision > snapshot.revision ||
+        (current.revision === snapshot.revision && !terminalChanged))
+    ) {
       return
     }
 
@@ -19,9 +88,21 @@ export const useAgentPlanStore = defineStore('agentPlan', () => {
       ...snapshots.value,
       [snapshot.sessionId]: snapshot
     }
+
+    if (isNewMessage) {
+      setViewState(snapshot.sessionId, {
+        collapsed: false,
+        dismissedMessageId: null
+      })
+      return
+    }
+
+    if (shouldAutoCollapse && !readViewState(snapshot.sessionId).collapsed) {
+      setViewState(snapshot.sessionId, { collapsed: true })
+    }
   }
 
-  const clear = (sessionId: string): void => {
+  const clearSnapshot = (sessionId: string): void => {
     if (!snapshots.value[sessionId]) {
       return
     }
@@ -31,26 +112,82 @@ export const useAgentPlanStore = defineStore('agentPlan', () => {
     snapshots.value = next
   }
 
-  const isCollapsed = (sessionId: string): boolean => collapsedBySession.value[sessionId] !== false
+  const beginTurn = (sessionId: string): void => {
+    clearSnapshot(sessionId)
+    setViewState(sessionId, {
+      ...defaultViewState(),
+      dismissedMessageId: null
+    })
+  }
+
+  const freezeActive = (
+    sessionId: string,
+    terminalReason: AgentPlanTerminalReason = 'aborted'
+  ): void => {
+    const current = snapshots.value[sessionId]
+    if (!current || !hasOpenStep(current) || current.terminalReason) {
+      return
+    }
+
+    snapshots.value = {
+      ...snapshots.value,
+      [sessionId]: {
+        ...current,
+        terminalReason
+      }
+    }
+  }
+
+  const purge = (sessionId: string): void => {
+    clearSnapshot(sessionId)
+    if (!viewStateBySession.value[sessionId]) {
+      return
+    }
+
+    const next = { ...viewStateBySession.value }
+    delete next[sessionId]
+    viewStateBySession.value = next
+  }
+
+  const isCollapsed = (sessionId: string): boolean => readViewState(sessionId).collapsed
 
   const setCollapsed = (sessionId: string, collapsed: boolean): void => {
-    collapsedBySession.value = {
-      ...collapsedBySession.value,
-      [sessionId]: collapsed
-    }
+    setViewState(sessionId, { collapsed })
   }
 
   const toggleCollapsed = (sessionId: string): void => {
     setCollapsed(sessionId, !isCollapsed(sessionId))
   }
 
+  const dismiss = (sessionId: string): void => {
+    const current = snapshots.value[sessionId]
+    setViewState(sessionId, {
+      ...(current ? { dismissedMessageId: current.messageId } : {}),
+      collapsed: true
+    })
+  }
+
+  const isVisible = (sessionId: string): boolean => {
+    const current = snapshots.value[sessionId]
+    if (!current || current.plan.length === 0) {
+      return false
+    }
+
+    return readViewState(sessionId).dismissedMessageId !== current.messageId
+  }
+
   return {
     snapshots,
-    collapsedBySession,
+    viewStateBySession,
     applySnapshot,
-    clear,
+    clearSnapshot,
+    beginTurn,
+    freezeActive,
+    purge,
     isCollapsed,
     setCollapsed,
-    toggleCollapsed
+    toggleCollapsed,
+    dismiss,
+    isVisible
   }
 })

--- a/src/renderer/src/stores/ui/session.ts
+++ b/src/renderer/src/stores/ui/session.ts
@@ -24,6 +24,7 @@ import {
 import { useAgentStore } from './agent'
 import { usePageRouterStore } from './pageRouter'
 import { useMessageStore } from './message'
+import { useAgentPlanStore } from './agentPlan'
 import { bindSessionStoreIpc } from './sessionIpc'
 
 export type UISessionStatus = 'completed' | 'working' | 'error' | 'none'
@@ -265,6 +266,7 @@ export const useSessionStore = defineStore('session', () => {
   const agentStore = useAgentStore()
   const pageRouter = usePageRouterStore()
   const messageStore = useMessageStore()
+  const agentPlanStore = useAgentPlanStore()
   const myWebContentsId = ref<number | null>(null)
   let rendererReadyNotified = false
   let groupModeLoadPromise: Promise<void> | null = null
@@ -357,6 +359,9 @@ export const useSessionStore = defineStore('session', () => {
   const removeSessions = (sessionIds: string[]): void => {
     const targetIds = new Set(sessionIds)
     sessions.value = sessions.value.filter((session) => !targetIds.has(session.id))
+    for (const sessionId of targetIds) {
+      agentPlanStore.purge(sessionId)
+    }
 
     if (bootstrapActiveSession.value && targetIds.has(bootstrapActiveSession.value.id)) {
       bootstrapActiveSession.value = null

--- a/src/shared/chat.d.ts
+++ b/src/shared/chat.d.ts
@@ -1,6 +1,6 @@
 import { FileMetaData } from './presenter'
 import type { ToolCallImagePreview } from './types/core/mcp'
-import type { AgentPlanDisplayItem } from './types/agent-plan'
+import type { AgentPlanDisplayItem, AgentPlanTerminalReason } from './types/agent-plan'
 
 export type Message = {
   id: string
@@ -193,6 +193,7 @@ export type AssistantMessageExtra = Record<string, string | number | object[] | 
   plan_explanation?: string
   plan_revision?: number
   plan_updated_at?: string
+  plan_terminal_reason?: AgentPlanTerminalReason
   subagentProgress?: string
   subagentFinal?: string
 }

--- a/src/shared/chat/agentPlanBlock.ts
+++ b/src/shared/chat/agentPlanBlock.ts
@@ -1,0 +1,173 @@
+import type { AssistantMessageBlock } from '../types/agent-interface'
+import type {
+  AgentPlanDisplayItem,
+  AgentPlanItem,
+  AgentPlanSnapshot,
+  AgentPlanTerminalReason
+} from '../types/agent-plan'
+import { UPDATE_PLAN_TOOL_NAME } from '../types/agent-plan'
+import {
+  normalizeAgentPlanEntries,
+  normalizeAgentPlanStatus,
+  normalizeAgentPlanTerminalReason
+} from '../types/agent-plan-block'
+
+export {
+  normalizeAgentPlanEntry,
+  normalizeAgentPlanEntries,
+  normalizeAgentPlanStatus,
+  normalizeAgentPlanTerminalReason,
+  snapshotFromAgentPlanBlock,
+  type AgentPlanBlockLike,
+  type AgentPlanHydratedSnapshot
+} from '../types/agent-plan-block'
+
+type AgentPlanBlockFields = {
+  plan: AgentPlanItem[]
+  explanation?: string
+  revision: number
+  updatedAt: string
+  terminalReason?: AgentPlanTerminalReason
+}
+
+type UpsertAgentPlanBlockOptions = {
+  toolCallId?: string
+}
+
+function toPlanBlockEntries(plan: AgentPlanItem[]): AgentPlanDisplayItem[] {
+  return plan.map((entry) => ({
+    step: entry.step,
+    status: normalizeAgentPlanStatus(entry.status)
+  }))
+}
+
+function applyPlanBlockFields(block: AssistantMessageBlock, fields: AgentPlanBlockFields): void {
+  block.type = 'plan'
+  block.content = fields.explanation ?? ''
+  block.status = 'success'
+  block.extra = {
+    ...block.extra,
+    plan_entries: toPlanBlockEntries(fields.plan),
+    ...(fields.explanation ? { plan_explanation: fields.explanation } : {}),
+    plan_revision: fields.revision,
+    plan_updated_at: fields.updatedAt,
+    ...(fields.terminalReason ? { plan_terminal_reason: fields.terminalReason } : {})
+  }
+}
+
+export function createAgentPlanBlock(fields: AgentPlanBlockFields): AssistantMessageBlock {
+  const block: AssistantMessageBlock = {
+    type: 'plan',
+    content: fields.explanation ?? '',
+    status: 'success',
+    timestamp: Date.now()
+  }
+  applyPlanBlockFields(block, fields)
+  return block
+}
+
+function findPlanBlockIndex(blocks: AssistantMessageBlock[]): number {
+  return blocks.findIndex((block) => block.type === 'plan')
+}
+
+function findPlanInsertIndex(
+  blocks: AssistantMessageBlock[],
+  options: UpsertAgentPlanBlockOptions
+): number {
+  const internalPlanToolCallIndex = blocks.findIndex(
+    (block) =>
+      block.type === 'tool_call' &&
+      block.extra?.internalTool === true &&
+      block.tool_call?.name === UPDATE_PLAN_TOOL_NAME
+  )
+  if (internalPlanToolCallIndex >= 0) {
+    return internalPlanToolCallIndex + 1
+  }
+
+  const exactToolCallIndex = options.toolCallId?.trim()
+    ? blocks.findIndex(
+        (block) => block.type === 'tool_call' && block.tool_call?.id === options.toolCallId
+      )
+    : -1
+
+  if (exactToolCallIndex >= 0) {
+    return exactToolCallIndex + 1
+  }
+
+  return blocks.length
+}
+
+export function upsertAgentPlanBlock(
+  blocks: AssistantMessageBlock[],
+  snapshot: AgentPlanSnapshot,
+  options: UpsertAgentPlanBlockOptions = {}
+): AssistantMessageBlock {
+  const fields: AgentPlanBlockFields = {
+    plan: snapshot.plan,
+    ...(snapshot.explanation ? { explanation: snapshot.explanation } : {}),
+    revision: snapshot.revision,
+    updatedAt: snapshot.updatedAt,
+    ...(snapshot.terminalReason ? { terminalReason: snapshot.terminalReason } : {})
+  }
+  const existingIndex = findPlanBlockIndex(blocks)
+  if (existingIndex >= 0) {
+    const block = blocks[existingIndex]
+    applyPlanBlockFields(block, fields)
+    return block
+  }
+
+  const block = createAgentPlanBlock(fields)
+  blocks.splice(findPlanInsertIndex(blocks, options), 0, block)
+  return block
+}
+
+export function stampLatestAgentPlanBlockTerminal(
+  blocks: AssistantMessageBlock[],
+  reason: AgentPlanTerminalReason,
+  updatedAt: string = new Date().toISOString()
+): AgentPlanSnapshot | null {
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index]
+    if (block.type !== 'plan') {
+      continue
+    }
+
+    const plan = normalizeAgentPlanEntries(block.extra?.plan_entries)
+    if (!plan.some((entry) => entry.status === 'in_progress')) {
+      return null
+    }
+
+    if (normalizeAgentPlanTerminalReason(block.extra?.plan_terminal_reason)) {
+      return null
+    }
+
+    const rawRevision = block.extra?.plan_revision
+    const revision = typeof rawRevision === 'number' && rawRevision > 0 ? rawRevision : 1
+    const rawExplanation = block.extra?.plan_explanation
+    const explanation =
+      typeof rawExplanation === 'string' && rawExplanation.trim()
+        ? rawExplanation.trim()
+        : block.content?.trim() || undefined
+
+    block.extra = {
+      ...block.extra,
+      plan_entries: toPlanBlockEntries(plan),
+      ...(explanation ? { plan_explanation: explanation } : {}),
+      plan_revision: revision,
+      plan_updated_at: updatedAt,
+      plan_terminal_reason: reason
+    }
+
+    return {
+      sessionId: '',
+      messageId: '',
+      plan,
+      ...(explanation ? { explanation } : {}),
+      revision,
+      updatedAt,
+      terminalReason: reason
+    }
+  }
+
+  return null
+}

--- a/src/shared/contracts/events/chat.events.ts
+++ b/src/shared/contracts/events/chat.events.ts
@@ -5,11 +5,7 @@ import {
   TimestampMsSchema,
   defineEventContract
 } from '../common'
-
-const AgentPlanItemSchema = z.object({
-  step: z.string(),
-  status: z.enum(['pending', 'in_progress', 'completed'])
-})
+import { agentPlanItemSchema, agentPlanTerminalReasonSchema } from '../../types/agent-plan'
 
 export const chatStreamUpdatedEvent = defineEventContract({
   name: 'chat.stream.updated',
@@ -50,9 +46,10 @@ export const chatPlanUpdatedEvent = defineEventContract({
     sessionId: EntityIdSchema,
     messageId: EntityIdSchema,
     toolCallId: z.string().optional(),
-    plan: z.array(AgentPlanItemSchema),
+    plan: z.array(agentPlanItemSchema),
     explanation: z.string().optional(),
     revision: z.number().int().positive(),
-    updatedAt: z.string()
+    updatedAt: z.string(),
+    terminalReason: agentPlanTerminalReasonSchema.optional()
   })
 })

--- a/src/shared/types/agent-interface.d.ts
+++ b/src/shared/types/agent-interface.d.ts
@@ -2,7 +2,7 @@ import type { ReasoningEffort, ReasoningVisibility, Verbosity } from './model-db
 import type { ImageGenerationOptions } from '../imageGenerationSettings'
 import type { VideoGenerationOptions } from '../videoGenerationSettings'
 import type { ToolCallImagePreview } from './core/mcp'
-import type { AgentPlanDisplayItem } from './agent-plan'
+import type { AgentPlanDisplayItem, AgentPlanTerminalReason } from './agent-plan'
 import type { DeepChatTapeViewManifestRecord } from './tape-view-manifest'
 import type { DeepChatTapeReplayExportOptions, DeepChatTapeReplaySlice } from './tape-replay'
 
@@ -448,6 +448,7 @@ export interface AssistantMessageExtra {
   plan_explanation?: string
   plan_revision?: number
   plan_updated_at?: string
+  plan_terminal_reason?: AgentPlanTerminalReason
   subagentProgress?: string
   subagentFinal?: string
   [key: string]: string | number | boolean | object[] | undefined

--- a/src/shared/types/agent-plan-block.ts
+++ b/src/shared/types/agent-plan-block.ts
@@ -1,0 +1,108 @@
+import type {
+  AgentPlanDisplayItem,
+  AgentPlanItem,
+  AgentPlanSnapshot,
+  AgentPlanStepStatus,
+  AgentPlanTerminalReason
+} from './agent-plan'
+
+export type AgentPlanBlockLike = {
+  type: string
+  content?: string
+  extra?: Record<string, unknown>
+}
+
+export type AgentPlanHydratedSnapshot = AgentPlanSnapshot & {
+  messageId: string
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+export function normalizeAgentPlanStatus(value: unknown): AgentPlanStepStatus {
+  if (value === 'completed' || value === 'done') {
+    return 'completed'
+  }
+  if (value === 'in_progress') {
+    return 'in_progress'
+  }
+  return 'pending'
+}
+
+export function normalizeAgentPlanEntry(value: unknown): AgentPlanDisplayItem | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const rawStep = typeof value.step === 'string' ? value.step : value.content
+  const step = typeof rawStep === 'string' ? rawStep.trim() : ''
+  if (!step) {
+    return null
+  }
+
+  return {
+    step,
+    status: normalizeAgentPlanStatus(value.status),
+    ...(typeof value.priority === 'string' ? { priority: value.priority } : {})
+  }
+}
+
+export function normalizeAgentPlanEntries(value: unknown): AgentPlanItem[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map(normalizeAgentPlanEntry)
+    .filter((entry): entry is AgentPlanDisplayItem => entry !== null)
+    .map((entry) => ({
+      step: entry.step || '',
+      status: normalizeAgentPlanStatus(entry.status)
+    }))
+    .filter((entry) => entry.step.length > 0)
+}
+
+export function normalizeAgentPlanTerminalReason(
+  value: unknown
+): AgentPlanTerminalReason | undefined {
+  if (value === 'aborted' || value === 'max_steps' || value === 'error') {
+    return value
+  }
+  return undefined
+}
+
+export function snapshotFromAgentPlanBlock(
+  sessionId: string,
+  messageId: string,
+  block: AgentPlanBlockLike
+): AgentPlanHydratedSnapshot | null {
+  if (block.type !== 'plan') {
+    return null
+  }
+
+  const plan = normalizeAgentPlanEntries(block.extra?.plan_entries)
+  if (plan.length === 0) {
+    return null
+  }
+
+  const rawRevision = block.extra?.plan_revision
+  const revision = typeof rawRevision === 'number' && rawRevision > 0 ? rawRevision : 1
+  const rawUpdatedAt = block.extra?.plan_updated_at
+  const updatedAt = typeof rawUpdatedAt === 'string' && rawUpdatedAt ? rawUpdatedAt : ''
+  const rawExplanation = block.extra?.plan_explanation
+  const explanation =
+    typeof rawExplanation === 'string' && rawExplanation.trim()
+      ? rawExplanation.trim()
+      : block.content?.trim() || undefined
+  const terminalReason = normalizeAgentPlanTerminalReason(block.extra?.plan_terminal_reason)
+
+  return {
+    sessionId,
+    messageId,
+    plan,
+    ...(explanation ? { explanation } : {}),
+    revision,
+    updatedAt: updatedAt || new Date(0).toISOString(),
+    ...(terminalReason ? { terminalReason } : {})
+  }
+}

--- a/src/shared/types/agent-plan.ts
+++ b/src/shared/types/agent-plan.ts
@@ -1,9 +1,22 @@
-export type AgentPlanStepStatus = 'pending' | 'in_progress' | 'completed'
+import { z } from 'zod'
 
-export interface AgentPlanItem {
-  step: string
-  status: AgentPlanStepStatus
-}
+export const UPDATE_PLAN_TOOL_NAME = 'update_plan'
+
+export const agentPlanStepStatusSchema = z.enum(['pending', 'in_progress', 'completed'])
+export const agentPlanTerminalReasonSchema = z.enum(['aborted', 'max_steps', 'error'])
+export const agentPlanItemSchema = z
+  .object({
+    step: z
+      .string()
+      .transform((value) => value.trim())
+      .refine((value) => value.length > 0, 'step must be a non-empty string'),
+    status: agentPlanStepStatusSchema
+  })
+  .strict()
+
+export type AgentPlanStepStatus = z.infer<typeof agentPlanStepStatusSchema>
+export type AgentPlanTerminalReason = z.infer<typeof agentPlanTerminalReasonSchema>
+export type AgentPlanItem = z.infer<typeof agentPlanItemSchema>
 
 export interface AgentPlanDisplayItem {
   step?: string
@@ -19,13 +32,13 @@ export interface UpdatePlanArgs {
 
 export interface AgentPlanSnapshot extends UpdatePlanArgs {
   sessionId: string
+  messageId?: string
   toolCallId?: string
   revision: number
   updatedAt: string
+  terminalReason?: AgentPlanTerminalReason
 }
 
 export interface AgentPlanState {
-  current: UpdatePlanArgs | null
   revision: number
-  updatedAt: string | null
 }

--- a/src/shared/types/core/chat.ts
+++ b/src/shared/types/core/chat.ts
@@ -1,7 +1,7 @@
 // Core chat types (strong-typed UI blocks)
 
 import type { ToolCallImagePreview } from './mcp'
-import type { AgentPlanDisplayItem } from '../agent-plan'
+import type { AgentPlanDisplayItem, AgentPlanTerminalReason } from '../agent-plan'
 import type { QuestionOption } from './question'
 
 export type Message = {
@@ -138,6 +138,7 @@ export type AssistantMessageExtra = Record<string, string | number | object[] | 
   plan_explanation?: string
   plan_revision?: number
   plan_updated_at?: string
+  plan_terminal_reason?: AgentPlanTerminalReason
 }
 
 export type {

--- a/src/shared/types/core/llm-events.ts
+++ b/src/shared/types/core/llm-events.ts
@@ -1,6 +1,7 @@
 // Strong-typed LLM core stream events (discriminated union)
 
 import type { ChatMessageProviderOptions } from './chat-message'
+import type { AgentPlanItem, AgentPlanTerminalReason } from '../agent-plan'
 
 export type StreamEventType =
   | 'text'
@@ -14,6 +15,7 @@ export type StreamEventType =
   | 'stop'
   | 'image_data'
   | 'rate_limit'
+  | 'plan'
 
 export interface TextStreamEvent {
   type: 'text'
@@ -93,6 +95,15 @@ export interface RateLimitStreamEvent {
   }
 }
 
+export interface PlanStreamEvent {
+  type: 'plan'
+  plan: AgentPlanItem[]
+  explanation?: string
+  revision?: number
+  updatedAt?: string
+  terminalReason?: AgentPlanTerminalReason
+}
+
 export type LLMCoreStreamEvent =
   | TextStreamEvent
   | ReasoningStreamEvent
@@ -105,6 +116,7 @@ export type LLMCoreStreamEvent =
   | StopStreamEvent
   | ImageDataStreamEvent
   | RateLimitStreamEvent
+  | PlanStreamEvent
 
 export type {
   ChatMessage,
@@ -127,6 +139,22 @@ export const createStreamEvent = {
     type: 'reasoning',
     reasoning_content,
     ...(provider_options ? { provider_options } : {})
+  }),
+  plan: (
+    plan: AgentPlanItem[],
+    options?: {
+      explanation?: string
+      revision?: number
+      updatedAt?: string
+      terminalReason?: AgentPlanTerminalReason
+    }
+  ): PlanStreamEvent => ({
+    type: 'plan',
+    plan,
+    ...(options?.explanation ? { explanation: options.explanation } : {}),
+    ...(typeof options?.revision === 'number' ? { revision: options.revision } : {}),
+    ...(options?.updatedAt ? { updatedAt: options.updatedAt } : {}),
+    ...(options?.terminalReason ? { terminalReason: options.terminalReason } : {})
   }),
   toolCallStart: (
     tool_call_id: string,

--- a/src/shared/types/presenters/tool.presenter.d.ts
+++ b/src/shared/types/presenters/tool.presenter.d.ts
@@ -99,6 +99,11 @@ export interface IToolPresenter {
   clearConversationToolMapping?(conversationId: string): void
 
   /**
+   * Reset only the per-turn agent plan state for a conversation.
+   */
+  clearAgentPlanState?(conversationId: string): void
+
+  /**
    * Build system prompt section for tool-related behavior.
    */
   buildToolSystemPrompt(context: {

--- a/test/main/presenter/agentRuntimePresenter/accumulator.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/accumulator.test.ts
@@ -85,6 +85,35 @@ describe('accumulate', () => {
     expect(state.blocks[1].type).toBe('content')
   })
 
+  it('upserts plan events into a plan block', () => {
+    accumulate(state, {
+      type: 'plan',
+      plan: [{ step: 'Inspect runtime', status: 'in_progress' }],
+      revision: 1,
+      updatedAt: '2026-05-18T00:00:00.000Z'
+    })
+    accumulate(state, {
+      type: 'plan',
+      plan: [
+        { step: 'Inspect runtime', status: 'completed' },
+        { step: 'Write tests', status: 'in_progress' }
+      ],
+      revision: 2,
+      updatedAt: '2026-05-18T00:00:01.000Z'
+    })
+
+    const planBlocks = state.blocks.filter((block) => block.type === 'plan')
+    expect(planBlocks).toHaveLength(1)
+    expect(planBlocks[0].extra).toMatchObject({
+      plan_entries: [
+        { step: 'Inspect runtime', status: 'completed' },
+        { step: 'Write tests', status: 'in_progress' }
+      ],
+      plan_revision: 2,
+      plan_updated_at: '2026-05-18T00:00:01.000Z'
+    })
+  })
+
   it('finalizes trailing content before a tool call starts', () => {
     accumulate(state, { type: 'text', content: 'Draft answer' })
     accumulate(state, {

--- a/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
@@ -549,6 +549,7 @@ function createMockToolPresenter(toolDefs: any[] = []) {
       content: 'tool result',
       rawData: { toolCallId: 'tc1', content: 'tool result', isError: false }
     }),
+    clearAgentPlanState: vi.fn(),
     buildToolSystemPrompt: vi.fn().mockReturnValue('')
   } as any
 }
@@ -1276,6 +1277,15 @@ describe('AgentRuntimePresenter', () => {
           })
         })
       )
+    })
+
+    it('resets agent plan state for each new assistant turn', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+
+      await agent.processMessage('s1', 'Hello')
+
+      expect(toolPresenter.clearAgentPlanState).toHaveBeenCalledTimes(1)
+      expect(toolPresenter.clearAgentPlanState).toHaveBeenCalledWith('s1')
     })
 
     it('resolves first-turn readiness before processMessage completes', async () => {
@@ -4197,6 +4207,10 @@ describe('AgentRuntimePresenter', () => {
         expect(processStream).toHaveBeenCalledTimes(2)
         expect(await agent.listPendingInputs('s1')).toEqual([])
       })
+
+      expect(toolPresenter.clearAgentPlanState).toHaveBeenCalledTimes(2)
+      expect(toolPresenter.clearAgentPlanState).toHaveBeenNthCalledWith(1, 's1')
+      expect(toolPresenter.clearAgentPlanState).toHaveBeenNthCalledWith(2, 's1')
 
       const userInserts = sqlitePresenter.deepchatMessagesTable.insert.mock.calls
         .map(([row]) => row)

--- a/test/main/presenter/agentRuntimePresenter/dispatch.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/dispatch.test.ts
@@ -55,7 +55,8 @@ vi.mock('@/presenter', () => ({
 import {
   executeTools as executeToolsInternal,
   finalize,
-  finalizeError
+  finalizeError,
+  persistAbortExceptionPlanState
 } from '@/presenter/agentRuntimePresenter/dispatch'
 import type { EchoHandle } from '@/presenter/agentRuntimePresenter/echo'
 import { accumulate } from '@/presenter/agentRuntimePresenter/accumulator'
@@ -296,7 +297,7 @@ describe('dispatch', () => {
       expect(toolBlock!.status).toBe('success')
     })
 
-    it('publishes plan update events without inserting plan blocks into messages', async () => {
+    it('upserts a single plan block and publishes plan update events', async () => {
       const tools = [makeAgentTool('update_plan')]
       const snapshot = {
         sessionId: 's1',
@@ -357,7 +358,17 @@ describe('dispatch', () => {
       const planBlock = state.blocks.find((block) => block.type === 'plan')
       const toolBlock = state.blocks.find((block) => block.type === 'tool_call')
 
-      expect(planBlock).toBeUndefined()
+      expect(planBlock).toMatchObject({
+        type: 'plan',
+        content: 'Repository inspected',
+        extra: {
+          plan_entries: snapshot.plan,
+          plan_explanation: 'Repository inspected',
+          plan_revision: 1,
+          plan_updated_at: snapshot.updatedAt
+        }
+      })
+      expect(state.blocks.indexOf(planBlock!)).toBe(state.blocks.indexOf(toolBlock!) + 1)
       expect(toolBlock?.extra?.internalTool).toBe(true)
 
       const planEventCall = publishDeepchatEventMock.mock.calls.find(
@@ -372,6 +383,154 @@ describe('dispatch', () => {
         revision: 1,
         updatedAt: snapshot.updatedAt
       })
+    })
+
+    it('mutates the existing plan block across revisions without duplicating it', async () => {
+      const tools = [makeAgentTool('update_plan')]
+      const snapshots = [
+        {
+          sessionId: 's1',
+          toolCallId: 'tc-plan',
+          plan: [{ step: 'Inspect runtime', status: 'in_progress' as const }],
+          revision: 1,
+          updatedAt: '2026-05-18T00:00:00.000Z'
+        },
+        {
+          sessionId: 's1',
+          toolCallId: 'tc-plan',
+          plan: [
+            { step: 'Inspect runtime', status: 'completed' as const },
+            { step: 'Write tests', status: 'in_progress' as const }
+          ],
+          revision: 2,
+          updatedAt: '2026-05-18T00:00:01.000Z'
+        }
+      ]
+      const toolPresenter = {
+        ...createMockToolPresenter(),
+        callTool: vi.fn(async (_request, options) => {
+          for (const snapshot of snapshots) {
+            options?.onProgress?.({
+              kind: 'agent_plan',
+              toolCallId: 'tc-plan',
+              snapshot
+            })
+          }
+          return {
+            content: '{}',
+            rawData: {
+              toolCallId: 'tc-plan',
+              content: '{}',
+              isError: false
+            }
+          }
+        })
+      } as unknown as IToolPresenter
+      const conversation = [{ role: 'user' as const, content: 'Plan this' }]
+
+      state.blocks.push({
+        type: 'tool_call',
+        content: '',
+        status: 'pending',
+        timestamp: Date.now(),
+        tool_call: { id: 'tc-plan', name: 'update_plan', params: '{}', response: '' }
+      })
+      state.completedToolCalls = [{ id: 'tc-plan', name: 'update_plan', arguments: '{}' }]
+
+      await executeTools(
+        state,
+        conversation,
+        0,
+        tools,
+        toolPresenter,
+        'gpt-4',
+        io,
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024,
+        undefined,
+        'openai'
+      )
+
+      const planBlocks = state.blocks.filter((block) => block.type === 'plan')
+      expect(planBlocks).toHaveLength(1)
+      expect(planBlocks[0].extra).toMatchObject({
+        plan_entries: snapshots[1].plan,
+        plan_revision: 2,
+        plan_updated_at: snapshots[1].updatedAt
+      })
+    })
+
+    it('ignores agent plan progress from parallel read-only tool batches', async () => {
+      const tools = [makeAgentTool('read')]
+      const toolPresenter = {
+        ...createMockToolPresenter(),
+        callTool: vi.fn(async (request, options) => {
+          options?.onProgress?.({
+            kind: 'agent_plan',
+            toolCallId: request.id,
+            snapshot: {
+              sessionId: 's1',
+              toolCallId: request.id,
+              plan: [{ step: 'Subagent-only progress', status: 'in_progress' }],
+              revision: 1,
+              updatedAt: '2026-05-18T00:00:00.000Z'
+            }
+          })
+          return {
+            content: '{}',
+            rawData: {
+              toolCallId: request.id,
+              content: '{}',
+              isError: false
+            }
+          }
+        })
+      } as unknown as IToolPresenter
+      const conversation = [{ role: 'user' as const, content: 'Read in parallel' }]
+
+      state.blocks.push(
+        {
+          type: 'tool_call',
+          content: '',
+          status: 'pending',
+          timestamp: Date.now(),
+          tool_call: { id: 'tc-read-a', name: 'read', params: '{}', response: '' }
+        },
+        {
+          type: 'tool_call',
+          content: '',
+          status: 'pending',
+          timestamp: Date.now(),
+          tool_call: { id: 'tc-read-b', name: 'read', params: '{}', response: '' }
+        }
+      )
+      state.completedToolCalls = [
+        { id: 'tc-read-a', name: 'read', arguments: '{}' },
+        { id: 'tc-read-b', name: 'read', arguments: '{}' }
+      ]
+
+      await executeTools(
+        state,
+        conversation,
+        0,
+        tools,
+        toolPresenter,
+        'gpt-4',
+        io,
+        'full_access',
+        new ToolOutputGuard(),
+        32000,
+        1024,
+        undefined,
+        'openai'
+      )
+
+      expect(state.blocks.some((block) => block.type === 'plan')).toBe(false)
+      expect(
+        publishDeepchatEventMock.mock.calls.some(([eventName]) => eventName === 'chat.plan.updated')
+      ).toBe(false)
     })
 
     it('runs all-read-only Agent tool batches in parallel and preserves result order', async () => {
@@ -2486,6 +2645,35 @@ describe('dispatch', () => {
         blocks: expect.any(Array)
       })
     })
+
+    it('stamps open plan blocks with max_steps before finalizing', () => {
+      state.planTerminalReason = 'max_steps'
+      state.blocks.push({
+        type: 'plan',
+        content: '',
+        status: 'success',
+        timestamp: Date.now(),
+        extra: {
+          plan_entries: [{ step: 'Still running', status: 'in_progress' }],
+          plan_revision: 3,
+          plan_updated_at: '2026-05-18T00:00:00.000Z'
+        }
+      })
+
+      finalize(state, io)
+
+      expect(state.blocks[0].extra?.plan_terminal_reason).toBe('max_steps')
+      expect(io.messageStore.finalizeAssistantMessage).toHaveBeenCalledWith(
+        'm1',
+        state.blocks,
+        expect.any(String)
+      )
+      expectDeepchatEvent('chat.plan.updated', {
+        sessionId: 's1',
+        messageId: 'm1',
+        terminalReason: 'max_steps'
+      })
+    })
   })
 
   describe('finalizeError', () => {
@@ -2538,6 +2726,128 @@ describe('dispatch', () => {
 
       const errorBlock = state.blocks.find((b) => b.type === 'error')
       expect(errorBlock!.content).toBe('string error')
+    })
+
+    it('stamps open plan blocks with error before setMessageError', () => {
+      const errorWrites: any[] = []
+      ;(io.messageStore.setMessageError as ReturnType<typeof vi.fn>).mockImplementation(
+        (_messageId, blocks) => {
+          errorWrites.push(structuredClone(blocks))
+        }
+      )
+      state.blocks.push({
+        type: 'plan',
+        content: '',
+        status: 'success',
+        timestamp: Date.now(),
+        extra: {
+          plan_entries: [{ step: 'Still running', status: 'in_progress' }],
+          plan_revision: 1,
+          plan_updated_at: '2026-05-18T00:00:00.000Z'
+        }
+      })
+
+      finalizeError(state, io, new Error('boom'))
+
+      const persistedPlanBlock = errorWrites[0]?.find(
+        (block: { type: string }) => block.type === 'plan'
+      )
+      expect(state.blocks[0].extra?.plan_terminal_reason).toBe('error')
+      expect(persistedPlanBlock?.extra?.plan_terminal_reason).toBe('error')
+      expect(io.messageStore.setMessageError).toHaveBeenCalledWith(
+        'm1',
+        state.blocks,
+        expect.any(String)
+      )
+      expectDeepchatEvent('chat.plan.updated', {
+        sessionId: 's1',
+        messageId: 'm1',
+        terminalReason: 'error'
+      })
+    })
+
+    it('stamps user cancel as aborted', () => {
+      state.blocks.push({
+        type: 'plan',
+        content: '',
+        status: 'success',
+        timestamp: Date.now(),
+        extra: {
+          plan_entries: [{ step: 'Still running', status: 'in_progress' }],
+          plan_revision: 1,
+          plan_updated_at: '2026-05-18T00:00:00.000Z'
+        }
+      })
+
+      finalizeError(state, io, 'common.error.userCanceledGeneration')
+
+      expect(state.blocks[0].extra?.plan_terminal_reason).toBe('aborted')
+      expectDeepchatEvent('chat.plan.updated', {
+        terminalReason: 'aborted'
+      })
+    })
+  })
+
+  describe('persistAbortExceptionPlanState', () => {
+    it('persists the aborted terminal marker for abort-exception early returns', () => {
+      const persistedWrites: any[] = []
+      ;(io.messageStore.updateAssistantContent as ReturnType<typeof vi.fn>).mockImplementation(
+        (_messageId, blocks) => {
+          persistedWrites.push(structuredClone(blocks))
+        }
+      )
+      state.blocks.push({
+        type: 'plan',
+        content: '',
+        status: 'success',
+        timestamp: Date.now(),
+        extra: {
+          plan_entries: [{ step: 'Still running', status: 'in_progress' }],
+          plan_revision: 1,
+          plan_updated_at: '2026-05-18T00:00:00.000Z'
+        }
+      })
+
+      persistAbortExceptionPlanState(state, io)
+
+      expect(state.blocks[0].extra?.plan_terminal_reason).toBe('aborted')
+      expect(persistedWrites[0][0].extra?.plan_terminal_reason).toBe('aborted')
+      expect(io.messageStore.updateAssistantContent).toHaveBeenCalledWith('m1', state.blocks)
+      expectDeepchatEvent('chat.plan.updated', {
+        sessionId: 's1',
+        messageId: 'm1',
+        terminalReason: 'aborted'
+      })
+      expectDeepchatEvent('chat.stream.updated', {
+        sessionId: 's1',
+        messageId: 'm1',
+        requestId: 'req-1'
+      })
+    })
+
+    it('is idempotent for already stamped plan blocks', () => {
+      state.blocks.push({
+        type: 'plan',
+        content: '',
+        status: 'success',
+        timestamp: Date.now(),
+        extra: {
+          plan_entries: [{ step: 'Still running', status: 'in_progress' }],
+          plan_revision: 1,
+          plan_updated_at: '2026-05-18T00:00:00.000Z'
+        }
+      })
+
+      persistAbortExceptionPlanState(state, io)
+      publishDeepchatEventMock.mockClear()
+      ;(io.messageStore.updateAssistantContent as ReturnType<typeof vi.fn>).mockClear()
+
+      persistAbortExceptionPlanState(state, io)
+
+      expect(io.messageStore.updateAssistantContent).not.toHaveBeenCalled()
+      expect(
+        publishDeepchatEventMock.mock.calls.some(([eventName]) => eventName === 'chat.plan.updated')
+      ).toBe(false)
     })
   })
 })

--- a/test/main/presenter/agentRuntimePresenter/process.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/process.test.ts
@@ -939,6 +939,95 @@ describe('processStream', () => {
     expect((coreStream as ReturnType<typeof vi.fn>).mock.calls.length).toBeLessThanOrEqual(129)
   })
 
+  it('stamps open plan blocks when the max tool calls limit stops the loop', async () => {
+    const finalWrites: any[] = []
+    messageStore.finalizeAssistantMessage.mockImplementation((_messageId, blocks) => {
+      finalWrites.push(structuredClone(blocks))
+    })
+    let callCount = 0
+    const toolPresenter = createMockToolPresenter({ action: 'done' })
+
+    const coreStream = vi.fn(function () {
+      callCount++
+      return (async function* () {
+        if (callCount === 1) {
+          yield {
+            type: 'plan',
+            plan: [{ step: 'Keep looping', status: 'in_progress' }],
+            revision: 1,
+            updatedAt: '2026-05-18T00:00:00.000Z'
+          } as LLMCoreStreamEvent
+        }
+        yield {
+          type: 'tool_call_start',
+          tool_call_id: `tc${callCount}`,
+          tool_call_name: 'action'
+        } as LLMCoreStreamEvent
+        yield {
+          type: 'tool_call_end',
+          tool_call_id: `tc${callCount}`,
+          tool_call_arguments_complete: '{}'
+        } as LLMCoreStreamEvent
+        yield { type: 'stop', stop_reason: 'tool_use' } as LLMCoreStreamEvent
+      })()
+    }) as unknown as ProcessParams['coreStream']
+
+    const params = createParams({
+      coreStream,
+      toolPresenter,
+      tools: [makeTool('action')]
+    })
+
+    const promise = processStream(params)
+    await vi.runAllTimersAsync()
+    await promise
+
+    const planBlock = finalWrites.at(-1)?.find((block: { type: string }) => block.type === 'plan')
+    expect(planBlock?.extra?.plan_terminal_reason).toBe('max_steps')
+    expectDeepchatEvent('chat.plan.updated', {
+      sessionId: 's1',
+      messageId: 'm1',
+      terminalReason: 'max_steps'
+    })
+  })
+
+  it('persists an aborted terminal marker when AbortError is thrown after a plan event', async () => {
+    const persistedWrites: any[] = []
+    messageStore.updateAssistantContent.mockImplementation((_messageId, blocks) => {
+      persistedWrites.push(structuredClone(blocks))
+    })
+    const abortError = new Error('Aborted')
+    abortError.name = 'AbortError'
+    const coreStream = vi.fn(async function* () {
+      yield {
+        type: 'plan',
+        plan: [{ step: 'Current work', status: 'in_progress' }],
+        revision: 1,
+        updatedAt: '2026-05-18T00:00:00.000Z'
+      } as LLMCoreStreamEvent
+      throw abortError
+    }) as unknown as ProcessParams['coreStream']
+
+    const result = await processStream(createParams({ coreStream }))
+
+    expect(result).toMatchObject({
+      status: 'aborted',
+      stopReason: 'user_stop',
+      errorMessage: 'common.error.userCanceledGeneration'
+    })
+    const planBlock = persistedWrites
+      .at(-1)
+      ?.find((block: { type: string }) => block.type === 'plan')
+    expect(planBlock?.extra?.plan_terminal_reason).toBe('aborted')
+    expect(messageStore.setMessageError).not.toHaveBeenCalled()
+    expect(messageStore.finalizeAssistantMessage).not.toHaveBeenCalled()
+    expectDeepchatEvent('chat.plan.updated', {
+      sessionId: 's1',
+      messageId: 'm1',
+      terminalReason: 'aborted'
+    })
+  })
+
   it('abort during stream', async () => {
     const abortController = new AbortController()
 

--- a/test/main/presenter/llmProviderPresenter/acpContentMapper.test.ts
+++ b/test/main/presenter/llmProviderPresenter/acpContentMapper.test.ts
@@ -103,12 +103,12 @@ describe('AcpContentMapper plan handling', () => {
 
     expect(result.planEntries).toHaveLength(3)
     expect(result.planEntries![0]).toMatchObject({
-      content: 'Analyze requirements',
+      step: 'Analyze requirements',
       status: 'completed',
       priority: 'high'
     })
     expect(result.planEntries![1]).toMatchObject({
-      content: 'Implement feature',
+      step: 'Implement feature',
       status: 'in_progress'
     })
   })
@@ -126,15 +126,21 @@ describe('AcpContentMapper plan handling', () => {
       })
     )
 
-    const reasoningEvent = result.events.find((e) => e.type === 'reasoning')
-    expect(reasoningEvent).toBeTruthy()
-    expect(reasoningEvent?.reasoning_content).toBe('')
+    const planEvent = result.events.find((e) => e.type === 'plan')
+    expect(planEvent).toMatchObject({
+      type: 'plan',
+      plan: [
+        { step: 'Step 1', status: 'completed' },
+        { step: 'Step 2', status: 'in_progress' }
+      ],
+      revision: 1
+    })
 
     const planBlock = result.blocks.find((block) => block.type === 'plan')
     expect(planBlock?.extra).toMatchObject({
       plan_entries: [
-        { content: 'Step 1', status: 'completed', priority: null },
-        { content: 'Step 2', status: 'in_progress', priority: null }
+        { step: 'Step 1', status: 'completed' },
+        { step: 'Step 2', status: 'in_progress' }
       ]
     })
   })
@@ -154,9 +160,9 @@ describe('AcpContentMapper plan handling', () => {
     )
 
     expect(result.planEntries).toEqual([
-      { content: 'Done task', status: 'completed', priority: null },
-      { content: 'Current task', status: 'in_progress', priority: null },
-      { content: 'Future task', status: 'pending', priority: null }
+      { step: 'Done task', status: 'completed', priority: null },
+      { step: 'Current task', status: 'in_progress', priority: null },
+      { step: 'Future task', status: 'pending', priority: null }
     ])
   })
 

--- a/test/main/presenter/toolPresenter/agentTools/agentPlanTool.test.ts
+++ b/test/main/presenter/toolPresenter/agentTools/agentPlanTool.test.ts
@@ -23,6 +23,7 @@ describe('AgentPlanTool', () => {
     )
 
     expect(result.content).toBe('{}')
+    expect(result.rawData.toolResult).toEqual({ kind: 'agent_plan' })
     expect(onProgress).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: 'agent_plan',
@@ -40,47 +41,40 @@ describe('AgentPlanTool', () => {
         })
       })
     )
-    expect(tool.getState('session-1')).toMatchObject({
-      revision: 1,
-      current: {
-        explanation: 'Repo inspected',
-        plan: [
-          { step: 'Inspect current runtime', status: 'completed' },
-          { step: 'Implement handler', status: 'in_progress' },
-          { step: 'Add tests', status: 'pending' }
-        ]
-      }
-    })
   })
 
   it('increments revision and allows an empty plan to clear the checklist', () => {
     const tool = new AgentPlanTool()
+    const onProgress = vi.fn()
 
     tool.call(
       {
         plan: [{ step: 'Start', status: 'in_progress' }]
       },
       'session-1',
-      { toolCallId: 'tool-1' }
+      { toolCallId: 'tool-1', onProgress }
     )
     tool.call(
       {
         plan: []
       },
       'session-1',
-      { toolCallId: 'tool-2' }
+      { toolCallId: 'tool-2', onProgress }
     )
 
-    expect(tool.getState('session-1')).toMatchObject({
-      revision: 2,
-      current: {
+    expect(onProgress).toHaveBeenLastCalledWith({
+      kind: 'agent_plan',
+      toolCallId: 'tool-2',
+      snapshot: expect.objectContaining({
+        revision: 2,
         plan: []
-      }
+      })
     })
   })
 
   it('rejects invalid payloads without updating state', () => {
     const tool = new AgentPlanTool()
+    const onProgress = vi.fn()
 
     expect(() =>
       tool.call(
@@ -115,9 +109,73 @@ describe('AgentPlanTool', () => {
       )
     ).toThrow('Unrecognized key')
 
-    expect(tool.getState('session-1')).toMatchObject({
-      revision: 0,
-      current: null
+    tool.call(
+      {
+        plan: [{ step: 'Valid', status: 'pending' }]
+      },
+      'session-1',
+      { toolCallId: 'tool-2', onProgress }
+    )
+
+    expect(onProgress).toHaveBeenCalledWith({
+      kind: 'agent_plan',
+      toolCallId: 'tool-2',
+      snapshot: expect.objectContaining({
+        revision: 1,
+        plan: [{ step: 'Valid', status: 'pending' }]
+      })
+    })
+  })
+
+  it('clears session state so revisions restart for that session', () => {
+    const tool = new AgentPlanTool()
+    const onProgress = vi.fn()
+
+    tool.call({ plan: [{ step: 'Start', status: 'pending' }] }, 'session-1', {
+      toolCallId: 'tool-1',
+      onProgress
+    })
+    tool.clearState('session-1')
+    tool.call({ plan: [{ step: 'Restart', status: 'pending' }] }, 'session-1', {
+      toolCallId: 'tool-2',
+      onProgress
+    })
+
+    expect(onProgress).toHaveBeenLastCalledWith({
+      kind: 'agent_plan',
+      toolCallId: 'tool-2',
+      snapshot: expect.objectContaining({
+        revision: 1,
+        plan: [{ step: 'Restart', status: 'pending' }]
+      })
+    })
+  })
+
+  it('rejects calls without a tool call ID', () => {
+    const tool = new AgentPlanTool()
+    const onProgress = vi.fn()
+
+    expect(() =>
+      tool.call(
+        {
+          plan: [{ step: 'Start', status: 'in_progress' }]
+        },
+        'session-1'
+      )
+    ).toThrow('update_plan requires a tool call ID')
+
+    tool.call({ plan: [{ step: 'Start', status: 'in_progress' }] }, 'session-1', {
+      toolCallId: 'tool-1',
+      onProgress
+    })
+
+    expect(onProgress).toHaveBeenCalledWith({
+      kind: 'agent_plan',
+      toolCallId: 'tool-1',
+      snapshot: expect.objectContaining({
+        revision: 1,
+        plan: [{ step: 'Start', status: 'in_progress' }]
+      })
     })
   })
 

--- a/test/main/presenter/toolPresenter/toolPresenter.test.ts
+++ b/test/main/presenter/toolPresenter/toolPresenter.test.ts
@@ -160,6 +160,36 @@ describe('ToolPresenter', () => {
     expect(sharedDefs[0].server?.name).toBe('mcp')
   })
 
+  it('clears only agent plan state without clearing tool mappings', async () => {
+    const mcpPresenter = {
+      getAllToolDefinitions: vi.fn().mockResolvedValue([]),
+      callTool: vi.fn()
+    } as any
+    const configPresenter = {
+      getSkillsEnabled: vi.fn().mockReturnValue(false),
+      getSkillsPath: vi.fn().mockReturnValue('C:\\\\skills'),
+      getModelConfig: vi.fn()
+    }
+
+    const toolPresenter = new ToolPresenter({
+      mcpPresenter,
+      configPresenter: configPresenter as any,
+      commandPermissionHandler: new CommandPermissionService(),
+      agentToolRuntime: buildAgentToolRuntimeMock()
+    })
+    await toolPresenter.getAllToolDefinitions({
+      chatMode: 'agent',
+      supportsVision: false,
+      agentWorkspacePath: 'C:\\\\workspace'
+    })
+    const agentToolManager = (toolPresenter as any).agentToolManager
+    agentToolManager.clearPlanState = vi.fn()
+
+    toolPresenter.clearAgentPlanState(' conv-1 ')
+
+    expect(agentToolManager.clearPlanState).toHaveBeenCalledWith('conv-1')
+  })
+
   it('falls back to jsonrepair when tool arguments are malformed', async () => {
     const mcpPresenter = {
       getAllToolDefinitions: vi.fn().mockResolvedValue([]),
@@ -423,6 +453,7 @@ describe('ToolPresenter', () => {
     expect(withProgress).toContain('## Progress Checklist Tool')
     expect(withProgress).toContain('Use `update_plan` for non-trivial multi-step tasks.')
     expect(withProgress).toContain('At most one step may be in_progress at a time.')
+    expect(withProgress).toContain('Before ending the turn, reconcile the checklist')
   })
 
   it('describes only enabled tape tools in the tape prompt', () => {

--- a/test/main/shared/agentPlanBlock.test.ts
+++ b/test/main/shared/agentPlanBlock.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { snapshotFromAgentPlanBlock } from '@shared/types/agent-plan-block'
+
+describe('snapshotFromAgentPlanBlock', () => {
+  it('hydrates a persisted plan block into a live snapshot', () => {
+    expect(
+      snapshotFromAgentPlanBlock('s1', 'm1', {
+        type: 'plan',
+        content: 'Current plan',
+        extra: {
+          plan_entries: [
+            { step: 'Inspect runtime', status: 'completed' },
+            { step: 'Patch store', status: 'in_progress' }
+          ],
+          plan_revision: 3,
+          plan_updated_at: '2026-05-18T00:00:00.000Z',
+          plan_terminal_reason: 'error'
+        }
+      })
+    ).toEqual({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [
+        { step: 'Inspect runtime', status: 'completed' },
+        { step: 'Patch store', status: 'in_progress' }
+      ],
+      explanation: 'Current plan',
+      revision: 3,
+      updatedAt: '2026-05-18T00:00:00.000Z',
+      terminalReason: 'error'
+    })
+  })
+
+  it('falls back revision and updatedAt when optional metadata is missing', () => {
+    const snapshot = snapshotFromAgentPlanBlock('s1', 'm1', {
+      type: 'plan',
+      extra: {
+        plan_entries: [{ content: 'Legacy entry', status: 'done' }]
+      }
+    })
+
+    expect(snapshot).toEqual({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Legacy entry', status: 'completed' }],
+      revision: 1,
+      updatedAt: new Date(0).toISOString()
+    })
+  })
+
+  it('ignores non-plan blocks and empty plan blocks', () => {
+    expect(
+      snapshotFromAgentPlanBlock('s1', 'm1', {
+        type: 'content',
+        content: 'No plan'
+      })
+    ).toBeNull()
+    expect(
+      snapshotFromAgentPlanBlock('s1', 'm1', {
+        type: 'plan',
+        extra: {
+          plan_entries: []
+        }
+      })
+    ).toBeNull()
+  })
+})

--- a/test/renderer/components/AgentProgressFloat.test.ts
+++ b/test/renderer/components/AgentProgressFloat.test.ts
@@ -5,13 +5,15 @@ import AgentProgressFloat from '@/components/chat/AgentProgressFloat.vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string, params?: Record<string, string>) => {
+    t: (key: string, params?: Record<string, string | number>) => {
       const messages: Record<string, string> = {
         'chat.workspace.plan.section': 'Plan',
+        'chat.workspace.plan.completedCount': '{completed}/{total} completed',
         'chat.workspace.plan.itemAriaLabel': '{status}: {step}',
         'chat.workspace.plan.status.completed': 'Completed',
         'chat.workspace.plan.status.in_progress': 'In Progress',
-        'chat.workspace.plan.status.pending': 'Pending'
+        'chat.workspace.plan.status.pending': 'Pending',
+        'chat.workspace.plan.status.interrupted': 'Interrupted'
       }
       return (messages[key] ?? key).replace(/\{(\w+)\}/g, (_, name) => params?.[name] ?? '')
     }
@@ -72,5 +74,20 @@ describe('AgentProgressFloat', () => {
     expect(wrapper.text()).toContain('1/2')
     expect(wrapper.find('button').attributes('aria-expanded')).toBe('false')
     expect(wrapper.find('[data-testid="agent-progress-float-body"]').isVisible()).toBe(false)
+  })
+
+  it('renders terminal in-progress steps without a spinner', () => {
+    const wrapper = mount(AgentProgressFloat, {
+      props: {
+        snapshot: {
+          ...snapshot,
+          terminalReason: 'aborted'
+        },
+        collapsed: false
+      }
+    })
+
+    expect(wrapper.find('.animate-spin').exists()).toBe(false)
+    expect(wrapper.find('[aria-label="Interrupted: Wire progress panel"]').exists()).toBe(true)
   })
 })

--- a/test/renderer/components/ChatPage.test.ts
+++ b/test/renderer/components/ChatPage.test.ts
@@ -128,10 +128,20 @@ const setup = async (options: SetupOptions = {}) => {
     ...options.pendingInputStorePatch
   })
 
+  const agentPlanSnapshots = reactive<Record<string, any>>({})
   const agentPlanStore = reactive({
-    snapshots: {},
-    applySnapshot: vi.fn(),
-    clear: vi.fn(),
+    snapshots: agentPlanSnapshots,
+    applySnapshot: vi.fn((snapshot: any) => {
+      agentPlanSnapshots[snapshot.sessionId] = snapshot
+    }),
+    clearSnapshot: vi.fn((sessionId: string) => {
+      delete agentPlanSnapshots[sessionId]
+    }),
+    beginTurn: vi.fn(),
+    freezeActive: vi.fn(),
+    dismiss: vi.fn(),
+    purge: vi.fn(),
+    isVisible: vi.fn((sessionId: string) => Boolean(agentPlanSnapshots[sessionId]?.plan?.length)),
     isCollapsed: vi.fn().mockReturnValue(false),
     toggleCollapsed: vi.fn()
   })
@@ -552,6 +562,126 @@ describe('ChatPage', () => {
     expect(pendingInputStore.loadPendingInputs).toHaveBeenCalledWith('s1')
   })
 
+  it('rehydrates the latest persisted plan for each switched session', async () => {
+    const { wrapper, messageStore, agentPlanStore, flushStartupDeferredTasks } = await setup({
+      deferStartupTasks: true,
+      messages: []
+    })
+    const messagesBySession = {
+      s1: [
+        buildAssistantMessage([
+          {
+            type: 'plan',
+            content: '',
+            status: 'success',
+            extra: {
+              plan_entries: [{ step: 'Old plan', status: 'completed' }],
+              plan_revision: 1,
+              plan_updated_at: '2026-05-18T00:00:00.000Z'
+            }
+          }
+        ]),
+        {
+          ...buildAssistantMessage([
+            {
+              type: 'plan',
+              content: '',
+              status: 'success',
+              extra: {
+                plan_entries: [{ step: 'Latest A plan', status: 'in_progress' }],
+                plan_revision: 2,
+                plan_updated_at: '2026-05-18T00:01:00.000Z'
+              }
+            }
+          ]),
+          id: 'm2'
+        }
+      ],
+      s2: [
+        {
+          ...buildAssistantMessage([
+            {
+              type: 'plan',
+              content: '',
+              status: 'success',
+              extra: {
+                plan_entries: [{ step: 'B plan', status: 'in_progress' }],
+                plan_revision: 1,
+                plan_updated_at: '2026-05-18T00:02:00.000Z'
+              }
+            }
+          ]),
+          id: 'm3',
+          sessionId: 's2'
+        }
+      ]
+    }
+    messageStore.loadMessages.mockImplementation(async (sessionId: 's1' | 's2') => {
+      messageStore.messages = messagesBySession[sessionId]
+    })
+
+    await flushStartupDeferredTasks()
+
+    expect(agentPlanStore.snapshots.s1.plan[0]?.step).toBe('Latest A plan')
+
+    await wrapper.setProps({ sessionId: 's2' })
+    await flushStartupDeferredTasks()
+
+    expect(agentPlanStore.snapshots.s2.plan[0]?.step).toBe('B plan')
+
+    await wrapper.setProps({ sessionId: 's1' })
+    await flushStartupDeferredTasks()
+
+    expect(agentPlanStore.snapshots.s1.plan[0]?.step).toBe('Latest A plan')
+  })
+
+  it('clears the active session snapshot when restored history has no plan block', async () => {
+    const { wrapper, messageStore, agentPlanStore, flushStartupDeferredTasks } = await setup({
+      deferStartupTasks: true,
+      messages: []
+    })
+    messageStore.loadMessages.mockImplementation(async (sessionId: string) => {
+      messageStore.messages =
+        sessionId === 's1'
+          ? [
+              buildAssistantMessage([
+                {
+                  type: 'plan',
+                  content: '',
+                  status: 'success',
+                  extra: {
+                    plan_entries: [{ step: 'A plan', status: 'in_progress' }],
+                    plan_revision: 1,
+                    plan_updated_at: '2026-05-18T00:00:00.000Z'
+                  }
+                }
+              ])
+            ]
+          : [
+              {
+                ...buildAssistantMessage([
+                  {
+                    type: 'content',
+                    content: 'No plan here',
+                    status: 'success'
+                  }
+                ]),
+                id: 'm2',
+                sessionId
+              }
+            ]
+    })
+
+    await flushStartupDeferredTasks()
+    expect(agentPlanStore.snapshots.s1.plan[0]?.step).toBe('A plan')
+
+    await wrapper.setProps({ sessionId: 's2' })
+    await flushStartupDeferredTasks()
+
+    expect(agentPlanStore.clearSnapshot).toHaveBeenCalledWith('s2')
+    expect(agentPlanStore.snapshots.s2).toBeUndefined()
+  })
+
   it('runs manual compaction instead of sending exact /compact in DeepChat sessions', async () => {
     const { wrapper, chatClient, sessionClient, messageStore } = await setup({
       activeSessionPatch: {
@@ -807,7 +937,7 @@ describe('ChatPage', () => {
     await flushPromises()
 
     expect(chatRespondToolInteraction).toHaveBeenCalledTimes(1)
-    expect(messageStore.loadMessages).toHaveBeenCalledWith('s1')
+    expect(messageStore.loadMessages).toHaveBeenCalledWith('s1', undefined)
     expect(wrapper.find('.chat-tool-interaction-overlay-stub').exists()).toBe(true)
   })
 
@@ -873,7 +1003,7 @@ describe('ChatPage', () => {
         granted: true
       }
     })
-    expect(messageStore.loadMessages).toHaveBeenCalledWith('s1')
+    expect(messageStore.loadMessages).toHaveBeenCalledWith('s1', undefined)
   })
 
   it('renders pending lane above the input box when no tool interaction is active', async () => {
@@ -904,7 +1034,7 @@ describe('ChatPage', () => {
     )
   })
 
-  it('clears the active plan after queued steer succeeds', async () => {
+  it('rebaselines the active plan after queued steer succeeds', async () => {
     const { wrapper, pendingInputStore, agentPlanStore } = await setup({
       isStreaming: true,
       pendingInputStorePatch: {
@@ -925,12 +1055,12 @@ describe('ChatPage', () => {
       }
     })
 
-    agentPlanStore.clear.mockClear()
+    agentPlanStore.beginTurn.mockClear()
     await wrapper.get('[data-testid="pending-lane-steer"]').trigger('click')
     await flushPromises()
 
     expect(pendingInputStore.steerPendingInput).toHaveBeenCalledWith('s1', 'p1')
-    expect(agentPlanStore.clear).toHaveBeenCalledWith('s1')
+    expect(agentPlanStore.beginTurn).toHaveBeenCalledWith('s1')
   })
 
   it('keeps the active plan when queued steer fails', async () => {
@@ -955,12 +1085,12 @@ describe('ChatPage', () => {
       }
     })
 
-    agentPlanStore.clear.mockClear()
+    agentPlanStore.beginTurn.mockClear()
     await wrapper.get('[data-testid="pending-lane-steer"]').trigger('click')
     await flushPromises()
 
     expect(pendingInputStore.steerPendingInput).toHaveBeenCalledWith('s1', 'p1')
-    expect(agentPlanStore.clear).not.toHaveBeenCalled()
+    expect(agentPlanStore.beginTurn).not.toHaveBeenCalled()
     expect(toast).toHaveBeenCalledWith({
       title: 'chat.pendingInput.steerFailed',
       variant: 'destructive'

--- a/test/renderer/components/message/MessageBlockBasics.test.ts
+++ b/test/renderer/components/message/MessageBlockBasics.test.ts
@@ -13,11 +13,13 @@ vi.mock('vue-i18n', () => ({
     t: (key: string, params?: Record<string, unknown>) => {
       const messages: Record<string, string> = {
         'chat.workspace.plan.section': 'Plan',
+        'chat.workspace.plan.completedCount': '{completed}/{total} completed',
         'chat.workspace.plan.empty': 'No tasks yet',
         'chat.workspace.plan.itemAriaLabel': '{status}: {step}',
         'chat.workspace.plan.status.completed': 'Completed',
         'chat.workspace.plan.status.in_progress': 'In Progress',
         'chat.workspace.plan.status.pending': 'Pending',
+        'chat.workspace.plan.status.interrupted': 'Interrupted',
         'chat.skillDraft.confirmationTitle': 'Skill Draft',
         'chat.skillDraft.confirmationQuestion': '已生成 skill draft：{name}',
         'chat.skillDraft.actions.view': '查看内容',
@@ -209,11 +211,28 @@ describe('MessageBlock basics', () => {
     })
 
     expect(wrapper.text()).toContain('Plan')
-    expect(wrapper.text()).toContain('1/2 Completed')
+    expect(wrapper.text()).toContain('1/2 completed')
     expect(wrapper.text()).toContain('Inspect runtime')
     expect(wrapper.text()).toContain('Write tests')
     expect(wrapper.find('[aria-label="Completed: Inspect runtime"]').exists()).toBe(true)
     expect(wrapper.find('[aria-label="Pending: Write tests"]').exists()).toBe(true)
+  })
+
+  it('renders terminal in-progress plan entries without a spinner', () => {
+    const wrapper = mount(MessageBlockPlan, {
+      props: {
+        block: createBlock({
+          type: 'plan',
+          extra: {
+            plan_entries: [{ step: 'Write tests', status: 'in_progress' }],
+            plan_terminal_reason: 'error'
+          }
+        })
+      }
+    })
+
+    expect(wrapper.find('.animate-spin').exists()).toBe(false)
+    expect(wrapper.find('[aria-label="Interrupted: Write tests"]').exists()).toBe(true)
   })
 
   it('expands error details and explanation', async () => {

--- a/test/renderer/stores/agentPlanStore.test.ts
+++ b/test/renderer/stores/agentPlanStore.test.ts
@@ -6,6 +6,20 @@ vi.mock('@vueuse/core', () => ({
   })
 }))
 
+type StoredAgentPlanViewState = {
+  collapsed?: boolean
+  dismissedMessageId?: string
+}
+
+const getViewStateBySession = (store: {
+  viewStateBySession: unknown
+}): Record<string, StoredAgentPlanViewState> => {
+  const storage = store.viewStateBySession as
+    | { value?: Record<string, StoredAgentPlanViewState> }
+    | Record<string, StoredAgentPlanViewState>
+  return 'value' in storage && storage.value ? storage.value : storage
+}
+
 describe('agentPlanStore', () => {
   beforeEach(async () => {
     vi.resetModules()
@@ -14,14 +28,18 @@ describe('agentPlanStore', () => {
     setActivePinia(createPinia())
   })
 
-  it('defaults new session progress panels to collapsed and ignores stale snapshots', async () => {
+  it('defaults new session progress panels to expanded and ignores stale snapshots', async () => {
     const { useAgentPlanStore } = await import('@/stores/ui/agentPlan')
     const store = useAgentPlanStore()
 
-    expect(store.isCollapsed('s1')).toBe(true)
+    expect(store.isCollapsed('s1')).toBe(false)
+    expect(getViewStateBySession(store).s1).toBeUndefined()
+    expect(store.isVisible('missing')).toBe(false)
+    expect(getViewStateBySession(store).missing).toBeUndefined()
 
     store.toggleCollapsed('s1')
-    expect(store.isCollapsed('s1')).toBe(false)
+    expect(store.isCollapsed('s1')).toBe(true)
+    expect(getViewStateBySession(store).s1).toEqual({ collapsed: true })
 
     store.applySnapshot({
       sessionId: 's1',
@@ -39,5 +57,235 @@ describe('agentPlanStore', () => {
     })
 
     expect(store.snapshots.s1.plan[0]?.step).toBe('Newer')
+  })
+
+  it('rebaselines each turn so revision 1 renders after a clear', async () => {
+    const { useAgentPlanStore } = await import('@/stores/ui/agentPlan')
+    const store = useAgentPlanStore()
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Old', status: 'completed' }],
+      revision: 4,
+      updatedAt: '2026-05-18T00:00:00.000Z'
+    })
+
+    store.beginTurn('s1')
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm2',
+      plan: [{ step: 'Fresh', status: 'in_progress' }],
+      revision: 1,
+      updatedAt: '2026-05-18T00:01:00.000Z'
+    })
+
+    expect(store.snapshots.s1.plan[0]?.step).toBe('Fresh')
+    expect(store.isVisible('s1')).toBe(true)
+  })
+
+  it('accepts a new message snapshot without an explicit beginTurn', async () => {
+    const { useAgentPlanStore } = await import('@/stores/ui/agentPlan')
+    const store = useAgentPlanStore()
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Old turn', status: 'in_progress' }],
+      revision: 4,
+      updatedAt: '2026-05-18T00:00:00.000Z'
+    })
+    store.dismiss('s1')
+
+    expect(store.isVisible('s1')).toBe(false)
+    expect(store.isCollapsed('s1')).toBe(true)
+    expect(getViewStateBySession(store).s1).toEqual({
+      collapsed: true,
+      dismissedMessageId: 'm1'
+    })
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm2',
+      plan: [{ step: 'Auto queued turn', status: 'in_progress' }],
+      revision: 1,
+      updatedAt: '2026-05-18T00:01:00.000Z'
+    })
+
+    expect(store.snapshots.s1.messageId).toBe('m2')
+    expect(store.snapshots.s1.plan[0]?.step).toBe('Auto queued turn')
+    expect(store.isVisible('s1')).toBe(true)
+    expect(store.isCollapsed('s1')).toBe(false)
+    expect(getViewStateBySession(store).s1).toEqual({ collapsed: false })
+  })
+
+  it('auto-collapses only when the same message first becomes fully completed', async () => {
+    const { useAgentPlanStore } = await import('@/stores/ui/agentPlan')
+    const store = useAgentPlanStore()
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Current', status: 'in_progress' }],
+      revision: 1,
+      updatedAt: '2026-05-18T00:00:00.000Z'
+    })
+
+    expect(store.isCollapsed('s1')).toBe(false)
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Current', status: 'completed' }],
+      revision: 2,
+      updatedAt: '2026-05-18T00:00:01.000Z'
+    })
+
+    expect(store.isCollapsed('s1')).toBe(true)
+
+    store.setCollapsed('s1', false)
+    expect(store.isCollapsed('s1')).toBe(false)
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Current', status: 'completed' }],
+      revision: 3,
+      updatedAt: '2026-05-18T00:00:02.000Z'
+    })
+
+    expect(store.isCollapsed('s1')).toBe(false)
+  })
+
+  it('drops same-revision non-terminal snapshots for the same message', async () => {
+    const { useAgentPlanStore } = await import('@/stores/ui/agentPlan')
+    const store = useAgentPlanStore()
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Current', status: 'in_progress' }],
+      revision: 2,
+      updatedAt: '2026-05-18T00:00:00.000Z'
+    })
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Duplicate same revision', status: 'completed' }],
+      revision: 2,
+      updatedAt: '2026-05-18T00:00:01.000Z'
+    })
+
+    expect(store.snapshots.s1.plan[0]?.step).toBe('Current')
+    expect(store.snapshots.s1.terminalReason).toBeUndefined()
+  })
+
+  it('accepts same-revision terminal updates', async () => {
+    const { useAgentPlanStore } = await import('@/stores/ui/agentPlan')
+    const store = useAgentPlanStore()
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Current', status: 'in_progress' }],
+      revision: 2,
+      updatedAt: '2026-05-18T00:00:00.000Z'
+    })
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Current', status: 'in_progress' }],
+      revision: 2,
+      updatedAt: '2026-05-18T00:00:01.000Z',
+      terminalReason: 'error'
+    })
+
+    expect(store.snapshots.s1.terminalReason).toBe('error')
+  })
+
+  it('allows backend terminal reason to replace optimistic freeze', async () => {
+    const { useAgentPlanStore } = await import('@/stores/ui/agentPlan')
+    const store = useAgentPlanStore()
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Current', status: 'in_progress' }],
+      revision: 2,
+      updatedAt: '2026-05-18T00:00:00.000Z'
+    })
+    store.freezeActive('s1')
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Current', status: 'in_progress' }],
+      revision: 2,
+      updatedAt: '2026-05-18T00:00:01.000Z',
+      terminalReason: 'max_steps'
+    })
+
+    expect(store.snapshots.s1.terminalReason).toBe('max_steps')
+  })
+
+  it('keeps dismiss sticky until the next turn begins', async () => {
+    const { useAgentPlanStore } = await import('@/stores/ui/agentPlan')
+    const store = useAgentPlanStore()
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Current', status: 'in_progress' }],
+      revision: 2,
+      updatedAt: '2026-05-18T00:00:00.000Z'
+    })
+    store.dismiss('s1')
+
+    expect(store.isVisible('s1')).toBe(false)
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Later same turn', status: 'in_progress' }],
+      revision: 3,
+      updatedAt: '2026-05-18T00:00:01.000Z'
+    })
+
+    expect(store.isVisible('s1')).toBe(false)
+
+    store.beginTurn('s1')
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm2',
+      plan: [{ step: 'Next turn', status: 'in_progress' }],
+      revision: 1,
+      updatedAt: '2026-05-18T00:01:00.000Z'
+    })
+
+    expect(store.isVisible('s1')).toBe(true)
+  })
+
+  it('freezes active plans and purges session state', async () => {
+    const { useAgentPlanStore } = await import('@/stores/ui/agentPlan')
+    const store = useAgentPlanStore()
+
+    store.applySnapshot({
+      sessionId: 's1',
+      messageId: 'm1',
+      plan: [{ step: 'Current', status: 'in_progress' }],
+      revision: 1,
+      updatedAt: '2026-05-18T00:00:00.000Z'
+    })
+    store.freezeActive('s1')
+    store.dismiss('s1')
+
+    expect(store.snapshots.s1.terminalReason).toBe('aborted')
+    expect(getViewStateBySession(store).s1).toEqual({
+      collapsed: true,
+      dismissedMessageId: 'm1'
+    })
+
+    store.purge('s1')
+    expect(store.snapshots.s1).toBeUndefined()
+    expect(getViewStateBySession(store).s1).toBeUndefined()
   })
 })


### PR DESCRIPTION
- add persisted inline plan blocks for agent-mode history
- propagate terminal plan reasons for abort, error, and max-steps exits
- rehydrate live plan state from persisted assistant message blocks
- fix turn-scoped dismiss/collapse behavior for auto-drained queued turns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan progress is now restored after reloading or switching conversations.
  * Plan steps can now show terminal states like interrupted, aborted, or max steps reached.

* **Bug Fixes**
  * Prevented plan progress from spinning indefinitely when a turn ends unexpectedly.
  * Improved handling so plan updates stay in sync across message history, retries, and stops.

* **Style**
  * Updated plan progress text, counts, and accessibility so the UI is clearer and easier to use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->