### PR TITLE
feat(remote): add feishu streaming cards

### DIFF
--- a/docs/archives/feishu-streaming-card-review-fixes/plan.md
+++ b/docs/archives/feishu-streaming-card-review-fixes/plan.md
@@ -1,0 +1,26 @@
+# Plan
+
+## Review findings
+
+CodeRabbit comments are valid. Three runtime/client issues are functional or stability risks and should be fixed before merge. Locale comments are lower risk but cheap and should also be fixed to keep UI consistent.
+
+## Implementation approach
+
+1. Update Feishu client CardKit send behavior:
+   - Return `Promise<string>` from `sendCardEntity`.
+   - Validate reply/create `message_id` immediately.
+   - Throw a clear error if the id is absent or blank.
+
+2. Update Feishu runtime streaming cleanup:
+   - Add a local close helper in `deliverConversationWithStreamingCard` for cancellation and loop-exit paths.
+   - Build card state immediately after `createStreamingCard`.
+   - If `sendCardEntity` fails, close the created card best-effort and rethrow so existing fallback continues.
+
+3. Update reviewed locale strings:
+   - Localize new Feishu `/pair` and CardKit streaming-card copy in the commented locale files.
+   - Preserve product names and permission strings.
+
+## Test strategy
+
+- Run Feishu client/runtime unit tests for the changed behavior.
+- Run `pnpm run format`, `pnpm run i18n`, `pnpm run lint`, and `pnpm run typecheck` before commit.

--- a/docs/archives/feishu-streaming-card-review-fixes/spec.md
+++ b/docs/archives/feishu-streaming-card-review-fixes/spec.md
@@ -1,0 +1,34 @@
+# Feishu streaming card review fixes
+
+## User need
+
+Review PR #1823 comments, fix valid issues, and push the fixes to the existing PR branch.
+
+## Goal
+
+Address valid review feedback for Feishu streaming cards with minimal, focused changes.
+
+## Acceptance criteria
+
+- `sendCardEntity` fails fast when Feishu does not return a non-empty `message_id`.
+- Any created CardKit streaming card is best-effort closed when a run is cancelled, exits mid-stream, or fails after card creation.
+- Reviewed Feishu settings strings are localized instead of leaving new English copy in localized bundles.
+- Relevant tests and project validation commands pass.
+- Fixes are committed and pushed to `feat/feishu-streaming-cards`.
+
+## Constraints
+
+- Preserve the existing markdown fallback behavior.
+- Do not weaken existing error handling or authentication.
+- Keep changes limited to PR review feedback.
+- Do not stage unrelated generated files.
+
+## Non-goals
+
+- Real Feishu/Lark app runtime validation.
+- Broader CardKit design changes.
+- Reworking unrelated i18n content.
+
+## Open questions
+
+None.

--- a/docs/archives/feishu-streaming-card-review-fixes/tasks.md
+++ b/docs/archives/feishu-streaming-card-review-fixes/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] Inspect PR #1823 review comments.
+- [x] Fix `sendCardEntity` missing `message_id` handling.
+- [x] Close streaming cards on cancellation, loop exit, and post-create send failure.
+- [x] Localize reviewed Feishu settings strings.
+- [x] Add or update focused tests.
+- [x] Run validation commands.
+- [x] Commit and push fixes to PR branch.

--- a/docs/archives/feishu-streaming-cards/plan.md
+++ b/docs/archives/feishu-streaming-cards/plan.md
@@ -1,0 +1,77 @@
+# Feishu/Lark Streaming Cards Plan
+
+## Existing flow
+
+- `RemoteSettings.vue` edits `FeishuRemoteSettings`, then `RemoteControlPresenter.saveFeishuSettings()` persists normalized settings.
+- `FeishuAdapter` creates `FeishuRuntime` with a `FeishuClient` and `FeishuCommandRouter`.
+- `FeishuRuntime.deliverConversation()` polls `RemoteConversationExecution.getSnapshot()` and currently calls `syncDeliverySegments()` to send/update Feishu post messages.
+
+## Data model and interfaces
+
+1. Add `enableStreamingCards: boolean` to:
+   - `FeishuRemoteSettings` shared type.
+   - `FeishuRemoteRuntimeConfig` main runtime config.
+   - Zod config normalization/defaults.
+2. Include the flag in Feishu adapter signatures and pass it from `FeishuAdapter` into `FeishuRuntime` as `enableStreamingCards`.
+3. Do not change IPC route names: channel settings use `z.custom<RemoteChannelSettings>()` and continue carrying the typed settings object.
+
+## CardKit client additions
+
+Add low-level methods to `FeishuClient`:
+
+- `createStreamingCard(initialContent?: string): Promise<{ cardId: string; elementId: string }>`
+  - Calls `POST /open-apis/cardkit/v1/cards` via `sdk.request`.
+  - Sends `{ type: 'card_json', data: JSON.stringify(cardJson) }`.
+  - Card JSON uses schema `2.0`, `config.streaming_mode = true`, `config.update_multi = true`, `streaming_config`, and a markdown element with `element_id: 'md_stream'`.
+- `sendCardEntity(target, cardId): Promise<string | null>`
+  - Sends `msg_type: 'interactive'` with content `{"type":"card","data":{"card_id":"..."}}`.
+  - Uses reply or create path consistently with existing message send methods.
+- `updateStreamingCardContent(cardId, elementId, content, sequence): Promise<void>`
+  - Calls `PUT /open-apis/cardkit/v1/cards/:card_id/elements/:element_id/content` with full text.
+- `closeStreamingCard(cardId, sequence): Promise<void>`
+  - Calls `PATCH /open-apis/cardkit/v1/cards/:card_id/settings` with `settings` containing `config.streaming_mode: false`.
+
+All CardKit helpers throw clear `Feishu CardKit ...` errors when API responses are non-zero or missing required IDs.
+
+## Runtime delivery
+
+When `enableStreamingCards` is false, keep existing `deliverConversation()` behavior.
+
+When true:
+
+1. Poll snapshots as before.
+2. Build the full card text by joining delivery segments in order:
+   - Live `statusText` is grouped under `**Status**` while the answer is active, so thinking/running state appears inside the streaming card.
+   - Process segments are grouped under `**Process**`.
+   - Answer/terminal segments are grouped under `**Answer**`.
+   - Use `optimizeMarkdownForFeishu()` on the final full text, preserving fenced code blocks and table content for CardKit markdown rendering.
+3. On first non-empty text, create a streaming card, send it, then update the markdown element with sequence `1`.
+4. On later text changes, update the same markdown element with the new full text and the next sequence.
+5. On completion or timeout, ensure final text is sent, then close streaming mode with the next sequence and clear remote delivery state.
+6. If any streaming card operation fails, log a warning and fall back to the existing `syncDeliverySegments()` path for that conversation.
+
+The runtime keeps streaming card state only in-memory within the active delivery call. This matches the current queue-based remote delivery lifecycle and avoids changing `RemoteBindingStore`'s generic message-id delivery state.
+
+## UI and i18n
+
+- Add a switch in the Feishu remote-control section after access rules and before default agent/workdir.
+- Use i18n keys:
+  - `settings.remote.feishu.streamingCards`
+  - `settings.remote.feishu.streamingCardsDescription`
+- Include the flag in `defaultFeishuSettings()`, field sync, and draft building.
+
+## Tests
+
+- `feishuClient.test.ts`: CardKit create/send/update/close serialization and error handling.
+- `feishuRuntime.test.ts`: streaming-card mode creates/sends/updates/closes; disabled mode still uses markdown; CardKit failure falls back to markdown; status/process/answer text and Markdown code/table content are preserved in streaming updates.
+- `RemoteSettings.test.ts`: switch renders from settings and persists changed flag.
+- Existing tests may need fixture updates to include `enableStreamingCards`.
+
+## Validation
+
+Run targeted tests first, then required project checks:
+
+1. `pnpm test -- --run test/main/presenter/remoteControlPresenter/feishuClient.test.ts test/main/presenter/remoteControlPresenter/feishuRuntime.test.ts test/renderer/components/RemoteSettings.test.ts`
+2. `pnpm run format`
+3. `pnpm run i18n`
+4. `pnpm run lint`

--- a/docs/archives/feishu-streaming-cards/spec.md
+++ b/docs/archives/feishu-streaming-cards/spec.md
@@ -1,0 +1,44 @@
+# Feishu/Lark Streaming Cards
+
+## User need
+
+Feishu/Lark remote-control users want AI responses to appear progressively with a token-by-token/typewriter effect instead of waiting for a normal message update or a complete answer.
+
+## Goal
+
+Add an opt-in Feishu/Lark remote-control setting that delivers AI conversation responses through CardKit streaming cards. When enabled, DeepChat creates a CardKit card entity with `streaming_mode` enabled, sends it to the target chat, updates its markdown component with full text snapshots using a strictly increasing sequence number, and closes streaming mode when the response finishes.
+
+## Acceptance criteria
+
+1. The Feishu/Lark remote settings page exposes a "Streaming Cards" switch with helper text explaining required CardKit permissions.
+2. The new setting persists with the remote-control Feishu configuration and defaults to off for existing users.
+3. When disabled, Feishu remote-control delivery keeps the existing standard markdown/post message behavior.
+4. When enabled for a conversation response:
+   - DeepChat creates a CardKit JSON 2.0 card entity with `config.streaming_mode: true` and `config.update_multi: true`.
+   - DeepChat sends that card entity as an interactive message using the returned `card_id`.
+   - DeepChat updates the card markdown element with the full rendered response text on each snapshot and uses strictly increasing `sequence` values.
+   - DeepChat preserves Markdown content for Feishu CardKit rendering, including fenced code blocks and pipe tables.
+   - DeepChat shows tool-call progress in the streaming card process section.
+   - DeepChat shows the current thinking/running status in the streaming card while the response is active.
+   - DeepChat closes streaming mode with the CardKit settings API when the response completes or times out.
+5. If CardKit creation, send, update, or close fails because of permissions or API errors, the runtime falls back to the current markdown/post delivery path and logs a clear warning without exposing secrets.
+6. Tests cover client request serialization, settings persistence/UI, streaming-card delivery updates, closing behavior, and fallback to standard markdown delivery.
+
+## Constraints
+
+- Use existing remote-control Presenter/Adapter boundaries and typed shared settings.
+- Use the existing Lark SDK client request escape hatch for CardKit endpoints because the installed SDK does not expose typed CardKit helpers.
+- Do not log App Secret, tokens, or other credentials.
+- Keep the implementation small: one streaming card per assistant response, one markdown element (`md_stream`) updated with full text.
+- Respect Feishu CardKit limits known from docs: JSON 2.0 cards, `update_multi: true`, card entity send-once, and increasing sequence values.
+
+## Non-goals
+
+- No custom streaming-card template editor.
+- No interactive buttons inside the streaming response card.
+- No streaming cards for generated image delivery; images continue through the existing image path after text completion.
+- No change to the official Feishu MCP plugin settings page.
+
+## Open questions
+
+None.

--- a/docs/archives/feishu-streaming-cards/tasks.md
+++ b/docs/archives/feishu-streaming-cards/tasks.md
@@ -1,0 +1,12 @@
+# Feishu/Lark Streaming Cards Tasks
+
+- [x] Inspect issue #1814 and existing Feishu remote-control flow.
+- [x] Create SDD spec, plan, and tasks.
+- [x] Extend Feishu remote settings/config types and normalization with `enableStreamingCards`.
+- [x] Add Feishu settings UI switch and i18n strings.
+- [x] Add CardKit streaming card helpers to `FeishuClient`.
+- [x] Implement streaming-card delivery path in `FeishuRuntime` with markdown fallback.
+- [x] Show live thinking/running status inside the streaming card and preserve Markdown code/table content in streaming updates.
+- [x] Update/add client, runtime, presenter, and renderer tests.
+- [x] Run targeted tests.
+- [x] Run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint`.

--- a/src/main/presenter/remoteControlPresenter/adapters/feishu/FeishuAdapter.ts
+++ b/src/main/presenter/remoteControlPresenter/adapters/feishu/FeishuAdapter.ts
@@ -35,6 +35,7 @@ export class FeishuAdapter extends ChannelAdapter {
     verificationToken: string
     encryptKey: string
   }
+  private readonly enableStreamingCards: boolean
   private client: FeishuClient | null = null
   private runtime: FeishuRuntime | null = null
   private feishuStatus: FeishuRuntimeStatusSnapshot = { ...DEFAULT_STATUS }
@@ -53,6 +54,7 @@ export class FeishuAdapter extends ChannelAdapter {
       verificationToken: String(config.channelConfig.verificationToken ?? '').trim(),
       encryptKey: String(config.channelConfig.encryptKey ?? '').trim()
     }
+    this.enableStreamingCards = config.channelConfig.enableStreamingCards === true
   }
 
   protected async performConnect(_signal: AbortSignal): Promise<void> {
@@ -71,6 +73,7 @@ export class FeishuAdapter extends ChannelAdapter {
         getRuntimeStatus: () => ({ ...this.feishuStatus })
       }),
       bindingStore: this.bindingStore,
+      enableStreamingCards: this.enableStreamingCards,
       logger,
       onStatusChange: (snapshot) => {
         this.handleStatusChange(snapshot)

--- a/src/main/presenter/remoteControlPresenter/feishu/feishuClient.ts
+++ b/src/main/presenter/remoteControlPresenter/feishu/feishuClient.ts
@@ -24,6 +24,14 @@ type FeishuMessageResponse = {
   }
 }
 
+type FeishuApiResponse = {
+  code?: number
+  msg?: string
+  data?: Record<string, unknown>
+}
+
+export const FEISHU_STREAMING_CARD_ELEMENT_ID = 'md_stream'
+
 const createTextPayload = (text: string): string =>
   JSON.stringify({
     text
@@ -37,6 +45,49 @@ const createMarkdownPayload = (text: string): string =>
   })
 
 const createCardPayload = (card: FeishuInteractiveCardPayload): string => JSON.stringify(card)
+
+const createStreamingCardEntityMessagePayload = (cardId: string): string =>
+  JSON.stringify({
+    type: 'card',
+    data: {
+      card_id: cardId
+    }
+  })
+
+const createStreamingCardJson = (initialContent: string): Record<string, unknown> => ({
+  schema: '2.0',
+  config: {
+    streaming_mode: true,
+    update_multi: true,
+    summary: {
+      content: ''
+    },
+    streaming_config: {
+      print_frequency_ms: {
+        default: 70,
+        android: 70,
+        ios: 70,
+        pc: 70
+      },
+      print_step: {
+        default: 1,
+        android: 1,
+        ios: 1,
+        pc: 1
+      },
+      print_strategy: 'fast'
+    }
+  },
+  body: {
+    elements: [
+      {
+        tag: 'markdown',
+        content: initialContent,
+        element_id: FEISHU_STREAMING_CARD_ELEMENT_ID
+      }
+    ]
+  }
+})
 
 const readHeaderValue = (headers: unknown, name: string): string | undefined => {
   if (!headers) {
@@ -88,6 +139,12 @@ const resolveLarkDomain = (brand: FeishuBrand): string | undefined => {
   }
 
   return ((Lark as any).Domain?.Feishu as string | undefined) ?? 'https://open.feishu.cn'
+}
+
+const assertFeishuApiSuccess = (response: FeishuApiResponse | null | undefined, action: string) => {
+  if (!response || response.code !== 0) {
+    throw new Error(response?.msg?.trim() || `Feishu CardKit ${action} failed.`)
+  }
 }
 
 export const chunkFeishuText = (
@@ -274,6 +331,98 @@ export class FeishuClient {
     }
 
     return messageId
+  }
+
+  async createStreamingCard(initialContent: string = ''): Promise<{
+    cardId: string
+    elementId: string
+  }> {
+    const response = (await (this.sdk as any).request({
+      method: 'POST',
+      url: '/open-apis/cardkit/v1/cards',
+      data: {
+        type: 'card_json',
+        data: JSON.stringify(createStreamingCardJson(initialContent))
+      }
+    })) as FeishuApiResponse & {
+      card_id?: string
+    }
+
+    assertFeishuApiSuccess(response, 'create streaming card')
+    const cardId = String(response?.data?.card_id ?? response?.card_id ?? '').trim()
+    if (!cardId) {
+      throw new Error('Feishu CardKit create streaming card did not return card_id.')
+    }
+
+    return {
+      cardId,
+      elementId: FEISHU_STREAMING_CARD_ELEMENT_ID
+    }
+  }
+
+  async sendCardEntity(target: FeishuTransportTarget, cardId: string): Promise<string | null> {
+    const content = createStreamingCardEntityMessagePayload(cardId)
+
+    if (target.replyToMessageId) {
+      const response = (await this.sdk.im.message.reply({
+        path: {
+          message_id: target.replyToMessageId
+        },
+        data: {
+          content,
+          msg_type: 'interactive',
+          reply_in_thread: Boolean(target.threadId)
+        }
+      })) as FeishuMessageResponse
+      return response.data?.message_id?.trim() || null
+    }
+
+    const response = (await this.sdk.im.message.create({
+      params: {
+        receive_id_type: 'chat_id'
+      },
+      data: {
+        receive_id: target.chatId,
+        msg_type: 'interactive',
+        content
+      }
+    })) as FeishuMessageResponse
+    return response.data?.message_id?.trim() || null
+  }
+
+  async updateStreamingCardContent(params: {
+    cardId: string
+    elementId: string
+    content: string
+    sequence: number
+  }): Promise<void> {
+    const response = (await (this.sdk as any).request({
+      method: 'PUT',
+      url: `/open-apis/cardkit/v1/cards/${encodeURIComponent(params.cardId)}/elements/${encodeURIComponent(params.elementId)}/content`,
+      data: {
+        content: params.content,
+        sequence: params.sequence
+      }
+    })) as FeishuApiResponse
+
+    assertFeishuApiSuccess(response, 'update streaming card content')
+  }
+
+  async closeStreamingCard(cardId: string, sequence: number): Promise<void> {
+    const response = (await (this.sdk as any).request({
+      method: 'PATCH',
+      url: `/open-apis/cardkit/v1/cards/${encodeURIComponent(cardId)}/settings`,
+      data: {
+        settings: JSON.stringify({
+          config: {
+            streaming_mode: false
+          }
+        }),
+        sequence
+      }
+    })) as FeishuApiResponse
+
+    assertFeishuApiSuccess(response, 'close streaming card')
   }
 
   async downloadMessageResource(params: {

--- a/src/main/presenter/remoteControlPresenter/feishu/feishuClient.ts
+++ b/src/main/presenter/remoteControlPresenter/feishu/feishuClient.ts
@@ -360,7 +360,7 @@ export class FeishuClient {
     }
   }
 
-  async sendCardEntity(target: FeishuTransportTarget, cardId: string): Promise<string | null> {
+  async sendCardEntity(target: FeishuTransportTarget, cardId: string): Promise<string> {
     const content = createStreamingCardEntityMessagePayload(cardId)
 
     if (target.replyToMessageId) {
@@ -374,7 +374,11 @@ export class FeishuClient {
           reply_in_thread: Boolean(target.threadId)
         }
       })) as FeishuMessageResponse
-      return response.data?.message_id?.trim() || null
+      const messageId = response.data?.message_id?.trim()
+      if (!messageId) {
+        throw new Error('Feishu CardKit send card entity did not return message_id.')
+      }
+      return messageId
     }
 
     const response = (await this.sdk.im.message.create({
@@ -387,7 +391,11 @@ export class FeishuClient {
         content
       }
     })) as FeishuMessageResponse
-    return response.data?.message_id?.trim() || null
+    const messageId = response.data?.message_id?.trim()
+    if (!messageId) {
+      throw new Error('Feishu CardKit send card entity did not return message_id.')
+    }
+    return messageId
   }
 
   async updateStreamingCardContent(params: {

--- a/src/main/presenter/remoteControlPresenter/feishu/feishuRuntime.ts
+++ b/src/main/presenter/remoteControlPresenter/feishu/feishuRuntime.ts
@@ -538,12 +538,23 @@ export class FeishuRuntime {
     startedAt: number
   ): Promise<boolean> {
     let cardState: FeishuStreamingCardDeliveryState | null = null
+    const closeAndFinish = async (): Promise<boolean> => {
+      try {
+        cardState = await this.closeStreamingCardIfNeeded(cardState)
+      } catch (error) {
+        console.warn('[FeishuRuntime] Failed to close streaming card before exit:', {
+          cardId: cardState?.cardId,
+          error: safeErrorMessage(error)
+        })
+      }
+      return true
+    }
 
     try {
       while (this.isCurrentRun(runId)) {
         const snapshot = await execution.getSnapshot()
         if (!this.isCurrentRun(runId)) {
-          return true
+          return await closeAndFinish()
         }
 
         const sourceMessageId = snapshot.messageId ?? execution.eventId ?? null
@@ -589,7 +600,7 @@ export class FeishuRuntime {
 
         if (Date.now() - startedAt >= FEISHU_CONVERSATION_POLL_TIMEOUT_MS) {
           if (!this.isCurrentRun(runId)) {
-            return true
+            return await closeAndFinish()
           }
           const timeoutText =
             'The current conversation timed out before finishing. Please try again.'
@@ -616,7 +627,7 @@ export class FeishuRuntime {
         await sleep(TELEGRAM_STREAM_POLL_INTERVAL_MS)
       }
 
-      return true
+      return await closeAndFinish()
     } catch (error) {
       console.warn('[FeishuRuntime] Streaming card delivery failed, falling back to markdown:', {
         chatId: target.chatId,
@@ -705,15 +716,22 @@ export class FeishuRuntime {
     target: FeishuTransportTarget
   ): Promise<FeishuStreamingCardDeliveryState> {
     const card = await this.deps.client.createStreamingCard('')
-    await this.deps.client.sendCardEntity(target, card.cardId)
-
-    return {
+    const state: FeishuStreamingCardDeliveryState = {
       cardId: card.cardId,
       elementId: card.elementId,
       sequence: 0,
       lastText: '',
       closed: false
     }
+
+    try {
+      await this.deps.client.sendCardEntity(target, card.cardId)
+    } catch (error) {
+      await this.closeStreamingCardAfterFailure(state, state.sequence + 1)
+      throw error
+    }
+
+    return state
   }
 
   private async closeStreamingCardIfNeeded(

--- a/src/main/presenter/remoteControlPresenter/feishu/feishuRuntime.ts
+++ b/src/main/presenter/remoteControlPresenter/feishu/feishuRuntime.ts
@@ -27,13 +27,19 @@ const sleep = async (ms: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+const safeErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
 const FEISHU_INTERNAL_ERROR_REPLY = 'An internal error occurred while processing your request.'
+const FEISHU_STREAMING_CARD_FALLBACK_NOTICE =
+  'Feishu CardKit streaming failed. Falling back to normal message updates. Check that the app has im:message and cardkit:card:write permissions.'
 
 type FeishuRuntimeDeps = {
   client: FeishuClient
   parser: FeishuParser
   router: FeishuCommandRouter
   bindingStore: RemoteBindingStore
+  enableStreamingCards?: boolean
   logger?: {
     error: (...params: unknown[]) => void
   }
@@ -54,6 +60,14 @@ type FeishuRemoteDeliveryState = {
     messageIds: Array<string | null>
     lastText: string
   }>
+}
+
+type FeishuStreamingCardDeliveryState = {
+  cardId: string
+  elementId: string
+  sequence: number
+  lastText: string
+  closed: boolean
 }
 
 export class FeishuRuntime {
@@ -403,6 +417,19 @@ export class FeishuRuntime {
     const startedAt = Date.now()
     const endpointKey = buildFeishuEndpointKey(target.chatId, target.threadId)
 
+    if (this.deps.enableStreamingCards) {
+      const streamed = await this.deliverConversationWithStreamingCard(
+        target,
+        execution,
+        runId,
+        endpointKey,
+        startedAt
+      )
+      if (streamed) {
+        return
+      }
+    }
+
     while (this.isCurrentRun(runId)) {
       const snapshot = await execution.getSnapshot()
       if (!this.isCurrentRun(runId)) {
@@ -500,6 +527,226 @@ export class FeishuRuntime {
       }
 
       await sleep(TELEGRAM_STREAM_POLL_INTERVAL_MS)
+    }
+  }
+
+  private async deliverConversationWithStreamingCard(
+    target: FeishuTransportTarget,
+    execution: RemoteConversationExecution,
+    runId: number,
+    endpointKey: string,
+    startedAt: number
+  ): Promise<boolean> {
+    let cardState: FeishuStreamingCardDeliveryState | null = null
+
+    try {
+      while (this.isCurrentRun(runId)) {
+        const snapshot = await execution.getSnapshot()
+        if (!this.isCurrentRun(runId)) {
+          return true
+        }
+
+        const sourceMessageId = snapshot.messageId ?? execution.eventId ?? null
+        let deliverySegments = this.getSnapshotDeliverySegments(snapshot, sourceMessageId)
+
+        if (snapshot.completed) {
+          if (snapshot.pendingInteraction) {
+            const pendingText = this.buildStreamingCardText(deliverySegments)
+            if (pendingText) {
+              cardState = await this.syncStreamingCardText(target, cardState, pendingText)
+            }
+            cardState = await this.closeStreamingCardIfNeeded(cardState)
+            await this.dispatchOutboundActions(
+              target,
+              [
+                {
+                  type: 'sendCard',
+                  card: buildFeishuPendingInteractionCard(snapshot.pendingInteraction),
+                  fallbackText: buildFeishuPendingInteractionText(snapshot.pendingInteraction)
+                }
+              ],
+              runId
+            )
+            this.deps.bindingStore.clearRemoteDeliveryState(endpointKey)
+            return true
+          }
+
+          const finalText = this.getFinalDeliveryText(snapshot)
+          deliverySegments = this.appendTerminalDeliverySegment(
+            deliverySegments,
+            sourceMessageId,
+            finalText
+          )
+          const completedText = this.buildStreamingCardText(deliverySegments) || finalText.trim()
+          if (completedText) {
+            cardState = await this.syncStreamingCardText(target, cardState, completedText)
+          }
+          cardState = await this.closeStreamingCardIfNeeded(cardState)
+          this.deps.bindingStore.clearRemoteDeliveryState(endpointKey)
+          await this.sendGeneratedImages(target, snapshot)
+          return true
+        }
+
+        if (Date.now() - startedAt >= FEISHU_CONVERSATION_POLL_TIMEOUT_MS) {
+          if (!this.isCurrentRun(runId)) {
+            return true
+          }
+          const timeoutText =
+            'The current conversation timed out before finishing. Please try again.'
+          const timeoutSegments = this.appendTerminalDeliverySegment(
+            deliverySegments,
+            sourceMessageId,
+            timeoutText
+          )
+          cardState = await this.syncStreamingCardText(
+            target,
+            cardState,
+            this.buildStreamingCardText(timeoutSegments) || timeoutText
+          )
+          cardState = await this.closeStreamingCardIfNeeded(cardState)
+          this.deps.bindingStore.clearRemoteDeliveryState(endpointKey)
+          return true
+        }
+
+        const streamingText = this.buildStreamingCardText(deliverySegments, snapshot.statusText)
+        if (streamingText) {
+          cardState = await this.syncStreamingCardText(target, cardState, streamingText)
+        }
+
+        await sleep(TELEGRAM_STREAM_POLL_INTERVAL_MS)
+      }
+
+      return true
+    } catch (error) {
+      console.warn('[FeishuRuntime] Streaming card delivery failed, falling back to markdown:', {
+        chatId: target.chatId,
+        threadId: target.threadId,
+        replyToMessageId: target.replyToMessageId,
+        error: safeErrorMessage(error)
+      })
+      if (this.isCurrentRun(runId)) {
+        try {
+          await this.deps.client.sendText(target, FEISHU_STREAMING_CARD_FALLBACK_NOTICE)
+        } catch (noticeError) {
+          console.warn('[FeishuRuntime] Failed to send streaming card fallback notice:', {
+            chatId: target.chatId,
+            threadId: target.threadId,
+            replyToMessageId: target.replyToMessageId,
+            error: safeErrorMessage(noticeError)
+          })
+        }
+      }
+      return false
+    }
+  }
+
+  private buildStreamingCardText(segments: RemoteDeliverySegment[], statusText?: string): string {
+    const status = statusText?.trim() ?? ''
+    const processText = segments
+      .filter((segment) => segment.kind === 'process')
+      .map((segment) => segment.text.trim())
+      .filter(Boolean)
+      .join('\n\n')
+    const answerText = segments
+      .filter((segment) => segment.kind !== 'process')
+      .map((segment) => segment.text.trim())
+      .filter(Boolean)
+      .join('\n\n')
+
+    return [
+      status ? `**Status**\n${status}` : '',
+      processText ? `**Process**\n${processText}` : '',
+      answerText ? `**Answer**\n${answerText}` : ''
+    ]
+      .filter(Boolean)
+      .join('\n\n')
+      .trim()
+  }
+
+  private async syncStreamingCardText(
+    target: FeishuTransportTarget,
+    state: FeishuStreamingCardDeliveryState | null,
+    text: string
+  ): Promise<FeishuStreamingCardDeliveryState> {
+    const normalized = optimizeMarkdownForFeishu(text.trim())
+    if (!normalized) {
+      if (state) {
+        return state
+      }
+      throw new Error('Feishu streaming card content is empty.')
+    }
+
+    const nextState = state ?? (await this.createStreamingCardState(target))
+    if (nextState.lastText === normalized) {
+      return nextState
+    }
+
+    const sequence = nextState.sequence + 1
+    try {
+      await this.deps.client.updateStreamingCardContent({
+        cardId: nextState.cardId,
+        elementId: nextState.elementId,
+        content: normalized,
+        sequence
+      })
+    } catch (error) {
+      await this.closeStreamingCardAfterFailure(nextState, sequence + 1)
+      throw error
+    }
+
+    return {
+      ...nextState,
+      sequence,
+      lastText: normalized
+    }
+  }
+
+  private async createStreamingCardState(
+    target: FeishuTransportTarget
+  ): Promise<FeishuStreamingCardDeliveryState> {
+    const card = await this.deps.client.createStreamingCard('')
+    await this.deps.client.sendCardEntity(target, card.cardId)
+
+    return {
+      cardId: card.cardId,
+      elementId: card.elementId,
+      sequence: 0,
+      lastText: '',
+      closed: false
+    }
+  }
+
+  private async closeStreamingCardIfNeeded(
+    state: FeishuStreamingCardDeliveryState | null
+  ): Promise<FeishuStreamingCardDeliveryState | null> {
+    if (!state || state.closed) {
+      return state
+    }
+
+    const sequence = state.sequence + 1
+    await this.deps.client.closeStreamingCard(state.cardId, sequence)
+    return {
+      ...state,
+      sequence,
+      closed: true
+    }
+  }
+
+  private async closeStreamingCardAfterFailure(
+    state: FeishuStreamingCardDeliveryState,
+    sequence: number
+  ): Promise<void> {
+    if (state.closed) {
+      return
+    }
+
+    try {
+      await this.deps.client.closeStreamingCard(state.cardId, sequence)
+    } catch (error) {
+      console.warn('[FeishuRuntime] Failed to close streaming card after failure:', {
+        cardId: state.cardId,
+        error: safeErrorMessage(error)
+      })
     }
   }
 
@@ -811,7 +1058,7 @@ export class FeishuRuntime {
       } catch (error) {
         console.warn(
           '[FeishuRuntime] Failed to send interactive card, falling back to text:',
-          error
+          safeErrorMessage(error)
         )
         await this.deps.client.sendMarkdown(target, optimizeMarkdownForFeishu(action.fallbackText))
       }

--- a/src/main/presenter/remoteControlPresenter/index.ts
+++ b/src/main/presenter/remoteControlPresenter/index.ts
@@ -242,6 +242,7 @@ export class RemoteControlPresenter {
       verificationToken: remoteConfig.verificationToken,
       encryptKey: remoteConfig.encryptKey,
       remoteEnabled: remoteConfig.enabled,
+      enableStreamingCards: remoteConfig.enableStreamingCards,
       defaultAgentId: remoteConfig.defaultAgentId,
       defaultWorkdir: remoteConfig.defaultWorkdir,
       pairedUserOpenIds: [...remoteConfig.pairedUserOpenIds]
@@ -617,6 +618,7 @@ export class RemoteControlPresenter {
       currentRemoteConfig.appSecret !== normalized.appSecret ||
       currentRemoteConfig.verificationToken !== normalized.verificationToken ||
       currentRemoteConfig.encryptKey !== normalized.encryptKey ||
+      currentRemoteConfig.enableStreamingCards !== normalized.enableStreamingCards ||
       currentRemoteConfig.defaultWorkdir !== normalized.defaultWorkdir
 
     this.bindingStore.updateFeishuConfig((config) => ({
@@ -627,6 +629,7 @@ export class RemoteControlPresenter {
       verificationToken: normalized.verificationToken,
       encryptKey: normalized.encryptKey,
       enabled: normalized.remoteEnabled,
+      enableStreamingCards: normalized.enableStreamingCards,
       defaultAgentId,
       defaultWorkdir: normalized.defaultWorkdir,
       pairedUserOpenIds: config.pairedUserOpenIds,
@@ -1369,7 +1372,8 @@ export class RemoteControlPresenter {
           appId: settings.appId.trim(),
           appSecret: settings.appSecret.trim(),
           verificationToken: settings.verificationToken.trim(),
-          encryptKey: settings.encryptKey.trim()
+          encryptKey: settings.encryptKey.trim(),
+          enableStreamingCards: settings.enableStreamingCards
         },
         configSignature
       )
@@ -1978,6 +1982,7 @@ export class RemoteControlPresenter {
       verificationToken: settings.verificationToken.trim(),
       encryptKey: settings.encryptKey.trim(),
       remoteEnabled: settings.remoteEnabled,
+      enableStreamingCards: settings.enableStreamingCards,
       defaultAgentId: settings.defaultAgentId.trim(),
       defaultWorkdir: settings.defaultWorkdir.trim()
     })

--- a/src/main/presenter/remoteControlPresenter/types.ts
+++ b/src/main/presenter/remoteControlPresenter/types.ts
@@ -309,6 +309,7 @@ export interface FeishuRemoteRuntimeConfig {
   verificationToken: string
   encryptKey: string
   enabled: boolean
+  enableStreamingCards: boolean
   defaultAgentId: string
   defaultWorkdir: string
   pairedUserOpenIds: string[]
@@ -933,6 +934,7 @@ export const createDefaultRemoteControlConfig = (): RemoteControlConfig => ({
     verificationToken: '',
     encryptKey: '',
     enabled: false,
+    enableStreamingCards: false,
     defaultAgentId: FEISHU_REMOTE_DEFAULT_AGENT_ID,
     defaultWorkdir: '',
     pairedUserOpenIds: [],
@@ -1030,6 +1032,7 @@ const FeishuRemoteRuntimeConfigSchema = z
     verificationToken: z.string().optional(),
     encryptKey: z.string().optional(),
     enabled: z.boolean().optional(),
+    enableStreamingCards: z.boolean().optional(),
     defaultAgentId: z.string().optional(),
     defaultWorkdir: z.string().optional(),
     pairedUserOpenIds: z.array(z.string()).optional(),
@@ -1149,6 +1152,7 @@ const extractLegacyFeishuConfig = (input: unknown): LegacyFeishuRemoteConfig | n
       'appSecret',
       'verificationToken',
       'encryptKey',
+      'enableStreamingCards',
       'pairedUserOpenIds',
       'lastFatalError'
     ]) &&
@@ -1412,6 +1416,7 @@ export const normalizeRemoteControlConfig = (input: unknown): RemoteControlConfi
       verificationToken: feishu.verificationToken?.trim() || '',
       encryptKey: feishu.encryptKey?.trim() || '',
       enabled: Boolean(feishu.enabled),
+      enableStreamingCards: Boolean(feishu.enableStreamingCards),
       defaultAgentId: feishu.defaultAgentId?.trim() || defaults.feishu.defaultAgentId,
       defaultWorkdir: feishu.defaultWorkdir?.trim() || '',
       pairedUserOpenIds: normalizeFeishuOpenIds(feishu.pairedUserOpenIds),
@@ -1721,6 +1726,7 @@ export const normalizeFeishuSettingsInput = (
   verificationToken: input.verificationToken?.trim() ?? '',
   encryptKey: input.encryptKey?.trim() ?? '',
   remoteEnabled: Boolean(input.remoteEnabled),
+  enableStreamingCards: Boolean(input.enableStreamingCards),
   defaultAgentId: input.defaultAgentId?.trim() || FEISHU_REMOTE_DEFAULT_AGENT_ID,
   defaultWorkdir: input.defaultWorkdir?.trim() ?? '',
   pairedUserOpenIds: normalizeFeishuOpenIds(input.pairedUserOpenIds)

--- a/src/renderer/settings/components/RemoteSettings.vue
+++ b/src/renderer/settings/components/RemoteSettings.vue
@@ -583,6 +583,31 @@
                   <div class="mt-1">{{ t('settings.remote.feishu.accessRule2') }}</div>
                 </div>
 
+                <label
+                  class="flex items-start justify-between gap-4 rounded-lg border bg-muted/20 p-3 text-sm"
+                >
+                  <div class="space-y-1">
+                    <div class="font-medium">{{ t('settings.remote.feishu.streamingCards') }}</div>
+                    <p class="text-xs text-muted-foreground">
+                      {{ t('settings.remote.feishu.streamingCardsDescription') }}
+                    </p>
+                  </div>
+                  <Switch
+                    data-testid="feishu-streaming-cards-toggle"
+                    :model-value="feishuSettings.enableStreamingCards"
+                    :disabled="saving.feishu"
+                    @update:model-value="
+                      (value) => {
+                        if (!feishuSettings) {
+                          return
+                        }
+                        feishuSettings.enableStreamingCards = value === true
+                        queueFeishuSettingsPersist()
+                      }
+                    "
+                  />
+                </label>
+
                 <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
                   <div class="space-y-2">
                     <Label class="text-xs text-muted-foreground">
@@ -1953,6 +1978,7 @@ const defaultFeishuSettings = (): FeishuRemoteSettings => ({
   verificationToken: '',
   encryptKey: '',
   remoteEnabled: false,
+  enableStreamingCards: false,
   defaultAgentId: 'deepchat',
   defaultWorkdir: '',
   pairedUserOpenIds: []
@@ -2597,6 +2623,7 @@ const buildFeishuDraftSettings = (): FeishuRemoteSettings | null => {
     verificationToken: settings.verificationToken,
     encryptKey: settings.encryptKey,
     remoteEnabled: settings.remoteEnabled,
+    enableStreamingCards: settings.enableStreamingCards,
     defaultAgentId: settings.defaultAgentId,
     defaultWorkdir: settings.defaultWorkdir,
     pairedUserOpenIds: [...(settings.pairedUserOpenIds ?? [])]

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -2107,7 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -2107,9 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Klik på Par nedenfor, og send derefter /pair-koden i en direkte chat med botten. Dette er den anbefalede godkendelsesmetode og fungerer stadig med installerede PersonalAgent-apps.",
+      "streamingCards": "CardKit-streamingkort",
+      "streamingCardsDescription": "Stream AI-svar via Feishu / Lark CardKit i realtid. Kræver tilladelserne im:message og cardkit:card:write; DeepChat falder tilbage til normale beskeder, hvis CardKit fejler."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/de-DE/settings.json
+++ b/src/renderer/src/i18n/de-DE/settings.json
@@ -2206,9 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Klicken Sie unten auf Koppeln und senden Sie anschließend den /pair-Code in einem Direktchat mit dem Bot. Dies ist der empfohlene Autorisierungsweg und funktioniert weiterhin mit installierten PersonalAgent-Apps.",
+      "streamingCards": "CardKit-Streaming-Karten",
+      "streamingCardsDescription": "Streamen Sie KI-Antworten in Echtzeit über Feishu / Lark CardKit. Erfordert die Berechtigungen im:message und cardkit:card:write; DeepChat fällt auf normale Nachrichten zurück, wenn CardKit fehlschlägt."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/de-DE/settings.json
+++ b/src/renderer/src/i18n/de-DE/settings.json
@@ -2206,7 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -2266,7 +2266,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/es-ES/settings.json
+++ b/src/renderer/src/i18n/es-ES/settings.json
@@ -2206,9 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Haz clic en Emparejar abajo y luego envía el código /pair en un chat directo con el bot. Esta es la ruta de autorización recomendada y sigue funcionando con aplicaciones PersonalAgent instaladas.",
+      "streamingCards": "Tarjetas de transmisión CardKit",
+      "streamingCardsDescription": "Transmite las respuestas de IA mediante Feishu / Lark CardKit en tiempo real. Requiere los permisos im:message y cardkit:card:write; DeepChat vuelve a los mensajes normales si CardKit falla."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/es-ES/settings.json
+++ b/src/renderer/src/i18n/es-ES/settings.json
@@ -2206,7 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -2107,7 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -2107,9 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "روی «جفت‌سازی» در زیر کلیک کنید، سپس کد /pair را در گفت‌وگوی مستقیم با ربات ارسال کنید. این مسیر مجوزدهی پیشنهادی است و همچنان با برنامه‌های PersonalAgent نصب‌شده کار می‌کند.",
+      "streamingCards": "کارت‌های استریم CardKit",
+      "streamingCardsDescription": "پاسخ‌های هوش مصنوعی را از طریق Feishu / Lark CardKit به‌صورت بلادرنگ استریم کنید. به مجوزهای im:message و cardkit:card:write نیاز دارد؛ اگر CardKit شکست بخورد، DeepChat به پیام‌های عادی بازمی‌گردد."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -2107,7 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -2107,9 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Cliquez sur Associer ci-dessous, puis envoyez le code /pair dans une conversation directe avec le bot. C’est le mode d’autorisation recommandé et il fonctionne toujours avec les applications PersonalAgent installées.",
+      "streamingCards": "Cartes de streaming CardKit",
+      "streamingCardsDescription": "Diffusez les réponses IA en temps réel via Feishu / Lark CardKit. Nécessite les autorisations im:message et cardkit:card:write ; DeepChat revient aux messages normaux si CardKit échoue."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -2107,7 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -2107,9 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "לחצו על צימוד למטה, ואז שלחו את קוד /pair בצ'אט ישיר עם הבוט. זהו מסלול ההרשאה המומלץ והוא עדיין עובד עם אפליקציות PersonalAgent מותקנות.",
+      "streamingCards": "כרטיסי סטרימינג של CardKit",
+      "streamingCardsDescription": "הזרימו תשובות AI בזמן אמת דרך Feishu / Lark CardKit. נדרשות ההרשאות im:message ו-cardkit:card:write; אם CardKit נכשל, DeepChat חוזר להודעות רגילות."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/id-ID/settings.json
+++ b/src/renderer/src/i18n/id-ID/settings.json
@@ -2206,9 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Klik Pasangkan di bawah, lalu kirim kode /pair dalam chat langsung dengan bot. Ini adalah jalur otorisasi yang direkomendasikan dan tetap berfungsi dengan aplikasi PersonalAgent yang sudah terpasang.",
+      "streamingCards": "Kartu Streaming CardKit",
+      "streamingCardsDescription": "Stream balasan AI melalui Feishu / Lark CardKit secara real-time. Memerlukan izin im:message dan cardkit:card:write; DeepChat akan kembali ke pesan normal jika CardKit gagal."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/id-ID/settings.json
+++ b/src/renderer/src/i18n/id-ID/settings.json
@@ -2206,7 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/it-IT/settings.json
+++ b/src/renderer/src/i18n/it-IT/settings.json
@@ -2206,9 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Fai clic su Associa qui sotto, poi invia il codice /pair in una chat diretta con il bot. Questo è il percorso di autorizzazione consigliato e funziona ancora con le app PersonalAgent installate.",
+      "streamingCards": "Schede streaming CardKit",
+      "streamingCardsDescription": "Trasmetti le risposte AI tramite Feishu / Lark CardKit in tempo reale. Richiede le autorizzazioni im:message e cardkit:card:write; DeepChat torna ai messaggi normali se CardKit fallisce."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/it-IT/settings.json
+++ b/src/renderer/src/i18n/it-IT/settings.json
@@ -2206,7 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -2107,7 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -2107,9 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "下の「ペアリング」をクリックし、その後ボットとのダイレクトチャットで /pair コードを送信します。これは推奨される認可方法で、インストール済みの PersonalAgent アプリでも引き続き使用できます。",
+      "streamingCards": "CardKit ストリーミングカード",
+      "streamingCardsDescription": "Feishu / Lark CardKit を通じて AI 返答をリアルタイムでストリーミングします。im:message および cardkit:card:write 権限が必要です。CardKit が失敗した場合、DeepChat は通常のメッセージにフォールバックします。"
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -2107,7 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -2107,9 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "아래의 페어링을 클릭한 다음 봇과의 다이렉트 채팅에서 /pair 코드를 보내세요. 권장되는 인증 방법이며 설치된 PersonalAgent 앱에서도 계속 작동합니다.",
+      "streamingCards": "CardKit 스트리밍 카드",
+      "streamingCardsDescription": "Feishu / Lark CardKit을 통해 AI 답변을 실시간으로 스트리밍합니다. im:message 및 cardkit:card:write 권한이 필요합니다. CardKit이 실패하면 DeepChat은 일반 메시지로 폴백합니다."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/ms-MY/settings.json
+++ b/src/renderer/src/i18n/ms-MY/settings.json
@@ -2206,9 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Klik Pasangkan di bawah, kemudian hantar kod /pair dalam sembang terus dengan bot. Ini ialah kaedah kebenaran yang disyorkan dan masih berfungsi dengan aplikasi PersonalAgent yang dipasang.",
+      "streamingCards": "Kad Strim CardKit",
+      "streamingCardsDescription": "Strim balasan AI melalui Feishu / Lark CardKit dalam masa nyata. Memerlukan keizinan im:message dan cardkit:card:write; DeepChat akan kembali ke mesej biasa jika CardKit gagal."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/ms-MY/settings.json
+++ b/src/renderer/src/i18n/ms-MY/settings.json
@@ -2206,7 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/pl-PL/settings.json
+++ b/src/renderer/src/i18n/pl-PL/settings.json
@@ -2206,9 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Kliknij Paruj poniżej, a następnie wyślij kod /pair w czacie bezpośrednim z botem. To zalecana ścieżka autoryzacji, która nadal działa z zainstalowanymi aplikacjami PersonalAgent.",
+      "streamingCards": "Karty strumieniowania CardKit",
+      "streamingCardsDescription": "Strumieniuj odpowiedzi AI przez Feishu / Lark CardKit w czasie rzeczywistym. Wymaga uprawnień im:message i cardkit:card:write; DeepChat wraca do normalnych wiadomości, jeśli CardKit zawiedzie."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/pl-PL/settings.json
+++ b/src/renderer/src/i18n/pl-PL/settings.json
@@ -2206,7 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -2107,7 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -2107,9 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Clique em Emparelhar abaixo e envie o código /pair em uma conversa direta com o bot. Este é o fluxo de autorização recomendado e continua funcionando com apps PersonalAgent instalados.",
+      "streamingCards": "Cartões de Streaming CardKit",
+      "streamingCardsDescription": "Transmita respostas de IA pelo Feishu / Lark CardKit em tempo real. Requer permissões im:message e cardkit:card:write; DeepChat volta para mensagens normais se o CardKit falhar."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -2107,7 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -2107,9 +2107,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Нажмите «Сопряжение» ниже, затем отправьте код /pair в личном чате с ботом. Это рекомендуемый способ авторизации, который продолжает работать с установленными приложениями PersonalAgent.",
+      "streamingCards": "Потоковые карточки CardKit",
+      "streamingCardsDescription": "Передавайте ответы ИИ в реальном времени через Feishu / Lark CardKit. Требуются разрешения im:message и cardkit:card:write; DeepChat вернётся к обычным сообщениям, если CardKit даст сбой."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/tr-TR/settings.json
+++ b/src/renderer/src/i18n/tr-TR/settings.json
@@ -2206,9 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Aşağıdaki Eşleştir'e tıklayın, ardından botla doğrudan sohbette /pair kodunu gönderin. Bu önerilen yetkilendirme yoludur ve yüklü PersonalAgent uygulamalarıyla da çalışmaya devam eder.",
+      "streamingCards": "CardKit Akış Kartları",
+      "streamingCardsDescription": "AI yanıtlarını Feishu / Lark CardKit üzerinden gerçek zamanlı olarak yayınlayın. im:message ve cardkit:card:write izinleri gerekir; CardKit başarısız olursa DeepChat normal mesajlara geri döner."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/tr-TR/settings.json
+++ b/src/renderer/src/i18n/tr-TR/settings.json
@@ -2206,7 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/vi-VN/settings.json
+++ b/src/renderer/src/i18n/vi-VN/settings.json
@@ -2206,9 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
-      "streamingCards": "CardKit Streaming Cards",
-      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
+      "pairAuthDescription": "Nhấp Ghép đôi bên dưới, sau đó gửi mã /pair trong cuộc trò chuyện trực tiếp với bot. Đây là luồng ủy quyền được khuyến nghị và vẫn hoạt động với các ứng dụng PersonalAgent đã cài đặt.",
+      "streamingCards": "Thẻ phát trực tiếp CardKit",
+      "streamingCardsDescription": "Phát trực tiếp câu trả lời AI qua Feishu / Lark CardKit theo thời gian thực. Yêu cầu quyền im:message và cardkit:card:write; DeepChat sẽ quay về tin nhắn thông thường nếu CardKit thất bại."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/vi-VN/settings.json
+++ b/src/renderer/src/i18n/vi-VN/settings.json
@@ -2206,7 +2206,9 @@
       "userAuthTitle": "Authorize remote-control users",
       "userAuthDescription": "After the bot app is installed, authorized Feishu / Lark users can control DeepChat. Use /pair in the bot chat, or use OAuth scan authorization for an existing manually configured app; both update the same authorized-principal list.",
       "pairAuthTitle": "/pair command",
-      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps."
+      "pairAuthDescription": "Click Pair below, then send /pair code in a direct chat with the bot. This is the recommended authorization path and still works with installed PersonalAgent apps.",
+      "streamingCards": "CardKit Streaming Cards",
+      "streamingCardsDescription": "Stream AI replies through Feishu / Lark CardKit in real time. Requires im:message and cardkit:card:write permissions; DeepChat falls back to normal messages if CardKit fails."
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -2266,7 +2266,9 @@
       "userAuthTitle": "远控用户授权",
       "userAuthDescription": "机器人应用安装完成后，已授权的飞书 / Lark 用户才能控制 DeepChat。可以在机器人会话里使用 /pair，也可以在已有手动配置应用时使用 OAuth 扫码授权；两者都会更新同一份授权主体列表。",
       "pairAuthTitle": "/pair 命令",
-      "pairAuthDescription": "点击下方“配对”生成配对码，然后在机器人私聊里发送 /pair 配对码。这是推荐授权方式，也适用于 PersonalAgent 安装后的应用。"
+      "pairAuthDescription": "点击下方“配对”生成配对码，然后在机器人私聊里发送 /pair 配对码。这是推荐授权方式，也适用于 PersonalAgent 安装后的应用。",
+      "streamingCards": "CardKit 流式卡片",
+      "streamingCardsDescription": "开启后，AI 回复会使用飞书 / Lark CardKit 流式卡片实时更新；需要应用具备 im:message 和 cardkit:card:write 权限，失败时会自动回退为普通消息。"
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -2107,7 +2107,9 @@
       "userAuthTitle": "遠控使用者授權",
       "userAuthDescription": "機器人應用安裝完成後，已授權的飛書 / Lark 使用者才能控制 DeepChat。可以在機器人會話裡使用 /pair，也可以在已有手動配置應用時使用 OAuth 掃碼授權；兩者都會更新同一份授權主體列表。",
       "pairAuthTitle": "/pair 命令",
-      "pairAuthDescription": "點擊下方「配對」生成配對碼，然後在機器人私聊裡發送 /pair 配對碼。這是推薦授權方式，也適用於 PersonalAgent 安裝後的應用。"
+      "pairAuthDescription": "點擊下方「配對」生成配對碼，然後在機器人私聊裡發送 /pair 配對碼。這是推薦授權方式，也適用於 PersonalAgent 安裝後的應用。",
+      "streamingCards": "CardKit 串流卡片",
+      "streamingCardsDescription": "開啟後，AI 回覆會使用飛書 / Lark CardKit 串流卡片即時更新；需要應用具備 im:message 和 cardkit:card:write 權限，失敗時會自動回退為普通消息。"
     },
     "discord": {
       "title": "Discord",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -2107,7 +2107,9 @@
       "userAuthTitle": "遠控使用者授權",
       "userAuthDescription": "機器人應用安裝完成後，已授權的飛書 / Lark 使用者才能控制 DeepChat。可以在機器人會話裡使用 /pair，也可以在已有手動配置應用時使用 OAuth 掃碼授權；兩者都會更新同一份授權主體列表。",
       "pairAuthTitle": "/pair 命令",
-      "pairAuthDescription": "點擊下方「配對」生成配對碼，然後在機器人私聊裡發送 /pair 配對碼。這是推薦授權方式，也適用於 PersonalAgent 安裝後的應用。"
+      "pairAuthDescription": "點擊下方「配對」生成配對碼，然後在機器人私聊裡發送 /pair 配對碼。這是推薦授權方式，也適用於 PersonalAgent 安裝後的應用。",
+      "streamingCards": "CardKit 串流卡片",
+      "streamingCardsDescription": "開啟後，AI 回覆會使用飛書 / Lark CardKit 串流卡片即時更新；需要應用具備 im:message 和 cardkit:card:write 權限，失敗時會自動回退為普通消息。"
     },
     "discord": {
       "title": "Discord",

--- a/src/shared/types/presenters/remote-control.presenter.d.ts
+++ b/src/shared/types/presenters/remote-control.presenter.d.ts
@@ -165,6 +165,7 @@ export interface FeishuRemoteSettings {
   verificationToken: string
   encryptKey: string
   remoteEnabled: boolean
+  enableStreamingCards: boolean
   defaultAgentId: string
   defaultWorkdir: string
   pairedUserOpenIds: string[]

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -2915,6 +2915,8 @@ declare module 'vue-i18n' {
         userAuthDescription: string
         pairAuthTitle: string
         pairAuthDescription: string
+        streamingCards: string
+        streamingCardsDescription: string
       }
       discord: {
         title: string

--- a/test/main/presenter/remoteControlPresenter/feishuClient.test.ts
+++ b/test/main/presenter/remoteControlPresenter/feishuClient.test.ts
@@ -356,6 +356,43 @@ describe('FeishuClient', () => {
     })
   })
 
+  it('fails fast when CardKit card entity omits message_id', async () => {
+    const client = new FeishuClient({
+      brand: 'feishu',
+      appId: 'cli_feishu',
+      appSecret: 'secret',
+      verificationToken: 'verify',
+      encryptKey: 'encrypt'
+    })
+    ;(client as any).sdk.im.message.reply.mockResolvedValue({
+      data: {
+        message_id: '  '
+      }
+    })
+    ;(client as any).sdk.im.message.create.mockResolvedValue({
+      data: {}
+    })
+
+    await expect(
+      client.sendCardEntity(
+        {
+          chatId: 'oc_1',
+          replyToMessageId: 'om_source'
+        },
+        'card_1'
+      )
+    ).rejects.toThrow('Feishu CardKit send card entity did not return message_id.')
+
+    await expect(
+      client.sendCardEntity(
+        {
+          chatId: 'oc_1'
+        },
+        'card_1'
+      )
+    ).rejects.toThrow('Feishu CardKit send card entity did not return message_id.')
+  })
+
   it('surfaces CardKit API errors clearly', async () => {
     const client = new FeishuClient({
       brand: 'feishu',

--- a/test/main/presenter/remoteControlPresenter/feishuClient.test.ts
+++ b/test/main/presenter/remoteControlPresenter/feishuClient.test.ts
@@ -228,6 +228,152 @@ describe('FeishuClient', () => {
     })
   })
 
+  it('creates and updates a CardKit streaming card', async () => {
+    const client = new FeishuClient({
+      brand: 'feishu',
+      appId: 'cli_feishu',
+      appSecret: 'secret',
+      verificationToken: 'verify',
+      encryptKey: 'encrypt'
+    })
+    ;(client as any).sdk.request
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          card_id: 'card_1'
+        }
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {}
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {}
+      })
+
+    const card = await client.createStreamingCard('')
+    await client.updateStreamingCardContent({
+      cardId: card.cardId,
+      elementId: card.elementId,
+      content: 'Hello',
+      sequence: 1
+    })
+    await client.closeStreamingCard(card.cardId, 2)
+
+    expect(card).toEqual({
+      cardId: 'card_1',
+      elementId: 'md_stream'
+    })
+    const createRequest = (client as any).sdk.request.mock.calls[0][0]
+    expect(createRequest).toEqual(
+      expect.objectContaining({
+        method: 'POST',
+        url: '/open-apis/cardkit/v1/cards',
+        data: expect.objectContaining({
+          type: 'card_json'
+        })
+      })
+    )
+    expect(JSON.parse(createRequest.data.data)).toEqual(
+      expect.objectContaining({
+        schema: '2.0',
+        config: expect.objectContaining({
+          streaming_mode: true,
+          update_multi: true
+        }),
+        body: {
+          elements: [
+            {
+              tag: 'markdown',
+              content: '',
+              element_id: 'md_stream'
+            }
+          ]
+        }
+      })
+    )
+    expect((client as any).sdk.request).toHaveBeenNthCalledWith(2, {
+      method: 'PUT',
+      url: '/open-apis/cardkit/v1/cards/card_1/elements/md_stream/content',
+      data: {
+        content: 'Hello',
+        sequence: 1
+      }
+    })
+    expect((client as any).sdk.request).toHaveBeenNthCalledWith(3, {
+      method: 'PATCH',
+      url: '/open-apis/cardkit/v1/cards/card_1/settings',
+      data: {
+        settings: JSON.stringify({
+          config: {
+            streaming_mode: false
+          }
+        }),
+        sequence: 2
+      }
+    })
+  })
+
+  it('sends a CardKit card entity as an interactive message reply', async () => {
+    const client = new FeishuClient({
+      brand: 'feishu',
+      appId: 'cli_feishu',
+      appSecret: 'secret',
+      verificationToken: 'verify',
+      encryptKey: 'encrypt'
+    })
+    ;(client as any).sdk.im.message.reply.mockResolvedValue({
+      data: {
+        message_id: 'om_card'
+      }
+    })
+
+    const messageId = await client.sendCardEntity(
+      {
+        chatId: 'oc_1',
+        threadId: 'omt_1',
+        replyToMessageId: 'om_source'
+      },
+      'card_1'
+    )
+
+    expect(messageId).toBe('om_card')
+    expect((client as any).sdk.im.message.reply).toHaveBeenCalledWith({
+      path: {
+        message_id: 'om_source'
+      },
+      data: {
+        content: JSON.stringify({
+          type: 'card',
+          data: {
+            card_id: 'card_1'
+          }
+        }),
+        msg_type: 'interactive',
+        reply_in_thread: true
+      }
+    })
+  })
+
+  it('surfaces CardKit API errors clearly', async () => {
+    const client = new FeishuClient({
+      brand: 'feishu',
+      appId: 'cli_feishu',
+      appSecret: 'secret',
+      verificationToken: 'verify',
+      encryptKey: 'encrypt'
+    })
+    ;(client as any).sdk.request.mockResolvedValue({
+      code: 300311,
+      msg: 'The current application does not have permission to update/use this card'
+    })
+
+    await expect(client.createStreamingCard()).rejects.toThrow(
+      'The current application does not have permission to update/use this card'
+    )
+  })
+
   it('fails fast when the image file is missing', async () => {
     const client = new FeishuClient({
       brand: 'feishu',

--- a/test/main/presenter/remoteControlPresenter/feishuRuntime.test.ts
+++ b/test/main/presenter/remoteControlPresenter/feishuRuntime.test.ts
@@ -39,7 +39,10 @@ const createDeferred = <T>() => {
   }
 }
 
-const createHarness = async (options?: { logger?: { error: (...params: unknown[]) => void } }) => {
+const createHarness = async (options?: {
+  logger?: { error: (...params: unknown[]) => void }
+  enableStreamingCards?: boolean
+}) => {
   let onMessage: ((event: unknown) => Promise<void>) | null = null
   const streamHandlers: Array<(event: unknown) => Promise<void>> = []
   let nextMessageId = 1
@@ -60,11 +63,20 @@ const createHarness = async (options?: { logger?: { error: (...params: unknown[]
     sendMarkdown: vi.fn().mockImplementation(async () => `om_bot_${nextMessageId++}`),
     updateMarkdown: vi.fn().mockResolvedValue(undefined),
     deleteMessage: vi.fn().mockResolvedValue(undefined),
+    createStreamingCard: vi.fn().mockResolvedValue({
+      cardId: 'card_1',
+      elementId: 'md_stream'
+    }),
+    sendCardEntity: vi.fn().mockImplementation(async () => `om_card_${nextMessageId++}`),
+    updateStreamingCardContent: vi.fn().mockResolvedValue(undefined),
+    closeStreamingCard: vi.fn().mockResolvedValue(undefined),
     downloadMessageResource: vi.fn().mockResolvedValue({
       data: Buffer.from('file').toString('base64'),
       mediaType: 'text/plain'
     }),
-    sendCard: vi.fn().mockResolvedValue(undefined)
+    sendCard: vi.fn().mockResolvedValue(undefined),
+    addReaction: vi.fn().mockResolvedValue('reaction_1'),
+    removeReaction: vi.fn().mockResolvedValue(undefined)
   }
   const parser = {
     parseEvent: vi.fn((event: { parsed?: FeishuInboundMessage | null }) => event.parsed ?? null)
@@ -96,6 +108,7 @@ const createHarness = async (options?: { logger?: { error: (...params: unknown[]
     parser: parser as any,
     router: router as any,
     bindingStore: bindingStore as any,
+    enableStreamingCards: options?.enableStreamingCards,
     logger: options?.logger
   })
   await runtime.start()
@@ -149,6 +162,266 @@ describe('FeishuRuntime', () => {
     })
 
     await harness.runtime.stop()
+  })
+
+  it('streams answer text through a CardKit streaming card when enabled', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const harness = await createHarness({ enableStreamingCards: true })
+      harness.router.handleMessage.mockResolvedValue({
+        replies: [],
+        conversation: {
+          sessionId: 'session-1',
+          eventId: 'msg-1',
+          getSnapshot: vi
+            .fn()
+            .mockResolvedValueOnce({
+              messageId: 'msg-1',
+              text: '',
+              traceText: '💻 shell_command: "git status"',
+              deliverySegments: [
+                {
+                  key: 'msg-1:0:process',
+                  kind: 'process',
+                  text: '💻 shell_command: "git status"',
+                  sourceMessageId: 'msg-1'
+                }
+              ],
+              statusText: 'Running: thinking...',
+              finalText: '',
+              completed: false,
+              pendingInteraction: null
+            })
+            .mockResolvedValueOnce({
+              messageId: 'msg-1',
+              text: 'Draft answer',
+              traceText: '💻 shell_command: "git status"',
+              deliverySegments: [
+                {
+                  key: 'msg-1:0:process',
+                  kind: 'process',
+                  text: '💻 shell_command: "git status"',
+                  sourceMessageId: 'msg-1'
+                },
+                {
+                  key: 'msg-1:1:answer',
+                  kind: 'answer',
+                  text: 'Draft answer',
+                  sourceMessageId: 'msg-1'
+                }
+              ],
+              statusText: 'Running: writing...',
+              finalText: '',
+              completed: false,
+              pendingInteraction: null
+            })
+            .mockResolvedValue({
+              messageId: 'msg-1',
+              text: 'Draft answer',
+              traceText: '💻 shell_command: "git status"',
+              deliverySegments: [
+                {
+                  key: 'msg-1:0:process',
+                  kind: 'process',
+                  text: '💻 shell_command: "git status"',
+                  sourceMessageId: 'msg-1'
+                },
+                {
+                  key: 'msg-1:1:answer',
+                  kind: 'answer',
+                  text: 'Final answer',
+                  sourceMessageId: 'msg-1'
+                }
+              ],
+              statusText: 'Running: writing...',
+              finalText: 'Final answer',
+              completed: true,
+              pendingInteraction: null
+            })
+        }
+      })
+
+      await harness.onMessage({
+        parsed: createParsedMessage({
+          messageId: 'om_stream_card'
+        })
+      })
+
+      await vi.waitFor(() => {
+        expect(harness.client.createStreamingCard).toHaveBeenCalledWith('')
+        expect(harness.client.sendCardEntity).toHaveBeenCalledWith(
+          {
+            chatId: 'oc_1',
+            threadId: null,
+            replyToMessageId: 'om_stream_card'
+          },
+          'card_1'
+        )
+        expect(harness.client.updateStreamingCardContent).toHaveBeenCalledWith({
+          cardId: 'card_1',
+          elementId: 'md_stream',
+          content:
+            '**Status**\nRunning: thinking...\n\n**Process**\n💻 shell_command: "git status"',
+          sequence: 1
+        })
+      })
+
+      await vi.advanceTimersByTimeAsync(TELEGRAM_STREAM_POLL_INTERVAL_MS)
+      await vi.waitFor(() => {
+        expect(harness.client.updateStreamingCardContent).toHaveBeenCalledWith({
+          cardId: 'card_1',
+          elementId: 'md_stream',
+          content:
+            '**Status**\nRunning: writing...\n\n**Process**\n💻 shell_command: "git status"\n\n**Answer**\nDraft answer',
+          sequence: 2
+        })
+      })
+
+      await vi.advanceTimersByTimeAsync(TELEGRAM_STREAM_POLL_INTERVAL_MS)
+      await vi.waitFor(() => {
+        expect(harness.client.updateStreamingCardContent).toHaveBeenCalledWith({
+          cardId: 'card_1',
+          elementId: 'md_stream',
+          content: '**Process**\n💻 shell_command: "git status"\n\n**Answer**\nFinal answer',
+          sequence: 3
+        })
+        expect(harness.client.closeStreamingCard).toHaveBeenCalledWith('card_1', 4)
+        expect(harness.client.sendMarkdown).not.toHaveBeenCalled()
+        expect(harness.bindingStore.clearRemoteDeliveryState).toHaveBeenCalledWith(
+          'feishu:oc_1:root'
+        )
+      })
+
+      await harness.runtime.stop()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('preserves fenced code blocks and tables in CardKit markdown updates', async () => {
+    const harness = await createHarness({ enableStreamingCards: true })
+    const markdownAnswer = [
+      'Here is the result:',
+      '',
+      '```ts',
+      "const value = 'ok'",
+      '```',
+      '',
+      '| Name | Status |',
+      '| --- | --- |',
+      '| CardKit | streaming |'
+    ].join('\n')
+
+    harness.router.handleMessage.mockResolvedValue({
+      replies: [],
+      conversation: {
+        sessionId: 'session-1',
+        eventId: 'msg-1',
+        getSnapshot: vi.fn().mockResolvedValue({
+          messageId: 'msg-1',
+          text: markdownAnswer,
+          traceText: '',
+          deliverySegments: [
+            {
+              key: 'msg-1:0:answer',
+              kind: 'answer',
+              text: markdownAnswer,
+              sourceMessageId: 'msg-1'
+            }
+          ],
+          statusText: 'Running: writing...',
+          finalText: markdownAnswer,
+          completed: true,
+          pendingInteraction: null
+        })
+      }
+    })
+
+    await harness.onMessage({
+      parsed: createParsedMessage({
+        messageId: 'om_markdown_card'
+      })
+    })
+
+    await vi.waitFor(() => {
+      expect(harness.client.updateStreamingCardContent).toHaveBeenCalled()
+    })
+
+    const content = harness.client.updateStreamingCardContent.mock.calls[0]?.[0]?.content
+    expect(content).toContain('```ts')
+    expect(content).toContain("const value = 'ok'")
+    expect(content).toContain('| Name | Status |')
+    expect(content).toContain('| CardKit | streaming |')
+    expect(harness.client.closeStreamingCard).toHaveBeenCalledWith('card_1', 2)
+    expect(harness.client.sendMarkdown).not.toHaveBeenCalled()
+
+    await harness.runtime.stop()
+  })
+
+  it('falls back to markdown delivery and closes the card when a streaming update fails', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const harness = await createHarness({ enableStreamingCards: true })
+      harness.client.updateStreamingCardContent.mockRejectedValueOnce(
+        new Error('missing cardkit scope')
+      )
+      harness.router.handleMessage.mockResolvedValue({
+        replies: [],
+        conversation: {
+          sessionId: 'session-1',
+          eventId: 'msg-1',
+          getSnapshot: vi.fn().mockResolvedValue({
+            messageId: 'msg-1',
+            text: 'Fallback answer',
+            traceText: '',
+            deliverySegments: [
+              {
+                key: 'msg-1:0:answer',
+                kind: 'answer',
+                text: 'Fallback answer',
+                sourceMessageId: 'msg-1'
+              }
+            ],
+            statusText: 'Running: writing...',
+            finalText: 'Fallback answer',
+            completed: true,
+            pendingInteraction: null
+          })
+        }
+      })
+
+      await harness.onMessage({
+        parsed: createParsedMessage({
+          messageId: 'om_card_fallback'
+        })
+      })
+
+      await vi.waitFor(() => {
+        expect(harness.client.sendMarkdown).toHaveBeenCalledWith(
+          {
+            chatId: 'oc_1',
+            threadId: null,
+            replyToMessageId: 'om_card_fallback'
+          },
+          'Fallback answer'
+        )
+        expect(harness.client.sendText).toHaveBeenCalledWith(
+          {
+            chatId: 'oc_1',
+            threadId: null,
+            replyToMessageId: 'om_card_fallback'
+          },
+          'Feishu CardKit streaming failed. Falling back to normal message updates. Check that the app has im:message and cardkit:card:write permissions.'
+        )
+        expect(harness.client.closeStreamingCard).toHaveBeenCalledWith('card_1', 2)
+      })
+
+      await harness.runtime.stop()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('streams answer text beside a persistent trace log', async () => {

--- a/test/main/presenter/remoteControlPresenter/feishuRuntime.test.ts
+++ b/test/main/presenter/remoteControlPresenter/feishuRuntime.test.ts
@@ -424,6 +424,111 @@ describe('FeishuRuntime', () => {
     }
   })
 
+  it('falls back to markdown delivery and closes the card when posting the card entity fails', async () => {
+    const harness = await createHarness({ enableStreamingCards: true })
+    harness.client.sendCardEntity.mockRejectedValueOnce(new Error('missing message id'))
+    harness.router.handleMessage.mockResolvedValue({
+      replies: [],
+      conversation: {
+        sessionId: 'session-1',
+        eventId: 'msg-1',
+        getSnapshot: vi.fn().mockResolvedValue({
+          messageId: 'msg-1',
+          text: 'Fallback answer',
+          traceText: '',
+          deliverySegments: [
+            {
+              key: 'msg-1:0:answer',
+              kind: 'answer',
+              text: 'Fallback answer',
+              sourceMessageId: 'msg-1'
+            }
+          ],
+          statusText: 'Running: writing...',
+          finalText: 'Fallback answer',
+          completed: true,
+          pendingInteraction: null
+        })
+      }
+    })
+
+    await harness.onMessage({
+      parsed: createParsedMessage({
+        messageId: 'om_card_entity_fallback'
+      })
+    })
+
+    await vi.waitFor(() => {
+      expect(harness.client.closeStreamingCard).toHaveBeenCalledWith('card_1', 1)
+      expect(harness.client.sendMarkdown).toHaveBeenCalledWith(
+        {
+          chatId: 'oc_1',
+          threadId: null,
+          replyToMessageId: 'om_card_entity_fallback'
+        },
+        'Fallback answer'
+      )
+    })
+
+    await harness.runtime.stop()
+  })
+
+  it('closes an active streaming card when the run stops before completion', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const harness = await createHarness({ enableStreamingCards: true })
+      harness.router.handleMessage.mockResolvedValue({
+        replies: [],
+        conversation: {
+          sessionId: 'session-1',
+          eventId: 'msg-1',
+          getSnapshot: vi.fn().mockResolvedValue({
+            messageId: 'msg-1',
+            text: 'Draft answer',
+            traceText: '',
+            deliverySegments: [
+              {
+                key: 'msg-1:0:answer',
+                kind: 'answer',
+                text: 'Draft answer',
+                sourceMessageId: 'msg-1'
+              }
+            ],
+            statusText: 'Running: writing...',
+            finalText: '',
+            completed: false,
+            pendingInteraction: null
+          })
+        }
+      })
+
+      await harness.onMessage({
+        parsed: createParsedMessage({
+          messageId: 'om_card_stop'
+        })
+      })
+
+      await vi.waitFor(() => {
+        expect(harness.client.updateStreamingCardContent).toHaveBeenCalledWith({
+          cardId: 'card_1',
+          elementId: 'md_stream',
+          content: '**Status**\nRunning: writing...\n\n**Answer**\nDraft answer',
+          sequence: 1
+        })
+      })
+
+      await harness.runtime.stop()
+      await vi.advanceTimersByTimeAsync(TELEGRAM_STREAM_POLL_INTERVAL_MS)
+
+      await vi.waitFor(() => {
+        expect(harness.client.closeStreamingCard).toHaveBeenCalledWith('card_1', 2)
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('streams answer text beside a persistent trace log', async () => {
     vi.useFakeTimers()
 

--- a/test/main/presenter/remoteControlPresenter/remoteControlPresenter.test.ts
+++ b/test/main/presenter/remoteControlPresenter/remoteControlPresenter.test.ts
@@ -1123,7 +1123,8 @@ describe('RemoteControlPresenter', () => {
       appSecret: 'secret',
       verificationToken: 'verify',
       encryptKey: '',
-      remoteEnabled: true,
+      remoteEnabled: false,
+      enableStreamingCards: true,
       defaultAgentId: 'deepchat',
       defaultWorkdir: '',
       pairedUserOpenIds: []
@@ -1135,6 +1136,7 @@ describe('RemoteControlPresenter', () => {
       expect.objectContaining({
         feishu: expect.objectContaining({
           appId: 'cli_new',
+          enableStreamingCards: true,
           pairedUserOpenIds: ['ou_paired']
         })
       })
@@ -1159,6 +1161,7 @@ describe('RemoteControlPresenter', () => {
       verificationToken: 'verify',
       encryptKey: '',
       remoteEnabled: false,
+      enableStreamingCards: false,
       defaultAgentId: 'deepchat',
       defaultWorkdir: '',
       pairedUserOpenIds: []

--- a/test/renderer/components/RemoteSettings.test.ts
+++ b/test/renderer/components/RemoteSettings.test.ts
@@ -98,6 +98,7 @@ const setup = async (options: SetupOptions = {}) => {
       verificationToken: '',
       encryptKey: '',
       remoteEnabled: false,
+      enableStreamingCards: false,
       defaultAgentId: 'deepchat',
       defaultWorkdir: '',
       pairedUserOpenIds: [] as string[]
@@ -1144,6 +1145,42 @@ describe('RemoteSettings', () => {
     expect(wrapper.find('[data-testid="feishu-pair-button"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="feishu-scan-auth-button"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="feishu-bindings-button"]').exists()).toBe(true)
+  })
+
+  it('persists the feishu streaming card setting', async () => {
+    const { wrapper, remoteControlPresenter, tabsComponents } = await setup({
+      feishuChannelSettingsOverride: {
+        remoteEnabled: true,
+        enableStreamingCards: false
+      }
+    })
+
+    const feishuTrigger = wrapper
+      .findAllComponents(tabsComponents.TabsTrigger)
+      .find((component) => component.attributes('data-testid') === 'remote-tab-feishu')
+
+    expect(feishuTrigger).toBeDefined()
+    await feishuTrigger!.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('settings.remote.feishu.streamingCards')
+    expect(wrapper.text()).toContain('settings.remote.feishu.streamingCardsDescription')
+
+    const toggle = wrapper.find('[data-testid="feishu-streaming-cards-toggle"]')
+    expect(toggle.exists()).toBe(true)
+    expect((toggle.element as HTMLInputElement).checked).toBe(false)
+
+    await toggle.setValue(true)
+    await flushPromises()
+
+    await vi.waitFor(() => {
+      expect(remoteControlPresenter.saveChannelSettings).toHaveBeenCalledWith(
+        'feishu',
+        expect.objectContaining({
+          enableStreamingCards: true
+        })
+      )
+    })
   })
 
   it('starts the official feishu web install flow and refreshes credentials', async () => {


### PR DESCRIPTION
## Summary
- Add an opt-in Feishu/Lark Remote Control setting for CardKit streaming cards.
- Stream AI responses through a single CardKit markdown element with increasing sequence updates, then close streaming mode on completion/timeout.
- Show status/thinking, tool-call progress, and answer content in the card; preserve Markdown code fences and tables for CardKit rendering.
- Fall back to the existing markdown/post update flow with a clear notice when CardKit permissions or APIs fail.

## UI layout

BEFORE:
```text
Feishu / Lark Remote
├─ Access rules
├─ Default agent
└─ Working directory
```

AFTER:
```text
Feishu / Lark Remote
├─ Access rules
├─ CardKit streaming cards [toggle]
│  └─ Requires Feishu/Lark CardKit create/update permissions.
├─ Default agent
└─ Working directory
```

## Validation
- `pnpm exec vitest run test/main/presenter/remoteControlPresenter/feishuClient.test.ts test/main/presenter/remoteControlPresenter/feishuRuntime.test.ts test/main/presenter/remoteControlPresenter/remoteControlPresenter.test.ts test/main/presenter/remoteControlPresenter/remoteBlockRenderer.test.ts test/main/presenter/remoteControlPresenter/remoteConversationRunner.test.ts test/renderer/components/RemoteSettings.test.ts --pool forks --poolOptions.forks.singleFork`
- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`

Closes #1814


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Feishu/Lark “Streaming Cards” toggle for remote responses.
  * Enabled real-time AI streaming using Feishu/Lark CardKit with correct streaming card lifecycle and ordered incremental updates.
  * Added multilingual UI text describing the feature and required permissions, plus automatic fallback to the standard delivery flow if streaming fails.

* **Bug Fixes**
  * Improved reliability of streamed updates, including preserving rich Markdown rendering.
  * Ensured streaming cards are properly closed on completion, timeout, or early interruption.
  * Strengthened error handling and user-facing fallback behavior for CardKit failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->