### PR TITLE
fix(message): skill activation follows messages, not sessions

### DIFF
--- a/docs/issues/model-list-fetch-404/plan.md
+++ b/docs/issues/model-list-fetch-404/plan.md
@@ -1,0 +1,19 @@
+# Plan
+
+## Cause
+
+`BaseLLMProvider.fetchModels()` wraps `this.fetchProviderModels().then(...)` in a synchronous `try/catch`. If `fetchProviderModels()` rejects asynchronously (for example `AiSdkProvider.requestProviderJson()` throws `ProviderHttpError` after fetch returns a 404), the rejection bypasses the catch block and propagates to `ModelManager.getModelList()` and the `models:list` route.
+
+## Implementation
+
+- Convert `BaseLLMProvider.fetchModels()` to `async`/`await` so both synchronous throws and asynchronous rejections are caught by the existing error handling.
+- Preserve `suppressErrors` semantics:
+  - default `true` returns `[]` on failure;
+  - `false` rethrows.
+- Keep model validation and `configPresenter.setProviderModels()` behavior unchanged.
+
+## Test strategy
+
+- Add a regression test with a provider whose `fetchProviderModels()` rejects asynchronously.
+- Assert default `fetchModels()` returns `[]` and does not throw.
+- Assert `fetchModels({ suppressErrors: false })` still rejects.

--- a/docs/issues/model-list-fetch-404/spec.md
+++ b/docs/issues/model-list-fetch-404/spec.md
@@ -1,0 +1,30 @@
+# Model List Fetch 404 Handling
+
+## User need
+
+When a provider model-list endpoint returns HTTP 404 (for example a provider/base URL that does not expose `/models`), the app should not surface an unhandled `deepchat:route:invoke` error for routine model-list refreshes.
+
+## Goal
+
+Keep runtime model-list route behavior resilient: default model fetches should honor the existing `suppressErrors` behavior and return an empty/cached-safe list instead of rejecting the IPC route.
+
+## Acceptance criteria
+
+- A rejected asynchronous provider model fetch is caught by `BaseLLMProvider.fetchModels()` when `suppressErrors` is true.
+- `refreshModels()` / explicit non-suppressed fetches still propagate provider HTTP errors.
+- The fix does not change provider authentication, request headers, or endpoint construction.
+- A regression test covers asynchronous rejection from `fetchProviderModels()`.
+
+## Constraints
+
+- Do not log or expose provider API keys or credentials.
+- Keep the change minimal and aligned with existing presenter/provider boundaries.
+
+## Non-goals
+
+- Changing provider base URLs or model endpoint formats.
+- Masking errors for explicit force refresh paths that intentionally request non-suppressed behavior.
+
+## Open questions
+
+None.

--- a/docs/issues/model-list-fetch-404/tasks.md
+++ b/docs/issues/model-list-fetch-404/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] Map stack trace to source and identify failure path.
+- [x] Document issue/spec/plan.
+- [x] Change `BaseLLMProvider.fetchModels()` catch behavior to handle async rejections.
+- [x] Add regression tests for suppressed and non-suppressed async fetch failures.
+- [x] Run targeted provider tests and relevant typecheck/lint checks.

--- a/docs/issues/model-list-fetch-404/tasks.md
+++ b/docs/issues/model-list-fetch-404/tasks.md
@@ -5,3 +5,6 @@
 - [x] Change `BaseLLMProvider.fetchModels()` catch behavior to handle async rejections.
 - [x] Add regression tests for suppressed and non-suppressed async fetch failures.
 - [x] Run targeted provider tests and relevant typecheck/lint checks.
+
+- [x] Address review feedback so only provider fetch failures are suppressed; validation/persistence failures now surface.
+- [x] Add regression coverage for provider model persistence failures.

--- a/docs/issues/skill-scope-and-refresh/plan.md
+++ b/docs/issues/skill-scope-and-refresh/plan.md
@@ -1,0 +1,57 @@
+# Plan
+
+## Approach
+
+Split skill state into three semantics:
+
+1. Explicit/manual session activation remains pinned state backed by `SkillPresenter.setActiveSkills` and `new_sessions.active_skills`.
+2. Composer-selected skills are message-scoped. The chat input keeps a local draft skill list, submits it with the next message as `SendMessageInput.activeSkills`, then clears the local list after successful submit/queue/steer/create-session.
+3. Agent `skill_view` root activation is runtime/message-loop state. The tool returns activation metadata, and the agent runtime keeps a per-generation/per-session set of runtime-activated skill names for the active message loop.
+
+Do not overload `isPinned` for runtime activation. `isPinned` must mean persisted/manual session pin only. Agent tool results may add separate fields such as `activatedForMessage`, `activationScope`, and `activeForCurrentMessage` to communicate runtime activation without polluting pinned semantics.
+
+When a message starts with composer active skills, initialize the runtime effective skill set with `manual session skills + message active skills`. When runtime activation changes the effective skill set, refresh both tools and the leading system prompt before the next provider request.
+
+## Affected Interfaces
+
+- `SendMessageInput`: add optional `activeSkills?: string[]` for message-scoped composer skill context.
+- Route schemas for chat send/steer/pending inputs: accept `activeSkills`.
+- `CreateSessionInput`: keep `activeSkills` for compatibility but treat it as initial-message active skills, not session pinning.
+- `ChatInputBox` / `useSkillsData`: make selected skills local composer state for existing conversations and expose consume/snapshot helpers.
+- `ChatPage` / `NewThreadPage`: include consumed composer skills in submitted message payload and clear after successful submit.
+- `AgentSessionPresenter`: stop persisting create-session `activeSkills`; pass them into the initial message payload.
+- `AgentRuntimePresenter`: initialize runtime message skills from normalized input, persist them on the user message record, materialize them back from normalized user-message tables, and include them in prompt/tool loading for that message loop.
+- `SkillTools.handleSkillView`: support viewing without presenter-side activation for agent runtime calls.
+- `AgentToolManager`: derive `activationApplied` from runtime active skill context instead of persisted active skills, and return message-scoped activation metadata without setting `isPinned` to true.
+- System/tool prompts: replace pinned wording for automatic `skill_view` activation with message-scoped activation wording.
+
+## Data Flow
+
+- Composer skill selection updates local input state only.
+- Submit path consumes local selected skills and sends `{ text, files, activeSkills }`.
+- New session creation passes active skills inside the initial message payload and does not call `setActiveSkills`.
+- Runtime start resets runtime activated skills, adds message-scoped active skills, then computes effective skills = session-pinned + message/runtime active.
+- User message content stores `activeSkills` so the message context is visible/auditable and retry can reuse it. The normalized materialization path must preserve the raw message-scoped `activeSkills` because the structured `deepchat_user_messages` table stores text/search/think but not skill names.
+- `skill_view` root call returns `activatedSkill` when the viewed skill is not already effective.
+- Runtime callback adds it to the local runtime set for the active message loop.
+- Tool refresh uses `manual + message/runtime` effective skills.
+- System prompt refresh rebuilds with the same effective skill set and replaces the first system message in the active conversation messages.
+- Tool output keeps `isPinned` equal to the persisted/manual pin state and reports runtime activation separately.
+
+## Compatibility
+
+- Existing manual active skills remain stored in `new_sessions.active_skills`.
+- Existing `skill_view` route behavior outside agent runtime remains read-only unless explicitly using session active APIs.
+- Existing skill_run scripts remain gated by active skill names, now including message/runtime activation for the current loop.
+- Existing consumers of `isPinned` can continue treating it as pinned/session state.
+- Existing stored messages without `activeSkills` continue to parse as empty message-scoped skills.
+
+## Test Strategy
+
+- Unit-level tests for `SkillTools.handleSkillView` avoiding persisted activation.
+- Unit-level tests for `AgentToolManager` activation metadata and non-pinned output.
+- Unit-level tests for `processStream` refreshing tools and system prompt after runtime activation.
+- Runtime tests ensuring `SendMessageInput.activeSkills` influences initial prompt/tools but does not persist session active skills.
+- Renderer tests ensuring composer skills clear after submit, are sent in the message payload, and appear on the corresponding user message item.
+- Message store tests ensuring materialized user message content preserves `activeSkills` from the raw message JSON.
+- Run targeted tests plus required repository checks: `pnpm run format`, `pnpm run i18n`, `pnpm run lint`.

--- a/docs/issues/skill-scope-and-refresh/spec.md
+++ b/docs/issues/skill-scope-and-refresh/spec.md
@@ -1,0 +1,59 @@
+# Skill Scope and Refresh
+
+## User Need
+
+Skills selected or discovered for a task should follow the message/task chain, not remain fixed in the conversation composer or permanently pollute an entire session. When the user selects a skill in the input box, that skill should be attached to the message being sent, then cleared from the input composer. When the model calls `skill_view`, the skill can become usable for the current generation flow, but it must not be represented as conversation-pinned state unless the user manually pins it elsewhere.
+
+## Problem
+
+Historically, root `skill_view` automatically called `setActiveSkills`, which persisted the skill in `new_sessions.active_skills`. This made model-selected skills follow the whole session instead of the relevant message/task chain.
+
+The first runtime-scoped fix stopped persistence for agent `skill_view`, but the user-facing composer path still used conversation active skills. Selecting a skill in the input box called `setActiveSkills` for existing sessions, stored the skill at session level, and kept the chip fixed in the input box after sending. That is semantically wrong: composer skill chips are task/message context, not global conversation pinned state.
+
+After moving composer skills to the outgoing message payload, the message list must still preserve and render that message-scoped metadata. The normalized user-message materialization path must not drop `activeSkills` when rebuilding message content for the renderer.
+
+In the same generation loop, skill activation must also refresh tool definitions and the system prompt so subsequent provider requests can use the activated skill immediately.
+
+## Goals
+
+- Keep explicit/manual session-pinned skills as session-level active skills where APIs still use `setActiveSkills`.
+- Make composer-selected skills message-scoped: attach them to the next sent/queued/steered message and clear the composer chip after successful submission.
+- Make model-triggered `skill_view` activation message-scoped/runtime-scoped rather than persisted to the session.
+- Show message-scoped skills on the corresponding user message item so the user can see which skills were applied to that turn, without placing those chips inside the message bubble body.
+- Do not report runtime activation as `isPinned: true`.
+- Expose explicit activation metadata such as `activationScope: "message"` / `activatedForMessage: true` for agent `skill_view` results.
+- Ensure runtime skill activation refreshes tool definitions and the active skill prompt for subsequent provider requests in the same generation loop.
+- Preserve existing manual skills settings behavior and new-thread/session creation compatibility.
+
+## Acceptance Criteria
+
+- Calling agent tool `skill_view` for a root `SKILL.md` no longer writes to `new_sessions.active_skills`.
+- The `skill_view` content for runtime activation does not claim `isPinned: true` unless the skill was manually/session pinned.
+- The `skill_view` result clearly reports current-message activation when applicable.
+- Selecting a skill in the chat input does not call `setActiveSkills` for the conversation.
+- Sending, queueing, steering, or creating a new first-turn session with composer skills sends those skills on that message payload.
+- After successful submission, composer skill chips are cleared from the input box.
+- User message records preserve their message-scoped skills when they are created, materialized from normalized tables, cloned, edited, or backfilled.
+- User message items display their message-scoped skills as lightweight metadata adjacent to the bubble, not inside the bubble content, and do not show them as composer/session pinned skills.
+- System prompt wording distinguishes session-pinned skills from message-activated skills and does not tell the model that root `skill_view` pins a skill to the conversation.
+- Subsequent provider requests in the same tool loop receive rebuilt system prompt content that includes message-scoped/runtime-activated skills.
+- `skill_run` exposure after runtime activation uses the union of manually active and message/runtime-activated skills.
+- Manual `setActiveSkills` continues to persist active skills at the session level.
+- Relevant tests cover non-persistence, non-pinned output, message payload skills, message item visibility, and same-loop refresh behavior where practical.
+
+## Non-goals
+
+- Full branch/lineage-scoped persisted skill state across future turns.
+- Redesigning the settings skills UI.
+- Adding a new debug UI for skills.
+- Changing MCP tool permissions or authentication behavior.
+
+## Constraints
+
+- Keep changes minimal and aligned with existing presenter boundaries.
+- Avoid introducing secret logging or broad trace payloads.
+- Do not remove manual session-level skill support.
+
+## Open Questions
+
+None.

--- a/docs/issues/skill-scope-and-refresh/tasks.md
+++ b/docs/issues/skill-scope-and-refresh/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+- [x] Update skill tool view path so agent `skill_view` does not persist active skills.
+- [x] Add runtime activation context for effective skills during a generation loop.
+- [x] Refresh tools using effective manual + runtime skills.
+- [x] Refresh leading system prompt after runtime skill activation.
+- [x] Stop representing runtime activation as conversation-pinned state in tool output and prompts.
+- [x] Add/adjust tests for message-scoped activation semantics.
+- [x] Add message-scoped `SendMessageInput.activeSkills` plumbing.
+- [x] Change composer skill selection to local message draft state instead of session active state.
+- [x] Send/queue/steer/create first-turn messages with composer skills and clear chips after submit.
+- [x] Initialize runtime effective skills from message active skills and persist them on the user message record.
+- [x] Preserve `activeSkills` when user messages are materialized from normalized message tables.
+- [x] Display message-scoped skills on the corresponding user message item and cover it with renderer tests.
+- [x] Move message-scoped skill chips out of the message bubble and restyle them as subtle message metadata.
+- [x] Add renderer/runtime tests for composer message-scoped skills.
+- [x] Run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint` after the visibility fix.

--- a/docs/issues/skill-scope-and-refresh/tasks.md
+++ b/docs/issues/skill-scope-and-refresh/tasks.md
@@ -15,3 +15,6 @@
 - [x] Move message-scoped skill chips out of the message bubble and restyle them as subtle message metadata.
 - [x] Add renderer/runtime tests for composer message-scoped skills.
 - [x] Run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint` after the visibility fix.
+
+- [x] Address review feedback for active skill fallback data, wording, refresh parameter flow, and composer naming clarity.
+- [x] Strengthen process stream coverage for hook-backed message-scope skill activation refresh.

--- a/src/main/presenter/agentRuntimePresenter/contextBuilder.ts
+++ b/src/main/presenter/agentRuntimePresenter/contextBuilder.ts
@@ -162,11 +162,21 @@ export function normalizeUserInput(input: string | SendMessageInput): SendMessag
   if (!input || typeof input !== 'object') {
     return { text: '', files: [] }
   }
+  const activeSkills = Array.isArray(input.activeSkills)
+    ? Array.from(
+        new Set(
+          input.activeSkills
+            .map((skillName) => (typeof skillName === 'string' ? skillName.trim() : ''))
+            .filter((skillName) => skillName.length > 0)
+        )
+      )
+    : []
   return {
     text: typeof input.text === 'string' ? input.text : '',
     files: Array.isArray(input.files)
       ? (input.files.filter((file): file is MessageFile => Boolean(file)) as MessageFile[])
-      : []
+      : [],
+    ...(activeSkills.length > 0 ? { activeSkills } : {})
   }
 }
 

--- a/src/main/presenter/agentRuntimePresenter/dispatch.ts
+++ b/src/main/presenter/agentRuntimePresenter/dispatch.ts
@@ -461,9 +461,9 @@ function extractSkillDraftPromptPayload(
   return { draftId, skillName }
 }
 
-function shouldRefreshToolsAfterCall(toolName: string, rawData: MCPToolResponse): boolean {
+function extractActivatedSkillAfterCall(toolName: string, rawData: MCPToolResponse): string | null {
   if (toolName !== 'skill_view') {
-    return false
+    return null
   }
 
   const toolResult =
@@ -471,7 +471,13 @@ function shouldRefreshToolsAfterCall(toolName: string, rawData: MCPToolResponse)
       ? (rawData.toolResult as Record<string, unknown>)
       : null
 
-  return toolResult?.activationApplied === true
+  if (toolResult?.activationApplied !== true) {
+    return null
+  }
+
+  const activatedSkill =
+    typeof toolResult.activatedSkill === 'string' ? toolResult.activatedSkill.trim() : ''
+  return activatedSkill || null
 }
 
 function isParallelReadOnlyToolCall(
@@ -977,7 +983,8 @@ async function runToolCall(params: {
       await toolPresenter.callTool(toolCall, {
         onProgress: applyProgressUpdate,
         signal: io.abortSignal,
-        permissionMode
+        permissionMode,
+        activeSkillNames: hooks?.getActiveSkillNames?.()
       })
 
     let toolCallResult = await callTool()
@@ -1061,6 +1068,11 @@ async function runToolCall(params: {
       preparedResult.kind === 'tool_error' ? preparedResult.message : preparedResult.content
     const stagedIsError = preparedResult.kind === 'tool_error' || toolRawData.isError === true
 
+    const activatedSkill = extractActivatedSkillAfterCall(completedToolCall.name, toolRawData)
+    if (activatedSkill) {
+      await hooks?.activateSkill?.(activatedSkill)
+    }
+
     return {
       kind: 'staged',
       stagedResult: {
@@ -1080,7 +1092,7 @@ async function runToolCall(params: {
         skillDraftPrompt: extractSkillDraftPromptPayload(toolRawData),
         postHookKind: stagedIsError ? 'failure' : 'success'
       },
-      toolsChanged: shouldRefreshToolsAfterCall(completedToolCall.name, toolRawData)
+      toolsChanged: Boolean(activatedSkill)
     }
   } catch (err) {
     return buildToolErrorOutcome(execution, err)

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -402,6 +402,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
   private readonly sessionProjectDirs: Map<string, string | null> = new Map()
   private readonly systemPromptCache: Map<string, SystemPromptCacheEntry> = new Map()
   private readonly toolProfileCache: Map<string, ToolProfileCacheEntry> = new Map()
+  private readonly runtimeActivatedSkillsBySession: Map<string, Set<string>> = new Map()
   private readonly sessionCompactionStates: Map<string, SessionCompactionState> = new Map()
   private readonly interactionLocks: Set<string> = new Set()
   private readonly resumingMessages: Set<string> = new Set()
@@ -587,6 +588,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     this.sessionProjectDirs.delete(sessionId)
     this.systemPromptCache.delete(sessionId)
     this.toolProfileCache.delete(sessionId)
+    this.runtimeActivatedSkillsBySession.delete(sessionId)
     this.sessionCompactionStates.delete(sessionId)
     this.drainingPendingQueues.delete(sessionId)
     this.toolPresenter?.clearConversationToolMapping?.(sessionId)
@@ -945,13 +947,19 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       )
       const maxTokens = capAgentRequestMaxTokens(generationSettings.maxTokens, contextBudgetLength)
       stepStartedAt = Date.now()
-      const activeSkillNames = await this.resolveActiveSkillNamesForToolProfile(sessionId)
+      this.resetRuntimeActivatedSkills(sessionId)
+      this.setRuntimeActivatedSkills(sessionId, normalizedInput.activeSkills ?? [])
+      const sessionActiveSkillNames = await this.resolveActiveSkillNamesForToolProfile(sessionId)
+      let effectiveActiveSkillNames = this.resolveEffectiveActiveSkillNames(
+        sessionActiveSkillNames,
+        sessionId
+      )
       this.logSlowPreStreamStep(sessionId, 'active-skills', stepStartedAt)
       stepStartedAt = Date.now()
       const tools = await this.loadToolDefinitionsForSession(
         sessionId,
         projectDir,
-        activeSkillNames
+        effectiveActiveSkillNames
       )
       this.logSlowPreStreamStep(sessionId, 'tool-definitions', stepStartedAt)
       const toolReserveTokens = estimateToolReserveTokens(tools)
@@ -961,7 +969,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         sessionId,
         generationSettings.systemPrompt,
         tools,
-        activeSkillNames
+        effectiveActiveSkillNames
       )
       this.logSlowPreStreamStep(sessionId, 'system-prompt', stepStartedAt)
       this.throwIfAbortRequested(preStreamAbortSignal)
@@ -972,7 +980,10 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         files: normalizedInput.files || [],
         links: [],
         search: false,
-        think: false
+        think: false,
+        ...(normalizedInput.activeSkills?.length
+          ? { activeSkills: normalizedInput.activeSkills }
+          : {})
       }
 
       let compactionIntent: CompactionIntent | null = null
@@ -1100,6 +1111,27 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         promptPreview: normalizedInput.text,
         tools,
         baseSystemPrompt,
+        refreshSystemPrompt: async (activeSkillNames, refreshedTools) => {
+          effectiveActiveSkillNames = this.resolveEffectiveActiveSkillNames(
+            activeSkillNames ?? sessionActiveSkillNames,
+            sessionId
+          )
+          const refreshedBasePrompt = await this.buildSystemPromptWithSkills(
+            sessionId,
+            generationSettings.systemPrompt,
+            refreshedTools,
+            effectiveActiveSkillNames
+          )
+          return await this.appendMemoryInjection(
+            sessionId,
+            appendReconstructionAnchorStateSection(
+              appendSummarySection(refreshedBasePrompt, summaryState.summaryText),
+              this.sessionStore.getReconstructionAnchorPromptState(sessionId)
+            ),
+            normalizedInput.text,
+            userMessageId
+          )
+        },
         interleavedReasoning,
         viewContext: {
           taskType: 'chat',
@@ -1244,6 +1276,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       }
     } finally {
       this.clearSessionAbortController(sessionId, preStreamAbortController)
+      this.resetRuntimeActivatedSkills(sessionId)
     }
   }
 
@@ -2880,6 +2913,10 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     promptPreview?: string
     interleavedReasoning?: InterleavedReasoningConfig
     viewContext?: PendingTapeViewContext
+    refreshSystemPrompt?: (
+      activeSkillNames: string[] | undefined,
+      toolDefinitions: MCPToolDefinition[]
+    ) => Promise<string>
     preStreamStartedAt?: number
     onRunRegistered?: (runId: string) => void
   }): Promise<{ runId: string; result: ProcessResult }> {
@@ -2894,6 +2931,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       promptPreview,
       interleavedReasoning: providedInterleavedReasoning,
       viewContext,
+      refreshSystemPrompt,
       preStreamStartedAt,
       onRunRegistered
     } = args
@@ -2989,7 +3027,17 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     const temperature = generationSettings.temperature
     const maxTokens = capAgentRequestMaxTokens(generationSettings.maxTokens, contextBudgetLength)
 
-    const tools = providedTools ?? (await this.loadToolDefinitionsForSession(sessionId, projectDir))
+    const streamSessionActiveSkillNames =
+      await this.resolveActiveSkillNamesForToolProfile(sessionId)
+    const getEffectiveRuntimeSkillNames = (baseSkillNames = streamSessionActiveSkillNames) =>
+      this.resolveEffectiveActiveSkillNames(baseSkillNames, sessionId)
+    const tools =
+      providedTools ??
+      (await this.loadToolDefinitionsForSession(
+        sessionId,
+        projectDir,
+        getEffectiveRuntimeSkillNames()
+      ))
     const supportsVision = this.supportsVision(state.providerId, state.modelId)
     const supportsAudioInput = this.supportsAudioInput(state.providerId, state.modelId)
 
@@ -3024,7 +3072,27 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       const result = await processStream({
         messages,
         tools,
-        refreshTools: async () => await this.loadToolDefinitionsForSession(sessionId, projectDir),
+        refreshTools: async (activeSkillNames) =>
+          await this.loadToolDefinitionsForSession(
+            sessionId,
+            projectDir,
+            getEffectiveRuntimeSkillNames(activeSkillNames)
+          ),
+        refreshSystemPrompt: async (activeSkillNames, refreshedTools) => {
+          if (refreshSystemPrompt) {
+            return await refreshSystemPrompt(
+              getEffectiveRuntimeSkillNames(activeSkillNames),
+              refreshedTools
+            )
+          }
+          const refreshedBasePrompt = await this.buildSystemPromptWithSkills(
+            sessionId,
+            generationSettings.systemPrompt,
+            refreshedTools,
+            getEffectiveRuntimeSkillNames(activeSkillNames)
+          )
+          return refreshedBasePrompt
+        },
         toolPresenter: this.toolPresenter,
         coreStream: async function* (
           requestMessages,
@@ -3361,6 +3429,11 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         shouldYieldForPendingInput: () =>
           Boolean(this.pendingInputCoordinator.getNextSteerInput(sessionId)),
         hooks: {
+          getActiveSkillNames: () => getEffectiveRuntimeSkillNames(),
+          activateSkill: async (skillName) => {
+            await this.activateRuntimeSkill(sessionId, skillName)
+            return getEffectiveRuntimeSkillNames()
+          },
           onPreToolUse: (tool) => {
             this.dispatchHook('PreToolUse', {
               sessionId,
@@ -4414,13 +4487,13 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         'Before replying, always scan available skills. If any skill plausibly matches the task, call `skill_view` first.'
       )
       lines.push(
-        'Viewing a skill root `SKILL.md` pins it to the current conversation; viewing linked skill files is read-only and does not pin the skill.'
+        'Viewing a skill root `SKILL.md` activates that skill for the current message/tool loop; it does not pin the skill to the conversation. Viewing linked skill files is read-only and does not activate the skill.'
       )
       hasContent = true
     }
     if (capabilities.canRunSkillScripts) {
       lines.push(
-        'Use `skill_run` only for pinned skills when a pinned skill provides bundled helper scripts.'
+        'Use `skill_run` only for skills that are active in the current message/tool loop, including manually pinned skills and skills activated by `skill_view`.'
       )
       hasContent = true
     }
@@ -4468,11 +4541,56 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       return ''
     }
     return [
-      '## Pinned Skills',
-      'These pinned skills are preloaded for this conversation. Follow them when relevant.',
+      '## Active Skills',
+      'These skills are active for the current message context. Some may be manually pinned for the conversation; others may have been activated by `skill_view` for this message/tool loop only. Follow them when relevant.',
       '',
       skillSections.join('\n\n')
     ].join('\n')
+  }
+
+  private resetRuntimeActivatedSkills(sessionId: string): void {
+    this.runtimeActivatedSkillsBySession.delete(sessionId)
+  }
+
+  private setRuntimeActivatedSkills(sessionId: string, skillNames: string[]): void {
+    const normalizedSkillNames = this.normalizeSkillNames(skillNames)
+    if (normalizedSkillNames.length === 0) {
+      return
+    }
+    this.runtimeActivatedSkillsBySession.set(sessionId, new Set(normalizedSkillNames))
+  }
+
+  private getRuntimeActivatedSkills(sessionId: string): string[] {
+    return this.normalizeSkillNames(
+      Array.from(this.runtimeActivatedSkillsBySession.get(sessionId) ?? [])
+    )
+  }
+
+  private async activateRuntimeSkill(sessionId: string, skillName: string): Promise<string[]> {
+    const normalizedSkillName = skillName.trim()
+    if (!normalizedSkillName) {
+      return this.getRuntimeActivatedSkills(sessionId)
+    }
+
+    let activeSkills = this.runtimeActivatedSkillsBySession.get(sessionId)
+    if (!activeSkills) {
+      activeSkills = new Set<string>()
+      this.runtimeActivatedSkillsBySession.set(sessionId, activeSkills)
+    }
+    activeSkills.add(normalizedSkillName)
+    this.invalidateSystemPromptCache(sessionId)
+    this.invalidateToolProfileCache(sessionId)
+    return this.getRuntimeActivatedSkills(sessionId)
+  }
+
+  private resolveEffectiveActiveSkillNames(
+    sessionActiveSkillNames: string[],
+    sessionId: string
+  ): string[] {
+    return this.normalizeSkillNames([
+      ...sessionActiveSkillNames,
+      ...this.getRuntimeActivatedSkills(sessionId)
+    ])
   }
 
   private normalizeSkillNames(skillNames: string[]): string[] {
@@ -5276,7 +5394,16 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       const files = Array.isArray((parsed as { files?: unknown }).files)
         ? ((parsed as { files?: unknown }).files as MessageFile[]).filter((file) => Boolean(file))
         : []
-      return { text, files }
+      const activeSkills = this.normalizeSkillNames(
+        Array.isArray((parsed as { activeSkills?: unknown }).activeSkills)
+          ? ((parsed as { activeSkills?: unknown }).activeSkills as string[])
+          : []
+      )
+      return {
+        text,
+        files,
+        ...(activeSkills.length > 0 ? { activeSkills } : {})
+      }
     } catch {
       return { text: content, files: [] }
     }
@@ -5293,7 +5420,14 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     const files = Array.isArray(input.files)
       ? input.files.filter((file): file is MessageFile => Boolean(file))
       : []
-    return { text, files }
+    const activeSkills = this.normalizeSkillNames(
+      Array.isArray(input.activeSkills) ? input.activeSkills : []
+    )
+    return {
+      text,
+      files,
+      ...(activeSkills.length > 0 ? { activeSkills } : {})
+    }
   }
 
   private queueVisibleSteerInput(
@@ -6044,7 +6178,8 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         disabledAgentTools: this.getDisabledAgentTools(sessionId),
         chatMode: 'agent',
         conversationId: sessionId,
-        agentWorkspacePath: projectDir
+        agentWorkspacePath: projectDir,
+        activeSkillNames: activeSkillNamesOverride
       })
 
       this.toolProfileCache.set(sessionId, {

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -950,7 +950,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       this.resetRuntimeActivatedSkills(sessionId)
       this.setRuntimeActivatedSkills(sessionId, normalizedInput.activeSkills ?? [])
       const sessionActiveSkillNames = await this.resolveActiveSkillNamesForToolProfile(sessionId)
-      let effectiveActiveSkillNames = this.resolveEffectiveActiveSkillNames(
+      const effectiveActiveSkillNames = this.resolveEffectiveActiveSkillNames(
         sessionActiveSkillNames,
         sessionId
       )
@@ -1112,15 +1112,11 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         tools,
         baseSystemPrompt,
         refreshSystemPrompt: async (activeSkillNames, refreshedTools) => {
-          effectiveActiveSkillNames = this.resolveEffectiveActiveSkillNames(
-            activeSkillNames ?? sessionActiveSkillNames,
-            sessionId
-          )
           const refreshedBasePrompt = await this.buildSystemPromptWithSkills(
             sessionId,
             generationSettings.systemPrompt,
             refreshedTools,
-            effectiveActiveSkillNames
+            activeSkillNames ?? effectiveActiveSkillNames
           )
           return await this.appendMemoryInjection(
             sessionId,

--- a/src/main/presenter/agentRuntimePresenter/messageStore.ts
+++ b/src/main/presenter/agentRuntimePresenter/messageStore.ts
@@ -740,12 +740,15 @@ export class DeepChatMessageStore {
         maps?.linkRows.get(row.id) ??
         this.sqlitePresenter.deepchatUserMessageLinksTable.listByMessageIds([row.id])
 
+      const rawUserContent = this.parseUserContent(row.content)
+      const activeSkills = rawUserContent?.activeSkills ?? []
       return JSON.stringify({
         text: userRow.text,
         files: fileRows.map((fileRow) => this.toMessageFile(fileRow)),
         links: linkRows.map((linkRow) => linkRow.url),
         search: userRow.search_enabled === 1,
-        think: userRow.think_enabled === 1
+        think: userRow.think_enabled === 1,
+        ...(activeSkills.length > 0 ? { activeSkills } : {})
       } satisfies UserMessageContent)
     }
 
@@ -782,11 +785,27 @@ export class DeepChatMessageStore {
           ? parsed.links.filter((item): item is string => typeof item === 'string')
           : [],
         search: parsed.search === true,
-        think: parsed.think === true
+        think: parsed.think === true,
+        activeSkills: this.normalizeActiveSkills(parsed.activeSkills)
       }
     } catch {
       return null
     }
+  }
+
+  private normalizeActiveSkills(activeSkills?: string[]): string[] {
+    if (!Array.isArray(activeSkills)) {
+      return []
+    }
+
+    return Array.from(
+      new Set(
+        activeSkills
+          .filter((item): item is string => typeof item === 'string')
+          .map((item) => item.trim())
+          .filter(Boolean)
+      )
+    )
   }
 
   private buildCompactionBlocks(status: 'compacting' | 'compacted'): AssistantMessageBlock[] {

--- a/src/main/presenter/agentRuntimePresenter/pendingInputCoordinator.ts
+++ b/src/main/presenter/agentRuntimePresenter/pendingInputCoordinator.ts
@@ -13,9 +13,20 @@ function normalizeInput(input: string | SendMessageInput): SendMessageInput {
     return { text: input, files: [] }
   }
 
+  const activeSkills = Array.isArray(input?.activeSkills)
+    ? Array.from(
+        new Set(
+          input.activeSkills
+            .map((skillName) => (typeof skillName === 'string' ? skillName.trim() : ''))
+            .filter((skillName) => skillName.length > 0)
+        )
+      )
+    : []
+
   return {
     text: typeof input?.text === 'string' ? input.text : '',
-    files: Array.isArray(input?.files) ? input.files.filter(Boolean) : []
+    files: Array.isArray(input?.files) ? input.files.filter(Boolean) : [],
+    ...(activeSkills.length > 0 ? { activeSkills } : {})
   }
 }
 

--- a/src/main/presenter/agentRuntimePresenter/pendingInputStore.ts
+++ b/src/main/presenter/agentRuntimePresenter/pendingInputStore.ts
@@ -12,9 +12,20 @@ function normalizeInput(input: string | SendMessageInput): SendMessageInput {
     return { text: input, files: [] }
   }
 
+  const activeSkills = Array.isArray(input?.activeSkills)
+    ? Array.from(
+        new Set(
+          input.activeSkills
+            .map((skillName) => (typeof skillName === 'string' ? skillName.trim() : ''))
+            .filter((skillName) => skillName.length > 0)
+        )
+      )
+    : []
+
   return {
     text: typeof input?.text === 'string' ? input.text : '',
-    files: Array.isArray(input?.files) ? input.files.filter(Boolean) : []
+    files: Array.isArray(input?.files) ? input.files.filter(Boolean) : [],
+    ...(activeSkills.length > 0 ? { activeSkills } : {})
   }
 }
 
@@ -108,8 +119,15 @@ export class DeepChatPendingInputStore {
     const next = normalizeInput(input)
     const text = [existing.text.trim(), next.text.trim()].filter(Boolean).join('\n\n')
     const files = [...(existing.files ?? []), ...(next.files ?? [])].filter(Boolean)
+    const activeSkills = Array.from(
+      new Set([...(existing.activeSkills ?? []), ...(next.activeSkills ?? [])])
+    )
     this.sqlitePresenter.deepchatPendingInputsTable.update(itemId, {
-      payload_json: JSON.stringify({ text, files })
+      payload_json: JSON.stringify({
+        text,
+        files,
+        ...(activeSkills.length > 0 ? { activeSkills } : {})
+      })
     })
     return this.toRecord(this.requireRow(itemId, row.session_id))
   }

--- a/src/main/presenter/agentRuntimePresenter/process.ts
+++ b/src/main/presenter/agentRuntimePresenter/process.ts
@@ -264,6 +264,22 @@ function appendStreamingProviderPermissionBlock(
   }
 }
 
+function replaceLeadingSystemMessage(
+  messages: ProcessParams['messages'],
+  systemPrompt: string
+): void {
+  if (!systemPrompt) {
+    return
+  }
+
+  if (messages[0]?.role === 'system') {
+    messages[0] = { ...messages[0], content: systemPrompt }
+    return
+  }
+
+  messages.unshift({ role: 'system', content: systemPrompt })
+}
+
 function markStreamingProviderPermissionResolved(
   block: AssistantMessageBlock,
   granted: boolean,
@@ -473,11 +489,28 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
         }
       }
 
-      if (executed.toolsChanged && params.refreshTools) {
-        try {
-          currentTools = await params.refreshTools()
-        } catch (error) {
-          console.warn('[ProcessStream] failed to refresh tools after skill activation:', error)
+      if (executed.toolsChanged) {
+        const activeSkillNames = hooks?.getActiveSkillNames?.()
+        if (params.refreshTools) {
+          try {
+            currentTools = await params.refreshTools(activeSkillNames)
+          } catch (error) {
+            console.warn('[ProcessStream] failed to refresh tools after skill activation:', error)
+          }
+        }
+        if (params.refreshSystemPrompt) {
+          try {
+            const refreshedSystemPrompt = await params.refreshSystemPrompt(
+              activeSkillNames,
+              currentTools
+            )
+            replaceLeadingSystemMessage(conversationMessages, refreshedSystemPrompt)
+          } catch (error) {
+            console.warn(
+              '[ProcessStream] failed to refresh system prompt after skill activation:',
+              error
+            )
+          }
         }
       }
     }

--- a/src/main/presenter/agentRuntimePresenter/types.ts
+++ b/src/main/presenter/agentRuntimePresenter/types.ts
@@ -102,6 +102,8 @@ export interface ProcessHooks {
     },
     commitDecision: (granted: boolean) => void
   ) => void
+  getActiveSkillNames?: () => string[]
+  activateSkill?: (skillName: string) => Promise<string[]>
   normalizeToolResult?: (tool: {
     sessionId: string
     toolCallId: string
@@ -162,7 +164,11 @@ export interface ProcessResult {
 export interface ProcessParams {
   messages: ChatMessage[]
   tools: MCPToolDefinition[]
-  refreshTools?: () => Promise<MCPToolDefinition[]>
+  refreshTools?: (activeSkillNames?: string[]) => Promise<MCPToolDefinition[]>
+  refreshSystemPrompt?: (
+    activeSkillNames: string[] | undefined,
+    toolDefinitions: MCPToolDefinition[]
+  ) => Promise<string>
   toolPresenter: IToolPresenter | null
   coreStream: (
     messages: ChatMessage[],

--- a/src/main/presenter/agentSessionPresenter/index.ts
+++ b/src/main/presenter/agentSessionPresenter/index.ts
@@ -406,10 +406,6 @@ export class AgentSessionPresenter {
       webContentsId
     })
 
-    if (input.activeSkills && input.activeSkills.length > 0 && this.skillPresenter) {
-      await this.skillPresenter.setActiveSkills(sessionId, input.activeSkills)
-    }
-
     // Return enriched session first
     const state = await agent.getSessionState(sessionId)
     const sessionResult: SessionWithState = {
@@ -437,17 +433,29 @@ export class AgentSessionPresenter {
       logger.info(`[AgentSessionPresenter] firing queuePendingInput (non-blocking)`)
       if (agent.queuePendingInput) {
         agent
-          .queuePendingInput(sessionId, normalizedInput, {
-            source: 'send',
-            projectDir
-          })
+          .queuePendingInput(
+            sessionId,
+            this.withInitialMessageActiveSkills(normalizedInput, input.activeSkills),
+            {
+              source: 'send',
+              projectDir
+            }
+          )
           .catch((err) => {
             console.error('[AgentSessionPresenter] queuePendingInput failed:', err)
           })
       } else {
-        agent.processMessage(sessionId, normalizedInput, { projectDir }).catch((err) => {
-          console.error('[AgentSessionPresenter] processMessage failed:', err)
-        })
+        agent
+          .processMessage(
+            sessionId,
+            this.withInitialMessageActiveSkills(normalizedInput, input.activeSkills),
+            {
+              projectDir
+            }
+          )
+          .catch((err) => {
+            console.error('[AgentSessionPresenter] processMessage failed:', err)
+          })
       }
       void this.generateSessionTitle(sessionId, title, providerId, modelId)
     }
@@ -3651,7 +3659,8 @@ export class AgentSessionPresenter {
           ? parsed.links.filter((item): item is string => typeof item === 'string')
           : [],
         search: parsed.search === true,
-        think: parsed.think === true
+        think: parsed.think === true,
+        activeSkills: this.normalizeActiveSkills(parsed.activeSkills)
       }
     } catch {
       return null
@@ -3958,7 +3967,12 @@ export class AgentSessionPresenter {
     const files = Array.isArray(content.files)
       ? content.files.filter((file): file is MessageFile => Boolean(file))
       : []
-    return { text, files }
+    const activeSkills = this.normalizeActiveSkills(content.activeSkills)
+    return {
+      text,
+      files,
+      ...(activeSkills.length > 0 ? { activeSkills } : {})
+    }
   }
 
   private normalizeCreateSessionInput(input: CreateSessionInput): SendMessageInput {
@@ -3966,7 +3980,18 @@ export class AgentSessionPresenter {
     const files = Array.isArray(input.files)
       ? input.files.filter((file): file is MessageFile => Boolean(file))
       : []
-    return { text, files }
+    return this.withInitialMessageActiveSkills({ text, files }, input.activeSkills)
+  }
+
+  private withInitialMessageActiveSkills(
+    input: SendMessageInput,
+    activeSkills?: string[]
+  ): SendMessageInput {
+    const normalizedActiveSkills = this.normalizeActiveSkills(activeSkills ?? input.activeSkills)
+    return {
+      ...input,
+      ...(normalizedActiveSkills.length > 0 ? { activeSkills: normalizedActiveSkills } : {})
+    }
   }
 
   private normalizeDisabledAgentTools(

--- a/src/main/presenter/llmProviderPresenter/baseProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/baseProvider.ts
@@ -246,24 +246,10 @@ export abstract class BaseLLMProvider {
    */
   public async fetchModels(options?: { suppressErrors?: boolean }): Promise<MODEL_META[]> {
     const suppressErrors = options?.suppressErrors ?? true
+    let models: MODEL_META[]
+
     try {
-      const models = await this.fetchProviderModels()
-      logger.info(
-        `[Provider] fetchModels: fetched ${models?.length || 0} models for provider "${this.provider.id}"`
-      )
-      // Validate that all models have correct providerId
-      const validatedModels = models.map((model) => {
-        if (model.providerId !== this.provider.id) {
-          logger.warn(
-            `[Provider] fetchModels: Model ${model.id} has incorrect providerId: expected "${this.provider.id}", got "${model.providerId}". Fixing it.`
-          )
-          model.providerId = this.provider.id
-        }
-        return model
-      })
-      this.models = validatedModels
-      this.configPresenter.setProviderModels(this.provider.id, validatedModels)
-      return validatedModels
+      models = await this.fetchProviderModels()
     } catch (e) {
       logger.error(
         `[Provider] fetchModels: Failed to fetch models for provider "${this.provider.id}":`,
@@ -277,6 +263,23 @@ export abstract class BaseLLMProvider {
       }
       return []
     }
+
+    logger.info(
+      `[Provider] fetchModels: fetched ${models?.length || 0} models for provider "${this.provider.id}"`
+    )
+    // Validate that all models have correct providerId
+    const validatedModels = models.map((model) => {
+      if (model.providerId !== this.provider.id) {
+        logger.warn(
+          `[Provider] fetchModels: Model ${model.id} has incorrect providerId: expected "${this.provider.id}", got "${model.providerId}". Fixing it.`
+        )
+        model.providerId = this.provider.id
+      }
+      return model
+    })
+    this.models = validatedModels
+    this.configPresenter.setProviderModels(this.provider.id, validatedModels)
+    return validatedModels
   }
 
   /**

--- a/src/main/presenter/llmProviderPresenter/baseProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/baseProvider.ts
@@ -247,24 +247,23 @@ export abstract class BaseLLMProvider {
   public async fetchModels(options?: { suppressErrors?: boolean }): Promise<MODEL_META[]> {
     const suppressErrors = options?.suppressErrors ?? true
     try {
-      return this.fetchProviderModels().then((models) => {
-        logger.info(
-          `[Provider] fetchModels: fetched ${models?.length || 0} models for provider "${this.provider.id}"`
-        )
-        // Validate that all models have correct providerId
-        const validatedModels = models.map((model) => {
-          if (model.providerId !== this.provider.id) {
-            logger.warn(
-              `[Provider] fetchModels: Model ${model.id} has incorrect providerId: expected "${this.provider.id}", got "${model.providerId}". Fixing it.`
-            )
-            model.providerId = this.provider.id
-          }
-          return model
-        })
-        this.models = validatedModels
-        this.configPresenter.setProviderModels(this.provider.id, validatedModels)
-        return validatedModels
+      const models = await this.fetchProviderModels()
+      logger.info(
+        `[Provider] fetchModels: fetched ${models?.length || 0} models for provider "${this.provider.id}"`
+      )
+      // Validate that all models have correct providerId
+      const validatedModels = models.map((model) => {
+        if (model.providerId !== this.provider.id) {
+          logger.warn(
+            `[Provider] fetchModels: Model ${model.id} has incorrect providerId: expected "${this.provider.id}", got "${model.providerId}". Fixing it.`
+          )
+          model.providerId = this.provider.id
+        }
+        return model
       })
+      this.models = validatedModels
+      this.configPresenter.setProviderModels(this.provider.id, validatedModels)
+      return validatedModels
     } catch (e) {
       logger.error(
         `[Provider] fetchModels: Failed to fetch models for provider "${this.provider.id}":`,

--- a/src/main/presenter/skillPresenter/index.ts
+++ b/src/main/presenter/skillPresenter/index.ts
@@ -678,16 +678,6 @@ export class SkillPresenter implements ISkillPresenter {
 
       const rawContent = await fs.promises.readFile(metadata.path, 'utf-8')
       const { content } = matter(rawContent)
-      let nextIsPinned = isPinned
-
-      if (options?.conversationId && !isPinned) {
-        const updatedSkills = await this.setActiveSkills(options.conversationId, [
-          ...pinnedSkills,
-          metadata.name
-        ])
-        nextIsPinned = updatedSkills.includes(metadata.name)
-      }
-
       return {
         success: true,
         name: metadata.name,
@@ -698,7 +688,7 @@ export class SkillPresenter implements ISkillPresenter {
         platforms: metadata.platforms,
         metadata: metadata.metadata,
         linkedFiles: await this.listSkillLinkedFiles(metadata.skillRoot),
-        isPinned: nextIsPinned
+        isPinned
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
@@ -1958,12 +1948,15 @@ export class SkillPresenter implements ISkillPresenter {
   /**
    * Get allowed tools for active skills in a conversation
    */
-  async getActiveSkillsAllowedTools(conversationId: string): Promise<string[]> {
+  async getActiveSkillsAllowedTools(
+    conversationId: string,
+    activeSkillNamesOverride?: string[]
+  ): Promise<string[]> {
     if (this.metadataCache.size === 0) {
       await this.discoverSkills()
     }
 
-    const activeSkills = await this.getActiveSkills(conversationId)
+    const activeSkills = activeSkillNamesOverride ?? (await this.getActiveSkills(conversationId))
     const allowedTools: Set<string> = new Set()
 
     for (const skillName of activeSkills) {

--- a/src/main/presenter/skillPresenter/skillExecutionService.ts
+++ b/src/main/presenter/skillPresenter/skillExecutionService.ts
@@ -134,7 +134,7 @@ export class SkillExecutionService {
     const activeSkills =
       activeSkillNames ?? (await this.skillPresenter.getActiveSkills(conversationId))
     if (!activeSkills.includes(input.skill)) {
-      throw new Error(`Skill "${input.skill}" is not pinned in this conversation`)
+      throw new Error(`Skill "${input.skill}" is not active in the current message/tool loop`)
     }
 
     const metadata = (await this.skillPresenter.getMetadataList()).find(

--- a/src/main/presenter/skillPresenter/skillExecutionService.ts
+++ b/src/main/presenter/skillPresenter/skillExecutionService.ts
@@ -41,6 +41,7 @@ export interface SkillRunRequest {
 
 export interface SkillRunOptions {
   conversationId: string
+  activeSkillNames?: string[]
 }
 
 interface SkillExecutionServiceOptions {
@@ -87,7 +88,7 @@ export class SkillExecutionService {
 
   async execute(input: SkillRunRequest, options: SkillRunOptions): Promise<SkillExecutionResult> {
     const plan = await this.preparePlanForExecution(
-      await this.buildSpawnPlan(input, options.conversationId)
+      await this.buildSpawnPlan(input, options.conversationId, options.activeSkillNames)
     )
     const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS
 
@@ -125,8 +126,13 @@ export class SkillExecutionService {
     }
   }
 
-  private async buildSpawnPlan(input: SkillRunRequest, conversationId: string): Promise<SpawnPlan> {
-    const activeSkills = await this.skillPresenter.getActiveSkills(conversationId)
+  private async buildSpawnPlan(
+    input: SkillRunRequest,
+    conversationId: string,
+    activeSkillNames?: string[]
+  ): Promise<SpawnPlan> {
+    const activeSkills =
+      activeSkillNames ?? (await this.skillPresenter.getActiveSkills(conversationId))
     if (!activeSkills.includes(input.skill)) {
       throw new Error(`Skill "${input.skill}" is not pinned in this conversation`)
     }

--- a/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
@@ -98,6 +98,7 @@ interface AgentToolExecutionOptions {
   onProgress?: (update: AgentToolProgressUpdate) => void
   signal?: AbortSignal
   allowExternalFileAccess?: boolean
+  activeSkillNames?: string[]
 }
 
 interface AgentToolPermissionCheckOptions {
@@ -355,6 +356,7 @@ export class AgentToolManager {
     supportsVision: boolean
     agentWorkspacePath: string | null
     conversationId?: string
+    activeSkillNames?: string[]
   }): Promise<MCPToolDefinition[]> {
     const defs: MCPToolDefinition[] = []
     const isAgentMode = context.chatMode === 'agent'
@@ -428,7 +430,10 @@ export class AgentToolManager {
       const skillDefs = this.getSkillToolDefinitions()
       defs.push(...skillDefs)
 
-      if (context.conversationId && (await this.hasRunnableSkillScripts(context.conversationId))) {
+      if (
+        context.conversationId &&
+        (await this.hasRunnableSkillScripts(context.conversationId, context.activeSkillNames))
+      ) {
         defs.push(this.getSkillRunToolDefinition())
       }
     }
@@ -436,10 +441,13 @@ export class AgentToolManager {
     // 4. DeepChat settings tools (agent mode only, skill gated)
     if (isAgentMode && this.isSkillsEnabled() && context.conversationId) {
       try {
-        const activeSkills = await this.getSkillPresenter().getActiveSkills(context.conversationId)
+        const activeSkills =
+          context.activeSkillNames ??
+          (await this.getSkillPresenter().getActiveSkills(context.conversationId))
         if (activeSkills.includes(CHAT_SETTINGS_SKILL_NAME)) {
           const allowedTools = await this.getSkillPresenter().getActiveSkillsAllowedTools(
-            context.conversationId
+            context.conversationId,
+            activeSkills
           )
           const requiredSettingsTools = Object.values(CHAT_SETTINGS_TOOL_NAMES)
           const nonOpenSettingsTools = requiredSettingsTools.filter(
@@ -548,11 +556,11 @@ export class AgentToolManager {
 
     // Route to Skill tools
     if (this.isSkillTool(toolName)) {
-      return await this.callSkillTool(toolName, args, conversationId)
+      return await this.callSkillTool(toolName, args, conversationId, options)
     }
 
     if (this.isSkillExecutionTool(toolName)) {
-      return await this.callSkillExecutionTool(toolName, args, conversationId)
+      return await this.callSkillExecutionTool(toolName, args, conversationId, options)
     }
 
     // Route to DeepChat settings tools
@@ -938,7 +946,8 @@ export class AgentToolManager {
     const allowedDirectories = await this.buildAllowedDirectories(workspaceRoot, conversationId, {
       includeSkillRoots: toolName !== 'exec',
       includeRuntimeRoots: toolName !== 'exec',
-      requiredPermission: this.getRequiredFilePermission(toolName)
+      requiredPermission: this.getRequiredFilePermission(toolName),
+      activeSkillNames: options?.activeSkillNames
     })
 
     if (toolName === 'exec') {
@@ -1217,6 +1226,7 @@ export class AgentToolManager {
       includeSkillRoots?: boolean
       includeRuntimeRoots?: boolean
       requiredPermission?: FilePermissionLevel
+      activeSkillNames?: string[]
     } = {}
   ): Promise<string[]> {
     const includeSkillRoots = options.includeSkillRoots !== false
@@ -1236,7 +1246,10 @@ export class AgentToolManager {
     addPath(this.agentWorkspacePath)
 
     if (conversationId && includeSkillRoots) {
-      const activeSkillRoots = await this.resolveActiveSkillRoots(conversationId)
+      const activeSkillRoots = await this.resolveActiveSkillRoots(
+        conversationId,
+        options.activeSkillNames
+      )
       for (const skillRoot of activeSkillRoots) {
         addPath(skillRoot)
       }
@@ -1261,7 +1274,10 @@ export class AgentToolManager {
     return ordered
   }
 
-  private async resolveActiveSkillRoots(conversationId: string): Promise<string[]> {
+  private async resolveActiveSkillRoots(
+    conversationId: string,
+    activeSkillNamesOverride?: string[]
+  ): Promise<string[]> {
     const skillPresenter = this.getSkillPresenter()
     if (!skillPresenter?.getActiveSkills || !skillPresenter?.getMetadataList) {
       return []
@@ -1272,7 +1288,7 @@ export class AgentToolManager {
 
     try {
       ;[activeSkillNames, metadataList] = await Promise.all([
-        skillPresenter.getActiveSkills(conversationId),
+        activeSkillNamesOverride ?? skillPresenter.getActiveSkills(conversationId),
         skillPresenter.getMetadataList()
       ])
     } catch (error) {
@@ -1880,7 +1896,7 @@ export class AgentToolManager {
       function: {
         name: 'skill_run',
         description:
-          'Run a bundled script from a pinned skill. This is the preferred way to execute skill-local Python, Node, or shell helpers without guessing paths.',
+          'Run a bundled script from a skill active in the current message/tool loop. This is the preferred way to execute skill-local Python, Node, or shell helpers without guessing paths.',
         parameters: toDeepChatJsonSchema(this.skillSchemas.skill_run) as {
           type: string
           properties: Record<string, unknown>
@@ -1903,9 +1919,13 @@ export class AgentToolManager {
     return toolName === 'skill_run'
   }
 
-  private async hasRunnableSkillScripts(conversationId: string): Promise<boolean> {
+  private async hasRunnableSkillScripts(
+    conversationId: string,
+    activeSkillNames?: string[]
+  ): Promise<boolean> {
     try {
-      const activeSkills = await this.getSkillPresenter().getActiveSkills(conversationId)
+      const activeSkills =
+        activeSkillNames ?? (await this.getSkillPresenter().getActiveSkills(conversationId))
       for (const skillName of activeSkills) {
         const scripts = await this.getSkillPresenter().listSkillScripts(skillName)
         if (scripts.some((script) => script.enabled)) {
@@ -2082,10 +2102,21 @@ export class AgentToolManager {
     )
   }
 
+  private normalizeActiveSkillOption(activeSkillNames?: string[]): string[] {
+    return Array.from(
+      new Set(
+        (activeSkillNames ?? [])
+          .map((skillName) => skillName.trim())
+          .filter((skillName) => skillName.length > 0)
+      )
+    )
+  }
+
   private async callSkillTool(
     toolName: string,
     args: Record<string, unknown>,
-    conversationId?: string
+    conversationId?: string,
+    options?: AgentToolExecutionOptions
   ): Promise<AgentToolCallResult> {
     if (!this.isSkillsEnabled()) {
       return {
@@ -2114,20 +2145,15 @@ export class AgentToolManager {
           ? validationResult.data.file_path.trim()
           : ''
       const isLinkedFileView = normalizedFilePath.length > 0
-      const previousActiveSkills =
-        conversationId && !isLinkedFileView
-          ? await this.getSkillPresenter().getActiveSkills(conversationId)
-          : []
+      const effectiveActiveSkills = this.normalizeActiveSkillOption(options?.activeSkillNames)
       const result = await skillTools.handleSkillView(conversationId, validationResult.data)
-      const nextActiveSkills =
-        conversationId && !isLinkedFileView
-          ? await this.getSkillPresenter().getActiveSkills(conversationId)
-          : previousActiveSkills
+      const normalizedViewedSkill = result.name?.trim() || validationResult.data.name.trim()
       const activationApplied =
         Boolean(conversationId) &&
+        result.success === true &&
         !isLinkedFileView &&
-        !previousActiveSkills.includes(validationResult.data.name) &&
-        nextActiveSkills.includes(validationResult.data.name)
+        Boolean(normalizedViewedSkill) &&
+        !effectiveActiveSkills.includes(normalizedViewedSkill)
       const activationSource =
         !conversationId || result.success !== true
           ? 'none'
@@ -2136,7 +2162,17 @@ export class AgentToolManager {
             : isLinkedFileView
               ? 'file'
               : 'none'
-      const content = JSON.stringify(result)
+      const content = JSON.stringify({
+        ...result,
+        isPinned: result.isPinned === true,
+        activeForCurrentMessage:
+          result.isPinned === true ||
+          (!isLinkedFileView &&
+            Boolean(normalizedViewedSkill) &&
+            (activationApplied || effectiveActiveSkills.includes(normalizedViewedSkill))),
+        activatedForMessage: activationApplied,
+        activationScope: activationApplied ? 'message' : 'none'
+      })
 
       return {
         content,
@@ -2145,7 +2181,7 @@ export class AgentToolManager {
           toolResult: {
             activationApplied,
             activationSource,
-            ...(activationApplied ? { activatedSkill: validationResult.data.name } : {})
+            ...(activationApplied ? { activatedSkill: normalizedViewedSkill } : {})
           }
         }
       }
@@ -2193,7 +2229,8 @@ export class AgentToolManager {
   private async callSkillExecutionTool(
     toolName: string,
     args: Record<string, unknown>,
-    conversationId?: string
+    conversationId?: string,
+    options?: AgentToolExecutionOptions
   ): Promise<AgentToolCallResult> {
     if (toolName !== 'skill_run') {
       throw new Error(`Unknown skill execution tool: ${toolName}`)
@@ -2209,7 +2246,8 @@ export class AgentToolManager {
     }
 
     const result = await this.getSkillExecutionService().execute(validationResult.data, {
-      conversationId
+      conversationId,
+      activeSkillNames: options?.activeSkillNames
     })
     const content =
       typeof result.output === 'string' ? result.output : JSON.stringify(result.output, null, 2)

--- a/src/main/presenter/toolPresenter/index.ts
+++ b/src/main/presenter/toolPresenter/index.ts
@@ -61,6 +61,7 @@ export interface IToolPresenter {
     supportsVision?: boolean
     agentWorkspacePath?: string | null
     conversationId?: string
+    activeSkillNames?: string[]
   }): Promise<MCPToolDefinition[]>
   syncAgentToolContext?(context: {
     chatMode?: 'agent' | 'acp agent'
@@ -72,6 +73,7 @@ export interface IToolPresenter {
       onProgress?: (update: AgentToolProgressUpdate) => void
       signal?: AbortSignal
       permissionMode?: PermissionMode
+      activeSkillNames?: string[]
     }
   ): Promise<{ content: unknown; rawData: MCPToolResponse }>
   preCheckToolPermission?(
@@ -163,6 +165,7 @@ export class ToolPresenter implements IToolPresenter {
     supportsVision?: boolean
     agentWorkspacePath?: string | null
     conversationId?: string
+    activeSkillNames?: string[]
   }): Promise<MCPToolDefinition[]> {
     const defs: MCPToolDefinition[] = []
     const mapper = this.resolveMapper(context.conversationId)
@@ -194,7 +197,8 @@ export class ToolPresenter implements IToolPresenter {
           chatMode,
           supportsVision,
           agentWorkspacePath,
-          conversationId: context.conversationId
+          conversationId: context.conversationId,
+          activeSkillNames: context.activeSkillNames
         }),
         'agent'
       )
@@ -260,6 +264,7 @@ export class ToolPresenter implements IToolPresenter {
       onProgress?: (update: AgentToolProgressUpdate) => void
       signal?: AbortSignal
       permissionMode?: PermissionMode
+      activeSkillNames?: string[]
     }
   ): Promise<{ content: unknown; rawData: MCPToolResponse }> {
     const toolName = request.function.name
@@ -300,7 +305,8 @@ export class ToolPresenter implements IToolPresenter {
           toolCallId: request.id,
           onProgress: options?.onProgress,
           signal: options?.signal,
-          allowExternalFileAccess: options?.permissionMode === 'full_access'
+          allowExternalFileAccess: options?.permissionMode === 'full_access',
+          activeSkillNames: options?.activeSkillNames
         }
       )
       const resolvedResponse = this.resolveAgentToolResponse(response)
@@ -613,12 +619,12 @@ export class ToolPresenter implements IToolPresenter {
     let hasContent = false
 
     if (toolNames.has('skill_list')) {
-      lines.push('- Use `skill_list` to inspect installed skills and pinned status.')
+      lines.push('- Use `skill_list` to inspect installed skills and manual pinned status.')
       hasContent = true
     }
     if (toolNames.has('skill_view')) {
       lines.push(
-        '- Use `skill_view` to inspect a skill or one of its linked files before relying on it.'
+        '- Use `skill_view` to inspect a skill or one of its linked files before relying on it. Root skill views activate the skill for the current message/tool loop only; they do not pin it to the conversation.'
       )
       hasContent = true
     }
@@ -629,7 +635,9 @@ export class ToolPresenter implements IToolPresenter {
       hasContent = true
     }
     if (toolNames.has('skill_run')) {
-      lines.push('- Use `skill_run` to execute bundled scripts from pinned skills.')
+      lines.push(
+        '- Use `skill_run` to execute bundled scripts from skills active in the current message/tool loop.'
+      )
       hasContent = true
     }
 

--- a/src/main/presenter/toolPresenter/index.ts
+++ b/src/main/presenter/toolPresenter/index.ts
@@ -619,7 +619,7 @@ export class ToolPresenter implements IToolPresenter {
     let hasContent = false
 
     if (toolNames.has('skill_list')) {
-      lines.push('- Use `skill_list` to inspect installed skills and manual pinned status.')
+      lines.push('- Use `skill_list` to inspect installed skills and manual pin status.')
       hasContent = true
     }
     if (toolNames.has('skill_view')) {

--- a/src/renderer/src/components/chat-input/SkillsIndicator.vue
+++ b/src/renderer/src/components/chat-input/SkillsIndicator.vue
@@ -9,18 +9,18 @@
               variant="outline"
               :class="[
                 'flex text-accent-foreground rounded-lg shadow-sm items-center gap-1.5 h-7 text-xs px-1.5 w-auto',
-                activeCount > 0 ? 'text-primary border-primary/50' : ''
+                composerActiveCount > 0 ? 'text-primary border-primary/50' : ''
               ]"
               size="icon"
             >
               <Icon v-if="loading" icon="lucide:loader" class="w-4 h-4 animate-spin" />
               <Icon v-else icon="lucide:sparkles" class="w-4 h-4" />
-              <span v-if="activeCount > 0" class="text-sm">{{ activeCount }}</span>
+              <span v-if="composerActiveCount > 0" class="text-sm">{{ composerActiveCount }}</span>
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p v-if="activeCount > 0">
-              {{ t('chat.skills.indicator.active', { count: activeCount }) }}
+            <p v-if="composerActiveCount > 0">
+              {{ t('chat.skills.indicator.active', { count: composerActiveCount }) }}
             </p>
             <p v-else>{{ t('chat.skills.indicator.none') }}</p>
           </TooltipContent>
@@ -30,7 +30,7 @@
       <PopoverContent class="w-72 p-0" align="start">
         <SkillsPanel
           :skills="skills"
-          :active-skills="activeSkills"
+          :active-skills="composerActiveSkills"
           @toggle="handleToggle"
           @manage="openSettings"
         />
@@ -66,9 +66,8 @@ const settingsClient = createSettingsClient()
 const panelOpen = ref(false)
 
 // Use skills data composable
-const { skills, activeSkills, activeCount, loading, toggleSkill, pendingSkills } = useSkillsData(
-  computed(() => props.conversationId)
-)
+const { skills, composerActiveSkills, composerActiveCount, loading, toggleSkill, pendingSkills } =
+  useSkillsData(computed(() => props.conversationId))
 
 // Handle skill toggle
 const handleToggle = async (skillName: string) => {

--- a/src/renderer/src/components/chat-input/composables/useSkillsData.ts
+++ b/src/renderer/src/components/chat-input/composables/useSkillsData.ts
@@ -15,9 +15,9 @@ import { useSkillsStore } from '@/stores/skillsStore'
  *
  * This composable provides:
  * - Access to all available skills from the skills store
- * - Per-conversation active skills management
- * - Pending skills for new threads (applied when conversation is created)
- * - Toggle functionality for activating/deactivating skills
+ * - Local composer skill selection for the next message
+ * - Session active skills for externally/manual pinned skills
+ * - Toggle functionality for selecting/deselecting message skills
  * - Event listeners for real-time updates
  */
 export function useSkillsData(conversationId: Ref<string | null> | ComputedRef<string | null>) {
@@ -27,7 +27,7 @@ export function useSkillsData(conversationId: Ref<string | null> | ComputedRef<s
 
   // === State ===
   const activeSkills = ref<string[]>([])
-  const pendingSkills = ref<string[]>([]) // Skills selected before conversation exists
+  const pendingSkills = ref<string[]>([]) // Skills selected for the next message in the composer
   const loading = ref(false)
 
   // === Computed ===
@@ -37,11 +37,10 @@ export function useSkillsData(conversationId: Ref<string | null> | ComputedRef<s
   const skills = computed<SkillMetadata[]>(() => skillsStore.skills)
 
   /**
-   * Effective active skills - uses pending skills if no conversation, otherwise real active skills
+   * Effective composer skills. Session-pinned active skills are loaded separately and are not
+   * shown as message chips in the composer.
    */
-  const effectiveActiveSkills = computed(() => {
-    return conversationId.value ? activeSkills.value : pendingSkills.value
-  })
+  const effectiveActiveSkills = computed(() => pendingSkills.value)
 
   /**
    * Count of currently active skills
@@ -86,74 +85,29 @@ export function useSkillsData(conversationId: Ref<string | null> | ComputedRef<s
   }
 
   /**
-   * Toggle a skill's activation state
-   * Works for both existing conversations and pending state
+   * Toggle a skill for the next message only.
    */
   const toggleSkill = async (skillName: string) => {
-    // If no conversation, toggle in pending skills
-    if (!conversationId.value) {
-      const isCurrentlyPending = pendingSkills.value.includes(skillName)
-      pendingSkills.value = isCurrentlyPending
-        ? pendingSkills.value.filter((s) => s !== skillName)
-        : [...pendingSkills.value, skillName]
-      return
-    }
-
-    const isCurrentlyActive = activeSkills.value.includes(skillName)
-    const updatedSkills = isCurrentlyActive
-      ? activeSkills.value.filter((s) => s !== skillName)
-      : [...activeSkills.value, skillName]
-
-    try {
-      await skillClient.setActiveSkills(conversationId.value, updatedSkills)
-      activeSkills.value = updatedSkills
-    } catch (error) {
-      console.error('[useSkillsData] Failed to toggle skill:', error)
-    }
+    const isCurrentlyPending = pendingSkills.value.includes(skillName)
+    pendingSkills.value = isCurrentlyPending
+      ? pendingSkills.value.filter((s) => s !== skillName)
+      : [...pendingSkills.value, skillName]
   }
 
   /**
-   * Activate a specific skill
+   * Select a specific skill for the next message only.
    */
   const activateSkill = async (skillName: string) => {
-    // If no conversation, add to pending skills
-    if (!conversationId.value) {
-      if (!pendingSkills.value.includes(skillName)) {
-        pendingSkills.value = [...pendingSkills.value, skillName]
-      }
-      return
-    }
-
-    if (activeSkills.value.includes(skillName)) return
-
-    const updatedSkills = [...activeSkills.value, skillName]
-    try {
-      await skillClient.setActiveSkills(conversationId.value, updatedSkills)
-      activeSkills.value = updatedSkills
-    } catch (error) {
-      console.error('[useSkillsData] Failed to activate skill:', error)
+    if (!pendingSkills.value.includes(skillName)) {
+      pendingSkills.value = [...pendingSkills.value, skillName]
     }
   }
 
   /**
-   * Deactivate a specific skill
+   * Deselect a skill from the next message.
    */
   const deactivateSkill = async (skillName: string) => {
-    // If no conversation, remove from pending skills
-    if (!conversationId.value) {
-      pendingSkills.value = pendingSkills.value.filter((s) => s !== skillName)
-      return
-    }
-
-    if (!activeSkills.value.includes(skillName)) return
-
-    const updatedSkills = activeSkills.value.filter((s) => s !== skillName)
-    try {
-      await skillClient.setActiveSkills(conversationId.value, updatedSkills)
-      activeSkills.value = updatedSkills
-    } catch (error) {
-      console.error('[useSkillsData] Failed to deactivate skill:', error)
-    }
+    pendingSkills.value = pendingSkills.value.filter((s) => s !== skillName)
   }
 
   /**
@@ -166,17 +120,10 @@ export function useSkillsData(conversationId: Ref<string | null> | ComputedRef<s
   }
 
   /**
-   * Apply pending skills to a newly created conversation
+   * Clear composer skills after they have been attached to a submitted message.
    */
-  const applyPendingSkillsToConversation = async (newConversationId: string) => {
-    const pending = consumePendingSkills()
-    if (pending.length > 0) {
-      try {
-        await skillClient.setActiveSkills(newConversationId, pending)
-      } catch (error) {
-        console.error('[useSkillsData] Failed to apply pending skills:', error)
-      }
-    }
+  const clearPendingSkills = () => {
+    pendingSkills.value = []
   }
 
   // === IPC Event Handlers ===
@@ -227,7 +174,7 @@ export function useSkillsData(conversationId: Ref<string | null> | ComputedRef<s
   return {
     // State
     skills,
-    activeSkills: effectiveActiveSkills, // Return effective skills (pending or real)
+    activeSkills: effectiveActiveSkills, // Composer skills for the next message
     activeCount,
     activeSkillItems,
     availableSkills,
@@ -240,6 +187,6 @@ export function useSkillsData(conversationId: Ref<string | null> | ComputedRef<s
     activateSkill,
     deactivateSkill,
     consumePendingSkills,
-    applyPendingSkillsToConversation
+    clearPendingSkills
   }
 }

--- a/src/renderer/src/components/chat-input/composables/useSkillsData.ts
+++ b/src/renderer/src/components/chat-input/composables/useSkillsData.ts
@@ -40,18 +40,18 @@ export function useSkillsData(conversationId: Ref<string | null> | ComputedRef<s
    * Effective composer skills. Session-pinned active skills are loaded separately and are not
    * shown as message chips in the composer.
    */
-  const effectiveActiveSkills = computed(() => pendingSkills.value)
+  const composerActiveSkills = computed(() => pendingSkills.value)
 
   /**
    * Count of currently active skills
    */
-  const activeCount = computed(() => effectiveActiveSkills.value.length)
+  const composerActiveCount = computed(() => composerActiveSkills.value.length)
 
   /**
    * Skills that are currently active (full metadata)
    */
-  const activeSkillItems = computed(() => {
-    const activeSet = new Set(effectiveActiveSkills.value)
+  const composerActiveSkillItems = computed(() => {
+    const activeSet = new Set(composerActiveSkills.value)
     return skills.value.filter((skill) => activeSet.has(skill.name))
   })
 
@@ -59,7 +59,7 @@ export function useSkillsData(conversationId: Ref<string | null> | ComputedRef<s
    * Skills that are available but not active
    */
   const availableSkills = computed(() => {
-    const activeSet = new Set(effectiveActiveSkills.value)
+    const activeSet = new Set(composerActiveSkills.value)
     return skills.value.filter((skill) => !activeSet.has(skill.name))
   })
 
@@ -174,9 +174,9 @@ export function useSkillsData(conversationId: Ref<string | null> | ComputedRef<s
   return {
     // State
     skills,
-    activeSkills: effectiveActiveSkills, // Composer skills for the next message
-    activeCount,
-    activeSkillItems,
+    composerActiveSkills,
+    composerActiveCount,
+    composerActiveSkillItems,
     availableSkills,
     loading,
     pendingSkills,

--- a/src/renderer/src/components/chat/ChatInputBox.vue
+++ b/src/renderer/src/components/chat/ChatInputBox.vue
@@ -147,7 +147,7 @@ let editorInstance: Editor | null = null
 const getEditor = () => editorInstance
 const conversationId = computed(() => props.sessionId)
 const skillsData = useSkillsData(conversationId)
-const activeSkillNames = computed(() => skillsData.activeSkills.value)
+const activeSkillNames = computed(() => skillsData.composerActiveSkills.value)
 
 const mentions = useChatInputMentions({
   getEditor,

--- a/src/renderer/src/components/chat/ChatInputBox.vue
+++ b/src/renderer/src/components/chat/ChatInputBox.vue
@@ -285,14 +285,7 @@ watch(
 
 watch(
   () => props.sessionId,
-  async (sessionId) => {
-    if (sessionId) {
-      if (skillsData.pendingSkills.value.length > 0) {
-        await skillsData.applyPendingSkillsToConversation(sessionId)
-      }
-      emit('pending-skills-change', [])
-      return
-    }
+  () => {
     emit('pending-skills-change', [...skillsData.pendingSkills.value])
   },
   { immediate: true }
@@ -438,6 +431,14 @@ function getPendingSkillsSnapshot(): string[] {
   return Array.from(new Set(skillsData.pendingSkills.value))
 }
 
+function consumePendingSkills(): string[] {
+  return Array.from(new Set(skillsData.consumePendingSkills()))
+}
+
+function clearPendingSkills() {
+  skillsData.clearPendingSkills()
+}
+
 function focusInput() {
   editor.chain().focus().scrollIntoView().run()
   setCaretToEnd(editor)
@@ -448,6 +449,8 @@ defineExpose({
   insertRecognizedText,
   insertWorkspaceReference,
   getPendingSkillsSnapshot,
+  consumePendingSkills,
+  clearPendingSkills,
   focusInput
 })
 </script>

--- a/src/renderer/src/components/chat/messageListItems.ts
+++ b/src/renderer/src/components/chat/messageListItems.ts
@@ -40,6 +40,7 @@ export type DisplayUserMessageContent = {
   links: string[]
   think: boolean
   search: boolean
+  activeSkills?: string[]
   text: string
   content?: (
     | DisplayUserMessageTextBlock

--- a/src/renderer/src/components/message/MessageItemUser.vue
+++ b/src/renderer/src/components/message/MessageItemUser.vue
@@ -18,6 +18,21 @@
         :name="message.name ?? 'user'"
         :timestamp="message.timestamp"
       />
+      <div
+        v-if="message.content.activeSkills?.length"
+        class="flex max-w-full flex-wrap justify-end gap-1.5 pr-1"
+        data-testid="user-message-active-skills"
+      >
+        <span
+          v-for="skillName in message.content.activeSkills"
+          :key="skillName"
+          class="inline-flex h-5 items-center gap-1 rounded-full border border-border/60 bg-background/70 px-2 text-[11px] leading-none text-muted-foreground shadow-sm dark:bg-background/40"
+          data-testid="user-message-active-skill"
+        >
+          <Icon icon="lucide:sparkles" class="h-3 w-3 text-primary/70" />
+          {{ skillName }}
+        </span>
+      </div>
       <!-- 消息内容 -->
       <div
         class="text-sm bg-muted dark:bg-muted rounded-lg p-2 border flex flex-col gap-1.5"

--- a/src/renderer/src/pages/ChatPage.vue
+++ b/src/renderer/src/pages/ChatPage.vue
@@ -1293,6 +1293,9 @@ const chatInputRef = ref<{
   triggerAttach: () => void
   insertRecognizedText?: (text: string) => void
   insertWorkspaceReference?: (targetPath: string) => boolean
+  getPendingSkillsSnapshot?: () => string[]
+  consumePendingSkills?: () => string[]
+  clearPendingSkills?: () => void
 } | null>(null)
 const isVoiceInputEnabled = ref(false)
 const isHandlingInteraction = ref(false)
@@ -1613,6 +1616,23 @@ async function prepareFilesForCurrentModel(files: MessageFile[]): Promise<Messag
   }
 }
 
+const getComposerSkillsSnapshot = (): string[] => {
+  return Array.from(new Set(chatInputRef.value?.getPendingSkillsSnapshot?.() ?? []))
+}
+
+const clearComposerSkills = () => {
+  chatInputRef.value?.clearPendingSkills?.()
+}
+
+const withMessageSkills = (text: string, files: MessageFile[]) => {
+  const activeSkills = getComposerSkillsSnapshot()
+  return {
+    text,
+    files,
+    ...(activeSkills.length > 0 ? { activeSkills } : {})
+  }
+}
+
 async function onSubmit() {
   if (isReadOnlySession.value) return
   if (isAcpWorkdirMissing.value) return
@@ -1626,14 +1646,16 @@ async function onSubmit() {
     }
     return
   }
+  const payload = withMessageSkills(text, files)
   if (isGenerating.value) {
-    await pendingInputStore.queueInput(props.sessionId, { text, files })
+    await pendingInputStore.queueInput(props.sessionId, payload)
   } else {
     agentPlanStore.beginTurn(props.sessionId)
-    await chatClient.sendMessage(props.sessionId, { text, files })
+    await chatClient.sendMessage(props.sessionId, payload)
   }
   message.value = ''
   attachedFiles.value = []
+  clearComposerSkills()
   schedulePostSubmitScrollToBottom()
 }
 
@@ -1649,13 +1671,15 @@ async function onCommandSubmit(command: string) {
   }
 
   const files = await prepareFilesForCurrentModel([...attachedFiles.value])
+  const payload = withMessageSkills(text, files)
   if (isGenerating.value) {
-    await pendingInputStore.queueInput(props.sessionId, { text, files })
+    await pendingInputStore.queueInput(props.sessionId, payload)
   } else {
     agentPlanStore.beginTurn(props.sessionId)
-    await chatClient.sendMessage(props.sessionId, { text, files })
+    await chatClient.sendMessage(props.sessionId, payload)
   }
   attachedFiles.value = []
+  clearComposerSkills()
   schedulePostSubmitScrollToBottom()
 }
 
@@ -1700,9 +1724,10 @@ async function onQueueSubmit() {
   if (await handleManualCompactionCommand(text)) {
     return
   }
-  await pendingInputStore.queueInput(props.sessionId, { text, files })
+  await pendingInputStore.queueInput(props.sessionId, withMessageSkills(text, files))
   message.value = ''
   attachedFiles.value = []
+  clearComposerSkills()
 }
 
 async function onSteer() {
@@ -1716,9 +1741,10 @@ async function onSteer() {
     return
   }
   agentPlanStore.beginTurn(props.sessionId)
-  await chatClient.steerActiveTurn(props.sessionId, { text, files })
+  await chatClient.steerActiveTurn(props.sessionId, withMessageSkills(text, files))
   message.value = ''
   attachedFiles.value = []
+  clearComposerSkills()
 }
 
 function onAttach() {

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -233,6 +233,7 @@ const chatInputRef = ref<{
   triggerAttach: () => void
   insertRecognizedText?: (text: string) => void
   getPendingSkillsSnapshot?: () => string[]
+  clearPendingSkills?: () => void
   focusInput?: () => void
 } | null>(null)
 const acpDraftSessionId = ref<string | null>(null)
@@ -837,12 +838,19 @@ async function submitText(text: string, files: MessageFile[]) {
   const draftGenerationSettings = draftStore.toGenerationSettings()
 
   try {
+    const pendingSkillsSnapshot =
+      chatInputRef.value?.getPendingSkillsSnapshot?.() ?? pendingSkills.value
+    const dedupedPendingSkills = Array.from(new Set(pendingSkillsSnapshot))
+    const messagePayload = {
+      text,
+      files,
+      ...(dedupedPendingSkills.length > 0 ? { activeSkills: dedupedPendingSkills } : {})
+    }
+
     if (isAcp && acpDraftSessionId.value) {
       await sessionStore.selectSession(acpDraftSessionId.value)
-      await sessionStore.sendMessage(acpDraftSessionId.value, {
-        text,
-        files
-      })
+      await sessionStore.sendMessage(acpDraftSessionId.value, messagePayload)
+      chatInputRef.value?.clearPendingSkills?.()
       return
     }
 
@@ -865,13 +873,9 @@ async function submitText(text: string, files: MessageFile[]) {
       modelId = resolved.modelId
     }
 
-    const pendingSkillsSnapshot =
-      chatInputRef.value?.getPendingSkillsSnapshot?.() ?? pendingSkills.value
-    const dedupedPendingSkills = Array.from(new Set(pendingSkillsSnapshot))
-
     await sessionStore.createSession({
-      message: text,
-      files,
+      message: messagePayload.text,
+      files: messagePayload.files,
       projectDir: selectedSessionProjectDir.value,
       agentId,
       providerId,
@@ -880,8 +884,9 @@ async function submitText(text: string, files: MessageFile[]) {
       disabledAgentTools: isAcp ? undefined : draftDisabledAgentTools,
       subagentEnabled: isAcp ? false : draftSubagentEnabled,
       generationSettings: draftGenerationSettings,
-      activeSkills: dedupedPendingSkills.length > 0 ? dedupedPendingSkills : undefined
+      activeSkills: messagePayload.activeSkills
     })
+    chatInputRef.value?.clearPendingSkills?.()
   } catch (error) {
     if (preparedHeroFlight) {
       cancelChatInputHeroFlight()

--- a/src/renderer/src/stores/ui/message.ts
+++ b/src/renderer/src/stores/ui/message.ts
@@ -237,7 +237,8 @@ export const useMessageStore = defineStore('message', () => {
       files: [],
       links: [],
       search: false,
-      think: false
+      think: false,
+      activeSkills: []
     }
     return entry.userContent
   }

--- a/src/renderer/src/stores/ui/message.ts
+++ b/src/renderer/src/stores/ui/message.ts
@@ -222,6 +222,7 @@ export const useMessageStore = defineStore('message', () => {
           links: parsed.links ?? [],
           search: parsed.search ?? false,
           think: parsed.think ?? false,
+          activeSkills: Array.isArray(parsed.activeSkills) ? parsed.activeSkills : [],
           continue: parsed.continue,
           resources: parsed.resources,
           prompts: parsed.prompts,

--- a/src/shared/contracts/common.ts
+++ b/src/shared/contracts/common.ts
@@ -159,7 +159,8 @@ export const MessageFileSchema = z.object({
 
 export const SendMessageInputSchema = z.object({
   text: z.string(),
-  files: z.array(MessageFileSchema).optional()
+  files: z.array(MessageFileSchema).optional(),
+  activeSkills: z.array(z.string()).optional()
 })
 
 export const ToolInteractionResponseSchema = z.discriminatedUnion('kind', [

--- a/src/shared/types/agent-interface.d.ts
+++ b/src/shared/types/agent-interface.d.ts
@@ -335,6 +335,7 @@ export interface UserMessageContent {
   links: string[]
   search: boolean
   think: boolean
+  activeSkills?: string[]
 }
 
 export interface LegacyImportStatus {
@@ -371,6 +372,7 @@ export interface MessageFile {
 export interface SendMessageInput {
   text: string
   files?: MessageFile[]
+  activeSkills?: string[]
 }
 
 export type PendingSessionInputMode = 'queue' | 'steer'

--- a/src/shared/types/core/chat.ts
+++ b/src/shared/types/core/chat.ts
@@ -36,6 +36,7 @@ export type UserMessageContent = {
   links: string[]
   think: boolean
   search: boolean
+  activeSkills?: string[]
   text: string
   content?: (UserMessageTextBlock | UserMessageMentionBlock | UserMessageCodeBlock)[]
 }

--- a/src/shared/types/presenters/tool.presenter.d.ts
+++ b/src/shared/types/presenters/tool.presenter.d.ts
@@ -36,6 +36,7 @@ export interface IToolPresenter {
     supportsVision?: boolean
     agentWorkspacePath?: string | null
     conversationId?: string
+    activeSkillNames?: string[]
   }): Promise<MCPToolDefinition[]>
 
   /**
@@ -56,6 +57,7 @@ export interface IToolPresenter {
       onProgress?: (update: AgentToolProgressUpdate) => void
       signal?: AbortSignal
       permissionMode?: PermissionMode
+      activeSkillNames?: string[]
     }
   ): Promise<{ content: unknown; rawData: MCPToolResponse }>
 

--- a/src/shared/types/skill.ts
+++ b/src/shared/types/skill.ts
@@ -236,7 +236,10 @@ export interface ISkillPresenter {
   validateSkillNames(names: string[]): Promise<string[]>
 
   // Tool integration
-  getActiveSkillsAllowedTools(conversationId: string): Promise<string[]>
+  getActiveSkillsAllowedTools(
+    conversationId: string,
+    activeSkillNames?: string[]
+  ): Promise<string[]>
 
   // Hot reload
   watchSkillFiles(): Promise<void>

--- a/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
@@ -2491,7 +2491,8 @@ describe('AgentRuntimePresenter', () => {
       }
 
       skillPresenter.getMetadataList.mockResolvedValue([{ name: 'skill-a' }])
-      skillPresenter.getActiveSkills.mockResolvedValueOnce([]).mockResolvedValueOnce(['skill-a'])
+      skillPresenter.getActiveSkills.mockResolvedValue(['skill-a'])
+      skillPresenter.getActiveSkills.mockResolvedValueOnce([])
       skillPresenter.loadSkillContent.mockResolvedValue({ content: 'Skill A instructions' })
 
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
@@ -2501,7 +2502,7 @@ describe('AgentRuntimePresenter', () => {
       expect(envBuilder).toHaveBeenCalledTimes(2)
 
       const secondCallArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[1][0]
-      expect(secondCallArgs.messages[0].content).toContain('## Pinned Skills')
+      expect(secondCallArgs.messages[0].content).toContain('## Active Skills')
       expect(secondCallArgs.messages[0].content).toContain('### skill-a')
       expect(secondCallArgs.messages[0].content).toContain('Skill A instructions')
     })
@@ -2522,7 +2523,7 @@ describe('AgentRuntimePresenter', () => {
       const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
       const systemPrompt = String(callArgs.messages[0].content)
 
-      expect(systemPrompt).not.toContain('## Pinned Skills')
+      expect(systemPrompt).not.toContain('## Active Skills')
       expect(skillPresenter.loadSkillContent).not.toHaveBeenCalled()
     })
 
@@ -2586,7 +2587,7 @@ describe('AgentRuntimePresenter', () => {
       ).toHaveLength(1)
       const runtimeIndex = systemPrompt.indexOf('RUNTIME_CAPABILITIES')
       const skillsIndex = systemPrompt.indexOf('## Skills')
-      const pinnedSkillsIndex = systemPrompt.indexOf('## Pinned Skills')
+      const activeSkillsIndex = systemPrompt.indexOf('## Active Skills')
       const envIndex = systemPrompt.indexOf('ENV_BLOCK')
       const toolingIndex = systemPrompt.indexOf('TOOLING_BLOCK')
       const permissionIndex = systemPrompt.indexOf('## Permission Rules')
@@ -2597,8 +2598,8 @@ describe('AgentRuntimePresenter', () => {
       expect(runtimeIndex).toBeGreaterThan(userPromptIndex)
       expect(envIndex).toBeGreaterThan(runtimeIndex)
       expect(skillsIndex).toBeGreaterThan(envIndex)
-      expect(pinnedSkillsIndex).toBeGreaterThan(skillsIndex)
-      expect(toolingIndex).toBeGreaterThan(pinnedSkillsIndex)
+      expect(activeSkillsIndex).toBeGreaterThan(skillsIndex)
+      expect(toolingIndex).toBeGreaterThan(activeSkillsIndex)
       expect(permissionIndex).toBeGreaterThan(toolingIndex)
       expect(verificationIndex).toBeGreaterThan(permissionIndex)
       expect(systemPrompt).toContain('- skill-a')

--- a/test/main/presenter/agentRuntimePresenter/dispatch.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/dispatch.test.ts
@@ -1144,10 +1144,12 @@ describe('dispatch', () => {
       const toolPresenter = {
         ...createMockToolPresenter(),
         callTool: vi.fn().mockResolvedValue({
-          content: '{"success":true,"name":"deepchat-settings","isPinned":true}',
+          content:
+            '{"success":true,"name":"deepchat-settings","isPinned":false,"activeForCurrentMessage":true,"activatedForMessage":true,"activationScope":"message"}',
           rawData: {
             toolCallId: 'tc1',
-            content: '{"success":true,"name":"deepchat-settings","isPinned":true}',
+            content:
+              '{"success":true,"name":"deepchat-settings","isPinned":false,"activeForCurrentMessage":true,"activatedForMessage":true,"activationScope":"message"}',
             isError: false,
             toolResult: {
               activationApplied: true,

--- a/test/main/presenter/agentRuntimePresenter/messageStore.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/messageStore.test.ts
@@ -373,6 +373,49 @@ describe('DeepChatMessageStore', () => {
         updatedAt: 1000
       })
     })
+
+    it('preserves message-scoped active skills when materializing normalized user content', () => {
+      sqlitePresenter.deepchatMessagesTable.getBySession.mockReturnValue([
+        {
+          id: 'm1',
+          session_id: 's1',
+          order_seq: 1,
+          role: 'user',
+          content: JSON.stringify({
+            text: 'raw text',
+            files: [],
+            links: [],
+            search: false,
+            think: false,
+            activeSkills: ['algorithmic-art']
+          }),
+          status: 'sent',
+          is_context_edge: 0,
+          metadata: '{}',
+          trace_count: 0,
+          created_at: 1000,
+          updated_at: 1000
+        }
+      ])
+      sqlitePresenter.deepchatUserMessagesTable.listByMessageIds.mockReturnValue([
+        {
+          message_id: 'm1',
+          text: 'normalized text',
+          search_enabled: 0,
+          think_enabled: 0
+        }
+      ])
+
+      const [message] = store.getMessages('s1')
+      expect(JSON.parse(message.content)).toEqual({
+        text: 'normalized text',
+        files: [],
+        links: [],
+        search: false,
+        think: false,
+        activeSkills: ['algorithmic-art']
+      })
+    })
   })
 
   describe('getMessageIds', () => {

--- a/test/main/presenter/agentRuntimePresenter/process.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/process.test.ts
@@ -496,6 +496,14 @@ describe('processStream', () => {
           }
         })
     } as unknown as IToolPresenter
+    const activeSkillNames: string[] = []
+    const activateSkill = vi.fn(async (skillName: string) => {
+      if (!activeSkillNames.includes(skillName)) {
+        activeSkillNames.push(skillName)
+      }
+      return [...activeSkillNames]
+    })
+    const getActiveSkillNames = vi.fn(() => [...activeSkillNames])
     const refreshTools = vi
       .fn()
       .mockResolvedValue([makeTool('skill_view'), makeTool('deepchat_settings_set_theme')])
@@ -552,21 +560,31 @@ describe('processStream', () => {
       toolPresenter,
       tools: [makeTool('skill_view')],
       refreshTools,
-      refreshSystemPrompt
+      refreshSystemPrompt,
+      hooks: {
+        activateSkill,
+        getActiveSkillNames
+      }
     })
 
     const promise = processStream(params)
     await vi.runAllTimersAsync()
     await promise
 
+    expect(activateSkill).toHaveBeenCalledWith('deepchat-settings')
+    expect(getActiveSkillNames).toHaveBeenCalled()
     expect(refreshTools).toHaveBeenCalledTimes(1)
+    expect(refreshTools).toHaveBeenCalledWith(['deepchat-settings'])
     expect(refreshSystemPrompt).toHaveBeenCalledTimes(1)
-    expect(refreshSystemPrompt).toHaveBeenCalledWith(undefined, [
-      expect.objectContaining({ function: expect.objectContaining({ name: 'skill_view' }) }),
-      expect.objectContaining({
-        function: expect.objectContaining({ name: 'deepchat_settings_set_theme' })
-      })
-    ])
+    expect(refreshSystemPrompt).toHaveBeenCalledWith(
+      ['deepchat-settings'],
+      [
+        expect.objectContaining({ function: expect.objectContaining({ name: 'skill_view' }) }),
+        expect.objectContaining({
+          function: expect.objectContaining({ name: 'deepchat_settings_set_theme' })
+        })
+      ]
+    )
     expect(coreStream).toHaveBeenCalledTimes(3)
     expect(toolPresenter.callTool).toHaveBeenCalledTimes(2)
   })

--- a/test/main/presenter/agentRuntimePresenter/process.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/process.test.ts
@@ -466,17 +466,19 @@ describe('processStream', () => {
     expect(finalizedBlocks[0].tool_call.response).toBe('Sunny, 72F')
   })
 
-  it('refreshes tools for the next loop iteration after skill_view activates a skill', async () => {
+  it('refreshes tools and system prompt for the next loop iteration after skill_view activates a skill', async () => {
     let callCount = 0
     const toolPresenter = {
       ...createMockToolPresenter(),
       callTool: vi
         .fn()
         .mockResolvedValueOnce({
-          content: '{"success":true,"name":"deepchat-settings","isPinned":true}',
+          content:
+            '{"success":true,"name":"deepchat-settings","isPinned":false,"activeForCurrentMessage":true,"activatedForMessage":true,"activationScope":"message"}',
           rawData: {
             toolCallId: 'tc1',
-            content: '{"success":true,"name":"deepchat-settings","isPinned":true}',
+            content:
+              '{"success":true,"name":"deepchat-settings","isPinned":false,"activeForCurrentMessage":true,"activatedForMessage":true,"activationScope":"message"}',
             isError: false,
             toolResult: {
               activationApplied: true,
@@ -497,9 +499,10 @@ describe('processStream', () => {
     const refreshTools = vi
       .fn()
       .mockResolvedValue([makeTool('skill_view'), makeTool('deepchat_settings_set_theme')])
+    const refreshSystemPrompt = vi.fn().mockResolvedValue('refreshed skill prompt')
 
     const coreStream = vi.fn(
-      function (_messages, _modelId, _modelConfig, _temperature, _maxTokens, tools) {
+      function (messages, _modelId, _modelConfig, _temperature, _maxTokens, tools) {
         callCount++
         if (callCount === 1) {
           expect(tools.map((tool) => tool.function.name)).toEqual(['skill_view'])
@@ -518,6 +521,7 @@ describe('processStream', () => {
           })()
         }
         if (callCount === 2) {
+          expect(messages[0]).toEqual({ role: 'system', content: 'refreshed skill prompt' })
           expect(tools.map((tool) => tool.function.name)).toEqual([
             'skill_view',
             'deepchat_settings_set_theme'
@@ -547,7 +551,8 @@ describe('processStream', () => {
       coreStream,
       toolPresenter,
       tools: [makeTool('skill_view')],
-      refreshTools
+      refreshTools,
+      refreshSystemPrompt
     })
 
     const promise = processStream(params)
@@ -555,6 +560,13 @@ describe('processStream', () => {
     await promise
 
     expect(refreshTools).toHaveBeenCalledTimes(1)
+    expect(refreshSystemPrompt).toHaveBeenCalledTimes(1)
+    expect(refreshSystemPrompt).toHaveBeenCalledWith(undefined, [
+      expect.objectContaining({ function: expect.objectContaining({ name: 'skill_view' }) }),
+      expect.objectContaining({
+        function: expect.objectContaining({ name: 'deepchat_settings_set_theme' })
+      })
+    ])
     expect(coreStream).toHaveBeenCalledTimes(3)
     expect(toolPresenter.callTool).toHaveBeenCalledTimes(2)
   })

--- a/test/main/presenter/agentSessionPresenter/agentSessionPresenter.test.ts
+++ b/test/main/presenter/agentSessionPresenter/agentSessionPresenter.test.ts
@@ -641,7 +641,7 @@ describe('AgentSessionPresenter', () => {
       ).rejects.toThrow('No provider or model configured')
     })
 
-    it('applies active skills before first message processing', async () => {
+    it('passes active skills as initial message-scoped skills without pinning the session', async () => {
       await presenter.createSession(
         {
           agentId: 'deepchat',
@@ -651,10 +651,16 @@ describe('AgentSessionPresenter', () => {
         1
       )
 
-      expect(skillPresenter.setActiveSkills).toHaveBeenCalledWith('mock-session-id', [
-        'skill-a',
-        'skill-b'
-      ])
+      expect(skillPresenter.setActiveSkills).not.toHaveBeenCalled()
+      expect(deepChatAgent.queuePendingInput).toHaveBeenCalledWith(
+        'mock-session-id',
+        {
+          text: 'Hello',
+          files: [],
+          activeSkills: ['skill-a', 'skill-b']
+        },
+        expect.objectContaining({ source: 'send' })
+      )
     })
 
     it('generates title asynchronously without blocking createSession', async () => {

--- a/test/main/presenter/llmProviderPresenter/baseProvider.test.ts
+++ b/test/main/presenter/llmProviderPresenter/baseProvider.test.ts
@@ -255,4 +255,24 @@ describe('BaseLLMProvider tool XML conversion', () => {
       'model endpoint returned 404'
     )
   })
+
+  it('does not suppress provider model persistence failures', async () => {
+    const persistenceError = new Error('model persistence failed')
+    const failingConfigPresenter = {
+      ...configPresenter,
+      setProviderModels: vi.fn(() => {
+        throw persistenceError
+      })
+    } as unknown as IConfigPresenter
+    const provider = new TestProvider(failingConfigPresenter, async () => [
+      {
+        id: 'model-1',
+        name: 'Model 1',
+        providerId: 'test-provider',
+        group: 'default'
+      } as MODEL_META
+    ])
+
+    await expect(provider.fetchModels()).rejects.toThrow('model persistence failed')
+  })
 })

--- a/test/main/presenter/llmProviderPresenter/baseProvider.test.ts
+++ b/test/main/presenter/llmProviderPresenter/baseProvider.test.ts
@@ -5,6 +5,7 @@ import type {
   LLM_PROVIDER,
   LLMResponse,
   MCPToolDefinition,
+  MODEL_META,
   ModelConfig
 } from '../../../../src/shared/presenter'
 import { BaseLLMProvider } from '../../../../src/main/presenter/llmProviderPresenter/baseProvider'
@@ -25,7 +26,10 @@ vi.mock('@/events', () => ({
 }))
 
 class TestProvider extends BaseLLMProvider {
-  constructor(configPresenter: IConfigPresenter) {
+  constructor(
+    configPresenter: IConfigPresenter,
+    private readonly modelFetcher: () => Promise<MODEL_META[]> = async () => []
+  ) {
     super(
       {
         id: 'test-provider',
@@ -97,8 +101,8 @@ class TestProvider extends BaseLLMProvider {
     return
   }
 
-  protected async fetchProviderModels() {
-    return []
+  protected async fetchProviderModels(): Promise<MODEL_META[]> {
+    return this.modelFetcher()
   }
 }
 
@@ -231,6 +235,24 @@ describe('BaseLLMProvider tool XML conversion', () => {
         apiKey: 'updated-key',
         baseUrl: 'https://example.com'
       })
+    )
+  })
+
+  it('suppresses asynchronous model fetch failures by default', async () => {
+    const provider = new TestProvider(configPresenter, async () => {
+      throw new Error('model endpoint returned 404')
+    })
+
+    await expect(provider.fetchModels()).resolves.toEqual([])
+  })
+
+  it('rethrows asynchronous model fetch failures when suppression is disabled', async () => {
+    const provider = new TestProvider(configPresenter, async () => {
+      throw new Error('model endpoint returned 404')
+    })
+
+    await expect(provider.fetchModels({ suppressErrors: false })).rejects.toThrow(
+      'model endpoint returned 404'
     )
   })
 })

--- a/test/main/presenter/skillPresenter/skillPresenter.test.ts
+++ b/test/main/presenter/skillPresenter/skillPresenter.test.ts
@@ -908,7 +908,7 @@ describe('SkillPresenter', () => {
       ])
     })
 
-    it('activates a skill after viewing the main SKILL.md in a new-agent session', async () => {
+    it('does not pin a skill after viewing the main SKILL.md in a new-agent session', async () => {
       ;(skillSessionStatePort.hasNewSession as Mock).mockResolvedValue(true)
       publishDeepchatEventMock.mockClear()
 
@@ -920,18 +920,16 @@ describe('SkillPresenter', () => {
         expect.objectContaining({
           success: true,
           name: 'test-skill',
-          isPinned: true
+          isPinned: false
         })
       )
-      expect(await skillPresenter.getActiveSkills('conv-view-auto-activate')).toEqual([
-        'test-skill'
-      ])
-      expect(publishDeepchatEventMock).toHaveBeenCalledWith('skills.session.changed', {
-        conversationId: 'conv-view-auto-activate',
-        skills: ['test-skill'],
-        change: 'activated',
-        version: expect.any(Number)
-      })
+      expect(await skillPresenter.getActiveSkills('conv-view-auto-activate')).toEqual([])
+      expect(publishDeepchatEventMock).not.toHaveBeenCalledWith(
+        'skills.session.changed',
+        expect.objectContaining({
+          conversationId: 'conv-view-auto-activate'
+        })
+      )
     })
 
     it('does not activate a skill when only viewing a linked file', async () => {
@@ -2265,6 +2263,15 @@ describe('SkillPresenter', () => {
       const tools = await skillPresenter.getActiveSkillsAllowedTools('conv-123')
 
       expect(tools).toEqual([])
+    })
+
+    it('returns allowed tools for message-scoped active skill overrides', async () => {
+      const tools = await skillPresenter.getActiveSkillsAllowedTools('conv-123', [
+        'skill-with-tools'
+      ])
+
+      expect(tools).toContain('read')
+      expect(tools).toContain('write')
     })
   })
 

--- a/test/main/presenter/skillPresenter/skillTools.test.ts
+++ b/test/main/presenter/skillPresenter/skillTools.test.ts
@@ -137,7 +137,7 @@ describe('SkillTools', () => {
   })
 
   describe('handleSkillView', () => {
-    it('passes file_path and conversationId through to the presenter', async () => {
+    it('passes file_path and conversationId through to the presenter by default', async () => {
       const result = await skillTools.handleSkillView('conv-123', {
         name: 'code-review',
         file_path: 'references/checklist.md'

--- a/test/main/presenter/toolPresenter/agentTools/agentToolManagerSettings.test.ts
+++ b/test/main/presenter/toolPresenter/agentTools/agentToolManagerSettings.test.ts
@@ -21,6 +21,7 @@ describe('AgentToolManager DeepChat settings tool gating', () => {
     viewSkill: vi.fn(),
     listSkillScripts: vi.fn().mockResolvedValue([]),
     manageDraftSkill: vi.fn(),
+    setActiveSkills: vi.fn(),
     getSkillExtension: vi.fn().mockResolvedValue({
       version: 1,
       env: {},
@@ -112,6 +113,25 @@ describe('AgentToolManager DeepChat settings tool gating', () => {
     expect(names).not.toContain(CHAT_SETTINGS_TOOL_NAMES.open)
   })
 
+  it('includes settings tools for message-scoped active skills', async () => {
+    skillPresenter.getActiveSkills.mockResolvedValue([])
+    skillPresenter.getActiveSkillsAllowedTools.mockResolvedValue([CHAT_SETTINGS_TOOL_NAMES.toggle])
+
+    const manager = buildManager()
+
+    const defs = await manager.getAllToolDefinitions({
+      chatMode: 'agent',
+      supportsVision: false,
+      agentWorkspacePath: null,
+      conversationId: 'conv-1',
+      activeSkillNames: [CHAT_SETTINGS_SKILL_NAME]
+    })
+
+    const names = defs.map((def) => def.function.name)
+    expect(names).toContain(CHAT_SETTINGS_TOOL_NAMES.toggle)
+    expect(skillPresenter.getActiveSkills).not.toHaveBeenCalled()
+  })
+
   it('includes skill_run when an active skill exposes runnable scripts', async () => {
     skillPresenter.getActiveSkills.mockResolvedValue(['ocr'])
     skillPresenter.getActiveSkillsAllowedTools.mockResolvedValue([])
@@ -157,17 +177,15 @@ describe('AgentToolManager DeepChat settings tool gating', () => {
     expect(names).not.toContain('skill_control')
   })
 
-  it('returns skill_view activation metadata after viewing a main SKILL.md', async () => {
-    skillPresenter.getActiveSkills
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(['deepchat-settings'])
+  it('returns runtime skill_view activation metadata without persisting session skills', async () => {
+    skillPresenter.getActiveSkills.mockResolvedValue([])
     skillPresenter.getActiveSkillsAllowedTools.mockResolvedValue([])
     skillPresenter.viewSkill.mockResolvedValue({
       success: true,
       name: 'deepchat-settings',
       filePath: null,
       content: '# Skill',
-      isPinned: true
+      isPinned: false
     })
 
     const manager = buildManager()
@@ -177,7 +195,12 @@ describe('AgentToolManager DeepChat settings tool gating', () => {
       'conv-1'
     )) as { content: string; rawData?: { toolResult?: unknown } }
 
-    expect(result.content).toContain('"isPinned":true')
+    const content = JSON.parse(result.content) as Record<string, unknown>
+    expect(content.isPinned).toBe(false)
+    expect(content.activeForCurrentMessage).toBe(true)
+    expect(content.activatedForMessage).toBe(true)
+    expect(content.activationScope).toBe('message')
+    expect(skillPresenter.setActiveSkills).not.toHaveBeenCalled()
     expect(result.rawData?.toolResult).toEqual({
       activationApplied: true,
       activationSource: 'skill_md',

--- a/test/renderer/components/ChatInputBox.test.ts
+++ b/test/renderer/components/ChatInputBox.test.ts
@@ -19,7 +19,9 @@ const consumePendingSkillsMock = vi.fn(() => {
   pendingSkillsRef.value = []
   return copied
 })
-const applyPendingSkillsToConversationMock = vi.fn().mockResolvedValue(undefined)
+const clearPendingSkillsMock = vi.fn(() => {
+  pendingSkillsRef.value = []
+})
 
 vi.mock('@tiptap/vue-3', () => {
   class MockEditor {
@@ -137,7 +139,7 @@ vi.mock('@/components/chat-input/composables/useSkillsData', () => ({
     activateSkill: activateSkillMock,
     deactivateSkill: deactivateSkillMock,
     consumePendingSkills: consumePendingSkillsMock,
-    applyPendingSkillsToConversation: applyPendingSkillsToConversationMock
+    clearPendingSkills: clearPendingSkillsMock
   })
 }))
 
@@ -373,10 +375,16 @@ describe('ChatInputBox attachments', () => {
     expect(deleteFileMock).toHaveBeenCalledWith(0)
   })
 
-  it('exposes deduplicated pending skills snapshot', async () => {
+  it('exposes and clears deduplicated pending skills snapshot', async () => {
     pendingSkillsRef.value = ['review', 'review', 'commit']
     const wrapper = await mountComponent()
     expect((wrapper.vm as any).getPendingSkillsSnapshot()).toEqual(['review', 'commit'])
+    expect((wrapper.vm as any).consumePendingSkills()).toEqual(['review', 'commit'])
+    expect(pendingSkillsRef.value).toEqual([])
+
+    pendingSkillsRef.value = ['commit']
+    ;(wrapper.vm as any).clearPendingSkills()
+    expect(pendingSkillsRef.value).toEqual([])
   })
 
   it('emits queue-submit on Tab only when queue submit is available', async () => {

--- a/test/renderer/components/ChatPage.test.ts
+++ b/test/renderer/components/ChatPage.test.ts
@@ -189,6 +189,8 @@ const setup = async (options: SetupOptions = {}) => {
   const toast = vi.fn()
   const chatInputInsertWorkspaceReference = vi.fn().mockReturnValue(true)
   const chatInputTriggerAttach = vi.fn()
+  const chatInputGetPendingSkillsSnapshot = vi.fn((): string[] => [])
+  const chatInputClearPendingSkills = vi.fn()
 
   const spotlightStore = reactive({
     pendingMessageJump: options.spotlightPendingJump ?? null,
@@ -325,7 +327,9 @@ const setup = async (options: SetupOptions = {}) => {
       setup(_, { expose }) {
         expose({
           triggerAttach: chatInputTriggerAttach,
-          insertWorkspaceReference: chatInputInsertWorkspaceReference
+          insertWorkspaceReference: chatInputInsertWorkspaceReference,
+          getPendingSkillsSnapshot: chatInputGetPendingSkillsSnapshot,
+          clearPendingSkills: chatInputClearPendingSkills
         })
       },
       template: '<div class="chat-input-box-stub"><slot name="toolbar" /></div>'
@@ -443,6 +447,8 @@ const setup = async (options: SetupOptions = {}) => {
     spotlightStore,
     chatInputInsertWorkspaceReference,
     chatInputTriggerAttach,
+    chatInputGetPendingSkillsSnapshot,
+    chatInputClearPendingSkills,
     flushStartupDeferredTasks: async () => {
       while (startupDeferredTasks.length > 0) {
         const task = startupDeferredTasks.shift()
@@ -772,6 +778,25 @@ describe('ChatPage', () => {
       text: '/compact',
       files: []
     })
+  })
+
+  it('sends composer skills with the message and clears the composer chip', async () => {
+    const { wrapper, chatClient, chatInputGetPendingSkillsSnapshot, chatInputClearPendingSkills } =
+      await setup()
+    chatInputGetPendingSkillsSnapshot.mockReturnValue(['algorithmic-art', 'algorithmic-art'])
+    const input = wrapper.findComponent({ name: 'ChatInputBox' })
+
+    input.vm.$emit('update:modelValue', 'what can this skill do?')
+    await flushPromises()
+    input.vm.$emit('submit')
+    await flushPromises()
+
+    expect(chatClient.sendMessage).toHaveBeenCalledWith('s1', {
+      text: 'what can this skill do?',
+      files: [],
+      activeSkills: ['algorithmic-art']
+    })
+    expect(chatInputClearPendingSkills).toHaveBeenCalled()
   })
 
   it('maps reasoning metadata into message usage for think duration fallback', async () => {

--- a/test/renderer/components/NewThreadPage.test.ts
+++ b/test/renderer/components/NewThreadPage.test.ts
@@ -10,6 +10,9 @@ const passthrough = (name: string) =>
   })
 
 const chatInputTriggerAttachMock = vi.fn()
+const chatInputClearPendingSkillsMock = vi.fn(() => {
+  chatInputPendingSkillsSnapshotRef.value = []
+})
 const chatInputPendingSkillsSnapshotRef: { value: string[] } = { value: [] }
 
 const createChatInputBoxStub = () =>
@@ -33,7 +36,8 @@ const createChatInputBoxStub = () =>
     setup(props, { expose }) {
       expose({
         triggerAttach: chatInputTriggerAttachMock,
-        getPendingSkillsSnapshot: () => [...chatInputPendingSkillsSnapshotRef.value]
+        getPendingSkillsSnapshot: () => [...chatInputPendingSkillsSnapshotRef.value],
+        clearPendingSkills: chatInputClearPendingSkillsMock
       })
       return () =>
         h('div', {
@@ -68,6 +72,7 @@ const setup = async (options?: {
 }) => {
   vi.resetModules()
   chatInputTriggerAttachMock.mockReset()
+  chatInputClearPendingSkillsMock.mockClear()
   chatInputPendingSkillsSnapshotRef.value = []
   const initialSelectedProject = Object.prototype.hasOwnProperty.call(
     options ?? {},
@@ -801,7 +806,7 @@ describe('NewThreadPage ACP draft session bootstrap', () => {
     )
   })
 
-  it('prefers ChatInputBox pending skills snapshot when creating deepchat session', async () => {
+  it('sends ChatInputBox pending skills as initial message-scoped skills', async () => {
     const { wrapper, sessionStore, agentStore, modelStore } = await setup()
 
     agentStore.selectedAgentId = 'deepchat'
@@ -823,6 +828,7 @@ describe('NewThreadPage ACP draft session bootstrap', () => {
         activeSkills: ['live-skill']
       })
     )
+    expect(chatInputClearPendingSkillsMock).toHaveBeenCalled()
   })
 
   it('ignores stale ensureAcpDraftSession response after agent/workdir switches', async () => {

--- a/test/renderer/components/message/MessageItemUser.test.ts
+++ b/test/renderer/components/message/MessageItemUser.test.ts
@@ -262,6 +262,20 @@ describe('MessageItemUser', () => {
     expect(wrapper.text()).toContain('const answer = 42;')
   })
 
+  it('shows message-scoped skills as metadata outside the message bubble', async () => {
+    const wrapper = mount(MessageItemUser, {
+      props: {
+        message: createMessage({}, { activeSkills: ['algorithmic-art', 'deep-research'] })
+      },
+      ...globalMountOptions
+    })
+
+    const skills = wrapper.findAll('[data-testid="user-message-active-skill"]')
+    expect(skills).toHaveLength(2)
+    expect(skills.map((skill) => skill.text())).toEqual(['algorithmic-art', 'deep-research'])
+    expect(wrapper.get('[data-message-content="true"]').text()).not.toContain('algorithmic-art')
+  })
+
   it('keeps attachments visible when long text collapses', async () => {
     const wrapper = mount(MessageItemUser, {
       props: {


### PR DESCRIPTION

<img width="576" height="464" alt="52a53650-df16-4e66-b9aa-6f6d8222691c" src="https://github.com/user-attachments/assets/b2e4d6da-486b-4878-8dc6-c11b803084ab" />


## Summary
- Make composer-selected skills message-scoped and clear the composer after successful send/queue/steer/create-session.
- Keep agent skill_view activation scoped to the current message/tool loop instead of persisting it as session-pinned state.
- Preserve and display message-scoped skills on the corresponding user message item.
- Ensure effective skill tools/prompts use message/runtime active skills consistently.
- Fix suppressed provider model-list fetch errors so routine 404s do not bubble through the route handler.

## Validation
- pnpm exec vitest run --config vitest.config.ts test/main/presenter/agentRuntimePresenter/messageStore.test.ts test/renderer/components/message/MessageItemUser.test.ts test/main/presenter/llmProviderPresenter/baseProvider.test.ts test/main/presenter/agentRuntimePresenter/process.test.ts test/main/presenter/skillPresenter/skillTools.test.ts test/main/presenter/toolPresenter/agentTools/agentToolManagerSettings.test.ts
- pnpm run typecheck
- pnpm run i18n
- pnpm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Composer-selected skills now attach to the next outgoing message and are cleared after sending.
  * Messages can display “active skills” as separate badges/metadata.
  * Runtime skill activation can update the current message/tool loop (including tools and system prompt) without permanently pinning.
* **Bug Fixes**
  * Model list refreshes now more reliably suppress failed provider model fetches by default (including async 404 cases) while preserving error propagation when not suppressed.
* **Tests**
  * Added/updated regression and coverage for async model-fetch handling and message-scoped skill activation/tool refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->