### PR TITLE
chore(deps): upgrade duckdb to 1.5.4

### DIFF
--- a/docs/issues/memory-first-turn-cold-start/plan.md
+++ b/docs/issues/memory-first-turn-cold-start/plan.md
@@ -67,7 +67,7 @@ open); turn 2+ (or any turn after warm resolves) restores full hybrid recall.
 
 - Make `scripts/installVss.js` **platform/arch-aware**: remove the macOS early `return` and accept
   explicit `--platform`/`--arch` flags that select the **target** triple (e.g. `osx_arm64` vs
-  `osx_amd64`), version-locked to `@duckdb/node-api` (1.5.3-r.1). Do **not** rely on the host
+  `osx_amd64`), version-locked to the current `@duckdb/node-api` package version. Do **not** rely on the host
   machine's architecture — a CI x64 box cross-building `build:mac:arm64` would otherwise bundle the
   wrong extension. (DuckDB `INSTALL` resolves the host platform by default; the script must fetch/
   copy the requested target's binary, mirroring how `installRuntime:*:<arch>` already takes `-a`.)

--- a/docs/issues/windows-arm64-duckdb-upgrade/spec.md
+++ b/docs/issues/windows-arm64-duckdb-upgrade/spec.md
@@ -24,8 +24,8 @@ That package version only ships native bindings for:
 It does not ship a `win32-arm64` binding, so the app crashed while loading the built-in knowledge
 base presenter on Windows ARM64.
 
-DeepChat now depends on `@duckdb/node-api@1.5.3-r.1`. The matching lockfile includes
-`@duckdb/node-bindings-win32-arm64@1.5.3-r.1`, and the Windows ARM64 workflow runs
+DeepChat now depends on `@duckdb/node-api@1.5.4-r.1`. The matching lockfile includes
+`@duckdb/node-bindings-win32-arm64@1.5.4-r.1`, and the Windows ARM64 workflow runs
 `pnpm run smoke:duckdb:vss` before app launch smoke coverage.
 
 ## User Stories

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@ai-sdk/provider": "^4.0.0",
     "@aws-sdk/client-bedrock": "^3.1057.0",
     "@aws-sdk/credential-providers": "^3.1057.0",
-    "@duckdb/node-api": "1.5.3-r.1",
+    "@duckdb/node-api": "1.5.4-r.1",
     "@electron-toolkit/utils": "^4.0.0",
     "@ff-labs/fff-node": "^0.9.3",
     "@jxa/run": "^1.4.0",


### PR DESCRIPTION
upgrade duckdb to 1.5.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated planning and platform upgrade notes to reflect the latest DuckDB version.
* **Chores**
  * Bumped the DuckDB integration to a newer release, including Windows ARM64 support updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->