### PR TITLE
fix(skill): conflict skill popup style fix

### DIFF
--- a/src/renderer/settings/components/skills/AdoptSkillDialog.vue
+++ b/src/renderer/settings/components/skills/AdoptSkillDialog.vue
@@ -49,35 +49,35 @@
           </Badge>
         </div>
 
-        <div class="space-y-3 rounded-md border px-3 py-3 text-sm">
-          <div>
+        <div class="min-w-0 space-y-3 rounded-md border px-3 py-3 text-sm">
+          <div class="min-w-0">
             <div class="text-xs font-medium text-muted-foreground">
               {{ t('settings.skills.agents.adoptDialog.currentLocation') }}
             </div>
-            <div class="mt-1 truncate font-mono text-xs" :title="preview.sourcePath">
+            <div class="mt-1 break-all font-mono text-xs leading-5" :title="preview.sourcePath">
               {{ preview.sourcePath }}
             </div>
           </div>
 
-          <div>
+          <div class="min-w-0">
             <div class="text-xs font-medium text-muted-foreground">
               {{ t('settings.skills.agents.adoptDialog.afterAdoption') }}
             </div>
-            <div class="mt-1 space-y-1">
-              <div class="truncate font-mono text-xs" :title="preview.targetPath">
+            <div class="mt-1 min-w-0 space-y-1">
+              <div class="break-all font-mono text-xs leading-5" :title="preview.targetPath">
                 {{ preview.targetPath }}
               </div>
-              <div class="truncate font-mono text-xs" :title="preview.agentPath">
+              <div class="break-all font-mono text-xs leading-5" :title="preview.agentPath">
                 {{ preview.agentPath }} {{ t('settings.skills.agents.adoptDialog.linkArrow') }}
               </div>
             </div>
           </div>
 
-          <div>
+          <div class="min-w-0">
             <div class="text-xs font-medium text-muted-foreground">
               {{ t('settings.skills.agents.adoptDialog.backup') }}
             </div>
-            <div class="mt-1 truncate font-mono text-xs" :title="preview.backupRoot">
+            <div class="mt-1 break-all font-mono text-xs leading-5" :title="preview.backupRoot">
               {{ preview.backupRoot }}
             </div>
           </div>


### PR DESCRIPTION
before:
<img width="2466" height="1936" alt="042dad88-a0a6-437e-b761-7845b9fb2520" src="https://github.com/user-attachments/assets/54294fff-e42b-4f42-989a-ef6aa6f03b08" />


after:
<img width="2466" height="1936" alt="7470f3e3-19db-4598-8df4-88c23288c113" src="https://github.com/user-attachments/assets/37e224bd-6422-47a5-a34c-ef27b57b0447" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout of skill adoption preview details for better readability.
  * Long path values now wrap cleanly across multiple lines instead of being cut off on one line.
  * Preserved hover tooltips for the displayed paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->