### PR TITLE
fix(memory): honor category on manual add

### DIFF
--- a/src/renderer/api/MemoryClient.ts
+++ b/src/renderer/api/MemoryClient.ts
@@ -33,6 +33,28 @@ import { getDeepchatBridge } from './core'
 
 export type MemoryUpdatedPayload = DeepchatEventPayload<typeof memoryUpdatedEvent.name>
 
+type MemoryAddKind = 'episodic' | 'semantic'
+type MemoryAddInputBase = {
+  content: string
+  importance?: number
+}
+type MemoryAddByKindInput = MemoryAddInputBase & {
+  kind?: MemoryAddKind
+  category?: never
+}
+type MemoryAddByCategoryInput = MemoryAddInputBase & {
+  kind?: never
+  category: AgentMemoryCategory
+}
+type MemoryAddInput = MemoryAddByKindInput | MemoryAddByCategoryInput
+type MemoryAddPayload = {
+  agentId: string
+  content: string
+  kind?: MemoryAddKind
+  category?: AgentMemoryCategory
+  importance?: number
+}
+
 export function createMemoryClient(bridge: DeepchatBridge = getDeepchatBridge()) {
   async function list(agentId: string): Promise<MemoryItem[]> {
     const result = await bridge.invoke(memoryListRoute.name, { agentId })
@@ -57,22 +79,19 @@ export function createMemoryClient(bridge: DeepchatBridge = getDeepchatBridge())
     return result.results
   }
 
-  async function add(
-    agentId: string,
-    input: {
-      content: string
-      kind?: 'episodic' | 'semantic'
-      category?: AgentMemoryCategory
-      importance?: number
-    }
-  ): Promise<MemoryAddResult> {
-    const result = await bridge.invoke(memoryAddRoute.name, {
+  async function add(agentId: string, input: MemoryAddInput): Promise<MemoryAddResult> {
+    const payload: MemoryAddPayload = {
       agentId,
       content: input.content,
-      kind: input.kind,
-      category: input.category,
       importance: input.importance
-    })
+    }
+    if (input.category !== undefined) {
+      payload.category = input.category
+    } else if (input.kind !== undefined) {
+      payload.kind = input.kind
+    }
+
+    const result = await bridge.invoke(memoryAddRoute.name, payload)
     return result.result
   }
 

--- a/src/renderer/api/MemoryClient.ts
+++ b/src/renderer/api/MemoryClient.ts
@@ -28,6 +28,7 @@ import {
   type MemoryViewManifest
 } from '@shared/contracts/routes'
 import { memoryUpdatedEvent, type DeepchatEventPayload } from '@shared/contracts/events'
+import type { AgentMemoryCategory } from '@shared/types/agent-memory'
 import { getDeepchatBridge } from './core'
 
 export type MemoryUpdatedPayload = DeepchatEventPayload<typeof memoryUpdatedEvent.name>
@@ -58,12 +59,18 @@ export function createMemoryClient(bridge: DeepchatBridge = getDeepchatBridge())
 
   async function add(
     agentId: string,
-    input: { content: string; kind?: 'episodic' | 'semantic'; importance?: number }
+    input: {
+      content: string
+      kind?: 'episodic' | 'semantic'
+      category?: AgentMemoryCategory
+      importance?: number
+    }
   ): Promise<MemoryAddResult> {
     const result = await bridge.invoke(memoryAddRoute.name, {
       agentId,
       content: input.content,
       kind: input.kind,
+      category: input.category,
       importance: input.importance
     })
     return result.result

--- a/src/renderer/settings/components/MemoryManagerPanel.vue
+++ b/src/renderer/settings/components/MemoryManagerPanel.vue
@@ -86,9 +86,15 @@
             class="min-h-16 text-xs"
             :placeholder="t('settings.deepchatAgents.memoryManager.addContentPlaceholder')"
           />
-          <div class="flex items-center gap-2">
-            <Select v-model="addKind">
-              <SelectTrigger class="h-8 flex-1 text-xs">
+          <div
+            class="grid gap-2"
+            :class="{
+              'sm:grid-cols-2': addCategorySelected,
+              'sm:grid-cols-3': !addCategorySelected
+            }"
+          >
+            <Select v-if="!addCategorySelected" v-model="addKind">
+              <SelectTrigger class="h-8 w-full text-xs">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -100,8 +106,29 @@
                 </SelectItem>
               </SelectContent>
             </Select>
+            <Select v-model="addCategory">
+              <SelectTrigger
+                class="h-8 w-full text-xs"
+                :aria-label="t('settings.deepchatAgents.memoryManager.addCategoryLabel')"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem :value="ADD_CATEGORY_NONE" class="text-xs">
+                  {{ t('settings.deepchatAgents.memoryManager.addCategoryNone') }}
+                </SelectItem>
+                <SelectItem
+                  v-for="category in AGENT_MEMORY_CATEGORIES"
+                  :key="category"
+                  :value="category"
+                  class="text-xs"
+                >
+                  {{ categoryLabel(category) }}
+                </SelectItem>
+              </SelectContent>
+            </Select>
             <Select v-model="addImportance">
-              <SelectTrigger class="h-8 flex-1 text-xs">
+              <SelectTrigger class="h-8 w-full text-xs">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -663,6 +690,7 @@ import type {
 } from '@shared/contracts/routes'
 
 type MemoryCategoryFilter = AgentMemoryCategory | 'all' | 'uncategorized'
+const ADD_CATEGORY_NONE = 'none'
 
 const props = defineProps<{
   agentId: string
@@ -688,6 +716,8 @@ const categoryFilter = ref<MemoryCategoryFilter>('all')
 const showAddForm = ref(false)
 const addContent = ref('')
 const addKind = ref<'episodic' | 'semantic'>('semantic')
+const addCategory = ref<AgentMemoryCategory | typeof ADD_CATEGORY_NONE>(ADD_CATEGORY_NONE)
+const addCategorySelected = computed(() => addCategory.value !== ADD_CATEGORY_NONE)
 const addImportance = ref<'low' | 'medium' | 'high'>('medium')
 const adding = ref(false)
 let searchTimer: ReturnType<typeof setTimeout> | null = null
@@ -973,6 +1003,7 @@ function resetAddForm(): void {
   showAddForm.value = false
   addContent.value = ''
   addKind.value = 'semantic'
+  addCategory.value = ADD_CATEGORY_NONE
   addImportance.value = 'medium'
 }
 
@@ -1008,9 +1039,11 @@ async function handleAdd(): Promise<void> {
   if (!content || adding.value || memoryDisabled.value) return
   adding.value = true
   try {
+    const category = addCategory.value === ADD_CATEGORY_NONE ? undefined : addCategory.value
     const result = await memoryClient.add(props.agentId, {
       content,
-      kind: addKind.value,
+      kind: category ? undefined : addKind.value,
+      category,
       importance: IMPORTANCE_VALUES[addImportance.value]
     })
     notifyAddOutcome(result)

--- a/src/renderer/settings/components/MemoryManagerPanel.vue
+++ b/src/renderer/settings/components/MemoryManagerPanel.vue
@@ -1040,12 +1040,11 @@ async function handleAdd(): Promise<void> {
   adding.value = true
   try {
     const category = addCategory.value === ADD_CATEGORY_NONE ? undefined : addCategory.value
-    const result = await memoryClient.add(props.agentId, {
-      content,
-      kind: category ? undefined : addKind.value,
-      category,
-      importance: IMPORTANCE_VALUES[addImportance.value]
-    })
+    const importance = IMPORTANCE_VALUES[addImportance.value]
+    const input = category
+      ? { content, category, importance }
+      : { content, kind: addKind.value, importance }
+    const result = await memoryClient.add(props.agentId, input)
     notifyAddOutcome(result)
     resetAddForm()
     await refresh()

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -2581,6 +2581,8 @@
       "noSearchResults": "Ingen minder matcher din søgning.",
       "addMemory": "Tilføj minde",
       "addContentPlaceholder": "Det, du vil have denne assistent til at huske…",
+      "addCategoryLabel": "Hukommelseskategori",
+      "addCategoryNone": "Ingen kategori",
       "kindSemantic": "Faktum",
       "kindEpisodic": "Hændelse",
       "importanceLow": "Vigtighed: Lav",

--- a/src/renderer/src/i18n/de-DE/settings.json
+++ b/src/renderer/src/i18n/de-DE/settings.json
@@ -212,6 +212,8 @@
       "noSearchResults": "Keine Erinnerungen entsprechen Ihrer Suche.",
       "addMemory": "Erinnerung hinzufügen",
       "addContentPlaceholder": "Was dieser Assistent sich merken soll…",
+      "addCategoryLabel": "Speicherkategorie",
+      "addCategoryNone": "Keine Kategorie",
       "kindSemantic": "Fakt",
       "kindEpisodic": "Ereignis",
       "importanceLow": "Wichtigkeit: Niedrig",

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -209,6 +209,8 @@
       "noSearchResults": "No memories match your search.",
       "addMemory": "Add memory",
       "addContentPlaceholder": "What you want this assistant to remember…",
+      "addCategoryLabel": "Memory category",
+      "addCategoryNone": "No category",
       "kindSemantic": "Fact",
       "kindEpisodic": "Event",
       "importanceLow": "Importance: Low",

--- a/src/renderer/src/i18n/es-ES/settings.json
+++ b/src/renderer/src/i18n/es-ES/settings.json
@@ -212,6 +212,8 @@
       "noSearchResults": "Ninguna memoria coincide con tu búsqueda.",
       "addMemory": "Añadir memoria",
       "addContentPlaceholder": "Lo que quieres que este asistente recuerde…",
+      "addCategoryLabel": "Categoría de memoria",
+      "addCategoryNone": "Sin categoría",
       "kindSemantic": "Hecho",
       "kindEpisodic": "Evento",
       "importanceLow": "Importancia: baja",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -2581,6 +2581,8 @@
       "noSearchResults": "هیچ حافظه‌ای با جست‌وجوی شما مطابقت ندارد.",
       "addMemory": "افزودن حافظه",
       "addContentPlaceholder": "آنچه می‌خواهید این دستیار به خاطر بسپارد…",
+      "addCategoryLabel": "دسته‌بندی حافظه",
+      "addCategoryNone": "بدون دسته‌بندی",
       "kindSemantic": "واقعیت",
       "kindEpisodic": "رویداد",
       "importanceLow": "اهمیت: کم",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -2581,6 +2581,8 @@
       "noSearchResults": "Aucune mémoire ne correspond à votre recherche.",
       "addMemory": "Ajouter une mémoire",
       "addContentPlaceholder": "Ce que vous voulez que cet assistant retienne…",
+      "addCategoryLabel": "Catégorie de mémoire",
+      "addCategoryNone": "Aucune catégorie",
       "kindSemantic": "Fait",
       "kindEpisodic": "Événement",
       "importanceLow": "Importance : faible",

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -2581,6 +2581,8 @@
       "noSearchResults": "אין זיכרונות התואמים את החיפוש שלך.",
       "addMemory": "הוסף זיכרון",
       "addContentPlaceholder": "מה שתרצה שהעוזר הזה יזכור…",
+      "addCategoryLabel": "קטגוריית זיכרון",
+      "addCategoryNone": "ללא קטגוריה",
       "kindSemantic": "עובדה",
       "kindEpisodic": "אירוע",
       "importanceLow": "חשיבות: נמוכה",

--- a/src/renderer/src/i18n/id-ID/settings.json
+++ b/src/renderer/src/i18n/id-ID/settings.json
@@ -212,6 +212,8 @@
       "noSearchResults": "Tidak ada memori yang cocok dengan pencarian Anda.",
       "addMemory": "Tambah memori",
       "addContentPlaceholder": "Hal yang ingin Anda ingat oleh asisten ini…",
+      "addCategoryLabel": "Kategori memori",
+      "addCategoryNone": "Tanpa kategori",
       "kindSemantic": "Fakta",
       "kindEpisodic": "Peristiwa",
       "importanceLow": "Tingkat kepentingan: Rendah",

--- a/src/renderer/src/i18n/it-IT/settings.json
+++ b/src/renderer/src/i18n/it-IT/settings.json
@@ -212,6 +212,8 @@
       "noSearchResults": "Nessuna memoria corrisponde alla tua ricerca.",
       "addMemory": "Aggiungi memoria",
       "addContentPlaceholder": "Ciò che vuoi che questo assistente ricordi…",
+      "addCategoryLabel": "Categoria della memoria",
+      "addCategoryNone": "Nessuna categoria",
       "kindSemantic": "Fatto",
       "kindEpisodic": "Evento",
       "importanceLow": "Importanza: bassa",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -2581,6 +2581,8 @@
       "noSearchResults": "検索に一致するメモリはありません。",
       "addMemory": "メモリを追加",
       "addContentPlaceholder": "このアシスタントに覚えさせたい内容…",
+      "addCategoryLabel": "メモリカテゴリ",
+      "addCategoryNone": "カテゴリなし",
       "kindSemantic": "事実",
       "kindEpisodic": "出来事",
       "importanceLow": "重要度：低",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -2581,6 +2581,8 @@
       "noSearchResults": "검색과 일치하는 메모리가 없습니다.",
       "addMemory": "메모리 추가",
       "addContentPlaceholder": "이 어시스턴트가 기억하길 원하는 내용…",
+      "addCategoryLabel": "메모리 카테고리",
+      "addCategoryNone": "카테고리 없음",
       "kindSemantic": "사실",
       "kindEpisodic": "사건",
       "importanceLow": "중요도: 낮음",

--- a/src/renderer/src/i18n/ms-MY/settings.json
+++ b/src/renderer/src/i18n/ms-MY/settings.json
@@ -212,6 +212,8 @@
       "noSearchResults": "Tiada ingatan sepadan dengan carian anda.",
       "addMemory": "Tambah ingatan",
       "addContentPlaceholder": "Perkara yang anda mahu pembantu ini ingat…",
+      "addCategoryLabel": "Kategori memori",
+      "addCategoryNone": "Tiada kategori",
       "kindSemantic": "Fakta",
       "kindEpisodic": "Peristiwa",
       "importanceLow": "Kepentingan: Rendah",

--- a/src/renderer/src/i18n/pl-PL/settings.json
+++ b/src/renderer/src/i18n/pl-PL/settings.json
@@ -212,6 +212,8 @@
       "noSearchResults": "Brak wspomnień pasujących do wyszukiwania.",
       "addMemory": "Dodaj wspomnienie",
       "addContentPlaceholder": "Co ten asystent ma zapamiętać…",
+      "addCategoryLabel": "Kategoria pamięci",
+      "addCategoryNone": "Bez kategorii",
       "kindSemantic": "Fakt",
       "kindEpisodic": "Zdarzenie",
       "importanceLow": "Ważność: niska",

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -2581,6 +2581,8 @@
       "noSearchResults": "Nenhuma memória corresponde à sua busca.",
       "addMemory": "Adicionar memória",
       "addContentPlaceholder": "O que você quer que este assistente lembre…",
+      "addCategoryLabel": "Categoria da memória",
+      "addCategoryNone": "Sem categoria",
       "kindSemantic": "Fato",
       "kindEpisodic": "Evento",
       "importanceLow": "Importância: baixa",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -2581,6 +2581,8 @@
       "noSearchResults": "Нет воспоминаний, соответствующих запросу.",
       "addMemory": "Добавить воспоминание",
       "addContentPlaceholder": "Что этот ассистент должен запомнить…",
+      "addCategoryLabel": "Категория памяти",
+      "addCategoryNone": "Без категории",
       "kindSemantic": "Факт",
       "kindEpisodic": "Событие",
       "importanceLow": "Важность: низкая",

--- a/src/renderer/src/i18n/tr-TR/settings.json
+++ b/src/renderer/src/i18n/tr-TR/settings.json
@@ -212,6 +212,8 @@
       "noSearchResults": "Aramanızla eşleşen anı yok.",
       "addMemory": "Anı ekle",
       "addContentPlaceholder": "Bu asistanın hatırlamasını istediğiniz şey…",
+      "addCategoryLabel": "Bellek kategorisi",
+      "addCategoryNone": "Kategori yok",
       "kindSemantic": "Gerçek",
       "kindEpisodic": "Olay",
       "importanceLow": "Önem: Düşük",

--- a/src/renderer/src/i18n/vi-VN/settings.json
+++ b/src/renderer/src/i18n/vi-VN/settings.json
@@ -212,6 +212,8 @@
       "noSearchResults": "Không có ký ức nào khớp với tìm kiếm của bạn.",
       "addMemory": "Thêm ký ức",
       "addContentPlaceholder": "Nội dung bạn muốn trợ lý này ghi nhớ…",
+      "addCategoryLabel": "Danh mục bộ nhớ",
+      "addCategoryNone": "Không có danh mục",
       "kindSemantic": "Sự thật",
       "kindEpisodic": "Sự kiện",
       "importanceLow": "Mức độ quan trọng: Thấp",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -209,6 +209,8 @@
       "noSearchResults": "没有匹配的记忆。",
       "addMemory": "添加记忆",
       "addContentPlaceholder": "想让该助手记住的内容…",
+      "addCategoryLabel": "记忆分类",
+      "addCategoryNone": "不指定分类",
       "kindSemantic": "事实",
       "kindEpisodic": "事件",
       "importanceLow": "重要性：低",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -2581,6 +2581,8 @@
       "noSearchResults": "沒有符合的記憶。",
       "addMemory": "新增記憶",
       "addContentPlaceholder": "想讓此助手記住的內容…",
+      "addCategoryLabel": "記憶分類",
+      "addCategoryNone": "不指定分類",
       "kindSemantic": "事實",
       "kindEpisodic": "事件",
       "importanceLow": "重要性：低",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -2581,6 +2581,8 @@
       "noSearchResults": "沒有符合的記憶。",
       "addMemory": "新增記憶",
       "addContentPlaceholder": "想讓此助手記住的內容…",
+      "addCategoryLabel": "記憶分類",
+      "addCategoryNone": "不指定分類",
       "kindSemantic": "事實",
       "kindEpisodic": "事件",
       "importanceLow": "重要性：低",

--- a/test/renderer/api/clients.test.ts
+++ b/test/renderer/api/clients.test.ts
@@ -26,6 +26,8 @@ import { createWindowClient } from '../../../src/renderer/api/WindowClient'
 
 describe('renderer api clients', () => {
   function createBridge(): DeepchatBridge {
+    let addedMemoryCategory: unknown = null
+
     return {
       invoke: vi
         .fn()
@@ -982,6 +984,27 @@ describe('renderer api clients', () => {
               return { path: '/workspace' }
             case 'tools.listDefinitions':
               return { tools: [] }
+            case 'memory.add':
+              addedMemoryCategory = payload?.category ?? null
+              return { result: { action: 'created', memoryId: 'mem-added' } }
+            case 'memory.list':
+              return {
+                memories: [
+                  {
+                    id: 'mem-added',
+                    agentId: payload?.agentId ?? 'agent-1',
+                    kind: 'semantic',
+                    category: typeof addedMemoryCategory === 'string' ? addedMemoryCategory : null,
+                    content: 'repo uses pnpm',
+                    importance: 0.6,
+                    status: 'embedded',
+                    sourceSession: null,
+                    sourceEntryIds: null,
+                    supersededBy: null,
+                    createdAt: 1000
+                  }
+                ]
+              }
             default:
               return {}
           }
@@ -1241,6 +1264,12 @@ describe('renderer api clients', () => {
     await memoryClient.approvePersonaDraft('agent-1', 'draft-1')
     await memoryClient.rejectPersonaDraft('agent-1', 'draft-1')
     await memoryClient.setPersonaAnchor('agent-1', 'ver-1', true)
+    await memoryClient.add('agent-1', {
+      content: 'repo uses pnpm',
+      category: 'project_fact'
+    })
+    const categorizedMemories = await memoryClient.list('agent-1')
+    await memoryClient.add('agent-1', { content: 'plain note' })
     const off = memoryClient.onUpdated(vi.fn())
 
     expect(bridge.invoke).toHaveBeenNthCalledWith(1, 'memory.list', { agentId: 'agent-1' })
@@ -1276,6 +1305,22 @@ describe('renderer api clients', () => {
       agentId: 'agent-1',
       versionId: 'ver-1',
       anchored: true
+    })
+    expect(bridge.invoke).toHaveBeenNthCalledWith(12, 'memory.add', {
+      agentId: 'agent-1',
+      content: 'repo uses pnpm',
+      kind: undefined,
+      category: 'project_fact',
+      importance: undefined
+    })
+    expect(bridge.invoke).toHaveBeenNthCalledWith(13, 'memory.list', { agentId: 'agent-1' })
+    expect(categorizedMemories[0].category).toBe('project_fact')
+    expect(bridge.invoke).toHaveBeenNthCalledWith(14, 'memory.add', {
+      agentId: 'agent-1',
+      content: 'plain note',
+      kind: undefined,
+      category: undefined,
+      importance: undefined
     })
     expect(bridge.on).toHaveBeenCalledWith('memory.updated', expect.any(Function))
     expect(typeof off).toBe('function')

--- a/test/renderer/api/clients.test.ts
+++ b/test/renderer/api/clients.test.ts
@@ -1309,19 +1309,18 @@ describe('renderer api clients', () => {
     expect(bridge.invoke).toHaveBeenNthCalledWith(12, 'memory.add', {
       agentId: 'agent-1',
       content: 'repo uses pnpm',
-      kind: undefined,
       category: 'project_fact',
       importance: undefined
     })
+    expect(bridge.invoke.mock.calls[11][1]).not.toHaveProperty('kind')
     expect(bridge.invoke).toHaveBeenNthCalledWith(13, 'memory.list', { agentId: 'agent-1' })
     expect(categorizedMemories[0].category).toBe('project_fact')
     expect(bridge.invoke).toHaveBeenNthCalledWith(14, 'memory.add', {
       agentId: 'agent-1',
       content: 'plain note',
-      kind: undefined,
-      category: undefined,
       importance: undefined
     })
+    expect(bridge.invoke.mock.calls[13][1]).not.toHaveProperty('category')
     expect(bridge.on).toHaveBeenCalledWith('memory.updated', expect.any(Function))
     expect(typeof off).toBe('function')
   })

--- a/test/renderer/components/MemoryManagerDialog.test.ts
+++ b/test/renderer/components/MemoryManagerDialog.test.ts
@@ -213,11 +213,57 @@ const failedToast = {
   title: 'settings.deepchatAgents.memoryManager.actionFailed'
 }
 
+function findSelectByText(wrapper: Awaited<ReturnType<typeof setup>>['wrapper'], text: string) {
+  const select = wrapper
+    .findAllComponents({ name: 'Select' })
+    .find((item) => item.text().includes(text))
+  if (!select) throw new Error(`Missing select containing text: ${text}`)
+  return select
+}
+
 async function setCategoryFilter(
   wrapper: Awaited<ReturnType<typeof setup>>['wrapper'],
   value: string
 ): Promise<void> {
-  wrapper.findComponent({ name: 'Select' }).vm.$emit('update:modelValue', value)
+  findSelectByText(wrapper, 'settings.deepchatAgents.memoryManager.categoryFilterAll').vm.$emit(
+    'update:modelValue',
+    value
+  )
+  await nextTick()
+}
+
+async function openAddForm(wrapper: Awaited<ReturnType<typeof setup>>['wrapper']): Promise<void> {
+  const addButton = wrapper
+    .findAllComponents(ButtonStub)
+    .find((button) => button.text().includes('settings.deepchatAgents.memoryManager.addMemory'))
+  await addButton!.trigger('click')
+  await nextTick()
+}
+
+async function setAddCategory(
+  wrapper: Awaited<ReturnType<typeof setup>>['wrapper'],
+  value: string
+): Promise<void> {
+  findSelectByText(wrapper, 'settings.deepchatAgents.memoryManager.addCategoryNone').vm.$emit(
+    'update:modelValue',
+    value
+  )
+  await nextTick()
+}
+
+async function submitAddForm(wrapper: Awaited<ReturnType<typeof setup>>['wrapper']): Promise<void> {
+  const addButtons = wrapper
+    .findAllComponents(ButtonStub)
+    .filter((button) => button.text().includes('settings.deepchatAgents.memoryManager.addMemory'))
+  await addButtons[addButtons.length - 1].trigger('click')
+  await flushPromises()
+}
+
+async function cancelAddForm(wrapper: Awaited<ReturnType<typeof setup>>['wrapper']): Promise<void> {
+  const cancelButton = wrapper
+    .findAllComponents(ButtonStub)
+    .find((button) => button.text().includes('common.cancel'))
+  await cancelButton!.trigger('click')
   await nextTick()
 }
 
@@ -326,6 +372,77 @@ describe('MemoryManagerDialog category UI (PR-3)', () => {
     expect(memoryClient.search).toHaveBeenCalledWith('a', 'missing')
     expect(wrapper.text()).toContain('settings.deepchatAgents.memoryManager.noSearchResults')
     expect(wrapper.text()).not.toContain('settings.deepchatAgents.memoryManager.noCategoryResults')
+  })
+})
+
+describe('MemoryManagerDialog manual add category passthrough (#15)', () => {
+  it('keeps kind and omits category when adding with the default category', async () => {
+    const { wrapper, memoryClient } = await setup()
+
+    await openAddForm(wrapper)
+    await wrapper.find('textarea').setValue('plain note')
+    await submitAddForm(wrapper)
+
+    expect(memoryClient.add).toHaveBeenCalledWith('a', {
+      content: 'plain note',
+      kind: 'semantic',
+      category: undefined,
+      importance: 0.5
+    })
+  })
+
+  it('passes the selected category when adding a memory', async () => {
+    const { wrapper, memoryClient } = await setup()
+
+    await openAddForm(wrapper)
+    await wrapper.find('textarea').setValue('repo uses pnpm')
+    await setAddCategory(wrapper, 'project_fact')
+    expect(wrapper.text()).not.toContain('settings.deepchatAgents.memoryManager.kindSemantic')
+    await submitAddForm(wrapper)
+
+    expect(memoryClient.add).toHaveBeenCalledWith('a', {
+      content: 'repo uses pnpm',
+      kind: undefined,
+      category: 'project_fact',
+      importance: 0.5
+    })
+  })
+
+  it('lets the main process derive episodic kind for task outcome memories', async () => {
+    const { wrapper, memoryClient } = await setup()
+
+    await openAddForm(wrapper)
+    await wrapper.find('textarea').setValue('task finished')
+    await setAddCategory(wrapper, 'task_outcome')
+    await submitAddForm(wrapper)
+
+    expect(memoryClient.add).toHaveBeenCalledWith('a', {
+      content: 'task finished',
+      kind: undefined,
+      category: 'task_outcome',
+      importance: 0.5
+    })
+  })
+
+  it('omits category by default after the add form is reset', async () => {
+    const { wrapper, memoryClient } = await setup()
+
+    await openAddForm(wrapper)
+    await setAddCategory(wrapper, 'project_fact')
+    await cancelAddForm(wrapper)
+    await openAddForm(wrapper)
+    await wrapper.find('textarea').setValue('plain note')
+    await submitAddForm(wrapper)
+
+    expect(memoryClient.add).toHaveBeenCalledWith(
+      'a',
+      expect.objectContaining({
+        content: 'plain note',
+        kind: 'semantic',
+        importance: 0.5
+      })
+    )
+    expect(memoryClient.add.mock.calls[0][1].category).toBeUndefined()
   })
 })
 

--- a/test/renderer/components/MemoryManagerDialog.test.ts
+++ b/test/renderer/components/MemoryManagerDialog.test.ts
@@ -386,9 +386,9 @@ describe('MemoryManagerDialog manual add category passthrough (#15)', () => {
     expect(memoryClient.add).toHaveBeenCalledWith('a', {
       content: 'plain note',
       kind: 'semantic',
-      category: undefined,
       importance: 0.5
     })
+    expect(memoryClient.add.mock.calls[0][1]).not.toHaveProperty('category')
   })
 
   it('passes the selected category when adding a memory', async () => {
@@ -402,10 +402,10 @@ describe('MemoryManagerDialog manual add category passthrough (#15)', () => {
 
     expect(memoryClient.add).toHaveBeenCalledWith('a', {
       content: 'repo uses pnpm',
-      kind: undefined,
       category: 'project_fact',
       importance: 0.5
     })
+    expect(memoryClient.add.mock.calls[0][1]).not.toHaveProperty('kind')
   })
 
   it('lets the main process derive episodic kind for task outcome memories', async () => {
@@ -418,10 +418,10 @@ describe('MemoryManagerDialog manual add category passthrough (#15)', () => {
 
     expect(memoryClient.add).toHaveBeenCalledWith('a', {
       content: 'task finished',
-      kind: undefined,
       category: 'task_outcome',
       importance: 0.5
     })
+    expect(memoryClient.add.mock.calls[0][1]).not.toHaveProperty('kind')
   })
 
   it('omits category by default after the add form is reset', async () => {
@@ -442,7 +442,7 @@ describe('MemoryManagerDialog manual add category passthrough (#15)', () => {
         importance: 0.5
       })
     )
-    expect(memoryClient.add.mock.calls[0][1].category).toBeUndefined()
+    expect(memoryClient.add.mock.calls[0][1]).not.toHaveProperty('category')
   })
 })
 


### PR DESCRIPTION
Fixes manual memory add category passthrough and makes category the source of truth for kind derivation in the memory manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional memory category when creating a new memory.
  * Updated the add-memory form to support category selection, including the appropriate show/hide behavior and responsive layout.
  * Added localized labels for “Memory category” and “No category” across multiple languages.
* **Bug Fixes**
  * Ensured the correct combination of category vs kind is sent when saving memories.
  * Improved add-memory form reset so defaults return reliably after canceling/submitting.
* **Tests**
  * Expanded automated coverage for categorized vs uncategorized memory add/list flows and payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->