### PR TITLE
feat: scope plugins skills and MCP by agent

### DIFF
--- a/docs/architecture/agent-scoped-extensions/plan.md
+++ b/docs/architecture/agent-scoped-extensions/plan.md
@@ -1,0 +1,110 @@
+# Plan: Agent-scoped Plugins, Skills, and MCP
+
+## Current Findings
+
+- DeepChat agent 配置已落在 `AgentRepository` 的 `DeepChatAgentConfig` 中，包含模型、system prompt、工具禁用列表、subagent、memory 等。
+- 技能库由 `SkillPresenter` 管理，主目录和启停状态是全局的；会话级 active skills 通过 `conversationId/sessionId` 保存。
+- 运行时构建 prompt/tools 时会读取 `skillPresenter.getMetadataList()`、`getActiveSkills(sessionId)`、`loadSkillContent()`，并按 active skills 注入 prompt。
+- 插件由 `PluginPresenter` 管理，全局安装/启用，插件贡献 MCP server、skills、settings、tool policy 等资源。
+- MCP server 定义与全局 MCP 开关由 `McpPresenter` / `useMcpStore` 管理；`agent_mcp_selections` 当前经 `AcpConfHelper` 退化为 shared selections，主要服务 ACP/shared 语义，不是 DeepChat agent scope。
+- 设置页中技能已有“外部 agent”Tab（Claude/Codex 等技能目录扫描），但这不是 DeepChat agent 级配置。
+- commit `eb81a612df06f93c5407cdf3bbb8c5c6e5fc3a5b` 将 Official Plugins、MCP、Skills 放入主窗口 `/plugins` hub，但其规格明确“不重写 MCP、Skill、Remote、Plugin presenter / 不新增统一持久化表 / 不改变 MCP schema”，所以该提交完成的是入口与视图归集，不是 agent-scoped 数据拆分。
+- 当前临时修复把 `/plugins/skills` 与 `/plugins/mcp` 替换成 `AgentExtensionPolicyPanel`，会丢失添加 skill/server、市场和详情等原有管理能力；需要改为“视图不变、启停语义按 agent”。
+
+## Target Model
+
+Introduce per DeepChat agent extension policy on `DeepChatAgentConfig`:
+
+```ts
+interface DeepChatAgentConfig {
+  enabledPluginIds?: string[] | null
+  enabledSkillNames?: string[] | null
+  enabledMcpServerIds?: string[] | null
+}
+```
+
+Semantics:
+
+- Built-in `deepchat` stores the source policy.
+- Newly created manual DeepChat agents inherit built-in `deepchat` policy through the existing config merge model.
+- `null` / `undefined` means inherit from built-in `deepchat` for manual agents; for built-in `deepchat`, it means current compatible global behavior.
+- `[]` explicitly disables all plugins / skills / MCP servers for that agent.
+- Non-empty array is an allow-list by plugin id / skill name / MCP server id.
+
+## Implementation Approach
+
+1. Add typed config fields and normalization/merge support in shared agent types and `AgentRepository`.
+2. Add routes/API helpers to read and patch an agent's extension policy through existing `config.updateDeepChatAgent` unless dedicated routes are needed.
+3. Update MCP runtime resolution:
+   - store DeepChat agent MCP policy in `DeepChatAgentConfig.enabledMcpServerIds` or a dedicated DeepChat agent policy table; do not reuse ACP shared selections.
+   - filter normal MCP tools by session `agentId` before `McpPresenter`/`ToolManager` expose tool definitions.
+   - include `agentId` and enabled MCP server ids in tool-profile cache fingerprints.
+   - keep global MCP server definitions, marketplace, install, and global MCP enabled state intact.
+4. Update skill runtime resolution:
+   - derive `agentId` from session runtime state.
+   - filter skill metadata by agent enabled skill names before presenting `<available_skills>`.
+   - filter manually active/session active/runtime-activated skill names against the agent allow-list.
+   - enforce the same allow-list inside skill tools: `skill_list` must hide disabled skills and `skill_view` must reject disabled skill names.
+   - preserve existing message-level active skills but ignore unavailable skills for prompt/tool profile.
+5. Update tool/profile resolution:
+   - ensure skill-provided tools/scripts are unavailable when their skill is not enabled for the session agent.
+   - ensure plugin-contributed resources can be filtered by session agent policy.
+6. Update plugin handling:
+   - keep global plugin installation/update/trust as global lifecycle.
+   - split runtime enablement by DeepChat agent: plugin runtime instances and their contributed resources must be started/stopped for the selected agent scope.
+   - lifecycle is config-driven by `(agentId, pluginId)` enablement, not session reference-count driven.
+   - plugin-owned MCP follows plugin enablement: when an agent enables a plugin, that plugin's MCP servers are automatically in-scope for that agent and are not separately selected in the normal MCP selector.
+   - model runtime identity as `(agentId, pluginId)` so errors/statuses do not collapse across agents.
+   - expose per-agent enabled/available/runtime status in renderer model.
+7. Update UI while preserving existing page layouts:
+   - `/plugins` can keep a compact plugin policy editor alongside the plugin catalog.
+   - `/plugins/skills` renders the existing `SkillsSettings` view in `scope="agent"` mode. It still loads the full global skill library and supports add/install/detail/edit, but skill card switches and detail enable toggles patch only `enabledSkillNames` for the target DeepChat agent.
+   - `/plugins/mcp` renders the existing `McpSettings` view in `scope="agent"` mode. It still supports add server, marketplace, detail, tools/prompts/resources views, but server card switches patch only `enabledMcpServerIds` for the target DeepChat agent.
+   - Target agent resolution: active session `agentId` -> selected agent id -> `deepchat`.
+   - When an allow-list is absent and the user toggles one item, initialize from currently globally available items, then apply the requested toggle.
+   - Preserve hidden existing allow-list ids when saving to avoid dropping entries not currently rendered.
+8. Add tests for config normalization, runtime MCP filtering, runtime skill filtering, plugin-owned MCP scoping, and policy persistence.
+
+## Affected Interfaces
+
+- `src/shared/types/agent-interface.d.ts`
+- `src/main/presenter/agentRepository/index.ts`
+- `src/main/presenter/agentRuntimePresenter/index.ts`
+- `src/main/presenter/pluginPresenter/index.ts`
+- `src/main/presenter/skillPresenter/index.ts`
+- `src/main/presenter/mcpPresenter/index.ts`
+- `src/main/presenter/mcpPresenter/toolManager.ts`
+- `src/main/presenter/mcpPresenter/agentMcpFilter.ts`
+- `src/shared/contracts/routes/config.routes.ts` if adding dedicated policy routes
+- `src/renderer/api/ConfigClient.ts`
+- `src/renderer/settings/components/skills/SkillsSettings.vue`
+- `src/renderer/settings/components/McpSettings.vue`
+- `src/renderer/src/components/mcp-config/components/McpServers.vue`
+- `src/renderer/src/pages/plugins/SkillsPluginsPage.vue`
+- `src/renderer/src/pages/plugins/McpPluginsPage.vue`
+
+## Compatibility and Migration
+
+- No database schema migration is required if policy is stored in existing `agents.config_json`.
+- Existing sessions keep their stored `agentId`; runtime policy is resolved dynamically from that agent's current config.
+- Existing global skill/plugin/MCP definitions remain untouched.
+- Existing ACP shared MCP selections remain compatible, but must not be treated as DeepChat agent MCP policy.
+- If policy fields are absent, built-in `deepchat` behaves as before.
+
+## Test Strategy
+
+- Unit tests for `AgentRepository.resolveDeepChatAgentConfig()` merging policy fields.
+- Runtime tests or focused presenter tests to assert unavailable MCP servers/tools are not exposed and cannot be called for a DeepChat agent.
+- Runtime tests or focused presenter tests to assert unavailable skills are not shown in prompt and cannot be loaded as active skills.
+- Presenter tests for plugin-owned MCP scoped server naming/status and per-agent plugin runtime activation/deactivation.
+- Renderer/component tests:
+  - `SkillsSettings` in agent scope renders original controls and saves `enabledSkillNames` without global `setSkillDisabled`.
+  - `McpServers`/`McpSettings` in agent scope renders original controls and saves `enabledMcpServerIds` without global `toggleServer`.
+- Manual smoke: create two DeepChat agents, select different MCP/skills/plugins, switch sessions, inspect available skills/tool list and plugin-owned MCP status.
+
+## Validation Commands
+
+- `pnpm run format`
+- `pnpm run i18n`
+- `pnpm run lint`
+- Targeted tests if added or existing relevant suites are identified.

--- a/docs/architecture/agent-scoped-extensions/spec.md
+++ b/docs/architecture/agent-scoped-extensions/spec.md
@@ -1,0 +1,55 @@
+# Agent-scoped Plugins, Skills, and MCP
+
+## User Need
+
+当前插件、技能和 MCP 已经在导航/视图上被放进 Plugins / agent 相关入口，但底层数据仍主要是全局或 ACP/shared 维度：切换不同 DeepChat agent 后，看到和运行时使用的插件、技能、MCP server 没有按 DeepChat agent 隔离，只是 UI 视角做了拆分。
+
+用户进一步明确：Chat Plugins 下的 Skills 与 MCP 页面不应改成新的简化选择器视图。页面应保持原有 Skills/MCP 管理体验（搜索、添加、安装、市场、详情等），但在该入口里点击启用/禁用时，必须修改当前 DeepChat agent 的配置，而不是全局禁用同名 skill 或全局关闭同一个 MCP server。
+
+## Goal
+
+让 DeepChat agent 能拥有独立的插件、技能与 MCP 配置，并确保 UI 展示、运行时可用能力、提示词/工具装配与持久化状态使用同一份 agent-scoped 数据。
+
+Chat Plugins 入口的 Skills/MCP 子页需要复用原有管理视图，同时把“启用/禁用”解释为当前 agent 的 allow-list 编辑。
+
+## Acceptance Criteria
+
+1. 每个 DeepChat agent 可以独立配置可用技能集合。
+2. 每个 DeepChat agent 可以独立配置可用插件集合，并影响该 agent 的插件 runtime 生命周期。
+3. 每个 DeepChat agent 可以独立配置可用 MCP server 集合。
+4. 切换 agent 后，设置页展示该 agent 自己的插件/技能/MCP 启用状态，而不是只展示全局列表。
+5. 发起会话或继续会话时，运行时按会话绑定的 `agentId` 解析对应 agent 的插件/技能/MCP 配置。
+6. 保留现有全局插件安装、MCP server 定义、技能安装/导入目录、外部 agent 技能同步能力；agent-scoped 配置只决定 DeepChat agent 是否使用这些资源。
+7. 缺省兼容：已有用户升级后，内置 `deepchat` agent 继续拥有当前全局行为，其他 agent 继承内置 `deepchat` 的配置。
+8. 设置页避免把“外部工具 agent（Claude/Codex 等技能目录同步）”、ACP shared MCP selections 和“DeepChat agent 配置”混为同一个作用域。
+9. `/plugins/skills` 保持原有 Skills 管理页面形态，仍可添加/安装/查看/编辑 skill；该页切换 skill 时只写当前 DeepChat agent 的 `enabledSkillNames`，不得调用全局 `setSkillDisabled`。
+10. `/plugins/mcp` 保持原有 MCP 管理页面形态，仍可添加 server、进入市场、查看详情；该页切换 server 时只写当前 DeepChat agent 的 `enabledMcpServerIds`，不得调用全局 `toggleServer`。
+11. Skills/MCP agent-scoped 页面进入时按当前会话 `agentId` 优先，其次当前选中的 agent，最后 `deepchat` 查询 agent 配置。
+12. 运行时 skill discovery/view 工具必须受当前 DeepChat agent 的 `enabledSkillNames` 约束；agent 禁用的 skill 不应出现在 `skill_list`，也不能被 `skill_view` 读取。
+
+## Constraints
+
+- 不降低现有插件信任、安装、运行时权限、安全校验。
+- 不把插件安装状态复制到每个 agent；安装/更新/信任仍是全局资源生命周期，但运行时启用按 agent 拆分。
+- 不复制 MCP server 定义到每个 agent；MCP server 配置仍是全局资源，agent 只保存选择/启用策略。
+- 不复制技能文件到每个 agent；技能文件库仍是全局资源，agent 只保存选择/启用策略。
+- 不破坏现有会话级 active skills：用户消息或工具临时激活的 skill 仍可作为本轮上下文状态，但必须受 agent 可用集合约束。
+- 遵循现有 Presenter、typed route contracts、renderer API client 与 Vue 组件模式。
+- Skills/MCP 原有管理能力（添加、详情、市场、安装等）仍是全局资源管理；仅启用/禁用状态在 Chat Plugins agent-scoped 入口下改为 agent allow-list。
+
+## Non-goals
+
+- 不实现插件市场、多源插件安装或插件沙箱重构。
+- 不改变第三方外部工具的技能目录格式。
+- 不迁移或删除当前全局技能库、插件安装库。
+- 不把 ACP agent 的外部运行时插件化。
+- 不重做 Skills/MCP 页面布局或替换为简化策略面板。
+
+## Decisions
+
+- 插件 agent-scoped 行为需要覆盖插件 runtime 生命周期：插件进程也应按 DeepChat agent 启停，而不是只在运行时过滤贡献能力。
+- 插件 runtime 生命周期按 agent 配置启用/禁用管理，不按单会话引用计数管理。
+- 插件贡献的 MCP server 只跟随插件启用；某 agent 启用插件后，该插件 owned MCP 自动属于该 agent，不再要求额外进入 MCP 选择列表。
+- MCP 也需要纳入 DeepChat agent scope；现有 ACP/shared MCP selections 不能代表 DeepChat agent 的 MCP 配置。
+- 新建 DeepChat agent 默认继承内置 `deepchat` agent 的插件/技能/MCP 配置。
+- Chat Plugins 的 Skills/MCP 页面复用原有管理 UI；通过 scope prop 切换保存语义，避免用户失去添加 skill/server 等原有入口。

--- a/docs/architecture/agent-scoped-extensions/tasks.md
+++ b/docs/architecture/agent-scoped-extensions/tasks.md
@@ -16,3 +16,4 @@
 - [x] Add or update tests.
 - [x] Run `pnpm run format`, `pnpm run i18n`, `pnpm run lint`, `pnpm run typecheck:web`, and targeted Vitest suites after the latest UI-scope correction.
 - [x] Address review findings: preserve undefined MCP/plugin runtime policies, respect the global MCP master switch in agent pages, use effective agent config in management views, keep skill detail state fresh, allow agent-scoped toggles for DeepChat-managed MCP servers, and enforce `enabledSkillNames` for `skill_list`/`skill_view`.
+- [x] Address review hardening for plugin-sourced MCP ownership, stale agent policy loads, and omitted active-skill overrides.

--- a/docs/architecture/agent-scoped-extensions/tasks.md
+++ b/docs/architecture/agent-scoped-extensions/tasks.md
@@ -15,4 +15,4 @@
 - [x] Update i18n strings.
 - [x] Add or update tests.
 - [x] Run `pnpm run format`, `pnpm run i18n`, `pnpm run lint`, `pnpm run typecheck:web`, and targeted Vitest suites after the latest UI-scope correction.
-- [x] Address review findings: preserve undefined MCP/plugin runtime policies, respect the global MCP master switch in agent pages, use effective agent config in management views, keep skill detail state fresh, and allow agent-scoped toggles for DeepChat-managed MCP servers.
+- [x] Address review findings: preserve undefined MCP/plugin runtime policies, respect the global MCP master switch in agent pages, use effective agent config in management views, keep skill detail state fresh, allow agent-scoped toggles for DeepChat-managed MCP servers, and enforce `enabledSkillNames` for `skill_list`/`skill_view`.

--- a/docs/architecture/agent-scoped-extensions/tasks.md
+++ b/docs/architecture/agent-scoped-extensions/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: Agent-scoped Plugins, Skills, and MCP
+
+- [x] Inspect current plugin, skill, MCP, and DeepChat agent architecture.
+- [x] Create SDD artifacts for agent-scoped extension architecture.
+- [x] Resolve open questions about plugin runtime boundary and new-agent defaults.
+- [x] Extend DeepChat agent config types with plugin/skill/MCP policy fields.
+- [x] Normalize/merge policy fields in `AgentRepository`.
+- [x] Filter runtime MCP tools/servers by session agent policy and enforce call-time allow-list checks.
+- [x] Filter runtime skill catalog and active skill loading by session agent policy.
+- [ ] Split plugin-contributed runtime resources and plugin-owned MCP servers by session agent policy.
+- [x] Add renderer client/helpers for reading and saving selected agent policies.
+- [x] Add chat plugin hub UI for per-agent plugin/skill/MCP selection.
+- [x] Keep `/plugins/skills` on the original Skills management view while making enable/disable update only the current agent.
+- [x] Keep `/plugins/mcp` on the original MCP management view while making server enable/disable update only the current agent.
+- [x] Update i18n strings.
+- [x] Add or update tests.
+- [x] Run `pnpm run format`, `pnpm run i18n`, `pnpm run lint`, `pnpm run typecheck:web`, and targeted Vitest suites after the latest UI-scope correction.
+- [x] Address review findings: preserve undefined MCP/plugin runtime policies, respect the global MCP master switch in agent pages, use effective agent config in management views, keep skill detail state fresh, and allow agent-scoped toggles for DeepChat-managed MCP servers.

--- a/src/main/presenter/agentRepository/index.ts
+++ b/src/main/presenter/agentRepository/index.ts
@@ -64,6 +64,24 @@ const sanitizeString = (value?: string | null): string | null => {
 
 const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
 
+const normalizeNullableStringList = (
+  value: string[] | null | undefined
+): string[] | null | undefined => {
+  if (value === null || value === undefined) {
+    return value
+  }
+
+  const normalized = Array.from(
+    new Set(value.map((item) => (typeof item === 'string' ? item.trim() : '')).filter(Boolean))
+  )
+  return normalized
+}
+
+const mergeNullableStringList = (
+  baseValue: string[] | null | undefined,
+  overrideValue: string[] | null | undefined
+): string[] | null | undefined => normalizeNullableStringList(overrideValue ?? baseValue)
+
 const mergeDeepChatConfig = (
   baseConfig: DeepChatAgentConfig,
   overrideConfig: DeepChatAgentConfig
@@ -78,6 +96,18 @@ const mergeDeepChatConfig = (
     systemPrompt: overrideConfig.systemPrompt ?? baseConfig.systemPrompt ?? '',
     permissionMode: overrideConfig.permissionMode ?? baseConfig.permissionMode ?? 'full_access',
     disabledAgentTools: overrideConfig.disabledAgentTools ?? baseConfig.disabledAgentTools ?? [],
+    enabledPluginIds: mergeNullableStringList(
+      baseConfig.enabledPluginIds,
+      overrideConfig.enabledPluginIds
+    ),
+    enabledSkillNames: mergeNullableStringList(
+      baseConfig.enabledSkillNames,
+      overrideConfig.enabledSkillNames
+    ),
+    enabledMcpServerIds: mergeNullableStringList(
+      baseConfig.enabledMcpServerIds,
+      overrideConfig.enabledMcpServerIds
+    ),
     subagentEnabled: overrideConfig.subagentEnabled ?? baseConfig.subagentEnabled ?? true,
     subagents:
       overrideConfig.subagents ?? baseConfig.subagents ?? createDefaultDeepChatSubagentSlots(),

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -196,6 +196,12 @@ type ResumeBudgetToolCall = {
   offloadPath?: string
 }
 
+type AgentExtensionPolicy = {
+  enabledPluginIds?: string[] | null
+  enabledSkillNames?: string[] | null
+  enabledMcpServerIds?: string[] | null
+}
+
 type PackageJsonManifest = {
   name?: unknown
   scripts?: Record<string, unknown>
@@ -3427,6 +3433,10 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         hooks: {
           getActiveSkillNames: () => getEffectiveRuntimeSkillNames(),
           activateSkill: async (skillName) => {
+            const policy = await this.resolveAgentExtensionPolicy(sessionId)
+            if (this.filterSkillNamesByPolicy([skillName], policy).length === 0) {
+              return getEffectiveRuntimeSkillNames()
+            }
             await this.activateRuntimeSkill(sessionId, skillName)
             return getEffectiveRuntimeSkillNames()
           },
@@ -4210,6 +4220,16 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     const skillDraftSuggestionsEnabled =
       this.configPresenter.getSkillDraftSuggestionsEnabled?.() ?? false
 
+    const extensionPolicy = await this.resolveAgentExtensionPolicy(sessionId)
+    const allowedSkillNameSet =
+      extensionPolicy.enabledSkillNames === null || extensionPolicy.enabledSkillNames === undefined
+        ? null
+        : new Set(this.normalizeSkillNames(extensionPolicy.enabledSkillNames))
+    const allowedPluginIdSet =
+      extensionPolicy.enabledPluginIds === null || extensionPolicy.enabledPluginIds === undefined
+        ? null
+        : new Set(this.normalizeSkillNames(extensionPolicy.enabledPluginIds))
+
     if (skillsEnabled && skillPresenter) {
       if (skillPresenter.getMetadataList) {
         const stepStartedAt = Date.now()
@@ -4217,7 +4237,12 @@ export class AgentRuntimePresenter implements IAgentImplementation {
           const metadataList = await skillPresenter.getMetadataList()
           for (const metadata of metadataList) {
             const skillName = metadata?.name?.trim()
-            if (skillName) {
+            const ownerPluginId = metadata?.ownerPluginId?.trim()
+            if (
+              skillName &&
+              (!allowedSkillNameSet || allowedSkillNameSet.has(skillName)) &&
+              (!ownerPluginId || !allowedPluginIdSet || allowedPluginIdSet.has(ownerPluginId))
+            ) {
               availableSkills.push({
                 name: skillName,
                 description: metadata.description?.trim() || '',
@@ -4258,8 +4283,9 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     let stepStartedAt = Date.now()
     const normalizedAvailableSkills = this.normalizeSkillMetadata(availableSkills)
     const availableSkillNames = new Set(normalizedAvailableSkills.map((skill) => skill.name))
-    const normalizedActiveSkills = this.normalizeSkillNames(
-      activeSkillNames.filter((skillName) => availableSkillNames.has(skillName))
+    const normalizedActiveSkills = this.filterSkillNamesByPolicy(
+      activeSkillNames.filter((skillName) => availableSkillNames.has(skillName)),
+      extensionPolicy
     )
     const agentToolNames = this.getAgentToolNames(toolDefinitions)
     const fingerprint = this.buildSystemPromptFingerprint({
@@ -6030,7 +6056,11 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       deferredAbortController?.signal ?? this.getAbortSignalForSession(sessionId)
 
     try {
+      const extensionPolicy = await this.resolveAgentExtensionPolicy(sessionId)
       const result = await this.toolPresenter.callTool(request, {
+        agentId: this.getSessionAgentId(sessionId) ?? 'deepchat',
+        enabledMcpServerIds: extensionPolicy.enabledMcpServerIds ?? undefined,
+        enabledPluginIds: extensionPolicy.enabledPluginIds ?? undefined,
         onProgress: (update) => {
           if (
             update.kind !== 'subagent_orchestrator' ||
@@ -6156,7 +6186,18 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     }
 
     try {
-      const profile = await this.resolveToolProfile(sessionId, projectDir, activeSkillNamesOverride)
+      const agentId = this.getSessionAgentId(sessionId) ?? 'deepchat'
+      const policy = await this.resolveAgentExtensionPolicy(sessionId)
+      const effectiveActiveSkillNames =
+        activeSkillNamesOverride === undefined
+          ? await this.resolveActiveSkillNamesForToolProfile(sessionId)
+          : this.filterSkillNamesByPolicy(activeSkillNamesOverride, policy)
+      const profile = await this.resolveToolProfile(
+        sessionId,
+        projectDir,
+        effectiveActiveSkillNames,
+        policy
+      )
       const cachedProfile = this.toolProfileCache.get(sessionId)
       if (
         cachedProfile &&
@@ -6171,11 +6212,14 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       }
 
       const tools = await this.toolPresenter.getAllToolDefinitions({
+        agentId,
+        enabledMcpServerIds: policy.enabledMcpServerIds ?? undefined,
+        enabledPluginIds: policy.enabledPluginIds ?? undefined,
         disabledAgentTools: this.getDisabledAgentTools(sessionId),
         chatMode: 'agent',
         conversationId: sessionId,
         agentWorkspacePath: projectDir,
-        activeSkillNames: activeSkillNamesOverride
+        activeSkillNames: effectiveActiveSkillNames
       })
 
       this.toolProfileCache.set(sessionId, {
@@ -6194,20 +6238,26 @@ export class AgentRuntimePresenter implements IAgentImplementation {
   private async resolveToolProfile(
     sessionId: string,
     projectDir: string | null,
-    activeSkillNamesOverride?: string[]
+    activeSkillNamesOverride?: string[],
+    extensionPolicy?: AgentExtensionPolicy
   ): Promise<{ kind: ToolProfileKind; fingerprint: string }> {
     const normalizedProjectDir = projectDir?.trim() || null
     const skillsEnabled = this.configPresenter.getSkillsEnabled()
-    const activeSkillNames =
-      activeSkillNamesOverride ?? (await this.resolveActiveSkillNamesForToolProfile(sessionId))
+    const policy = extensionPolicy ?? (await this.resolveAgentExtensionPolicy(sessionId))
+    const activeSkillNames = this.filterSkillNamesByPolicy(
+      activeSkillNamesOverride ?? (await this.resolveActiveSkillNamesForToolProfile(sessionId)),
+      policy
+    )
     const disabledAgentTools = this.getDisabledAgentTools(sessionId)
     const state = this.runtimeState.get(sessionId)
+    const agentId = this.getSessionAgentId(sessionId) ?? 'deepchat'
     const kind: ToolProfileKind = normalizedProjectDir ? 'code' : 'general'
 
     return {
       kind,
       fingerprint: JSON.stringify({
         kind,
+        agentId,
         projectDir: normalizedProjectDir ?? '',
         providerId: state?.providerId ?? '',
         modelId: state?.modelId ?? '',
@@ -6215,6 +6265,9 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         disabledAgentTools: [...disabledAgentTools].sort((left, right) =>
           left.localeCompare(right)
         ),
+        enabledMcpServerIds: this.normalizeNullablePolicyList(policy.enabledMcpServerIds),
+        enabledPluginIds: this.normalizeNullablePolicyList(policy.enabledPluginIds),
+        enabledSkillNames: this.normalizeNullablePolicyList(policy.enabledSkillNames),
         skillsEnabled,
         activeSkillNames
       })
@@ -6227,7 +6280,11 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     }
 
     try {
-      return this.normalizeSkillNames(await this.skillPresenter.getActiveSkills(sessionId))
+      const policy = await this.resolveAgentExtensionPolicy(sessionId)
+      return this.filterSkillNamesByPolicy(
+        this.normalizeSkillNames(await this.skillPresenter.getActiveSkills(sessionId)),
+        policy
+      )
     } catch (error) {
       console.warn(
         `[DeepChatAgent] Failed to load active skills for tool profile in session ${sessionId}:`,
@@ -6235,6 +6292,48 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       )
       return []
     }
+  }
+
+  private async resolveAgentExtensionPolicy(sessionId: string): Promise<AgentExtensionPolicy> {
+    const agentId = this.getSessionAgentId(sessionId) ?? 'deepchat'
+    if (typeof this.configPresenter.resolveDeepChatAgentConfig !== 'function') {
+      return {}
+    }
+
+    try {
+      const config = await this.configPresenter.resolveDeepChatAgentConfig(agentId)
+      return {
+        enabledPluginIds: config.enabledPluginIds,
+        enabledSkillNames: config.enabledSkillNames,
+        enabledMcpServerIds: config.enabledMcpServerIds
+      }
+    } catch (error) {
+      console.warn(
+        `[DeepChatAgent] Failed to resolve extension policy for agent ${agentId}:`,
+        error
+      )
+      return {}
+    }
+  }
+
+  private normalizeNullablePolicyList(value?: string[] | null): string[] | null | undefined {
+    if (value === null || value === undefined) {
+      return value
+    }
+    return this.normalizeSkillNames(value)
+  }
+
+  private filterSkillNamesByPolicy(
+    skillNames: string[] | undefined,
+    policy: AgentExtensionPolicy
+  ): string[] {
+    const normalizedSkillNames = this.normalizeSkillNames(skillNames ?? [])
+    if (policy.enabledSkillNames === null || policy.enabledSkillNames === undefined) {
+      return normalizedSkillNames
+    }
+
+    const allowed = new Set(this.normalizeSkillNames(policy.enabledSkillNames))
+    return normalizedSkillNames.filter((skillName) => allowed.has(skillName))
   }
 
   private getDisabledAgentTools(sessionId: string): string[] {

--- a/src/main/presenter/mcpPresenter/index.ts
+++ b/src/main/presenter/mcpPresenter/index.ts
@@ -24,6 +24,36 @@ import { presenter } from '@/presenter'
 import { publishDeepchatEvent } from '@/routes/publishDeepchatEvent'
 import { extractToolCallImagePreviews } from '@/lib/toolCallImagePreviews'
 
+type McpToolAccessContext = {
+  enabledTools?: string[]
+  enabledServerIds?: string[]
+  enabledPluginIds?: string[]
+  agentId?: string
+  conversationId?: string
+}
+
+const normalizeStringList = (items?: string[]): string[] | undefined => {
+  if (!Array.isArray(items)) {
+    return undefined
+  }
+  return Array.from(new Set(items.map((item) => item.trim()).filter(Boolean)))
+}
+
+const normalizeToolAccessContext = (
+  input?: string[] | McpToolAccessContext
+): McpToolAccessContext => {
+  if (Array.isArray(input)) {
+    return { enabledTools: normalizeStringList(input) }
+  }
+  return {
+    enabledTools: normalizeStringList(input?.enabledTools),
+    enabledServerIds: normalizeStringList(input?.enabledServerIds),
+    enabledPluginIds: normalizeStringList(input?.enabledPluginIds),
+    agentId: input?.agentId?.trim() || undefined,
+    conversationId: input?.conversationId?.trim() || undefined
+  }
+}
+
 // Complete McpPresenter implementation
 export class McpPresenter implements IMCPPresenter {
   private serverManager: ServerManager
@@ -85,6 +115,19 @@ export class McpPresenter implements IMCPPresenter {
   private async isPluginOwnedServerName(serverName: string): Promise<boolean> {
     const servers = await this.configPresenter.getMcpServers()
     return this.isPluginOwnedServerConfig(servers[serverName])
+  }
+
+  private isServerAllowedByContext(
+    serverName: string,
+    serverConfig: MCPServerConfig | undefined,
+    context: McpToolAccessContext
+  ): boolean {
+    const ownerPluginId = serverConfig?.ownerPluginId?.trim()
+    if (ownerPluginId) {
+      return !context.enabledPluginIds || context.enabledPluginIds.includes(ownerPluginId)
+    }
+
+    return !context.enabledServerIds || context.enabledServerIds.includes(serverName)
   }
 
   async initialize() {
@@ -475,14 +518,20 @@ export class McpPresenter implements IMCPPresenter {
     return this.serverManager.getServerLastError(serverName)
   }
 
-  async getAllToolDefinitions(enabledMcpTools?: string[]): Promise<MCPToolDefinition[]> {
+  async getAllToolDefinitions(
+    enabledMcpTools?: string[] | McpToolAccessContext
+  ): Promise<MCPToolDefinition[]> {
+    const context = normalizeToolAccessContext(enabledMcpTools)
     const enabled = await this.configPresenter.getMcpEnabled()
-    const tools = await this.toolManager.getAllToolDefinitions(enabledMcpTools)
-    if (enabled) {
-      return tools
-    }
+    const tools = await this.toolManager.getAllToolDefinitions(context)
     const servers = await this.configPresenter.getMcpServers()
-    return tools.filter((tool) => this.isPluginOwnedServerConfig(servers[tool.server.name]))
+    return tools.filter((tool) => {
+      const serverConfig = servers[tool.server.name]
+      if (!enabled && !this.isPluginOwnedServerConfig(serverConfig)) {
+        return false
+      }
+      return this.isServerAllowedByContext(tool.server.name, serverConfig, context)
+    })
   }
 
   /**
@@ -566,8 +615,11 @@ export class McpPresenter implements IMCPPresenter {
     return resourcesList
   }
 
-  async callTool(request: MCPToolCall): Promise<{ content: string; rawData: MCPToolResponse }> {
-    const toolCallResult = await this.toolManager.callTool(request)
+  async callTool(
+    request: MCPToolCall,
+    options?: { agentId?: string; enabledServerIds?: string[]; enabledPluginIds?: string[] }
+  ): Promise<{ content: string; rawData: MCPToolResponse }> {
+    const toolCallResult = await this.toolManager.callTool(request, options)
     const imagePreviews = await extractToolCallImagePreviews({
       toolName: request.function.name,
       toolArgs: request.function.arguments,
@@ -628,7 +680,10 @@ export class McpPresenter implements IMCPPresenter {
    * Pre-check tool permissions without executing the tool
    * Delegates to ToolManager for the actual permission check
    */
-  async preCheckToolPermission(request: MCPToolCall): Promise<{
+  async preCheckToolPermission(
+    request: MCPToolCall,
+    options?: { agentId?: string; enabledServerIds?: string[]; enabledPluginIds?: string[] }
+  ): Promise<{
     needsPermission: true
     toolName: string
     serverName: string
@@ -644,7 +699,7 @@ export class McpPresenter implements IMCPPresenter {
       baseCommand?: string
     }
   } | null> {
-    return await this.toolManager.preCheckToolPermission(request)
+    return await this.toolManager.preCheckToolPermission(request, options)
   }
 
   async handleSamplingRequest(request: McpSamplingRequestPayload): Promise<McpSamplingDecision> {

--- a/src/main/presenter/mcpPresenter/index.ts
+++ b/src/main/presenter/mcpPresenter/index.ts
@@ -122,7 +122,9 @@ export class McpPresenter implements IMCPPresenter {
     serverConfig: MCPServerConfig | undefined,
     context: McpToolAccessContext
   ): boolean {
-    const ownerPluginId = serverConfig?.ownerPluginId?.trim()
+    const ownerPluginId =
+      serverConfig?.ownerPluginId?.trim() ||
+      (serverConfig?.source === 'plugin' ? serverConfig.sourceId?.trim() : undefined)
     if (ownerPluginId) {
       return !context.enabledPluginIds || context.enabledPluginIds.includes(ownerPluginId)
     }

--- a/src/main/presenter/mcpPresenter/toolManager.ts
+++ b/src/main/presenter/mcpPresenter/toolManager.ts
@@ -21,6 +21,36 @@ import { publishDeepchatEvent } from '@/routes/publishDeepchatEvent'
 
 const CUA_PLUGIN_ID = 'com.deepchat.plugins.cua'
 
+type McpToolAccessContext = {
+  enabledTools?: string[]
+  enabledServerIds?: string[]
+  enabledPluginIds?: string[]
+  agentId?: string
+  conversationId?: string
+}
+
+const normalizeStringList = (items?: string[]): string[] | undefined => {
+  if (!Array.isArray(items)) {
+    return undefined
+  }
+  return Array.from(new Set(items.map((item) => item.trim()).filter(Boolean)))
+}
+
+const normalizeToolAccessContext = (
+  input?: string[] | McpToolAccessContext
+): McpToolAccessContext => {
+  if (Array.isArray(input)) {
+    return { enabledTools: normalizeStringList(input) }
+  }
+  return {
+    enabledTools: normalizeStringList(input?.enabledTools),
+    enabledServerIds: normalizeStringList(input?.enabledServerIds),
+    enabledPluginIds: normalizeStringList(input?.enabledPluginIds),
+    agentId: input?.agentId?.trim() || undefined,
+    conversationId: input?.conversationId?.trim() || undefined
+  }
+}
+
 export class ToolManager {
   private configPresenter: IConfigPresenter
   private serverManager: ServerManager
@@ -71,17 +101,12 @@ export class ToolManager {
     return this.serverManager.getRunningClients()
   }
   // Get all tool definitions
-  public async getAllToolDefinitions(enabledTools?: string[]): Promise<MCPToolDefinition[]> {
+  public async getAllToolDefinitions(
+    access?: string[] | McpToolAccessContext
+  ): Promise<MCPToolDefinition[]> {
+    const context = normalizeToolAccessContext(access)
     if (this.cachedToolDefinitions !== null && this.cachedToolDefinitions.length > 0) {
-      if (enabledTools) {
-        const enabledSet = new Set(enabledTools)
-        return this.cachedToolDefinitions.filter((toolDef) => {
-          const finalName = toolDef.function.name
-          const originalName = this.toolNameToTargetMap?.get(finalName)?.originalName || finalName
-          return enabledSet.has(finalName) || enabledSet.has(originalName)
-        })
-      }
-      return this.cachedToolDefinitions
+      return this.filterToolDefinitionsByContext(this.cachedToolDefinitions, context)
     }
 
     console.info('Fetching/refreshing tool definitions and target map...')
@@ -242,16 +267,59 @@ export class ToolManager {
     this.cachedToolDefinitions = results
     console.info(`Cached ${results.length} final tool definitions and populated target map.`)
 
-    if (enabledTools && enabledTools.length > 0) {
-      const enabledSet = new Set(enabledTools)
-      return this.cachedToolDefinitions.filter((toolDef) => {
-        const finalName = toolDef.function.name
-        const originalName = this.toolNameToTargetMap?.get(finalName)?.originalName || finalName
-        return enabledSet.has(finalName) || enabledSet.has(originalName)
-      })
+    return this.filterToolDefinitionsByContext(this.cachedToolDefinitions, context)
+  }
+
+  private filterToolDefinitionsByContext(
+    toolDefinitions: MCPToolDefinition[],
+    context: McpToolAccessContext
+  ): MCPToolDefinition[] {
+    if (!context.enabledTools && !context.enabledServerIds && !context.enabledPluginIds) {
+      return toolDefinitions
     }
 
-    return this.cachedToolDefinitions
+    return toolDefinitions.filter((toolDef) => {
+      const finalName = toolDef.function.name
+      const target = this.toolNameToTargetMap?.get(finalName)
+      const originalName = target?.originalName || finalName
+      if (
+        context.enabledTools &&
+        !context.enabledTools.includes(finalName) &&
+        !context.enabledTools.includes(originalName)
+      ) {
+        return false
+      }
+      return this.isServerAllowedByContext(toolDef.server.name, context)
+    })
+  }
+
+  private isServerAllowedByContext(serverName: string, context: McpToolAccessContext): boolean {
+    const serverConfig = this.getServerConfigFromTargetMap(serverName)
+    if (!serverConfig) {
+      return !context.enabledServerIds || context.enabledServerIds.includes(serverName)
+    }
+    return this.isServerConfigAllowedByContext(serverName, serverConfig, context)
+  }
+
+  private isServerConfigAllowedByContext(
+    serverName: string,
+    serverConfig: MCPServerConfig,
+    context: McpToolAccessContext
+  ): boolean {
+    const ownerPluginId = serverConfig.ownerPluginId?.trim()
+    if (ownerPluginId) {
+      return !context.enabledPluginIds || context.enabledPluginIds.includes(ownerPluginId)
+    }
+    return !context.enabledServerIds || context.enabledServerIds.includes(serverName)
+  }
+
+  private getServerConfigFromTargetMap(serverName: string): MCPServerConfig | undefined {
+    for (const target of this.toolNameToTargetMap?.values() ?? []) {
+      if (target.client.serverName === serverName) {
+        return target.client.serverConfig as unknown as MCPServerConfig
+      }
+    }
+    return undefined
   }
 
   // 确定权限类型的新方法
@@ -393,7 +461,10 @@ export class ToolManager {
    * Pre-check tool permissions without executing the tool
    * Returns permission requirement info if permission is needed, null if already has permission
    */
-  async preCheckToolPermission(toolCall: MCPToolCall): Promise<{
+  async preCheckToolPermission(
+    toolCall: MCPToolCall,
+    access?: Pick<McpToolAccessContext, 'agentId' | 'enabledServerIds' | 'enabledPluginIds'>
+  ): Promise<{
     needsPermission: true
     toolName: string
     serverName: string
@@ -432,6 +503,18 @@ export class ToolManager {
     // Get server config to check auto-approve settings
     const servers = await this.configPresenter.getMcpServers()
     const serverConfig = servers[toolServerName]
+    const accessContext = normalizeToolAccessContext({
+      agentId: access?.agentId,
+      enabledServerIds: access?.enabledServerIds,
+      enabledPluginIds: access?.enabledPluginIds,
+      conversationId: toolCall.conversationId
+    })
+    if (
+      serverConfig &&
+      !this.isServerConfigAllowedByContext(toolServerName, serverConfig, accessContext)
+    ) {
+      return null
+    }
     const autoApprove = serverConfig?.autoApprove || []
     const pluginPolicy = getPluginToolPolicy(toolServerName, originalName)
 
@@ -461,7 +544,10 @@ export class ToolManager {
     }
   }
 
-  async callTool(toolCall: MCPToolCall): Promise<MCPToolResponse> {
+  async callTool(
+    toolCall: MCPToolCall,
+    access?: Pick<McpToolAccessContext, 'agentId' | 'enabledServerIds' | 'enabledPluginIds'>
+  ): Promise<MCPToolResponse> {
     try {
       const finalName = toolCall.function.name
       const argsString = toolCall.function.arguments
@@ -498,6 +584,12 @@ export class ToolManager {
 
       const { client: targetClient, originalName } = targetInfo
       const toolServerName = targetClient.serverName
+      const accessContext = normalizeToolAccessContext({
+        agentId: access?.agentId,
+        enabledServerIds: access?.enabledServerIds,
+        enabledPluginIds: access?.enabledPluginIds,
+        conversationId: toolCall.conversationId
+      })
       const hintedProviderId = toolCall.providerId?.trim()
       const shouldResolveAcpContext =
         Boolean(toolCall.conversationId) && (!hintedProviderId || hintedProviderId === 'acp')
@@ -564,6 +656,13 @@ export class ToolManager {
         return {
           toolCallId: toolCall.id,
           content: `Error: Configuration missing for server '${toolServerName}'.`,
+          isError: true
+        }
+      }
+      if (!this.isServerConfigAllowedByContext(toolServerName, serverConfig, accessContext)) {
+        return {
+          toolCallId: toolCall.id,
+          content: `MCP server '${toolServerName}' is not allowed for DeepChat agent '${accessContext.agentId ?? 'unknown'}'. Configure MCP access in DeepChat agent settings.`,
           isError: true
         }
       }

--- a/src/main/presenter/mcpPresenter/toolManager.ts
+++ b/src/main/presenter/mcpPresenter/toolManager.ts
@@ -306,7 +306,9 @@ export class ToolManager {
     serverConfig: MCPServerConfig,
     context: McpToolAccessContext
   ): boolean {
-    const ownerPluginId = serverConfig.ownerPluginId?.trim()
+    const ownerPluginId =
+      serverConfig.ownerPluginId?.trim() ||
+      (serverConfig.source === 'plugin' ? serverConfig.sourceId?.trim() : undefined)
     if (ownerPluginId) {
       return !context.enabledPluginIds || context.enabledPluginIds.includes(ownerPluginId)
     }

--- a/src/main/presenter/skillPresenter/skillTools.ts
+++ b/src/main/presenter/skillPresenter/skillTools.ts
@@ -66,7 +66,7 @@ export class SkillTools {
       }
     }
 
-    return await this.skillPresenter.viewSkill(input.name, {
+    return await this.skillPresenter.viewSkill(requestedSkillName, {
       filePath: input.file_path,
       conversationId
     })

--- a/src/main/presenter/skillPresenter/skillTools.ts
+++ b/src/main/presenter/skillPresenter/skillTools.ts
@@ -9,15 +9,25 @@ import type {
 export class SkillTools {
   constructor(private readonly skillPresenter: ISkillPresenter) {}
 
-  async handleSkillList(conversationId?: string): Promise<{
+  async handleSkillList(
+    conversationId?: string,
+    allowedSkillNames?: string[]
+  ): Promise<{
     skills: SkillListItem[]
     pinnedCount: number
     activeCount: number
     totalCount: number
   }> {
-    const allSkills = await this.skillPresenter.getMetadataList()
+    const allowedSkillSet = Array.isArray(allowedSkillNames)
+      ? new Set(allowedSkillNames.map((skillName) => skillName.trim()).filter(Boolean))
+      : undefined
+    const allSkills = (await this.skillPresenter.getMetadataList()).filter(
+      (skill) => !allowedSkillSet || allowedSkillSet.has(skill.name)
+    )
     const pinnedSkills = conversationId
-      ? await this.skillPresenter.getActiveSkills(conversationId)
+      ? (await this.skillPresenter.getActiveSkills(conversationId)).filter(
+          (skillName) => !allowedSkillSet || allowedSkillSet.has(skillName)
+        )
       : []
     const pinnedSet = new Set(pinnedSkills)
 
@@ -41,8 +51,21 @@ export class SkillTools {
 
   async handleSkillView(
     conversationId: string | undefined,
-    input: { name: string; file_path?: string }
+    input: { name: string; file_path?: string },
+    allowedSkillNames?: string[]
   ): Promise<SkillViewResult> {
+    const requestedSkillName = input.name.trim()
+    const allowedSkillSet = Array.isArray(allowedSkillNames)
+      ? new Set(allowedSkillNames.map((skillName) => skillName.trim()).filter(Boolean))
+      : undefined
+    if (allowedSkillSet && !allowedSkillSet.has(requestedSkillName)) {
+      return {
+        success: false,
+        name: requestedSkillName,
+        error: `Skill '${requestedSkillName}' is not enabled for this agent`
+      }
+    }
+
     return await this.skillPresenter.viewSkill(input.name, {
       filePath: input.file_path,
       conversationId

--- a/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
@@ -2102,10 +2102,14 @@ export class AgentToolManager {
     )
   }
 
-  private normalizeActiveSkillOption(activeSkillNames?: string[]): string[] {
+  private normalizeActiveSkillOption(activeSkillNames?: string[]): string[] | undefined {
+    if (!Array.isArray(activeSkillNames)) {
+      return undefined
+    }
+
     return Array.from(
       new Set(
-        (activeSkillNames ?? [])
+        activeSkillNames
           .map((skillName) => skillName.trim())
           .filter((skillName) => skillName.length > 0)
       )
@@ -2152,12 +2156,13 @@ export class AgentToolManager {
         effectiveActiveSkills
       )
       const normalizedViewedSkill = result.name?.trim() || validationResult.data.name.trim()
+      const activeSkillNamesForResult = effectiveActiveSkills ?? []
       const activationApplied =
         Boolean(conversationId) &&
         result.success === true &&
         !isLinkedFileView &&
         Boolean(normalizedViewedSkill) &&
-        !effectiveActiveSkills.includes(normalizedViewedSkill)
+        !activeSkillNamesForResult.includes(normalizedViewedSkill)
       const activationSource =
         !conversationId || result.success !== true
           ? 'none'
@@ -2173,7 +2178,7 @@ export class AgentToolManager {
           result.isPinned === true ||
           (!isLinkedFileView &&
             Boolean(normalizedViewedSkill) &&
-            (activationApplied || effectiveActiveSkills.includes(normalizedViewedSkill))),
+            (activationApplied || activeSkillNamesForResult.includes(normalizedViewedSkill))),
         activatedForMessage: activationApplied,
         activationScope: activationApplied ? 'message' : 'none'
       })

--- a/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
@@ -2128,9 +2128,10 @@ export class AgentToolManager {
     }
 
     const skillTools = this.getSkillTools()
+    const effectiveActiveSkills = this.normalizeActiveSkillOption(options?.activeSkillNames)
 
     if (toolName === 'skill_list') {
-      const result = await skillTools.handleSkillList(conversationId)
+      const result = await skillTools.handleSkillList(conversationId, effectiveActiveSkills)
       return { content: JSON.stringify(result) }
     }
 
@@ -2145,8 +2146,11 @@ export class AgentToolManager {
           ? validationResult.data.file_path.trim()
           : ''
       const isLinkedFileView = normalizedFilePath.length > 0
-      const effectiveActiveSkills = this.normalizeActiveSkillOption(options?.activeSkillNames)
-      const result = await skillTools.handleSkillView(conversationId, validationResult.data)
+      const result = await skillTools.handleSkillView(
+        conversationId,
+        validationResult.data,
+        effectiveActiveSkills
+      )
       const normalizedViewedSkill = result.name?.trim() || validationResult.data.name.trim()
       const activationApplied =
         Boolean(conversationId) &&

--- a/src/main/presenter/toolPresenter/index.ts
+++ b/src/main/presenter/toolPresenter/index.ts
@@ -56,6 +56,9 @@ interface PreCheckedPermissionResult {
 export interface IToolPresenter {
   getAllToolDefinitions(context: {
     enabledMcpTools?: string[]
+    enabledMcpServerIds?: string[]
+    enabledPluginIds?: string[]
+    agentId?: string
     disabledAgentTools?: string[]
     chatMode?: 'agent' | 'acp agent'
     supportsVision?: boolean
@@ -74,6 +77,9 @@ export interface IToolPresenter {
       signal?: AbortSignal
       permissionMode?: PermissionMode
       activeSkillNames?: string[]
+      agentId?: string
+      enabledMcpServerIds?: string[]
+      enabledPluginIds?: string[]
     }
   ): Promise<{ content: unknown; rawData: MCPToolResponse }>
   preCheckToolPermission?(
@@ -125,6 +131,15 @@ const normalizeToolNames = (toolNames?: string[]): string[] => {
   )
 }
 
+const normalizeOptionalToolNames = (toolNames?: string[]): string[] | undefined =>
+  Array.isArray(toolNames) ? normalizeToolNames(toolNames) : undefined
+
+type StoredMcpAccessContext = {
+  agentId?: string
+  enabledMcpServerIds?: string[]
+  enabledPluginIds?: string[]
+}
+
 /**
  * ToolPresenter - Unified tool routing presenter
  * Manages all tool sources (MCP, Agent) and provides unified interface
@@ -132,6 +147,7 @@ const normalizeToolNames = (toolNames?: string[]): string[] => {
 export class ToolPresenter implements IToolPresenter {
   private readonly mapper: ToolMapper
   private readonly conversationMappers: Map<string, ToolMapper>
+  private readonly conversationMcpAccessContexts = new Map<string, StoredMcpAccessContext>()
   private readonly options: ToolPresenterOptions
   private agentToolManager: AgentToolManager | null = null
 
@@ -160,6 +176,9 @@ export class ToolPresenter implements IToolPresenter {
    */
   async getAllToolDefinitions(context: {
     enabledMcpTools?: string[]
+    enabledMcpServerIds?: string[]
+    enabledPluginIds?: string[]
+    agentId?: string
     disabledAgentTools?: string[]
     chatMode?: 'agent' | 'acp agent'
     supportsVision?: boolean
@@ -177,12 +196,23 @@ export class ToolPresenter implements IToolPresenter {
     const chatMode = context.chatMode || 'agent'
     const supportsVision = context.supportsVision || false
     const agentWorkspacePath = context.agentWorkspacePath || null
+    this.rememberConversationMcpAccessContext(context.conversationId, {
+      agentId: context.agentId,
+      enabledMcpServerIds: context.enabledMcpServerIds,
+      enabledPluginIds: context.enabledPluginIds
+    })
 
     // 1. Get MCP tools
     const mcpDefs = withToolSource(
-      (await this.options.mcpPresenter.getAllToolDefinitions(context.enabledMcpTools)).filter(
-        (tool) => !RESERVED_AGENT_TOOL_NAMES.has(tool.function.name)
-      ),
+      (
+        await this.options.mcpPresenter.getAllToolDefinitions({
+          enabledTools: context.enabledMcpTools,
+          enabledServerIds: context.enabledMcpServerIds,
+          enabledPluginIds: context.enabledPluginIds,
+          agentId: context.agentId,
+          conversationId: context.conversationId
+        })
+      ).filter((tool) => !RESERVED_AGENT_TOOL_NAMES.has(tool.function.name)),
       'mcp'
     )
     defs.push(...mcpDefs)
@@ -243,6 +273,7 @@ export class ToolPresenter implements IToolPresenter {
     }
 
     this.conversationMappers.delete(normalizedConversationId)
+    this.conversationMcpAccessContexts.delete(normalizedConversationId)
     this.clearAgentPlanState(normalizedConversationId)
   }
 
@@ -265,6 +296,9 @@ export class ToolPresenter implements IToolPresenter {
       signal?: AbortSignal
       permissionMode?: PermissionMode
       activeSkillNames?: string[]
+      agentId?: string
+      enabledMcpServerIds?: string[]
+      enabledPluginIds?: string[]
     }
   ): Promise<{ content: unknown; rawData: MCPToolResponse }> {
     const toolName = request.function.name
@@ -339,7 +373,12 @@ export class ToolPresenter implements IToolPresenter {
     }
 
     // Route to MCP (default)
-    return await this.options.mcpPresenter.callTool(request)
+    const storedAccess = this.getConversationMcpAccessContext(request.conversationId)
+    return await this.options.mcpPresenter.callTool(request, {
+      agentId: options?.agentId ?? storedAccess?.agentId,
+      enabledServerIds: options?.enabledMcpServerIds ?? storedAccess?.enabledMcpServerIds,
+      enabledPluginIds: options?.enabledPluginIds ?? storedAccess?.enabledPluginIds
+    })
   }
 
   /**
@@ -402,7 +441,12 @@ export class ToolPresenter implements IToolPresenter {
 
     // Route to MCP for permission pre-check
     if (this.options.mcpPresenter.preCheckToolPermission) {
-      return await this.options.mcpPresenter.preCheckToolPermission(request)
+      const storedAccess = this.getConversationMcpAccessContext(request.conversationId)
+      return await this.options.mcpPresenter.preCheckToolPermission(request, {
+        agentId: storedAccess?.agentId,
+        enabledServerIds: storedAccess?.enabledMcpServerIds,
+        enabledPluginIds: storedAccess?.enabledPluginIds
+      })
     }
 
     // If MCP presenter doesn't support preCheckToolPermission, skip it
@@ -414,6 +458,31 @@ export class ToolPresenter implements IToolPresenter {
       return { content: response }
     }
     return response
+  }
+
+  private rememberConversationMcpAccessContext(
+    conversationId: string | undefined,
+    context: StoredMcpAccessContext
+  ): void {
+    const normalizedConversationId = conversationId?.trim()
+    if (!normalizedConversationId) {
+      return
+    }
+
+    this.conversationMcpAccessContexts.set(normalizedConversationId, {
+      agentId: context.agentId?.trim() || undefined,
+      enabledMcpServerIds: normalizeOptionalToolNames(context.enabledMcpServerIds),
+      enabledPluginIds: normalizeOptionalToolNames(context.enabledPluginIds)
+    })
+  }
+
+  private getConversationMcpAccessContext(
+    conversationId?: string
+  ): StoredMcpAccessContext | undefined {
+    const normalizedConversationId = conversationId?.trim()
+    return normalizedConversationId
+      ? this.conversationMcpAccessContexts.get(normalizedConversationId)
+      : undefined
   }
 
   private resolveMapper(conversationId?: string): ToolMapper {

--- a/src/renderer/settings/components/McpSettings.vue
+++ b/src/renderer/settings/components/McpSettings.vue
@@ -4,7 +4,7 @@
   </div>
 
   <div
-    v-else-if="showMcpSkeleton"
+    v-else-if="showMcpSkeleton || agentPolicyLoading"
     data-testid="settings-mcp-page"
     class="w-full h-full flex flex-col p-4 gap-4 animate-pulse"
   >
@@ -45,6 +45,7 @@
             <Switch
               dir="ltr"
               :model-value="mcpEnabled"
+              :disabled="isAgentScope"
               @update:model-value="handleMcpEnabledChange"
             />
           </div>
@@ -56,7 +57,13 @@
     <!-- Server list -->
     <div class="min-h-0 flex-1 overflow-hidden">
       <div v-if="mcpEnabled" class="h-full min-h-0">
-        <McpServers ref="mcpServersRef" :show-footer-add-button="false">
+        <McpServers
+          ref="mcpServersRef"
+          :show-footer-add-button="false"
+          :server-enabled-overrides="serverEnabledOverrides"
+          :agent-scoped-toggle="isAgentScope"
+          @toggle-agent-server="handleToggleAgentServer"
+        >
           <template #status-bar>
             <div class="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1">
               <span class="text-xs text-muted-foreground">
@@ -196,7 +203,7 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { computed, ref, onMounted } from 'vue'
+import { computed, ref, onMounted, watch } from 'vue'
 import McpServers from '@/components/mcp-config/components/McpServers.vue'
 import McpBuiltinMarket from './McpBuiltinMarket.vue'
 import { Switch } from '@shadcn/components/ui/switch'
@@ -214,16 +221,32 @@ import {
 } from '@shadcn/components/ui/dialog'
 import { useMcpStore } from '@/stores/mcp'
 import { useLanguageStore } from '@/stores/language'
+import { useAgentStore } from '@/stores/ui/agent'
+import { useSessionStore } from '@/stores/ui/session'
 import { useToast } from '@/components/use-toast'
 import { useRoute, useRouter } from 'vue-router'
 import GuidedOnboardingOverlay from '@/components/onboarding/GuidedOnboardingOverlay.vue'
 import { useGuidedOnboardingStep } from '@/composables/useGuidedOnboardingStep'
 import { createWindowClient } from '@api/WindowClient'
 import { continueGuidedOnboardingFromSettings } from '../lib/guidedOnboardingSettings'
+import { createConfigClient } from '@api/ConfigClient'
+import type { Agent, DeepChatAgentConfig } from '@shared/types/agent-interface'
+
+const props = withDefaults(
+  defineProps<{
+    scope?: 'global' | 'agent'
+  }>(),
+  {
+    scope: 'global'
+  }
+)
 
 const { t } = useI18n()
 const languageStore = useLanguageStore()
 const mcpStore = useMcpStore()
+const agentStore = useAgentStore()
+const sessionStore = useSessionStore()
+const configClient = createConfigClient()
 const { toast } = useToast()
 const route = useRoute()
 const router = useRouter()
@@ -255,6 +278,61 @@ const npmRegistryStatus = ref<{
 const refreshing = ref(false)
 const customRegistryInput = ref('')
 const npmAdvancedDialogOpen = ref(false)
+const targetAgent = ref<Agent | null>(null)
+const targetAgentConfig = ref<DeepChatAgentConfig>({})
+const agentPolicyLoading = ref(false)
+
+const normalizeList = (value: string[] | null | undefined): string[] =>
+  Array.from(new Set((value ?? []).map((item) => item.trim()).filter(Boolean))).sort(
+    (left, right) => left.localeCompare(right)
+  )
+const isAgentScope = computed(() => props.scope === 'agent')
+const targetAgentId = computed(() => {
+  const activeSessionAgentId = sessionStore.activeSession?.agentId?.trim()
+  if (activeSessionAgentId) {
+    return activeSessionAgentId
+  }
+
+  const selectedAgentId = agentStore.selectedAgentId?.trim()
+  if (selectedAgentId) {
+    return selectedAgentId
+  }
+
+  return 'deepchat'
+})
+const isDeepChatTarget = computed(() =>
+  Boolean(targetAgent.value && targetAgent.value.type === 'deepchat')
+)
+const globallyAvailableServerIds = computed(() =>
+  normalizeList(
+    mcpStore.serverList
+      .filter((server) => {
+        const config = mcpStore.config.mcpServers[server.name]
+        return config?.enabled !== false && !config?.disable
+      })
+      .map((server) => server.name)
+  )
+)
+const agentEnabledMcpServerIds = computed(() => targetAgentConfig.value.enabledMcpServerIds)
+const agentEnabledMcpServerSet = computed(() => {
+  const enabledServerIds = agentEnabledMcpServerIds.value
+  if (enabledServerIds === null || enabledServerIds === undefined) {
+    return new Set(globallyAvailableServerIds.value)
+  }
+  return new Set(normalizeList(enabledServerIds))
+})
+const serverEnabledOverrides = computed<Record<string, boolean>>(() => {
+  if (!isAgentScope.value) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    mcpStore.serverList.map((server) => [
+      server.name,
+      agentEnabledMcpServerSet.value.has(server.name)
+    ])
+  )
+})
 const runningCount = computed(() => mcpStore.serverList.filter((server) => server.isRunning).length)
 const builtInCount = computed(
   () =>
@@ -316,6 +394,94 @@ const handleMcpGuideExpert = async () => {
 
 const handleMcpEnabledChange = async (enabled: boolean) => {
   await mcpStore.setMcpEnabled(enabled)
+}
+
+watch(targetAgentId, () => {
+  void loadAgentPolicy()
+})
+
+const loadAgentPolicy = async () => {
+  if (!isAgentScope.value) {
+    targetAgent.value = null
+    targetAgentConfig.value = {}
+    return
+  }
+
+  agentPolicyLoading.value = true
+  try {
+    const [agents, effectiveConfig] = await Promise.all([
+      configClient.listAgents({
+        agentType: 'deepchat',
+        ids: [targetAgentId.value]
+      }),
+      configClient.resolveDeepChatAgentConfig(targetAgentId.value)
+    ])
+    const agent = agents[0] ?? null
+    targetAgent.value = agent
+    targetAgentConfig.value = effectiveConfig ?? agent?.config ?? {}
+  } catch (error) {
+    targetAgent.value = null
+    targetAgentConfig.value = {}
+    toast({
+      title: t('settings.pluginsHub.agentScopeUnsupported'),
+      description: error instanceof Error ? error.message : String(error),
+      variant: 'destructive'
+    })
+  } finally {
+    agentPolicyLoading.value = false
+  }
+}
+
+const buildNextAgentMcpServerIds = (serverName: string, enabled: boolean): string[] => {
+  const currentPolicy = agentEnabledMcpServerIds.value
+  const visibleServerIds = globallyAvailableServerIds.value
+  const nextSet =
+    currentPolicy === null || currentPolicy === undefined
+      ? new Set(visibleServerIds)
+      : new Set(normalizeList(currentPolicy))
+
+  if (enabled && visibleServerIds.includes(serverName)) {
+    nextSet.add(serverName)
+  } else {
+    nextSet.delete(serverName)
+  }
+
+  return normalizeList(Array.from(nextSet))
+}
+
+const handleToggleAgentServer = async (serverName: string, enabled: boolean) => {
+  if (!targetAgent.value || !isDeepChatTarget.value) {
+    toast({
+      title: t('settings.pluginsHub.agentScopeUnsupported'),
+      variant: 'destructive'
+    })
+    return
+  }
+
+  try {
+    const enabledMcpServerIds = buildNextAgentMcpServerIds(serverName, enabled)
+    const updatedAgent = await configClient.updateDeepChatAgent(targetAgent.value.id, {
+      config: {
+        enabledMcpServerIds
+      }
+    })
+    targetAgent.value = updatedAgent ?? targetAgent.value
+    targetAgentConfig.value = {
+      ...targetAgentConfig.value,
+      ...updatedAgent?.config,
+      enabledMcpServerIds
+    }
+    await agentStore.refreshAgentsByIds('deepchat', [targetAgent.value.id])
+    toast({
+      title: t('settings.mcp.saveSuccess')
+    })
+  } catch (error) {
+    toast({
+      title: t('settings.mcp.saveFailed'),
+      description: error instanceof Error ? error.message : String(error),
+      variant: 'destructive'
+    })
+  }
 }
 
 const openAddServerDialog = () => {
@@ -491,6 +657,7 @@ const clearCustomNpmRegistry = async () => {
 
 onMounted(() => {
   loadNpmRegistryStatus()
+  void loadAgentPolicy()
 })
 
 const closeMarketView = async () => {

--- a/src/renderer/settings/components/McpSettings.vue
+++ b/src/renderer/settings/components/McpSettings.vue
@@ -281,6 +281,7 @@ const npmAdvancedDialogOpen = ref(false)
 const targetAgent = ref<Agent | null>(null)
 const targetAgentConfig = ref<DeepChatAgentConfig>({})
 const agentPolicyLoading = ref(false)
+const agentPolicyRequestId = ref(0)
 
 const normalizeList = (value: string[] | null | undefined): string[] =>
   Array.from(new Set((value ?? []).map((item) => item.trim()).filter(Boolean))).sort(
@@ -402,24 +403,44 @@ watch(targetAgentId, () => {
 
 const loadAgentPolicy = async () => {
   if (!isAgentScope.value) {
+    agentPolicyRequestId.value += 1
     targetAgent.value = null
     targetAgentConfig.value = {}
+    agentPolicyLoading.value = false
     return
   }
 
+  const requestId = ++agentPolicyRequestId.value
+  const requestedAgentId = targetAgentId.value
   agentPolicyLoading.value = true
   try {
-    const [agents, effectiveConfig] = await Promise.all([
-      configClient.listAgents({
-        agentType: 'deepchat',
-        ids: [targetAgentId.value]
-      }),
-      configClient.resolveDeepChatAgentConfig(targetAgentId.value)
-    ])
+    const agents = await configClient.listAgents({
+      agentType: 'deepchat',
+      ids: [requestedAgentId]
+    })
+    if (requestId !== agentPolicyRequestId.value || requestedAgentId !== targetAgentId.value) {
+      return
+    }
+
     const agent = agents[0] ?? null
+    if (!agent) {
+      targetAgent.value = null
+      targetAgentConfig.value = {}
+      return
+    }
+
+    const effectiveConfig = await configClient.resolveDeepChatAgentConfig(requestedAgentId)
+    if (requestId !== agentPolicyRequestId.value || requestedAgentId !== targetAgentId.value) {
+      return
+    }
+
     targetAgent.value = agent
     targetAgentConfig.value = effectiveConfig ?? agent?.config ?? {}
   } catch (error) {
+    if (requestId !== agentPolicyRequestId.value) {
+      return
+    }
+
     targetAgent.value = null
     targetAgentConfig.value = {}
     toast({
@@ -428,7 +449,9 @@ const loadAgentPolicy = async () => {
       variant: 'destructive'
     })
   } finally {
-    agentPolicyLoading.value = false
+    if (requestId === agentPolicyRequestId.value) {
+      agentPolicyLoading.value = false
+    }
   }
 }
 

--- a/src/renderer/settings/components/skills/SkillsSettings.vue
+++ b/src/renderer/settings/components/skills/SkillsSettings.vue
@@ -241,6 +241,7 @@ const isAgentScope = computed(() => props.scope === 'agent')
 const targetAgent = ref<Agent | null>(null)
 const targetAgentConfig = ref<DeepChatAgentConfig>({})
 const agentPolicyLoading = ref(false)
+const agentPolicyRequestId = ref(0)
 
 const normalizeList = (value: string[] | null | undefined): string[] =>
   Array.from(new Set((value ?? []).map((item) => item.trim()).filter(Boolean))).sort(
@@ -392,24 +393,44 @@ watch(agentScopedSkills, () => {
 
 const loadAgentPolicy = async () => {
   if (!isAgentScope.value) {
+    agentPolicyRequestId.value += 1
     targetAgent.value = null
     targetAgentConfig.value = {}
+    agentPolicyLoading.value = false
     return
   }
 
+  const requestId = ++agentPolicyRequestId.value
+  const requestedAgentId = targetAgentId.value
   agentPolicyLoading.value = true
   try {
-    const [agents, effectiveConfig] = await Promise.all([
-      configClient.listAgents({
-        agentType: 'deepchat',
-        ids: [targetAgentId.value]
-      }),
-      configClient.resolveDeepChatAgentConfig(targetAgentId.value)
-    ])
+    const agents = await configClient.listAgents({
+      agentType: 'deepchat',
+      ids: [requestedAgentId]
+    })
+    if (requestId !== agentPolicyRequestId.value || requestedAgentId !== targetAgentId.value) {
+      return
+    }
+
     const agent = agents[0] ?? null
+    if (!agent) {
+      targetAgent.value = null
+      targetAgentConfig.value = {}
+      return
+    }
+
+    const effectiveConfig = await configClient.resolveDeepChatAgentConfig(requestedAgentId)
+    if (requestId !== agentPolicyRequestId.value || requestedAgentId !== targetAgentId.value) {
+      return
+    }
+
     targetAgent.value = agent
     targetAgentConfig.value = effectiveConfig ?? agent?.config ?? {}
   } catch (error) {
+    if (requestId !== agentPolicyRequestId.value) {
+      return
+    }
+
     targetAgent.value = null
     targetAgentConfig.value = {}
     toast({
@@ -418,7 +439,9 @@ const loadAgentPolicy = async () => {
       variant: 'destructive'
     })
   } finally {
-    agentPolicyLoading.value = false
+    if (requestId === agentPolicyRequestId.value) {
+      agentPolicyLoading.value = false
+    }
   }
 }
 

--- a/src/renderer/settings/components/skills/SkillsSettings.vue
+++ b/src/renderer/settings/components/skills/SkillsSettings.vue
@@ -71,7 +71,7 @@
 
           <Separator class="mb-4" />
 
-          <div v-if="loading" class="space-y-3 pb-4 animate-pulse">
+          <div v-if="loading || agentPolicyLoading" class="space-y-3 pb-4 animate-pulse">
             <div v-for="index in 4" :key="`skill-skeleton-${index}`" class="rounded-xl border p-4">
               <div class="space-y-3">
                 <div class="h-4 w-40 rounded bg-muted/60"></div>
@@ -169,7 +169,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
@@ -187,9 +187,12 @@ import {
 } from '@shadcn/components/ui/dropdown-menu'
 import { useToast } from '@/components/use-toast'
 import { useSkillsStore } from '@/stores/skillsStore'
+import { useAgentStore } from '@/stores/ui/agent'
+import { useSessionStore } from '@/stores/ui/session'
 import { createConfigClient } from '@api/ConfigClient'
 import { createSkillClient } from '@api/SkillClient'
 import { createWindowClient } from '@api/WindowClient'
+import type { Agent, DeepChatAgentConfig } from '@shared/types/agent-interface'
 import type { SkillExtensionConfig } from '@shared/types/skill'
 import type { UnifiedSkillItem } from '@shared/types/skillManagement'
 import type { SkillDetail } from '@shared/types/skillSync'
@@ -206,9 +209,20 @@ import GuidedOnboardingOverlay from '@/components/onboarding/GuidedOnboardingOve
 import { useGuidedOnboardingStep } from '@/composables/useGuidedOnboardingStep'
 import { continueGuidedOnboardingFromSettings } from '../../lib/guidedOnboardingSettings'
 
+const props = withDefaults(
+  defineProps<{
+    scope?: 'global' | 'agent'
+  }>(),
+  {
+    scope: 'global'
+  }
+)
+
 const { t } = useI18n()
 const { toast } = useToast()
 const skillsStore = useSkillsStore()
+const agentStore = useAgentStore()
+const sessionStore = useSessionStore()
 const configClient = createConfigClient()
 const skillClient = createSkillClient()
 const windowClient = createWindowClient()
@@ -223,10 +237,58 @@ const { skills, skillExtensions, skillScripts, loading } = storeToRefs(skillsSto
 const activeTab = ref('library')
 const searchQuery = ref('')
 const draftSuggestionsEnabled = ref(false)
+const isAgentScope = computed(() => props.scope === 'agent')
+const targetAgent = ref<Agent | null>(null)
+const targetAgentConfig = ref<DeepChatAgentConfig>({})
+const agentPolicyLoading = ref(false)
+
+const normalizeList = (value: string[] | null | undefined): string[] =>
+  Array.from(new Set((value ?? []).map((item) => item.trim()).filter(Boolean))).sort(
+    (left, right) => left.localeCompare(right)
+  )
+
+const targetAgentId = computed(() => {
+  const activeSessionAgentId = sessionStore.activeSession?.agentId?.trim()
+  if (activeSessionAgentId) {
+    return activeSessionAgentId
+  }
+
+  const selectedAgentId = agentStore.selectedAgentId?.trim()
+  if (selectedAgentId) {
+    return selectedAgentId
+  }
+
+  return 'deepchat'
+})
+const isDeepChatTarget = computed(() =>
+  Boolean(targetAgent.value && targetAgent.value.type === 'deepchat')
+)
+const globallyAvailableSkillNames = computed(() =>
+  normalizeList(skills.value.filter((skill) => !skill.deepchatDisabled).map((skill) => skill.name))
+)
+const agentEnabledSkillNames = computed(() => targetAgentConfig.value.enabledSkillNames)
+const agentEnabledSkillSet = computed(() => {
+  const enabledNames = agentEnabledSkillNames.value
+  if (enabledNames === null || enabledNames === undefined) {
+    return new Set(globallyAvailableSkillNames.value)
+  }
+  return new Set(normalizeList(enabledNames))
+})
+const agentScopedSkills = computed<UnifiedSkillItem[]>(() => {
+  if (!isAgentScope.value) {
+    return skills.value
+  }
+
+  return skills.value.map((skill) => ({
+    ...skill,
+    deepchatDisabled: skill.deepchatDisabled || !agentEnabledSkillSet.value.has(skill.name)
+  }))
+})
 const filteredSkills = computed(() => {
-  if (!searchQuery.value) return skills.value
+  const sourceSkills = agentScopedSkills.value
+  if (!searchQuery.value) return sourceSkills
   const query = searchQuery.value.toLowerCase()
-  return skills.value.filter(
+  return sourceSkills.filter(
     (skill) =>
       skill.name.toLowerCase().includes(query) || skill.description.toLowerCase().includes(query)
   )
@@ -295,7 +357,7 @@ const eventCleanup = ref<(() => void) | null>(null)
 onMounted(async () => {
   const enabled = await configClient.getSkillDraftSuggestionsEnabled()
   draftSuggestionsEnabled.value = enabled ?? false
-  await skillsStore.loadSkills()
+  await Promise.all([skillsStore.loadSkills(), loadAgentPolicy()])
   setupEventListeners()
 })
 
@@ -313,9 +375,114 @@ const setupEventListeners = () => {
   eventCleanup.value = skillClient.onCatalogChanged(handleSkillEvent)
 }
 
+watch(targetAgentId, () => {
+  void loadAgentPolicy()
+})
+
+watch(agentScopedSkills, () => {
+  const selectedSkillName = selectedDetailSkill.value?.name
+  if (!selectedSkillName) {
+    return
+  }
+  const nextSkill = agentScopedSkills.value.find((skill) => skill.name === selectedSkillName)
+  if (nextSkill) {
+    selectedDetailSkill.value = nextSkill
+  }
+})
+
+const loadAgentPolicy = async () => {
+  if (!isAgentScope.value) {
+    targetAgent.value = null
+    targetAgentConfig.value = {}
+    return
+  }
+
+  agentPolicyLoading.value = true
+  try {
+    const [agents, effectiveConfig] = await Promise.all([
+      configClient.listAgents({
+        agentType: 'deepchat',
+        ids: [targetAgentId.value]
+      }),
+      configClient.resolveDeepChatAgentConfig(targetAgentId.value)
+    ])
+    const agent = agents[0] ?? null
+    targetAgent.value = agent
+    targetAgentConfig.value = effectiveConfig ?? agent?.config ?? {}
+  } catch (error) {
+    targetAgent.value = null
+    targetAgentConfig.value = {}
+    toast({
+      title: t('settings.pluginsHub.agentScopeUnsupported'),
+      description: error instanceof Error ? error.message : String(error),
+      variant: 'destructive'
+    })
+  } finally {
+    agentPolicyLoading.value = false
+  }
+}
+
+const buildNextAgentSkillNames = (skillName: string, disabled: boolean): string[] => {
+  const currentPolicy = agentEnabledSkillNames.value
+  const visibleSkillNames = globallyAvailableSkillNames.value
+  const nextSet =
+    currentPolicy === null || currentPolicy === undefined
+      ? new Set(visibleSkillNames)
+      : new Set(normalizeList(currentPolicy))
+
+  if (disabled) {
+    nextSet.delete(skillName)
+  } else if (visibleSkillNames.includes(skillName)) {
+    nextSet.add(skillName)
+  }
+
+  return normalizeList(Array.from(nextSet))
+}
+
+const updateAgentSkillPolicy = async (skill: UnifiedSkillItem, disabled: boolean) => {
+  if (!targetAgent.value || !isDeepChatTarget.value) {
+    toast({
+      title: t('settings.pluginsHub.agentScopeUnsupported'),
+      variant: 'destructive'
+    })
+    return false
+  }
+
+  try {
+    const enabledSkillNames = buildNextAgentSkillNames(skill.name, disabled)
+    const updatedAgent = await configClient.updateDeepChatAgent(targetAgent.value.id, {
+      config: {
+        enabledSkillNames
+      }
+    })
+    targetAgent.value = updatedAgent ?? targetAgent.value
+    targetAgentConfig.value = {
+      ...targetAgentConfig.value,
+      ...updatedAgent?.config,
+      enabledSkillNames
+    }
+    await agentStore.refreshAgentsByIds('deepchat', [targetAgent.value.id])
+    toast({
+      title: disabled ? t('settings.skills.disable.success') : t('settings.skills.enable.success'),
+      description: disabled
+        ? t('settings.skills.disable.successMessage', { name: skill.name })
+        : t('settings.skills.enable.successMessage', { name: skill.name })
+    })
+    return true
+  } catch (error) {
+    toast({
+      title: disabled ? t('settings.skills.disable.failed') : t('settings.skills.enable.failed'),
+      description: error instanceof Error ? error.message : String(error),
+      variant: 'destructive'
+    })
+    return false
+  }
+}
+
 const openSkillDetail = async (skill: UnifiedSkillItem) => {
   try {
-    selectedDetailSkill.value = skill
+    selectedDetailSkill.value =
+      agentScopedSkills.value.find((item) => item.name === skill.name) ?? skill
     skillDetail.value = {
       name: skill.name,
       description: skill.description,
@@ -339,6 +506,10 @@ const openInstallToAgent = (skill: UnifiedSkillItem) => {
 }
 
 const toggleSkillDisabled = async (skill: UnifiedSkillItem, disabled: boolean) => {
+  if (isAgentScope.value) {
+    return await updateAgentSkillPolicy(skill, disabled)
+  }
+
   try {
     await skillsStore.setSkillDisabled(skill.name, disabled)
     toast({

--- a/src/renderer/src/components/mcp-config/components/McpServers.vue
+++ b/src/renderer/src/components/mcp-config/components/McpServers.vue
@@ -38,11 +38,19 @@ const router = useRouter()
 const props = withDefaults(
   defineProps<{
     showFooterAddButton?: boolean
+    serverEnabledOverrides?: Record<string, boolean>
+    agentScopedToggle?: boolean
   }>(),
   {
-    showFooterAddButton: true
+    showFooterAddButton: true,
+    serverEnabledOverrides: () => ({}),
+    agentScopedToggle: false
   }
 )
+
+const emit = defineEmits<{
+  'toggle-agent-server': [serverName: string, enabled: boolean]
+}>()
 
 const isAddServerDialogOpen = ref(false)
 const isEditServerDialogOpen = ref(false)
@@ -116,6 +124,9 @@ const getServerResourcesCount = (serverName: string) => {
   return mcpStore.visibleResources.filter((resource) => resource.client.name === serverName).length
 }
 
+const getServerEnabled = (serverName: string, fallback: boolean) =>
+  props.serverEnabledOverrides[serverName] ?? fallback
+
 const handleAddServer = async (serverName: string, serverConfig: MCPServerConfig) => {
   const result = await mcpStore.addServer(serverName, serverConfig)
   if (result.success) {
@@ -156,6 +167,16 @@ const confirmRemoveServer = async () => {
 }
 
 const handleToggleServer = async (serverName: string) => {
+  if (mcpStore.serverLoadingStates[serverName]) {
+    return
+  }
+
+  if (props.agentScopedToggle) {
+    const server = mcpStore.serverList.find((item) => item.name === serverName)
+    emit('toggle-agent-server', serverName, !getServerEnabled(serverName, Boolean(server?.enabled)))
+    return
+  }
+
   const config = mcpStore.config.mcpServers[serverName]
   if (isDeepChatManagedServer(config)) {
     toast({
@@ -165,9 +186,6 @@ const handleToggleServer = async (serverName: string) => {
     return
   }
 
-  if (mcpStore.serverLoadingStates[serverName]) {
-    return
-  }
   const success = await mcpStore.toggleServer(serverName)
   if (!success) {
     toast({
@@ -292,7 +310,10 @@ defineExpose({
           <McpServerCard
             v-for="server in filteredServers"
             :key="server.name"
-            :server="server"
+            :server="{
+              ...server,
+              enabled: getServerEnabled(server.name, Boolean(server.enabled))
+            }"
             :is-built-in="isBuiltInServer(server.name)"
             :is-managed="mcpStore.config.mcpServers[server.name]?.source === 'deepchat'"
             :is-loading="mcpStore.serverLoadingStates[server.name]"

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -2756,6 +2756,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "DeepChats ComputerUse-plugin implementeret med udgangspunkt i trycua/cua-projektet."
+    "cuaDescription": "DeepChats ComputerUse-plugin implementeret med udgangspunkt i trycua/cua-projektet.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/de-DE/settings.json
+++ b/src/renderer/src/i18n/de-DE/settings.json
@@ -2747,6 +2747,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "DeepChats ComputerUse-Plugin, implementiert auf Basis des Projekts trycua/cua."
+    "cuaDescription": "DeepChats ComputerUse-Plugin, implementiert auf Basis des Projekts trycua/cua.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -2643,7 +2643,25 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "DeepChat's ComputerUse plugin built on the trycua/cua project."
+    "cuaDescription": "DeepChat's ComputerUse plugin built on the trycua/cua project.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   },
   "controlCenter": {
     "groups": {

--- a/src/renderer/src/i18n/es-ES/settings.json
+++ b/src/renderer/src/i18n/es-ES/settings.json
@@ -2747,6 +2747,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "Plugin ComputerUse de DeepChat implementado a partir del proyecto trycua/cua."
+    "cuaDescription": "Plugin ComputerUse de DeepChat implementado a partir del proyecto trycua/cua.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -2756,6 +2756,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "افزونه ComputerUse DeepChat که بر پایه پروژه trycua/cua پیاده‌سازی شده است."
+    "cuaDescription": "افزونه ComputerUse DeepChat که بر پایه پروژه trycua/cua پیاده‌سازی شده است.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -2756,6 +2756,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "Plugin ComputerUse de DeepChat, implémenté à partir du projet trycua/cua."
+    "cuaDescription": "Plugin ComputerUse de DeepChat, implémenté à partir du projet trycua/cua.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -2756,6 +2756,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "תוסף ComputerUse של DeepChat שמיושם על בסיס הפרויקט trycua/cua."
+    "cuaDescription": "תוסף ComputerUse של DeepChat שמיושם על בסיס הפרויקט trycua/cua.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/id-ID/settings.json
+++ b/src/renderer/src/i18n/id-ID/settings.json
@@ -2747,6 +2747,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "Plugin ComputerUse DeepChat yang diimplementasikan berdasarkan proyek trycua/cua."
+    "cuaDescription": "Plugin ComputerUse DeepChat yang diimplementasikan berdasarkan proyek trycua/cua.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/it-IT/settings.json
+++ b/src/renderer/src/i18n/it-IT/settings.json
@@ -2747,6 +2747,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "Plugin ComputerUse di DeepChat implementato sulla base del progetto trycua/cua."
+    "cuaDescription": "Plugin ComputerUse di DeepChat implementato sulla base del progetto trycua/cua.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -2756,6 +2756,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "trycua/cua プロジェクトをベースに DeepChat が実装した ComputerUse プラグインです。"
+    "cuaDescription": "trycua/cua プロジェクトをベースに DeepChat が実装した ComputerUse プラグインです。",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -2756,6 +2756,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "DeepChat이 trycua/cua 프로젝트를 기반으로 구현한 ComputerUse 플러그인입니다."
+    "cuaDescription": "DeepChat이 trycua/cua 프로젝트를 기반으로 구현한 ComputerUse 플러그인입니다.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/ms-MY/settings.json
+++ b/src/renderer/src/i18n/ms-MY/settings.json
@@ -2747,6 +2747,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "Plugin ComputerUse DeepChat yang dilaksanakan berdasarkan projek trycua/cua."
+    "cuaDescription": "Plugin ComputerUse DeepChat yang dilaksanakan berdasarkan projek trycua/cua.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/pl-PL/settings.json
+++ b/src/renderer/src/i18n/pl-PL/settings.json
@@ -2747,6 +2747,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "Wtyczka ComputerUse DeepChat zaimplementowana na podstawie projektu trycua/cua."
+    "cuaDescription": "Wtyczka ComputerUse DeepChat zaimplementowana na podstawie projektu trycua/cua.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -2756,6 +2756,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "Plugin ComputerUse do DeepChat implementado com base no projeto trycua/cua."
+    "cuaDescription": "Plugin ComputerUse do DeepChat implementado com base no projeto trycua/cua.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -2756,6 +2756,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "Плагин ComputerUse от DeepChat, реализованный на базе проекта trycua/cua."
+    "cuaDescription": "Плагин ComputerUse от DeepChat, реализованный на базе проекта trycua/cua.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/tr-TR/settings.json
+++ b/src/renderer/src/i18n/tr-TR/settings.json
@@ -2747,6 +2747,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "DeepChat'in trycua/cua projesi temel alınarak uygulanmış ComputerUse eklentisi."
+    "cuaDescription": "DeepChat'in trycua/cua projesi temel alınarak uygulanmış ComputerUse eklentisi.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/vi-VN/settings.json
+++ b/src/renderer/src/i18n/vi-VN/settings.json
@@ -2747,6 +2747,24 @@
     "pluginNotFound": "Plugin not found.",
     "capabilities": "Capabilities",
     "actionResult": "Action result",
-    "cuaDescription": "Plugin ComputerUse của DeepChat được triển khai dựa trên dự án trycua/cua."
+    "cuaDescription": "Plugin ComputerUse của DeepChat được triển khai dựa trên dự án trycua/cua.",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -2643,7 +2643,25 @@
     "pluginNotFound": "未找到插件。",
     "capabilities": "能力",
     "actionResult": "操作结果",
-    "cuaDescription": "DeepChat 基于 trycua/cua 项目实现的 ComputerUse 插件"
+    "cuaDescription": "DeepChat 基于 trycua/cua 项目实现的 ComputerUse 插件",
+    "agentScopeTitle": "当前 Agent 作用域",
+    "agentScopeDescription": "选择当前 DeepChat Agent 可使用的全局插件、技能和 MCP 服务。插件自带的 MCP 服务跟随插件选择。",
+    "agentScopeNoAgent": "当前未选择 DeepChat Agent。",
+    "agentScopeUnsupported": "Agent 级扩展配置仅支持 DeepChat Agent。",
+    "agentScopeRefresh": "刷新",
+    "agentScopePlugins": "插件",
+    "agentScopeSkills": "技能",
+    "agentScopeMcp": "MCP 服务",
+    "agentScopeInherited": "继承",
+    "agentScopeCustom": "自定义",
+    "agentScopeInheritedSummary": "使用默认可用范围（{count} 项可用）。",
+    "agentScopeDenyAllSummary": "未选择任何项；该类别对此 Agent 禁用。",
+    "agentScopeSelectedSummary": "已选择 {count} 项",
+    "agentScopeSelectAll": "全选",
+    "agentScopeClearAll": "清空",
+    "agentScopeNoPlugins": "暂无可用的已启用插件。",
+    "agentScopeNoSkills": "暂无可用技能。",
+    "agentScopeNoMcp": "暂无可用的全局 MCP 服务。"
   },
   "controlCenter": {
     "groups": {

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -2756,6 +2756,24 @@
     "pluginNotFound": "找不到插件。",
     "capabilities": "能力",
     "actionResult": "操作結果",
-    "cuaDescription": "DeepChat 基於 trycua/cua 專案實作的 ComputerUse 插件"
+    "cuaDescription": "DeepChat 基於 trycua/cua 專案實作的 ComputerUse 插件",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -2756,6 +2756,24 @@
     "pluginNotFound": "找不到插件。",
     "capabilities": "能力",
     "actionResult": "操作結果",
-    "cuaDescription": "DeepChat 基於 trycua/cua 專案實作的 ComputerUse 插件"
+    "cuaDescription": "DeepChat 基於 trycua/cua 專案實作的 ComputerUse 插件",
+    "agentScopeTitle": "Current agent scope",
+    "agentScopeDescription": "Choose which globally installed plugins, skills, and MCP servers the current DeepChat agent can use. Plugin-owned MCP servers follow plugin selection.",
+    "agentScopeNoAgent": "No DeepChat agent is selected.",
+    "agentScopeUnsupported": "Agent-scoped extensions are only available for DeepChat agents.",
+    "agentScopeRefresh": "Refresh",
+    "agentScopePlugins": "Plugins",
+    "agentScopeSkills": "Skills",
+    "agentScopeMcp": "MCP servers",
+    "agentScopeInherited": "Inherited",
+    "agentScopeCustom": "Custom",
+    "agentScopeInheritedSummary": "Use the default availability ({count} available).",
+    "agentScopeDenyAllSummary": "None selected; this category is disabled for this agent.",
+    "agentScopeSelectedSummary": "{count} selected",
+    "agentScopeSelectAll": "Select all",
+    "agentScopeClearAll": "Clear",
+    "agentScopeNoPlugins": "No enabled plugins available.",
+    "agentScopeNoSkills": "No skills available.",
+    "agentScopeNoMcp": "No global MCP servers available."
   }
 }

--- a/src/renderer/src/pages/plugins/AgentExtensionPolicyPanel.vue
+++ b/src/renderer/src/pages/plugins/AgentExtensionPolicyPanel.vue
@@ -1,0 +1,428 @@
+<template>
+  <section
+    data-testid="agent-extension-policy-panel"
+    :class="[
+      'shrink-0 bg-muted/20 px-5 py-3',
+      props.standalone ? 'h-full overflow-y-auto' : 'border-b border-border/70'
+    ]"
+  >
+    <div class="mx-auto flex w-full max-w-5xl flex-col gap-3">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="flex min-w-0 items-center gap-2">
+            <Icon icon="lucide:sliders-horizontal" class="size-4 text-muted-foreground" />
+            <h2 class="truncate text-sm font-semibold">
+              {{ t('settings.pluginsHub.agentScopeTitle') }}
+            </h2>
+            <span
+              v-if="targetAgent"
+              class="shrink-0 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground"
+            >
+              {{ targetAgent.name }}
+            </span>
+          </div>
+          <p class="mt-1 text-xs text-muted-foreground">
+            {{ panelDescription }}
+          </p>
+        </div>
+
+        <div class="flex shrink-0 items-center gap-2">
+          <Button variant="outline" size="sm" :disabled="loading || saving" @click="loadPolicy">
+            <Icon
+              icon="lucide:refresh-cw"
+              class="mr-1.5 size-3.5"
+              :class="loading ? 'animate-spin' : ''"
+            />
+            {{ t('settings.pluginsHub.agentScopeRefresh') }}
+          </Button>
+          <Button
+            data-testid="agent-extension-policy-save"
+            size="sm"
+            :disabled="!targetAgent || loading || saving || !isDeepChatTarget"
+            @click="savePolicy"
+          >
+            {{ saving ? t('common.saving') : t('common.save') }}
+          </Button>
+        </div>
+      </div>
+
+      <div
+        v-if="errorMessage"
+        class="rounded-lg border border-destructive/40 px-3 py-2 text-xs text-destructive"
+      >
+        {{ errorMessage }}
+      </div>
+
+      <div v-if="isDeepChatTarget" :class="categoryGridClass">
+        <div
+          v-for="category in visibleCategories"
+          :key="category.kind"
+          class="space-y-3 rounded-xl border border-border bg-background p-3"
+        >
+          <div class="flex items-start justify-between gap-3">
+            <div class="min-w-0">
+              <div class="text-sm font-medium">{{ category.title }}</div>
+              <p class="mt-1 text-xs text-muted-foreground">
+                {{ policySummary(category.kind) }}
+              </p>
+            </div>
+            <Button
+              :data-testid="`agent-extension-${category.kind}-mode`"
+              variant="outline"
+              size="sm"
+              class="shrink-0"
+              @click="toggleMode(category.kind)"
+            >
+              {{ modeLabel(getMode(category.kind)) }}
+            </Button>
+          </div>
+
+          <div v-if="getMode(category.kind) === 'custom'" class="space-y-2">
+            <div class="flex flex-wrap gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                class="h-7 px-2 text-xs"
+                @click="selectAll(category.kind)"
+              >
+                {{ t('settings.pluginsHub.agentScopeSelectAll') }}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                class="h-7 px-2 text-xs"
+                @click="clearAll(category.kind)"
+              >
+                {{ t('settings.pluginsHub.agentScopeClearAll') }}
+              </Button>
+            </div>
+
+            <div
+              v-if="category.options.length === 0"
+              class="rounded-lg border border-dashed px-3 py-3 text-xs text-muted-foreground"
+            >
+              {{ category.emptyText }}
+            </div>
+            <div v-else class="flex max-h-28 flex-wrap gap-2 overflow-y-auto pr-1">
+              <Button
+                v-for="option in category.options"
+                :key="option.id"
+                type="button"
+                variant="outline"
+                size="sm"
+                class="h-8 max-w-full rounded-xl px-3 text-xs shadow-none transition-colors"
+                :class="
+                  isSelected(category.kind, option.id)
+                    ? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground'
+                    : 'border-border bg-background text-foreground hover:bg-muted'
+                "
+                :title="option.label"
+                @click="toggleSelection(category.kind, option.id)"
+              >
+                <span class="truncate">{{ option.label }}</span>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Icon } from '@iconify/vue'
+import { Button } from '@shadcn/components/ui/button'
+import { createConfigClient } from '@api/ConfigClient'
+import { createMcpClient } from '@api/McpClient'
+import { createPluginClient } from '@api/PluginClient'
+import { createSkillClient } from '@api/SkillClient'
+import { useAgentStore } from '@/stores/ui/agent'
+import { useSessionStore } from '@/stores/ui/session'
+import type { Agent, DeepChatAgentConfig } from '@shared/types/agent-interface'
+import type { MCPServerConfig } from '@shared/presenter'
+import type { PluginListItem } from '@shared/types/plugin'
+import type { SkillMetadata } from '@shared/types/skill'
+
+type PolicyKind = 'plugins' | 'skills' | 'mcp'
+type PolicyMode = 'inherit' | 'custom'
+type PolicyOption = {
+  id: string
+  label: string
+}
+type McpServerOption = {
+  id: string
+  config: MCPServerConfig
+}
+
+const props = withDefaults(
+  defineProps<{
+    kinds?: PolicyKind[]
+    standalone?: boolean
+  }>(),
+  {
+    kinds: () => ['plugins', 'skills', 'mcp'],
+    standalone: false
+  }
+)
+
+const { t } = useI18n()
+const agentStore = useAgentStore()
+const sessionStore = useSessionStore()
+const configClient = createConfigClient()
+const mcpClient = createMcpClient()
+const pluginClient = createPluginClient()
+const skillClient = createSkillClient()
+
+const loading = ref(false)
+const saving = ref(false)
+const errorMessage = ref('')
+const targetAgent = ref<Agent | null>(null)
+const plugins = ref<PluginListItem[]>([])
+const skills = ref<SkillMetadata[]>([])
+const mcpServers = ref<McpServerOption[]>([])
+const pluginMode = ref<PolicyMode>('inherit')
+const skillMode = ref<PolicyMode>('inherit')
+const mcpMode = ref<PolicyMode>('inherit')
+const selectedPluginIds = ref<string[]>([])
+const selectedSkillNames = ref<string[]>([])
+const selectedMcpServerIds = ref<string[]>([])
+
+const normalizeList = (value: string[] | null | undefined): string[] =>
+  Array.from(new Set((value ?? []).map((item) => item.trim()).filter(Boolean))).sort(
+    (left, right) => left.localeCompare(right)
+  )
+const modeFromConfig = (value: string[] | null | undefined): PolicyMode =>
+  value === null || value === undefined ? 'inherit' : 'custom'
+const valueForSave = (mode: PolicyMode, values: string[]): string[] | null =>
+  mode === 'inherit' ? null : normalizeList(values)
+
+const targetAgentId = computed(() => {
+  const activeSessionAgentId = sessionStore.activeSession?.agentId?.trim()
+  if (activeSessionAgentId) {
+    return activeSessionAgentId
+  }
+
+  const selectedAgentId = agentStore.selectedAgentId?.trim()
+  if (selectedAgentId) {
+    return selectedAgentId
+  }
+
+  return 'deepchat'
+})
+const isDeepChatTarget = computed(() =>
+  Boolean(targetAgent.value && targetAgent.value.type === 'deepchat')
+)
+const pluginOptions = computed<PolicyOption[]>(() =>
+  plugins.value
+    .filter((plugin) => plugin.installed !== false && plugin.enabled)
+    .map((plugin) => ({ id: plugin.id, label: plugin.name }))
+    .sort((left, right) => left.label.localeCompare(right.label))
+)
+const skillOptions = computed<PolicyOption[]>(() =>
+  skills.value
+    .map((skill) => ({ id: skill.name, label: skill.name }))
+    .sort((left, right) => left.label.localeCompare(right.label))
+)
+const mcpOptions = computed<PolicyOption[]>(() =>
+  mcpServers.value
+    .filter(
+      (server) =>
+        server.config.enabled !== false && !server.config.disable && !server.config.ownerPluginId
+    )
+    .map((server) => ({ id: server.id, label: server.config.descriptions || server.id }))
+    .sort((left, right) => left.label.localeCompare(right.label))
+)
+const categories = computed(() => [
+  {
+    kind: 'plugins' as const,
+    title: t('settings.pluginsHub.agentScopePlugins'),
+    emptyText: t('settings.pluginsHub.agentScopeNoPlugins'),
+    options: pluginOptions.value
+  },
+  {
+    kind: 'skills' as const,
+    title: t('settings.pluginsHub.agentScopeSkills'),
+    emptyText: t('settings.pluginsHub.agentScopeNoSkills'),
+    options: skillOptions.value
+  },
+  {
+    kind: 'mcp' as const,
+    title: t('settings.pluginsHub.agentScopeMcp'),
+    emptyText: t('settings.pluginsHub.agentScopeNoMcp'),
+    options: mcpOptions.value
+  }
+])
+const visibleCategories = computed(() => {
+  const allowed = new Set(props.kinds)
+  return categories.value.filter((category) => allowed.has(category.kind))
+})
+const categoryGridClass = computed(() =>
+  props.standalone || visibleCategories.value.length === 1
+    ? 'grid gap-3'
+    : 'grid gap-3 lg:grid-cols-3'
+)
+const panelDescription = computed(() => {
+  if (loading.value) {
+    return t('common.loading')
+  }
+  if (!targetAgent.value) {
+    return t('settings.pluginsHub.agentScopeNoAgent')
+  }
+  if (!isDeepChatTarget.value) {
+    return t('settings.pluginsHub.agentScopeUnsupported')
+  }
+  return t('settings.pluginsHub.agentScopeDescription')
+})
+
+function optionIds(kind: PolicyKind): string[] {
+  if (kind === 'plugins') return pluginOptions.value.map((option) => option.id)
+  if (kind === 'skills') return skillOptions.value.map((option) => option.id)
+  return mcpOptions.value.map((option) => option.id)
+}
+
+function getMode(kind: PolicyKind): PolicyMode {
+  if (kind === 'plugins') return pluginMode.value
+  if (kind === 'skills') return skillMode.value
+  return mcpMode.value
+}
+
+function setMode(kind: PolicyKind, mode: PolicyMode): void {
+  if (kind === 'plugins') pluginMode.value = mode
+  else if (kind === 'skills') skillMode.value = mode
+  else mcpMode.value = mode
+}
+
+function selectedValues(kind: PolicyKind): string[] {
+  if (kind === 'plugins') return selectedPluginIds.value
+  if (kind === 'skills') return selectedSkillNames.value
+  return selectedMcpServerIds.value
+}
+
+function setSelectedValues(kind: PolicyKind, values: string[]): void {
+  const normalized = normalizeList(values)
+  if (kind === 'plugins') selectedPluginIds.value = normalized
+  else if (kind === 'skills') selectedSkillNames.value = normalized
+  else selectedMcpServerIds.value = normalized
+}
+
+function modeLabel(mode: PolicyMode): string {
+  return mode === 'inherit'
+    ? t('settings.pluginsHub.agentScopeInherited')
+    : t('settings.pluginsHub.agentScopeCustom')
+}
+
+function policySummary(kind: PolicyKind): string {
+  const mode = getMode(kind)
+  if (mode === 'inherit') {
+    return t('settings.pluginsHub.agentScopeInheritedSummary', { count: optionIds(kind).length })
+  }
+
+  const count = selectedValues(kind).length
+  return count === 0
+    ? t('settings.pluginsHub.agentScopeDenyAllSummary')
+    : t('settings.pluginsHub.agentScopeSelectedSummary', { count })
+}
+
+function toggleMode(kind: PolicyKind): void {
+  if (getMode(kind) === 'inherit') {
+    setSelectedValues(kind, optionIds(kind))
+    setMode(kind, 'custom')
+    return
+  }
+
+  setMode(kind, 'inherit')
+}
+
+function isSelected(kind: PolicyKind, id: string): boolean {
+  return selectedValues(kind).includes(id)
+}
+
+function toggleSelection(kind: PolicyKind, id: string): void {
+  const next = new Set(selectedValues(kind))
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  setSelectedValues(kind, Array.from(next))
+}
+
+function selectAll(kind: PolicyKind): void {
+  setSelectedValues(kind, optionIds(kind))
+}
+
+function clearAll(kind: PolicyKind): void {
+  setSelectedValues(kind, [])
+}
+
+function applyConfig(config: DeepChatAgentConfig | null | undefined): void {
+  pluginMode.value = modeFromConfig(config?.enabledPluginIds)
+  skillMode.value = modeFromConfig(config?.enabledSkillNames)
+  mcpMode.value = modeFromConfig(config?.enabledMcpServerIds)
+  selectedPluginIds.value = normalizeList(config?.enabledPluginIds)
+  selectedSkillNames.value = normalizeList(config?.enabledSkillNames)
+  selectedMcpServerIds.value = normalizeList(config?.enabledMcpServerIds)
+}
+
+async function loadPolicy(): Promise<void> {
+  const agentId = targetAgentId.value
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const [agents, pluginList, skillList, serverMap] = await Promise.all([
+      configClient.listAgents({ ids: [agentId] }),
+      pluginClient.listPlugins().catch(() => []),
+      skillClient.getMetadataList().catch(() => []),
+      mcpClient.getMcpServers().catch(() => ({}))
+    ])
+
+    targetAgent.value = agents[0] ?? null
+    plugins.value = Array.isArray(pluginList) ? pluginList : []
+    skills.value = Array.isArray(skillList) ? skillList : []
+    mcpServers.value = Object.entries(serverMap ?? {}).map(([id, config]) => ({ id, config }))
+    applyConfig(targetAgent.value?.config)
+  } catch (error) {
+    targetAgent.value = null
+    errorMessage.value = error instanceof Error ? error.message : String(error)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function savePolicy(): Promise<void> {
+  const agent = targetAgent.value
+  if (!agent || agent.type !== 'deepchat') {
+    return
+  }
+
+  saving.value = true
+  errorMessage.value = ''
+  try {
+    const config: DeepChatAgentConfig = {}
+    const kinds = new Set(props.kinds)
+    if (kinds.has('plugins')) {
+      config.enabledPluginIds = valueForSave(pluginMode.value, selectedPluginIds.value)
+    }
+    if (kinds.has('skills')) {
+      config.enabledSkillNames = valueForSave(skillMode.value, selectedSkillNames.value)
+    }
+    if (kinds.has('mcp')) {
+      config.enabledMcpServerIds = valueForSave(mcpMode.value, selectedMcpServerIds.value)
+    }
+
+    const updated = await configClient.updateDeepChatAgent(agent.id, {
+      config
+    })
+    if (updated) {
+      targetAgent.value = updated
+      applyConfig(updated.config)
+      void agentStore.refreshAgentsByIds('deepchat', [updated.id])
+    }
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : String(error)
+  } finally {
+    saving.value = false
+  }
+}
+
+watch(targetAgentId, () => void loadPolicy(), { immediate: true })
+</script>

--- a/src/renderer/src/pages/plugins/AgentExtensionPolicyPanel.vue
+++ b/src/renderer/src/pages/plugins/AgentExtensionPolicyPanel.vue
@@ -197,6 +197,8 @@ const modeFromConfig = (value: string[] | null | undefined): PolicyMode =>
   value === null || value === undefined ? 'inherit' : 'custom'
 const valueForSave = (mode: PolicyMode, values: string[]): string[] | null =>
   mode === 'inherit' ? null : normalizeList(values)
+const isPluginOwnedMcpServer = (config: MCPServerConfig): boolean =>
+  Boolean(config.ownerPluginId?.trim() || (config.source === 'plugin' && config.sourceId?.trim()))
 
 const targetAgentId = computed(() => {
   const activeSessionAgentId = sessionStore.activeSession?.agentId?.trim()
@@ -229,7 +231,9 @@ const mcpOptions = computed<PolicyOption[]>(() =>
   mcpServers.value
     .filter(
       (server) =>
-        server.config.enabled !== false && !server.config.disable && !server.config.ownerPluginId
+        server.config.enabled !== false &&
+        !server.config.disable &&
+        !isPluginOwnedMcpServer(server.config)
     )
     .map((server) => ({ id: server.id, label: server.config.descriptions || server.id }))
     .sort((left, right) => left.label.localeCompare(right.label))

--- a/src/renderer/src/pages/plugins/McpPluginsPage.vue
+++ b/src/renderer/src/pages/plugins/McpPluginsPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <McpSettings />
+  <McpSettings scope="agent" />
 </template>
 
 <script setup lang="ts">

--- a/src/renderer/src/pages/plugins/PluginsCatalogPage.vue
+++ b/src/renderer/src/pages/plugins/PluginsCatalogPage.vue
@@ -21,6 +21,8 @@
         {{ errorMessage }}
       </div>
 
+      <AgentExtensionPolicyPanel :kinds="['plugins']" />
+
       <section class="space-y-4">
         <div class="border-b border-border/70 pb-2">
           <h2 class="text-sm font-semibold">{{ t('settings.pluginsHub.available') }}</h2>
@@ -90,6 +92,7 @@ import { createPluginClient } from '@api/PluginClient'
 import { createRemoteControlClient } from '@api/RemoteControlClient'
 import type { PluginActionResult, PluginListItem } from '@shared/types/plugin'
 import type { RemoteChannel, RemoteChannelDescriptor, RemoteChannelStatus } from '@shared/presenter'
+import AgentExtensionPolicyPanel from './AgentExtensionPolicyPanel.vue'
 
 type CatalogItem = {
   id: string

--- a/src/renderer/src/pages/plugins/SkillsPluginsPage.vue
+++ b/src/renderer/src/pages/plugins/SkillsPluginsPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <SkillsSettings />
+  <SkillsSettings scope="agent" />
 </template>
 
 <script setup lang="ts">

--- a/src/shared/contracts/domainSchemas.ts
+++ b/src/shared/contracts/domainSchemas.ts
@@ -676,6 +676,9 @@ export const DeepChatAgentConfigSchema = z.looseObject({
   systemPrompt: z.string().optional(),
   permissionMode: z.enum(['default', 'full_access']).optional(),
   disabledAgentTools: z.array(z.string()).optional(),
+  enabledPluginIds: z.array(z.string()).nullable().optional(),
+  enabledSkillNames: z.array(z.string()).nullable().optional(),
+  enabledMcpServerIds: z.array(z.string()).nullable().optional(),
   subagentEnabled: z.boolean().optional(),
   defaultProjectPath: z.string().nullable().optional()
 })

--- a/src/shared/types/agent-interface.d.ts
+++ b/src/shared/types/agent-interface.d.ts
@@ -709,6 +709,9 @@ export interface DeepChatAgentConfig {
   systemPrompt?: string
   permissionMode?: PermissionMode
   disabledAgentTools?: string[]
+  enabledPluginIds?: string[] | null
+  enabledSkillNames?: string[] | null
+  enabledMcpServerIds?: string[] | null
   subagentEnabled?: boolean
   subagents?: DeepChatSubagentSlot[]
   autoCompactionEnabled?: boolean

--- a/src/shared/types/presenters/core.presenter.d.ts
+++ b/src/shared/types/presenters/core.presenter.d.ts
@@ -1772,7 +1772,17 @@ export interface IMCPPresenter {
   startServer(serverName: string): Promise<void>
   stopServer(serverName: string): Promise<void>
   getServerLastError?(serverName: string): string | undefined
-  getAllToolDefinitions(enabledMcpTools?: string[]): Promise<MCPToolDefinition[]>
+  getAllToolDefinitions(
+    enabledMcpTools?:
+      | string[]
+      | {
+          enabledTools?: string[]
+          enabledServerIds?: string[]
+          enabledPluginIds?: string[]
+          agentId?: string
+          conversationId?: string
+        }
+  ): Promise<MCPToolDefinition[]>
   getAllPrompts(): Promise<Array<PromptListEntry & { client: { name: string; icon: string } }>>
   getAllResources(): Promise<Array<ResourceListEntry & { client: { name: string; icon: string } }>>
   getPrompt(prompt: PromptListEntry, args?: Record<string, unknown>): Promise<unknown>
@@ -1787,9 +1797,19 @@ export interface IMCPPresenter {
         progressJson: string
       }) => void
       signal?: AbortSignal
+      agentId?: string
+      enabledServerIds?: string[]
+      enabledPluginIds?: string[]
     }
   ): Promise<{ content: string; rawData: MCPToolResponse }>
-  preCheckToolPermission?(request: MCPToolCall): Promise<{
+  preCheckToolPermission?(
+    request: MCPToolCall,
+    options?: {
+      agentId?: string
+      enabledServerIds?: string[]
+      enabledPluginIds?: string[]
+    }
+  ): Promise<{
     needsPermission: true
     toolName: string
     serverName: string

--- a/src/shared/types/presenters/tool.presenter.d.ts
+++ b/src/shared/types/presenters/tool.presenter.d.ts
@@ -31,6 +31,9 @@ export interface IToolPresenter {
    */
   getAllToolDefinitions(context: {
     enabledMcpTools?: string[]
+    enabledMcpServerIds?: string[]
+    enabledPluginIds?: string[]
+    agentId?: string
     disabledAgentTools?: string[]
     chatMode?: 'agent' | 'acp agent'
     supportsVision?: boolean
@@ -58,6 +61,9 @@ export interface IToolPresenter {
       signal?: AbortSignal
       permissionMode?: PermissionMode
       activeSkillNames?: string[]
+      agentId?: string
+      enabledMcpServerIds?: string[]
+      enabledPluginIds?: string[]
     }
   ): Promise<{ content: unknown; rawData: MCPToolResponse }>
 

--- a/test/main/presenter/agentRepository.test.ts
+++ b/test/main/presenter/agentRepository.test.ts
@@ -451,6 +451,60 @@ describe('AgentRepository', () => {
     ).toBe(2000)
   })
 
+  it('inherits extension policies from builtin and lets custom agents override with empty arrays', () => {
+    const now = Date.now()
+    const makeRow = (id: string, source: string, config: object) => ({
+      id,
+      agent_type: 'deepchat',
+      source,
+      name: id,
+      enabled: 1,
+      protected: source === 'builtin' ? 1 : 0,
+      description: null,
+      icon: null,
+      avatar_json: null,
+      config_json: JSON.stringify(config),
+      state_json: null,
+      created_at: now,
+      updated_at: now
+    })
+    const rows = new Map<string, any>([
+      [
+        'deepchat',
+        makeRow('deepchat', 'builtin', {
+          enabledPluginIds: [' plugin-a ', 'plugin-a'],
+          enabledSkillNames: ['skill-a'],
+          enabledMcpServerIds: ['server-a']
+        })
+      ],
+      ['inheriting-agent', makeRow('inheriting-agent', 'manual', {})],
+      [
+        'overriding-agent',
+        makeRow('overriding-agent', 'manual', {
+          enabledPluginIds: [],
+          enabledSkillNames: ['skill-b'],
+          enabledMcpServerIds: []
+        })
+      ]
+    ])
+    const repository = new AgentRepository({
+      agentsTable: {
+        get: (id: string) => rows.get(id)
+      }
+    } as never)
+
+    expect(repository.resolveDeepChatAgentConfig('inheriting-agent')).toMatchObject({
+      enabledPluginIds: ['plugin-a'],
+      enabledSkillNames: ['skill-a'],
+      enabledMcpServerIds: ['server-a']
+    })
+    expect(repository.resolveDeepChatAgentConfig('overriding-agent')).toMatchObject({
+      enabledPluginIds: [],
+      enabledSkillNames: ['skill-b'],
+      enabledMcpServerIds: []
+    })
+  })
+
   it('clears registry ACP installation state without deleting the row', () => {
     const row = {
       id: 'codex-acp',

--- a/test/main/presenter/mcpPresenter.test.ts
+++ b/test/main/presenter/mcpPresenter.test.ts
@@ -329,6 +329,39 @@ describe('McpPresenter#setMcpServerEnabled', () => {
     expect(tools.map((tool) => tool.function.name)).toEqual(['plugin_tool'])
   })
 
+  it('gates source plugin tools by plugin policy before server policy', async () => {
+    const configPresenter = createConfigPresenter(true, false, {
+      plugin: { enabled: true, source: 'plugin', sourceId: 'plugin-a' }
+    })
+    toolManagerMocks.getAllToolDefinitions.mockResolvedValue([
+      {
+        type: 'function',
+        function: {
+          name: 'plugin_tool',
+          description: '',
+          parameters: { type: 'object', properties: {} }
+        },
+        server: { name: 'plugin', icons: '', description: '' }
+      }
+    ])
+    const presenter = new McpPresenter(configPresenter)
+    ;(presenter as any).toolManager = {
+      getAllToolDefinitions: toolManagerMocks.getAllToolDefinitions
+    }
+
+    const blockedTools = await presenter.getAllToolDefinitions({
+      enabledServerIds: ['plugin'],
+      enabledPluginIds: []
+    })
+    const allowedTools = await presenter.getAllToolDefinitions({
+      enabledServerIds: [],
+      enabledPluginIds: ['plugin-a']
+    })
+
+    expect(blockedTools).toEqual([])
+    expect(allowedTools.map((tool) => tool.function.name)).toEqual(['plugin_tool'])
+  })
+
   it('rejects when the runtime transition fails after persisting config', async () => {
     const configPresenter = createConfigPresenter(true)
     const presenter = new McpPresenter(configPresenter)

--- a/test/main/presenter/mcpPresenter/toolManager.test.ts
+++ b/test/main/presenter/mcpPresenter/toolManager.test.ts
@@ -244,6 +244,30 @@ describe('ToolManager', () => {
     ])
   })
 
+  it('gates source plugin MCP servers by plugin policy instead of server policy', async () => {
+    const pluginClient = createClient('plugin-source-server', undefined, {
+      source: 'plugin',
+      sourceId: 'plugin-b'
+    })
+    const configPresenter = createConfigPresenter('plugin-source-server')
+    const manager = new ToolManager(
+      configPresenter as never,
+      createServerManager([pluginClient]) as never
+    )
+
+    const blockedDefinitions = await manager.getAllToolDefinitions({
+      enabledServerIds: ['plugin-source-server'],
+      enabledPluginIds: []
+    })
+    const allowedDefinitions = await manager.getAllToolDefinitions({
+      enabledServerIds: [],
+      enabledPluginIds: ['plugin-b']
+    })
+
+    expect(blockedDefinitions).toEqual([])
+    expect(allowedDefinitions.map((tool) => tool.server.name)).toEqual(['plugin-source-server'])
+  })
+
   it('blocks DeepChat MCP tool calls outside enabled server policy', async () => {
     const client = createClient('blocked-server')
     const configPresenter = createConfigPresenter('blocked-server')

--- a/test/main/presenter/mcpPresenter/toolManager.test.ts
+++ b/test/main/presenter/mcpPresenter/toolManager.test.ts
@@ -219,6 +219,61 @@ describe('ToolManager', () => {
     expect(configPresenter.getAgentMcpSelections).toHaveBeenCalledWith('agent-1')
   })
 
+  it('filters DeepChat MCP tool definitions by enabled server and plugin policies', async () => {
+    const normalClient = createClient('server-a')
+    const blockedClient = createClient('server-b')
+    const pluginClient = createClient('plugin-server', undefined, {
+      source: 'plugin',
+      ownerPluginId: 'plugin-a'
+    })
+    const configPresenter = createConfigPresenter('server-a')
+    const manager = new ToolManager(
+      configPresenter as never,
+      createServerManager([normalClient, blockedClient, pluginClient]) as never
+    )
+
+    const definitions = await manager.getAllToolDefinitions({
+      agentId: 'agent-1',
+      enabledServerIds: ['server-a'],
+      enabledPluginIds: ['plugin-a']
+    })
+
+    expect(definitions.map((tool) => tool.server.name).sort()).toEqual([
+      'plugin-server',
+      'server-a'
+    ])
+  })
+
+  it('blocks DeepChat MCP tool calls outside enabled server policy', async () => {
+    const client = createClient('blocked-server')
+    const configPresenter = createConfigPresenter('blocked-server')
+    const manager = new ToolManager(
+      configPresenter as never,
+      createServerManager([client]) as never
+    )
+
+    const result = await manager.callTool(
+      {
+        id: 'tool-deepchat-blocked',
+        type: 'function',
+        function: {
+          name: 'echo',
+          arguments: '{}'
+        },
+        conversationId: 'session-deepchat',
+        providerId: 'openai'
+      },
+      {
+        agentId: 'agent-1',
+        enabledServerIds: ['allowed-server']
+      }
+    )
+
+    expect(result.isError).toBe(true)
+    expect(result.content).toContain("MCP server 'blocked-server' is not allowed")
+    expect(client.callTool).not.toHaveBeenCalled()
+  })
+
   it('records plugin tool-list failures without showing a global toast', async () => {
     const client = createClient('plugin-server', [], {
       source: 'plugin',

--- a/test/main/presenter/skillPresenter/skillTools.test.ts
+++ b/test/main/presenter/skillPresenter/skillTools.test.ts
@@ -156,7 +156,7 @@ describe('SkillTools', () => {
   describe('handleSkillView', () => {
     it('passes file_path and conversationId through to the presenter by default', async () => {
       const result = await skillTools.handleSkillView('conv-123', {
-        name: 'code-review',
+        name: ' code-review ',
         file_path: 'references/checklist.md'
       })
 

--- a/test/main/presenter/skillPresenter/skillTools.test.ts
+++ b/test/main/presenter/skillPresenter/skillTools.test.ts
@@ -134,6 +134,23 @@ describe('SkillTools', () => {
         })
       )
     })
+
+    it('filters listed and pinned skills by the agent allowlist', async () => {
+      ;(mockSkillPresenter.getActiveSkills as Mock).mockResolvedValue(['code-review', 'git-commit'])
+
+      const result = await skillTools.handleSkillList('conv-123', ['git-commit'])
+
+      expect(result.totalCount).toBe(1)
+      expect(result.pinnedCount).toBe(1)
+      expect(result.activeCount).toBe(1)
+      expect(result.skills).toEqual([
+        expect.objectContaining({
+          name: 'git-commit',
+          isPinned: true,
+          active: true
+        })
+      ])
+    })
   })
 
   describe('handleSkillView', () => {
@@ -153,6 +170,23 @@ describe('SkillTools', () => {
           name: 'code-review'
         })
       )
+    })
+
+    it('rejects viewing skills outside the agent allowlist', async () => {
+      const result = await skillTools.handleSkillView(
+        'conv-123',
+        {
+          name: 'code-review'
+        },
+        ['git-commit']
+      )
+
+      expect(mockSkillPresenter.viewSkill).not.toHaveBeenCalled()
+      expect(result).toEqual({
+        success: false,
+        name: 'code-review',
+        error: "Skill 'code-review' is not enabled for this agent"
+      })
     })
   })
 

--- a/test/main/presenter/toolPresenter/agentTools/agentToolManagerSettings.test.ts
+++ b/test/main/presenter/toolPresenter/agentTools/agentToolManagerSettings.test.ts
@@ -18,6 +18,7 @@ describe('AgentToolManager DeepChat settings tool gating', () => {
   const skillPresenter = {
     getActiveSkills: vi.fn(),
     getActiveSkillsAllowedTools: vi.fn(),
+    getMetadataList: vi.fn(),
     viewSkill: vi.fn(),
     listSkillScripts: vi.fn().mockResolvedValue([]),
     manageDraftSkill: vi.fn(),
@@ -66,6 +67,15 @@ describe('AgentToolManager DeepChat settings tool gating', () => {
     resolveConversationWorkdir.mockResolvedValue(null)
     resolveConversationSessionInfo.mockResolvedValue(null)
     skillPresenter.listSkillScripts.mockResolvedValue([])
+    skillPresenter.getMetadataList.mockResolvedValue([
+      {
+        name: 'code-review',
+        description: 'Code Review',
+        category: 'engineering',
+        platforms: [],
+        metadata: {}
+      }
+    ])
     skillPresenter.viewSkill.mockResolvedValue({
       success: true,
       name: 'code-review',
@@ -175,6 +185,24 @@ describe('AgentToolManager DeepChat settings tool gating', () => {
     expect(names).toContain('skill_view')
     expect(names).toContain('skill_manage')
     expect(names).not.toContain('skill_control')
+  })
+
+  it('keeps skill_list unrestricted when active skill override is omitted', async () => {
+    skillPresenter.getActiveSkills.mockResolvedValue(['code-review'])
+    skillPresenter.getActiveSkillsAllowedTools.mockResolvedValue([])
+
+    const manager = buildManager()
+    const result = (await manager.callTool('skill_list', {}, 'conv-1')) as { content: string }
+    const content = JSON.parse(result.content) as {
+      skills: Array<{ name: string; active: boolean }>
+    }
+
+    expect(content.skills).toEqual([
+      expect.objectContaining({
+        name: 'code-review',
+        active: true
+      })
+    ])
   })
 
   it('returns runtime skill_view activation metadata without persisting session skills', async () => {

--- a/test/main/presenter/toolPresenter/toolPresenter.test.ts
+++ b/test/main/presenter/toolPresenter/toolPresenter.test.ts
@@ -300,6 +300,93 @@ describe('ToolPresenter', () => {
     expect(defs.some((tool) => tool.function.name === 'ls')).toBe(false)
   })
 
+  it('passes DeepChat agent MCP policy context to MCP presenter', async () => {
+    const mcpPresenter = {
+      getAllToolDefinitions: vi.fn().mockResolvedValue([]),
+      callTool: vi.fn()
+    } as any
+    const configPresenter = {
+      getSkillsEnabled: vi.fn().mockReturnValue(false),
+      getSkillsPath: vi.fn().mockReturnValue('C:\\skills'),
+      getModelConfig: vi.fn()
+    }
+
+    const toolPresenter = new ToolPresenter({
+      mcpPresenter,
+      configPresenter: configPresenter as any,
+      commandPermissionHandler: new CommandPermissionService(),
+      agentToolRuntime: buildAgentToolRuntimeMock()
+    })
+
+    await toolPresenter.getAllToolDefinitions({
+      agentId: 'agent-1',
+      enabledMcpServerIds: ['server-a'],
+      enabledPluginIds: ['plugin-a'],
+      chatMode: 'agent',
+      conversationId: 'session-1'
+    })
+
+    expect(mcpPresenter.getAllToolDefinitions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: 'agent-1',
+        enabledServerIds: ['server-a'],
+        enabledPluginIds: ['plugin-a'],
+        conversationId: 'session-1'
+      })
+    )
+  })
+
+  it('preserves unrestricted MCP policy in stored conversation context', async () => {
+    const mcpPresenter = {
+      getAllToolDefinitions: vi
+        .fn()
+        .mockResolvedValue([buildToolDefinition('mcp_only', 'open-server')]),
+      callTool: vi.fn().mockResolvedValue({ content: 'ok' })
+    } as any
+    const configPresenter = {
+      getSkillsEnabled: vi.fn().mockReturnValue(false),
+      getSkillsPath: vi.fn().mockReturnValue('C:\\skills'),
+      getModelConfig: vi.fn()
+    }
+
+    const toolPresenter = new ToolPresenter({
+      mcpPresenter,
+      configPresenter: configPresenter as any,
+      commandPermissionHandler: new CommandPermissionService(),
+      agentToolRuntime: buildAgentToolRuntimeMock()
+    })
+
+    await toolPresenter.getAllToolDefinitions({
+      agentId: 'agent-1',
+      enabledMcpServerIds: undefined,
+      enabledPluginIds: undefined,
+      chatMode: 'agent',
+      conversationId: 'session-unrestricted'
+    })
+
+    await toolPresenter.callTool({
+      id: 'tool-1',
+      type: 'function',
+      function: {
+        name: 'mcp_only',
+        arguments: '{}'
+      },
+      server: {
+        name: 'open-server'
+      },
+      conversationId: 'session-unrestricted'
+    } as any)
+
+    expect(mcpPresenter.callTool).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: 'session-unrestricted' }),
+      expect.objectContaining({
+        agentId: 'agent-1',
+        enabledServerIds: undefined,
+        enabledPluginIds: undefined
+      })
+    )
+  })
+
   it('omits YoBrowser prompt text when no yobrowser tools are enabled', () => {
     const mcpPresenter = {
       getAllToolDefinitions: vi.fn().mockResolvedValue([]),

--- a/test/renderer/components/AgentExtensionPolicyPanel.test.ts
+++ b/test/renderer/components/AgentExtensionPolicyPanel.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+const ButtonStub = defineComponent({
+  name: 'Button',
+  props: {
+    disabled: { type: Boolean, default: false }
+  },
+  emits: ['click'],
+  template:
+    '<button v-bind="$attrs" :disabled="disabled" @click="$emit(\'click\', $event)"><slot /></button>'
+})
+
+const mocks = vi.hoisted(() => ({
+  configClient: {
+    listAgents: vi.fn(),
+    updateDeepChatAgent: vi.fn(),
+    onAgentsChanged: vi.fn(),
+    getSetting: vi.fn()
+  },
+  pluginClient: {
+    listPlugins: vi.fn()
+  },
+  skillClient: {
+    getMetadataList: vi.fn()
+  },
+  mcpClient: {
+    getMcpServers: vi.fn()
+  }
+}))
+
+vi.mock('@api/ConfigClient', () => ({
+  createConfigClient: () => mocks.configClient
+}))
+vi.mock('@api/PluginClient', () => ({
+  createPluginClient: () => mocks.pluginClient
+}))
+vi.mock('@api/SkillClient', () => ({
+  createSkillClient: () => mocks.skillClient
+}))
+vi.mock('@api/McpClient', () => ({
+  createMcpClient: () => mocks.mcpClient
+}))
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params?.count === undefined ? key : `${key}:${String(params.count)}`
+  })
+}))
+vi.mock('@iconify/vue', () => ({
+  Icon: defineComponent({
+    name: 'Icon',
+    template: '<span />'
+  })
+}))
+
+describe('AgentExtensionPolicyPanel', () => {
+  async function mountPanel(options: { kinds?: string[]; standalone?: boolean } = {}) {
+    vi.resetModules()
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+
+    const agent = {
+      id: 'deepchat',
+      type: 'deepchat',
+      name: 'DeepChat',
+      enabled: true,
+      protected: true,
+      config: {}
+    }
+
+    mocks.configClient.listAgents.mockResolvedValue([agent])
+    mocks.configClient.updateDeepChatAgent.mockResolvedValue(agent)
+    mocks.configClient.onAgentsChanged.mockReturnValue(() => undefined)
+    mocks.configClient.getSetting.mockResolvedValue(null)
+    mocks.pluginClient.listPlugins.mockResolvedValue([
+      {
+        id: 'plugin-alpha',
+        name: 'Plugin Alpha',
+        version: '1.0.0',
+        publisher: 'DeepChat',
+        installed: true,
+        enabled: true,
+        trusted: true,
+        trustState: 'trusted',
+        official: true,
+        capabilities: []
+      }
+    ])
+    mocks.skillClient.getMetadataList.mockResolvedValue([
+      { name: 'skill-alpha', description: 'Skill Alpha', path: '', skillRoot: '' }
+    ])
+    mocks.mcpClient.getMcpServers.mockResolvedValue({
+      'server-alpha': {
+        command: '',
+        args: [],
+        env: {},
+        descriptions: 'Server Alpha',
+        icons: '',
+        autoApprove: [],
+        enabled: true,
+        type: 'stdio'
+      },
+      'plugin-owned': {
+        command: '',
+        args: [],
+        env: {},
+        descriptions: 'Plugin Owned',
+        icons: '',
+        autoApprove: [],
+        enabled: true,
+        type: 'stdio',
+        ownerPluginId: 'plugin-alpha'
+      }
+    })
+
+    const { useAgentStore } = await import('@/stores/ui/agent')
+    const { useSessionStore } = await import('@/stores/ui/session')
+    useAgentStore().setSelectedAgent('deepchat')
+    useSessionStore().activeSessionId = null
+
+    const AgentExtensionPolicyPanel = (
+      await import('@/pages/plugins/AgentExtensionPolicyPanel.vue')
+    ).default
+    const wrapper = shallowMount(AgentExtensionPolicyPanel, {
+      props: options,
+      global: {
+        stubs: {
+          Button: ButtonStub,
+          Icon: true
+        }
+      }
+    })
+    await flushPromises()
+
+    return { wrapper }
+  }
+
+  it('renders a skills-only agent policy view without global skill toggles', async () => {
+    const { wrapper } = await mountPanel({ kinds: ['skills'], standalone: true })
+
+    expect(wrapper.find('[data-testid="agent-extension-plugins-mode"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="agent-extension-mcp-mode"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="agent-extension-skills-mode"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('settings.skills.title')
+
+    await wrapper.find('[data-testid="agent-extension-skills-mode"]').trigger('click')
+    expect(wrapper.text()).toContain('skill-alpha')
+
+    await wrapper.find('[data-testid="agent-extension-policy-save"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.configClient.updateDeepChatAgent).toHaveBeenCalledWith('deepchat', {
+      config: {
+        enabledSkillNames: ['skill-alpha']
+      }
+    })
+  })
+
+  it('saves plugin skill and global MCP policy for the current agent', async () => {
+    const { wrapper } = await mountPanel()
+
+    expect(wrapper.text()).not.toContain('Plugin Owned')
+
+    for (const selector of [
+      '[data-testid="agent-extension-plugins-mode"]',
+      '[data-testid="agent-extension-skills-mode"]',
+      '[data-testid="agent-extension-mcp-mode"]'
+    ]) {
+      await wrapper.find(selector).trigger('click')
+    }
+
+    expect(wrapper.text()).toContain('Plugin Alpha')
+    expect(wrapper.text()).toContain('skill-alpha')
+    expect(wrapper.text()).toContain('Server Alpha')
+    expect(wrapper.text()).not.toContain('Plugin Owned')
+
+    await wrapper.find('[data-testid="agent-extension-policy-save"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.configClient.updateDeepChatAgent).toHaveBeenCalledWith('deepchat', {
+      config: {
+        enabledPluginIds: ['plugin-alpha'],
+        enabledSkillNames: ['skill-alpha'],
+        enabledMcpServerIds: ['server-alpha']
+      }
+    })
+  })
+})

--- a/test/renderer/components/AgentExtensionPolicyPanel.test.ts
+++ b/test/renderer/components/AgentExtensionPolicyPanel.test.ts
@@ -113,6 +113,18 @@ describe('AgentExtensionPolicyPanel', () => {
         enabled: true,
         type: 'stdio',
         ownerPluginId: 'plugin-alpha'
+      },
+      'plugin-source-owned': {
+        command: '',
+        args: [],
+        env: {},
+        descriptions: 'Plugin Source Owned',
+        icons: '',
+        autoApprove: [],
+        enabled: true,
+        type: 'stdio',
+        source: 'plugin',
+        sourceId: 'plugin-alpha'
       }
     })
 
@@ -163,6 +175,7 @@ describe('AgentExtensionPolicyPanel', () => {
     const { wrapper } = await mountPanel()
 
     expect(wrapper.text()).not.toContain('Plugin Owned')
+    expect(wrapper.text()).not.toContain('Plugin Source Owned')
 
     for (const selector of [
       '[data-testid="agent-extension-plugins-mode"]',
@@ -176,6 +189,7 @@ describe('AgentExtensionPolicyPanel', () => {
     expect(wrapper.text()).toContain('skill-alpha')
     expect(wrapper.text()).toContain('Server Alpha')
     expect(wrapper.text()).not.toContain('Plugin Owned')
+    expect(wrapper.text()).not.toContain('Plugin Source Owned')
 
     await wrapper.find('[data-testid="agent-extension-policy-save"]').trigger('click')
     await flushPromises()

--- a/test/renderer/components/McpServers.test.ts
+++ b/test/renderer/components/McpServers.test.ts
@@ -22,7 +22,9 @@ const serverCardStub = defineComponent({
       required: true
     }
   },
-  template: '<div data-testid="server-card">{{ server.name }}</div>'
+  emits: ['toggle'],
+  template:
+    '<button data-testid="server-card" @click="$emit(\'toggle\')">{{ server.name }}:{{ server.enabled }}</button>'
 })
 
 type SetupOptions = {
@@ -209,8 +211,60 @@ describe('McpServers', () => {
 
     const cards = wrapper.findAll('[data-testid="server-card"]').map((card) => card.text())
 
-    expect(cards).toEqual(['user-server'])
+    expect(cards).toEqual(['user-server:false'])
     expect(wrapper.text()).not.toContain('feishu-tools')
+  })
+
+  it('uses agent-scoped toggle overrides without toggling the global server', async () => {
+    const { wrapper, mcpStore } = await setup({ withServers: true })
+
+    await wrapper.setProps({
+      agentScopedToggle: true,
+      serverEnabledOverrides: {
+        'running-server': false
+      }
+    })
+    await wrapper.find('[data-testid="server-card"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="server-card"]').text()).toContain('running-server:false')
+    expect(mcpStore.toggleServer).not.toHaveBeenCalled()
+    expect(wrapper.emitted('toggle-agent-server')?.[0]).toEqual(['running-server', true])
+  })
+
+  it('allows agent-scoped toggles for DeepChat-managed servers without global toggles', async () => {
+    const { wrapper, mcpStore } = await setup({
+      serverList: [
+        {
+          name: 'Artifacts',
+          icons: '',
+          descriptions: '',
+          command: '',
+          args: [],
+          enabled: true,
+          isRunning: true
+        }
+      ],
+      config: {
+        mcpServers: {
+          Artifacts: {
+            type: 'inmemory',
+            source: 'deepchat'
+          }
+        }
+      }
+    })
+
+    await wrapper.setProps({
+      agentScopedToggle: true,
+      serverEnabledOverrides: {
+        Artifacts: false
+      }
+    })
+    await wrapper.find('[data-testid="server-card"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="server-card"]').text()).toContain('Artifacts:false')
+    expect(mcpStore.toggleServer).not.toHaveBeenCalled()
+    expect(wrapper.emitted('toggle-agent-server')?.[0]).toEqual(['Artifacts', true])
   })
 
   it('shows the empty state when only plugin-owned MCP servers exist', async () => {

--- a/test/renderer/components/McpSettings.test.ts
+++ b/test/renderer/components/McpSettings.test.ts
@@ -16,7 +16,11 @@ const buttonStub = defineComponent({
   template: '<button @click="$emit(\'click\')"><slot /></button>'
 })
 
-const setup = async (query: Record<string, string> = {}) => {
+const setup = async (
+  query: Record<string, string> = {},
+  props: Record<string, unknown> = {},
+  options: { mcpEnabled?: boolean } = {}
+) => {
   vi.resetModules()
 
   const route = reactive({
@@ -33,8 +37,37 @@ const setup = async (query: Record<string, string> = {}) => {
   }
 
   const toast = vi.fn()
+  const configClient = {
+    listAgents: vi.fn().mockResolvedValue([
+      {
+        id: 'deepchat',
+        type: 'deepchat',
+        name: 'DeepChat',
+        enabled: true,
+        config: {
+          enabledMcpServerIds: ['Artifacts']
+        }
+      }
+    ]),
+    resolveDeepChatAgentConfig: vi.fn().mockResolvedValue({
+      enabledMcpServerIds: ['Artifacts']
+    }),
+    updateDeepChatAgent: vi.fn().mockResolvedValue({
+      id: 'deepchat',
+      type: 'deepchat',
+      name: 'DeepChat',
+      enabled: true,
+      config: {
+        enabledMcpServerIds: ['Artifacts', 'Custom']
+      }
+    })
+  }
+  const agentStore = {
+    selectedAgentId: 'deepchat',
+    refreshAgentsByIds: vi.fn().mockResolvedValue(undefined)
+  }
   const mcpStore = reactive({
-    mcpEnabled: true,
+    mcpEnabled: options.mcpEnabled ?? true,
     configLoading: false,
     serverList: [
       {
@@ -85,6 +118,17 @@ const setup = async (query: Record<string, string> = {}) => {
       dir: 'ltr'
     })
   }))
+  vi.doMock('@/stores/ui/agent', () => ({
+    useAgentStore: () => agentStore
+  }))
+  vi.doMock('@/stores/ui/session', () => ({
+    useSessionStore: () => ({
+      activeSession: null
+    })
+  }))
+  vi.doMock('@api/ConfigClient', () => ({
+    createConfigClient: () => configClient
+  }))
   vi.doMock('@/composables/useGuidedOnboardingStep', () => ({
     useGuidedOnboardingStep: () => ({
       showGuide: ref(false),
@@ -115,6 +159,7 @@ const setup = async (query: Record<string, string> = {}) => {
     .default
 
   const wrapper = mount(McpSettings, {
+    props,
     global: {
       stubs: {
         Switch: true,
@@ -139,7 +184,13 @@ const setup = async (query: Record<string, string> = {}) => {
         GuidedOnboardingOverlay: true,
         McpServers: defineComponent({
           name: 'McpServers',
-          template: '<div data-testid="servers-view" />'
+          props: {
+            serverEnabledOverrides: { type: Object, default: () => ({}) },
+            agentScopedToggle: { type: Boolean, default: false }
+          },
+          emits: ['toggle-agent-server'],
+          template:
+            '<button data-testid="servers-view" @click="$emit(\'toggle-agent-server\', \'Custom\', true)">{{ agentScopedToggle }}:{{ serverEnabledOverrides.Custom }}</button>'
         }),
         McpBuiltinMarket: defineComponent({
           name: 'McpBuiltinMarket',
@@ -154,7 +205,9 @@ const setup = async (query: Record<string, string> = {}) => {
 
   return {
     wrapper,
-    router
+    router,
+    configClient,
+    mcpStore
   }
 }
 
@@ -183,6 +236,29 @@ describe('McpSettings', () => {
     expect(wrapper.find('[data-testid="settings-mcp-page"]').classes()).toContain('min-h-0')
     expect(serverPanel?.className).toContain('min-h-0')
     expect(scrollFrame?.className).toContain('overflow-hidden')
+  })
+
+  it('respects the global MCP master switch in agent scope', async () => {
+    const { wrapper } = await setup({}, { scope: 'agent' }, { mcpEnabled: false })
+
+    expect(wrapper.find('[data-testid="servers-view"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('settings.mcp.enableToAccess')
+  })
+
+  it('saves MCP server toggles to the current agent in agent scope', async () => {
+    const { wrapper, configClient, mcpStore } = await setup({}, { scope: 'agent' })
+
+    expect(wrapper.find('[data-testid="servers-view"]').text()).toContain('true:false')
+
+    await wrapper.find('[data-testid="servers-view"]').trigger('click')
+    await flushPromises()
+
+    expect(mcpStore.setMcpEnabled).not.toHaveBeenCalled()
+    expect(configClient.updateDeepChatAgent).toHaveBeenCalledWith('deepchat', {
+      config: {
+        enabledMcpServerIds: ['Artifacts', 'Custom']
+      }
+    })
   })
 
   it('renders the market subview and clears only the market query on back', async () => {

--- a/test/renderer/components/PluginPageWrappers.test.ts
+++ b/test/renderer/components/PluginPageWrappers.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import skillsSource from '../../../src/renderer/src/pages/plugins/SkillsPluginsPage.vue?raw'
+import mcpSource from '../../../src/renderer/src/pages/plugins/McpPluginsPage.vue?raw'
+
+describe('plugins page wrappers', () => {
+  it('renders the original skills settings view in agent scope', () => {
+    expect(skillsSource).toContain('<SkillsSettings scope="agent" />')
+    expect(skillsSource).toContain('settings/components/skills/SkillsSettings.vue')
+    expect(skillsSource).not.toContain('AgentExtensionPolicyPanel')
+  })
+
+  it('renders the original MCP settings view in agent scope', () => {
+    expect(mcpSource).toContain('<McpSettings scope="agent" />')
+    expect(mcpSource).toContain('settings/components/McpSettings.vue')
+    expect(mcpSource).not.toContain('AgentExtensionPolicyPanel')
+  })
+})

--- a/test/renderer/components/SkillsSettingsAgentScope.test.ts
+++ b/test/renderer/components/SkillsSettingsAgentScope.test.ts
@@ -91,6 +91,43 @@ const SkillCardStub = defineComponent({
     '<button :data-testid="`skill-${skill.name}`" @click="$emit(\'toggle-disabled\', !skill.deepchatDisabled)">{{ skill.name }}:{{ skill.deepchatDisabled }}</button>'
 })
 
+const mountAgentScopeSkillsSettings = async () => {
+  const SkillsSettings = (
+    await import('../../../src/renderer/settings/components/skills/SkillsSettings.vue')
+  ).default
+  return mount(SkillsSettings, {
+    props: {
+      scope: 'agent'
+    },
+    global: {
+      stubs: {
+        SettingsPageShell: passthrough('SettingsPageShell'),
+        GuidedOnboardingOverlay: true,
+        Separator: true,
+        Button: defineComponent({ name: 'Button', template: '<button><slot /></button>' }),
+        Input: true,
+        Switch: true,
+        Tabs: passthrough('Tabs'),
+        TabsList: passthrough('TabsList'),
+        TabsTrigger: passthrough('TabsTrigger'),
+        TabsContent: tabsContentStub,
+        DropdownMenu: passthrough('DropdownMenu'),
+        DropdownMenuTrigger: passthrough('DropdownMenuTrigger'),
+        DropdownMenuContent: passthrough('DropdownMenuContent'),
+        DropdownMenuItem: passthrough('DropdownMenuItem'),
+        SkillCard: SkillCardStub,
+        SkillAgentsTab: true,
+        SkillImportExportTab: true,
+        SkillInstallDialog: true,
+        InstallFromGitDialog: true,
+        InstallSkillToAgentDialog: true,
+        SkillDetailDialog: true,
+        Icon: true
+      }
+    }
+  })
+}
+
 describe('SkillsSettings agent scope', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -150,40 +187,7 @@ describe('SkillsSettings agent scope', () => {
     const { useAgentStore } = await import('@/stores/ui/agent')
     useAgentStore().setSelectedAgent('agent-a')
 
-    const SkillsSettings = (
-      await import('../../../src/renderer/settings/components/skills/SkillsSettings.vue')
-    ).default
-    const wrapper = mount(SkillsSettings, {
-      props: {
-        scope: 'agent'
-      },
-      global: {
-        stubs: {
-          SettingsPageShell: passthrough('SettingsPageShell'),
-          GuidedOnboardingOverlay: true,
-          Separator: true,
-          Button: defineComponent({ name: 'Button', template: '<button><slot /></button>' }),
-          Input: true,
-          Switch: true,
-          Tabs: passthrough('Tabs'),
-          TabsList: passthrough('TabsList'),
-          TabsTrigger: passthrough('TabsTrigger'),
-          TabsContent: tabsContentStub,
-          DropdownMenu: passthrough('DropdownMenu'),
-          DropdownMenuTrigger: passthrough('DropdownMenuTrigger'),
-          DropdownMenuContent: passthrough('DropdownMenuContent'),
-          DropdownMenuItem: passthrough('DropdownMenuItem'),
-          SkillCard: SkillCardStub,
-          SkillAgentsTab: true,
-          SkillImportExportTab: true,
-          SkillInstallDialog: true,
-          InstallFromGitDialog: true,
-          InstallSkillToAgentDialog: true,
-          SkillDetailDialog: true,
-          Icon: true
-        }
-      }
-    })
+    const wrapper = await mountAgentScopeSkillsSettings()
 
     await flushPromises()
 
@@ -200,5 +204,61 @@ describe('SkillsSettings agent scope', () => {
         enabledSkillNames: ['skill-alpha', 'skill-beta']
       }
     })
+  })
+
+  it('ignores stale agent policy responses after the selected agent changes', async () => {
+    const { useAgentStore } = await import('@/stores/ui/agent')
+    const agentStore = useAgentStore()
+    agentStore.setSelectedAgent('agent-a')
+
+    let resolveAgentA: ((agents: unknown[]) => void) | undefined
+    mocks.configClient.listAgents.mockImplementation(({ ids }: { ids: string[] }) => {
+      if (ids[0] === 'agent-a') {
+        return new Promise((resolve) => {
+          resolveAgentA = resolve
+        })
+      }
+      return Promise.resolve([
+        {
+          id: 'agent-b',
+          type: 'deepchat',
+          name: 'Agent B',
+          enabled: true,
+          config: {
+            enabledSkillNames: ['skill-beta']
+          }
+        }
+      ])
+    })
+    mocks.configClient.resolveDeepChatAgentConfig.mockImplementation((agentId: string) =>
+      Promise.resolve({
+        enabledSkillNames: agentId === 'agent-b' ? ['skill-beta'] : ['skill-alpha']
+      })
+    )
+
+    const wrapper = await mountAgentScopeSkillsSettings()
+
+    await Promise.resolve()
+    agentStore.setSelectedAgent('agent-b')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="skill-skill-alpha"]').text()).toContain('skill-alpha:true')
+    expect(wrapper.find('[data-testid="skill-skill-beta"]').text()).toContain('skill-beta:false')
+
+    resolveAgentA?.([
+      {
+        id: 'agent-a',
+        type: 'deepchat',
+        name: 'Agent A',
+        enabled: true,
+        config: {
+          enabledSkillNames: ['skill-alpha']
+        }
+      }
+    ])
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="skill-skill-alpha"]').text()).toContain('skill-alpha:true')
+    expect(wrapper.find('[data-testid="skill-skill-beta"]').text()).toContain('skill-beta:false')
   })
 })

--- a/test/renderer/components/SkillsSettingsAgentScope.test.ts
+++ b/test/renderer/components/SkillsSettingsAgentScope.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+const mocks = vi.hoisted(() => ({
+  configClient: {
+    getSkillDraftSuggestionsEnabled: vi.fn(),
+    listAgents: vi.fn(),
+    resolveDeepChatAgentConfig: vi.fn(),
+    updateDeepChatAgent: vi.fn(),
+    onAgentsChanged: vi.fn(),
+    getSetting: vi.fn()
+  },
+  skillClient: {
+    getUnifiedSkillCatalog: vi.fn(),
+    getSkillExtension: vi.fn(),
+    listSkillScripts: vi.fn(),
+    onCatalogChanged: vi.fn(),
+    readSkillFile: vi.fn(),
+    setSkillDisabled: vi.fn()
+  }
+}))
+
+vi.mock('@api/ConfigClient', () => ({
+  createConfigClient: () => mocks.configClient
+}))
+vi.mock('@api/SkillClient', () => ({
+  createSkillClient: () => mocks.skillClient
+}))
+vi.mock('@api/WindowClient', () => ({
+  createWindowClient: () => ({})
+}))
+vi.mock('@/components/use-toast', () => ({
+  useToast: () => ({
+    toast: vi.fn()
+  })
+}))
+vi.mock('@/composables/useGuidedOnboardingStep', () => ({
+  useGuidedOnboardingStep: () => ({
+    showGuide: { value: false },
+    stepIndex: { value: 1 },
+    totalSteps: { value: 1 },
+    currentStepId: { value: 'skills' },
+    stepState: { value: null },
+    canGoPrevious: { value: false },
+    dismissGuide: vi.fn(),
+    completeStep: vi.fn(),
+    activatePreviousStep: vi.fn(),
+    skipStep: vi.fn(),
+    forceComplete: vi.fn()
+  })
+}))
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params?.name ? `${key}:${String(params.name)}` : key
+  })
+}))
+vi.mock('@iconify/vue', () => ({
+  Icon: defineComponent({ name: 'Icon', template: '<span />' })
+}))
+
+const passthrough = (name: string) =>
+  defineComponent({
+    name,
+    template: '<div><slot name="actions" /><slot /></div>'
+  })
+
+const tabsContentStub = defineComponent({
+  name: 'TabsContent',
+  props: {
+    value: {
+      type: String,
+      required: true
+    }
+  },
+  template: '<div v-if="value === \'library\'"><slot /></div>'
+})
+
+const SkillCardStub = defineComponent({
+  name: 'SkillCard',
+  props: {
+    skill: { type: Object, required: true }
+  },
+  emits: ['toggle-disabled'],
+  template:
+    '<button :data-testid="`skill-${skill.name}`" @click="$emit(\'toggle-disabled\', !skill.deepchatDisabled)">{{ skill.name }}:{{ skill.deepchatDisabled }}</button>'
+})
+
+describe('SkillsSettings agent scope', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+
+    mocks.configClient.getSkillDraftSuggestionsEnabled.mockResolvedValue(false)
+    mocks.configClient.listAgents.mockResolvedValue([
+      {
+        id: 'agent-a',
+        type: 'deepchat',
+        name: 'Agent A',
+        enabled: true,
+        config: {
+          enabledSkillNames: ['skill-alpha']
+        }
+      }
+    ])
+    mocks.configClient.resolveDeepChatAgentConfig.mockResolvedValue({
+      enabledSkillNames: ['skill-alpha']
+    })
+    mocks.configClient.updateDeepChatAgent.mockResolvedValue({
+      id: 'agent-a',
+      type: 'deepchat',
+      name: 'Agent A',
+      enabled: true,
+      config: {
+        enabledSkillNames: ['skill-alpha', 'skill-beta']
+      }
+    })
+    mocks.configClient.onAgentsChanged.mockReturnValue(() => undefined)
+    mocks.configClient.getSetting.mockResolvedValue(null)
+    mocks.skillClient.getUnifiedSkillCatalog.mockResolvedValue([
+      {
+        name: 'skill-alpha',
+        description: 'Alpha',
+        path: '',
+        skillRoot: '',
+        deepchatDisabled: false,
+        mutable: true
+      },
+      {
+        name: 'skill-beta',
+        description: 'Beta',
+        path: '',
+        skillRoot: '',
+        deepchatDisabled: false,
+        mutable: true
+      }
+    ])
+    mocks.skillClient.getSkillExtension.mockResolvedValue(null)
+    mocks.skillClient.listSkillScripts.mockResolvedValue([])
+    mocks.skillClient.onCatalogChanged.mockReturnValue(() => undefined)
+  })
+
+  it('keeps the skills management view and saves toggles to the current agent only', async () => {
+    const { useAgentStore } = await import('@/stores/ui/agent')
+    useAgentStore().setSelectedAgent('agent-a')
+
+    const SkillsSettings = (
+      await import('../../../src/renderer/settings/components/skills/SkillsSettings.vue')
+    ).default
+    const wrapper = mount(SkillsSettings, {
+      props: {
+        scope: 'agent'
+      },
+      global: {
+        stubs: {
+          SettingsPageShell: passthrough('SettingsPageShell'),
+          GuidedOnboardingOverlay: true,
+          Separator: true,
+          Button: defineComponent({ name: 'Button', template: '<button><slot /></button>' }),
+          Input: true,
+          Switch: true,
+          Tabs: passthrough('Tabs'),
+          TabsList: passthrough('TabsList'),
+          TabsTrigger: passthrough('TabsTrigger'),
+          TabsContent: tabsContentStub,
+          DropdownMenu: passthrough('DropdownMenu'),
+          DropdownMenuTrigger: passthrough('DropdownMenuTrigger'),
+          DropdownMenuContent: passthrough('DropdownMenuContent'),
+          DropdownMenuItem: passthrough('DropdownMenuItem'),
+          SkillCard: SkillCardStub,
+          SkillAgentsTab: true,
+          SkillImportExportTab: true,
+          SkillInstallDialog: true,
+          InstallFromGitDialog: true,
+          InstallSkillToAgentDialog: true,
+          SkillDetailDialog: true,
+          Icon: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('settings.skills.addSkill')
+    expect(wrapper.find('[data-testid="skill-skill-alpha"]').text()).toContain('skill-alpha:false')
+    expect(wrapper.find('[data-testid="skill-skill-beta"]').text()).toContain('skill-beta:true')
+
+    await wrapper.find('[data-testid="skill-skill-beta"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.skillClient.setSkillDisabled).not.toHaveBeenCalled()
+    expect(mocks.configClient.updateDeepChatAgent).toHaveBeenCalledWith('agent-a', {
+      config: {
+        enabledSkillNames: ['skill-alpha', 'skill-beta']
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add DeepChat agent policy fields for plugins, skills, and MCP allowlists and enforce them in runtime tool/skill/MCP paths
- keep /plugins/skills and /plugins/mcp on the original management views while making enable/disable toggles update the current agent policy
- add agent policy panel, SDD docs, i18n strings, and regression tests for global MCP state, wrapper pages, effective config, and managed MCP toggles

## Validation
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck:web
- pnpm vitest run test/main/presenter/toolPresenter/toolPresenter.test.ts test/renderer/components/McpSettings.test.ts test/renderer/components/McpServers.test.ts test/renderer/components/PluginPageWrappers.test.ts test/renderer/components/SkillsSettingsAgentScope.test.ts test/renderer/components/AgentExtensionPolicyPanel.test.ts
- commit hooks: pnpm run typecheck (typecheck:node + typecheck:web)

Note: local environment prints Node engine warnings because current Node is v26.0.0 while package expects >=24.14.1 <25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-scoped policy controls for plugins, skills, and MCP servers, including a dedicated policy panel.
  * Updated Plugins/Skills/MCP settings to support an agent-scoped view with per-agent enable/disable toggles and summaries.

* **Bug Fixes**
  * Tool and skill availability now strictly follows the selected agent’s extension policy for discovery, viewing, and execution.
  * MCP tool listing, permission checks, and calls are filtered consistently, including plugin-owned MCP servers.

* **Tests**
  * Added/expanded automated coverage for agent-scoped policy behavior across settings UI and runtime tool routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->