### PR TITLE
fix(settings): clone hooks config for ipc

### DIFF
--- a/docs/issues/hooks-settings-clone-error/plan.md
+++ b/docs/issues/hooks-settings-clone-error/plan.md
@@ -1,0 +1,32 @@
+# Plan
+
+## Implementation Approach
+
+1. Convert the Vue reactive hooks settings object to raw, structured-cloneable data before invoking `config.setHooksNotifications`.
+2. Keep the returned normalized config assignment unchanged so the UI reflects main-process validation/normalization.
+3. Add focused renderer/API test coverage proving a reactive hooks settings object is sanitized before IPC.
+
+## Affected Interfaces
+
+- Renderer settings component: `src/renderer/settings/components/NotificationsHooksSettings.vue`
+- Renderer config client: `src/renderer/api/ConfigClient.ts`
+- Existing route contract: `config.setHooksNotifications` remains unchanged.
+
+## Data Flow
+
+Current failing flow:
+
+`Vue ref/proxy config` -> `ConfigClient.setHooksNotificationsConfig` -> `window.deepchat.invoke` -> Electron structured clone failure
+
+Fixed flow:
+
+`Vue ref/proxy config` -> plain hooks config clone -> `ConfigClient.setHooksNotificationsConfig` -> route validation -> Electron IPC -> main presenter normalization
+
+## Compatibility
+
+The serialized payload remains `{ hooks: [{ id, name, enabled, command, events }] }`; persisted data and API contracts are unchanged.
+
+## Test Strategy
+
+- Add/adjust renderer API client unit test to call `setHooksNotificationsConfig` with a Vue reactive object and assert the bridge receives a non-reactive plain object.
+- Run required repository checks after implementation: `pnpm run format`, `pnpm run i18n`, `pnpm run lint`.

--- a/docs/issues/hooks-settings-clone-error/spec.md
+++ b/docs/issues/hooks-settings-clone-error/spec.md
@@ -1,0 +1,36 @@
+# Hooks Settings Clone Error
+
+## User Need
+
+Users can open and edit the notifications hooks settings page without Electron IPC failing with `an object could not be cloned`.
+
+## Problem
+
+The hooks settings page stores the editable configuration in Vue reactive state. Save operations pass that reactive object directly into `config.setHooksNotifications`. Electron IPC uses the structured clone algorithm and cannot clone Vue reactive proxies, causing the settings page to fail when adding, toggling, editing, or testing hooks.
+
+## Goal
+
+Ensure hooks notification settings sent over IPC are plain structured-cloneable data.
+
+## Acceptance Criteria
+
+- Adding a hook saves without `an object could not be cloned`.
+- Toggling enabled state, changing events, editing name, and editing command save without clone errors.
+- Testing a hook still persists pending edits before running the test.
+- The fix does not change the persisted hooks schema or user-visible settings behavior.
+
+## Constraints
+
+- Keep the change minimal and localized to the hooks settings flow unless a shared utility is already established nearby.
+- Preserve route contract validation in preload/main.
+- Do not weaken validation or accept unsupported hook events.
+
+## Non-Goals
+
+- Redesigning the hooks settings UI.
+- Changing hook execution behavior.
+- Migrating stored configuration format.
+
+## Open Questions
+
+None.

--- a/docs/issues/hooks-settings-clone-error/tasks.md
+++ b/docs/issues/hooks-settings-clone-error/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+- [x] Locate the hooks settings save path and confirm reactive state is passed to IPC.
+- [x] Document the issue with spec and plan.
+- [x] Convert hooks settings IPC payloads to plain cloneable data.
+- [x] Add focused test coverage for reactive hooks settings input.
+- [x] Run focused renderer API test: `pnpm vitest run test/renderer/api/clients.test.ts -- --runInBand`.
+- [x] Run `pnpm run format`.
+- [x] Run `pnpm run i18n`.
+- [x] Run `pnpm run lint`.

--- a/src/renderer/api/ConfigClient.ts
+++ b/src/renderer/api/ConfigClient.ts
@@ -116,6 +116,18 @@ type VoiceAIConfig = {
   agentId: string
 }
 
+const cloneHooksNotificationsConfigForIpc = (
+  config: HooksNotificationsSettings
+): HooksNotificationsSettings => ({
+  hooks: config.hooks.map((hook) => ({
+    id: hook.id,
+    name: hook.name,
+    enabled: hook.enabled,
+    command: hook.command,
+    events: [...hook.events]
+  }))
+})
+
 type GeminiSafetyValue =
   | 'BLOCK_NONE'
   | 'BLOCK_ONLY_HIGH'
@@ -318,7 +330,9 @@ export function createConfigClient(bridge: DeepchatBridge = getDeepchatBridge())
   async function setHooksNotificationsConfig(
     config: HooksNotificationsSettings
   ): Promise<HooksNotificationsSettings> {
-    const result = await bridge.invoke(configSetHooksNotificationsRoute.name, { config })
+    const result = await bridge.invoke(configSetHooksNotificationsRoute.name, {
+      config: cloneHooksNotificationsConfigForIpc(config)
+    })
     return result.config
   }
 

--- a/test/renderer/api/clients.test.ts
+++ b/test/renderer/api/clients.test.ts
@@ -1,4 +1,6 @@
+import { isReactive, reactive } from 'vue'
 import type { DeepchatBridge } from '@shared/contracts/bridge'
+import type { HooksNotificationsSettings } from '@shared/hooksNotifications'
 import { createAcpTerminalClient } from '../../../src/renderer/api/AcpTerminalClient'
 import { createAppRuntimeClient } from '../../../src/renderer/api/AppRuntimeClient'
 import { createBrowserClient } from '../../../src/renderer/api/BrowserClient'
@@ -1582,7 +1584,7 @@ describe('renderer api clients', () => {
     await configClient.setSkillDraftSuggestionsEnabled(true)
     await configClient.refreshProviderDb(true)
     await configClient.getHooksNotificationsConfig()
-    await configClient.setHooksNotificationsConfig({
+    const hooksConfig = reactive<HooksNotificationsSettings>({
       hooks: [
         {
           id: 'hook-1',
@@ -1593,6 +1595,7 @@ describe('renderer api clients', () => {
         }
       ]
     })
+    await configClient.setHooksNotificationsConfig(hooksConfig)
     await configClient.testHookCommand('hook-1')
 
     expect(bridge.invoke).toHaveBeenNthCalledWith(1, 'config.getProxySettings', {})
@@ -1617,6 +1620,12 @@ describe('renderer api clients', () => {
       force: true
     })
     expect(bridge.invoke).toHaveBeenNthCalledWith(12, 'config.getHooksNotifications', {})
+    const hooksPayload = vi.mocked(bridge.invoke).mock.calls[12]?.[1] as {
+      config: HooksNotificationsSettings
+    }
+    expect(isReactive(hooksPayload.config)).toBe(false)
+    expect(isReactive(hooksPayload.config.hooks)).toBe(false)
+    expect(isReactive(hooksPayload.config.hooks[0])).toBe(false)
     expect(bridge.invoke).toHaveBeenNthCalledWith(13, 'config.setHooksNotifications', {
       config: {
         hooks: [


### PR DESCRIPTION
## Summary
- clone hooks notification settings before IPC so Vue reactive proxies are not sent through Electron structured clone
- add renderer API coverage for reactive hooks config payloads
- document the issue with SDD spec/plan/tasks

## Testing
- pnpm vitest run test/renderer/api/clients.test.ts -- --runInBand
- pnpm run format
- pnpm run i18n
- pnpm run lint
- commit hook: pnpm run typecheck

Note: local commands emitted the existing Node engine warning because this shell is on Node v26.0.0 while the repo expects >=24.14.1 <25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where saving hook settings could fail in Electron when reactive app data was sent through the settings bridge.
  * Hook settings are now converted into a plain, serializable format before being saved, preventing persistence errors while keeping behavior unchanged.

* **Documentation**
  * Added issue notes, a proposed plan, and implementation tasks for the hook settings save flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->