### PR TITLE
fix(memory): tighten lifecycle contract

### DIFF
--- a/resources/acp-registry/registry.json
+++ b/resources/acp-registry/registry.json
@@ -103,7 +103,7 @@
     {
       "id": "claude-acp",
       "name": "Claude Agent",
-      "version": "0.53.0",
+      "version": "0.54.1",
       "description": "ACP wrapper for Anthropic's Claude",
       "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
       "authors": [
@@ -114,7 +114,7 @@
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "@agentclientprotocol/claude-agent-acp@0.53.0"
+          "package": "@agentclientprotocol/claude-agent-acp@0.54.1"
         }
       },
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/claude-acp.svg"
@@ -467,7 +467,7 @@
     {
       "id": "dimcode",
       "name": "DimCode",
-      "version": "0.2.12",
+      "version": "0.2.15",
       "description": "A coding agent that puts leading models at your command.",
       "website": "https://dimcode.dev/docs/acp.html",
       "authors": [
@@ -476,7 +476,7 @@
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "dimcode@0.2.12",
+          "package": "dimcode@0.2.15",
           "args": [
             "acp"
           ]
@@ -508,7 +508,7 @@
     {
       "id": "factory-droid",
       "name": "Factory Droid",
-      "version": "0.159.1",
+      "version": "0.161.0",
       "description": "Factory Droid - AI coding agent powered by Factory AI",
       "website": "https://factory.ai/product/cli",
       "authors": [
@@ -517,7 +517,7 @@
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "droid@0.159.1",
+          "package": "droid@0.161.0",
           "args": [
             "exec",
             "--output-format",
@@ -534,7 +534,7 @@
     {
       "id": "fast-agent",
       "name": "fast-agent",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "description": "Code and build agents with comprehensive multi-provider support",
       "repository": "https://github.com/evalstate/fast-agent",
       "website": "https://fast-agent.ai",
@@ -544,7 +544,7 @@
       "license": "Apache 2.0",
       "distribution": {
         "uvx": {
-          "package": "fast-agent-acp==0.8.1",
+          "package": "fast-agent-acp==0.8.2",
           "args": [
             "-x"
           ]
@@ -576,7 +576,7 @@
     {
       "id": "github-copilot-cli",
       "name": "GitHub Copilot",
-      "version": "1.0.65",
+      "version": "1.0.67",
       "description": "GitHub's AI pair programmer",
       "repository": "https://github.com/github/copilot-cli",
       "website": "https://github.com/features/copilot/cli/",
@@ -586,7 +586,7 @@
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "@github/copilot@1.0.65",
+          "package": "@github/copilot@1.0.67",
           "args": [
             "--acp"
           ]
@@ -666,7 +666,7 @@
     {
       "id": "grok-build",
       "name": "Grok Build",
-      "version": "0.2.75",
+      "version": "0.2.79",
       "description": "xAI's coding agent and CLI",
       "website": "https://x.ai/cli",
       "authors": [
@@ -675,7 +675,7 @@
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "@xai-official/grok@0.2.75",
+          "package": "@xai-official/grok@0.2.79",
           "args": [
             "agent",
             "stdio"
@@ -687,7 +687,7 @@
     {
       "id": "junie",
       "name": "Junie",
-      "version": "2045.46.0",
+      "version": "2144.7.0",
       "description": "AI Coding Agent by JetBrains",
       "repository": "https://github.com/JetBrains/junie",
       "website": "https://junie.jetbrains.com",
@@ -698,35 +698,35 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/JetBrains/junie/releases/download/2045.46/junie-release-2045.46-macos-aarch64.zip",
+            "archive": "https://github.com/JetBrains/junie/releases/download/2144.7/junie-release-2144.7-macos-aarch64.zip",
             "cmd": "./Applications/junie.app/Contents/MacOS/junie",
             "args": [
               "--acp=true"
             ]
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/JetBrains/junie/releases/download/2045.46/junie-release-2045.46-macos-amd64.zip",
+            "archive": "https://github.com/JetBrains/junie/releases/download/2144.7/junie-release-2144.7-macos-amd64.zip",
             "cmd": "./Applications/junie.app/Contents/MacOS/junie",
             "args": [
               "--acp=true"
             ]
           },
           "linux-aarch64": {
-            "archive": "https://github.com/JetBrains/junie/releases/download/2045.46/junie-release-2045.46-linux-aarch64.zip",
+            "archive": "https://github.com/JetBrains/junie/releases/download/2144.7/junie-release-2144.7-linux-aarch64.zip",
             "cmd": "./junie-app/bin/junie",
             "args": [
               "--acp=true"
             ]
           },
           "linux-x86_64": {
-            "archive": "https://github.com/JetBrains/junie/releases/download/2045.46/junie-release-2045.46-linux-amd64.zip",
+            "archive": "https://github.com/JetBrains/junie/releases/download/2144.7/junie-release-2144.7-linux-amd64.zip",
             "cmd": "./junie-app/bin/junie",
             "args": [
               "--acp=true"
             ]
           },
           "windows-x86_64": {
-            "archive": "https://github.com/JetBrains/junie/releases/download/2045.46/junie-release-2045.46-windows-amd64.zip",
+            "archive": "https://github.com/JetBrains/junie/releases/download/2144.7/junie-release-2144.7-windows-amd64.zip",
             "cmd": "./junie/junie.exe",
             "args": [
               "--acp=true"
@@ -869,7 +869,7 @@
     {
       "id": "mistral-vibe",
       "name": "Mistral Vibe",
-      "version": "2.18.2",
+      "version": "2.18.3",
       "description": "Mistral's open-source coding assistant",
       "repository": "https://github.com/mistralai/mistral-vibe",
       "website": "https://mistral.ai/products/vibe",
@@ -881,23 +881,23 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.18.2/vibe-acp-darwin-aarch64-2.18.2.zip",
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.18.3/vibe-acp-darwin-aarch64-2.18.3.zip",
             "cmd": "./vibe-acp"
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.18.2/vibe-acp-darwin-x86_64-2.18.2.zip",
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.18.3/vibe-acp-darwin-x86_64-2.18.3.zip",
             "cmd": "./vibe-acp"
           },
           "linux-aarch64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.18.2/vibe-acp-linux-aarch64-2.18.2.zip",
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.18.3/vibe-acp-linux-aarch64-2.18.3.zip",
             "cmd": "./vibe-acp"
           },
           "linux-x86_64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.18.2/vibe-acp-linux-x86_64-2.18.2.zip",
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.18.3/vibe-acp-linux-x86_64-2.18.3.zip",
             "cmd": "./vibe-acp"
           },
           "windows-x86_64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.18.2/vibe-acp-windows-x86_64-2.18.2.zip",
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.18.3/vibe-acp-windows-x86_64-2.18.3.zip",
             "cmd": "./vibe-acp.exe"
           }
         }
@@ -906,7 +906,7 @@
     {
       "id": "nova",
       "name": "Nova",
-      "version": "1.1.21",
+      "version": "1.1.23",
       "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
       "repository": "https://github.com/Compass-Agentic-Platform/nova",
       "website": "https://www.compassap.ai/portfolio/nova.html",
@@ -917,7 +917,7 @@
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/nova.svg",
       "distribution": {
         "npx": {
-          "package": "@compass-ai/nova@1.1.21",
+          "package": "@compass-ai/nova@1.1.23",
           "args": [
             "acp"
           ]
@@ -927,7 +927,7 @@
     {
       "id": "opencode",
       "name": "OpenCode",
-      "version": "1.17.11",
+      "version": "1.17.12",
       "description": "The open source coding agent",
       "repository": "https://github.com/anomalyco/opencode",
       "website": "https://opencode.ai",
@@ -939,42 +939,42 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.11/opencode-darwin-arm64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.12/opencode-darwin-arm64.zip",
             "cmd": "./opencode",
             "args": [
               "acp"
             ]
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.11/opencode-darwin-x64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.12/opencode-darwin-x64.zip",
             "cmd": "./opencode",
             "args": [
               "acp"
             ]
           },
           "linux-aarch64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.11/opencode-linux-arm64.tar.gz",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.12/opencode-linux-arm64.tar.gz",
             "cmd": "./opencode",
             "args": [
               "acp"
             ]
           },
           "linux-x86_64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.11/opencode-linux-x64.tar.gz",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.12/opencode-linux-x64.tar.gz",
             "cmd": "./opencode",
             "args": [
               "acp"
             ]
           },
           "windows-aarch64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.11/opencode-windows-arm64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.12/opencode-windows-arm64.zip",
             "cmd": "./opencode",
             "args": [
               "acp"
             ]
           },
           "windows-x86_64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.11/opencode-windows-x64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.12/opencode-windows-x64.zip",
             "cmd": "./opencode.exe",
             "args": [
               "acp"
@@ -1104,7 +1104,7 @@
     {
       "id": "sigit",
       "name": "siGit Code",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "description": "Local-first coding agent. Runs entirely on your machine with optional on-device LLM inference via Onde.",
       "repository": "https://github.com/getsigit/sigit",
       "website": "https://github.com/getsigit/sigit",
@@ -1115,32 +1115,32 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.2.2/sigit-macos-arm64.tar.gz",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.3.0/sigit-macos-arm64.tar.gz",
             "cmd": "./sigit"
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.2.2/sigit-macos-amd64.tar.gz",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.3.0/sigit-macos-amd64.tar.gz",
             "cmd": "./sigit"
           },
           "linux-aarch64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.2.2/sigit-linux-arm64",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.3.0/sigit-linux-arm64",
             "cmd": "./sigit-linux-arm64"
           },
           "linux-x86_64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.2.2/sigit-linux-amd64",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.3.0/sigit-linux-amd64",
             "cmd": "./sigit-linux-amd64"
           },
           "windows-aarch64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.2.2/sigit-win-arm64.exe",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.3.0/sigit-win-arm64.exe",
             "cmd": "./sigit-win-arm64.exe"
           },
           "windows-x86_64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.2.2/sigit-win-amd64.exe",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.3.0/sigit-win-amd64.exe",
             "cmd": "./sigit-win-amd64.exe"
           }
         },
         "npx": {
-          "package": "@smbcloud/sigit@1.2.2"
+          "package": "@smbcloud/sigit@1.3.0"
         }
       },
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/sigit.svg"

--- a/src/main/presenter/memoryPresenter/index.ts
+++ b/src/main/presenter/memoryPresenter/index.ts
@@ -2316,14 +2316,14 @@ export class MemoryPresenter implements MemoryRuntimePort {
     return this.deps.repository.listByAgent(agentId, { includeArchived: true })
   }
 
-  getLifecycle(agentId: string, memoryId: string): MemoryLifecycle[] {
+  getLifecycle(agentId: string, memoryId: string): MemoryLifecycle | null {
     this.assertSafeAgentId(agentId)
-    if (!this.isManagedAgent(agentId)) return []
+    if (!this.isManagedAgent(agentId)) return null
 
     const row = this.deps.repository.getById(memoryId)
-    if (!row || row.agent_id !== agentId || row.kind === 'working') return []
+    if (!row || row.agent_id !== agentId || row.kind === 'working') return null
     const context = this.createLifecycleDerivationContext(agentId)
-    return [deriveLifecycle(row, context.now, context.options)]
+    return deriveLifecycle(row, context.now, context.options)
   }
 
   getArchiveCandidateLifecyclePreview(agentId: string): MemoryArchiveCandidateLifecyclePreview {

--- a/src/main/presenter/memoryPresenter/lifecycle.ts
+++ b/src/main/presenter/memoryPresenter/lifecycle.ts
@@ -45,8 +45,8 @@ export function deriveLifecycle(
   const exempt = exemptReasons.length > 0
   const recallable = row.kind !== 'persona' && active
   const forget = deriveForget(row, now, importance)
-  const oldEnough = row.created_at <= now - archiveAgeMs
-  const decayedEnough = forget.decayScore <= archiveDecayThreshold
+  const oldEnough = row.created_at < now - archiveAgeMs
+  const decayedEnough = forget.decayScore < archiveDecayThreshold
   const neverAccessed = row.access_count === 0
   const eligible = !exempt && active && oldEnough && decayedEnough && neverAccessed
   const decayTier = deriveDecayTier(forget.decayScore, eligible, archiveDecayThreshold)
@@ -167,10 +167,12 @@ function deriveArchiveGaps(input: {
   const gaps: MemoryLifecycle['archiveEligibility']['gaps'] = {}
   if (!input.oldEnough) {
     const ageFromCreated = Math.max(0, input.now - input.row.created_at)
-    gaps.daysUntilOldEnough = Math.max(0, (input.archiveAgeMs - ageFromCreated) / DAY_MS)
+    const daysUntilOldEnough = Math.max(0, (input.archiveAgeMs - ageFromCreated) / DAY_MS)
+    if (daysUntilOldEnough > 0) gaps.daysUntilOldEnough = daysUntilOldEnough
   }
   if (!input.decayedEnough) {
-    gaps.decayAboveThresholdBy = Math.max(0, input.decayScore - input.archiveDecayThreshold)
+    const decayAboveThresholdBy = Math.max(0, input.decayScore - input.archiveDecayThreshold)
+    if (decayAboveThresholdBy > 0) gaps.decayAboveThresholdBy = decayAboveThresholdBy
   }
   if (!input.neverAccessed) {
     gaps.accessCount = input.row.access_count

--- a/src/main/routes/index.ts
+++ b/src/main/routes/index.ts
@@ -2263,10 +2263,10 @@ export async function dispatchDeepchatRoute(
       const input = memoryGetLifecycleRoute.input.parse(rawInput)
       const agentType = await runtime.configPresenter.getAgentType(input.agentId)
       if (agentType !== 'deepchat') {
-        return memoryGetLifecycleRoute.output.parse({ lifecycles: [] })
+        return memoryGetLifecycleRoute.output.parse({ lifecycle: null })
       }
       return memoryGetLifecycleRoute.output.parse({
-        lifecycles: runtime.memoryPresenter.getLifecycle(input.agentId, input.memoryId)
+        lifecycle: runtime.memoryPresenter.getLifecycle(input.agentId, input.memoryId)
       })
     }
 

--- a/src/renderer/api/MemoryClient.ts
+++ b/src/renderer/api/MemoryClient.ts
@@ -77,9 +77,9 @@ export function createMemoryClient(bridge: DeepchatBridge = getDeepchatBridge())
     return result.health
   }
 
-  async function getLifecycle(agentId: string, memoryId: string): Promise<MemoryLifecycle[]> {
+  async function getLifecycle(agentId: string, memoryId: string): Promise<MemoryLifecycle | null> {
     const result = await bridge.invoke(memoryGetLifecycleRoute.name, { agentId, memoryId })
-    return result.lifecycles
+    return result.lifecycle
   }
 
   async function getArchiveCandidateLifecyclePreview(

--- a/src/renderer/settings/components/MemoryManagerPanel.vue
+++ b/src/renderer/settings/components/MemoryManagerPanel.vue
@@ -311,6 +311,7 @@
 
                 <div class="flex shrink-0 items-center gap-1">
                   <Button
+                    v-if="isLifecycleSupported(memory)"
                     variant="ghost"
                     size="sm"
                     class="h-7 w-7 px-0"
@@ -372,7 +373,7 @@
                 </div>
               </div>
               <MemoryLifecyclePanel
-                v-if="isLifecycleExpanded(memory.id)"
+                v-if="isLifecycleSupported(memory) && isLifecycleExpanded(memory.id)"
                 class="mt-2"
                 :lifecycle="lifecycleFor(memory.id)"
                 :loading="isLifecycleLoading(memory.id)"
@@ -1039,6 +1040,15 @@ function hasLifecycleCache(memoryId: string): boolean {
   return Object.prototype.hasOwnProperty.call(lifecycleCache.value, memoryId)
 }
 
+function isLifecycleSupported(memory: { kind: string }): boolean {
+  return memory.kind !== 'working'
+}
+
+function isLifecycleSupportedById(memoryId: string): boolean {
+  const memory = baseDisplayedMemories.value.find((item) => item.id === memoryId)
+  return Boolean(memory && isLifecycleSupported(memory))
+}
+
 function setLifecycleExpanded(memoryId: string, expanded: boolean): void {
   const next = new Set(expandedLifecycleIds.value)
   if (expanded) next.add(memoryId)
@@ -1047,6 +1057,7 @@ function setLifecycleExpanded(memoryId: string, expanded: boolean): void {
 }
 
 async function toggleLifecycle(memoryId: string): Promise<void> {
+  if (!isLifecycleSupportedById(memoryId)) return
   if (isLifecycleExpanded(memoryId)) {
     setLifecycleExpanded(memoryId, false)
     return
@@ -1058,15 +1069,15 @@ async function toggleLifecycle(memoryId: string): Promise<void> {
 
 async function loadLifecycle(memoryId: string): Promise<void> {
   const agentId = props.agentId
-  if (!agentId) return
+  if (!agentId || !isLifecycleSupportedById(memoryId)) return
   const requestId = ++lifecycleRequestSeq
   lifecycleRequestIds.set(memoryId, requestId)
   lifecycleLoading.value = { ...lifecycleLoading.value, [memoryId]: true }
   lifecycleErrors.value = { ...lifecycleErrors.value, [memoryId]: null }
   try {
-    const lifecycles = await memoryClient.getLifecycle(agentId, memoryId)
+    const lifecycle = await memoryClient.getLifecycle(agentId, memoryId)
     if (!isCurrentLifecycleRequest(agentId, memoryId, requestId)) return
-    lifecycleCache.value = { ...lifecycleCache.value, [memoryId]: lifecycles[0] ?? null }
+    lifecycleCache.value = { ...lifecycleCache.value, [memoryId]: lifecycle }
   } catch (e) {
     if (!isCurrentLifecycleRequest(agentId, memoryId, requestId)) return
     lifecycleErrors.value = {

--- a/src/shared/contracts/routes/memory.routes.ts
+++ b/src/shared/contracts/routes/memory.routes.ts
@@ -205,10 +205,18 @@ export const MemoryLifecycleSchema = z
 
 export type MemoryLifecycle = z.infer<typeof MemoryLifecycleSchema>
 
+const MemoryArchiveCandidateLifecycleSchema = MemoryLifecycleSchema.refine(
+  (lifecycle) => lifecycle.archiveEligibility.eligible,
+  {
+    path: ['archiveEligibility', 'eligible'],
+    message: 'archive candidate lifecycle must be eligible'
+  }
+)
+
 export const MemoryArchiveCandidateLifecyclePreviewSchema = z
   .object({
     lifecycles: z
-      .array(MemoryLifecycleSchema)
+      .array(MemoryArchiveCandidateLifecycleSchema)
       .max(MEMORY_ARCHIVE_CANDIDATE_LIFECYCLE_PREVIEW_LIMIT),
     previewLimit: z.literal(MEMORY_ARCHIVE_CANDIDATE_LIFECYCLE_PREVIEW_LIMIT),
     scanLimit: z.literal(MEMORY_ARCHIVE_CANDIDATE_LIFECYCLE_SCAN_LIMIT),
@@ -325,7 +333,7 @@ export const memoryGetHealthRoute = defineRouteContract({
 export const memoryGetLifecycleRoute = defineRouteContract({
   name: 'memory.getLifecycle',
   input: z.object({ agentId: AgentIdSchema, memoryId: z.string().min(1) }),
-  output: z.object({ lifecycles: z.array(MemoryLifecycleSchema) })
+  output: z.object({ lifecycle: MemoryLifecycleSchema.nullable() })
 })
 
 export const memoryGetArchiveCandidateLifecyclePreviewRoute = defineRouteContract({

--- a/test/main/presenter/memoryLifecycle.test.ts
+++ b/test/main/presenter/memoryLifecycle.test.ts
@@ -171,10 +171,9 @@ describe('MemoryPresenter.getLifecycle', () => {
     const { presenter } = makePresenter(enabledConfig, repo)
     const candidateSpy = vi.spyOn(repo, 'listArchiveCandidateLifecycleRows')
 
-    const lifecycles = presenter.getLifecycle('a', 'm1')
+    const lifecycle = presenter.getLifecycle('a', 'm1')
 
-    expect(lifecycles).toHaveLength(1)
-    expect(lifecycles[0].memoryId).toBe('m1')
+    expect(lifecycle?.memoryId).toBe('m1')
     expect(candidateSpy).not.toHaveBeenCalled()
   })
 
@@ -354,8 +353,8 @@ describe('MemoryPresenter.getLifecycle', () => {
     repo.insert({ id: 'w1', agentId: 'a', kind: 'working', content: 'working' })
     const { presenter } = makePresenter(enabledConfig, repo)
 
-    expect(presenter.getLifecycle('b', 'm1')).toEqual([])
-    expect(presenter.getLifecycle('a', 'w1')).toEqual([])
+    expect(presenter.getLifecycle('b', 'm1')).toBeNull()
+    expect(presenter.getLifecycle('a', 'w1')).toBeNull()
   })
 
   it('treats an explicitly provided empty memory id as a single-memory read', () => {
@@ -364,7 +363,7 @@ describe('MemoryPresenter.getLifecycle', () => {
     const { presenter } = makePresenter(enabledConfig, repo)
     const getSpy = vi.spyOn(repo, 'getById')
 
-    expect(presenter.getLifecycle('a', '')).toEqual([])
+    expect(presenter.getLifecycle('a', '')).toBeNull()
     expect(getSpy).toHaveBeenCalledWith('')
   })
 
@@ -377,11 +376,11 @@ describe('MemoryPresenter.getLifecycle', () => {
 
     expect(lifecycle.archiveEligibility.oldEnough).toBe(true)
     expect(lifecycle.archiveEligibility.decayedEnough).toBe(
-      lifecycle.forget.decayScore <= ARCHIVE_DECAY_THRESHOLD
+      lifecycle.forget.decayScore < ARCHIVE_DECAY_THRESHOLD
     )
   })
 
-  it('treats exact archive age and decay thresholds as reached', () => {
+  it('treats exact archive age and decay thresholds as not yet eligible', () => {
     const row = makeRow({
       created_at: NOW - ARCHIVE_AGE_MS,
       last_accessed: NOW - ARCHIVE_AGE_MS,
@@ -390,16 +389,16 @@ describe('MemoryPresenter.getLifecycle', () => {
     const threshold = decayScore(row, NOW)
     const lifecycle = deriveLifecycle(row, NOW, { archiveDecayThreshold: threshold })
 
-    expect(lifecycle.archiveEligibility.oldEnough).toBe(true)
-    expect(lifecycle.archiveEligibility.decayedEnough).toBe(true)
+    expect(lifecycle.archiveEligibility.oldEnough).toBe(false)
+    expect(lifecycle.archiveEligibility.decayedEnough).toBe(false)
     expect(lifecycle.archiveEligibility.gaps).toEqual({})
-    expect(lifecycle.archiveEligibility.eligible).toBe(true)
-    expect(lifecycle.decayTier).toBe('archive_candidate')
+    expect(lifecycle.archiveEligibility.eligible).toBe(false)
+    expect(lifecycle.decayTier).toBe('stale')
 
     const accessed = deriveLifecycle({ ...row, access_count: 1 }, NOW, {
       archiveDecayThreshold: threshold
     })
-    expect(accessed.archiveEligibility.decayedEnough).toBe(true)
+    expect(accessed.archiveEligibility.decayedEnough).toBe(false)
     expect(accessed.decayTier).toBe('stale')
   })
 

--- a/test/main/routes/dispatcher.test.ts
+++ b/test/main/routes/dispatcher.test.ts
@@ -1403,54 +1403,66 @@ describe('dispatchDeepchatRoute', () => {
 
   it('dispatches memory lifecycle with deepchat guard and empty fallback', async () => {
     const { runtime, configPresenter } = createRuntime()
-    const lifecycles = [
-      {
-        memoryId: 'm1',
-        kind: 'semantic',
-        status: 'embedded',
-        recallable: true,
-        decayTier: 'fresh',
-        recall: {
-          weights: { similarity: 0.6, recency: 0.25, importance: 0.15 },
-          similarity: 0.3,
-          similaritySource: 'baseline',
-          recency: 1,
-          importance: 0.5,
-          confidenceFactor: 1,
-          importanceFloor: 0.075,
-          final: 0.48,
-          flooredByImportance: false,
-          halfLifeMs: 14 * 24 * 60 * 60 * 1000
-        },
-        forget: {
-          anchorAt: 1000,
-          ageDays: 0,
-          halfLifeDays: 30,
-          decayScore: 1,
-          materializedDecay: null,
-          materializedStale: true
-        },
-        archiveEligibility: {
-          eligible: false,
-          oldEnough: false,
-          decayedEnough: false,
-          neverAccessed: true,
-          active: true,
-          exempt: false,
-          exemptReasons: [],
-          gaps: {}
-        }
+    const lifecycle = {
+      memoryId: 'm1',
+      kind: 'semantic',
+      status: 'embedded',
+      recallable: true,
+      decayTier: 'fresh',
+      recall: {
+        weights: { similarity: 0.6, recency: 0.25, importance: 0.15 },
+        similarity: 0.3,
+        similaritySource: 'baseline',
+        recency: 1,
+        importance: 0.5,
+        confidenceFactor: 1,
+        importanceFloor: 0.075,
+        final: 0.48,
+        flooredByImportance: false,
+        halfLifeMs: 14 * 24 * 60 * 60 * 1000
+      },
+      forget: {
+        anchorAt: 1000,
+        ageDays: 0,
+        halfLifeDays: 30,
+        decayScore: 1,
+        materializedDecay: null,
+        materializedStale: true
+      },
+      archiveEligibility: {
+        eligible: false,
+        oldEnough: false,
+        decayedEnough: false,
+        neverAccessed: true,
+        active: true,
+        exempt: false,
+        exemptReasons: [],
+        gaps: {}
       }
-    ]
+    }
+    const archiveCandidateLifecycle = {
+      ...lifecycle,
+      decayTier: 'archive_candidate',
+      archiveEligibility: {
+        eligible: true,
+        oldEnough: true,
+        decayedEnough: true,
+        neverAccessed: true,
+        active: true,
+        exempt: false,
+        exemptReasons: [],
+        gaps: {}
+      }
+    }
     const preview = {
-      lifecycles,
+      lifecycles: [archiveCandidateLifecycle],
       previewLimit: 25,
       scanLimit: 200,
       scanned: 1,
       previewTruncated: false,
       scanTruncated: false
     }
-    const getLifecycle = vi.fn(() => lifecycles)
+    const getLifecycle = vi.fn(() => lifecycle)
     const getArchiveCandidateLifecyclePreview = vi.fn(() => preview)
     ;(runtime as any).memoryPresenter = { getLifecycle, getArchiveCandidateLifecyclePreview }
 
@@ -1461,7 +1473,7 @@ describe('dispatchDeepchatRoute', () => {
         { agentId: 'other', memoryId: 'm1' },
         { webContentsId: 42, windowId: 7 }
       )
-    ).resolves.toEqual({ lifecycles: [] })
+    ).resolves.toEqual({ lifecycle: null })
     expect(getLifecycle).not.toHaveBeenCalled()
 
     vi.mocked(configPresenter.getAgentType).mockResolvedValueOnce('deepchat')
@@ -1472,7 +1484,7 @@ describe('dispatchDeepchatRoute', () => {
         { agentId: 'deepchat', memoryId: 'm1' },
         { webContentsId: 42, windowId: 7 }
       )
-    ).resolves.toEqual({ lifecycles })
+    ).resolves.toEqual({ lifecycle })
     expect(getLifecycle).toHaveBeenCalledWith('deepchat', 'm1')
 
     await expect(

--- a/test/main/routes/memoryDto.test.ts
+++ b/test/main/routes/memoryDto.test.ts
@@ -91,6 +91,23 @@ function makeLifecycle(overrides: Partial<MemoryLifecycle> = {}): MemoryLifecycl
   }
 }
 
+function makeArchiveCandidateLifecycle(overrides: Partial<MemoryLifecycle> = {}): MemoryLifecycle {
+  return makeLifecycle({
+    decayTier: 'archive_candidate',
+    archiveEligibility: {
+      eligible: true,
+      oldEnough: true,
+      decayedEnough: true,
+      neverAccessed: true,
+      active: true,
+      exempt: false,
+      exemptReasons: [],
+      gaps: {}
+    },
+    ...overrides
+  })
+}
+
 describe('toMemoryItemDto sourceEntryIds passthrough', () => {
   it('deserializes a valid source_entry_ids array alongside its session', () => {
     const dto = toMemoryItemDto(
@@ -236,70 +253,36 @@ describe('memory.getLifecycle route contract', () => {
     expect(() => memoryGetLifecycleRoute.input.parse({ agentId: 'deepchat' })).toThrow()
 
     const parsed = memoryGetLifecycleRoute.output.parse({
-      lifecycles: [
-        {
-          memoryId: 'm1',
-          kind: 'semantic',
-          status: 'embedded',
-          recallable: true,
-          decayTier: 'aging',
-          recall: {
-            weights: { similarity: 0.6, recency: 0.25, importance: 0.15 },
-            similarity: 0.3,
-            similaritySource: 'baseline',
-            recency: 0.8,
-            importance: 0.5,
-            confidenceFactor: 1,
-            importanceFloor: 0.075,
-            final: 0.455,
-            flooredByImportance: false,
-            halfLifeMs: 14 * 24 * 60 * 60 * 1000
-          },
-          forget: {
-            anchorAt: 1000,
-            ageDays: 10,
-            halfLifeDays: 45,
-            decayScore: 0.8,
-            materializedDecay: null,
-            materializedStale: true
-          },
-          archiveEligibility: {
-            eligible: false,
-            oldEnough: false,
-            decayedEnough: false,
-            neverAccessed: true,
-            active: true,
-            exempt: false,
-            exemptReasons: [],
-            gaps: { daysUntilOldEnough: 80, decayAboveThresholdBy: 0.75 }
-          }
-        }
-      ]
+      lifecycle: makeLifecycle()
     })
 
-    expect(parsed.lifecycles[0].memoryId).toBe('m1')
+    expect(parsed.lifecycle?.memoryId).toBe('m1')
+    expect(memoryGetLifecycleRoute.output.safeParse({ lifecycle: null }).success).toBe(true)
+    expect(
+      memoryGetLifecycleRoute.output.safeParse({ lifecycles: [makeLifecycle()] }).success
+    ).toBe(false)
     expect(JSON.stringify(parsed)).not.toMatch(/nextReview|reinforcement|promotion|reviewInterval/)
   })
 
   it('rejects lifecycle outputs that violate public lifecycle invariants', () => {
     const workingLifecycle = { ...makeLifecycle(), kind: 'working' }
 
-    expect(
-      memoryGetLifecycleRoute.output.safeParse({ lifecycles: [workingLifecycle] }).success
-    ).toBe(false)
+    expect(memoryGetLifecycleRoute.output.safeParse({ lifecycle: workingLifecycle }).success).toBe(
+      false
+    )
     expect(
       memoryGetLifecycleRoute.output.safeParse({
-        lifecycles: [makeLifecycle({ kind: 'semantic', recall: null })]
+        lifecycle: makeLifecycle({ kind: 'semantic', recall: null })
       }).success
     ).toBe(false)
     expect(
       memoryGetLifecycleRoute.output.safeParse({
-        lifecycles: [makeLifecycle({ kind: 'persona', recall: makeLifecycleRecall() })]
+        lifecycle: makeLifecycle({ kind: 'persona', recall: makeLifecycleRecall() })
       }).success
     ).toBe(false)
     expect(
       memoryGetLifecycleRoute.output.safeParse({
-        lifecycles: [makeLifecycle({ kind: 'persona', recall: null })]
+        lifecycle: makeLifecycle({ kind: 'persona', recall: null })
       }).success
     ).toBe(true)
   })
@@ -307,7 +290,7 @@ describe('memory.getLifecycle route contract', () => {
   it('round-trips archive candidate lifecycle predictions', () => {
     const parsed = memoryGetArchiveCandidateLifecyclePreviewRoute.output.parse({
       preview: {
-        lifecycles: [makeLifecycle({ decayTier: 'archive_candidate' })],
+        lifecycles: [makeArchiveCandidateLifecycle()],
         previewLimit: 25,
         scanLimit: 200,
         scanned: 1,
@@ -329,12 +312,36 @@ describe('memory.getLifecycle route contract', () => {
       memoryGetArchiveCandidateLifecyclePreviewRoute.output.safeParse({
         preview: {
           lifecycles: Array.from({ length: 26 }, (_, index) =>
-            makeLifecycle({ memoryId: `m${index}` })
+            makeArchiveCandidateLifecycle({ memoryId: `m${index}` })
           ),
           previewLimit: 25,
           scanLimit: 200,
           scanned: 26,
           previewTruncated: false,
+          scanTruncated: false
+        }
+      }).success
+    ).toBe(false)
+    expect(
+      memoryGetArchiveCandidateLifecyclePreviewRoute.output.safeParse({
+        preview: {
+          lifecycles: [makeLifecycle({ decayTier: 'archive_candidate' })],
+          previewLimit: 25,
+          scanLimit: 200,
+          scanned: 1,
+          previewTruncated: false,
+          scanTruncated: false
+        }
+      }).success
+    ).toBe(false)
+    expect(
+      memoryGetArchiveCandidateLifecyclePreviewRoute.output.safeParse({
+        preview: {
+          lifecycles: [makeArchiveCandidateLifecycle()],
+          previewLimit: 25,
+          scanLimit: 200,
+          scanned: 1,
+          previewTruncated: true,
           scanTruncated: false
         }
       }).success

--- a/test/renderer/api/clients.test.ts
+++ b/test/renderer/api/clients.test.ts
@@ -1026,45 +1026,43 @@ describe('renderer api clients', () => {
               }
             case 'memory.getLifecycle':
               return {
-                lifecycles: [
-                  {
-                    memoryId: payload?.memoryId ?? 'mem-1',
-                    kind: 'semantic',
-                    status: 'embedded',
-                    recallable: true,
-                    decayTier: 'fresh',
-                    recall: {
-                      weights: { similarity: 0.6, recency: 0.25, importance: 0.15 },
-                      similarity: 0.3,
-                      similaritySource: 'baseline',
-                      recency: 1,
-                      importance: 0.5,
-                      confidenceFactor: 1,
-                      importanceFloor: 0.075,
-                      final: 0.48,
-                      flooredByImportance: false,
-                      halfLifeMs: 14 * 24 * 60 * 60 * 1000
-                    },
-                    forget: {
-                      anchorAt: 1000,
-                      ageDays: 0,
-                      halfLifeDays: 30,
-                      decayScore: 1,
-                      materializedDecay: null,
-                      materializedStale: true
-                    },
-                    archiveEligibility: {
-                      eligible: false,
-                      oldEnough: false,
-                      decayedEnough: false,
-                      neverAccessed: true,
-                      active: true,
-                      exempt: false,
-                      exemptReasons: [],
-                      gaps: {}
-                    }
+                lifecycle: {
+                  memoryId: payload?.memoryId ?? 'mem-1',
+                  kind: 'semantic',
+                  status: 'embedded',
+                  recallable: true,
+                  decayTier: 'fresh',
+                  recall: {
+                    weights: { similarity: 0.6, recency: 0.25, importance: 0.15 },
+                    similarity: 0.3,
+                    similaritySource: 'baseline',
+                    recency: 1,
+                    importance: 0.5,
+                    confidenceFactor: 1,
+                    importanceFloor: 0.075,
+                    final: 0.48,
+                    flooredByImportance: false,
+                    halfLifeMs: 14 * 24 * 60 * 60 * 1000
+                  },
+                  forget: {
+                    anchorAt: 1000,
+                    ageDays: 0,
+                    halfLifeDays: 30,
+                    decayScore: 1,
+                    materializedDecay: null,
+                    materializedStale: true
+                  },
+                  archiveEligibility: {
+                    eligible: false,
+                    oldEnough: false,
+                    decayedEnough: false,
+                    neverAccessed: true,
+                    active: true,
+                    exempt: false,
+                    exemptReasons: [],
+                    gaps: {}
                   }
-                ]
+                }
               }
             case 'memory.getArchiveCandidateLifecyclePreview':
               return {
@@ -1075,7 +1073,7 @@ describe('renderer api clients', () => {
                       kind: 'semantic',
                       status: 'embedded',
                       recallable: true,
-                      decayTier: 'fresh',
+                      decayTier: 'archive_candidate',
                       recall: {
                         weights: { similarity: 0.6, recency: 0.25, importance: 0.15 },
                         similarity: 0.3,
@@ -1097,9 +1095,9 @@ describe('renderer api clients', () => {
                         materializedStale: true
                       },
                       archiveEligibility: {
-                        eligible: false,
-                        oldEnough: false,
-                        decayedEnough: false,
+                        eligible: true,
+                        oldEnough: true,
+                        decayedEnough: true,
                         neverAccessed: true,
                         active: true,
                         exempt: false,
@@ -1399,7 +1397,7 @@ describe('renderer api clients', () => {
     const categorizedMemories = await memoryClient.list('agent-1')
     await memoryClient.add('agent-1', { content: 'plain note' })
     const health = await memoryClient.getHealth('agent-1')
-    const lifecycles = await memoryClient.getLifecycle('agent-1', 'mem-1')
+    const lifecycle = await memoryClient.getLifecycle('agent-1', 'mem-1')
     const archiveCandidatePreview =
       await memoryClient.getArchiveCandidateLifecyclePreview('agent-1')
     const off = memoryClient.onUpdated(vi.fn())
@@ -1459,7 +1457,7 @@ describe('renderer api clients', () => {
       agentId: 'agent-1',
       memoryId: 'mem-1'
     })
-    expect(lifecycles[0].memoryId).toBe('mem-1')
+    expect(lifecycle?.memoryId).toBe('mem-1')
     expect(bridge.invoke).toHaveBeenNthCalledWith(
       17,
       'memory.getArchiveCandidateLifecyclePreview',

--- a/test/renderer/components/MemoryManagerDialog.test.ts
+++ b/test/renderer/components/MemoryManagerDialog.test.ts
@@ -187,8 +187,23 @@ const lifecycle: MemoryLifecycle = {
   }
 }
 
+const archiveCandidateLifecycle: MemoryLifecycle = {
+  ...lifecycle,
+  decayTier: 'archive_candidate',
+  archiveEligibility: {
+    eligible: true,
+    oldEnough: true,
+    decayedEnough: true,
+    neverAccessed: true,
+    active: true,
+    exempt: false,
+    exemptReasons: [],
+    gaps: {}
+  }
+}
+
 const archiveCandidateLifecyclePreview: MemoryArchiveCandidateLifecyclePreview = {
-  lifecycles: [lifecycle],
+  lifecycles: [archiveCandidateLifecycle],
   previewLimit: 25,
   scanLimit: 200,
   scanned: 1,
@@ -222,7 +237,7 @@ async function setup(
     archiveCandidateLifecyclePreviewPromise?: Promise<MemoryArchiveCandidateLifecyclePreview>
     archiveCandidateLifecyclePreviewReject?: boolean
     lifecycle?: MemoryLifecycle
-    lifecyclePromise?: Promise<MemoryLifecycle[]>
+    lifecyclePromise?: Promise<MemoryLifecycle | null>
     lifecycleReject?: boolean
     auditPromise?: Promise<MemoryAuditEvent[]>
     manifestPromise?: Promise<MemoryViewManifest[]>
@@ -246,7 +261,7 @@ async function setup(
       ? vi.fn().mockReturnValue(overrides.lifecyclePromise)
       : overrides.lifecycleReject
         ? vi.fn().mockRejectedValue(new Error('lifecycle unavailable'))
-        : vi.fn().mockResolvedValue([overrides.lifecycle ?? lifecycle]),
+        : vi.fn().mockResolvedValue(overrides.lifecycle ?? lifecycle),
     getArchiveCandidateLifecyclePreview: overrides.archiveCandidateLifecyclePreviewPromise
       ? vi.fn().mockReturnValue(overrides.archiveCandidateLifecyclePreviewPromise)
       : overrides.archiveCandidateLifecyclePreviewReject
@@ -1171,14 +1186,14 @@ describe('MemoryManagerDialog memory health', () => {
 
     fresh.resolve({
       ...archiveCandidateLifecyclePreview,
-      lifecycles: [{ ...lifecycle, memoryId: 'fresh-candidate' }]
+      lifecycles: [{ ...archiveCandidateLifecycle, memoryId: 'fresh-candidate' }]
     })
     await flushPromises()
     expect(wrapper.text()).toContain('fresh-candidate')
 
     stale.resolve({
       ...archiveCandidateLifecyclePreview,
-      lifecycles: [{ ...lifecycle, memoryId: 'stale-candidate' }]
+      lifecycles: [{ ...archiveCandidateLifecycle, memoryId: 'stale-candidate' }]
     })
     await flushPromises()
 
@@ -1443,7 +1458,7 @@ describe('MemoryManagerDialog lifecycle inspector', () => {
     const { wrapper, memoryClient } = await setup()
     vi.mocked(memoryClient.getLifecycle)
       .mockRejectedValueOnce(new Error('lifecycle unavailable'))
-      .mockResolvedValueOnce([lifecycle])
+      .mockResolvedValueOnce(lifecycle)
 
     await lifecycleToggle(wrapper)!.trigger('click')
     await flushPromises()
@@ -1463,7 +1478,7 @@ describe('MemoryManagerDialog lifecycle inspector', () => {
 
   it('caches a successful empty lifecycle result as an empty state', async () => {
     const { wrapper, memoryClient } = await setup()
-    vi.mocked(memoryClient.getLifecycle).mockResolvedValueOnce([])
+    vi.mocked(memoryClient.getLifecycle).mockResolvedValueOnce(null)
 
     await lifecycleToggle(wrapper)!.trigger('click')
     await flushPromises()
@@ -1478,6 +1493,15 @@ describe('MemoryManagerDialog lifecycle inspector', () => {
 
     expect(memoryClient.getLifecycle).toHaveBeenCalledTimes(1)
     expect(wrapper.text()).toContain('settings.deepchatAgents.memoryManager.lifecycle.empty')
+  })
+
+  it('does not render the lifecycle toggle for working memory rows', async () => {
+    const { wrapper, memoryClient } = await setup({
+      items: [{ ...memory, id: 'w1', kind: 'working', content: 'session summary' } as MemoryItem]
+    })
+
+    expect(lifecycleToggle(wrapper)).toBeUndefined()
+    expect(memoryClient.getLifecycle).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
- Restore strict archive threshold parity
- Return a single lifecycle object from getLifecycle
- Require eligible archive preview items
- Hide lifecycle controls for working memory rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory lifecycle retrieval now returns a single lifecycle result (or none), simplifying how lifecycle status is displayed across the app.
* **Bug Fixes**
  * Tightened lifecycle eligibility boundaries so memories only become eligible after strictly passing age/decay thresholds.
  * Updated archive-candidate lifecycle preview to show only truly eligible lifecycles.
  * Lifecycle controls and panels are now hidden and won’t load for unsupported memories (including working items).
* **Chores**
  * Updated agent registry versions and download coordinates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->