### PR TITLE
fix(acp): settle permission requests

### DIFF
--- a/docs/architecture/agent-system.md
+++ b/docs/architecture/agent-system.md
@@ -3,6 +3,29 @@
 本文档描述 retirement 后仍然有效的 agent system。旧 `AgentPresenter` 细节不再作为仓库内
 长期文档保留；需要对照时用 `git log` / `git show` 查看历史提交。
 
+DeepChat Agent 与 ACP Agent 的当前代码路径对比见
+[deepchat-vs-acp-agents/](./deepchat-vs-acp-agents/)。
+
+## Agent 类型
+
+DeepChat 支持两种 agent 执行架构:
+
+### DeepChat Agent
+- **原生 TypeScript** agent 运行时
+- **Tape-based** 完整对话历史持久化 (受 [tape.systems](https://tape.systems/) 启发)
+- **直接 LLM 集成** 通过 LLMProviderPresenter
+- **完整调试能力** 支持重放、审计、分叉
+- **适用场景**: 需要深度集成、上下文控制、审计追溯
+
+### ACP Agent
+- **协议化** agent 系统,遵循 [ACP 官方规范](https://modelcontextprotocol.io/acp)
+- **进程隔离** 外部 agent 进程通过 JSON-RPC 通信
+- **语言无关** 任何实现 ACP 协议的 agent
+- **灵活性优先** agent 自主管理状态和工具
+- **适用场景**: 多语言支持、第三方集成、进程隔离需求
+
+**详细对比** 请参见 [deepchat-vs-acp-agents/spec.md](./deepchat-vs-acp-agents/spec.md)。
+
 ## 当前运行时所有权
 
 ```mermaid

--- a/docs/architecture/deepchat-vs-acp-agents/README.md
+++ b/docs/architecture/deepchat-vs-acp-agents/README.md
@@ -1,0 +1,31 @@
+# DeepChat Agent vs ACP Agent
+
+Status: reviewed on 2026-07-06.
+
+This note compares the live DeepChat agent runtime with the ACP provider path. It keeps only
+findings backed by current code. Earlier draft items that assumed non-existent multi-writer or
+rollback behavior were removed.
+
+## Files
+
+- [spec.md](./spec.md): current architecture comparison and verified conclusions.
+- [issues/P0-1-acp-permission-timeout.md](./issues/P0-1-acp-permission-timeout.md):
+  implemented ACP permission timeout and cancellation fix.
+
+## Removed Findings
+
+The following review items are not retained:
+
+- P0-2 Tape write ordering: current tape writes run through synchronous `better-sqlite3` in the
+  Electron main process. There is no current multi-writer path that justifies adding a session lock.
+- P0-3 Pending input deadlock: pending input drain already uses single-flight cleanup and claimed-row
+  recovery. A watchdog would duplicate existing recovery logic.
+- P1-5 ACP config rollback: `setSessionConfigOption()` waits for the ACP response before updating
+  local config state. There is no optimistic local write to roll back.
+- P1-6 Tool output retry: retrying a smaller tool batch would rerun already executed tools and can
+  duplicate side effects. The existing guard truncates, downgrades, or returns a terminal error.
+
+## Current Fix
+
+ACP permission requests now settle when the user cancels/stops a session or when no decision arrives
+within the timeout window. See [GitHub issue #1881](https://github.com/ThinkInAIXYZ/deepchat/issues/1881).

--- a/docs/architecture/deepchat-vs-acp-agents/issues/P0-1-acp-permission-timeout.md
+++ b/docs/architecture/deepchat-vs-acp-agents/issues/P0-1-acp-permission-timeout.md
@@ -1,0 +1,37 @@
+# P0-1 ACP Permission Timeout
+
+Status: fixed.
+
+Linked issue: [#1881](https://github.com/ThinkInAIXYZ/deepchat/issues/1881)
+
+## Problem
+
+ACP permission requests could remain pending when generation was cancelled or when no permission
+decision arrived. The provider promise stayed in `pendingPermissions`, while the runtime could remove
+its active permission handle without settling the provider-side request.
+
+## Root Cause
+
+- `AcpProvider.registerPendingPermission()` created a promise with no timeout.
+- `AcpProvider.resolvePermissionRequest()` removed the map entry only when the user answered.
+- `AgentRuntimePresenter.clearActiveProviderPermissionsForSession()` deleted active permission
+  records without calling their resolver.
+
+## Fix
+
+- Add a 60-second timeout to ACP pending permissions.
+- Store and clear the timeout for explicit resolve, session cleanup, and provider cleanup.
+- Resolve timed-out permissions with ACP `cancelled` outcome.
+- Resolve active runtime ACP permissions with `false` when clearing a session.
+
+## Validation
+
+```bash
+pnpm vitest run test/main/presenter/acpProvider.test.ts test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+```
+
+Covered cases:
+
+- pending ACP permission requests cancel on timeout;
+- explicit permission resolution clears the timeout;
+- runtime session cleanup calls the live ACP provider resolver with `false`.

--- a/docs/architecture/deepchat-vs-acp-agents/spec.md
+++ b/docs/architecture/deepchat-vs-acp-agents/spec.md
@@ -1,0 +1,127 @@
+# DeepChat Agent vs ACP Agent Architecture
+
+## Scope
+
+This document compares two live execution paths:
+
+- DeepChat Agent: in-process runtime owned by `AgentRuntimePresenter`.
+- ACP Agent: external agent process accessed through `AcpProvider` and the ACP SDK.
+
+It is not a roadmap. Only verified risks are listed.
+
+## Ownership Model
+
+| Area | DeepChat Agent | ACP Agent |
+| --- | --- | --- |
+| Runtime owner | DeepChat main process | External ACP process |
+| State owner | DeepChat session/message/tape stores | ACP process owns agent state; DeepChat caches session metadata |
+| Tool execution | DeepChat `ToolPresenter` | ACP agent decides through protocol callbacks |
+| Permission UI | DeepChat runtime action blocks | ACP provider emits DeepChat permission events |
+| Failure boundary | Same Electron main process | Separate process, but protocol promises must be settled |
+
+## DeepChat Agent Path
+
+Main files:
+
+- `src/main/presenter/agentRuntimePresenter/index.ts`
+- `src/main/presenter/agentRuntimePresenter/process.ts`
+- `src/main/presenter/agentRuntimePresenter/dispatch.ts`
+- `src/main/presenter/agentRuntimePresenter/messageStore.ts`
+- `src/main/presenter/agentRuntimePresenter/pendingInputCoordinator.ts`
+
+Flow:
+
+```text
+Renderer sendMessage
+  -> AgentSessionPresenter
+  -> AgentRuntimePresenter.processMessage or queued pending input
+  -> context and tape view construction
+  -> processStream
+  -> dispatch tool calls or permission/question interactions
+  -> message store and stream events
+```
+
+Important current behavior:
+
+- Tape appends currently run in the Electron main process through synchronous SQLite calls.
+- Pending input drain has single-flight cleanup and recovery for claimed rows.
+- Tool output fitting does not rerun tools after side effects have already happened.
+
+## ACP Agent Path
+
+Main files:
+
+- `src/main/presenter/llmProviderPresenter/providers/acpProvider.ts`
+- `src/main/presenter/llmProviderPresenter/acp/acpProcessManager.ts`
+- `src/main/presenter/llmProviderPresenter/acp/acpSessionManager.ts`
+- `src/main/presenter/acpClientPresenter/index.ts`
+
+Flow:
+
+```text
+Renderer sendMessage
+  -> AgentSessionPresenter
+  -> AgentRuntimePresenter
+  -> LLMProviderPresenter
+  -> AcpProvider.coreStream
+  -> ACP process prompt
+  -> ACP content/tool/permission callbacks
+  -> DeepChat stream events and action blocks
+```
+
+The ACP process boundary is useful, but it means every pending protocol callback must have a clear
+settlement path. Permission requests were the missing path.
+
+## Verified Issue
+
+### ACP Permission Timeout
+
+Status: fixed in this change.
+
+Before the fix, `AcpProvider.registerPendingPermission()` stored a resolver in `pendingPermissions`
+without a timeout. `AgentRuntimePresenter.clearActiveProviderPermissionsForSession()` only removed
+the runtime map entry, so cancel/stop could drop DeepChat's handle without resolving the ACP
+provider promise.
+
+Fix:
+
+- `AcpProvider` adds a 60-second permission timeout.
+- Resolving, session cleanup, and provider cleanup clear the timeout.
+- `AgentRuntimePresenter.clearActiveProviderPermissionsForSession()` now resolves active ACP
+  provider permissions with `false` before removing them.
+
+Issue record:
+
+- [Architecture issue note](./issues/P0-1-acp-permission-timeout.md)
+- [SDD issue spec](../../issues/acp-permission-timeout/spec.md)
+- [GitHub issue #1881](https://github.com/ThinkInAIXYZ/deepchat/issues/1881)
+
+## Rejected Findings
+
+### Tape Write Ordering
+
+Not retained. The reviewed code does not have a current multi-writer tape path. Adding a JavaScript
+session lock would add state without fixing a demonstrated bug.
+
+### Pending Input Deadlock
+
+Not retained. The current coordinator and runtime drain code already use cleanup and recovery paths.
+No additional watchdog is justified by the inspected code.
+
+### ACP Config Rollback
+
+Not retained. ACP config state is updated after the remote ACP response is received. The reviewed
+code does not do the optimistic local mutation assumed by the draft review.
+
+### Tool Output Retry
+
+Not retained. Retrying with fewer tools after execution would rerun side-effectful tools. The current
+`ToolOutputGuard` behavior is the safer boundary.
+
+## Validation
+
+Focused tests cover:
+
+- ACP pending permission timeout cleanup.
+- ACP pending permission timer cleanup after explicit resolution.
+- Runtime session cleanup resolving live ACP provider permission requests as denied.

--- a/docs/issues/acp-permission-timeout/spec.md
+++ b/docs/issues/acp-permission-timeout/spec.md
@@ -1,0 +1,41 @@
+# ACP Permission Timeout
+
+Linked GitHub issue: [#1881](https://github.com/ThinkInAIXYZ/deepchat/issues/1881)
+
+## Issue
+
+ACP permission requests could remain pending after generation cancel/stop or after the user never
+answers the permission prompt. This left the ACP provider promise unresolved.
+
+## Impact
+
+- ACP prompt handling could hang until broader provider/process cleanup.
+- Runtime state could drop the active permission record without waking the provider request.
+- Users could see a permission interaction that no longer had a useful live backend path.
+
+## Root Cause
+
+- `src/main/presenter/llmProviderPresenter/providers/acpProvider.ts` stored pending permission
+  promises without a timeout.
+- `src/main/presenter/agentRuntimePresenter/index.ts` cleared active ACP provider permissions by
+  deleting them from `activeProviderPermissions` only.
+
+## Fix Plan
+
+- Add a bounded timeout for ACP pending permissions.
+- Clear pending permission timers on explicit resolve and cleanup.
+- Cancel provider-side permissions when runtime session cleanup removes active ACP permission state.
+- Add focused tests for provider timeout cleanup and runtime cleanup.
+
+## Tasks
+
+- [x] Add ACP pending permission timeout.
+- [x] Clear timeout on explicit permission resolution.
+- [x] Clear timeout on session/provider cleanup.
+- [x] Resolve live ACP provider permission as denied during runtime session cleanup.
+- [x] Add focused tests.
+- [x] Update architecture docs and remove unsupported review findings.
+
+## Validation
+
+- [x] `pnpm vitest run test/main/presenter/acpProvider.test.ts test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts`

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -6172,6 +6172,14 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     for (const [requestId, permission] of this.activeProviderPermissions.entries()) {
       if (permission.sessionId === sessionId) {
         this.activeProviderPermissions.delete(requestId)
+        void this.resolveProviderPermissionSafely(() => permission.resolve(false)).catch(
+          (error) => {
+            console.warn(
+              `[DeepChatAgent] Failed to cancel ACP permission request ${requestId}:`,
+              error
+            )
+          }
+        )
       }
     }
   }

--- a/src/main/presenter/llmProviderPresenter/providers/acpProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/acpProvider.ts
@@ -95,7 +95,10 @@ type PendingPermissionState = {
   context: PermissionRequestContext
   resolve: (response: schema.RequestPermissionResponse) => void
   reject: (error: Error) => void
+  timeoutId: ReturnType<typeof setTimeout>
 }
+
+const ACP_PERMISSION_TIMEOUT_MS = 60_000
 
 type AcpConnectionWithModelSelection = {
   unstable_setSessionModel?: (
@@ -1525,13 +1528,23 @@ export class AcpProvider extends BaseLLMProvider {
     const requestId = nanoid()
 
     const promise = new Promise<schema.RequestPermissionResponse>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        const state = this.removePendingPermission(requestId)
+        if (!state) {
+          return
+        }
+        console.warn(`[ACP] Permission request timed out: ${requestId}`)
+        state.resolve({ outcome: { outcome: 'cancelled' } })
+      }, ACP_PERMISSION_TIMEOUT_MS)
+
       this.pendingPermissions.set(requestId, {
         requestId,
         sessionId: params.sessionId,
         params,
         context,
         resolve,
-        reject
+        reject,
+        timeoutId
       })
     })
 
@@ -1638,12 +1651,10 @@ export class AcpProvider extends BaseLLMProvider {
   }
 
   public async resolvePermissionRequest(requestId: string, granted: boolean): Promise<void> {
-    const state = this.pendingPermissions.get(requestId)
+    const state = this.removePendingPermission(requestId)
     if (!state) {
       throw new Error(`Unknown ACP permission request: ${requestId}`)
     }
-
-    this.pendingPermissions.delete(requestId)
 
     const option = this.pickPermissionOption(state.params.options, granted ? 'allow' : 'deny')
     if (option) {
@@ -1656,11 +1667,20 @@ export class AcpProvider extends BaseLLMProvider {
     }
   }
 
+  private removePendingPermission(requestId: string): PendingPermissionState | undefined {
+    const state = this.pendingPermissions.get(requestId)
+    if (!state) {
+      return undefined
+    }
+    this.pendingPermissions.delete(requestId)
+    clearTimeout(state.timeoutId)
+    return state
+  }
+
   private clearPendingPermissionsForSession(sessionId: string): void {
     for (const [requestId, state] of this.pendingPermissions.entries()) {
       if (state.sessionId === sessionId) {
-        this.pendingPermissions.delete(requestId)
-        state.resolve({ outcome: { outcome: 'cancelled' } })
+        this.removePendingPermission(requestId)?.resolve({ outcome: { outcome: 'cancelled' } })
       }
     }
   }
@@ -2007,9 +2027,8 @@ export class AcpProvider extends BaseLLMProvider {
       console.warn('[ACP] Cleanup: failed to shutdown process manager:', error)
     }
 
-    for (const [requestId, state] of this.pendingPermissions.entries()) {
-      state.resolve({ outcome: { outcome: 'cancelled' } })
-      this.pendingPermissions.delete(requestId)
+    for (const [requestId] of this.pendingPermissions.entries()) {
+      this.removePendingPermission(requestId)?.resolve({ outcome: { outcome: 'cancelled' } })
     }
   }
 }

--- a/test/main/presenter/acpProvider.test.ts
+++ b/test/main/presenter/acpProvider.test.ts
@@ -559,6 +559,78 @@ describe('AcpProvider runDebugAction error handling', () => {
     expect(payload.description).toBe('components.messageBlockPermissionRequest.description.command')
   })
 
+  it('cancels pending permission requests when they time out', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const provider = Object.create(AcpProvider.prototype) as any
+      provider.pendingPermissions = new Map()
+
+      const { requestId, promise } = provider.registerPendingPermission(
+        {
+          sessionId: 'session-1',
+          toolCall: {
+            toolCallId: 'tc-terminal',
+            title: 'Terminal',
+            kind: 'execute',
+            rawInput: { command: 'dir' }
+          },
+          options: []
+        },
+        {
+          conversationId: 'conv-1',
+          agent: { id: 'agent1', name: 'Claude Agent', command: 'claude' }
+        }
+      )
+
+      expect(provider.pendingPermissions.has(requestId)).toBe(true)
+
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      await expect(promise).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+      expect(provider.pendingPermissions.has(requestId)).toBe(false)
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears pending permission timeout when resolving a request', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const provider = Object.create(AcpProvider.prototype) as any
+      provider.pendingPermissions = new Map()
+
+      const { requestId, promise } = provider.registerPendingPermission(
+        {
+          sessionId: 'session-1',
+          toolCall: {
+            toolCallId: 'tc-terminal',
+            title: 'Terminal',
+            kind: 'execute',
+            rawInput: { command: 'dir' }
+          },
+          options: [{ optionId: 'allow-1', kind: 'allow_once', name: 'Allow' }]
+        },
+        {
+          conversationId: 'conv-1',
+          agent: { id: 'agent1', name: 'Claude Agent', command: 'claude' }
+        }
+      )
+
+      await provider.resolvePermissionRequest(requestId, true)
+
+      await expect(promise).resolves.toEqual({
+        outcome: { outcome: 'selected', optionId: 'allow-1' }
+      })
+      expect(provider.pendingPermissions.has(requestId)).toBe(false)
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('prepares ACP session without prompt and emits ready events', async () => {
     const configState = createConfigState()
     const provider = Object.create(AcpProvider.prototype) as any

--- a/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
@@ -6858,6 +6858,35 @@ describe('AgentRuntimePresenter', () => {
       expect((agent as any).activeProviderPermissions.has('acp-req-1')).toBe(false)
     })
 
+    it('cancels live ACP permission resolvers when clearing a session', async () => {
+      const resolve = vi.fn().mockResolvedValue(undefined)
+      ;(agent as any).activeProviderPermissions.set('acp-req-1', {
+        requestId: 'acp-req-1',
+        sessionId: 's1',
+        messageId: 'm1',
+        toolCallId: 'tc1',
+        providerId: 'acp',
+        permissionType: 'command',
+        resolve
+      })
+      ;(agent as any).activeProviderPermissions.set('acp-req-2', {
+        requestId: 'acp-req-2',
+        sessionId: 's2',
+        messageId: 'm2',
+        toolCallId: 'tc2',
+        providerId: 'acp',
+        permissionType: 'command',
+        resolve: vi.fn().mockResolvedValue(undefined)
+      })
+
+      ;(agent as any).clearActiveProviderPermissionsForSession('s1')
+      await Promise.resolve()
+
+      expect(resolve).toHaveBeenCalledWith(false)
+      expect((agent as any).activeProviderPermissions.has('acp-req-1')).toBe(false)
+      expect((agent as any).activeProviderPermissions.has('acp-req-2')).toBe(true)
+    })
+
     it('falls back to direct ACP permission resolve when live resolver is missing', async () => {
       await agent.initSession('s1', { providerId: 'acp', modelId: 'claude-code-acp' })
       makeAssistantRow({


### PR DESCRIPTION
## Summary
- settle ACP pending permission requests with a timeout and cleanup cancellation
- add focused provider/runtime tests
- replace draft ACP architecture notes with code-backed docs and SDD issue

## Tests
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck:node
- pnpm vitest run test/main/presenter/acpProvider.test.ts test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts

Closes #1881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ACP permission prompts now reliably settle when a session is canceled or no response is received, preventing stuck permission dialogs.
  * Session cleanup now closes related ACP permission requests instead of leaving them pending.

* **New Features**
  * Added clearer architecture documentation comparing DeepChat and ACP agent paths, with updated guidance on when each applies.

* **Documentation**
  * Expanded issue and spec notes with reviewed findings, validation steps, and updated behavior details.

* **Tests**
  * Added coverage for permission timeout handling and session-based permission cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->