### PR TITLE
feat(provider): add OpenCode Go

### DIFF
--- a/docs/features/opencode-go-provider/plan.md
+++ b/docs/features/opencode-go-provider/plan.md
@@ -1,0 +1,45 @@
+# Plan
+
+## Provider Path
+
+Use the existing AI SDK provider infrastructure with a small provider-specific registry definition:
+
+- Runtime family: mixed OpenAI-compatible plus Anthropic route selection.
+- Default route: OpenAI-compatible `/chat/completions`.
+- Anthropic route: selected for documented `/messages` model IDs.
+- Auth: existing API-key field, sent as bearer key by the selected AI SDK transport.
+- Model metadata source: live OpenCode Go `/models` endpoint.
+
+## Affected Files
+
+- `src/main/presenter/configPresenter/providers.ts`
+  - Add the built-in `opencode-go` provider entry.
+- `src/main/presenter/llmProviderPresenter/providerRegistry.ts`
+  - Add Go-specific model source and route strategy values.
+  - Register `opencode-go` with `checkStrategy: generate-text` and `checkModelId: kimi-k2.7-code`.
+- `src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts`
+  - Add OpenCode Go model endpoint mapping.
+  - Route documented `/messages` model IDs to `providerKind: 'anthropic'`.
+- Focused tests under `test/main/**`.
+
+## Data Flow
+
+1. User enables `opencode-go` and saves the OpenCode Go API key.
+2. Model refresh calls `GET https://opencode.ai/zen/go/v1/models` with the provider API key.
+3. Models documented for `/messages` receive `endpointType: 'anthropic'`; other Go chat models receive `endpointType: 'openai'`.
+4. Runtime route selection patches Anthropic models to `apiType: 'anthropic'` with the same OpenCode Go base URL.
+5. OpenAI-compatible models use the default OpenAI-compatible runtime against `/chat/completions`.
+
+## Compatibility
+
+- Existing OpenAI-compatible and Anthropic providers are unchanged.
+- OpenCode Go does not depend on PublicProviderConf refresh availability.
+- Users can unlock and edit the base URL through the existing built-in provider UI if needed.
+
+## Test Strategy
+
+- Unit test default provider metadata.
+- Unit test registry definition and connection-check model.
+- Unit test model mapping from mocked `/models` payload.
+- Unit test route selection by invoking `check()` for OpenAI and Anthropic Go model IDs with the AI SDK generate-text runner mocked.
+- Run focused tests, then `pnpm run format`, `pnpm run i18n`, and `pnpm run lint`.

--- a/docs/features/opencode-go-provider/spec.md
+++ b/docs/features/opencode-go-provider/spec.md
@@ -1,5 +1,7 @@
 # OpenCode Go Provider
 
+Linked GitHub issue: #1896
+
 ## User Need
 
 DeepChat users with an OpenCode Go subscription need to configure their Go API key and use the Go model catalog from DeepChat as a built-in provider.

--- a/docs/features/opencode-go-provider/spec.md
+++ b/docs/features/opencode-go-provider/spec.md
@@ -1,0 +1,48 @@
+# OpenCode Go Provider
+
+## User Need
+
+DeepChat users with an OpenCode Go subscription need to configure their Go API key and use the Go model catalog from DeepChat as a built-in provider.
+
+## Goal
+
+Add OpenCode Go as a built-in DeepChat provider using the documented OpenCode Go endpoints at `https://opencode.ai/zen/go/v1`.
+
+## Requirements
+
+- Add a disabled built-in provider with:
+  - provider ID: `opencode-go`
+  - display name: `OpenCode Go`
+  - auth: API key copied from OpenCode Zen
+  - default base URL: `https://opencode.ai/zen/go/v1`
+- Use the official documentation URLs:
+  - official/API key console: `https://opencode.ai/auth`
+  - docs: `https://opencode.ai/docs/zh-cn/go/`
+  - models endpoint: `https://opencode.ai/zen/go/v1/models`
+- Fetch available models from `GET /models` and map OpenCode Go model IDs into DeepChat `MODEL_META` records.
+- Route models documented for `https://opencode.ai/zen/go/v1/chat/completions` through the OpenAI-compatible runtime.
+- Route models documented for `https://opencode.ai/zen/go/v1/messages` through the existing Anthropic runtime.
+- Use `kimi-k2.7-code` as the connection-check model because it is a documented OpenAI-compatible Go coding model.
+- Keep credentials in the existing provider API-key field; do not add OAuth or renderer-side credential storage.
+- Preserve proxy support and existing AiSdkProvider behaviors.
+
+## Acceptance Criteria
+
+- `DEFAULT_PROVIDERS` includes `opencode-go` as disabled with the documented base URL and websites.
+- `resolveAiSdkProviderDefinition` resolves `opencode-go` to an AI SDK provider definition with a Go-specific model source and route strategy.
+- Fetching models maps OpenCode Go `/models` payloads to DeepChat models and marks documented `/messages` models for Anthropic routing.
+- OpenCode Go Anthropic-routed model IDs build runtime context with `providerKind: 'anthropic'` and OpenCode Go base URL.
+- OpenCode Go OpenAI-compatible model IDs build runtime context with `providerKind: 'openai-compatible'`.
+- Focused tests cover provider registration, model mapping, route selection, and check-model configuration.
+- SDD files contain no unresolved `[NEEDS CLARIFICATION]` markers.
+
+## Non-Goals
+
+- No new SDK dependency.
+- No special OAuth flow.
+- No PublicProviderConf/provider-db metadata dependency for OpenCode Go in this change.
+- No support for endpoints outside the documented chat/completions, messages, and models routes.
+
+## Open Questions
+
+None.

--- a/docs/features/opencode-go-provider/tasks.md
+++ b/docs/features/opencode-go-provider/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [x] Read OpenCode Go documentation and derive provider details.
+- [x] Inspect existing DeepChat provider architecture and test conventions.
+- [x] Add built-in OpenCode Go provider metadata.
+- [x] Add OpenCode Go registry definition and model/route strategies.
+- [x] Add OpenCode Go model mapping and route selection.
+- [x] Add focused tests for registration, model mapping, routing, and check strategy.
+- [x] Run formatting, i18n, lint, and focused tests.
+- [x] Self-review the diff, fix findings, and repeat review until clean.
+- [ ] Open a PR targeting `dev`.

--- a/docs/features/opencode-go-provider/tasks.md
+++ b/docs/features/opencode-go-provider/tasks.md
@@ -8,4 +8,4 @@
 - [x] Add focused tests for registration, model mapping, routing, and check strategy.
 - [x] Run formatting, i18n, lint, and focused tests.
 - [x] Self-review the diff, fix findings, and repeat review until clean.
-- [ ] Open a PR targeting `dev`.
+- [x] Open a PR targeting `dev`.

--- a/src/main/presenter/configPresenter/providers.ts
+++ b/src/main/presenter/configPresenter/providers.ts
@@ -323,6 +323,21 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
     }
   },
   {
+    id: 'opencode-go',
+    name: 'OpenCode Go',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://opencode.ai/zen/go/v1',
+    enable: false,
+    websites: {
+      official: 'https://opencode.ai/auth',
+      apiKey: 'https://opencode.ai/auth',
+      docs: 'https://opencode.ai/docs/zh-cn/go/',
+      models: 'https://opencode.ai/zen/go/v1/models',
+      defaultBaseUrl: 'https://opencode.ai/zen/go/v1'
+    }
+  },
+  {
     id: 'poe',
     name: 'Poe',
     apiType: 'poe',

--- a/src/main/presenter/llmProviderPresenter/providerRegistry.ts
+++ b/src/main/presenter/llmProviderPresenter/providerRegistry.ts
@@ -12,6 +12,7 @@ export type AiSdkBehaviorPreset =
 export type AiSdkModelSourceStrategy =
   | 'openai'
   | 'openai-codex'
+  | 'opencode-go'
   | 'kimi-for-coding'
   | 'github'
   | 'together'
@@ -41,7 +42,7 @@ export type AiSdkCheckStrategy = 'fetch-models' | 'key-status' | 'generate-text'
 
 export type AiSdkCredentialStrategy = 'none' | 'api-key' | 'anthropic' | 'vertex' | 'bedrock'
 
-export type AiSdkRouteStrategy = 'none' | 'grok' | 'new-api' | 'zenmux'
+export type AiSdkRouteStrategy = 'none' | 'grok' | 'new-api' | 'opencode-go' | 'zenmux'
 
 export type AiSdkEmbeddingStrategy = 'none' | 'openai' | 'google' | 'new-api' | 'zenmux'
 
@@ -415,6 +416,21 @@ const PROVIDER_ID_REGISTRY = new Map<string, AiSdkProviderDefinition>([
       ...TITLE_SUMMARY_OPENAI,
       modelSource: 'provider-db',
       providerDbGroup: 'o3fan'
+    })
+  ],
+  [
+    'opencode-go',
+    createDefinition({
+      ...OPENAI_BASE,
+      modelSource: 'opencode-go',
+      checkStrategy: 'generate-text',
+      credentialStrategy: 'api-key',
+      routeStrategy: 'opencode-go',
+      embeddingStrategy: 'none',
+      checkModelId: 'kimi-k2.7-code',
+      checkPrompt: 'Hello',
+      checkTemperature: 0.2,
+      checkMaxTokens: 16
     })
   ],
   [

--- a/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
@@ -75,6 +75,15 @@ const OPENAI_CODEX_RECOMMENDED_MODEL_IDS = [
   'gpt-5.4-mini',
   'gpt-5.3-codex-spark'
 ]
+// Keep this aligned with the OpenCode Go docs table for models served by /messages.
+const OPENCODE_GO_ANTHROPIC_MODEL_IDS = new Set([
+  'minimax-m3',
+  'minimax-m2.7',
+  'minimax-m2.5',
+  'qwen3.7-max',
+  'qwen3.7-plus',
+  'qwen3.6-plus'
+])
 const DEFAULT_NEW_API_BASE_URL = 'https://www.newapi.ai'
 
 type RouteDecision = {
@@ -309,6 +318,7 @@ export class AiSdkProvider extends BaseLLMProvider {
   private getBehaviorPreset(decision: RouteDecision): AiSdkBehaviorPreset {
     switch (this.getRouteStrategy()) {
       case 'new-api':
+      case 'opencode-go':
       case 'zenmux':
         if (decision.providerKind === 'anthropic' || decision.providerKind === 'aws-bedrock') {
           return 'anthropic'
@@ -463,6 +473,17 @@ export class AiSdkProvider extends BaseLLMProvider {
         providerPatch: {
           apiType: 'anthropic',
           baseUrl: this.getConfiguredAnthropicBaseUrl(),
+          capabilityProviderId: 'anthropic'
+        }
+      }
+    }
+
+    if (strategy === 'opencode-go' && OPENCODE_GO_ANTHROPIC_MODEL_IDS.has(modelId)) {
+      return {
+        providerKind: 'anthropic',
+        providerPatch: {
+          apiType: 'anthropic',
+          baseUrl: this.provider.baseUrl,
           capabilityProviderId: 'anthropic'
         }
       }
@@ -1508,6 +1529,8 @@ export class AiSdkProvider extends BaseLLMProvider {
         return this.mapProviderDbModels(this.definition.providerDbGroup || 'default')
       case 'openai-codex':
         return this.mapOpenAICodexModels()
+      case 'opencode-go':
+        return this.fetchOpenCodeGoModels()
       case 'kimi-for-coding':
         return this.mapKimiForCodingModels()
       case 'github': {
@@ -1853,6 +1876,38 @@ export class AiSdkProvider extends BaseLLMProvider {
         model.id.startsWith('anthropic.')
       )
     }
+  }
+
+  private async fetchOpenCodeGoModels(): Promise<MODEL_META[]> {
+    const records = await this.fetchOpenAIModelRecords({ timeout: this.getModelFetchTimeout() })
+
+    return records
+      .filter((model): model is Record<string, unknown> & { id: string } => {
+        return typeof model.id === 'string' && model.id.trim().length > 0
+      })
+      .map((model) => {
+        const modelId = model.id.trim()
+        const isAnthropicModel = OPENCODE_GO_ANTHROPIC_MODEL_IDS.has(modelId)
+        const existingConfig = this.getProviderModelConfig(modelId)
+        const endpointType = isAnthropicModel ? 'anthropic' : 'openai'
+
+        return {
+          id: modelId,
+          name: modelId,
+          group: isAnthropicModel ? 'Messages' : 'Chat Completions',
+          providerId: this.provider.id,
+          isCustom: false,
+          endpointType,
+          supportedEndpointTypes: [endpointType],
+          ownedBy: typeof model.owned_by === 'string' ? model.owned_by : 'opencode',
+          contextLength: existingConfig.contextLength || DEFAULT_MODEL_CONTEXT_LENGTH,
+          maxTokens: existingConfig.maxTokens || DEFAULT_MODEL_MAX_TOKENS,
+          vision: existingConfig.vision || false,
+          functionCall: existingConfig.functionCall || false,
+          reasoning: existingConfig.reasoning || false,
+          type: ModelType.Chat
+        } satisfies MODEL_META
+      })
   }
 
   private async fetchNewApiModels(): Promise<MODEL_META[]> {

--- a/test/main/presenter/configPresenter/defaultProviders.test.ts
+++ b/test/main/presenter/configPresenter/defaultProviders.test.ts
@@ -78,5 +78,18 @@ describe('DEFAULT_PROVIDERS', () => {
       baseUrl: 'https://api.minimax.io/anthropic/v1',
       enable: false
     })
+    expect(providersById.get('opencode-go')).toMatchObject({
+      name: 'OpenCode Go',
+      apiType: 'openai-completions',
+      baseUrl: 'https://opencode.ai/zen/go/v1',
+      enable: false,
+      websites: expect.objectContaining({
+        official: 'https://opencode.ai/auth',
+        apiKey: 'https://opencode.ai/auth',
+        docs: 'https://opencode.ai/docs/zh-cn/go/',
+        models: 'https://opencode.ai/zen/go/v1/models',
+        defaultBaseUrl: 'https://opencode.ai/zen/go/v1'
+      })
+    })
   })
 })

--- a/test/main/presenter/llmProviderPresenter/basicApiKeyProviders.test.ts
+++ b/test/main/presenter/llmProviderPresenter/basicApiKeyProviders.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { IConfigPresenter, LLM_PROVIDER } from '../../../../src/shared/presenter'
 import { AiSdkProvider } from '../../../../src/main/presenter/llmProviderPresenter/providers/aiSdkProvider'
 import { resolveAiSdkProviderDefinition } from '../../../../src/main/presenter/llmProviderPresenter/providerRegistry'
@@ -7,6 +7,8 @@ const { mockGetProvider, mockRunAiSdkGenerateText } = vi.hoisted(() => ({
   mockGetProvider: vi.fn(),
   mockRunAiSdkGenerateText: vi.fn()
 }))
+
+const originalFetch = global.fetch
 
 vi.mock('electron', () => ({
   app: {
@@ -98,7 +100,12 @@ const createConfigPresenter = (): IConfigPresenter =>
 describe('basic API-key provider registrations', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    global.fetch = originalFetch
     mockRunAiSdkGenerateText.mockResolvedValue({ content: 'ok' })
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
   })
 
   it('resolves OpenAI-compatible providers through provider-db backed definitions', () => {
@@ -130,6 +137,26 @@ describe('basic API-key provider registrations', () => {
     }
   })
 
+  it('resolves OpenCode Go through its mixed-route provider definition', () => {
+    expect(
+      resolveAiSdkProviderDefinition(
+        createProvider({
+          id: 'opencode-go',
+          name: 'OpenCode Go',
+          baseUrl: 'https://opencode.ai/zen/go/v1'
+        })
+      )
+    ).toMatchObject({
+      runtimeKind: 'openai-compatible',
+      modelSource: 'opencode-go',
+      checkStrategy: 'generate-text',
+      credentialStrategy: 'api-key',
+      routeStrategy: 'opencode-go',
+      embeddingStrategy: 'none',
+      checkModelId: 'kimi-k2.7-code'
+    })
+  })
+
   it('resolves MiniMax global through the Anthropic-compatible runtime', () => {
     expect(
       resolveAiSdkProviderDefinition(
@@ -149,6 +176,67 @@ describe('basic API-key provider registrations', () => {
       credentialStrategy: 'api-key',
       checkModelId: 'MiniMax-M2.1'
     })
+  })
+
+  it('maps OpenCode Go model records and marks messages models for Anthropic routing', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        object: 'list',
+        data: [
+          { id: 'kimi-k2.7-code', object: 'model', owned_by: 'opencode' },
+          { id: 'minimax-m3', object: 'model', owned_by: 'opencode' },
+          { id: 'hy3-preview', object: 'model', owned_by: 'opencode' }
+        ]
+      })
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: 'opencode-go',
+        name: 'OpenCode Go',
+        baseUrl: 'https://opencode.ai/zen/go/v1'
+      }),
+      createConfigPresenter()
+    )
+    const models = await provider.fetchModels()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://opencode.ai/zen/go/v1/models',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-key'
+        })
+      })
+    )
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: 'kimi-k2.7-code',
+        group: 'Chat Completions',
+        providerId: 'opencode-go',
+        endpointType: 'openai',
+        supportedEndpointTypes: ['openai'],
+        ownedBy: 'opencode'
+      }),
+      expect.objectContaining({
+        id: 'minimax-m3',
+        group: 'Messages',
+        providerId: 'opencode-go',
+        endpointType: 'anthropic',
+        supportedEndpointTypes: ['anthropic'],
+        ownedBy: 'opencode'
+      }),
+      expect.objectContaining({
+        id: 'hy3-preview',
+        group: 'Chat Completions',
+        providerId: 'opencode-go',
+        endpointType: 'openai',
+        supportedEndpointTypes: ['openai'],
+        ownedBy: 'opencode'
+      })
+    ])
   })
 
   it('maps provider DB metadata into built-in provider models', async () => {
@@ -191,6 +279,97 @@ describe('basic API-key provider registrations', () => {
         maxTokens: 8192
       })
     ])
+  })
+
+  it('routes OpenCode Go chat completions models through OpenAI-compatible runtime', async () => {
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: 'opencode-go',
+        name: 'OpenCode Go',
+        baseUrl: 'https://opencode.ai/zen/go/v1'
+      }),
+      createConfigPresenter()
+    )
+    ;(provider as any).isInitialized = true
+
+    await expect(provider.check()).resolves.toEqual({
+      isOk: true,
+      errorMsg: null
+    })
+    expect(mockRunAiSdkGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerKind: 'openai-compatible',
+        provider: expect.objectContaining({
+          id: 'opencode-go',
+          apiType: 'openai-completions',
+          baseUrl: 'https://opencode.ai/zen/go/v1'
+        })
+      }),
+      [{ role: 'user', content: 'Hello' }],
+      'kimi-k2.7-code',
+      expect.any(Object),
+      0.2,
+      16
+    )
+  })
+
+  it('uses Anthropic behavior for OpenCode Go messages models', async () => {
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: 'opencode-go',
+        name: 'OpenCode Go',
+        baseUrl: 'https://opencode.ai/zen/go/v1'
+      }),
+      createConfigPresenter()
+    )
+    ;(provider as any).isInitialized = true
+
+    await provider.summaryTitles(
+      [{ role: 'user', content: 'Explain provider routing' }],
+      'minimax-m3'
+    )
+
+    expect(mockRunAiSdkGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerKind: 'anthropic'
+      }),
+      expect.any(Array),
+      'minimax-m3',
+      expect.any(Object),
+      0.3,
+      50
+    )
+  })
+
+  it('routes OpenCode Go messages models through Anthropic runtime', async () => {
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: 'opencode-go',
+        name: 'OpenCode Go',
+        baseUrl: 'https://opencode.ai/zen/go/v1'
+      }),
+      createConfigPresenter()
+    )
+    ;(provider as any).isInitialized = true
+
+    await provider.runText([{ role: 'user', content: 'Hello' }], 'minimax-m3')
+
+    expect(mockRunAiSdkGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerKind: 'anthropic',
+        provider: expect.objectContaining({
+          id: 'opencode-go',
+          apiType: 'anthropic',
+          baseUrl: 'https://opencode.ai/zen/go/v1',
+          capabilityProviderId: 'anthropic'
+        })
+      }),
+      [{ role: 'user', content: 'Hello' }],
+      'minimax-m3',
+      expect.any(Object),
+      undefined,
+      undefined
+    )
   })
 
   it('uses the configured check model for MiniMax global', async () => {


### PR DESCRIPTION
## Summary
- add OpenCode Go as a built-in provider using the documented Go API endpoints
- fetch Go models from the live /models endpoint and route documented /messages models through the Anthropic runtime
- cover provider registration, model mapping, OpenAI-compatible routing, Anthropic routing, and Anthropic behavior presets

## Validation
- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm exec vitest run test/main/presenter/configPresenter/defaultProviders.test.ts test/main/presenter/llmProviderPresenter/basicApiKeyProviders.test.ts --pool=forks

Closes #1896


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in support for the **OpenCode Go** provider, including provider details, model discovery, and mixed routing for chat and messages models.
  * Certain models now automatically use the appropriate runtime based on their endpoint type.
* **Documentation**
  * Added feature plan, specification, and task-tracking docs for the new provider.
* **Tests**
  * Expanded coverage for provider setup, model mapping/classification, routing behavior, and improved fetch mocking isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->