### PR TITLE
docs(sdd): narrow issue sync scope

### DIFF
--- a/.agents/skills/deepchat-sdd/SKILL.md
+++ b/.agents/skills/deepchat-sdd/SKILL.md
@@ -1,29 +1,45 @@
 ---
 name: deepchat-sdd
-description: Use before DeepChat code, configuration, documentation, test, build, feature, issue, refactor, or architecture changes. Classify work into feature SDD, small-bug issue spec, or architecture SDD; optionally sync feature and bug work to GitHub issues with [feature] or [bug] labels when local gh is usable; keep broad documentation cleanup for the separate deepchat-sdd-cleanup skill.
+description: Use before substantial DeepChat code, configuration, documentation, test, build, feature, issue, refactor, or architecture changes that need a durable spec. Skip trivial style fixes, small localized logic changes, routine docs edits, and simple bugs unless the developer asks for SDD. Classify substantial work into feature SDD, complex-bug issue spec, or architecture SDD; ask before optional GitHub issue sync unless the developer explicitly requested sync.
 ---
 
 # DeepChat SDD
 
 ## When To Use
 
-Use this skill before changing DeepChat source code, configuration, tests, docs, build scripts, release workflows, or project structure.
+Use this skill before substantial DeepChat source code, configuration, tests, docs, build
+scripts, release workflows, or project structure changes that need shared context or a durable
+decision record.
+
+Skip SDD for trivial or tightly localized work unless the developer explicitly asks for it:
+
+- visual/style fixes, copy changes, and small UI layout adjustments
+- simple localized logic changes with a clear owner module
+- routine docs edits that do not change project direction
+- release metadata already covered by the release flow
+
+If the scope is unclear, inspect first and then ask whether SDD is wanted instead of creating
+artifacts by default.
 
 ## Classify The Goal
 
 Create one kebab-case folder per goal:
 
-- New capability, user-visible behavior, integration, or tool: `docs/features/<goal>/`
-- Small bug, regression, failing test, CI failure, reliability problem, or prompt/runtime issue:
+- New capability, user-visible behavior, integration, or tool large enough to need a shared plan:
+  `docs/features/<goal>/`
+- Complex bug, regression, failing test, CI failure, reliability problem, or prompt/runtime issue:
   `docs/issues/<goal>/`
 - Refactor, migration, dependency boundary, shared contract, runtime architecture, or cross-module
   design: `docs/architecture/<goal>/`
 
 If one request contains multiple independent goals, split them into separate folders. Keep current architecture reference docs such as `docs/architecture/agent-system.md` in place; use subfolders for new architecture targets.
 
-Treat a bug as small only when the failure is narrow, the owner module is clear, and the fix does not
-introduce a new user-visible capability, data migration, public contract, or cross-module redesign.
-If it does, classify the work as feature or architecture instead.
+Treat a bug as SDD-worthy only when the root cause, blast radius, or fix path is complex enough that
+future developers benefit from the written record. For simple style defects or obvious local logic
+fixes, skip `docs/issues/*` and implement directly.
+
+If a bug fix introduces a new user-visible capability, data migration, public contract, or
+cross-module redesign, classify the work as feature or architecture instead.
 
 ## Required Artifacts
 
@@ -33,24 +49,39 @@ Feature and architecture goals use the full SDD set:
 - `plan.md`: implementation approach, affected interfaces, data flow, compatibility, test strategy
 - `tasks.md`: ordered tasks that can map to commits or review slices
 
-Small bug goals use one file only:
+Complex bug goals use one file only:
 
 - `spec.md`: issue description, impact, root cause or suspected location, fix plan, task checklist,
   validation, and linked GitHub issue if one exists
 
-Resolve every `[NEEDS CLARIFICATION]` marker before implementation. If a requested change is tiny,
-keep the artifact short and concrete.
+Resolve every `[NEEDS CLARIFICATION]` marker before implementation. If the requested change is tiny,
+prefer skipping SDD over creating a token artifact.
 
 ## GitHub Issue Sync
 
-For feature and small bug goals only, sync to GitHub when local `gh` is installed and authenticated:
+Do not sync GitHub issues by default. Issue sync is a follow-up record, not a gate for local SDD or
+implementation.
+
+Only create or link a GitHub issue when the developer explicitly asks, or after asking and getting
+approval once the SDD artifacts are written or the implementation is complete.
+
+Eligible work:
+
+- Complex bugs only; simple style defects and obvious local logic fixes should not get issues.
+- Whole new features or major feature rewrites only; single actions, small behavior tweaks, and
+  ordinary adjustments should not get issues.
+
+If eligibility is unclear, ask the developer after the work is understood. Never self-authorize issue
+creation just because local `gh` is installed and authenticated.
+
+When approved:
 
 - Feature issues use the `[feature]` label.
 - Bug issues use the `[bug]` label.
 - Create the label first if it is missing and `gh` has permission.
 - Record the issue URL or number in the SDD artifact.
 - If `gh` is unavailable or unauthorized, continue local-only and note that no GitHub issue was
-  created.
+  created only when sync was requested or approved.
 
 When creating a PR for linked work, include `Closes #NNN` in the PR body so GitHub closes the issue
 automatically after merge.
@@ -58,9 +89,9 @@ automatically after merge.
 ## Workflow
 
 1. Inspect the current code and docs first.
-2. Pick the target folder from the classification rules.
-3. Create or update the required artifact set for that classification.
-4. Sync a GitHub issue for feature or small bug work when `gh` is usable.
+2. Decide whether the work is substantial enough for SDD; skip artifacts for trivial/local changes.
+3. Pick the target folder from the classification rules when SDD is needed.
+4. Create or update the required artifact set for that classification.
 5. Keep the implementation aligned with existing DeepChat patterns:
    - main process Presenter boundaries
    - typed `shared/contracts/*`
@@ -70,7 +101,10 @@ automatically after merge.
    retained `spec.md` if it is still a maintained contract.
 7. Implement the change after the SDD artifacts are complete.
 8. Update `tasks.md` or the issue spec checklist as work lands.
-9. Run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint` before handoff.
+9. Ask whether to sync an eligible GitHub issue only after the docs or implementation clarify the
+   scope, unless the developer already requested issue sync.
+10. Run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint` before handoff when app code,
+    tests, i18n, or project docs changed.
 
 ## Documentation Hygiene
 

--- a/.agents/skills/deepchat-sdd/agents/openai.yaml
+++ b/.agents/skills/deepchat-sdd/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "DeepChat SDD"
-  short_description: "Classify DeepChat changes before implementation"
-  default_prompt: "Use $deepchat-sdd before implementing DeepChat changes to choose the right feature, issue, or architecture artifact workflow."
+  short_description: "Spec substantial DeepChat changes only"
+  default_prompt: "Use $deepchat-sdd for substantial DeepChat changes that need SDD; skip trivial fixes and ask before GitHub issue sync."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@
 ## Commit & Pull Request Guidelines
 - Conventional commits enforced by hook: `type(scope): subject` ≤ 50 chars; types: `feat|fix|docs|dx|style|refactor|perf|test|workflow|build|ci|chore|types|wip|release`.
 - Do not include AI co-authoring footers in commits.
-- PRs: clear description, link issues (`Closes #123`), screenshots/GIFs for UI, pass lint/typecheck/tests. Keep changes focused.
+- PRs: clear description, link synced issues when available (`Closes #123`), screenshots/GIFs for UI, pass lint/typecheck/tests. Keep changes focused.
 - Default PR base is `dev`; use `gh pr create --base dev` for routine feature, bugfix, docs, test, and refactor branches. Target `main` only for `release/<version>` branches following `docs/release-flow.md`.
 - UI changes: include BEFORE/AFTER ASCII layout blocks to communicate structure.
 
@@ -49,18 +49,20 @@
 
 ## Specification-Driven Development
 
-Follow the SDD methodology before changing code, tests, configuration, documentation, build scripts, or project structure. See [docs/spec-driven-dev.md](docs/spec-driven-dev.md).
+Use SDD before substantial changes to code, tests, configuration, documentation, build scripts, or project structure when the work needs shared context or a durable decision record. Skip SDD for trivial or tightly localized work unless the developer explicitly asks for it. See [docs/spec-driven-dev.md](docs/spec-driven-dev.md).
 
 Pure release metadata work does not require SDD. Version bumps, `CHANGELOG.md` updates, release branch management, tags, and release PR preparation should follow [docs/release-flow.md](docs/release-flow.md) without creating
 `docs/features/*release*` folders.
 
-Create one kebab-case folder per goal and use the artifact set that matches the work:
+Create one kebab-case folder per goal when SDD is needed and use the artifact set that matches the work:
 
-- `docs/features/<goal>/` for new features, user-visible capabilities, integrations, and tools; keep `spec.md`, `plan.md`, and `tasks.md`.
-- `docs/issues/<goal>/` for small bug fixes, regressions, failing tests, CI failures, reliability issues, and prompt/runtime problems; keep one `spec.md` containing issue details, location/root cause, fix plan, task checklist, validation, and linked GitHub issue when available.
+- `docs/features/<goal>/` for new features, user-visible capabilities, integrations, and tools large enough to need a shared plan; keep `spec.md`, `plan.md`, and `tasks.md`.
+- `docs/issues/<goal>/` for complex bug fixes, regressions, failing tests, CI failures, reliability issues, and prompt/runtime problems; keep one `spec.md` containing issue details, location/root cause, fix plan, task checklist, validation, and linked GitHub issue when available.
 - `docs/architecture/<goal>/` for refactors, migrations, dependency boundaries, shared contracts, runtime architecture, and cross-module design; keep `spec.md`, `plan.md`, and `tasks.md`, and update affected historical feature specs when they remain maintained contracts.
 
-For feature and small bug work, create or link a GitHub issue with `[feature]` or `[bug]` when local `gh` is installed and authenticated. PR bodies for linked work must include `Closes #NNN`.
+Skip SDD for visual/style fixes, copy changes, small UI layout adjustments, simple localized logic changes, and routine docs edits that do not change project direction.
+
+Do not sync GitHub issues by default. Only create or link an issue when the developer explicitly asks, or after asking and getting approval once the SDD artifacts are written or implementation is complete. Eligible sync is limited to complex bugs and whole new features or major feature rewrites; simple bugs, single actions, small behavior tweaks, and ordinary adjustments should not get issues. PR bodies for linked work must include `Closes #NNN`.
 
 Resolve every `[NEEDS CLARIFICATION]` item before implementation. Run SDD cleanup only when the developer explicitly asks for it; use the dedicated cleanup skill to remove completed issue docs, stale plan/task files, and obsolete feature or architecture docs.
 

--- a/docs/spec-driven-dev.md
+++ b/docs/spec-driven-dev.md
@@ -4,15 +4,26 @@
 
 Specification-Driven Development (SDD) eliminates the gap between requirements and implementation by making specifications the primary artifact. Specifications don't serve code—code serves specifications. When implementing features in DeepChat, start with clear specifications that define WHAT users need and WHY, before deciding HOW to implement.
 
-In practice, SDD works best when the spec is concrete enough to drive design decisions, tests, and PR review. Prefer small, reviewable increments that keep spec → plan → code traceability.
+In practice, SDD works best when the spec is concrete enough to drive design decisions, tests, and
+PR review. Use it for substantial work that needs shared context or a durable decision record, not
+for every small edit. Prefer small, reviewable increments that keep spec → plan → code traceability.
 
 ## Required Artifacts
 
-Keep every active change in a lightweight SDD folder so reviewers can find the intent without hunting through code. Use one kebab-case folder per goal:
+Keep substantial active changes in a lightweight SDD folder so reviewers can find the intent without
+hunting through code. Use one kebab-case folder per goal when SDD is needed:
 
-- `docs/features/<goal>/` - new features, user-visible capabilities, integrations, and tools
-- `docs/issues/<goal>/` - small bug fixes, regressions, failing tests, CI failures, reliability issues, and prompt/runtime problems
+- `docs/features/<goal>/` - new features, user-visible capabilities, integrations, and tools large
+  enough to need a shared plan
+- `docs/issues/<goal>/` - complex bug fixes, regressions, failing tests, CI failures, reliability
+  issues, and prompt/runtime problems
 - `docs/architecture/<goal>/` - refactors, migrations, dependency boundaries, shared contracts, runtime architecture, and cross-module design
+
+Skip SDD unless a developer explicitly asks for it when the change is trivial or tightly localized:
+
+- visual/style fixes, copy changes, and small UI layout adjustments
+- simple localized logic changes with a clear owner module
+- routine docs edits that do not change project direction
 
 Pure release metadata work is exempt from SDD. Version bumps, `CHANGELOG.md` updates, release branch
 management, tags, and release PR preparation should follow `docs/release-flow.md` without creating a
@@ -24,40 +35,58 @@ Feature and architecture goals use the full SDD set:
 - `plan.md` - architecture decisions, event flow, data model, compatibility, test strategy
 - `tasks.md` - small, ordered tasks that map to commits/PRs
 
-Small bug goals use one file:
+Complex bug goals use one file:
 
 - `spec.md` - issue description, impact, root cause or suspected location, fix plan, task checklist,
   validation, and linked GitHub issue if one exists
 
-A bug is small only when the failure is narrow, the owner module is clear, and the fix does not
-introduce a new user-visible capability, data migration, public contract, or cross-module redesign.
-If it does, classify the work as feature or architecture instead.
+A bug is SDD-worthy only when the root cause, blast radius, or fix path is complex enough that
+future developers benefit from the written record. For simple style defects or obvious local logic
+fixes, skip `docs/issues/*` and implement directly.
 
-If a change is tiny, keep the artifact short.
+If a bug fix introduces a new user-visible capability, data migration, public contract, or
+cross-module redesign, classify the work as feature or architecture instead.
+
+If a change is tiny, prefer skipping SDD over creating a token artifact.
 
 ## GitHub Issue Sync
 
-For feature and small bug work, create or link a GitHub issue when local `gh` is installed and
-authenticated:
+Do not sync GitHub issues by default. Issue sync is a follow-up record, not a gate for local SDD or
+implementation.
+
+Only create or link a GitHub issue when the developer explicitly asks, or after asking and getting
+approval once the SDD artifacts are written or the implementation is complete.
+
+Eligible work:
+
+- Complex bugs only; simple style defects and obvious local logic fixes should not get issues.
+- Whole new features or major feature rewrites only; single actions, small behavior tweaks, and
+  ordinary adjustments should not get issues.
+
+If eligibility is unclear, ask the developer after the work is understood. Never self-authorize issue
+creation just because local `gh` is installed and authenticated.
+
+When approved:
 
 - Feature work uses the `[feature]` label.
 - Bug work uses the `[bug]` label.
 - If the label is missing and `gh` has permission, create it.
 - Record the issue URL or number in the SDD artifact.
 - If `gh` is unavailable or unauthorized, continue local-only and note that no GitHub issue was
-  created.
+  created only when sync was requested or approved.
 
 When opening a PR for linked work, include `Closes #NNN` in the PR body so GitHub closes the issue
 after merge.
 
 ## Workflow
 
-1. **Classification** - Choose feature, small bug, or architecture.
-2. **Specification** - Write the required artifact set for that classification.
-3. **GitHub Sync** - Create or link a labeled GitHub issue for feature and small bug work when
-   local `gh` is usable.
-4. **Implementation & Validation** - TDD (pragmatic), Presenter patterns, UI consistency, quality
+1. **Classification** - Decide whether SDD is needed, then choose feature, complex bug, or
+   architecture.
+2. **Specification** - Write the required artifact set for that classification when SDD is needed.
+3. **Implementation & Validation** - TDD (pragmatic), Presenter patterns, UI consistency, quality
    gates.
+4. **GitHub Sync** - Ask whether to sync an eligible GitHub issue only after the docs or
+   implementation clarify the scope, unless the developer already requested issue sync.
 
 Before implementation, inspect existing docs and code, choose the correct SDD folder, and resolve every `[NEEDS CLARIFICATION]` marker. For architecture work that changes or replaces a historical feature, update that feature's retained `spec.md` if it is still a maintained contract.
 
@@ -132,7 +161,7 @@ Use Vitest + Vue Test Utils for testing. Test files mirror source structure unde
 - [ ] Key UX states covered (loading/empty/error)
 - [ ] No `[NEEDS CLARIFICATION]` markers remain
 - [ ] Business value articulated
-- [ ] GitHub issue linked or local-only reason recorded for feature and small bug work
+- [ ] GitHub issue linked or sync decision recorded for eligible feature and complex bug work
 
 ### Planning Phase
 - [ ] Identify all involved Presenters
@@ -199,4 +228,4 @@ A change is “done” when:
 - Lint/typecheck/tests pass locally
 - User-facing strings use i18n keys
 - Any migrations or breaking changes are documented
-- Linked GitHub issues are referenced from the PR with `Closes #NNN`
+- Linked GitHub issues, when any, are referenced from the PR with `Closes #NNN`


### PR DESCRIPTION
## Summary
- narrow SDD usage to substantial DeepChat changes
- make GitHub issue sync opt-in or post-work approval only
- align AGENTS.md, spec-driven-dev docs, and the deepchat-sdd skill

## Validation
- corepack pnpm run format
- corepack pnpm run i18n
- corepack pnpm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when to use the spec-driven workflow versus skipping it for small, localized changes.
  * Updated guidance for handling complex bug work, issue tracking, and PR links.

* **Chores**
  * Revised contributor and agent instructions to align on when GitHub issue syncing should happen and what information must be recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->