### PR TITLE
fix(menu): preserve macOS hide behavior

### DIFF
--- a/src/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.ts
+++ b/src/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.ts
@@ -12,7 +12,6 @@ import { WINDOW_EVENTS, TRAY_EVENTS, FLOATING_BUTTON_EVENTS } from '@/events'
 import { handleShowHiddenWindow } from '@/utils'
 import { presenter } from '@/presenter'
 import { LifecyclePhase } from '@shared/lifecycle'
-import { activateAppOnMac } from '@/lib/activateApp'
 
 export const eventListenerSetupHook: LifecycleHook = {
   name: 'event-listener-setup',
@@ -32,30 +31,15 @@ export const eventListenerSetupHook: LifecycleHook = {
       optimizer.watchWindowShortcuts(window)
     })
 
-    // Handle app activation event (like clicking Dock icon on macOS)
+    // Handle app activation event (like launching the app or clicking the Dock icon on macOS).
+    // Do not reveal existing hidden windows here: opening the system/app menu also activates the app,
+    // and auto-showing would make the native Hide menu item impossible to use reliably.
     app.on('activate', function () {
-      // On macOS, it's common to re-create a window when the dock icon is clicked
-      // Also handle showing hidden windows
       const allWindows = presenter.windowPresenter.getAllWindows()
       if (allWindows.length === 0) {
         presenter.windowPresenter.createAppWindow({
           initialRoute: 'chat'
         })
-      } else {
-        // Try to show the most recently focused window, otherwise show the first window
-        const targetWindow = presenter.windowPresenter.getFocusedWindow() || allWindows[0]
-        if (!targetWindow.isDestroyed()) {
-          targetWindow.show()
-          targetWindow.focus() // Ensure window gets focus
-          activateAppOnMac()
-        } else {
-          console.warn(
-            'eventListenerSetupHook: App activated but target window is destroyed, creating new window.'
-          )
-          presenter.windowPresenter.createAppWindow({
-            initialRoute: 'chat'
-          })
-        }
       }
     })
 

--- a/src/main/presenter/trayPresenter.ts
+++ b/src/main/presenter/trayPresenter.ts
@@ -61,10 +61,13 @@ export class TrayPresenter {
 
     this.tray.setContextMenu(contextMenu)
 
-    // 点击托盘图标时显示窗口
-    this.tray.on('click', () => {
-      eventBus.sendToMain(TRAY_EVENTS.SHOW_HIDDEN_WINDOW, true)
-    })
+    // On macOS, clicking the status item opens the system menu. Do not also reveal the window,
+    // otherwise the menu's Open/Hide item can never hide the app reliably.
+    if (process.platform !== 'darwin') {
+      this.tray.on('click', () => {
+        eventBus.sendToMain(TRAY_EVENTS.SHOW_HIDDEN_WINDOW, true)
+      })
+    }
   }
 
   public init(): void {

--- a/test/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.test.ts
+++ b/test/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const appOnMock = vi.hoisted(() => vi.fn())
+const optimizerWatchMock = vi.hoisted(() => vi.fn())
+const loggerInfoMock = vi.hoisted(() => vi.fn())
+const windowPresenterMock = vi.hoisted(() => ({
+  getAllWindows: vi.fn(),
+  getFocusedWindow: vi.fn(),
+  createAppWindow: vi.fn(),
+  createSettingsWindow: vi.fn(),
+  sendSettingsNavigation: vi.fn(),
+  sendSettingsCheckForUpdates: vi.fn()
+}))
+const floatingButtonPresenterMock = vi.hoisted(() => ({
+  setEnabled: vi.fn()
+}))
+const shortcutPresenterMock = vi.hoisted(() => ({
+  registerShortcuts: vi.fn(),
+  unregisterShortcuts: vi.fn()
+}))
+const eventBusMock = vi.hoisted(() => ({
+  on: vi.fn(),
+  sendToMain: vi.fn()
+}))
+
+vi.mock('@shared/logger', () => ({
+  default: {
+    info: loggerInfoMock
+  }
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    on: appOnMock
+  }
+}))
+
+vi.mock('@electron-toolkit/utils', () => ({
+  optimizer: {
+    watchWindowShortcuts: optimizerWatchMock
+  }
+}))
+
+vi.mock('@/presenter', () => ({
+  presenter: {
+    windowPresenter: windowPresenterMock,
+    floatingButtonPresenter: floatingButtonPresenterMock,
+    shortcutPresenter: shortcutPresenterMock
+  }
+}))
+
+vi.mock('@/eventbus', () => ({
+  eventBus: eventBusMock
+}))
+
+const { eventListenerSetupHook } =
+  await import('@/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook')
+
+describe('eventListenerSetupHook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    windowPresenterMock.getAllWindows.mockReturnValue([])
+    windowPresenterMock.getFocusedWindow.mockReturnValue(undefined)
+  })
+
+  it('creates a chat window when macOS activates the app with no existing windows', async () => {
+    await eventListenerSetupHook.execute({} as never)
+
+    const activateHandler = appOnMock.mock.calls.find(
+      ([eventName]) => eventName === 'activate'
+    )?.[1]
+    expect(activateHandler).toBeTypeOf('function')
+
+    activateHandler()
+
+    expect(windowPresenterMock.createAppWindow).toHaveBeenCalledWith({ initialRoute: 'chat' })
+  })
+
+  it('does not reveal existing hidden windows on generic macOS activation', async () => {
+    const hiddenWindow = {
+      id: 7,
+      isDestroyed: vi.fn(() => false),
+      isVisible: vi.fn(() => false),
+      show: vi.fn(),
+      focus: vi.fn()
+    }
+    windowPresenterMock.getAllWindows.mockReturnValue([hiddenWindow])
+    windowPresenterMock.getFocusedWindow.mockReturnValue(hiddenWindow)
+
+    await eventListenerSetupHook.execute({} as never)
+
+    const activateHandler = appOnMock.mock.calls.find(
+      ([eventName]) => eventName === 'activate'
+    )?.[1]
+    expect(activateHandler).toBeTypeOf('function')
+
+    activateHandler()
+
+    expect(windowPresenterMock.createAppWindow).not.toHaveBeenCalled()
+    expect(hiddenWindow.show).not.toHaveBeenCalled()
+    expect(hiddenWindow.focus).not.toHaveBeenCalled()
+  })
+})

--- a/test/main/presenter/trayPresenter.test.ts
+++ b/test/main/presenter/trayPresenter.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const trayOnMock = vi.hoisted(() => vi.fn())
+const setContextMenuMock = vi.hoisted(() => vi.fn())
+const setToolTipMock = vi.hoisted(() => vi.fn())
+const setTemplateImageMock = vi.hoisted(() => vi.fn())
+const resizeMock = vi.hoisted(() => vi.fn(() => ({ setTemplateImage: setTemplateImageMock })))
+const createFromPathMock = vi.hoisted(() => vi.fn(() => ({ resize: resizeMock })))
+const buildFromTemplateMock = vi.hoisted(() => vi.fn((template) => ({ template })))
+const eventBusMock = vi.hoisted(() => ({
+  sendToMain: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: vi.fn(() => '/mock/app'),
+    quit: vi.fn()
+  },
+  nativeImage: {
+    createFromPath: createFromPathMock
+  },
+  Menu: {
+    buildFromTemplate: buildFromTemplateMock
+  },
+  Tray: vi.fn(() => ({
+    setToolTip: setToolTipMock,
+    setContextMenu: setContextMenuMock,
+    on: trayOnMock,
+    destroy: vi.fn()
+  }))
+}))
+
+vi.mock('@/presenter', () => ({
+  presenter: {
+    configPresenter: {
+      getLanguage: vi.fn(() => 'zh-CN')
+    }
+  }
+}))
+
+vi.mock('@/eventbus', () => ({
+  eventBus: eventBusMock
+}))
+
+describe('TrayPresenter', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform
+    })
+  })
+
+  it('does not reveal the app when the macOS tray status item is clicked', async () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'darwin'
+    })
+    const { TrayPresenter } = await import('@/presenter/trayPresenter')
+
+    new TrayPresenter().init()
+
+    expect(trayOnMock).not.toHaveBeenCalledWith('click', expect.any(Function))
+  })
+
+  it('keeps tray click reveal behavior on non-macOS platforms', async () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'win32'
+    })
+    const { TRAY_EVENTS } = await import('@/events')
+    const { TrayPresenter } = await import('@/presenter/trayPresenter')
+
+    new TrayPresenter().init()
+
+    const clickHandler = trayOnMock.mock.calls.find(([eventName]) => eventName === 'click')?.[1]
+    expect(clickHandler).toBeTypeOf('function')
+
+    clickHandler()
+
+    expect(eventBusMock.sendToMain).toHaveBeenCalledWith(TRAY_EVENTS.SHOW_HIDDEN_WINDOW, true)
+  })
+})


### PR DESCRIPTION
## Summary
- stop generic macOS app activation from revealing existing hidden windows
- avoid binding macOS tray/status item clicks to forced window reveal so the Open/Hide menu item can toggle reliably
- add regression coverage for activate and tray click behavior

## Tests
- pnpm vitest --project main test/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.test.ts test/main/presenter/trayPresenter.test.ts --run
- pnpm run format
- pnpm run i18n
- pnpm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted app activation behavior so a new window is only created when no windows are open.
  * Updated tray icon behavior so clicking the tray only shows the hidden window on non-macOS platforms.

* **Tests**
  * Added coverage for app activation on macOS-style flows.
  * Added coverage for tray click behavior across macOS and Windows-like platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->