### PR TITLE
feat(provider): add Codex 5.6 models

### DIFF
--- a/src/main/presenter/llmProviderPresenter/openaiCodexAdapter.ts
+++ b/src/main/presenter/llmProviderPresenter/openaiCodexAdapter.ts
@@ -8,6 +8,9 @@ type FetchInitWithDispatcher = RequestInit & {
 }
 
 const OPENAI_CODEX_PRODUCT_SKU = 'codex'
+const OPENAI_CODEX_ORIGINATOR = 'codex_cli_rs'
+const OPENAI_CODEX_CLIENT_VERSION = '0.144.1'
+const OPENAI_CODEX_USER_AGENT = `${OPENAI_CODEX_ORIGINATOR}/${OPENAI_CODEX_CLIENT_VERSION} (Ubuntu 22.4.0; x86_64) xterm-256color`
 
 function stripResponsesSuffix(pathname: string): string {
   return pathname.replace(/\/responses\/?$/i, '') || '/'
@@ -166,6 +169,9 @@ function applyCodexHeaders(
     headers.set('ChatGPT-Account-ID', auth.accountId)
   }
   headers.set('OAI-Product-Sku', OPENAI_CODEX_PRODUCT_SKU)
+  headers.set('Originator', OPENAI_CODEX_ORIGINATOR)
+  headers.set('Version', OPENAI_CODEX_CLIENT_VERSION)
+  headers.set('User-Agent', OPENAI_CODEX_USER_AGENT)
   if (!headers.has('Accept')) {
     headers.set('Accept', 'text/event-stream')
   }

--- a/src/main/presenter/llmProviderPresenter/providerRegistry.ts
+++ b/src/main/presenter/llmProviderPresenter/providerRegistry.ts
@@ -104,7 +104,7 @@ const OPENAI_CODEX = createDefinition({
   embeddingStrategy: 'none',
   providerDbSourceId: 'openai',
   providerDbGroup: 'Codex',
-  checkModelId: 'gpt-5.5',
+  checkModelId: 'gpt-5.6-luna',
   checkPrompt: 'Hello',
   checkTemperature: 0.2,
   checkMaxTokens: 16

--- a/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
@@ -71,6 +71,9 @@ const OPENAI_IMAGE_GENERATION_MODELS = ['gpt-4o-all', 'gpt-4o-image']
 const OPENAI_IMAGE_GENERATION_MODEL_PREFIXES = ['dall-e-', 'gpt-image-']
 const OPENAI_CODEX_RECOMMENDED_MODEL_IDS = [
   'gpt-5.5',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
   'gpt-5.4',
   'gpt-5.4-mini',
   'gpt-5.3-codex-spark'

--- a/test/main/presenter/llmProviderPresenter/openaiCodexAdapter.test.ts
+++ b/test/main/presenter/llmProviderPresenter/openaiCodexAdapter.test.ts
@@ -72,7 +72,8 @@ describe('OpenAI Codex adapter', () => {
       method: 'POST',
       headers: {
         'api-key': 'old-api-key',
-        'x-api-key': 'old-x-api-key'
+        'x-api-key': 'old-x-api-key',
+        'User-Agent': 'DeepChat/1.0.0'
       }
     })
 
@@ -83,6 +84,11 @@ describe('OpenAI Codex adapter', () => {
     expect(firstHeaders.get('Authorization')).toBe('Bearer old-token')
     expect(firstHeaders.get('ChatGPT-Account-ID')).toBe('acct-1')
     expect(firstHeaders.get('OAI-Product-Sku')).toBe('codex')
+    expect(firstHeaders.get('Originator')).toBe('codex_cli_rs')
+    expect(firstHeaders.get('Version')).toBe('0.144.1')
+    expect(firstHeaders.get('User-Agent')).toBe(
+      'codex_cli_rs/0.144.1 (Ubuntu 22.4.0; x86_64) xterm-256color'
+    )
     expect(firstHeaders.get('Accept')).toBe('text/event-stream')
     expect(firstHeaders.has('api-key')).toBe(false)
     expect(firstHeaders.has('x-api-key')).toBe(false)

--- a/test/main/presenter/llmProviderPresenter/openaiCodexProvider.test.ts
+++ b/test/main/presenter/llmProviderPresenter/openaiCodexProvider.test.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/presenter', () => ({
@@ -13,6 +14,8 @@ import { providerDbLoader } from '../../../../src/main/presenter/configPresenter
 import { AiSdkProvider } from '../../../../src/main/presenter/llmProviderPresenter/providers/aiSdkProvider'
 import { resolveAiSdkProviderDefinition } from '../../../../src/main/presenter/llmProviderPresenter/providerRegistry'
 import type { LLM_PROVIDER } from '../../../../src/shared/presenter'
+
+const CODEX_5_6_RESOURCE_MODEL_IDS = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra']
 
 describe('OpenAI Codex provider registration', () => {
   it('keeps OpenAI Codex separate from the OpenAI API-key provider', () => {
@@ -41,7 +44,19 @@ describe('OpenAI Codex provider registration', () => {
     expect(definition?.runtimeKind).toBe('openai-codex')
     expect(definition?.modelSource).toBe('openai-codex')
     expect(definition?.providerDbSourceId).toBe('openai')
-    expect(definition?.checkModelId).toBe('gpt-5.5')
+    expect(definition?.checkModelId).toBe('gpt-5.6-luna')
+  })
+
+  it('has Codex 5.6 models in the bundled OpenAI provider database', async () => {
+    const fs = await vi.importActual<typeof import('fs')>('fs')
+    const providerDbPath = path.join(process.cwd(), 'resources', 'model-db', 'providers.json')
+    const db = JSON.parse(fs.readFileSync(providerDbPath, 'utf-8'))
+    const openaiProvider = db.providers.openai
+    const modelIds = new Set(openaiProvider.models.map((model: { id: string }) => model.id))
+
+    for (const modelId of CODEX_5_6_RESOURCE_MODEL_IDS) {
+      expect(modelIds.has(modelId)).toBe(true)
+    }
   })
 
   it('loads current Codex recommended models from the OpenAI provider database', async () => {
@@ -79,6 +94,38 @@ describe('OpenAI Codex provider registration', () => {
           reasoning: { supported: true }
         },
         {
+          id: 'gpt-5.6',
+          display_name: 'GPT-5.6',
+          modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+          limit: { context: 1050000, output: 128000 },
+          tool_call: true,
+          reasoning: { supported: true }
+        },
+        {
+          id: 'gpt-5.6-sol',
+          display_name: 'GPT-5.6 Sol',
+          modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+          limit: { context: 1050000, output: 128000 },
+          tool_call: true,
+          reasoning: { supported: true }
+        },
+        {
+          id: 'gpt-5.6-luna',
+          display_name: 'GPT-5.6 Luna',
+          modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+          limit: { context: 1050000, output: 128000 },
+          tool_call: true,
+          reasoning: { supported: true }
+        },
+        {
+          id: 'gpt-5.6-terra',
+          display_name: 'GPT-5.6 Terra',
+          modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+          limit: { context: 1050000, output: 128000 },
+          tool_call: true,
+          reasoning: { supported: true }
+        },
+        {
           id: 'gpt-5.5',
           display_name: 'GPT-5.5',
           modalities: { input: ['text', 'image'], output: ['text'] },
@@ -111,13 +158,17 @@ describe('OpenAI Codex provider registration', () => {
 
     expect(models.map((model) => model.id)).toEqual([
       'gpt-5.5',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
       'gpt-5.4',
       'gpt-5.4-mini',
       'gpt-5.3-codex-spark'
     ])
+    expect(models.some((model) => model.id === 'gpt-5.6')).toBe(false)
     expect(models.every((model) => model.group === 'Codex')).toBe(true)
     expect(models.every((model) => model.providerId === 'openai-codex')).toBe(true)
-    expect(models.find((model) => model.id === 'gpt-5.5')?.reasoning).toBe(true)
+    expect(models.find((model) => model.id === 'gpt-5.6-luna')?.reasoning).toBe(true)
     expect(configPresenter.setProviderModels).toHaveBeenCalledWith('openai-codex', models)
   })
 })


### PR DESCRIPTION
## Summary

- expose Codex 5.6 Sol, Terra, and Luna models from the bundled OpenAI model database
- use `gpt-5.6-luna` for OpenAI Codex connection checks while excluding the base `gpt-5.6` model from the picker
- align Codex requests with Codex CLI client identity headers
- add regression coverage for the bundled model catalog and request headers

## Validation

- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec vitest --config vitest.config.ts test/main/presenter/llmProviderPresenter/openaiCodexAdapter.test.ts test/main/presenter/llmProviderPresenter/openaiCodexProvider.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional OpenAI Codex 5.6 models, including Sol, Terra, and Luna.
  * Updated the recommended Codex model list and model availability checks.
  * Added Codex client metadata to outbound requests.

* **Bug Fixes**
  * Updated Codex model identification to recognize the latest supported model version.

* **Tests**
  * Expanded coverage for Codex request metadata and model availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->