### PR TITLE
fix(window): restore macOS main window

### DIFF
--- a/src/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.ts
+++ b/src/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.ts
@@ -31,16 +31,29 @@ export const eventListenerSetupHook: LifecycleHook = {
       optimizer.watchWindowShortcuts(window)
     })
 
-    // Handle app activation event (like launching the app or clicking the Dock icon on macOS).
-    // Do not reveal existing hidden windows here: opening the system/app menu also activates the app,
-    // and auto-showing would make the native Hide menu item impossible to use reliably.
+    // Restore a main window hidden by close-to-tray when the Dock activates the app.
+    // Keep native macOS Hide behavior intact by restoring only explicitly tracked close events.
     app.on('activate', function () {
+      if (presenter.windowPresenter.restoreMainWindowHiddenByClose()) {
+        return
+      }
+
       const allWindows = presenter.windowPresenter.getAllWindows()
       if (allWindows.length === 0) {
         presenter.windowPresenter.createAppWindow({
           initialRoute: 'chat'
         })
       }
+    })
+
+    // Electron exposes no dedicated event for the application-level native macOS Hide command.
+    // Wait for AppKit to update the hidden state before clearing close-to-hide restoration.
+    app.on('did-resign-active', () => {
+      setTimeout(() => {
+        if (app.isHidden()) {
+          presenter.windowPresenter.clearMainWindowHiddenByClose()
+        }
+      }, 0)
     })
 
     // Listen for floating button configuration change events

--- a/src/main/presenter/windowPresenter/index.ts
+++ b/src/main/presenter/windowPresenter/index.ts
@@ -59,6 +59,8 @@ export class WindowPresenter implements IWindowPresenter {
   private focusedWindowId: number | null = null
   // Main window ID
   private mainWindowId: number | null = null
+  // Tracks close-to-hide separately from the native macOS Hide command.
+  private mainWindowHiddenByClose = false
   private floatingChatWindow: FloatingChatWindow | null = null
   private settingsWindow: BrowserWindow | null = null
   private settingsWindowReady = false
@@ -318,6 +320,9 @@ export class WindowPresenter implements IWindowPresenter {
     }
 
     targetWindow.show()
+    if (targetWindow.id === this.mainWindowId) {
+      this.mainWindowHiddenByClose = false
+    }
     if (shouldFocus) {
       targetWindow.focus() // Bring to foreground
       activateAppOnMac()
@@ -742,6 +747,13 @@ export class WindowPresenter implements IWindowPresenter {
       }
     })
 
+    // Clear close-to-hide state for every main-window show path, including direct BrowserWindow.show().
+    appWindow.on('show', () => {
+      if (windowId === this.mainWindowId) {
+        this.mainWindowHiddenByClose = false
+      }
+    })
+
     // 窗口获得焦点
     appWindow.on('focus', () => {
       logger.info(`Window ${windowId} gained focus.`)
@@ -867,6 +879,7 @@ export class WindowPresenter implements IWindowPresenter {
         if (shouldPreventDefault) {
           logger.info(`Window ${windowId}: Preventing default close behavior, hiding instead.`)
           event.preventDefault() // 阻止默认窗口关闭行为
+          this.mainWindowHiddenByClose = true
 
           // 处理全屏窗口隐藏时的黑屏问题 (同 hide 方法)
           if (appWindow.isFullScreen()) {
@@ -911,6 +924,9 @@ export class WindowPresenter implements IWindowPresenter {
       appWindow.removeListener('restore', handleRestore)
 
       this.windows.delete(windowIdBeingClosed) // 从 Map 中移除
+      if (windowIdBeingClosed === this.mainWindowId) {
+        this.mainWindowHiddenByClose = false
+      }
       managedWindowState.unmanage() // 停止管理窗口状态
       eventBus.sendToMain(WINDOW_EVENTS.WINDOW_CLOSED, windowIdBeingClosed)
       this.publishWindowStateChanged(windowIdBeingClosed, false)
@@ -1452,8 +1468,21 @@ export class WindowPresenter implements IWindowPresenter {
 
     mainWindow.show()
     mainWindow.focus()
+    this.mainWindowHiddenByClose = false
     activateAppOnMac()
     return true
+  }
+
+  public restoreMainWindowHiddenByClose(): boolean {
+    if (!this.mainWindowHiddenByClose) {
+      return false
+    }
+
+    return this.focusMainWindow()
+  }
+
+  public clearMainWindowHiddenByClose(): void {
+    this.mainWindowHiddenByClose = false
   }
 
   public setPendingSettingsProviderInstall(preview: ProviderInstallPreview): void {

--- a/src/shared/types/presenters/window.presenter.d.ts
+++ b/src/shared/types/presenters/window.presenter.d.ts
@@ -45,6 +45,8 @@ export interface IWindowPresenter {
   closeSettingsWindow(): void
   getSettingsWindowId(): number | null
   focusMainWindow(): boolean
+  restoreMainWindowHiddenByClose(): boolean
+  clearMainWindowHiddenByClose(): void
   notifySettingsReady(senderWebContentsId: number): void
   setPendingSettingsProviderInstall(preview: ProviderInstallPreview): void
   consumePendingSettingsProviderInstall(): ProviderInstallPreview | null

--- a/test/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.test.ts
+++ b/test/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.test.ts
@@ -1,12 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const appOnMock = vi.hoisted(() => vi.fn())
+const appIsHiddenMock = vi.hoisted(() => vi.fn())
 const optimizerWatchMock = vi.hoisted(() => vi.fn())
 const loggerInfoMock = vi.hoisted(() => vi.fn())
 const windowPresenterMock = vi.hoisted(() => ({
   getAllWindows: vi.fn(),
   getFocusedWindow: vi.fn(),
   createAppWindow: vi.fn(),
+  restoreMainWindowHiddenByClose: vi.fn(),
+  clearMainWindowHiddenByClose: vi.fn(),
   createSettingsWindow: vi.fn(),
   sendSettingsNavigation: vi.fn(),
   sendSettingsCheckForUpdates: vi.fn()
@@ -31,7 +34,8 @@ vi.mock('@shared/logger', () => ({
 
 vi.mock('electron', () => ({
   app: {
-    on: appOnMock
+    on: appOnMock,
+    isHidden: appIsHiddenMock
   }
 }))
 
@@ -61,6 +65,8 @@ describe('eventListenerSetupHook', () => {
     vi.clearAllMocks()
     windowPresenterMock.getAllWindows.mockReturnValue([])
     windowPresenterMock.getFocusedWindow.mockReturnValue(undefined)
+    windowPresenterMock.restoreMainWindowHiddenByClose.mockReturnValue(false)
+    appIsHiddenMock.mockReturnValue(false)
   })
 
   it('creates a chat window when macOS activates the app with no existing windows', async () => {
@@ -76,7 +82,24 @@ describe('eventListenerSetupHook', () => {
     expect(windowPresenterMock.createAppWindow).toHaveBeenCalledWith({ initialRoute: 'chat' })
   })
 
-  it('does not reveal existing hidden windows on generic macOS activation', async () => {
+  it('restores a main window hidden by close when macOS activates the app', async () => {
+    windowPresenterMock.restoreMainWindowHiddenByClose.mockReturnValue(true)
+
+    await eventListenerSetupHook.execute({} as never)
+
+    const activateHandler = appOnMock.mock.calls.find(
+      ([eventName]) => eventName === 'activate'
+    )?.[1]
+    expect(activateHandler).toBeTypeOf('function')
+
+    activateHandler()
+
+    expect(windowPresenterMock.restoreMainWindowHiddenByClose).toHaveBeenCalledOnce()
+    expect(windowPresenterMock.getAllWindows).not.toHaveBeenCalled()
+    expect(windowPresenterMock.createAppWindow).not.toHaveBeenCalled()
+  })
+
+  it('does not reveal windows hidden by the native macOS Hide command', async () => {
     const hiddenWindow = {
       id: 7,
       isDestroyed: vi.fn(() => false),
@@ -96,8 +119,50 @@ describe('eventListenerSetupHook', () => {
 
     activateHandler()
 
+    expect(windowPresenterMock.restoreMainWindowHiddenByClose).toHaveBeenCalledOnce()
     expect(windowPresenterMock.createAppWindow).not.toHaveBeenCalled()
     expect(hiddenWindow.show).not.toHaveBeenCalled()
     expect(hiddenWindow.focus).not.toHaveBeenCalled()
+  })
+
+  it('clears close-to-hide restoration when macOS hides the application', async () => {
+    vi.useFakeTimers()
+    appIsHiddenMock.mockReturnValue(true)
+
+    try {
+      await eventListenerSetupHook.execute({} as never)
+
+      const didResignActiveHandler = appOnMock.mock.calls.find(
+        ([eventName]) => eventName === 'did-resign-active'
+      )?.[1]
+      expect(didResignActiveHandler).toBeTypeOf('function')
+
+      didResignActiveHandler()
+      await vi.runAllTimersAsync()
+
+      expect(windowPresenterMock.clearMainWindowHiddenByClose).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps close-to-hide restoration when macOS only deactivates the application', async () => {
+    vi.useFakeTimers()
+
+    try {
+      await eventListenerSetupHook.execute({} as never)
+
+      const didResignActiveHandler = appOnMock.mock.calls.find(
+        ([eventName]) => eventName === 'did-resign-active'
+      )?.[1]
+      expect(didResignActiveHandler).toBeTypeOf('function')
+
+      didResignActiveHandler()
+      await vi.runAllTimersAsync()
+
+      expect(windowPresenterMock.clearMainWindowHiddenByClose).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/test/main/presenter/windowPresenter.test.ts
+++ b/test/main/presenter/windowPresenter.test.ts
@@ -1,6 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { BrowserWindow } from 'electron'
 import { SETTINGS_EVENTS } from '@/events'
+
+const activateAppOnMacMock = vi.hoisted(() => vi.fn())
+const originalBrowserWindowFromId = (BrowserWindow as any).fromId
+
+vi.mock('@/lib/activateApp', () => ({
+  activateAppOnMac: activateAppOnMacMock
+}))
 
 vi.mock('electron-window-state', () => ({
   default: vi.fn(() => ({
@@ -24,9 +31,13 @@ vi.mock('@/presenter', () => ({
   }
 }))
 
-describe('WindowPresenter settings navigation queue', () => {
+describe('WindowPresenter', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    ;(BrowserWindow as any).fromId = originalBrowserWindowFromId
   })
 
   it('queues settings events until the settings renderer reports ready', async () => {
@@ -148,6 +159,71 @@ describe('WindowPresenter settings navigation queue', () => {
 
     ;(presenter as any).handleSettingsWindowNavigationStart(9, true, false)
     expect((presenter as any).settingsWindowReady).toBe(false)
+  })
+
+  it('restores the main window only after close-to-hide', async () => {
+    const windowHandlers = new Map<string, (...args: any[]) => void>()
+    const appWindow = {
+      id: 7,
+      loadURL: vi.fn(),
+      loadFile: vi.fn(),
+      on: vi.fn((eventName: string, handler: (...args: any[]) => void) => {
+        windowHandlers.set(eventName, handler)
+      }),
+      once: vi.fn(),
+      removeListener: vi.fn(),
+      webContents: {
+        id: 70,
+        send: vi.fn(),
+        on: vi.fn(),
+        setWindowOpenHandler: vi.fn(),
+        setBackgroundThrottling: vi.fn(),
+        setFrameRate: vi.fn(),
+        openDevTools: vi.fn(),
+        isDestroyed: vi.fn(() => false)
+      },
+      isDestroyed: vi.fn(() => false),
+      isFullScreen: vi.fn(() => false),
+      isMinimized: vi.fn(() => false),
+      setFullScreen: vi.fn(),
+      setContentProtection: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setHiddenInMissionControl: vi.fn(),
+      setSkipTaskbar: vi.fn(),
+      close: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn(),
+      hide: vi.fn(),
+      restore: vi.fn()
+    }
+    vi.mocked(BrowserWindow).mockImplementationOnce(() => appWindow as any)
+    ;(BrowserWindow as any).fromId = vi.fn(() => appWindow)
+
+    const { WindowPresenter } = await import('@/presenter/windowPresenter')
+    const presenter = new WindowPresenter({
+      getContentProtectionEnabled: vi.fn(() => false),
+      getCloseToQuit: vi.fn(() => false)
+    } as any)
+
+    await presenter.createAppWindow({ x: 0, y: 0 })
+
+    expect(presenter.restoreMainWindowHiddenByClose()).toBe(false)
+
+    const preventDefault = vi.fn()
+    windowHandlers.get('close')?.({ preventDefault })
+    windowHandlers.get('show')?.()
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(appWindow.hide).toHaveBeenCalledOnce()
+    expect(presenter.restoreMainWindowHiddenByClose()).toBe(false)
+
+    windowHandlers.get('close')?.({ preventDefault })
+
+    expect(presenter.restoreMainWindowHiddenByClose()).toBe(true)
+    expect(appWindow.show).toHaveBeenCalledOnce()
+    expect(appWindow.focus).toHaveBeenCalledOnce()
+    expect(activateAppOnMacMock).toHaveBeenCalledOnce()
+    expect(presenter.restoreMainWindowHiddenByClose()).toBe(false)
   })
 
   it('sets a minimum size for the settings window', async () => {


### PR DESCRIPTION
## Summary

- track when the main window is hidden by close-to-tray on macOS
- restore only close-hidden windows when the Dock activates the app
- preserve native macOS Hide behavior and clear stale restore state on direct window shows
- add regression coverage for close-to-hide, Dock activation, and native app hiding

## Behavior

```text
BEFORE

Cmd+W -> window.hide() -> Dock activate -> no action

AFTER

Cmd+W -> mark close-hidden -> window.hide()
                             -> Dock activate -> show + focus

Cmd+H -> app.isHidden() -> clear close-hidden mark
                         -> preserve native Hide behavior
```

## Validation

- `pnpm run format`
- `pnpm run format:check`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec vitest run test/main/presenter/windowPresenter.test.ts test/main/presenter/lifecyclePresenter/hooks/ready/eventListenerSetupHook.test.ts test/main/presenter/trayPresenter.test.ts` (13 tests passed)

## Known unrelated test failures

The full `test:main` suite currently has two reproducible failures outside this change:

- `test/main/routes/debug/createMockChatSession.test.ts`: expected mock session plan block is missing
- `test/main/presenter/agentSessionPresenter/integration.test.ts`: long converted steer rebudget assertion fails


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS window restoration when a main window is hidden to the system tray.
  - Prevented unnecessary window creation or display when restoring an existing hidden window.
  - Improved handling of macOS app hide and activation events for more predictable window visibility and focus behavior.

- **Tests**
  - Added coverage for close-to-tray restoration and macOS lifecycle edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->