### PR TITLE
fix(chat): guard history restore races

### DIFF
--- a/src/renderer/src/pages/ChatPage.vue
+++ b/src/renderer/src/pages/ChatPage.vue
@@ -1059,13 +1059,19 @@ async function loadOlderMessagesAtTop(): Promise<void> {
     return
   }
 
+  const sessionId = props.sessionId
+  const requestId = sessionRestoreRequestId
   const previousScrollHeight = el.scrollHeight
   const loadedCount = await messageStore.loadOlderMessages()
-  if (loadedCount === 0) {
+  if (loadedCount === 0 || props.sessionId !== sessionId || sessionRestoreRequestId !== requestId) {
     return
   }
 
   await nextTick()
+  if (props.sessionId !== sessionId || sessionRestoreRequestId !== requestId) {
+    return
+  }
+
   const container = scrollContainer.value
   if (!container) {
     return

--- a/test/renderer/components/ChatPage.test.ts
+++ b/test/renderer/components/ChatPage.test.ts
@@ -875,6 +875,48 @@ describe('ChatPage', () => {
     expect(pendingInputStore.loadPendingInputs).toHaveBeenCalledWith('s1')
   })
 
+  it('does not compensate history scroll after switching sessions', async () => {
+    const deferredHistoryLoad = createDeferred<number>()
+    const deferredSessionLoad = createDeferred<unknown>()
+    const { wrapper, messageStore } = await setup({ deferStartupTasks: true })
+    const chatPage = wrapper.get('[data-testid="chat-page"]').element as HTMLDivElement
+
+    let scrollHeight = 1000
+    let scrollTop = 40
+    Object.defineProperty(chatPage, 'clientHeight', {
+      configurable: true,
+      get: () => 500
+    })
+    Object.defineProperty(chatPage, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+    Object.defineProperty(chatPage, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value
+      }
+    })
+
+    messageStore.hasMoreHistory = true
+    messageStore.loadOlderMessages.mockReturnValueOnce(deferredHistoryLoad.promise)
+    await wrapper.get('[data-testid="chat-page"]').trigger('scroll')
+    expect(messageStore.loadOlderMessages).toHaveBeenCalledOnce()
+
+    messageStore.loadMessages.mockReturnValueOnce(deferredSessionLoad.promise)
+    await wrapper.setProps({ sessionId: 's2' })
+    scrollHeight = 1500
+
+    deferredHistoryLoad.resolve(20)
+    await flushPromises()
+
+    expect(scrollTop).toBe(40)
+
+    deferredSessionLoad.resolve(undefined)
+    wrapper.unmount()
+  })
+
   it('does not rehydrate persisted plan blocks when switching sessions', async () => {
     const { wrapper, messageStore, agentPlanStore, flushStartupDeferredTasks } = await setup({
       deferStartupTasks: true,


### PR DESCRIPTION
## Summary
- prevent an in-flight older-history load from compensating the scroll position after a session switch
- invalidate completions using both the active session ID and restore request ID across asynchronous boundaries
- add a regression test for switching sessions while older history is still loading

## Validation
- `pnpm exec vitest --config vitest.config.renderer.ts test/renderer/components/ChatPage.test.ts --run`
- `pnpm run i18n`
- `pnpm run typecheck:web`
- `git diff --check origin/dev...HEAD`

## UI layout
No visual layout changes.

```text
Before
[Session A: history load pending] --resolves after--> [Session B scroll position overwritten]

After
[Session A: history load pending] --resolves after--> [Session B unchanged]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat history loading when switching sessions, preventing stale scroll adjustments from moving the conversation unexpectedly.
  * Preserved the current scroll position while deferred messages and session data finish loading.

* **Tests**
  * Added coverage for session switching during deferred history loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->