### PR TITLE
fix(startup): settle cancelled tasks once

### DIFF
--- a/src/main/presenter/startupWorkloadCoordinator/index.ts
+++ b/src/main/presenter/startupWorkloadCoordinator/index.ts
@@ -117,7 +117,7 @@ export class StartupWorkloadCoordinator {
     for (const task of tasks) {
       if (task.state === 'pending' || task.state === 'running') {
         task.controller.abort()
-        this.settleTask(task, 'cancelled', this.createAbortError(task.id))
+        this.settleTask(task, 'cancelled', this.createAbortError(task.id), false)
       }
     }
 
@@ -333,7 +333,8 @@ export class StartupWorkloadCoordinator {
   private settleTask(
     task: StartupTaskRecord<unknown>,
     finalState: 'cancelled' | 'completed' | 'failed',
-    result: unknown
+    result: unknown,
+    shouldPublish = true
   ): void {
     if (task.settled) {
       return
@@ -362,7 +363,9 @@ export class StartupWorkloadCoordinator {
       runState.visibleTasks.set(task.visibleId, task)
     }
 
-    this.publishSnapshot(task.target)
+    if (shouldPublish) {
+      this.publishSnapshot(task.target)
+    }
   }
 
   private removePendingTask(internalKey: string): void {

--- a/src/main/presenter/startupWorkloadCoordinator/index.ts
+++ b/src/main/presenter/startupWorkloadCoordinator/index.ts
@@ -61,6 +61,7 @@ type StartupTaskRecord<T> = {
   resolve: (value: T | PromiseLike<T>) => void
   reject: (reason?: unknown) => void
   promise: Promise<T>
+  settled: boolean
 }
 
 const PHASE_PRIORITY: Record<StartupWorkloadPhase, number> = {
@@ -114,19 +115,9 @@ export class StartupWorkloadCoordinator {
 
     const tasks = [...runState.tasks]
     for (const task of tasks) {
-      if (task.state === 'pending') {
-        this.removePendingTask(task.internalKey)
-      }
-
       if (task.state === 'pending' || task.state === 'running') {
         task.controller.abort()
-        task.state = 'cancelled'
-        task.updatedAt = Date.now()
-        task.reject(this.createAbortError(task.id))
-      }
-
-      if (!task.visibleId) {
-        runState.tasks.delete(task)
+        this.settleTask(task, 'cancelled', this.createAbortError(task.id))
       }
     }
 
@@ -197,7 +188,8 @@ export class StartupWorkloadCoordinator {
       run: options.run,
       resolve: resolveTask,
       reject: rejectTask,
-      promise
+      promise,
+      settled: false
     }
 
     runState.tasks.add(task as StartupTaskRecord<unknown>)
@@ -290,13 +282,12 @@ export class StartupWorkloadCoordinator {
   private async startTask(task: StartupTaskRecord<unknown>): Promise<void> {
     const runState = this.runs.get(task.target)
     if (!runState || runState.runId !== task.runId) {
-      task.reject(this.createAbortError(task.id))
-      this.finishTask(task, 'cancelled')
+      this.settleTask(task, 'cancelled', this.createAbortError(task.id))
       return
     }
 
     if (task.controller.signal.aborted) {
-      this.finishTask(task, 'cancelled')
+      this.settleTask(task, 'cancelled', this.createAbortError(task.id))
       return
     }
 
@@ -321,32 +312,44 @@ export class StartupWorkloadCoordinator {
     try {
       const result = await task.run(context)
       if (task.controller.signal.aborted) {
-        task.reject(this.createAbortError(task.id))
-        this.finishTask(task, 'cancelled')
+        this.settleTask(task, 'cancelled', this.createAbortError(task.id))
         return
       }
 
-      task.resolve(result)
-      this.finishTask(task, 'completed')
+      this.settleTask(task, 'completed', result)
     } catch (error) {
       if (task.controller.signal.aborted || this.isAbortError(error)) {
-        task.reject(this.createAbortError(task.id))
-        this.finishTask(task, 'cancelled')
+        this.settleTask(task, 'cancelled', this.createAbortError(task.id))
         return
       }
 
-      task.reject(error)
-      this.finishTask(task, 'failed')
+      this.settleTask(task, 'failed', error)
     } finally {
       this.runningCounts[task.resource] -= 1
       this.pump()
     }
   }
 
-  private finishTask(task: StartupTaskRecord<unknown>, finalState: StartupWorkloadState): void {
+  private settleTask(
+    task: StartupTaskRecord<unknown>,
+    finalState: 'cancelled' | 'completed' | 'failed',
+    result: unknown
+  ): void {
+    if (task.settled) {
+      return
+    }
+
+    task.settled = true
     task.state = finalState
     task.updatedAt = Date.now()
+    this.removePendingTask(task.internalKey)
     this.inFlightByDedupeKey.delete(task.dedupeKey)
+
+    if (finalState === 'completed') {
+      task.resolve(result)
+    } else {
+      task.reject(result)
+    }
 
     const runState = this.runs.get(task.target)
     if (!runState || runState.runId !== task.runId) {

--- a/test/main/presenter/startupWorkloadCoordinator.test.ts
+++ b/test/main/presenter/startupWorkloadCoordinator.test.ts
@@ -16,6 +16,22 @@ function createDeferred<T>() {
   return { promise, resolve, reject }
 }
 
+type TaskSettlementHooks = {
+  resolve: (value: unknown) => void
+  reject: (reason?: unknown) => void
+}
+
+type CoordinatorInternals = {
+  runs: Map<string, { tasks: Set<TaskSettlementHooks> }>
+  pendingTasks: unknown[]
+  runningCounts: { cpu: number; io: number }
+  inFlightByDedupeKey: Map<string, unknown>
+}
+
+function getInternals(coordinator: object): CoordinatorInternals {
+  return coordinator as unknown as CoordinatorInternals
+}
+
 describe('StartupWorkloadCoordinator', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -164,6 +180,112 @@ describe('StartupWorkloadCoordinator', () => {
 
     expect(maxRunningCpu).toBe(1)
     expect(maxRunningIo).toBe(2)
+  })
+
+  it('cleans pending task records across repeated target cancellation', async () => {
+    const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
+    const coordinator = new StartupWorkloadCoordinator()
+    coordinator.createRun('main')
+
+    const blockerStarted = createDeferred<void>()
+    const blockerGate = createDeferred<void>()
+    const blockerTask = coordinator.scheduleTask({
+      id: 'main:blocker',
+      target: 'main',
+      phase: 'deferred',
+      resource: 'cpu',
+      labelKey: 'startup.main.blocker',
+      run: async () => {
+        blockerStarted.resolve()
+        await blockerGate.promise
+      }
+    })
+
+    await blockerStarted.promise
+
+    const internals = getInternals(coordinator)
+    expect(internals.runningCounts.cpu).toBe(1)
+
+    for (let index = 0; index < 20; index += 1) {
+      coordinator.createRun('settings')
+      const pendingTask = coordinator.scheduleTask({
+        id: `settings:pending:${index}`,
+        target: 'settings',
+        phase: 'deferred',
+        resource: 'cpu',
+        labelKey: 'startup.settings.pending',
+        run: async () => {}
+      })
+      const cancellation = expect(pendingTask).rejects.toMatchObject({ name: 'AbortError' })
+
+      coordinator.cancelTarget('settings')
+      await cancellation
+
+      expect(internals.pendingTasks).toHaveLength(0)
+      expect(internals.inFlightByDedupeKey.size).toBe(1)
+      expect(internals.runs.has('settings')).toBe(false)
+      expect([...internals.runs.values()].reduce((sum, run) => sum + run.tasks.size, 0)).toBe(1)
+    }
+
+    blockerGate.resolve()
+    await blockerTask
+
+    expect(coordinator.isIdle()).toBe(true)
+    expect(internals.pendingTasks).toHaveLength(0)
+    expect(internals.inFlightByDedupeKey.size).toBe(0)
+    expect([...internals.runs.values()].reduce((sum, run) => sum + run.tasks.size, 0)).toBe(0)
+  })
+
+  it('settles a cancelled running task only once and restores its lane', async () => {
+    const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
+    const coordinator = new StartupWorkloadCoordinator()
+    coordinator.createRun('settings')
+
+    const started = createDeferred<void>()
+    const runGate = createDeferred<void>()
+    const runSettled = createDeferred<void>()
+    const taskPromise = coordinator.scheduleTask({
+      id: 'settings:running',
+      target: 'settings',
+      phase: 'interactive',
+      resource: 'cpu',
+      labelKey: 'startup.settings.running',
+      run: async () => {
+        started.resolve()
+        try {
+          await runGate.promise
+        } finally {
+          runSettled.resolve()
+        }
+      }
+    })
+
+    await started.promise
+
+    const internals = getInternals(coordinator)
+    const task = [...(internals.runs.get('settings')?.tasks ?? [])][0]!
+    const originalResolve = task.resolve
+    const originalReject = task.reject
+    const resolveSpy = vi.fn((value: unknown) => originalResolve(value))
+    const rejectSpy = vi.fn((reason?: unknown) => originalReject(reason))
+    task.resolve = resolveSpy
+    task.reject = rejectSpy
+    const cancellation = expect(taskPromise).rejects.toMatchObject({ name: 'AbortError' })
+
+    coordinator.cancelTarget('settings')
+    await cancellation
+    expect(rejectSpy).toHaveBeenCalledTimes(1)
+
+    runGate.reject(new Error('late failure'))
+    await runSettled.promise
+    await vi.waitFor(() => expect(coordinator.isIdle()).toBe(true))
+
+    expect(rejectSpy).toHaveBeenCalledTimes(1)
+    expect(resolveSpy).not.toHaveBeenCalled()
+    expect(internals.pendingTasks).toHaveLength(0)
+    expect(internals.inFlightByDedupeKey.size).toBe(0)
+    expect(internals.runs.has('settings')).toBe(false)
+    expect(internals.runningCounts.cpu).toBe(0)
   })
 
   it('cancels visible settings tasks and publishes the cancelled state', async () => {

--- a/test/main/presenter/startupWorkloadCoordinator.test.ts
+++ b/test/main/presenter/startupWorkloadCoordinator.test.ts
@@ -276,26 +276,47 @@ describe('StartupWorkloadCoordinator', () => {
     await cancellation
     expect(rejectSpy).toHaveBeenCalledTimes(1)
 
+    const nextTaskStarted = vi.fn()
+    coordinator.createRun('main')
+    const nextTask = coordinator.scheduleTask({
+      id: 'main:next',
+      target: 'main',
+      phase: 'interactive',
+      resource: 'cpu',
+      labelKey: 'startup.main.next',
+      run: async () => {
+        nextTaskStarted()
+      }
+    })
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(nextTaskStarted).not.toHaveBeenCalled()
+    expect(internals.pendingTasks).toHaveLength(1)
+    expect(internals.runningCounts.cpu).toBe(1)
+
     runGate.reject(new Error('late failure'))
     await runSettled.promise
+    await nextTask
     await vi.waitFor(() => expect(coordinator.isIdle()).toBe(true))
 
     expect(rejectSpy).toHaveBeenCalledTimes(1)
     expect(resolveSpy).not.toHaveBeenCalled()
+    expect(nextTaskStarted).toHaveBeenCalledOnce()
     expect(internals.pendingTasks).toHaveLength(0)
     expect(internals.inFlightByDedupeKey.size).toBe(0)
     expect(internals.runs.has('settings')).toBe(false)
     expect(internals.runningCounts.cpu).toBe(0)
   })
 
-  it('cancels visible settings tasks and publishes the cancelled state', async () => {
+  it('publishes one atomic snapshot when cancelling multiple visible tasks', async () => {
     const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
     const coordinator = new StartupWorkloadCoordinator()
     coordinator.createRun('settings')
 
-    const started = createDeferred<void>()
+    const firstStarted = createDeferred<void>()
+    const secondStarted = createDeferred<void>()
 
-    const taskPromise = coordinator.scheduleTask({
+    const firstTask = coordinator.scheduleTask({
       id: 'settings.providers.summary',
       target: 'settings',
       phase: 'interactive',
@@ -303,7 +324,7 @@ describe('StartupWorkloadCoordinator', () => {
       labelKey: 'startup.settings.providers.summary',
       visibleId: 'settings.providers.summary',
       run: async ({ signal }) => {
-        started.resolve()
+        firstStarted.resolve()
         await new Promise<void>((_, reject) => {
           signal.addEventListener(
             'abort',
@@ -318,18 +339,54 @@ describe('StartupWorkloadCoordinator', () => {
       }
     })
 
-    await started.promise
+    const secondTask = coordinator.scheduleTask({
+      id: 'settings.provider.models',
+      target: 'settings',
+      phase: 'interactive',
+      resource: 'io',
+      labelKey: 'startup.settings.provider.models',
+      visibleId: 'settings.provider.models',
+      run: async ({ signal }) => {
+        secondStarted.resolve()
+        await new Promise<void>((_, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              const error = new Error('aborted')
+              error.name = 'AbortError'
+              reject(error)
+            },
+            { once: true }
+          )
+        })
+      }
+    })
+
+    await Promise.all([firstStarted.promise, secondStarted.promise])
+    const callsBeforeCancel = publishDeepchatEventMock.mock.calls.length
+    const cancellations = [firstTask, secondTask].map((task) =>
+      expect(task).rejects.toMatchObject({ name: 'AbortError' })
+    )
+
     coordinator.cancelTarget('settings')
+    await Promise.all(cancellations)
+    await new Promise((resolve) => setImmediate(resolve))
 
-    await expect(taskPromise).rejects.toMatchObject({ name: 'AbortError' })
+    const cancellationEvents = publishDeepchatEventMock.mock.calls.slice(callsBeforeCancel)
+    expect(cancellationEvents).toHaveLength(1)
+    expect(cancellationEvents[0]?.[0]).toBe('startup.workload.changed')
 
-    const lastPayload = publishDeepchatEventMock.mock.calls.at(-1)?.[1]
+    const lastPayload = cancellationEvents[0]?.[1]
     expect(lastPayload).toEqual(
       expect.objectContaining({
         target: 'settings',
         tasks: [
           expect.objectContaining({
             id: 'settings.providers.summary',
+            state: 'cancelled'
+          }),
+          expect.objectContaining({
+            id: 'settings.provider.models',
             state: 'cancelled'
           })
         ]


### PR DESCRIPTION
## Scope

Implements `CRD-001` from the architecture/performance audit plan and addresses the cancellation-settlement half of finding `A-10`.

This PR is intentionally limited to `StartupWorkloadCoordinator` cancellation cleanup. It does **not** change `whenIdle()` semantics or implement `CRD-002`.

## Why

`cancelTarget()` removed pending tasks from the queue and rejected task promises, but pending records could remain in the dedupe map forever. Running tasks could also attempt to reject the same outer promise again when their underlying `run()` settled later.

Repeated startup target recreation therefore retained coordinator records, while the cancellation path had no single settlement owner.

## How

- Route completed, failed, and cancelled tasks through one guarded `settleTask()` path.
- Remove terminal tasks from the pending queue and `inFlightByDedupeKey` exactly once.
- Keep visible cancellation snapshots atomic: cancelling multiple tasks publishes one final snapshot, not intermediate mixed states.
- Keep a cancelled running task's resource lane occupied until its underlying `run()` actually returns; this preserves the configured concurrency limit.
- Add focused regression coverage for repeated create/cancel cycles, single rejection, atomic snapshots, late settlement, lane handoff, and final idle state.

## Impact

- No renderer, route schema, database, or user-data migration changes.
- Cancellation becomes deterministic and coordinator bookkeeping no longer grows across repeated target recreation.
- A cancelled but non-cooperative underlying task still occupies its resource lane until it settles. Releasing it early would permit concurrency above the configured limit; hard termination belongs to the task owner and is outside `CRD-001`.

## Automated validation

- `test/main/presenter/startupWorkloadCoordinator.test.ts`: 5/5 passed
- `pnpm run typecheck`: passed
- `pnpm run format`: passed
- `pnpm run i18n`: passed
- `pnpm run lint`: passed
- Independent verification: passed after two blocking review findings were fixed
- Full suite on this branch: 4,465 passed, 5 failed

The five failures are identical to the base-branch baseline; this PR adds no new full-suite failures:

- `test/main/routes/debug/createMockChatSession.test.ts`: 1
- `test/main/presenter/agentSessionPresenter/integration.test.ts`: 1
- `test/renderer/components/SpotlightOverlay.test.ts`: 3

The repository's `PR Check` workflow only runs for PRs targeting `main` or `dev`, so this intermediate-base PR has no GitHub status rollup. The command results above and an independent verify pass are the automated delivery evidence for this slice.

## Additional runtime validation

Automated tests cover cooperative cancellation and a delayed late settlement. For a real task that ignores `AbortSignal` indefinitely, inspect startup workload logs and confirm the lane remains occupied rather than allowing excess concurrent work. This behavior is deliberate and unchanged.

## Rollback

Revert this PR. It contains no persistent schema or data changes.
