### PR TITLE
fix(chat): remove scroll-time content-visibility

### DIFF
--- a/src/renderer/src/pages/ChatPage.vue
+++ b/src/renderer/src/pages/ChatPage.vue
@@ -2798,11 +2798,6 @@ onUnmounted(() => {
   --dc-blur-overlay: 12px;
 }
 
-.message-list-container.dc-list-scrolling .message-list-row {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 180px;
-}
-
 .agent-question-panel {
   isolation: isolate;
   border: 1px solid transparent;


### PR DESCRIPTION
Scroll-time content-visibility collapsed off-screen rows to the 180px placeholder while overflow-anchor is disabled, breaking
scroll geometry (viewport jumps to top) and triggering full-list relayout storms that could crash the renderer. Windowed rendering already covers long-list performance, so drop the rule.

Closes #1919

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message list rendering behavior during active scrolling.
  * Removed scrolling-related optimizations that could affect message visibility or layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->