### PR TITLE
test(architecture): guard debt growth

### DIFF
--- a/docs/architecture/baselines/architecture-growth.json
+++ b/docs/architecture/baselines/architecture-growth.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "updatedOn": "2026-07-10",
+  "mainComposition": {
+    "routeRootLoc": 4351,
+    "routeTypedCaseCount": 349,
+    "routeConcretePresenterImportCount": 12,
+    "routeConcreteSqliteTableImportCount": 3,
+    "presenterCompatibilityCoreLoc": 2592
+  },
+  "agentEdge": {
+    "sharedToMainImplementationImportCount": 2
+  }
+}

--- a/scripts/architecture-guard.mjs
+++ b/scripts/architecture-guard.mjs
@@ -43,11 +43,15 @@ const PRESENTER_COMPATIBILITY_CORE_PATH = path.join(
 )
 const MAIN_PRESENTER_ROOT = path.join(ROOT, 'src/main/presenter')
 const SQLITE_TABLE_ROOT = path.join(MAIN_PRESENTER_ROOT, 'sqlitePresenter/tables')
-const ARCHITECTURE_GROWTH_BASELINE_PATH = path.resolve(
+const TRACKED_ARCHITECTURE_GROWTH_BASELINE_PATH = path.join(
   ROOT,
-  process.env.DEEPCHAT_ARCHITECTURE_GROWTH_BASELINE_PATH ??
-    'docs/architecture/baselines/architecture-growth.json'
+  'docs/architecture/baselines/architecture-growth.json'
 )
+const ARCHITECTURE_GROWTH_BASELINE_PATH =
+  process.env.NODE_ENV === 'test' &&
+  process.env.DEEPCHAT_TEST_ARCHITECTURE_GROWTH_BASELINE_PATH
+    ? path.resolve(ROOT, process.env.DEEPCHAT_TEST_ARCHITECTURE_GROWTH_BASELINE_PATH)
+    : TRACKED_ARCHITECTURE_GROWTH_BASELINE_PATH
 const MEMORY_PRESENTER_ROOT = path.join(ROOT, 'src/main/presenter/memoryPresenter')
 const MEMORY_PRESENTER_FACADE_PATH = path.join(MEMORY_PRESENTER_ROOT, 'index.ts')
 const MEMORY_PRESENTER_CORE_ROOT = path.join(MEMORY_PRESENTER_ROOT, 'core')
@@ -298,6 +302,20 @@ async function collectHotPathDirectEdges() {
 async function loadArchitectureGrowthBaseline() {
   const raw = await fs.readFile(ARCHITECTURE_GROWTH_BASELINE_PATH, 'utf8')
   const parsed = JSON.parse(raw)
+
+  if (parsed?.version !== 1) {
+    throw new Error(`version must be 1, found ${String(parsed?.version)}`)
+  }
+  const updatedOnTimestamp = Date.parse(`${parsed?.updatedOn}T00:00:00Z`)
+  if (
+    typeof parsed.updatedOn !== 'string' ||
+    !/^\d{4}-\d{2}-\d{2}$/.test(parsed.updatedOn) ||
+    Number.isNaN(updatedOnTimestamp) ||
+    new Date(updatedOnTimestamp).toISOString().slice(0, 10) !== parsed.updatedOn
+  ) {
+    throw new Error('updatedOn must be a valid YYYY-MM-DD date')
+  }
+
   const limits = {
     mainComposition: {
       routeRootLoc: parsed?.mainComposition?.routeRootLoc,

--- a/scripts/architecture-guard.mjs
+++ b/scripts/architecture-guard.mjs
@@ -35,6 +35,19 @@ const RENDERER_TYPED_BOUNDARY_WINDOW_API_ALLOWLIST = [
   path.join(ROOT, 'src/renderer/api/runtime.ts')
 ]
 const MAIN_SOURCE_ROOT = path.join(ROOT, 'src/main')
+const SHARED_SOURCE_ROOT = path.join(ROOT, 'src/shared')
+const ROUTE_ROOT_PATH = path.join(ROOT, 'src/main/routes/index.ts')
+const PRESENTER_COMPATIBILITY_CORE_PATH = path.join(
+  ROOT,
+  'src/shared/types/presenters/core.presenter.d.ts'
+)
+const MAIN_PRESENTER_ROOT = path.join(ROOT, 'src/main/presenter')
+const SQLITE_TABLE_ROOT = path.join(MAIN_PRESENTER_ROOT, 'sqlitePresenter/tables')
+const ARCHITECTURE_GROWTH_BASELINE_PATH = path.resolve(
+  ROOT,
+  process.env.DEEPCHAT_ARCHITECTURE_GROWTH_BASELINE_PATH ??
+    'docs/architecture/baselines/architecture-growth.json'
+)
 const MEMORY_PRESENTER_ROOT = path.join(ROOT, 'src/main/presenter/memoryPresenter')
 const MEMORY_PRESENTER_FACADE_PATH = path.join(MEMORY_PRESENTER_ROOT, 'index.ts')
 const MEMORY_PRESENTER_CORE_ROOT = path.join(MEMORY_PRESENTER_ROOT, 'core')
@@ -126,6 +139,7 @@ const INLINE_IPC_CHANNEL_PATTERN =
   /(?:window\.electron(?:\?\.|\.)ipcRenderer|ipcRenderer|ipcMain)(?:\?\.|\.)(?:invoke|send|on|once|handle|handleOnce|removeListener|removeAllListeners|addListener)\s*\(\s*['"`][^'"`]+['"`]/g
 const INLINE_EVENTBUS_CHANNEL_PATTERN =
   /(?:sendToRenderer|publish|publishToWindow|publishToWebContents)\s*\(\s*['"`][^'"`]+['"`]/g
+const TYPED_ROUTE_CASE_PATTERN = /\bcase\s+[A-Za-z_$][\w$]*Route\.name\s*:/g
 
 function toPosix(value) {
   return value.split(path.sep).join('/')
@@ -194,6 +208,31 @@ function countMatches(source, pattern) {
   return count
 }
 
+function countPhysicalLines(source) {
+  if (source.length === 0) return 0
+
+  const lineCount = source.split(/\r\n|\r|\n/).length
+  return /(?:\r\n|\r|\n)$/.test(source) ? lineCount - 1 : lineCount
+}
+
+function extractModuleSpecifierOccurrences(source) {
+  const specifiers = []
+  const patterns = [
+    /\bfrom\s*['"]([^'"]+)['"]/g,
+    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+    /\bimport\s*['"]([^'"]+)['"]/g
+  ]
+
+  for (const pattern of patterns) {
+    let match
+    while ((match = pattern.exec(source)) !== null) {
+      specifiers.push(match[1])
+    }
+  }
+
+  return specifiers
+}
+
 async function resolveImport(specifier, importer, aliasRoot = MAIN_SOURCE_ROOT) {
   const tryFile = async (basePath) => {
     const candidates = [
@@ -254,6 +293,127 @@ async function collectHotPathDirectEdges() {
   }
 
   return edges.sort()
+}
+
+async function loadArchitectureGrowthBaseline() {
+  const raw = await fs.readFile(ARCHITECTURE_GROWTH_BASELINE_PATH, 'utf8')
+  const parsed = JSON.parse(raw)
+  const limits = {
+    mainComposition: {
+      routeRootLoc: parsed?.mainComposition?.routeRootLoc,
+      routeTypedCaseCount: parsed?.mainComposition?.routeTypedCaseCount,
+      routeConcretePresenterImportCount:
+        parsed?.mainComposition?.routeConcretePresenterImportCount,
+      routeConcreteSqliteTableImportCount:
+        parsed?.mainComposition?.routeConcreteSqliteTableImportCount,
+      presenterCompatibilityCoreLoc: parsed?.mainComposition?.presenterCompatibilityCoreLoc
+    },
+    agentEdge: {
+      sharedToMainImplementationImportCount:
+        parsed?.agentEdge?.sharedToMainImplementationImportCount
+    }
+  }
+
+  for (const [category, metrics] of Object.entries(limits)) {
+    for (const [metric, value] of Object.entries(metrics)) {
+      if (!Number.isInteger(value) || value < 0) {
+        throw new Error(`${category}.${metric} must be a non-negative integer`)
+      }
+    }
+  }
+
+  return limits
+}
+
+function isSharedToMainImplementationSpecifier(specifier, importer) {
+  if (specifier === '@/presenter' || specifier.startsWith('@/presenter/')) {
+    return true
+  }
+
+  if (specifier === 'src/main' || specifier.startsWith('src/main/')) {
+    return true
+  }
+
+  if (!specifier.startsWith('.') && !path.isAbsolute(specifier)) {
+    return false
+  }
+
+  const target = path.isAbsolute(specifier)
+    ? path.resolve(specifier)
+    : path.resolve(path.dirname(importer), specifier)
+  return isUnder(target, MAIN_SOURCE_ROOT)
+}
+
+async function collectArchitectureGrowthMetrics(fileSet) {
+  const [routeSource, presenterCompatibilityCoreSource] = await Promise.all([
+    fs.readFile(ROUTE_ROOT_PATH, 'utf8'),
+    fs.readFile(PRESENTER_COMPATIBILITY_CORE_PATH, 'utf8')
+  ])
+  const routeSpecifiers = extractModuleSpecifierOccurrences(routeSource)
+  let routeConcretePresenterImportCount = 0
+  let routeConcreteSqliteTableImportCount = 0
+
+  for (const specifier of routeSpecifiers) {
+    const resolved = await resolveImport(specifier, ROUTE_ROOT_PATH)
+    if (!resolved) continue
+
+    if (isUnder(resolved, MAIN_PRESENTER_ROOT)) {
+      routeConcretePresenterImportCount += 1
+    }
+    if (isUnder(resolved, SQLITE_TABLE_ROOT)) {
+      routeConcreteSqliteTableImportCount += 1
+    }
+  }
+
+  let sharedToMainImplementationImportCount = 0
+  for (const filePath of fileSet) {
+    if (!isUnder(filePath, SHARED_SOURCE_ROOT)) continue
+
+    const source = await fs.readFile(filePath, 'utf8')
+    for (const specifier of extractModuleSpecifierOccurrences(source)) {
+      if (isSharedToMainImplementationSpecifier(specifier, filePath)) {
+        sharedToMainImplementationImportCount += 1
+      }
+    }
+  }
+
+  return {
+    mainComposition: {
+      routeRootLoc: countPhysicalLines(routeSource),
+      routeTypedCaseCount: countMatches(routeSource, TYPED_ROUTE_CASE_PATTERN),
+      routeConcretePresenterImportCount,
+      routeConcreteSqliteTableImportCount,
+      presenterCompatibilityCoreLoc: countPhysicalLines(presenterCompatibilityCoreSource)
+    },
+    agentEdge: {
+      sharedToMainImplementationImportCount
+    }
+  }
+}
+
+async function checkArchitectureGrowth(fileSet, violations) {
+  let limits
+
+  try {
+    limits = await loadArchitectureGrowthBaseline()
+  } catch (error) {
+    violations.push(
+      `[architecture-growth-baseline-invalid] ${error instanceof Error ? error.message : String(error)}`
+    )
+    return
+  }
+
+  const actual = await collectArchitectureGrowthMetrics(fileSet)
+  for (const [category, metrics] of Object.entries(actual)) {
+    for (const [metric, value] of Object.entries(metrics)) {
+      const limit = limits[category][metric]
+      if (value > limit) {
+        violations.push(
+          `[${category === 'mainComposition' ? 'main-composition' : 'agent-edge'}-growth] ${metric} expected <= ${limit}, found ${value}`
+        )
+      }
+    }
+  }
 }
 
 function memoryPresenterLayer(filePath) {
@@ -588,6 +748,8 @@ async function main() {
       }
     }
   }
+
+  await checkArchitectureGrowth(fileSet, violations)
 
   const hotPathEdges = await collectHotPathDirectEdges()
   if (hotPathEdges.length > HOT_PATH_EDGE_BASELINE) {

--- a/test/main/scripts/architectureGuard.test.ts
+++ b/test/main/scripts/architectureGuard.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process'
-import { rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -24,13 +25,37 @@ const MEMORY_ROOT_FIXTURE_PATH = path.join(
   ROOT,
   'src/main/presenter/memoryPresenter/__architecture_guard_root_fixture__.ts'
 )
+const AGENT_EDGE_FIXTURE_PATH = path.join(
+  ROOT,
+  'src/shared/__architecture_guard_agent_edge_fixture__.ts'
+)
+const TRACKED_GROWTH_BASELINE_PATH = path.join(
+  ROOT,
+  'docs/architecture/baselines/architecture-growth.json'
+)
 const FIXTURE_PATHS = [
   FIXTURE_PATH,
   MEMORY_CORE_FIXTURE_PATH,
   MEMORY_INFRA_FIXTURE_PATH,
   MEMORY_SERVICE_FIXTURE_PATH,
-  MEMORY_ROOT_FIXTURE_PATH
+  MEMORY_ROOT_FIXTURE_PATH,
+  AGENT_EDGE_FIXTURE_PATH
 ]
+const TEMP_DIRS: string[] = []
+const MAIN_COMPOSITION_METRICS = [
+  'routeRootLoc',
+  'routeTypedCaseCount',
+  'routeConcretePresenterImportCount',
+  'routeConcreteSqliteTableImportCount',
+  'presenterCompatibilityCoreLoc'
+] as const
+
+type ArchitectureGrowthBaseline = {
+  version: number
+  updatedOn: string
+  mainComposition: Record<(typeof MAIN_COMPOSITION_METRICS)[number], number>
+  agentEdge: Record<'sharedToMainImplementationImportCount', number>
+}
 
 async function writeSettingsFixture(source: string) {
   await writeFile(FIXTURE_PATH, source, 'utf8')
@@ -40,16 +65,94 @@ async function writeFixture(filePath: string, source: string) {
   await writeFile(filePath, source, 'utf8')
 }
 
-function runArchitectureGuard() {
+async function readTrackedGrowthBaseline() {
+  return JSON.parse(
+    await readFile(TRACKED_GROWTH_BASELINE_PATH, 'utf8')
+  ) as ArchitectureGrowthBaseline
+}
+
+async function writeTemporaryGrowthBaseline(baseline: ArchitectureGrowthBaseline) {
+  const dirPath = await mkdtemp(path.join(tmpdir(), 'deepchat-architecture-guard-'))
+  const baselinePath = path.join(dirPath, 'architecture-growth.json')
+  TEMP_DIRS.push(dirPath)
+  await writeFile(baselinePath, JSON.stringify(baseline), 'utf8')
+  return baselinePath
+}
+
+function runArchitectureGuard(baselinePath = TRACKED_GROWTH_BASELINE_PATH) {
   return spawnSync(process.execPath, ['scripts/architecture-guard.mjs'], {
     cwd: ROOT,
-    encoding: 'utf8'
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DEEPCHAT_ARCHITECTURE_GROWTH_BASELINE_PATH: baselinePath
+    }
   })
 }
 
 describe.sequential('architecture guard', () => {
   afterEach(async () => {
-    await Promise.all(FIXTURE_PATHS.map((filePath) => rm(filePath, { force: true })))
+    await Promise.all([
+      ...FIXTURE_PATHS.map((filePath) => rm(filePath, { force: true })),
+      ...TEMP_DIRS.splice(0).map((dirPath) => rm(dirPath, { force: true, recursive: true }))
+    ])
+  })
+
+  it('allows the tracked historical debt at its current baseline', async () => {
+    const baseline = await readTrackedGrowthBaseline()
+
+    expect(Object.values(baseline.mainComposition).every((value) => value > 0)).toBe(true)
+    expect(baseline.agentEdge.sharedToMainImplementationImportCount).toBeGreaterThan(0)
+
+    const result = runArchitectureGuard()
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Architecture guard passed.')
+  })
+
+  it('allows metrics to fall below a stale baseline', async () => {
+    const baseline = await readTrackedGrowthBaseline()
+    for (const metric of MAIN_COMPOSITION_METRICS) {
+      baseline.mainComposition[metric] += 1
+    }
+    baseline.agentEdge.sharedToMainImplementationImportCount += 1
+
+    const baselinePath = await writeTemporaryGrowthBaseline(baseline)
+    const result = runArchitectureGuard(baselinePath)
+
+    expect(result.status).toBe(0)
+  })
+
+  it.each(MAIN_COMPOSITION_METRICS)(
+    'reports main-composition growth when %s exceeds its baseline',
+    async (metric) => {
+      const baseline = await readTrackedGrowthBaseline()
+      baseline.mainComposition[metric] -= 1
+
+      const baselinePath = await writeTemporaryGrowthBaseline(baseline)
+      const result = runArchitectureGuard(baselinePath)
+
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain('[main-composition-growth]')
+      expect(result.stderr).toContain(metric)
+    }
+  )
+
+  it.each([
+    ['main presenter alias', '@/presenter/configPresenter/shortcutKeySettings'],
+    ['relative main path', '../main/presenter/configPresenter'],
+    [
+      'absolute main path',
+      path.join(ROOT, 'src/main/presenter/configPresenter').split(path.sep).join('/')
+    ]
+  ])('reports agent-edge growth for a shared %s import', async (_label, specifier) => {
+    await writeFixture(AGENT_EDGE_FIXTURE_PATH, `import '${specifier}'\n`)
+
+    const result = runArchitectureGuard()
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('[agent-edge-growth]')
+    expect(result.stderr).toContain('sharedToMainImplementationImportCount')
   })
 
   it('fails when settings imports or calls the retired legacy presenter bridge', async () => {

--- a/test/main/scripts/architectureGuard.test.ts
+++ b/test/main/scripts/architectureGuard.test.ts
@@ -79,14 +79,18 @@ async function writeTemporaryGrowthBaseline(baseline: ArchitectureGrowthBaseline
   return baselinePath
 }
 
-function runArchitectureGuard(baselinePath = TRACKED_GROWTH_BASELINE_PATH) {
+function runArchitectureGuard(baselinePath?: string, nodeEnv = 'test') {
+  const env = {
+    ...process.env,
+    NODE_ENV: nodeEnv
+  }
+  delete env.DEEPCHAT_TEST_ARCHITECTURE_GROWTH_BASELINE_PATH
+  if (baselinePath) env.DEEPCHAT_TEST_ARCHITECTURE_GROWTH_BASELINE_PATH = baselinePath
+
   return spawnSync(process.execPath, ['scripts/architecture-guard.mjs'], {
     cwd: ROOT,
     encoding: 'utf8',
-    env: {
-      ...process.env,
-      DEEPCHAT_ARCHITECTURE_GROWTH_BASELINE_PATH: baselinePath
-    }
+    env
   })
 }
 
@@ -123,6 +127,40 @@ describe.sequential('architecture guard', () => {
     expect(result.status).toBe(0)
   })
 
+  it('fails closed for an unsupported baseline version', async () => {
+    const baseline = await readTrackedGrowthBaseline()
+    baseline.version = 2
+
+    const baselinePath = await writeTemporaryGrowthBaseline(baseline)
+    const result = runArchitectureGuard(baselinePath)
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('[architecture-growth-baseline-invalid]')
+    expect(result.stderr).toContain('version must be 1')
+  })
+
+  it('fails closed for malformed baseline metadata', async () => {
+    const baseline = await readTrackedGrowthBaseline()
+    baseline.updatedOn = '2026-02-30'
+
+    const baselinePath = await writeTemporaryGrowthBaseline(baseline)
+    const result = runArchitectureGuard(baselinePath)
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('[architecture-growth-baseline-invalid]')
+    expect(result.stderr).toContain('updatedOn must be a valid YYYY-MM-DD date')
+  })
+
+  it('ignores the test baseline override outside test mode', async () => {
+    const baseline = await readTrackedGrowthBaseline()
+    baseline.version = 2
+
+    const baselinePath = await writeTemporaryGrowthBaseline(baseline)
+    const result = runArchitectureGuard(baselinePath, 'production')
+
+    expect(result.status).toBe(0)
+  })
+
   it.each(MAIN_COMPOSITION_METRICS)(
     'reports main-composition growth when %s exceeds its baseline',
     async (metric) => {
@@ -140,6 +178,7 @@ describe.sequential('architecture guard', () => {
 
   it.each([
     ['main presenter alias', '@/presenter/configPresenter/shortcutKeySettings'],
+    ['explicit main specifier', 'src/main/presenter/configPresenter'],
     ['relative main path', '../main/presenter/configPresenter'],
     [
       'absolute main path',


### PR DESCRIPTION
## Scope

ARC-001 only. This PR freezes growth in three known architecture debt areas without changing runtime behavior:

- src/main/routes/index.ts composition size and concrete dependencies
- src/shared/types/presenters/core.presenter.d.ts compatibility size
- src/shared to main implementation import edges

It does not split routes, move declarations, or change any route/runtime contract.

## Why

The existing architecture guard covered selected transport and presenter edges, but its name overstated its coverage. The audited route root, compatibility declaration, and shared-to-main dependency debt could continue growing without an automated signal.

## How

- Add a tracked versioned baseline under docs/architecture/baselines.
- Measure route physical LOC, typed Route.name cases, concrete Presenter imports, concrete SQLite table imports, compatibility-core LOC, and shared-to-main import occurrences.
- Fail only when a metric grows; current debt and reductions remain allowed.
- Classify failures as main-composition or agent-edge while retaining existing transport checks.
- Fail closed on unsupported baseline versions, malformed dates, and invalid numeric limits.
- Restrict temporary baseline overrides to NODE_ENV=test so normal lint and CI always use the tracked baseline.

## Impact and expected benefit

There is no application runtime, schema, route, declaration, or UI behavior change. CI and local lint now reject new debt in the audited boundaries. A legitimate increase must either reduce another part of the same metric or update the reviewed baseline explicitly.

The guard is intentionally a trend barrier, not an architecture migration. ARC-001 prevents the current large-file and dependency-boundary debt from worsening while later DCL-001 and RTE-002 make the actual structural changes.

## Automated validation

Independent develop and verify agents were used.

- Focused architecture guard tests: 21/21 passed
- pnpm run lint:architecture: passed
- pnpm run typecheck: passed
- pnpm run format and format:check: passed
- pnpm run i18n: passed
- pnpm run lint: passed
- git diff --check: passed
- Full suite before the verification follow-up: 4,474 passed, 6 failed, 135 skipped

Five full-suite failures exactly match the recorded baseline:

- test/main/routes/debug/createMockChatSession.test.ts: 1
- test/main/presenter/agentSessionPresenter/integration.test.ts: 1
- test/renderer/components/SpotlightOverlay.test.ts: 3

The sixth failure was environment-only in test/renderer/assets/markstreamTailwindSource.test.ts because the isolated worktree had no local node_modules symlink. The asserted dependency exists in the primary installed workspace. ARC-001 does not modify the dependency or asset path.

The repository PR Check workflow does not create a status rollup for this intermediate base branch, so the local automated evidence and independent verification above are the merge gate.

## Known boundaries and manual review points

- Import detection is a static literal/regex trend check. Computed imports, CommonJS require, and indirect helper reach-through are not counted.
- Comments or string-like text can theoretically create regex false positives.
- Physical LOC is deliberately format-sensitive.
- SQLite table imports are intentionally counted both in the Presenter total and as a high-risk subset.
- A reduced metric remains below a stale baseline until reviewers ratchet the tracked baseline down; reductions do not update it automatically.
- Updating the tracked baseline in the same PR is possible and must remain a visible review decision.

No manual product flow is required because this PR has no runtime behavior. Review should compare any future baseline increase with the accompanying architecture rationale.

## Rollback

Revert this PR. It has no data migration, persisted-state change, or compatibility effect.
