### PR TITLE
fix(startup): add generation idle barrier

### DIFF
--- a/docs/issues/startup-workload-idle-barrier/spec.md
+++ b/docs/issues/startup-workload-idle-barrier/spec.md
@@ -35,11 +35,18 @@ executing when `whenIdle(target, callback)` is called.
 - Normal completion, rejection, and cancellation all finish a captured task only when no underlying
   execution remains. A cancelled pending task finishes immediately because it never acquired a lane.
 - Tasks submitted after `whenIdle()` captures its generation belong to a later generation and do not
-  extend the current wait. This fixed cutoff prevents continuous task submission from starving the
-  callback forever.
+  extend the current wait. While at least one waiter still references a captured pending task, that
+  task runs before unprotected later tasks on the same resource; protected tasks retain their normal
+  phase and sequence ordering among themselves. This scoped priority prevents later same-resource
+  submissions from starving the captured generation without changing global phase semantics.
 - The generation is coordinator-wide, matching the existing global `isIdle()` check and the retained
-  "coordinator idle" startup policy. `target` owns the waiter lifecycle; cancelling or replacing that
-  target run rejects the waiter with `AbortError` and never invokes its callback.
+  "coordinator idle" startup policy. `target` owns the waiting lifecycle: cancelling or replacing
+  that target run before the callback begins rejects the waiter with `AbortError`. Once the callback
+  begins, its own owner controls cancellation and its result or error is propagated unchanged. The
+  production callback schedules its warmup as a target/run-owned task, so that work remains
+  cancellable through the existing task contract.
+- Each `whenIdle()` call owns its callback. Concurrent waiters may capture the same generation, and
+  each callback runs exactly once; the old scheduled-task dedupe behavior is intentionally removed.
 - A waiter is not workload: it consumes no CPU/IO lane, has no visible task, and emits no unchanged
   `startup.workload.changed` snapshot.
 
@@ -47,9 +54,11 @@ executing when `whenIdle(target, callback)` is called.
 
 - Track the physical completion of each scheduled task separately from its public promise settlement.
 - Capture current active task completion promises in `whenIdle()` and wait without consuming a lane.
+- Reference-count captured tasks per active waiter and give protected pending work one local ordering
+  layer over later unprotected work on the same resource.
 - Tie the wait to the target run cancellation signal and remove its abort listener on every outcome.
-- Keep phase ordering, resource limits, dedupe, public snapshots, and CRD-001 settlement semantics
-  unchanged.
+- Keep ordinary phase ordering, resource limits, task dedupe, public snapshots, and CRD-001
+  settlement semantics unchanged.
 
 ## Acceptance Criteria
 
@@ -57,8 +66,15 @@ executing when `whenIdle(target, callback)` is called.
 - A captured task rejection still delays the callback until execution cleanup, without making the
   barrier fail.
 - A task scheduled after the barrier starts does not delay that barrier.
+- A later interactive task on the same resource cannot starve a captured background task; the later
+  task still does not become part of the captured generation.
 - Target cancellation rejects the barrier once, never calls the callback, and late task settlement
   restores the lane without retained active, pending, run, or dedupe records.
+- A physically running task remains visible to a barrier owned by another target after its public
+  promise is cancelled.
+- Concurrent waiters each invoke their own callback once; an immediate-idle callback runs directly.
+- Callback rejection is propagated by identity, and target cancellation after callback start does not
+  replace the callback outcome.
 - Existing priority, concurrency, cancellation settlement, and atomic snapshot tests continue to pass.
 
 ## Non-Goals
@@ -74,14 +90,20 @@ executing when `whenIdle(target, callback)` is called.
 - [x] Implement physical task completion tracking and the lane-free barrier.
 - [x] Run focused and repository validation.
 - [x] Record the final validation evidence.
+- [x] Protect captured pending tasks from later same-resource phase starvation.
+- [x] Cover cross-target late execution, concurrent waiters, immediate idle, and callback ownership.
+- [x] Re-run focused and repository validation after independent review findings.
 
 ## Validation
 
-- `pnpm vitest run test/main/presenter/startupWorkloadCoordinator.test.ts`: 8 passed.
+- The independent-review follow-up tests failed before the scheduling protection was added: a later
+  interactive CPU task started before the captured background CPU task, and waiter references were
+  not tracked or released.
+- `pnpm vitest run test/main/presenter/startupWorkloadCoordinator.test.ts`: 13 passed.
 - `pnpm run typecheck`: passed.
 - `pnpm run format`: passed.
 - `pnpm run i18n`: passed.
 - `pnpm run lint`: passed, including architecture and agent-cleanup guards.
-- `pnpm run test:main -- --reporter=dot`: 3,256 passed and 135 skipped. The two failures are
+- `pnpm run test:main -- --reporter=dot`: 3,261 passed and 135 skipped. The two failures are
   unchanged baseline failures in `createMockChatSession.test.ts` and
   `agentSessionPresenter/integration.test.ts`; no startup coordinator test failed.

--- a/docs/issues/startup-workload-idle-barrier/spec.md
+++ b/docs/issues/startup-workload-idle-barrier/spec.md
@@ -35,10 +35,11 @@ executing when `whenIdle(target, callback)` is called.
 - Normal completion, rejection, and cancellation all finish a captured task only when no underlying
   execution remains. A cancelled pending task finishes immediately because it never acquired a lane.
 - Tasks submitted after `whenIdle()` captures its generation belong to a later generation and do not
-  extend the current wait. While at least one waiter still references a captured pending task, that
-  task runs before unprotected later tasks on the same resource; protected tasks retain their normal
-  phase and sequence ordering among themselves. This scoped priority prevents later same-resource
-  submissions from starving the captured generation without changing global phase semantics.
+  extend the current wait. Each non-empty waiter registers an independent token containing its
+  captured generation, task-sequence cutoff, and waiter order. For each resource, the scheduler uses
+  the oldest active token that still has captured pending work on that resource and admits only
+  pending tasks at or before that token's cutoff. Eligible tasks retain their normal phase and
+  sequence ordering. A token with no captured pending work on a resource does not block that resource.
 - The generation is coordinator-wide, matching the existing global `isIdle()` check and the retained
   "coordinator idle" startup policy. `target` owns the waiting lifecycle: cancelling or replacing
   that target run before the callback begins rejects the waiter with `AbortError`. Once the callback
@@ -49,13 +50,17 @@ executing when `whenIdle(target, callback)` is called.
   each callback runs exactly once; the old scheduled-task dedupe behavior is intentionally removed.
 - A waiter is not workload: it consumes no CPU/IO lane, has no visible task, and emits no unchanged
   `startup.workload.changed` snapshot.
+- The local scheduling consequence is intentional: a background task captured before a barrier may
+  run before an interactive task submitted after that barrier on the same resource. The token is
+  removed when its wait succeeds or aborts, so this is not a global phase reorder.
 
 ## Fix Plan
 
 - Track the physical completion of each scheduled task separately from its public promise settlement.
 - Capture current active task completion promises in `whenIdle()` and wait without consuming a lane.
-- Reference-count captured tasks per active waiter and give protected pending work one local ordering
-  layer over later unprotected work on the same resource.
+- Register an independent cutoff token for each active non-empty wait and remove it in `finally`.
+- At dispatch, apply only the oldest relevant token cutoff per resource before using existing
+  phase/sequence ordering.
 - Tie the wait to the target run cancellation signal and remove its abort listener on every outcome.
 - Keep ordinary phase ordering, resource limits, task dedupe, public snapshots, and CRD-001
   settlement semantics unchanged.
@@ -68,6 +73,9 @@ executing when `whenIdle(target, callback)` is called.
 - A task scheduled after the barrier starts does not delay that barrier.
 - A later interactive task on the same resource cannot starve a captured background task; the later
   task still does not become part of the captured generation.
+- Interleaved waiters retain independent cutoffs: a later waiter may include work excluded by an
+  earlier waiter without allowing that work to overtake the earlier generation.
+- A token with captured pending CPU work does not delay later IO work, or vice versa.
 - Target cancellation rejects the barrier once, never calls the callback, and late task settlement
   restores the lane without retained active, pending, run, or dedupe records.
 - A physically running task remains visible to a barrier owned by another target after its public
@@ -93,12 +101,18 @@ executing when `whenIdle(target, callback)` is called.
 - [x] Protect captured pending tasks from later same-resource phase starvation.
 - [x] Cover cross-target late execution, concurrent waiters, immediate idle, and callback ownership.
 - [x] Re-run focused and repository validation after independent review findings.
+- [x] Replace per-task waiter-reference union with independent ordered cutoff tokens.
+- [x] Cover interleaved waiter cutoffs and token cleanup on success and cancellation.
+- [x] Re-run focused and repository validation after the second independent review.
 
 ## Validation
 
 - The independent-review follow-up tests failed before the scheduling protection was added: a later
   interactive CPU task started before the captured background CPU task, and waiter references were
   not tracked or released.
+- The second-review interleaving test failed against the per-task reference model: waiter B made its
+  later interactive task appear protected to waiter A, so it started before A's captured background
+  task. The independent token set was also absent before the token implementation.
 - `pnpm vitest run test/main/presenter/startupWorkloadCoordinator.test.ts`: 13 passed.
 - `pnpm run typecheck`: passed.
 - `pnpm run format`: passed.

--- a/docs/issues/startup-workload-idle-barrier/spec.md
+++ b/docs/issues/startup-workload-idle-barrier/spec.md
@@ -1,0 +1,87 @@
+# Startup Workload Idle Barrier
+
+## Issue
+
+`StartupWorkloadCoordinator.whenIdle()` is named and used as an idle barrier, but its current
+implementation schedules an ordinary `background/io` task. Because the coordinator has two IO
+lanes, that task can start while another IO task and the CPU task are still running.
+
+The only production caller uses the callback to start the full provider warmup. The retained startup
+orchestration decision says this warmup must begin only after coordinator work already registered at
+the barrier has finished. This is therefore a state-machine defect, not an intentional definition of
+idle as "an IO lane is available."
+
+## Impact
+
+- Provider warmup can overlap the startup CPU task and another IO task.
+- Startup work can contend for the main process at the exact point the idle policy was meant to avoid.
+- Tests cannot use `whenIdle()` as a reliable completion boundary.
+
+## Root Cause
+
+- `whenIdle()` is represented as a normal scheduled task instead of a dependency barrier.
+- Scheduler priority and resource capacity decide when the callback starts; task completion does not.
+- A running task cancelled by `cancelTarget()` settles its public promise before its underlying
+  execution returns and releases its resource lane. A correct barrier must not mistake that early
+  public settlement for execution completion.
+
+## Contract
+
+An **idle generation** is the snapshot of all coordinator task records that are pending or still
+executing when `whenIdle(target, callback)` is called.
+
+- The callback starts exactly once, after every task in that captured generation has physically
+  finished and released its scheduler lane.
+- Normal completion, rejection, and cancellation all finish a captured task only when no underlying
+  execution remains. A cancelled pending task finishes immediately because it never acquired a lane.
+- Tasks submitted after `whenIdle()` captures its generation belong to a later generation and do not
+  extend the current wait. This fixed cutoff prevents continuous task submission from starving the
+  callback forever.
+- The generation is coordinator-wide, matching the existing global `isIdle()` check and the retained
+  "coordinator idle" startup policy. `target` owns the waiter lifecycle; cancelling or replacing that
+  target run rejects the waiter with `AbortError` and never invokes its callback.
+- A waiter is not workload: it consumes no CPU/IO lane, has no visible task, and emits no unchanged
+  `startup.workload.changed` snapshot.
+
+## Fix Plan
+
+- Track the physical completion of each scheduled task separately from its public promise settlement.
+- Capture current active task completion promises in `whenIdle()` and wait without consuming a lane.
+- Tie the wait to the target run cancellation signal and remove its abort listener on every outcome.
+- Keep phase ordering, resource limits, dedupe, public snapshots, and CRD-001 settlement semantics
+  unchanged.
+
+## Acceptance Criteria
+
+- A captured deferred CPU task and two concurrently running IO tasks all finish before the callback.
+- A captured task rejection still delays the callback until execution cleanup, without making the
+  barrier fail.
+- A task scheduled after the barrier starts does not delay that barrier.
+- Target cancellation rejects the barrier once, never calls the callback, and late task settlement
+  restores the lane without retained active, pending, run, or dedupe records.
+- Existing priority, concurrency, cancellation settlement, and atomic snapshot tests continue to pass.
+
+## Non-Goals
+
+- No scheduler phase, priority, or concurrency redesign.
+- No automatic inclusion of descendant or continuously arriving tasks in an open generation.
+- No changes to provider warmup behavior, startup event schemas, or renderer state.
+- No timeout for task bodies that ignore cancellation; their lane remains occupied by design.
+
+## Tasks
+
+- [x] Add focused failing generation, rejection, cutoff, cancellation, and late-settlement tests.
+- [x] Implement physical task completion tracking and the lane-free barrier.
+- [x] Run focused and repository validation.
+- [x] Record the final validation evidence.
+
+## Validation
+
+- `pnpm vitest run test/main/presenter/startupWorkloadCoordinator.test.ts`: 8 passed.
+- `pnpm run typecheck`: passed.
+- `pnpm run format`: passed.
+- `pnpm run i18n`: passed.
+- `pnpm run lint`: passed, including architecture and agent-cleanup guards.
+- `pnpm run test:main -- --reporter=dot`: 3,256 passed and 135 skipped. The two failures are
+  unchanged baseline failures in `createMockChatSession.test.ts` and
+  `agentSessionPresenter/integration.test.ts`; no startup coordinator test failed.

--- a/src/main/presenter/startupWorkloadCoordinator/index.ts
+++ b/src/main/presenter/startupWorkloadCoordinator/index.ts
@@ -63,9 +63,14 @@ type StartupTaskRecord<T> = {
   reject: (reason?: unknown) => void
   promise: Promise<T>
   settled: boolean
-  idleBarrierRefs: number
   finishedPromise: Promise<void>
   resolveFinished: () => void
+}
+
+type StartupIdleBarrierToken = {
+  order: number
+  cutoffSequence: number
+  generation: StartupTaskRecord<unknown>[]
 }
 
 const PHASE_PRIORITY: Record<StartupWorkloadPhase, number> = {
@@ -87,9 +92,11 @@ export class StartupWorkloadCoordinator {
     io: 0
   }
   private readonly activeTasks = new Set<StartupTaskRecord<unknown>>()
+  private readonly activeIdleBarriers = new Set<StartupIdleBarrierToken>()
   private readonly inFlightByDedupeKey = new Map<string, StartupTaskRecord<unknown>>()
   private sequence = 0
   private runSequence = 0
+  private idleBarrierSequence = 0
   private pumping = false
 
   createRun(target: StartupWorkloadTarget): string {
@@ -199,7 +206,6 @@ export class StartupWorkloadCoordinator {
       reject: rejectTask,
       promise,
       settled: false,
-      idleBarrierRefs: 0,
       finishedPromise,
       resolveFinished
     }
@@ -219,6 +225,7 @@ export class StartupWorkloadCoordinator {
 
   async whenIdle<T>(target: StartupWorkloadTarget, callback: () => Promise<T>): Promise<T> {
     const generation = [...this.activeTasks]
+    const cutoffSequence = this.sequence
     if (generation.length === 0) {
       return await callback()
     }
@@ -229,15 +236,16 @@ export class StartupWorkloadCoordinator {
       throw this.createAbortError(`${target}:idle`)
     }
 
-    for (const task of generation) {
-      task.idleBarrierRefs += 1
+    const barrier: StartupIdleBarrierToken = {
+      order: ++this.idleBarrierSequence,
+      cutoffSequence,
+      generation
     }
+    this.activeIdleBarriers.add(barrier)
     try {
       await this.waitForGeneration(generation, runState.controller.signal, `${target}:idle`)
     } finally {
-      for (const task of generation) {
-        task.idleBarrierRefs -= 1
-      }
+      this.activeIdleBarriers.delete(barrier)
     }
 
     if (this.runs.get(target)?.runId !== runId) {
@@ -284,9 +292,16 @@ export class StartupWorkloadCoordinator {
   }
 
   private pickNextTask(): StartupTaskRecord<unknown> | null {
-    const protectedResources = new Set(
-      this.pendingTasks.filter((task) => task.idleBarrierRefs > 0).map((task) => task.resource)
-    )
+    const cutoffByResource: Partial<Record<StartupWorkloadResource, number>> = {}
+    const barriers = [...this.activeIdleBarriers].sort((left, right) => left.order - right.order)
+    for (const barrier of barriers) {
+      for (const task of barrier.generation) {
+        if (task.state === 'pending' && cutoffByResource[task.resource] === undefined) {
+          cutoffByResource[task.resource] = barrier.cutoffSequence
+        }
+      }
+    }
+
     const sortedPending = [...this.pendingTasks].sort((left, right) => {
       const phaseDelta = PHASE_PRIORITY[left.phase] - PHASE_PRIORITY[right.phase]
       if (phaseDelta !== 0) {
@@ -296,7 +311,8 @@ export class StartupWorkloadCoordinator {
     })
 
     for (const task of sortedPending) {
-      if (task.idleBarrierRefs === 0 && protectedResources.has(task.resource)) {
+      const cutoffSequence = cutoffByResource[task.resource]
+      if (cutoffSequence !== undefined && task.sequence > cutoffSequence) {
         continue
       }
       if (this.runningCounts[task.resource] >= MAX_CONCURRENCY[task.resource]) {

--- a/src/main/presenter/startupWorkloadCoordinator/index.ts
+++ b/src/main/presenter/startupWorkloadCoordinator/index.ts
@@ -63,6 +63,7 @@ type StartupTaskRecord<T> = {
   reject: (reason?: unknown) => void
   promise: Promise<T>
   settled: boolean
+  idleBarrierRefs: number
   finishedPromise: Promise<void>
   resolveFinished: () => void
 }
@@ -198,6 +199,7 @@ export class StartupWorkloadCoordinator {
       reject: rejectTask,
       promise,
       settled: false,
+      idleBarrierRefs: 0,
       finishedPromise,
       resolveFinished
     }
@@ -227,7 +229,17 @@ export class StartupWorkloadCoordinator {
       throw this.createAbortError(`${target}:idle`)
     }
 
-    await this.waitForGeneration(generation, runState.controller.signal, `${target}:idle`)
+    for (const task of generation) {
+      task.idleBarrierRefs += 1
+    }
+    try {
+      await this.waitForGeneration(generation, runState.controller.signal, `${target}:idle`)
+    } finally {
+      for (const task of generation) {
+        task.idleBarrierRefs -= 1
+      }
+    }
+
     if (this.runs.get(target)?.runId !== runId) {
       throw this.createAbortError(`${target}:idle`)
     }
@@ -272,6 +284,9 @@ export class StartupWorkloadCoordinator {
   }
 
   private pickNextTask(): StartupTaskRecord<unknown> | null {
+    const protectedResources = new Set(
+      this.pendingTasks.filter((task) => task.idleBarrierRefs > 0).map((task) => task.resource)
+    )
     const sortedPending = [...this.pendingTasks].sort((left, right) => {
       const phaseDelta = PHASE_PRIORITY[left.phase] - PHASE_PRIORITY[right.phase]
       if (phaseDelta !== 0) {
@@ -281,6 +296,9 @@ export class StartupWorkloadCoordinator {
     })
 
     for (const task of sortedPending) {
+      if (task.idleBarrierRefs === 0 && protectedResources.has(task.resource)) {
+        continue
+      }
       if (this.runningCounts[task.resource] >= MAX_CONCURRENCY[task.resource]) {
         continue
       }

--- a/src/main/presenter/startupWorkloadCoordinator/index.ts
+++ b/src/main/presenter/startupWorkloadCoordinator/index.ts
@@ -37,6 +37,7 @@ type StartupWorkloadTaskOptions<T> = {
 
 type StartupWorkloadRunState = {
   runId: string
+  controller: AbortController
   visibleTasks: Map<StartupWorkloadTaskId, StartupTaskRecord<unknown>>
   tasks: Set<StartupTaskRecord<unknown>>
 }
@@ -62,6 +63,8 @@ type StartupTaskRecord<T> = {
   reject: (reason?: unknown) => void
   promise: Promise<T>
   settled: boolean
+  finishedPromise: Promise<void>
+  resolveFinished: () => void
 }
 
 const PHASE_PRIORITY: Record<StartupWorkloadPhase, number> = {
@@ -82,6 +85,7 @@ export class StartupWorkloadCoordinator {
     cpu: 0,
     io: 0
   }
+  private readonly activeTasks = new Set<StartupTaskRecord<unknown>>()
   private readonly inFlightByDedupeKey = new Map<string, StartupTaskRecord<unknown>>()
   private sequence = 0
   private runSequence = 0
@@ -92,6 +96,7 @@ export class StartupWorkloadCoordinator {
     const runId = `${target}:${Date.now()}:${++this.runSequence}`
     this.runs.set(target, {
       runId,
+      controller: new AbortController(),
       visibleTasks: new Map(),
       tasks: new Set()
     })
@@ -113,6 +118,7 @@ export class StartupWorkloadCoordinator {
       return
     }
 
+    runState.controller.abort()
     const tasks = [...runState.tasks]
     for (const task of tasks) {
       if (task.state === 'pending' || task.state === 'running') {
@@ -133,9 +139,7 @@ export class StartupWorkloadCoordinator {
   }
 
   isIdle(): boolean {
-    return (
-      this.pendingTasks.length === 0 && this.runningCounts.cpu === 0 && this.runningCounts.io === 0
-    )
+    return this.activeTasks.size === 0
   }
 
   async scheduleTask<T>(options: StartupWorkloadTaskOptions<T>): Promise<T> {
@@ -169,6 +173,10 @@ export class StartupWorkloadCoordinator {
       resolveTask = resolve
       rejectTask = reject
     })
+    let resolveFinished!: () => void
+    const finishedPromise = new Promise<void>((resolve) => {
+      resolveFinished = resolve
+    })
 
     const now = Date.now()
     const task: StartupTaskRecord<T> = {
@@ -189,10 +197,13 @@ export class StartupWorkloadCoordinator {
       resolve: resolveTask,
       reject: rejectTask,
       promise,
-      settled: false
+      settled: false,
+      finishedPromise,
+      resolveFinished
     }
 
     runState.tasks.add(task as StartupTaskRecord<unknown>)
+    this.activeTasks.add(task as StartupTaskRecord<unknown>)
     if (options.visibleId) {
       runState.visibleTasks.set(options.visibleId, task as StartupTaskRecord<unknown>)
     }
@@ -205,21 +216,23 @@ export class StartupWorkloadCoordinator {
   }
 
   async whenIdle<T>(target: StartupWorkloadTarget, callback: () => Promise<T>): Promise<T> {
-    if (this.isIdle()) {
+    const generation = [...this.activeTasks]
+    if (generation.length === 0) {
       return await callback()
     }
 
-    return await this.scheduleTask({
-      id: `${target}:idle`,
-      target,
-      phase: 'background',
-      resource: 'io',
-      labelKey: 'startup.workload.idle',
-      dedupeKey: `${target}:idle`,
-      run: async () => {
-        return await callback()
-      }
-    })
+    const runId = this.ensureRun(target)
+    const runState = this.runs.get(target)
+    if (!runState || runState.runId !== runId) {
+      throw this.createAbortError(`${target}:idle`)
+    }
+
+    await this.waitForGeneration(generation, runState.controller.signal, `${target}:idle`)
+    if (this.runs.get(target)?.runId !== runId) {
+      throw this.createAbortError(`${target}:idle`)
+    }
+
+    return await callback()
   }
 
   static async yieldToMain(signal?: AbortSignal): Promise<void> {
@@ -326,6 +339,7 @@ export class StartupWorkloadCoordinator {
       this.settleTask(task, 'failed', error)
     } finally {
       this.runningCounts[task.resource] -= 1
+      this.finishTaskExecution(task)
       this.pump()
     }
   }
@@ -340,6 +354,7 @@ export class StartupWorkloadCoordinator {
       return
     }
 
+    const wasPending = task.state === 'pending'
     task.settled = true
     task.state = finalState
     task.updatedAt = Date.now()
@@ -350,6 +365,9 @@ export class StartupWorkloadCoordinator {
       task.resolve(result)
     } else {
       task.reject(result)
+    }
+    if (wasPending) {
+      this.finishTaskExecution(task)
     }
 
     const runState = this.runs.get(task.target)
@@ -365,6 +383,36 @@ export class StartupWorkloadCoordinator {
 
     if (shouldPublish) {
       this.publishSnapshot(task.target)
+    }
+  }
+
+  private finishTaskExecution(task: StartupTaskRecord<unknown>): void {
+    if (!this.activeTasks.delete(task)) {
+      return
+    }
+
+    task.resolveFinished()
+  }
+
+  private async waitForGeneration(
+    generation: StartupTaskRecord<unknown>[],
+    signal: AbortSignal,
+    taskId: string
+  ): Promise<void> {
+    if (signal.aborted) {
+      throw this.createAbortError(taskId)
+    }
+
+    let abortListener!: () => void
+    const aborted = new Promise<never>((_, reject) => {
+      abortListener = () => reject(this.createAbortError(taskId))
+      signal.addEventListener('abort', abortListener, { once: true })
+    })
+
+    try {
+      await Promise.race([Promise.all(generation.map((task) => task.finishedPromise)), aborted])
+    } finally {
+      signal.removeEventListener('abort', abortListener)
     }
   }
 

--- a/test/main/presenter/startupWorkloadCoordinator.test.ts
+++ b/test/main/presenter/startupWorkloadCoordinator.test.ts
@@ -23,6 +23,7 @@ type TaskSettlementHooks = {
 
 type CoordinatorInternals = {
   runs: Map<string, { tasks: Set<TaskSettlementHooks> }>
+  activeTasks: Set<unknown>
   pendingTasks: unknown[]
   runningCounts: { cpu: number; io: number }
   inFlightByDedupeKey: Map<string, unknown>
@@ -180,6 +181,192 @@ describe('StartupWorkloadCoordinator', () => {
 
     expect(maxRunningCpu).toBe(1)
     expect(maxRunningIo).toBe(2)
+  })
+
+  it('waits for the captured cpu and io generation before running the idle callback', async () => {
+    const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
+    const coordinator = new StartupWorkloadCoordinator()
+    coordinator.createRun('main')
+
+    const cpuStarted = createDeferred<void>()
+    const firstIoStarted = createDeferred<void>()
+    const secondIoStarted = createDeferred<void>()
+    const cpuGate = createDeferred<void>()
+    const firstIoGate = createDeferred<void>()
+    const secondIoGate = createDeferred<void>()
+
+    const cpuTask = coordinator.scheduleTask({
+      id: 'main:cpu',
+      target: 'main',
+      phase: 'deferred',
+      resource: 'cpu',
+      labelKey: 'startup.main.cpu',
+      run: async () => {
+        cpuStarted.resolve()
+        await cpuGate.promise
+      }
+    })
+    const firstIoTask = coordinator.scheduleTask({
+      id: 'main:io:first',
+      target: 'main',
+      phase: 'deferred',
+      resource: 'io',
+      labelKey: 'startup.main.io.first',
+      run: async () => {
+        firstIoStarted.resolve()
+        await firstIoGate.promise
+      }
+    })
+    const secondIoTask = coordinator.scheduleTask({
+      id: 'main:io:second',
+      target: 'main',
+      phase: 'deferred',
+      resource: 'io',
+      labelKey: 'startup.main.io.second',
+      run: async () => {
+        secondIoStarted.resolve()
+        await secondIoGate.promise
+        throw new Error('expected task failure')
+      }
+    })
+    const secondIoFailure = expect(secondIoTask).rejects.toThrow('expected task failure')
+
+    await Promise.all([cpuStarted.promise, firstIoStarted.promise, secondIoStarted.promise])
+
+    const callback = vi.fn()
+    const callsBeforeBarrier = publishDeepchatEventMock.mock.calls.length
+    const idleBarrier = coordinator.whenIdle('main', async () => {
+      callback()
+    })
+
+    expect(publishDeepchatEventMock.mock.calls).toHaveLength(callsBeforeBarrier)
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(callback).not.toHaveBeenCalled()
+
+    cpuGate.resolve()
+    await cpuTask
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(callback).not.toHaveBeenCalled()
+
+    firstIoGate.resolve()
+    await firstIoTask
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(callback).not.toHaveBeenCalled()
+
+    secondIoGate.resolve()
+    await secondIoFailure
+    await idleBarrier
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(coordinator.isIdle()).toBe(true)
+  })
+
+  it('does not extend an idle generation with tasks scheduled after the barrier starts', async () => {
+    const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
+    const coordinator = new StartupWorkloadCoordinator()
+    coordinator.createRun('main')
+
+    const capturedStarted = createDeferred<void>()
+    const capturedGate = createDeferred<void>()
+    const capturedTask = coordinator.scheduleTask({
+      id: 'main:captured',
+      target: 'main',
+      phase: 'deferred',
+      resource: 'cpu',
+      labelKey: 'startup.main.captured',
+      run: async () => {
+        capturedStarted.resolve()
+        await capturedGate.promise
+      }
+    })
+    await capturedStarted.promise
+
+    const callback = vi.fn()
+    const idleBarrier = coordinator.whenIdle('main', async () => {
+      callback()
+    })
+
+    const laterStarted = createDeferred<void>()
+    const laterGate = createDeferred<void>()
+    const laterTask = coordinator.scheduleTask({
+      id: 'main:later',
+      target: 'main',
+      phase: 'deferred',
+      resource: 'io',
+      labelKey: 'startup.main.later',
+      run: async () => {
+        laterStarted.resolve()
+        await laterGate.promise
+      }
+    })
+
+    await laterStarted.promise
+    expect(callback).not.toHaveBeenCalled()
+
+    capturedGate.resolve()
+    await capturedTask
+    await idleBarrier
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(coordinator.isIdle()).toBe(false)
+
+    laterGate.resolve()
+    await laterTask
+    expect(coordinator.isIdle()).toBe(true)
+  })
+
+  it('cancels an idle barrier once without leaking late task execution', async () => {
+    const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
+    const coordinator = new StartupWorkloadCoordinator()
+    coordinator.createRun('main')
+
+    const taskStarted = createDeferred<void>()
+    const taskGate = createDeferred<void>()
+    const executionSettled = createDeferred<void>()
+    const task = coordinator.scheduleTask({
+      id: 'main:late-settlement',
+      target: 'main',
+      phase: 'deferred',
+      resource: 'cpu',
+      labelKey: 'startup.main.lateSettlement',
+      run: async () => {
+        taskStarted.resolve()
+        try {
+          await taskGate.promise
+        } finally {
+          executionSettled.resolve()
+        }
+      }
+    })
+    const taskCancellation = expect(task).rejects.toMatchObject({ name: 'AbortError' })
+    await taskStarted.promise
+
+    const callback = vi.fn()
+    const idleBarrier = coordinator.whenIdle('main', async () => {
+      callback()
+    })
+    const barrierCancellation = expect(idleBarrier).rejects.toMatchObject({ name: 'AbortError' })
+
+    coordinator.cancelTarget('main')
+    await Promise.all([taskCancellation, barrierCancellation])
+
+    const internals = getInternals(coordinator)
+    expect(callback).not.toHaveBeenCalled()
+    expect(internals.activeTasks.size).toBe(1)
+    expect(internals.runningCounts.cpu).toBe(1)
+    expect(internals.inFlightByDedupeKey.size).toBe(0)
+    expect(internals.runs.has('main')).toBe(false)
+
+    taskGate.reject(new Error('late failure'))
+    await executionSettled.promise
+    await vi.waitFor(() => expect(coordinator.isIdle()).toBe(true))
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(internals.activeTasks.size).toBe(0)
+    expect(internals.pendingTasks).toHaveLength(0)
+    expect(internals.runningCounts.cpu).toBe(0)
+    expect(internals.inFlightByDedupeKey.size).toBe(0)
+    expect(internals.runs.has('main')).toBe(false)
   })
 
   it('cleans pending task records across repeated target cancellation', async () => {

--- a/test/main/presenter/startupWorkloadCoordinator.test.ts
+++ b/test/main/presenter/startupWorkloadCoordinator.test.ts
@@ -19,11 +19,12 @@ function createDeferred<T>() {
 type TaskSettlementHooks = {
   resolve: (value: unknown) => void
   reject: (reason?: unknown) => void
+  idleBarrierRefs: number
 }
 
 type CoordinatorInternals = {
   runs: Map<string, { tasks: Set<TaskSettlementHooks> }>
-  activeTasks: Set<unknown>
+  activeTasks: Set<TaskSettlementHooks>
   pendingTasks: unknown[]
   runningCounts: { cpu: number; io: number }
   inFlightByDedupeKey: Map<string, unknown>
@@ -315,6 +316,235 @@ describe('StartupWorkloadCoordinator', () => {
     expect(coordinator.isIdle()).toBe(true)
   })
 
+  it('protects captured pending work from later same-resource phase starvation', async () => {
+    const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
+    const coordinator = new StartupWorkloadCoordinator()
+    coordinator.createRun('main')
+
+    const blockerStarted = createDeferred<void>()
+    const blockerGate = createDeferred<void>()
+    const capturedGate = createDeferred<void>()
+    const laterStarted = createDeferred<void>()
+    const laterGate = createDeferred<void>()
+    const startOrder: string[] = []
+
+    const blockerTask = coordinator.scheduleTask({
+      id: 'main:blocker',
+      target: 'main',
+      phase: 'deferred',
+      resource: 'cpu',
+      labelKey: 'startup.main.blocker',
+      run: async () => {
+        startOrder.push('blocker')
+        blockerStarted.resolve()
+        await blockerGate.promise
+      }
+    })
+    await blockerStarted.promise
+
+    const capturedTask = coordinator.scheduleTask({
+      id: 'main:captured-background',
+      target: 'main',
+      phase: 'background',
+      resource: 'cpu',
+      labelKey: 'startup.main.capturedBackground',
+      run: async () => {
+        startOrder.push('captured')
+        await capturedGate.promise
+      }
+    })
+
+    const callback = vi.fn()
+    const idleBarrier = coordinator.whenIdle('main', async () => {
+      callback()
+    })
+
+    const laterTask = coordinator.scheduleTask({
+      id: 'main:later-interactive',
+      target: 'main',
+      phase: 'interactive',
+      resource: 'cpu',
+      labelKey: 'startup.main.laterInteractive',
+      run: async () => {
+        startOrder.push('later')
+        laterStarted.resolve()
+        await laterGate.promise
+      }
+    })
+
+    blockerGate.resolve()
+    await blockerTask
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(startOrder).toEqual(['blocker', 'captured'])
+    expect(callback).not.toHaveBeenCalled()
+
+    capturedGate.resolve()
+    await capturedTask
+    await laterStarted.promise
+    await idleBarrier
+
+    expect(startOrder).toEqual(['blocker', 'captured', 'later'])
+    expect(callback).toHaveBeenCalledOnce()
+    expect(coordinator.isIdle()).toBe(false)
+
+    laterGate.resolve()
+    await laterTask
+    expect(coordinator.isIdle()).toBe(true)
+  })
+
+  it('waits across targets for a publicly cancelled task to release its lane', async () => {
+    const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
+    const coordinator = new StartupWorkloadCoordinator()
+    coordinator.createRun('main')
+
+    const taskStarted = createDeferred<void>()
+    const taskGate = createDeferred<void>()
+    const executionSettled = createDeferred<void>()
+    const task = coordinator.scheduleTask({
+      id: 'main:cancelled-but-running',
+      target: 'main',
+      phase: 'deferred',
+      resource: 'cpu',
+      labelKey: 'startup.main.cancelledButRunning',
+      run: async () => {
+        taskStarted.resolve()
+        try {
+          await taskGate.promise
+        } finally {
+          executionSettled.resolve()
+        }
+      }
+    })
+    const taskCancellation = expect(task).rejects.toMatchObject({ name: 'AbortError' })
+    await taskStarted.promise
+
+    coordinator.cancelTarget('main')
+    await taskCancellation
+
+    const callback = vi.fn()
+    const idleBarrier = coordinator.whenIdle('settings', async () => {
+      callback()
+    })
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(callback).not.toHaveBeenCalled()
+    expect(getInternals(coordinator).runningCounts.cpu).toBe(1)
+
+    taskGate.resolve()
+    await executionSettled.promise
+    await idleBarrier
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(coordinator.isIdle()).toBe(true)
+    expect(getInternals(coordinator).activeTasks.size).toBe(0)
+  })
+
+  it('runs every callback once when multiple idle waiters capture one generation', async () => {
+    const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
+    const coordinator = new StartupWorkloadCoordinator()
+    coordinator.createRun('main')
+
+    const taskStarted = createDeferred<void>()
+    const taskGate = createDeferred<void>()
+    const task = coordinator.scheduleTask({
+      id: 'main:shared-generation',
+      target: 'main',
+      phase: 'deferred',
+      resource: 'cpu',
+      labelKey: 'startup.main.sharedGeneration',
+      run: async () => {
+        taskStarted.resolve()
+        await taskGate.promise
+      }
+    })
+    await taskStarted.promise
+
+    const firstCallback = vi.fn(async () => 'first')
+    const secondCallback = vi.fn(async () => 'second')
+    const firstWaiter = coordinator.whenIdle('main', firstCallback)
+    const secondWaiter = coordinator.whenIdle('main', secondCallback)
+    const taskRecord = [...getInternals(coordinator).activeTasks][0]!
+
+    expect(taskRecord.idleBarrierRefs).toBe(2)
+
+    taskGate.resolve()
+    await task
+
+    await expect(Promise.all([firstWaiter, secondWaiter])).resolves.toEqual(['first', 'second'])
+    expect(firstCallback).toHaveBeenCalledOnce()
+    expect(secondCallback).toHaveBeenCalledOnce()
+    expect(taskRecord.idleBarrierRefs).toBe(0)
+  })
+
+  it('runs an immediate idle callback directly without publishing workload state', async () => {
+    const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
+    const coordinator = new StartupWorkloadCoordinator()
+    coordinator.createRun('main')
+
+    const callback = vi.fn(async () => 42)
+    const callsBeforeBarrier = publishDeepchatEventMock.mock.calls.length
+
+    await expect(coordinator.whenIdle('main', callback)).resolves.toBe(42)
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(publishDeepchatEventMock.mock.calls).toHaveLength(callsBeforeBarrier)
+    expect(coordinator.isIdle()).toBe(true)
+  })
+
+  it('preserves callback rejection after the callback owns cancellation', async () => {
+    const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
+    const coordinator = new StartupWorkloadCoordinator()
+    coordinator.createRun('main')
+
+    const taskStarted = createDeferred<void>()
+    const taskGate = createDeferred<void>()
+    const task = coordinator.scheduleTask({
+      id: 'main:before-callback',
+      target: 'main',
+      phase: 'deferred',
+      resource: 'cpu',
+      labelKey: 'startup.main.beforeCallback',
+      run: async () => {
+        taskStarted.resolve()
+        await taskGate.promise
+      }
+    })
+    await taskStarted.promise
+
+    const callbackStarted = createDeferred<void>()
+    const callbackGate = createDeferred<void>()
+    const callback = vi.fn(async () => {
+      callbackStarted.resolve()
+      await callbackGate.promise
+    })
+    const idleBarrier = coordinator.whenIdle('main', callback)
+    const barrierOutcome = idleBarrier.then(
+      () => undefined,
+      (error: unknown) => error
+    )
+    const taskRecord = [...getInternals(coordinator).activeTasks][0]!
+
+    taskGate.resolve()
+    await task
+    await callbackStarted.promise
+
+    expect(taskRecord.idleBarrierRefs).toBe(0)
+
+    const callbackError = new Error('callback owns this failure')
+    coordinator.cancelTarget('main')
+    callbackGate.reject(callbackError)
+
+    expect(await barrierOutcome).toBe(callbackError)
+    expect(callback).toHaveBeenCalledOnce()
+
+    const internals = getInternals(coordinator)
+    expect(internals.activeTasks.size).toBe(0)
+    expect(internals.pendingTasks).toHaveLength(0)
+    expect(internals.inFlightByDedupeKey.size).toBe(0)
+    expect(internals.runs.has('main')).toBe(false)
+  })
+
   it('cancels an idle barrier once without leaking late task execution', async () => {
     const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
     const coordinator = new StartupWorkloadCoordinator()
@@ -346,6 +576,7 @@ describe('StartupWorkloadCoordinator', () => {
       callback()
     })
     const barrierCancellation = expect(idleBarrier).rejects.toMatchObject({ name: 'AbortError' })
+    const taskRecord = [...getInternals(coordinator).activeTasks][0]!
 
     coordinator.cancelTarget('main')
     await Promise.all([taskCancellation, barrierCancellation])
@@ -356,6 +587,7 @@ describe('StartupWorkloadCoordinator', () => {
     expect(internals.runningCounts.cpu).toBe(1)
     expect(internals.inFlightByDedupeKey.size).toBe(0)
     expect(internals.runs.has('main')).toBe(false)
+    expect(taskRecord.idleBarrierRefs).toBe(0)
 
     taskGate.reject(new Error('late failure'))
     await executionSettled.promise

--- a/test/main/presenter/startupWorkloadCoordinator.test.ts
+++ b/test/main/presenter/startupWorkloadCoordinator.test.ts
@@ -19,12 +19,12 @@ function createDeferred<T>() {
 type TaskSettlementHooks = {
   resolve: (value: unknown) => void
   reject: (reason?: unknown) => void
-  idleBarrierRefs: number
 }
 
 type CoordinatorInternals = {
   runs: Map<string, { tasks: Set<TaskSettlementHooks> }>
   activeTasks: Set<TaskSettlementHooks>
+  activeIdleBarriers: Set<unknown>
   pendingTasks: unknown[]
   runningCounts: { cpu: number; io: number }
   inFlightByDedupeKey: Map<string, unknown>
@@ -316,7 +316,7 @@ describe('StartupWorkloadCoordinator', () => {
     expect(coordinator.isIdle()).toBe(true)
   })
 
-  it('protects captured pending work from later same-resource phase starvation', async () => {
+  it('keeps interleaved idle waiters on independent resource cutoffs', async () => {
     const { StartupWorkloadCoordinator } = await import('@/presenter/startupWorkloadCoordinator')
     const coordinator = new StartupWorkloadCoordinator()
     coordinator.createRun('main')
@@ -354,10 +354,23 @@ describe('StartupWorkloadCoordinator', () => {
       }
     })
 
-    const callback = vi.fn()
-    const idleBarrier = coordinator.whenIdle('main', async () => {
-      callback()
+    const firstCallback = vi.fn()
+    const firstBarrier = coordinator.whenIdle('main', async () => {
+      firstCallback()
     })
+
+    const unrelatedIoStarted = vi.fn()
+    await coordinator.scheduleTask({
+      id: 'main:unrelated-io',
+      target: 'main',
+      phase: 'interactive',
+      resource: 'io',
+      labelKey: 'startup.main.unrelatedIo',
+      run: async () => {
+        unrelatedIoStarted()
+      }
+    })
+    expect(unrelatedIoStarted).toHaveBeenCalledOnce()
 
     const laterTask = coordinator.scheduleTask({
       id: 'main:later-interactive',
@@ -372,25 +385,40 @@ describe('StartupWorkloadCoordinator', () => {
       }
     })
 
+    const secondCallback = vi.fn()
+    const secondBarrier = coordinator.whenIdle('main', async () => {
+      secondCallback()
+    })
+    const internals = getInternals(coordinator)
+
     blockerGate.resolve()
     await blockerTask
     await new Promise((resolve) => setImmediate(resolve))
 
     expect(startOrder).toEqual(['blocker', 'captured'])
-    expect(callback).not.toHaveBeenCalled()
+    expect(internals.activeIdleBarriers.size).toBe(2)
+    expect(firstCallback).not.toHaveBeenCalled()
+    expect(secondCallback).not.toHaveBeenCalled()
 
     capturedGate.resolve()
     await capturedTask
     await laterStarted.promise
-    await idleBarrier
+    await new Promise((resolve) => setImmediate(resolve))
 
     expect(startOrder).toEqual(['blocker', 'captured', 'later'])
-    expect(callback).toHaveBeenCalledOnce()
+    expect(firstCallback).toHaveBeenCalledOnce()
+    expect(secondCallback).not.toHaveBeenCalled()
     expect(coordinator.isIdle()).toBe(false)
+    expect(internals.activeIdleBarriers.size).toBe(1)
+    await firstBarrier
 
     laterGate.resolve()
     await laterTask
+    await secondBarrier
+
+    expect(secondCallback).toHaveBeenCalledOnce()
     expect(coordinator.isIdle()).toBe(true)
+    expect(internals.activeIdleBarriers.size).toBe(0)
   })
 
   it('waits across targets for a publicly cancelled task to release its lane', async () => {
@@ -464,9 +492,9 @@ describe('StartupWorkloadCoordinator', () => {
     const secondCallback = vi.fn(async () => 'second')
     const firstWaiter = coordinator.whenIdle('main', firstCallback)
     const secondWaiter = coordinator.whenIdle('main', secondCallback)
-    const taskRecord = [...getInternals(coordinator).activeTasks][0]!
+    const internals = getInternals(coordinator)
 
-    expect(taskRecord.idleBarrierRefs).toBe(2)
+    expect(internals.activeIdleBarriers.size).toBe(2)
 
     taskGate.resolve()
     await task
@@ -474,7 +502,7 @@ describe('StartupWorkloadCoordinator', () => {
     await expect(Promise.all([firstWaiter, secondWaiter])).resolves.toEqual(['first', 'second'])
     expect(firstCallback).toHaveBeenCalledOnce()
     expect(secondCallback).toHaveBeenCalledOnce()
-    expect(taskRecord.idleBarrierRefs).toBe(0)
+    expect(internals.activeIdleBarriers.size).toBe(0)
   })
 
   it('runs an immediate idle callback directly without publishing workload state', async () => {
@@ -490,6 +518,7 @@ describe('StartupWorkloadCoordinator', () => {
     expect(callback).toHaveBeenCalledOnce()
     expect(publishDeepchatEventMock.mock.calls).toHaveLength(callsBeforeBarrier)
     expect(coordinator.isIdle()).toBe(true)
+    expect(getInternals(coordinator).activeIdleBarriers.size).toBe(0)
   })
 
   it('preserves callback rejection after the callback owns cancellation', async () => {
@@ -523,13 +552,12 @@ describe('StartupWorkloadCoordinator', () => {
       () => undefined,
       (error: unknown) => error
     )
-    const taskRecord = [...getInternals(coordinator).activeTasks][0]!
 
     taskGate.resolve()
     await task
     await callbackStarted.promise
 
-    expect(taskRecord.idleBarrierRefs).toBe(0)
+    expect(getInternals(coordinator).activeIdleBarriers.size).toBe(0)
 
     const callbackError = new Error('callback owns this failure')
     coordinator.cancelTarget('main')
@@ -576,7 +604,6 @@ describe('StartupWorkloadCoordinator', () => {
       callback()
     })
     const barrierCancellation = expect(idleBarrier).rejects.toMatchObject({ name: 'AbortError' })
-    const taskRecord = [...getInternals(coordinator).activeTasks][0]!
 
     coordinator.cancelTarget('main')
     await Promise.all([taskCancellation, barrierCancellation])
@@ -587,7 +614,7 @@ describe('StartupWorkloadCoordinator', () => {
     expect(internals.runningCounts.cpu).toBe(1)
     expect(internals.inFlightByDedupeKey.size).toBe(0)
     expect(internals.runs.has('main')).toBe(false)
-    expect(taskRecord.idleBarrierRefs).toBe(0)
+    expect(internals.activeIdleBarriers.size).toBe(0)
 
     taskGate.reject(new Error('late failure'))
     await executionSettled.promise


### PR DESCRIPTION
## Scope

CRD-002 only. This PR replaces StartupWorkloadCoordinator.whenIdle with a generation-aware barrier.

It does not change startup phases, configured CPU/IO concurrency, provider warmup internals, event schemas, renderer state, or any unrelated startup owner.

## Why

The previous whenIdle implementation scheduled an ordinary background IO task. The coordinator has two IO lanes, so that callback could start while another IO task and the CPU task were still running. Its name and only production use both require a real completion boundary before provider warmup begins.

CRD-001 fixed public settlement and dedupe cleanup. CRD-002 builds on that invariant and distinguishes public cancellation from physical execution completion.

## Contract

- A call captures every coordinator-wide task record that is pending or physically executing at that moment.
- The callback runs exactly once after all captured tasks physically finish and release scheduler lanes.
- Pending cancellation finishes immediately; running cancellation remains part of the generation until the underlying task returns.
- Tasks submitted after capture belong to a later generation and do not extend the earlier wait.
- Every non-empty waiter owns an independent ordered cutoff token.
- For each resource, the oldest token that still has captured pending work temporarily excludes post-cutoff tasks on that resource, then preserves existing phase/sequence order among eligible tasks.
- Tokens with no pending work for a resource do not block that resource.
- Target cancellation before callback invocation rejects with AbortError. Once callback starts, the callback owner controls cancellation and its result/error propagates unchanged.
- Concurrent whenIdle calls each own and invoke their callback once; the old accidental idle-task dedupe is intentionally removed.

## Implementation

- Track physical task completion separately from public promise settlement.
- Keep active task records until execution cleanup and lane release.
- Add a run-level AbortController for waiter lifecycle.
- Wait directly on captured physical-completion promises without consuming CPU/IO capacity or publishing a fake workload task.
- Register an ordered cutoff token for each active non-empty waiter and remove it in finally.
- Apply cutoff filtering per resource before the existing phase/sequence selection.

## Impact and expected benefit

Provider warmup can no longer overlap the initial captured startup generation merely because an IO lane is free. Tests and callers can use whenIdle as a real generation barrier.

There is one deliberate local scheduling effect: a background task captured before a barrier may run before an interactive task submitted later on the same resource. This applies only while the relevant token still has captured pending work. It is necessary to make the earlier generation finite and does not globally reorder phases. Other resources remain available.

No database, schema, IPC, UI, or persisted-state change is introduced.

## Automated validation

Independent develop and verify agents were used. Two review loops found and fixed real concurrency defects:

1. A simple generation snapshot could still be starved by later higher-phase work on the same resource.
2. Per-task waiter reference counts merged overlapping generations, allowing a task captured only by waiter B to overtake waiter A's earlier cutoff.

The final ordered-token implementation has independent cutoff semantics.

Validation:

- StartupWorkloadCoordinator focused tests: 13/13 passed
- pnpm run typecheck: passed
- pnpm run format: passed
- pnpm run i18n: passed
- pnpm run lint: passed
- git diff --check: passed
- pnpm run test:main: 3,261 passed, 135 skipped, 2 failed

The two main failures exactly match the recorded baseline:

- test/main/routes/debug/createMockChatSession.test.ts
- test/main/presenter/agentSessionPresenter/integration.test.ts

No startup coordinator test failed. The repository PR Check workflow does not create a status rollup for this intermediate base branch, so the local checks and independent verification above are the merge gate.

## Covered concurrency cases

Automated tests cover:

- one deferred CPU task plus two concurrent IO tasks
- captured task rejection
- post-cutoff work on another resource
- later interactive work on the same resource
- interleaved waiter A/B generations
- publicly cancelled but physically running work captured by another target
- target cancellation and late physical settlement
- concurrent waiters
- immediate-idle callback
- callback rejection and cancellation after callback ownership begins
- token cleanup on success and abort
- existing priority, concurrency, dedupe, lane handoff, and atomic cancellation snapshot behavior

## Manual validation and residual boundaries

Automation does not reproduce a full packaged cold start with real skills, MCP servers, remote control, and provider warmup. Recommended smoke:

1. Start with at least one slow skill/MCP/remote initialization task.
2. Record startup workload events and provider-warmup start.
3. Confirm warmup begins only after every task captured by the initial main barrier has physically completed.
4. Open settings during startup and confirm later settings IO can progress when the barrier protects only CPU work.
5. Close/reopen the target and confirm no warmup callback runs for the cancelled run.

Residual boundaries:

- A task that ignores AbortSignal and never settles still holds its lane and any generation that captured it. Releasing the lane early would violate the concurrency limit; forced termination belongs to that task owner.
- Tasks submitted after capture, including descendants scheduled later by a captured task, may overlap the callback by contract.
- The generation is coordinator-wide, matching the prior global isIdle policy; another target's already-active physical task is included.
- No timeout is added to whenIdle in this slice.

## Rollback

Revert this PR. There is no data migration or compatibility state. Rollback restores the previous early-callback behavior, so it should be used only if the new startup ordering causes a demonstrated regression.
