### PR TITLE
fix(prompt): add source snapshots

### DIFF
--- a/docs/issues/system-prompt-cache-coherence/spec.md
+++ b/docs/issues/system-prompt-cache-coherence/spec.md
@@ -554,12 +554,15 @@ MCP 自身仍由 `toolRegistryRevision` 管理；不合并两种 revision owner�
 
 ### `PRM-002A` tasks
 
-- [ ] 先写 env timeout/late result、transient retry boundary、rendered-no-change failing tests。
-- [ ] 实现 `lastKnownGood`、shared `pending`、`settledAt`、`nextAttemptAt` source state。
-- [ ] 导出 `SystemEnvPromptSnapshot`；准确缓存 `.git` marker-presence observation。
-- [ ] 将 verification policy 改为单次 async read/parse 的 `VerificationPolicySnapshot`。
-- [ ] 给两个 lookup 接入 `AbortSignal`/absolute deadline 参数；保留 compatibility wrappers。
-- [ ] 验证 A 单独 merge 后输出 bytes/首轮预算兼容，记录 outer coherence 尚待 C。
+- [x] 先写 env timeout/late result、transient retry boundary、rendered-no-change failing tests。
+- [x] 实现 `lastKnownGood`、shared `pending`、`settledAt`、`nextAttemptAt` source state。
+- [x] 导出 `SystemEnvPromptSnapshot`；准确缓存 `.git` marker-presence observation。
+- [x] 将 verification policy 改为单次 async read/parse 的 `VerificationPolicySnapshot`。
+- [x] 给两个 lookup 接入 `AbortSignal`/absolute deadline 参数；保留 compatibility wrappers。
+- [x] 验证 A 单独 merge 后输出 bytes/首轮预算兼容，记录 outer coherence 尚待 C。
+
+`PRM-002A` 只发布 source-owner snapshots。外层 `systemPromptCache` fingerprint、skill snapshot/epoch 和
+prompt/tool orchestration 仍分别等待 `PRM-002B`、`PRM-002C`；本 slice 不关闭 P-07。
 
 ### `PRM-002B` tasks
 
@@ -599,7 +602,7 @@ MCP 自身仍由 `toolRegistryRevision` 管理；不合并两种 revision owner�
 - [x] `PRM-001`: 固定 env/verification rendered revisions、immutable skill snapshot/epoch、deadline、
       failure/reconcile 和 cache hit contract。
 - [x] `PRM-001`: 拆分 `PRM-002A`–`PRM-002C` 的 depends-on、validation 与 rollback order。
-- [ ] `PRM-002A`: source snapshots。
+- [x] `PRM-002A`: source snapshots。
 - [ ] `PRM-002B`: skill immutable snapshot/epoch。
 - [ ] `PRM-002C`: orchestration cache wiring and final validation。
 

--- a/docs/issues/system-prompt-cache-coherence/spec.md
+++ b/docs/issues/system-prompt-cache-coherence/spec.md
@@ -548,7 +548,7 @@ MCP 自身仍由 `toolRegistryRevision` 管理；不合并两种 revision owner�
 
 | Slice | Depends on | 独立交付内容 | 独立运行条件 | 独立回滚 |
 | --- | --- | --- | --- | --- |
-| `PRM-002A` source snapshots | `PRM-001` | `SystemEnvPromptSnapshot`、`VerificationPolicySnapshot`、shared pending/30s retry 状态机；保留现有 string builder compatibility wrapper | focused source tests、typecheck/lint/full baseline 通过；outer cache behavior 暂不宣称已修复 | 可单独 revert；旧 builder call sites/outer key 仍可运行 |
+| `PRM-002A` source snapshots | `PRM-001` | `SystemEnvPromptSnapshot`、`VerificationPolicySnapshot`、shared pending/30s retry 状态机；保留现有 string builder compatibility wrapper，并让生产 compatibility calls 共享同一个 `200ms` deadline 并行启动 | focused source tests、生产链并行 deadline test、typecheck/lint/full baseline 通过；outer cache behavior 暂不宣称已修复 | 可单独 revert；旧 outer key 仍可运行 |
 | `PRM-002B` skill immutable snapshot/epoch | `PRM-002A` | staged source version、immutable published LKG snapshot、quarantine/reconcile、odd/even publish epoch、abortable/deadline-bound wait；现有 skill APIs 改为从 published snapshot 读取 | 所有 SkillPresenter/ToolPresenter tests 通过；尚未要求 outer prompt 使用新 epoch | 可在 `PRM-002C` 合入前单独 revert，`PRM-002A` 保留 |
 | `PRM-002C` orchestration cache wiring | `PRM-002A` + `PRM-002B` | env/verification/skill 并行 shared deadline；同一 immutable skill snapshot 生成 prompt/tool pair；outer/tool profile fingerprints 接 revisions/epoch | 真实组合测试、完整 baseline、manual smoke 全部通过；此 slice 才关闭 P-07 | 可先单独 revert C，恢复旧 orchestration 但保留 A/B owner invariants；随后才允许按 B→A 逆序回滚 |
 
@@ -559,6 +559,8 @@ MCP 自身仍由 `toolRegistryRevision` 管理；不合并两种 revision owner�
 - [x] 导出 `SystemEnvPromptSnapshot`；准确缓存 `.git` marker-presence observation。
 - [x] 将 verification policy 改为单次 async read/parse 的 `VerificationPolicySnapshot`。
 - [x] 给两个 lookup 接入 `AbortSignal`/absolute deadline 参数；保留 compatibility wrappers。
+- [x] 生产 outer cache miss 链立即并行启动两个 compatibility lookup，共享一个 absolute `200ms`
+      deadline；不接 source revision fingerprint。
 - [x] 验证 A 单独 merge 后输出 bytes/首轮预算兼容，记录 outer coherence 尚待 C。
 
 `PRM-002A` 只发布 source-owner snapshots。外层 `systemPromptCache` fingerprint、skill snapshot/epoch 和
@@ -581,7 +583,7 @@ prompt/tool orchestration 仍分别等待 `PRM-002B`、`PRM-002C`；本 slice �
 ### `PRM-002C` tasks
 
 - [ ] 先写真实 outer + A/B source owner 的 failing integration tests。
-- [ ] 建一个 absolute `200ms` pre-stream source deadline，并行启动 env、verification 和 stable skill lookup。
+- [ ] 把 stable skill lookup 接入 A 已建立的 absolute `200ms` pre-stream source deadline；三者保持并行。
 - [ ] 从同一个 immutable skill snapshot 构造 metadata/content/tool pair。
 - [ ] composed prompt/tool profile cache entry 与 fingerprint 加入 source revisions/stable epoch。
 - [ ] 实现一次 bounded rebuild、fully matching previous stable fallback 和 typed

--- a/src/main/lib/agentRuntime/systemEnvPromptBuilder.ts
+++ b/src/main/lib/agentRuntime/systemEnvPromptBuilder.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import * as fs from 'node:fs'
 import path from 'node:path'
 import logger from '@shared/logger'
@@ -11,6 +12,13 @@ export interface BuildSystemEnvPromptOptions {
   now?: Date
   agentsFilePath?: string
   modelLookup?: Pick<ProviderCatalogPort, 'getProviderModels' | 'getCustomModels'>
+  signal?: AbortSignal
+  deadlineAt?: number
+}
+
+export interface SystemEnvPromptSnapshot {
+  readonly prompt: string
+  readonly revision: string
 }
 
 export interface RuntimeCapabilitiesPromptOptions {
@@ -23,13 +31,16 @@ const SYSTEM_ENV_SLOW_STEP_MS = 500
 const AGENTS_READ_BUDGET_MS = 200
 const AGENTS_CACHE_TTL_MS = 30_000
 
-type AgentsCacheEntry = {
-  content: string
-  refreshedAt: number
-  pending?: Promise<string>
+type SourceEntry<T> = {
+  hasLastKnownGood: boolean
+  lastKnownGood?: T
+  pending?: Promise<void>
+  settledAt: number
+  nextAttemptAt: number
 }
 
-const agentsInstructionsCache = new Map<string, AgentsCacheEntry>()
+const agentsInstructionsCache = new Map<string, SourceEntry<string | null>>()
+const gitRepositoryMarkerCache = new Map<string, SourceEntry<boolean>>()
 
 function logSlowSystemEnvStep(step: string, startedAt: number): void {
   const elapsed = Date.now() - startedAt
@@ -93,12 +104,19 @@ function resolveWorkdir(workdir?: string | null): string {
   return process.cwd()
 }
 
-function isGitRepository(workdir: string): boolean {
+async function readGitRepositoryMarkerPresent(workdir: string): Promise<boolean> {
   let current = path.resolve(workdir)
   while (true) {
-    if (fs.existsSync(path.join(current, '.git'))) {
+    try {
+      await fs.promises.access(path.join(current, '.git'))
       return true
+    } catch (error) {
+      const nodeError = error as NodeJS.ErrnoException
+      if (nodeError.code !== 'ENOENT' && nodeError.code !== 'ENOTDIR') {
+        throw error
+      }
     }
+
     const parent = path.dirname(current)
     if (parent === current) {
       return false
@@ -107,87 +125,186 @@ function isGitRepository(workdir: string): boolean {
   }
 }
 
-async function readAgentsInstructionsFromDisk(sourcePath: string): Promise<string> {
+async function readAgentsInstructionsFromDisk(sourcePath: string): Promise<string | null> {
   try {
     return await fs.promises.readFile(sourcePath, 'utf8')
   } catch (error) {
     const nodeError = error as NodeJS.ErrnoException
     if (nodeError.code === 'ENOENT' || nodeError.code === 'ENOTDIR') {
-      return ''
+      return null
     }
-
-    logger.warn('[SystemEnvPromptBuilder] Failed to read AGENTS.md', {
-      sourcePath,
-      code: nodeError.code,
-      message: error instanceof Error ? error.message : String(error)
-    })
-    return ''
+    throw error
   }
 }
 
-function refreshAgentsInstructions(sourcePath: string, fallback: AgentsCacheEntry | undefined) {
-  const pending = readAgentsInstructionsFromDisk(sourcePath).then((content) => {
-    agentsInstructionsCache.set(sourcePath, {
-      content,
-      refreshedAt: Date.now()
-    })
-    return content
-  })
+function createSourceEntry<T>(): SourceEntry<T> {
+  return {
+    hasLastKnownGood: false,
+    settledAt: 0,
+    nextAttemptAt: 0
+  }
+}
 
-  agentsInstructionsCache.set(sourcePath, {
-    content: fallback?.content ?? '',
-    refreshedAt: fallback?.refreshedAt ?? 0,
-    pending
-  })
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    signal.throwIfAborted()
+  }
+}
 
+async function waitForPending(
+  pending: Promise<void>,
+  signal: AbortSignal | undefined,
+  deadlineAt: number
+): Promise<boolean> {
+  throwIfAborted(signal)
+  const remainingMs = Math.max(0, deadlineAt - Date.now())
+  if (remainingMs === 0) {
+    return false
+  }
+
+  return new Promise<boolean>((resolve, reject) => {
+    let timeout: NodeJS.Timeout | undefined
+    let finished = false
+    const cleanup = () => {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+      signal?.removeEventListener('abort', onAbort)
+    }
+    const finish = (settled: boolean) => {
+      if (finished) {
+        return
+      }
+      finished = true
+      cleanup()
+      resolve(settled)
+    }
+    const onAbort = () => {
+      if (finished) {
+        return
+      }
+      finished = true
+      cleanup()
+      reject(signal?.reason ?? new DOMException('This operation was aborted', 'AbortError'))
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+    timeout = setTimeout(() => finish(false), remainingMs)
+    pending.then(
+      () => finish(true),
+      () => finish(true)
+    )
+  })
+}
+
+function startAgentsInstructionsRefresh(
+  sourcePath: string,
+  entry: SourceEntry<string | null>
+): Promise<void> {
+  const pending = (async () => {
+    try {
+      entry.lastKnownGood = await readAgentsInstructionsFromDisk(sourcePath)
+      entry.hasLastKnownGood = true
+    } catch (error) {
+      const nodeError = error as NodeJS.ErrnoException
+      logger.warn('[SystemEnvPromptBuilder] Failed to read AGENTS.md', {
+        sourcePath,
+        code: nodeError.code,
+        message: error instanceof Error ? error.message : String(error)
+      })
+    } finally {
+      entry.settledAt = Date.now()
+      entry.nextAttemptAt = entry.settledAt + AGENTS_CACHE_TTL_MS
+      entry.pending = undefined
+    }
+  })()
+  entry.pending = pending
   return pending
 }
 
-async function waitForAgentsInstructions(
-  sourcePath: string,
-  pending: Promise<string>,
-  fallback: string
-): Promise<string> {
-  let timeout: NodeJS.Timeout | undefined
-  const result = await Promise.race([
-    pending.then((content) => ({ content })),
-    new Promise<{ timedOut: true }>((resolve) => {
-      timeout = setTimeout(() => resolve({ timedOut: true }), AGENTS_READ_BUDGET_MS)
-    })
-  ])
-
-  if (timeout) {
-    clearTimeout(timeout)
-  }
-
-  if ('timedOut' in result) {
-    logger.warn('[SystemEnvPromptBuilder] AGENTS.md read deferred', {
-      sourcePath,
-      budgetMs: AGENTS_READ_BUDGET_MS
-    })
-    return fallback
-  }
-
-  return result.content
+function startGitRepositoryMarkerRefresh(
+  workdir: string,
+  entry: SourceEntry<boolean>
+): Promise<void> {
+  const pending = (async () => {
+    try {
+      entry.lastKnownGood = await readGitRepositoryMarkerPresent(workdir)
+      entry.hasLastKnownGood = true
+    } catch (error) {
+      const nodeError = error as NodeJS.ErrnoException
+      logger.warn('[SystemEnvPromptBuilder] Failed to inspect git repository marker', {
+        workdir,
+        code: nodeError.code,
+        message: error instanceof Error ? error.message : String(error)
+      })
+    } finally {
+      entry.settledAt = Date.now()
+      entry.nextAttemptAt = entry.settledAt + AGENTS_CACHE_TTL_MS
+      entry.pending = undefined
+    }
+  })()
+  entry.pending = pending
+  return pending
 }
 
-async function readAgentsInstructions(sourcePath: string): Promise<string> {
-  const cached = agentsInstructionsCache.get(sourcePath)
+async function readAgentsInstructions(
+  sourcePath: string,
+  signal: AbortSignal | undefined,
+  deadlineAt: number,
+  waitBudgetMs: number
+): Promise<string> {
+  throwIfAborted(signal)
+  let entry = agentsInstructionsCache.get(sourcePath)
+  if (!entry) {
+    entry = createSourceEntry<string | null>()
+    agentsInstructionsCache.set(sourcePath, entry)
+  }
+
   const now = Date.now()
-  if (cached && now - cached.refreshedAt < AGENTS_CACHE_TTL_MS) {
-    return cached.content
+  if (!entry.pending && now >= entry.nextAttemptAt) {
+    startAgentsInstructionsRefresh(sourcePath, entry)
   }
 
-  if (cached?.pending) {
-    return cached.content
+  if (entry.hasLastKnownGood) {
+    return entry.lastKnownGood ?? ''
   }
 
-  const pending = refreshAgentsInstructions(sourcePath, cached)
-  if (cached) {
-    return cached.content
+  if (entry.pending && !(await waitForPending(entry.pending, signal, deadlineAt))) {
+    logger.warn('[SystemEnvPromptBuilder] AGENTS.md read deferred', {
+      sourcePath,
+      budgetMs: waitBudgetMs
+    })
   }
 
-  return waitForAgentsInstructions(sourcePath, pending, '')
+  return entry.hasLastKnownGood ? (entry.lastKnownGood ?? '') : ''
+}
+
+async function readGitRepositoryMarker(
+  workdir: string,
+  signal: AbortSignal | undefined,
+  deadlineAt: number
+): Promise<boolean> {
+  throwIfAborted(signal)
+  let entry = gitRepositoryMarkerCache.get(workdir)
+  if (!entry) {
+    entry = createSourceEntry<boolean>()
+    gitRepositoryMarkerCache.set(workdir, entry)
+  }
+
+  const now = Date.now()
+  if (!entry.pending && now >= entry.nextAttemptAt) {
+    startGitRepositoryMarkerRefresh(workdir, entry)
+  }
+
+  if (entry.hasLastKnownGood) {
+    return entry.lastKnownGood ?? false
+  }
+
+  if (entry.pending) {
+    await waitForPending(entry.pending, signal, deadlineAt)
+  }
+
+  return entry.hasLastKnownGood ? (entry.lastKnownGood ?? false) : false
 }
 
 export function buildRuntimeCapabilitiesPrompt(
@@ -221,9 +338,16 @@ export function buildRuntimeCapabilitiesPrompt(
   return lines.length > 1 ? lines.join('\n') : ''
 }
 
-export async function buildSystemEnvPrompt(
+export async function buildSystemEnvPromptSnapshot(
   options: BuildSystemEnvPromptOptions = {}
-): Promise<string> {
+): Promise<SystemEnvPromptSnapshot> {
+  throwIfAborted(options.signal)
+  const lookupStartedAt = Date.now()
+  const deadlineAt = Math.min(
+    options.deadlineAt ?? lookupStartedAt + AGENTS_READ_BUDGET_MS,
+    lookupStartedAt + AGENTS_READ_BUDGET_MS
+  )
+  const waitBudgetMs = Math.max(0, deadlineAt - lookupStartedAt)
   const now = options.now ?? new Date()
   const platform = options.platform ?? process.platform
   const workdir = resolveWorkdir(options.workdir)
@@ -231,8 +355,12 @@ export async function buildSystemEnvPrompt(
     ? path.resolve(options.agentsFilePath)
     : path.join(workdir, 'AGENTS.md')
   let stepStartedAt = Date.now()
-  const agentsContent = await readAgentsInstructions(agentsFilePath)
-  logSlowSystemEnvStep('read-agents', stepStartedAt)
+  const [agentsContent, gitRepositoryMarkerPresent] = await Promise.all([
+    readAgentsInstructions(agentsFilePath, options.signal, deadlineAt, waitBudgetMs),
+    readGitRepositoryMarker(workdir, options.signal, deadlineAt)
+  ])
+  throwIfAborted(options.signal)
+  logSlowSystemEnvStep('read-sources', stepStartedAt)
   stepStartedAt = Date.now()
   const { modelName, exactModelId } = resolveModelIdentity(
     options.providerId,
@@ -240,9 +368,6 @@ export async function buildSystemEnvPrompt(
     options.modelLookup
   )
   logSlowSystemEnvStep('model-identity', stepStartedAt)
-  stepStartedAt = Date.now()
-  const isGitRepo = isGitRepository(workdir)
-  logSlowSystemEnvStep('git-detect', stepStartedAt)
 
   const promptLines = [
     `You are powered by the model named ${modelName}.`,
@@ -250,7 +375,7 @@ export async function buildSystemEnvPrompt(
     `Here is some useful information about the environment you are running in:`,
     '<env>',
     `Working directory: ${workdir}`,
-    `Is directory a git repo: ${isGitRepo ? 'yes' : 'no'}`,
+    `Is directory a git repo: ${gitRepositoryMarkerPresent ? 'yes' : 'no'}`,
     `Platform: ${platform}`,
     `Today's date: ${now.toDateString()}`,
     '</env>'
@@ -260,5 +385,15 @@ export async function buildSystemEnvPrompt(
     promptLines.push(`Instructions from: ${agentsFilePath}\n`, agentsContent)
   }
 
-  return promptLines.join('\n')
+  const prompt = promptLines.join('\n')
+  return {
+    prompt,
+    revision: createHash('sha256').update(prompt, 'utf8').digest('hex')
+  }
+}
+
+export async function buildSystemEnvPrompt(
+  options: BuildSystemEnvPromptOptions = {}
+): Promise<string> {
+  return (await buildSystemEnvPromptSnapshot(options)).prompt
 }

--- a/src/main/lib/agentRuntime/verificationPolicyPromptBuilder.ts
+++ b/src/main/lib/agentRuntime/verificationPolicyPromptBuilder.ts
@@ -1,0 +1,254 @@
+import { createHash } from 'node:crypto'
+import * as fs from 'node:fs'
+import path from 'node:path'
+import logger from '@shared/logger'
+
+export interface BuildVerificationPolicySnapshotOptions {
+  workdir?: string | null
+  signal?: AbortSignal
+  deadlineAt?: number
+}
+
+export interface VerificationPolicySnapshot {
+  readonly prompt: string
+  readonly revision: string
+}
+
+type PackageJsonManifest = {
+  name?: unknown
+  scripts?: Record<string, unknown>
+}
+
+type PackageSourceEntry = {
+  hasLastKnownGood: boolean
+  lastKnownGood?: VerificationPolicySnapshot
+  pending?: Promise<void>
+  settledAt: number
+  nextAttemptAt: number
+}
+
+const SOURCE_READ_BUDGET_MS = 200
+const SOURCE_REFRESH_INTERVAL_MS = 30_000
+const packageSourceCache = new Map<string, PackageSourceEntry>()
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    signal.throwIfAborted()
+  }
+}
+
+async function waitForPending(
+  pending: Promise<void>,
+  signal: AbortSignal | undefined,
+  deadlineAt: number
+): Promise<boolean> {
+  throwIfAborted(signal)
+  const remainingMs = Math.max(0, deadlineAt - Date.now())
+  if (remainingMs === 0) {
+    return false
+  }
+
+  return new Promise<boolean>((resolve, reject) => {
+    let timeout: NodeJS.Timeout | undefined
+    let finished = false
+    const cleanup = () => {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+      signal?.removeEventListener('abort', onAbort)
+    }
+    const finish = (settled: boolean) => {
+      if (finished) {
+        return
+      }
+      finished = true
+      cleanup()
+      resolve(settled)
+    }
+    const onAbort = () => {
+      if (finished) {
+        return
+      }
+      finished = true
+      cleanup()
+      reject(signal?.reason ?? new DOMException('This operation was aborted', 'AbortError'))
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+    timeout = setTimeout(() => finish(false), remainingMs)
+    pending.then(
+      () => finish(true),
+      () => finish(true)
+    )
+  })
+}
+
+async function readPackageJsonManifest(
+  packageJsonPath: string
+): Promise<PackageJsonManifest | null> {
+  let content: string
+  try {
+    content = await fs.promises.readFile(packageJsonPath, 'utf8')
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException
+    if (nodeError.code === 'ENOENT' || nodeError.code === 'ENOTDIR') {
+      return null
+    }
+    throw error
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content) as unknown
+  } catch {
+    throw Object.assign(new Error('package.json contains invalid JSON'), {
+      code: 'INVALID_PACKAGE_JSON'
+    })
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw Object.assign(new Error('package.json must contain a JSON object'), {
+      code: 'INVALID_PACKAGE_JSON'
+    })
+  }
+  return parsed as PackageJsonManifest
+}
+
+function startPackageRefresh(packageJsonPath: string, entry: PackageSourceEntry): Promise<void> {
+  const pending = (async () => {
+    try {
+      const manifest = await readPackageJsonManifest(packageJsonPath)
+      entry.lastKnownGood = createVerificationPolicySnapshot(manifest)
+      entry.hasLastKnownGood = true
+    } catch (error) {
+      const nodeError = error as NodeJS.ErrnoException
+      logger.warn('[VerificationPolicyPromptBuilder] Failed to read package.json', {
+        packageJsonPath,
+        code: nodeError.code,
+        message: error instanceof Error ? error.message : String(error)
+      })
+    } finally {
+      entry.settledAt = Date.now()
+      entry.nextAttemptAt = entry.settledAt + SOURCE_REFRESH_INTERVAL_MS
+      entry.pending = undefined
+    }
+  })()
+  entry.pending = pending
+  return pending
+}
+
+async function getPackageVerificationPolicySnapshot(
+  packageJsonPath: string,
+  signal: AbortSignal | undefined,
+  deadlineAt: number
+): Promise<VerificationPolicySnapshot> {
+  throwIfAborted(signal)
+  let entry = packageSourceCache.get(packageJsonPath)
+  if (!entry) {
+    entry = {
+      hasLastKnownGood: false,
+      settledAt: 0,
+      nextAttemptAt: 0
+    }
+    packageSourceCache.set(packageJsonPath, entry)
+  }
+
+  const now = Date.now()
+  if (!entry.pending && now >= entry.nextAttemptAt) {
+    startPackageRefresh(packageJsonPath, entry)
+  }
+
+  if (entry.hasLastKnownGood) {
+    return entry.lastKnownGood ?? BASE_VERIFICATION_POLICY_SNAPSHOT
+  }
+
+  if (entry.pending) {
+    await waitForPending(entry.pending, signal, deadlineAt)
+  }
+
+  return entry.hasLastKnownGood
+    ? (entry.lastKnownGood ?? BASE_VERIFICATION_POLICY_SNAPSHOT)
+    : BASE_VERIFICATION_POLICY_SNAPSHOT
+}
+
+function getVerificationScriptNames(manifest: PackageJsonManifest | null): string[] {
+  const scripts = manifest?.scripts
+  if (!scripts || typeof scripts !== 'object' || Array.isArray(scripts)) {
+    return []
+  }
+
+  return Object.entries(scripts)
+    .filter(
+      ([name, value]) => typeof name === 'string' && typeof value === 'string' && value.trim()
+    )
+    .map(([name]) => name)
+}
+
+function renderVerificationPolicyPrompt(manifest: PackageJsonManifest | null): string {
+  const lines = [
+    '## Verification Policy',
+    'After changing code, configuration, tests, docs that affect behavior, or generated assets, check verification status before the final response.',
+    'If verification was not run, state the reason explicitly in the final response.'
+  ]
+  const verificationScripts = getVerificationScriptNames(manifest)
+  const isDeepChatWorkspace =
+    String(manifest?.name ?? '').toLowerCase() === 'deepchat' ||
+    ['format', 'i18n', 'lint'].every((scriptName) => verificationScripts.includes(scriptName))
+
+  if (isDeepChatWorkspace) {
+    lines.push(
+      'In the DeepChat repository, prioritize `pnpm run format`, `pnpm run i18n`, and `pnpm run lint` after feature work.'
+    )
+  } else if (verificationScripts.length > 0) {
+    const suggestedScripts = verificationScripts
+      .slice(0, 4)
+      .map((scriptName) => `\`${scriptName}\``)
+    lines.push(
+      `When relevant, prefer project-local verification scripts such as ${suggestedScripts.join(', ')}.`
+    )
+  }
+
+  return lines.join('\n')
+}
+
+function createVerificationPolicySnapshot(
+  manifest: PackageJsonManifest | null
+): VerificationPolicySnapshot {
+  const prompt = renderVerificationPolicyPrompt(manifest)
+  return {
+    prompt,
+    revision: createHash('sha256').update(prompt, 'utf8').digest('hex')
+  }
+}
+
+const BASE_VERIFICATION_POLICY_SNAPSHOT = createVerificationPolicySnapshot(null)
+
+export async function buildVerificationPolicySnapshot(
+  options: BuildVerificationPolicySnapshotOptions = {}
+): Promise<VerificationPolicySnapshot> {
+  throwIfAborted(options.signal)
+  const normalizedWorkdir = options.workdir?.trim()
+  if (!normalizedWorkdir) {
+    return BASE_VERIFICATION_POLICY_SNAPSHOT
+  }
+
+  const lookupStartedAt = Date.now()
+  const deadlineAt = Math.min(
+    options.deadlineAt ?? lookupStartedAt + SOURCE_READ_BUDGET_MS,
+    lookupStartedAt + SOURCE_READ_BUDGET_MS
+  )
+  const packageJsonPath = path.join(path.resolve(normalizedWorkdir), 'package.json')
+  const snapshot = await getPackageVerificationPolicySnapshot(
+    packageJsonPath,
+    options.signal,
+    deadlineAt
+  )
+  throwIfAborted(options.signal)
+  return snapshot
+}
+
+export async function buildVerificationPolicyPrompt(
+  workdir: string | null,
+  options: Omit<BuildVerificationPolicySnapshotOptions, 'workdir'> = {}
+): Promise<string> {
+  return (await buildVerificationPolicySnapshot({ ...options, workdir })).prompt
+}

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -219,6 +219,7 @@ const AUTO_APPROVE_REVIEW_MAX_CONTENT_CHARS = 2_000
 const AUTO_APPROVE_REVIEW_TIMEOUT_MS = 30_000
 const MEMORY_INJECTION_ACCESS_TURN_TTL_MS = 30 * 60 * 1000
 const MEMORY_INJECTION_ACCESS_MAX_TURNS_PER_SESSION = 128
+const SYSTEM_PROMPT_SOURCE_LOOKUP_BUDGET_MS = 200
 
 function normalizePermissionMode(mode: PermissionMode | null | undefined): PermissionMode {
   return mode === 'default' || mode === 'auto_approve' ? mode : 'full_access'
@@ -4750,20 +4751,41 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       this.logSlowPreStreamStep(sessionId, 'system-prompt.pinned-skills-load', stepStartedAt)
     }
 
-    let envPrompt = ''
-    try {
-      stepStartedAt = Date.now()
-      envPrompt = await buildSystemEnvPrompt({
-        providerId,
-        modelId,
-        workdir,
-        now,
-        modelLookup: this.providerCatalogPort
-      })
-      this.logSlowPreStreamStep(sessionId, 'system-prompt.env-prompt', stepStartedAt)
-    } catch (error) {
-      console.warn(`[DeepChatAgent] Failed to build env prompt for session ${sessionId}:`, error)
-    }
+    const sourceLookupDeadlineAt = Date.now() + SYSTEM_PROMPT_SOURCE_LOOKUP_BUDGET_MS
+    const envPromptStartedAt = Date.now()
+    const envPromptPromise = buildSystemEnvPrompt({
+      providerId,
+      modelId,
+      workdir,
+      now,
+      modelLookup: this.providerCatalogPort,
+      deadlineAt: sourceLookupDeadlineAt
+    }).then(
+      (prompt) => {
+        this.logSlowPreStreamStep(sessionId, 'system-prompt.env-prompt', envPromptStartedAt)
+        return prompt
+      },
+      (error) => {
+        console.warn(`[DeepChatAgent] Failed to build env prompt for session ${sessionId}:`, error)
+        return ''
+      }
+    )
+    const verificationPolicyStartedAt = Date.now()
+    const verificationPolicyPromptPromise = buildVerificationPolicyPrompt(workdir, {
+      deadlineAt: sourceLookupDeadlineAt
+    }).then((prompt) => {
+      this.logSlowPreStreamStep(
+        sessionId,
+        'system-prompt.verification-policy',
+        verificationPolicyStartedAt
+      )
+      return prompt
+    })
+
+    const [envPrompt, verificationPolicyPrompt] = await Promise.all([
+      envPromptPromise,
+      verificationPolicyPromptPromise
+    ])
 
     let toolingPrompt = ''
     if (this.toolPresenter) {
@@ -4781,10 +4803,6 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         )
       }
     }
-
-    stepStartedAt = Date.now()
-    const verificationPolicyPrompt = await buildVerificationPolicyPrompt(workdir)
-    this.logSlowPreStreamStep(sessionId, 'system-prompt.verification-policy', stepStartedAt)
 
     stepStartedAt = Date.now()
     const composedPrompt = this.composePromptSections([

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -1,7 +1,5 @@
 import logger from '@shared/logger'
 import { createHash } from 'crypto'
-import fs from 'fs'
-import path from 'path'
 import type {
   AssistantMessageBlock,
   AgentTapeAnchorResult,
@@ -88,6 +86,7 @@ import {
   buildRuntimeCapabilitiesPrompt,
   buildSystemEnvPrompt
 } from '@/lib/agentRuntime/systemEnvPromptBuilder'
+import { buildVerificationPolicyPrompt } from '@/lib/agentRuntime/verificationPolicyPromptBuilder'
 import type { ContextBuildMetadata } from './contextBuilder'
 import {
   buildTapeChatView,
@@ -212,11 +211,6 @@ type ResumeBudgetToolCall = {
 type AgentExtensionPolicy = {
   enabledPluginIds?: string[] | null
   enabledSkillNames?: string[] | null
-}
-
-type PackageJsonManifest = {
-  name?: unknown
-  scripts?: Record<string, unknown>
 }
 
 const PROVIDER_OVERFLOW_RETRY_EXTRA_RESERVE_CAP = 8_192
@@ -470,38 +464,6 @@ function buildProviderContextOverflowAfterRecoveryErrorMessage(
 function normalizeTopP(value: unknown): number | undefined {
   const numeric = parseFiniteNumericValue(value)
   return numeric !== undefined && numeric >= 0.1 && numeric <= 1 ? numeric : undefined
-}
-
-function readPackageJsonManifest(workdir: string): PackageJsonManifest | null {
-  try {
-    const packageJsonPath = path.join(workdir, 'package.json')
-    if (!fs.existsSync(packageJsonPath)) {
-      return null
-    }
-
-    const parsed = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as unknown
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return null
-    }
-
-    return parsed as PackageJsonManifest
-  } catch {
-    return null
-  }
-}
-
-function getVerificationScriptNames(workdir: string): string[] {
-  const manifest = readPackageJsonManifest(workdir)
-  const scripts = manifest?.scripts
-  if (!scripts || typeof scripts !== 'object') {
-    return []
-  }
-
-  return Object.entries(scripts)
-    .filter(
-      ([name, value]) => typeof name === 'string' && typeof value === 'string' && value.trim()
-    )
-    .map(([name]) => name)
 }
 
 type ActiveProviderPermission = {
@@ -4821,6 +4783,10 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     }
 
     stepStartedAt = Date.now()
+    const verificationPolicyPrompt = await buildVerificationPolicyPrompt(workdir)
+    this.logSlowPreStreamStep(sessionId, 'system-prompt.verification-policy', stepStartedAt)
+
+    stepStartedAt = Date.now()
     const composedPrompt = this.composePromptSections([
       normalizedBase,
       runtimePrompt,
@@ -4829,7 +4795,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       skillsPrompt,
       toolingPrompt,
       this.buildPermissionRulesPrompt(agentToolNames),
-      this.buildVerificationPolicyPrompt(workdir)
+      verificationPolicyPrompt
     ])
     this.logSlowPreStreamStep(sessionId, 'system-prompt.compose', stepStartedAt)
 
@@ -4875,40 +4841,6 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       )
     }
     lines.push('Do not assume approval for file writes or commands when the session asks for it.')
-
-    return lines.join('\n')
-  }
-
-  private buildVerificationPolicyPrompt(workdir: string | null): string {
-    const lines = [
-      '## Verification Policy',
-      'After changing code, configuration, tests, docs that affect behavior, or generated assets, check verification status before the final response.',
-      'If verification was not run, state the reason explicitly in the final response.'
-    ]
-
-    const normalizedWorkdir = workdir?.trim()
-    if (!normalizedWorkdir) {
-      return lines.join('\n')
-    }
-
-    const verificationScripts = getVerificationScriptNames(normalizedWorkdir)
-    const manifest = readPackageJsonManifest(normalizedWorkdir)
-    const isDeepChatWorkspace =
-      String(manifest?.name ?? '').toLowerCase() === 'deepchat' ||
-      ['format', 'i18n', 'lint'].every((scriptName) => verificationScripts.includes(scriptName))
-
-    if (isDeepChatWorkspace) {
-      lines.push(
-        'In the DeepChat repository, prioritize `pnpm run format`, `pnpm run i18n`, and `pnpm run lint` after feature work.'
-      )
-    } else if (verificationScripts.length > 0) {
-      const suggestedScripts = verificationScripts
-        .slice(0, 4)
-        .map((scriptName) => `\`${scriptName}\``)
-      lines.push(
-        `When relevant, prefer project-local verification scripts such as ${suggestedScripts.join(', ')}.`
-      )
-    }
 
     return lines.join('\n')
   }

--- a/test/main/lib/agentRuntime/systemEnvPromptBuilder.test.ts
+++ b/test/main/lib/agentRuntime/systemEnvPromptBuilder.test.ts
@@ -10,6 +10,8 @@ function fileError(code: string): NodeJS.ErrnoException {
 describe('buildSystemEnvPrompt', () => {
   beforeEach(() => {
     vi.mocked(fs.existsSync).mockReturnValue(false)
+    vi.mocked(fs.promises.access).mockReset()
+    vi.mocked(fs.promises.access).mockRejectedValue(fileError('ENOENT'))
     vi.mocked(fs.promises.readFile).mockReset()
     vi.mocked(logger.warn).mockClear()
   })

--- a/test/main/lib/agentRuntime/systemPromptSourceSnapshots.test.ts
+++ b/test/main/lib/agentRuntime/systemPromptSourceSnapshots.test.ts
@@ -345,6 +345,31 @@ describe('system prompt source snapshots', () => {
     expect(missingAgain.revision).toBe(missing.revision)
   })
 
+  it('keeps the package last-known-good policy across a transient I/O failure', async () => {
+    vi.mocked(fs.promises.readFile)
+      .mockResolvedValueOnce('{"name":"DeepChat","scripts":{}}')
+      .mockRejectedValueOnce(fileError('EIO'))
+      .mockResolvedValueOnce('{"name":"other","scripts":{"test":"vitest"}}')
+    const options = { workdir: '/tmp/prm-002a-package-lkg' }
+
+    const initial = await buildVerificationPolicySnapshot(options)
+    expect(initial.prompt).toContain('In the DeepChat repository')
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(await buildVerificationPolicySnapshot(options)).toEqual(initial)
+    await settleRefresh()
+    expect(await buildVerificationPolicySnapshot(options)).toEqual(initial)
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(await buildVerificationPolicySnapshot(options)).toEqual(initial)
+    await settleRefresh()
+    const recovered = await buildVerificationPolicySnapshot(options)
+    expect(recovered.prompt).not.toContain('In the DeepChat repository')
+    expect(recovered.prompt).toContain('`test`')
+    expect(recovered.revision).not.toBe(initial.revision)
+  })
+
   it('shares package pending reads and lets one waiter abort independently', async () => {
     const read = deferred<string>()
     vi.mocked(fs.promises.readFile).mockReturnValue(

--- a/test/main/lib/agentRuntime/systemPromptSourceSnapshots.test.ts
+++ b/test/main/lib/agentRuntime/systemPromptSourceSnapshots.test.ts
@@ -1,0 +1,436 @@
+import { createHash } from 'node:crypto'
+import * as fs from 'node:fs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import logger from '@shared/logger'
+import {
+  buildSystemEnvPromptSnapshot,
+  type BuildSystemEnvPromptOptions
+} from '@/lib/agentRuntime/systemEnvPromptBuilder'
+import {
+  buildVerificationPolicyPrompt,
+  buildVerificationPolicySnapshot
+} from '@/lib/agentRuntime/verificationPolicyPromptBuilder'
+
+function fileError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`${code} mock error`), { code })
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {}
+  let reject: (error: unknown) => void = () => {}
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+async function settleRefresh(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function envOptions(workdir: string): BuildSystemEnvPromptOptions {
+  return {
+    workdir,
+    providerId: 'provider',
+    modelId: 'model',
+    now: new Date('2026-06-22T00:00:00Z'),
+    platform: 'linux'
+  }
+}
+
+describe('system prompt source snapshots', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-10T00:00:00Z'))
+    vi.mocked(fs.promises.access).mockReset()
+    vi.mocked(fs.promises.access).mockRejectedValue(fileError('ENOENT'))
+    vi.mocked(fs.promises.readFile).mockReset()
+    vi.mocked(logger.warn).mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('caps the first env wait at 200ms and exposes the shared late result', async () => {
+    const read = deferred<string>()
+    vi.mocked(fs.promises.readFile).mockReturnValue(
+      read.promise as ReturnType<typeof fs.promises.readFile>
+    )
+    const options = envOptions('/tmp/prm-002a-env-timeout')
+    const deadlineAt = Date.now() + 1_000
+
+    const first = buildSystemEnvPromptSnapshot({ ...options, deadlineAt })
+    const second = buildSystemEnvPromptSnapshot({ ...options, deadlineAt })
+
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(200)
+    expect((await first).prompt).not.toContain('Instructions from:')
+    expect((await second).prompt).not.toContain('Instructions from:')
+
+    read.resolve('Late instructions.\n')
+    await settleRefresh()
+
+    const late = await buildSystemEnvPromptSnapshot(options)
+    expect(late.prompt).toContain('Late instructions.')
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a transient env failure at 30,000ms, not 29,999ms', async () => {
+    vi.mocked(fs.promises.readFile)
+      .mockRejectedValueOnce(fileError('EIO'))
+      .mockResolvedValueOnce('Recovered instructions.\n')
+    const options = envOptions('/tmp/prm-002a-env-retry')
+
+    expect((await buildSystemEnvPromptSnapshot(options)).prompt).not.toContain('Instructions from:')
+    await vi.advanceTimersByTimeAsync(29_999)
+    await buildSystemEnvPromptSnapshot(options)
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    const callers = await Promise.all([
+      buildSystemEnvPromptSnapshot(options),
+      buildSystemEnvPromptSnapshot(options)
+    ])
+    expect(callers[0].prompt).toContain('Recovered instructions.')
+    expect(callers[1].prompt).toContain('Recovered instructions.')
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps AGENTS.md last-known-good until a later refresh succeeds', async () => {
+    vi.mocked(fs.promises.readFile)
+      .mockResolvedValueOnce('Instructions A.\n')
+      .mockRejectedValueOnce(fileError('EIO'))
+      .mockResolvedValueOnce('Instructions B.\n')
+    const options = envOptions('/tmp/prm-002a-env-lkg')
+
+    const initial = await buildSystemEnvPromptSnapshot(options)
+    expect(initial.prompt).toContain('Instructions A.')
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect((await buildSystemEnvPromptSnapshot(options)).prompt).toBe(initial.prompt)
+    await settleRefresh()
+    expect((await buildSystemEnvPromptSnapshot(options)).prompt).toBe(initial.prompt)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect((await buildSystemEnvPromptSnapshot(options)).prompt).toBe(initial.prompt)
+    await settleRefresh()
+    const refreshed = await buildSystemEnvPromptSnapshot(options)
+    expect(refreshed.prompt).toContain('Instructions B.')
+    expect(refreshed.revision).not.toBe(initial.revision)
+  })
+
+  it('digests rendered bytes and treats missing, empty, and whitespace instructions alike', async () => {
+    vi.mocked(fs.promises.readFile)
+      .mockRejectedValueOnce(fileError('ENOENT'))
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('  \n')
+      .mockResolvedValueOnce('Use the source truth.\n')
+    const options = envOptions('/tmp/prm-002a-env-rendered-revision')
+
+    const missing = await buildSystemEnvPromptSnapshot(options)
+    expect(missing.revision).toBe(createHash('sha256').update(missing.prompt, 'utf8').digest('hex'))
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await buildSystemEnvPromptSnapshot(options)
+    await settleRefresh()
+    const empty = await buildSystemEnvPromptSnapshot(options)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await buildSystemEnvPromptSnapshot(options)
+    await settleRefresh()
+    const whitespace = await buildSystemEnvPromptSnapshot(options)
+
+    expect(empty.prompt).toBe(missing.prompt)
+    expect(whitespace.prompt).toBe(missing.prompt)
+    expect(empty.revision).toBe(missing.revision)
+    expect(whitespace.revision).toBe(missing.revision)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await buildSystemEnvPromptSnapshot(options)
+    await settleRefresh()
+    const changed = await buildSystemEnvPromptSnapshot(options)
+    expect(changed.prompt).toContain('Use the source truth.')
+    expect(changed.revision).not.toBe(missing.revision)
+  })
+
+  it('does not repeat fresh AGENTS.md reads or git marker scans', async () => {
+    vi.mocked(fs.promises.readFile).mockResolvedValue('Cached instructions.\n')
+    vi.mocked(fs.promises.access).mockImplementation(async (candidate) => {
+      if (String(candidate) === '/tmp/prm-002a-env-fresh/.git') {
+        return
+      }
+      throw fileError('ENOENT')
+    })
+    const options = envOptions('/tmp/prm-002a-env-fresh')
+
+    const first = await buildSystemEnvPromptSnapshot(options)
+    const accessCount = vi.mocked(fs.promises.access).mock.calls.length
+    const second = await buildSystemEnvPromptSnapshot(options)
+
+    expect(first.prompt).toContain('Is directory a git repo: yes')
+    expect(second).toEqual(first)
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(1)
+    expect(fs.promises.access).toHaveBeenCalledTimes(accessCount)
+  })
+
+  it('shares an in-flight git marker scan across callers', async () => {
+    const marker = deferred<void>()
+    vi.mocked(fs.promises.readFile).mockRejectedValue(fileError('ENOENT'))
+    vi.mocked(fs.promises.access).mockReturnValue(
+      marker.promise as ReturnType<typeof fs.promises.access>
+    )
+    const options = envOptions('/tmp/prm-002a-git-pending')
+    const deadlineAt = Date.now() + 200
+
+    const first = buildSystemEnvPromptSnapshot({ ...options, deadlineAt })
+    const second = buildSystemEnvPromptSnapshot({ ...options, deadlineAt })
+    expect(fs.promises.access).toHaveBeenCalledTimes(1)
+
+    marker.resolve()
+    expect((await first).prompt).toContain('Is directory a git repo: yes')
+    expect((await second).prompt).toContain('Is directory a git repo: yes')
+    expect(fs.promises.access).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the git marker last-known-good through a transient scan failure', async () => {
+    vi.mocked(fs.promises.readFile).mockRejectedValue(fileError('ENOENT'))
+    let markerState: 'present' | 'error' | 'missing' = 'present'
+    vi.mocked(fs.promises.access).mockImplementation(async (candidate) => {
+      if (markerState === 'error') {
+        throw fileError('EIO')
+      }
+      if (markerState === 'present' && String(candidate) === '/tmp/prm-002a-git-lkg/.git') {
+        return
+      }
+      throw fileError('ENOENT')
+    })
+    const options = envOptions('/tmp/prm-002a-git-lkg')
+
+    expect((await buildSystemEnvPromptSnapshot(options)).prompt).toContain(
+      'Is directory a git repo: yes'
+    )
+
+    markerState = 'error'
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect((await buildSystemEnvPromptSnapshot(options)).prompt).toContain(
+      'Is directory a git repo: yes'
+    )
+    await settleRefresh()
+    expect((await buildSystemEnvPromptSnapshot(options)).prompt).toContain(
+      'Is directory a git repo: yes'
+    )
+
+    markerState = 'missing'
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect((await buildSystemEnvPromptSnapshot(options)).prompt).toContain(
+      'Is directory a git repo: yes'
+    )
+    await settleRefresh()
+    expect((await buildSystemEnvPromptSnapshot(options)).prompt).toContain(
+      'Is directory a git repo: no'
+    )
+  })
+
+  it('aborts one env waiter without cancelling the shared source read', async () => {
+    const read = deferred<string>()
+    vi.mocked(fs.promises.readFile).mockReturnValue(
+      read.promise as ReturnType<typeof fs.promises.readFile>
+    )
+    const options = envOptions('/tmp/prm-002a-env-abort')
+    const controller = new AbortController()
+    const deadlineAt = Date.now() + 200
+
+    const aborted = buildSystemEnvPromptSnapshot({
+      ...options,
+      signal: controller.signal,
+      deadlineAt
+    })
+    const surviving = buildSystemEnvPromptSnapshot({ ...options, deadlineAt })
+    controller.abort()
+
+    await expect(aborted).rejects.toMatchObject({ name: 'AbortError' })
+    read.resolve('Shared instructions.\n')
+    await expect(surviving).resolves.toMatchObject({
+      prompt: expect.stringContaining('Shared instructions.')
+    })
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps package last-known-good through parse failure and retries on its boundary', async () => {
+    vi.mocked(fs.promises.readFile)
+      .mockResolvedValueOnce('{"name":"DeepChat","scripts":{}}')
+      .mockResolvedValueOnce('{broken')
+      .mockResolvedValueOnce('{"name":"other","scripts":{"test":"vitest"}}')
+    const options = { workdir: '/tmp/prm-002a-package-parse' }
+
+    const initial = await buildVerificationPolicySnapshot(options)
+    expect(initial.prompt).toContain('In the DeepChat repository')
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect((await buildVerificationPolicySnapshot(options)).prompt).toBe(initial.prompt)
+    await settleRefresh()
+    expect((await buildVerificationPolicySnapshot(options)).prompt).toBe(initial.prompt)
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[VerificationPolicyPromptBuilder] Failed to read package.json',
+      expect.objectContaining({
+        code: 'INVALID_PACKAGE_JSON',
+        message: 'package.json contains invalid JSON'
+      })
+    )
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain('{broken')
+
+    await vi.advanceTimersByTimeAsync(29_999)
+    await buildVerificationPolicySnapshot(options)
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1)
+    expect((await buildVerificationPolicySnapshot(options)).prompt).toBe(initial.prompt)
+    await settleRefresh()
+    expect((await buildVerificationPolicySnapshot(options)).prompt).toContain('`test`')
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(3)
+  })
+
+  it('changes package revision only when the rendered verification policy changes', async () => {
+    vi.mocked(fs.promises.readFile)
+      .mockResolvedValueOnce('{"name":"other","scripts":{"test":"vitest"}}')
+      .mockResolvedValueOnce('{"name":"other","description":"no-op","scripts":{"test":"vitest"}}')
+      .mockResolvedValueOnce(
+        '{"name":"other","description":"changed","scripts":{"test":"vitest","lint":"oxlint"}}'
+      )
+    const options = { workdir: '/tmp/prm-002a-package-revision' }
+
+    const initial = await buildVerificationPolicySnapshot(options)
+    expect(initial.revision).toBe(createHash('sha256').update(initial.prompt, 'utf8').digest('hex'))
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await buildVerificationPolicySnapshot(options)
+    await settleRefresh()
+    const noOp = await buildVerificationPolicySnapshot(options)
+    expect(noOp.prompt).toBe(initial.prompt)
+    expect(noOp.revision).toBe(initial.revision)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await buildVerificationPolicySnapshot(options)
+    await settleRefresh()
+    const relevant = await buildVerificationPolicySnapshot(options)
+    expect(relevant.prompt).toContain('`test`, `lint`')
+    expect(relevant.revision).not.toBe(initial.revision)
+  })
+
+  it('treats package missing as a successful observation and preserves the string wrapper', async () => {
+    vi.mocked(fs.promises.readFile)
+      .mockRejectedValueOnce(fileError('ENOENT'))
+      .mockResolvedValueOnce('{"name":"DeepChat","scripts":{}}')
+      .mockRejectedValueOnce(fileError('ENOTDIR'))
+    const workdir = '/tmp/prm-002a-package-missing'
+
+    const missing = await buildVerificationPolicySnapshot({ workdir })
+    expect(missing.prompt).not.toContain('In the DeepChat repository')
+    expect(await buildVerificationPolicyPrompt(workdir)).toBe(missing.prompt)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await buildVerificationPolicySnapshot({ workdir })
+    await settleRefresh()
+    const present = await buildVerificationPolicySnapshot({ workdir })
+    expect(present.prompt).toContain('In the DeepChat repository')
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await buildVerificationPolicySnapshot({ workdir })
+    await settleRefresh()
+    const missingAgain = await buildVerificationPolicySnapshot({ workdir })
+    expect(missingAgain.prompt).toBe(missing.prompt)
+    expect(missingAgain.revision).toBe(missing.revision)
+  })
+
+  it('shares package pending reads and lets one waiter abort independently', async () => {
+    const read = deferred<string>()
+    vi.mocked(fs.promises.readFile).mockReturnValue(
+      read.promise as ReturnType<typeof fs.promises.readFile>
+    )
+    const workdir = '/tmp/prm-002a-package-abort'
+    const controller = new AbortController()
+    const deadlineAt = Date.now() + 200
+
+    const aborted = buildVerificationPolicySnapshot({
+      workdir,
+      signal: controller.signal,
+      deadlineAt
+    })
+    const surviving = buildVerificationPolicySnapshot({ workdir, deadlineAt })
+    controller.abort()
+
+    await expect(aborted).rejects.toMatchObject({ name: 'AbortError' })
+    read.resolve('{"name":"DeepChat","scripts":{}}')
+    await expect(surviving).resolves.toMatchObject({
+      prompt: expect.stringContaining('In the DeepChat repository')
+    })
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds parallel env and verification lookups by one absolute deadline', async () => {
+    const envRead = deferred<string>()
+    const packageRead = deferred<string>()
+    vi.mocked(fs.promises.readFile).mockImplementation((candidate) => {
+      return (String(candidate).endsWith('AGENTS.md') ? envRead.promise : packageRead.promise) as
+        | ReturnType<typeof fs.promises.readFile>
+        | never
+    })
+    const deadlineAt = Date.now() + 200
+
+    const snapshots = Promise.all([
+      buildSystemEnvPromptSnapshot({
+        ...envOptions('/tmp/prm-002a-shared-deadline'),
+        deadlineAt
+      }),
+      buildVerificationPolicySnapshot({
+        workdir: '/tmp/prm-002a-shared-deadline',
+        deadlineAt
+      })
+    ])
+
+    await vi.advanceTimersByTimeAsync(199)
+    let settled = false
+    void snapshots.then(() => {
+      settled = true
+    })
+    await settleRefresh()
+    expect(settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    const [env, verification] = await snapshots
+    expect(Date.now()).toBe(new Date('2026-07-10T00:00:00Z').getTime() + 200)
+    expect(env.prompt).not.toContain('Instructions from:')
+    expect(verification.prompt).not.toContain('In the DeepChat repository')
+
+    envRead.resolve('Late env.\n')
+    packageRead.resolve('{"name":"DeepChat","scripts":{}}')
+    await settleRefresh()
+    expect(
+      (await buildSystemEnvPromptSnapshot(envOptions('/tmp/prm-002a-shared-deadline'))).prompt
+    ).toContain('Late env.')
+    expect(
+      (
+        await buildVerificationPolicySnapshot({
+          workdir: '/tmp/prm-002a-shared-deadline'
+        })
+      ).prompt
+    ).toContain('In the DeepChat repository')
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not read package.json when workdir is absent or while a source entry is fresh', async () => {
+    const staticSnapshot = await buildVerificationPolicySnapshot({ workdir: null })
+    expect(staticSnapshot.prompt).toContain('## Verification Policy')
+    expect(fs.promises.readFile).not.toHaveBeenCalled()
+
+    vi.mocked(fs.promises.readFile).mockResolvedValue('{"scripts":{"test":"vitest"}}')
+    const options = { workdir: '/tmp/prm-002a-package-fresh' }
+    const first = await buildVerificationPolicySnapshot(options)
+    const second = await buildVerificationPolicySnapshot(options)
+    expect(second).toEqual(first)
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
@@ -98,6 +98,10 @@ vi.mock('@/lib/agentRuntime/systemEnvPromptBuilder', () => ({
   )
 }))
 
+vi.mock('@/lib/agentRuntime/verificationPolicyPromptBuilder', () => ({
+  buildVerificationPolicyPrompt: vi.fn(async () => '## Verification Policy')
+}))
+
 // Mock processStream to avoid timer/async complexity
 vi.mock('@/presenter/agentRuntimePresenter/process', () => ({
   processStream: vi.fn().mockResolvedValue({ status: 'completed' })
@@ -111,6 +115,7 @@ import {
   buildRuntimeCapabilitiesPrompt,
   buildSystemEnvPrompt
 } from '@/lib/agentRuntime/systemEnvPromptBuilder'
+import { buildVerificationPolicyPrompt } from '@/lib/agentRuntime/verificationPolicyPromptBuilder'
 
 function getPublishedPayloads(eventName: string): any[] {
   return (publishDeepchatEvent as ReturnType<typeof vi.fn>).mock.calls
@@ -2513,6 +2518,62 @@ describe('AgentRuntimePresenter', () => {
       const firstCallArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
       const secondCallArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[1][0]
       expect(firstCallArgs.messages[0].content).toBe(secondCallArgs.messages[0].content)
+    })
+
+    it('starts source lookups together under one 200ms deadline on a prompt cache miss', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-03-05T08:00:00.000Z'))
+      const startedAt = Date.now()
+      const envBuilder = buildSystemEnvPrompt as ReturnType<typeof vi.fn>
+      const verificationBuilder = buildVerificationPolicyPrompt as ReturnType<typeof vi.fn>
+      const envStarted = deferred<void>()
+      let envDeadlineAt: number | undefined
+      let verificationDeadlineAt: number | undefined
+
+      envBuilder.mockImplementationOnce(
+        async (options: { deadlineAt?: number }) =>
+          new Promise<string>((resolve) => {
+            envDeadlineAt = options.deadlineAt
+            envStarted.resolve()
+            setTimeout(
+              () => resolve('ENV_DEADLINE_FALLBACK'),
+              Math.max(0, (options.deadlineAt ?? Date.now()) - Date.now())
+            )
+          })
+      )
+      verificationBuilder.mockImplementationOnce(
+        async (_workdir: string | null, options: { deadlineAt?: number }) =>
+          new Promise<string>((resolve) => {
+            verificationDeadlineAt = options.deadlineAt
+            setTimeout(
+              () => resolve('## Verification Policy\nVERIFICATION_DEADLINE_FALLBACK'),
+              Math.max(0, (options.deadlineAt ?? Date.now()) - Date.now())
+            )
+          })
+      )
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      const processing = agent.processMessage('s1', 'First message')
+      await envStarted.promise
+
+      expect(verificationBuilder).toHaveBeenCalledTimes(1)
+      expect(envDeadlineAt).toBe(startedAt + 200)
+      expect(verificationDeadlineAt).toBe(envDeadlineAt)
+
+      let settled = false
+      void processing.then(() => {
+        settled = true
+      })
+      await vi.advanceTimersByTimeAsync(199)
+      expect(settled).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(1)
+      await processing
+      expect(Date.now()).toBe(startedAt + 200)
+
+      const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(callArgs.messages[0].content).toContain('ENV_DEADLINE_FALLBACK')
+      expect(callArgs.messages[0].content).toContain('VERIFICATION_DEADLINE_FALLBACK')
     })
 
     it('invalidates cached tools when the MCP client list changes', async () => {


### PR DESCRIPTION
## Scope

This PR delivers PRM-002A only: file-backed system prompt source snapshots.

- Add rendered SHA-256 revisions for the system environment and verification policy prompts.
- Replace repeated synchronous package reads with one asynchronous read/parse per refresh.
- Add shared pending work, last-known-good fallback, and a fixed 30-second retry window for AGENTS.md, repository-marker, and package.json sources.
- Preserve compatibility string builders and the existing composed prompt section order.
- Start the environment and verification lookups together on a production cache miss and share one absolute 200 ms deadline.

It intentionally does not add source revisions to the outer prompt cache, does not introduce the immutable skill epoch, and does not close P-07. Those are PRM-002B and PRM-002C.

## Why

The previous implementation mixed three undesirable behaviors:

1. AGENTS.md could complete after the caller timed out without a coherent rendered revision.
2. The verification policy read and parsed package.json synchronously on the pre-stream path.
3. Independent 200 ms waits could be paid serially in the production orchestration path.

This slice establishes source-owner contracts while keeping the outer cache behavior unchanged, which limits stability drift and keeps rollback local.

## Implementation

- Each source cache tracks shared pending work, last-known-good state, settlement time, and next retry time.
- Missing files are valid source observations; transient I/O and malformed JSON retain the previous last-known-good snapshot.
- Revisions hash the exact rendered UTF-8 prompt bytes, so source changes that do not affect output do not churn revisions.
- Late refresh results update the source cache but do not resume an already timed-out caller.
- AbortSignal and absolute deadlines bound only waiting; fresh last-known-good data returns immediately while refresh may continue in the background.
- AgentRuntimePresenter creates one deadline, launches both compatibility lookups synchronously, awaits them together, and preserves the previous output order.

## Impact

User-visible prompt text remains byte-compatible for the same inputs. Cold source reads are bounded by one shared 200 ms window instead of potentially two serial windows. Warm calls avoid repeated file reads and repository scans. Transient source failures no longer erase a valid prior prompt.

The new caches are process-local and keyed by resolved paths. They currently have no eviction policy. This is a non-blocking residual for unusually high workspace churn and should be included in future capacity observation.

## Automated validation

Independent verification completed:

- Focused tests: 195 passed.
- Full suite: 4,503 passed, 5 known baseline failures, 135 skipped.
- The five failures are unchanged: one debug mock-session test, one AgentSession integration test, and three SpotlightOverlay tests.
- typecheck, format check, i18n, lint, architecture growth guard, and diff check passed.
- Deterministic tests cover 199/200 ms shared deadlines, late settlement, AbortSignal, 29,999/30,000 ms retry boundaries, LKG behavior, package EIO/malformed/missing states, rendered revisions, shared pending work, and read/scan deduplication.

## Manual validation and gaps

No interactive smoke is required for this source-owner slice because deadline and late-result semantics are covered with deterministic deferred/fake-clock tests. The end-to-end prompt/tool coherence smoke remains mandatory for PRM-002C, after outer fingerprints and the immutable skill snapshot are wired.

The current automated suite does not measure unbounded path-cardinality over a very long-lived process. That residual is explicitly outside PRM-002A and does not affect correctness of the current source contract.

## Rollback

Revert both commits in this PR. Compatibility callers and the existing outer cache key remain intact, so rollback does not require data migration or a coordinated downgrade.
