### PR TITLE
docs(scheduler): define operation contract

### DIFF
--- a/docs/architecture/scheduler-operation-contract/plan.md
+++ b/docs/architecture/scheduler-operation-contract/plan.md
@@ -304,7 +304,7 @@ acceptance/rollback，再修改 guard；不能在 SCH-003 内替未来 owner 猜
 - 提前返回 null 会破坏旧 renderer。
 
 三种都不稳定。所以 003A 只作为 backend review commit；003B 集成 renderer 和全部 caller，二者通过后才创建
-一个 production PR。无 operation id 的 compatibility 是“副作用前立即 typed reject”，不是等待策略。
+一个 production PR。无 operation id 由 required Zod schema 在副作用前 generic reject，不是等待策略。
 
 ## Development slice SCH-003A：Session create operation backend
 
@@ -314,7 +314,8 @@ acceptance/rollback，再修改 guard；不能在 SCH-003 内替未来 owner 猜
 - `src/main/routes/sessions/sessionService.ts`、`src/main/routes/index.ts`；
 - `src/main/presenter/agentSessionPresenter/*`；
 - `src/main/presenter/sqlitePresenter/schemaCatalog.ts` 与 domain-specific table；
-- focused table/service/dispatcher/presenter tests。
+- focused table/service/dispatcher/presenter tests；
+- `test/renderer/api/createBridge.test.ts` 或 dedicated session-create boundary test：真实/等价 IPC serialization。
 
 明确不改 `src/shared/types/agent-interface.d.ts` 来承载 operation DTO。
 
@@ -329,21 +330,30 @@ stable error code、dismissed/created/updated timestamps；不保存 prompt、fi
 
 新增/修改 route：
 
-- `sessions.create`：需要 operation id，返回 operation envelope；
+- `sessions.create`：需要 operation id，返回 `kind: operation | existing | conflict` 的 Zod discriminated union；
 - `sessions.getCreateOperation`：按已知 id reconcile；
 - `sessions.listCreateOperations`：cursor pagination，`limit 1..50, default 20`，返回所有 content-free identity
   与 `dismissedAt`；
 - dismiss route：只写 `dismissedAt` 供 UI 折叠；history/fingerprint/retry guard 仍能查到，不删 session/identity。
 
-虽然 schema 可为 staged rollout 暂时 parse optional id，handler 必须在副作用前对 missing id 返回
-`OperationIdRequiredError`。present id 必须满足 UUID 且 length 36；production caller guard 必须为零，后续可把
-schema 收紧为 required。
+schema 直接 required，operation id 必须满足 UUID 且 length 36；missing/malformed 由 generic Zod validation
+在副作用前拒绝，production caller guard 必须为零。renderer 不按 validation Error 的 prototype/code 分支。
+
+create route 的 renderer 分支数据全部在正常 output：
+
+- `operation`：operation envelope + nullable session；
+- `existing`：stable code + old content-free operation identity/state，表示不同新 id 命中 unresolved fingerprint；
+- `conflict`：stable code + 原 operation identity/state，表示同 id 已属于不同 fingerprint。
+
+service 内部仍可用 typed error；route adapter 用 `instanceof` 或 stable internal code exhaustive mapping，禁止按
+message 分类。unexpected error 仍作为 generic IPC rejection。
 
 ### Backend 实施步骤
 
 1. schema validation 后 canonicalize input、计算 DB-only fingerprint、预分配 session id。
-2. 副作用前登记 operation：same id/same fingerprint single-flight；different fingerprint typed conflict；新
-   id 若命中同 fingerprint `pending/unknown`（含 dismissed），返回 existing operation typed error且零 mutation。
+2. 副作用前登记 operation：same id/same fingerprint single-flight；different fingerprint 返回 `conflict`
+   variant；新 id 若命中同 fingerprint `pending/unknown`（含 dismissed），返回 `existing` variant；两者都带
+   old checkable identity/state且零 mutation。
 3. 按 durable boundary 更新 `record_created`、`runtime_ready`、
    `input_not_required/input_accepted`、`completed`。
 4. initial-input stage 只 await 当前 production `queuePendingInput()` durable record；删除 unreachable
@@ -371,12 +381,20 @@ schema 收紧为 required。
 | one cleanup unknown | unknown，不自动 retry |
 | restart incomplete | pending -> unknown，不 replay payload |
 | invalid operation id | missing/empty/whitespace/non-UUID/overlength 全部 pre-effect reject |
+| create output union | operation/existing/conflict 都经 Zod parse；renderer 所需 id/state/code 只来自 output |
+| conflict/existing | 都返回可 Check 的 old identity；DB/runtime/input/event count = 0 |
 | invalid cursor/limit | Zod reject；DB query count = 0 |
 | history | cursor 全量覆盖同毫秒记录、content-free、dismissed 可查、hasMore 正确 |
 | dismiss | recovery UI 折叠；history/retry guard 可见；session/identity 不删除 |
 | unbound create | previous/null main binding 在 pending/success/late success 后完全不变 |
 | create notification | `created` 一次且无 active fields；不发布 `activated` |
 | schema ownership | agent-interface 无 operation DTO duplicate |
+
+IPC boundary test 使用真实 Electron invoke smoke，或等价的 fake `IpcRendererLike`：fake 的 main side 调 route
+adapter，把正常 output `structuredClone` 后交给真实 `createBridge()`/route Zod parse；throw path 则只重建
+`new Error(original.message)`，模拟 Electron 不保留 custom fields。必须断言三种 output variant 仍有完整
+id/state/code，并断言 renderer 没有读取 negative-control Error 上消失的字段。只测
+`dispatchDeepchatRoute(runtime, ...)` 同进程返回值不算覆盖此 gate。
 
 ### 003A 边界
 
@@ -401,8 +419,9 @@ atomic production PR。
 4. succeeded/current 才 upsert，显式 await `sessions.activate(sessionId)` exactly once，再 navigate/onboarding；
    succeeded/stale 只刷新 list，零 activate。
 5. failed/unknown 保留 draft，不自动 create retry；query transient error 也不换 operation id。
-6. create 返回 `ExistingCreateOperationError` 时显示“有一条未确认的相同创建”，提供显式 Check；不自动把当前
-   draft 绑定旧 operation，也不生成第三个 id 重试。该 error 即使指向 dismissed row 也同样处理。
+6. create 返回 `kind: 'existing'` 时显示“有一条未确认的相同创建”，提供显式 Check；不自动把当前 draft
+   绑定旧 operation，也不生成第三个 id 重试。dismissed row 同样处理。`kind: 'conflict'` 也只用 output 中的
+   old identity/state 显示冲突并允许 Check。
 7. app startup 调 cursor history：
    - 只显示 operation 时间/状态，不展示内容；
    - 连续翻页可找回所有 pending/unknown/dismissed identity；
@@ -449,7 +468,10 @@ Restart recovery
 | page leave | polling cleanup，main operation 不取消 |
 | transient reconcile error | 同 id 可重查，不创建新 operation |
 | failed/unknown | draft 保留；retry 先 reconcile；相同 unresolved fingerprint 不创建 |
-| existing operation error | 显示 content-free Check；不自动关联 draft、不再 create；dismissed row 同样拦截 |
+| existing output | 显示 content-free Check；不自动关联 draft、不再 create；dismissed row 同样拦截 |
+| conflict output | 显示 stable conflict copy并可 Check old operation；不读取 Error fields/message |
+| IPC serialization boundary | operation/existing/conflict 经 structured clone + preload/renderer parse 后字段完整 |
+| custom Error negative control | Electron-like rejection 只保留 message；renderer 行为不依赖丢失 code/id/state |
 | restart one/many/many pages | 都可 cursor 找回且需显式选择，不绑定当前 draft |
 | history data | UI/API 不出现 prompt/file/title/provider/fingerprint |
 | dismiss | open panel 折叠；history/duplicate guard 仍见；不删 session |
@@ -516,6 +538,8 @@ pnpm test
 12. 所有 numeric input 是否 finite/nonnegative/bounded validation？
 13. create backend 是否完全不 bind，stale/current activate count 是否分别为 0/1？
 14. 新 id + same unresolved fingerprint（含 dismissed）是否在副作用前返回 existing operation？
+15. renderer domain 分支是否只读 operation/existing/conflict output，而不是 Electron Error custom fields/message？
+16. serialization test 是否真的经过 createBridge/structured boundary，而不是只直调 dispatcher？
 
 ## 完成判定
 
@@ -530,7 +554,8 @@ pnpm test
 7. restart history content-free、cursor-complete、dismissed recoverable、explicit selection；
 8. create backend 不 bind；current/stale activate exactly 1/0，previous binding retained；
 9. 003A/B atomic cutover 完成，missing/malformed id caller count = 0；
-10. cancelGeneration exactly-once settlement 回归通过；
-11. renderer stale/unknown/draft/manual smoke 与 full suite 无新增失败。
+10. operation/existing/conflict 通过 IPC-equivalent serialization boundary；renderer 零 Error-field 分支；
+11. cancelGeneration exactly-once settlement 回归通过；
+12. renderer stale/unknown/draft/manual smoke 与 full suite 无新增失败。
 
 只完成 runner rename、只调大 timeout、只合 backend 或只做 UI，都不能关闭 finding。

--- a/docs/architecture/scheduler-operation-contract/plan.md
+++ b/docs/architecture/scheduler-operation-contract/plan.md
@@ -7,7 +7,7 @@
 1. 先做只服务真实 consumer 的 timing primitive；
 2. 再迁移已经能证明安全的 session/chat/catalog 路径；
 3. provider probe 暂时保留 5 秒遗留观察 deadline，并交给 provider owner 补真实 cancellation；
-4. 先给 initial input 建立“已接收、不是整轮生成完成”的边界；
+4. create 复用当前唯一 production runtime 的 durable pending-input queue，不预建 fallback API；
 5. session create backend 与 renderer 一起原子切换，任何 production caller 都不能落入无 id 的中间态；
 6. 最后清掉 legacy timeout，并用 restart、stale intent、cleanup uncertainty 测试收口。
 
@@ -29,11 +29,9 @@ SES-002 -> SCH-002B safe migration   PRV-CAN-001 provider owner cancellation
                             v
                     legacy timeout = create only
 
-SCH-003P initial-input acceptance
-        |
-        +-------------------- SES-003
-        |                       |
-        v                       v
+current durable queue inventory + SES-003
+                         |
+                         v
 SCH-003A backend commit -> SCH-003B renderer/integration commit
              \____________ atomic production PR ____________/
                               |
@@ -50,7 +48,7 @@ SCH-003A backend commit -> SCH-003B renderer/integration commit
 | --- | --- | --- |
 | `SES-002` session 四态与 binding 语义 | `SCH-002B` rebase 到它之后；restore/getActive 只消费 typed result | 不复制一套 null/error-string adapter，session migration 暂停 |
 | `SES-003` route/renderer compatibility | `SCH-003B` 显式依赖并复用它的 schema/client 结构 | 003A 可写成未合入 commit，但 003 atomic PR 不 merge |
-| initial-input acceptance | `SCH-003P` 必须在 journal stage 前完成 | 无 accepted handle 就不能写 `input_accepted/completed`，003 cutover 阻塞 |
+| initial-input acceptance | deepchat/acp 当前都 resolve 到 `agentRuntimeAgent.queuePendingInput()`；003A 直接 await durable record | static guard 若发现无 queue production owner，先停 003 并另写 owner spec |
 | provider cancellation | `PRV-CAN-001` 与 003 可并行，owner 能力完成后再删 route 5 秒 wrapper | SCH 不假称 owner timeout，保留精确 legacy exception |
 | `CHAT-001/002` generation owner | SCH 只处理 route observation 与 acceptance，不发明 generation settlement | cancel request semantics 保持不变 |
 
@@ -61,7 +59,6 @@ SES-002
   -> SCH-002A
   -> SCH-002B
   -> PRV-CAN-001 (can be parallel with the next prerequisites)
-  -> SCH-003P
   -> SES-003
   -> SCH-003A + SCH-003B atomic PR
 ```
@@ -78,7 +75,9 @@ SES-002
 - milliseconds：有限整数，`0..2_147_483_647`；
 - `maxAttempts`：有限正整数；当前 session contract 固定为 `2`；
 - `backoff`：有限非负，计算后的 delay 仍须是合法 milliseconds；
-- discovery `limit`：Zod 限制整数 `1..20`，默认 `10`；
+- history `limit`：Zod 限制整数 `1..50`，默认 `20`；cursor 的 `createdAt` 是 finite nonnegative integer，
+  `operationId` 复用 UUID/length schema；
+- create `operationId`：`z.string().uuid().length(36)`；empty、whitespace、non-UUID、超长全部 pre-effect reject；
 - `NaN`、`Infinity`、负数、小数毫秒和溢出全部 typed reject，task 调用次数必须为 `0`。
 
 这些值不从未验证的 IPC input 直接进入 runner。`2 attempts/25ms` 是 SES contract，不允许 caller 自由调参。
@@ -278,45 +277,21 @@ route 无法单方面取消 provider SDK request。只有 provider owner 能决�
 - model/no-model 都有 owner-level finite contract；
 - architecture guard 从两项 legacy consumer 降为 create 一项，或在 003 已合入时降为零。
 
-## Slice SCH-003P：Initial-input acceptance seam
+## Initial-input acceptance：不新增 slice
 
-### 目的
+代码 inventory 已经给出足够边界：`AgentSessionPresenter` 只注册 `agentRuntimeAgent` 为 `deepchat`；
+`resolveAgentImplementation()` 对 `deepchat/acp` 都返回它；该 runtime 的 `queuePendingInput()` 在 SQLite record
+创建后 resolve，再异步启动/排空 generation。
 
-让 create journal 能诚实区分“首条输入已被 owner 接收”与“整轮 generation 已结束”。
+因此 003A 只做三件事：
 
-### 代码真相
+1. 无首条输入写 `input_not_required`；
+2. 有输入时 await 现有 `queuePendingInput()`，再写 `input_accepted`，不等待 generation terminal；
+3. 删除 create 中 unreachable 的 `else processMessage()`，加 static guard 固定所有 production create owner
+   必须有 durable queue。
 
-- DeepChat `queuePendingInput()` 会创建 SQLite pending-input record，然后后台启动/排空 generation；await 它只等
-  queue acceptance，不等 generation，正好是需要的 seam。
-- fallback `processMessage()` 是完整 processing Promise。直接 await 会让 create 等整轮；fire-and-forget 又没有
-  accepted proof。
-
-### 实施步骤
-
-1. 在 agent/session owner 定义窄返回：`not_required` 或 content-free `acceptedHandle`。
-2. 无首条输入返回 `not_required`。
-3. DeepChat path await `queuePendingInput()` 的 durable record，再返回 accepted；generation 保持后台运行。
-4. fallback owner 提供 start/accepted API：只有 owner 已接管后 resolve，不能把 Promise 创建当 acceptance。
-5. 静态 inventory 证明每个 production agent path 都命中 queue 或 accepted-start；否则 003 merge gate
-   失败。
-6. 不改 generation terminal settlement、不改 cancelGeneration、不把 title generation 放进 acceptance。
-
-### Focused tests
-
-| Case | 必须证明 |
-| --- | --- |
-| no initial input | `not_required`，不启动 message |
-| DeepChat queue success | record durable 后 resolve，generation 可仍 deferred |
-| queue reject | acceptance reject，不能写 accepted stage |
-| fallback start | accepted handle 在 owner 接管后、generation settle 前 resolve |
-| fallback unsupported | typed failure，003 cutover gate失败，不伪造 accepted |
-| duplicate create intent | 同 operation 不重复 enqueue |
-
-### 影响与收益
-
-- create 不会为了“准确”而等待整轮 LLM generation；
-- journal completed 能代表 session/runtime/input 已被接收，而不是仅仅调用了一个 Promise；
-- fallback 的旧 fire-and-forget 模糊语义被隔离在 owner，不扩散到 operation framework。
+不新增 accepted-start API，不做 fallback smoke。未来新增无 queue agent 时，必须先独立说明 durable
+acceptance/rollback，再修改 guard；不能在 SCH-003 内替未来 owner 猜接口。
 
 ## Atomic delivery SCH-003A + SCH-003B
 
@@ -349,28 +324,38 @@ route 无法单方面取消 provider SDK request。只有 provider owner 能决�
 stable error code、dismissed/created/updated timestamps；不保存 prompt、files、title、agent/provider/model 或 payload
 副本。
 
+表增加两个窄索引：`(input_fingerprint, state)` 服务每次 create 的 unresolved duplicate guard，
+`(created_at, operation_id)` 服务 cursor history。没有这两个索引，history 增长后会把正确性检查退化为全表扫描。
+
 新增/修改 route：
 
 - `sessions.create`：需要 operation id，返回 operation envelope；
 - `sessions.getCreateOperation`：按已知 id reconcile；
-- `sessions.listIncompleteCreateOperations`：`limit 1..20, default 10`，只返回 content-free identity；
-- dismiss route：只写 `dismissedAt`，不删 session、不清 dedupe identity。
+- `sessions.listCreateOperations`：cursor pagination，`limit 1..50, default 20`，返回所有 content-free identity
+  与 `dismissedAt`；
+- dismiss route：只写 `dismissedAt` 供 UI 折叠；history/fingerprint/retry guard 仍能查到，不删 session/identity。
 
 虽然 schema 可为 staged rollout 暂时 parse optional id，handler 必须在副作用前对 missing id 返回
-`OperationIdRequiredError`。production caller guard 必须为零，后续可把 schema 收紧为 required。
+`OperationIdRequiredError`。present id 必须满足 UUID 且 length 36；production caller guard 必须为零，后续可把
+schema 收紧为 required。
 
 ### Backend 实施步骤
 
 1. schema validation 后 canonicalize input、计算 DB-only fingerprint、预分配 session id。
-2. 副作用前登记 operation；same id/same fingerprint single-flight；different fingerprint typed conflict。
+2. 副作用前登记 operation：same id/same fingerprint single-flight；different fingerprint typed conflict；新
+   id 若命中同 fingerprint `pending/unknown`（含 dismissed），返回 existing operation typed error且零 mutation。
 3. 按 durable boundary 更新 `record_created`、`runtime_ready`、
    `input_not_required/input_accepted`、`completed`。
-4. initial-input stage 只调用 `SCH-003P` seam；绝不 await whole generation。
+4. initial-input stage 只 await 当前 production `queuePendingInput()` durable record；删除 unreachable
+   `processMessage` fallback，绝不 await whole generation。
 5. 保留 `5_000ms` 作为 create 首次 observation deadline；到点返回 `pending`，不 abort、不写 failed。
 6. owner failure 收集所有 compensation outcome：全部 settle success 才 `failed`，任一不确定为 `unknown`。
 7. restart：succeeded + readable session 可重建；incomplete pending 转 unknown；不 replay payload。
-8. discovery 只返回未 dismiss 的 pending/unknown，按 `updatedAt DESC, operationId ASC`，同时给 `truncated`。
-9. succeeded row 随 session delete；failed/unknown 用 dismiss 隐藏但保留 dedupe evidence，不加 speculative TTL worker。
+8. history 按 immutable `(createdAt DESC, operationId ASC)` cursor 翻页，返回所有保留 row；state/update/dismiss
+   不改变分页位置，dismissed 只由 UI 折叠。
+9. create backend 不接收/使用 `webContentsId`，不 bind window。terminal success 后只发一次不带 active fields 的
+   `reason: 'created'` list notification；event 不进入 journal stage。
+10. succeeded row 随 session delete；failed/unknown 保留 dedupe/reconcile evidence，不加 speculative TTL worker。
 
 ### Backend tests
 
@@ -381,13 +366,16 @@ stable error code、dismissed/created/updated timestamps；不保存 prompt、fi
 | deferred record/runtime | deadline 返回 pending，late success 可 query |
 | duplicate pending/succeeded | create/runtime/input count = 1 |
 | same id/different input | conflict，旧 state 不变 |
+| new id/same unresolved fingerprint | 返回 existing id；含 dismissed row；create/runtime/input count = 0 |
 | cleanup all success | failed，record 不残留 |
 | one cleanup unknown | unknown，不自动 retry |
 | restart incomplete | pending -> unknown，不 replay payload |
-| missing operation id | typed finite error；所有 mutation count = 0 |
-| invalid limit | Zod reject；DB query count = 0 |
-| discovery | max 20、稳定排序、content-free、truncated 正确 |
-| dismiss | current list 隐藏；identity 保留；session 不删除 |
+| invalid operation id | missing/empty/whitespace/non-UUID/overlength 全部 pre-effect reject |
+| invalid cursor/limit | Zod reject；DB query count = 0 |
+| history | cursor 全量覆盖同毫秒记录、content-free、dismissed 可查、hasMore 正确 |
+| dismiss | recovery UI 折叠；history/retry guard 可见；session/identity 不删除 |
+| unbound create | previous/null main binding 在 pending/success/late success 后完全不变 |
+| create notification | `created` 一次且无 active fields；不发布 `activated` |
 | schema ownership | agent-interface 无 operation DTO duplicate |
 
 ### 003A 边界
@@ -400,8 +388,8 @@ stable error code、dismissed/created/updated timestamps；不保存 prompt、fi
 
 ### 显式依赖
 
-`SCH-003B depends on SCH-003A + SES-003 + SCH-003P`。它在集成 branch 上包含 003A backend commit，完成后
-只提交一个 atomic production PR。
+`SCH-003B depends on SCH-003A + SES-003`。它在集成 branch 上包含 003A backend commit，完成后只提交一个
+atomic production PR。
 
 ### Renderer 实施步骤
 
@@ -410,16 +398,20 @@ stable error code、dismissed/created/updated timestamps；不保存 prompt、fi
 2. store 保存 current intent token；draft 继续由原 draft owner 管理，不复制到 operation state/journal。
 3. pending 只在 current create page 生命周期内 polling：每 `2_000ms` 一次，最多自动查询 `15` 次；之后停
    timer 并保留手工 Check。页面离开停止观察，不取消 main operation。
-4. succeeded/current 才 upsert + activate/navigate + onboarding；succeeded/stale 只刷新 list。
+4. succeeded/current 才 upsert，显式 await `sessions.activate(sessionId)` exactly once，再 navigate/onboarding；
+   succeeded/stale 只刷新 list，零 activate。
 5. failed/unknown 保留 draft，不自动 create retry；query transient error 也不换 operation id。
-6. app startup 调 bounded discovery：
+6. create 返回 `ExistingCreateOperationError` 时显示“有一条未确认的相同创建”，提供显式 Check；不自动把当前
+   draft 绑定旧 operation，也不生成第三个 id 重试。该 error 即使指向 dismissed row 也同样处理。
+7. app startup 调 cursor history：
    - 只显示 operation 时间/状态，不展示内容；
+   - 连续翻页可找回所有 pending/unknown/dismissed identity；
    - 一条或多条都要求用户显式点 `Check`；
    - 不把 recovery item 关联当前 draft，不自动 activate/navigate；
-   - dismiss 只隐藏 record。
-7. i18n 增加 pending/unknown/discovery/dismiss/error copy，不暴露 internal error/fingerprint。
-8. 同一 atomic PR 更新所有 production caller；guard 证明 missing operation id caller = 0。
-9. 删除 create legacy timeout。若 `PRV-CAN-001` 已完成则删除整个 adapter；否则 adapter 只剩精确 provider
+   - dismiss 只折叠到 history，不影响 main duplicate/retry guard。
+8. i18n 增加 pending/unknown/history/dismiss/existing-operation/error copy，不暴露 internal error/fingerprint。
+9. 同一 atomic PR 更新所有 production caller；guard 证明 missing operation id caller = 0。
+10. 删除 create legacy timeout。若 `PRV-CAN-001` 已完成则删除整个 adapter；否则 adapter 只剩精确 provider
    项。
 
 ### UI 行为
@@ -436,8 +428,9 @@ Restart recovery
 | Unconfirmed creations                      |
 | 10:42  unknown                 [Check]      |
 | 10:39  unknown                 [Check]      |
-|                              [Dismiss]      |
+|                  [Dismiss] [Show history]   |
 +--------------------------------------------+
+| Dismissed identities remain in history.    |
 | Current draft is separate.                 |
 +--------------------------------------------+
 ```
@@ -450,25 +443,28 @@ Restart recovery
 | Case | 必须证明 |
 | --- | --- |
 | fast success | 原 create/navigation/onboarding 一致 |
-| pending -> success/current | draft 到 success 前保留，只导航一次 |
-| pending -> success/stale | 只刷新 list，不抢 route/active session |
+| pending -> success/current | draft 到 success 前保留；activate/bind/event/navigate 各一次 |
+| pending -> success/stale | 只刷新 list；activate count = 0；main previous binding retained |
+| current activate rejects | created session 留在 list；previous binding retained；不 navigate/onboarding，可显式重试 activate |
 | page leave | polling cleanup，main operation 不取消 |
 | transient reconcile error | 同 id 可重查，不创建新 operation |
-| failed/unknown | draft 保留，无 auto retry |
-| restart one/many | 都需显式选择，不绑定当前 draft |
-| discovery data | UI/API 不出现 prompt/file/title/provider/fingerprint |
-| dismiss | 只隐藏 identity，不删 session |
-| legacy missing id | typed finite error，mutation count 0 |
-| duplicate event + reconcile | upsert/activate/onboarding idempotent |
+| failed/unknown | draft 保留；retry 先 reconcile；相同 unresolved fingerprint 不创建 |
+| existing operation error | 显示 content-free Check；不自动关联 draft、不再 create；dismissed row 同样拦截 |
+| restart one/many/many pages | 都可 cursor 找回且需显式选择，不绑定当前 draft |
+| history data | UI/API 不出现 prompt/file/title/provider/fingerprint |
+| dismiss | open panel 折叠；history/duplicate guard 仍见；不删 session |
+| invalid operation id | missing/empty/whitespace/non-UUID/overlength 全部 mutation count 0 |
+| duplicate notification + reconcile | upsert idempotent；只有 current path 显式 activate 一次 |
 
 ### Manual smoke
 
-1. DeepChat 正常 create：首条输入只入队一次、session 激活、generation 可继续。
-2. ACP/fallback production path：accepted handle 在 generation completion 前返回；没有 seam 就阻止 merge。
+1. DeepChat 正常 create：首条输入只入队一次；create 本身不 bind，current renderer 显式 activate 后 generation
+   可继续。
+2. ACP create：确认实际仍走同一个 durable `queuePendingInput()`，不执行 `processMessage` fallback。
 3. 人为延迟 record/runtime/queue 超过 deadline：UI pending、不报失败、不丢 draft，late success 收敛。
-4. pending 后切换已有 session：late success 不抢页面。
+4. pending 后切换已有 session：late success 只刷新 list，原 main binding 不变。
 5. compensation 一项失败：unknown，无自动 duplicate create。
-6. pending 时重启：content-free discovery 出现，必须手选；当前 draft 不关联。
+6. pending 时重启：cursor history 可找回 open/dismissed identity，必须手选；当前 draft 不关联。
 7. 检查 log 和 journal：无 raw prompt/file/payload，log 无 fingerprint。
 
 ### 影响、收益、风险
@@ -477,7 +473,7 @@ Restart recovery
 | --- | --- | --- |
 | 用户认知 | 新增 pending/unknown/recovery 状态 | 不再“先失败、后冒出 session” |
 | Draft | cleanup 延后到 confirmed success | 慢请求/restart 不丢当前输入 |
-| 导航 | late success 检查 intent token | 不抢当前页面 |
+| Binding/导航 | create 不 bind；current intent 显式 activate | stale late success 不抢当前 main binding/页面 |
 | 数据 | 每个 create intent 一条 content-free journal | dedupe/reconcile 有 durable truth |
 | Privacy | recovery 不显示内容，journal 不复制 payload | restart 能找 id，但不扩大敏感数据副本 |
 | Compatibility | backend/renderer 必须同 PR | 没有无限 wait 或旧 5 秒半成品窗口 |
@@ -511,13 +507,15 @@ pnpm test
 3. restore/getActive 是否都保留 `2 attempts/25ms`，且 transient/deadline 不清 binding？
 4. 是否加入了没有真实 consumer 的 `runCancellable()`？
 5. provider model 60 秒/no-model path 是否被误称为 owner timeout？
-6. initial input accepted 是否误等整轮 generation，或在 fire-and-forget 时提前写 completed？
+6. initial input 是否只 await 当前 durable queue，是否误留 speculative fallback 或等待整轮 generation？
 7. cleanup uncertainty 是否误写 failed？
-8. restart recovery 是否复制/显示 payload，或自动绑定当前 draft？
+8. restart history 是否 cursor 全量覆盖 dismissed identity，或复制/显示 payload、自动绑定当前 draft？
 9. 003A 是否被错误当成可独立 merge？003B 是否明确依赖 003A + SES-003？
-10. missing operation id 是否在副作用前 finite reject？
+10. operation id missing/empty/malformed/overlength 是否在副作用前 finite reject？
 11. DTO 是否只由 sessions route schema inference 拥有？
 12. 所有 numeric input 是否 finite/nonnegative/bounded validation？
+13. create backend 是否完全不 bind，stale/current activate count 是否分别为 0/1？
+14. 新 id + same unresolved fingerprint（含 dismissed）是否在副作用前返回 existing operation？
 
 ## 完成判定
 
@@ -528,10 +526,11 @@ pnpm test
 3. restore/getActive 的 typed transient `2 attempts/25ms` 与 binding retention 全部通过；
 4. provider model/no-model 都有 owner-level finite cancellation/settlement，不能只剩 observation race；
 5. session create slow path 返回 pending/unknown 并可 reconcile；
-6. initial input accepted 不等待 generation terminal，也不提前伪造；
-7. restart discovery content-free、bounded、explicit selection；
-8. 003A/B atomic cutover 完成，missing id caller count = 0；
-9. cancelGeneration exactly-once settlement 回归通过；
-10. renderer stale/unknown/draft/manual smoke 与 full suite 无新增失败。
+6. initial input acceptance 只复用当前 durable queue，不等待 generation terminal、不保留 fallback；
+7. restart history content-free、cursor-complete、dismissed recoverable、explicit selection；
+8. create backend 不 bind；current/stale activate exactly 1/0，previous binding retained；
+9. 003A/B atomic cutover 完成，missing/malformed id caller count = 0；
+10. cancelGeneration exactly-once settlement 回归通过；
+11. renderer stale/unknown/draft/manual smoke 与 full suite 无新增失败。
 
 只完成 runner rename、只调大 timeout、只合 backend 或只做 UI，都不能关闭 finding。

--- a/docs/architecture/scheduler-operation-contract/plan.md
+++ b/docs/architecture/scheduler-operation-contract/plan.md
@@ -1,97 +1,155 @@
 # Scheduler Operation Contract Implementation Plan
 
-## 实施原则
+## 先说结论
 
-本计划不做 big-bang Scheduler rewrite。按“先修 timing primitive，再迁安全 consumer，最后给 create
-mutation 建 operation identity”推进。每个 sub-slice 独立 branch/PR、独立 develop/verify，前一片通过后
-后一片才开始。
+不能把所有 `Promise.race` 一次删掉，也不能先发布只有 backend 认识 operation id 的半成品。安全顺序是：
+
+1. 先做只服务真实 consumer 的 timing primitive；
+2. 再迁移已经能证明安全的 session/chat/catalog 路径；
+3. provider probe 暂时保留 5 秒遗留观察 deadline，并交给 provider owner 补真实 cancellation；
+4. 先给 initial input 建立“已接收、不是整轮生成完成”的边界；
+5. session create backend 与 renderer 一起原子切换，任何 production caller 都不能落入无 id 的中间态；
+6. 最后清掉 legacy timeout，并用 restart、stale intent、cleanup uncertainty 测试收口。
+
+这不是按代码文件排顺序，而是按“先获得什么证据，下一步才有资格做什么”排顺序。
+
+## 交付图
 
 ```text
-SCH-001 docs
-   |
-   v
-SCH-002A OperationRunner core
-   |
-   v
-SCH-002B safe consumer migration
-   |
-   v
-SCH-003A session create operation backend
-   |
-   v
-SCH-003B renderer reconciliation + legacy cleanup
+SCH-001 decision docs
+        |
+        v
+SCH-002A OperationRunner core --------+
+        |                              |
+        v                              v
+SES-002 -> SCH-002B safe migration   PRV-CAN-001 provider owner cancellation
+                  |                    |
+                  +---------+----------+
+                            |
+                            v
+                    legacy timeout = create only
+
+SCH-003P initial-input acceptance
+        |
+        +-------------------- SES-003
+        |                       |
+        v                       v
+SCH-003A backend commit -> SCH-003B renderer/integration commit
+             \____________ atomic production PR ____________/
+                              |
+                              v
+                    legacy timeout consumer = 0
 ```
 
-## 依赖与冲突安排
+`SCH-003A` 与 `SCH-003B` 是为了 review 清楚而拆的 development slices，不是两个可分别发布的版本。
+`SCH-003B depends on SCH-003A + SES-003`；最终只能以一个 atomic production PR merge。
 
-| 依赖/并行工作 | 安排 |
-| --- | --- |
-| `SES-002` 修改 `SessionService` / session resolution | `SCH-002A` 可并行；`SCH-002B` 的 session slice 必须基于已合入 `SES-002`，不能双边各自改同一语义 |
-| `SES-003` 修改 route/session renderer | `SCH-003B` 在其后 rebase，复用四态字段；不复制 compatibility adapter |
-| `CHAT-001/002` 决定 enqueue/generation owner | SCH 只移除 false mutation deadline、保留 cancel request semantics；generation handle 的增删由 `CHAT-*` 决定 |
-| `PRM-*` / fatal work | 无 contract 依赖；如共同修改 route root，只按 merge 顺序 rebase，不合并目标 |
+## 依赖、冲突与 merge 顺序
 
-推荐 merge 顺序：`SES-002` → `SCH-002A` → `SCH-002B` → `SES-003` → `SCH-003A` →
-`SCH-003B`。若 `SES-003` 尚未开始，`SCH-003A` 可先做 backend，但 renderer slice 仍需在最终 session route
-schema 上验证。
+| 依赖/并行工作 | 处理方式 | 不满足时怎么办 |
+| --- | --- | --- |
+| `SES-002` session 四态与 binding 语义 | `SCH-002B` rebase 到它之后；restore/getActive 只消费 typed result | 不复制一套 null/error-string adapter，session migration 暂停 |
+| `SES-003` route/renderer compatibility | `SCH-003B` 显式依赖并复用它的 schema/client 结构 | 003A 可写成未合入 commit，但 003 atomic PR 不 merge |
+| initial-input acceptance | `SCH-003P` 必须在 journal stage 前完成 | 无 accepted handle 就不能写 `input_accepted/completed`，003 cutover 阻塞 |
+| provider cancellation | `PRV-CAN-001` 与 003 可并行，owner 能力完成后再删 route 5 秒 wrapper | SCH 不假称 owner timeout，保留精确 legacy exception |
+| `CHAT-001/002` generation owner | SCH 只处理 route observation 与 acceptance，不发明 generation settlement | cancel request semantics 保持不变 |
+
+推荐 production merge 顺序：
+
+```text
+SES-002
+  -> SCH-002A
+  -> SCH-002B
+  -> PRV-CAN-001 (can be parallel with the next prerequisites)
+  -> SCH-003P
+  -> SES-003
+  -> SCH-003A + SCH-003B atomic PR
+```
+
+如果 `PRV-CAN-001` 较慢，003 atomic PR 可以先完成；但 A-04 仍保持 open，architecture guard 中只剩
+`providers.testConnection` 一项遗留 consumer，直到 provider owner slice 合入。
+
+## 全局实施规则
+
+### 数值先验证
+
+在任何 task/timer 启动前验证：
+
+- milliseconds：有限整数，`0..2_147_483_647`；
+- `maxAttempts`：有限正整数；当前 session contract 固定为 `2`；
+- `backoff`：有限非负，计算后的 delay 仍须是合法 milliseconds；
+- discovery `limit`：Zod 限制整数 `1..20`，默认 `10`；
+- `NaN`、`Infinity`、负数、小数毫秒和溢出全部 typed reject，task 调用次数必须为 `0`。
+
+这些值不从未验证的 IPC input 直接进入 runner。`2 attempts/25ms` 是 SES contract，不允许 caller 自由调参。
+
+### DTO 只有一个 owner
+
+session operation 的 input/output/status schema 只写在
+`src/shared/contracts/routes/sessions.routes.ts`，TypeScript 类型由 Zod/schema 或 route inference 得到。
+`src/shared/types/agent-interface.d.ts` 不增加 operation DTO；它不拥有 sessions route contract。
+
+### 每个 slice 的验证责任
+
+- develop 与 final verify 使用不同 agent；
+- blocking finding 回原 branch 修复，再从头 verify；
+- focused test 证明本 slice 的 contract，full suite 证明没有外围回归；
+- PR body 记录 before/after truth、影响、收益、manual gap、回滚；
+- 不用“调用了 abort”“等了更久”“测试 happy path 通过”替代 physical settlement 证据。
 
 ## Slice SCH-002A：OperationRunner core
 
-### 目标
+### 目的
 
-只改 timing primitive 和 focused tests，不动 domain behavior。建立可证明的 runner contract，并保留一个
-最小 compatibility adapter 让 consumer migration 能分 PR 完成。
+把当前 `Scheduler` 收窄成真实能力：observation deadline、abortable sleep、settled-only retry。当前没有真实
+signal owner consumer，所以本片不实现 `runCancellable()`。
 
 ### 影响文件
 
-- `src/main/routes/scheduler.ts`：重命名/收窄为 `operationRunner.ts`，实现新 API。
-- `src/main/routes/index.ts`：composition root 改用 `createNodeOperationRunner()`。
-- `test/main/routes/scheduler.test.ts`：迁移为 capability contract tests。
-- architecture guard/baseline（仅当 rename 触发 tracked path）。
+- `src/main/routes/scheduler.ts`：迁移/重命名为 `operationRunner.ts`；
+- `src/main/routes/index.ts`：composition root；
+- `test/main/routes/operationRunner.test.ts`；
+- 必要的 architecture guard/baseline。
 
-### 实现步骤
+### 实施步骤
 
-1. 定义 typed errors：
-   - `ObservationDeadlineError`：只说明 observer deadline；
-   - `TimeoutError`：仅供 cooperative cancellable attempt abort 后 settle；
-   - `AbortError`：external abort 且 cancellable attempt settle；
-   - 普通 owner error 保留 `cause`，不靠 message 分类。
-2. `observeIdempotent()`：
-   - listener/timer 先于 task factory；
-   - late resolve/reject 都有 drain handler；
-   - deadline/abort 后不会执行任何 callback/retry。
-3. `runCancellable()`：
-   - runner 创建内部 controller；
-   - external signal/deadline 只发一次 abort；
-   - await task settlement 后再映射 timeout/abort；
-   - task 在 abort 后 fulfilled 时也不得把 value 返回 caller。
-4. `retryIdempotent()`：
-   - 单 while loop，attempt 必须 settle 后才 backoff；
-   - `shouldRetry` 默认由 caller 显式传入；
-   - overall deadline/abort 关闭 loop；running attempt late settle 后不得启动下一轮；
-   - backoff 使用 runner `sleep()` 并响应 loop closure。
-5. 暂保留 legacy `timeout()` adapter，但加清晰 deprecated 注释；不改其语义，不让新代码使用。
-6. 不引入 `p-retry`，不新增 queue/registry。
+1. 定义 `ObservationDeadlineError`，名字明确表示 caller 停止观察，不表示 operation 失败。
+2. 实现 `observeIdempotent()`：先装 listener/timer，再调用 task factory；late resolve/reject 全部 drain。
+3. 实现 `retryIdempotent()`：
+   - 只有已 settle rejection 且 `shouldRetry` 为 true 才 backoff；
+   - running attempt 或 backoff 中 overall deadline 到达后，不再启动新 attempt；
+   - `maxConcurrentAttempts` 永远为 1；
+   - classifier 不按 error message substring。
+4. 实现 abortable `sleep()`，并按全局规则验证所有数值。
+5. 暂留 deprecated legacy `timeout(task: Promise)` adapter，供 consumer 分片迁移；新代码禁止使用。
+6. 不导出、不测试 `runCancellable()`。future owner-specific slice 必须同时提交真实 signal propagation 与
+   settlement proof，不能先放一个 unused port method。
 
-### Focused test matrix
+### Focused tests
 
-| Case | 断言 |
+| Case | 必须证明 |
 | --- | --- |
-| task factory sync throw | timer/listener cleanup；原 error 返回 |
-| signal pre-aborted | task factory 不调用 |
-| idempotent observation deadline | caller 得 `ObservationDeadlineError`；late resolve drained |
-| late reject after observation deadline | 无 unhandled rejection；无 retry |
-| cancellable deadline | task 收到 aborted signal；task settle 前 runner 不 settle |
-| cancellable task resolves after abort | caller 仍得 `TimeoutError`，不返回 stale value |
-| external abort | settle 后 `AbortError`；deadline timer 清理 |
-| immediate transient reject then success | 顺序两次，结果 success |
-| first attempt deferred | second attempt 调用次数为 0，直到 first reject |
-| deadline while attempt deferred | caller 结束；first late reject 后 second 仍为 0 |
+| task factory sync throw | 原 error 返回，timer/listener cleanup |
+| pre-aborted signal | task factory 不调用 |
+| observation deadline | 返回 `ObservationDeadlineError`，late result 不写 caller state |
+| late rejection | 无 unhandled rejection，不触发 retry |
+| first attempt deferred | first settle 前 second count = 0 |
+| deferred 超过 overall deadline | caller 结束观察；late settle 后 second 仍为 0 |
 | deadline during backoff | 下一 attempt 永不启动 |
-| retry classifier false | 只调用一次，原 error 返回 |
-| max attempts/backoff | 尝试次数和 delay 序列准确，`maxConcurrentAttempts=1` |
+| classifier false | 原 error 返回，只调用一次 |
+| immediate transient then success | 串行两次，结果 success，最大并发 1 |
+| invalid number matrix | task/timer 都不启动，typed validation error |
 
-### 自动验证
+### 影响、收益、风险
+
+| 维度 | 影响 | 收益/控制 |
+| --- | --- | --- |
+| API | rename 会触及 composition/fake types | 名字不再暗示 queue/Cron owner |
+| 行为 | production consumer 暂由 legacy adapter 保持 | core PR 可独立验证，不混入 domain 变化 |
+| 性能 | 少量 timer/listener 管理 | 主要收益是消除 overlap，不宣称吞吐提升 |
+| 风险 | late Promise、fake timer cleanup 容易漏 | deferred/late rejection/listener tests 阻断 |
+
+### 验证与回滚
 
 ```bash
 pnpm exec vitest run test/main/routes/operationRunner.test.ts
@@ -101,86 +159,84 @@ pnpm run lint:architecture
 pnpm run lint
 ```
 
-### 影响与收益
-
-- 收益：以后看到 `TimeoutError` 可以知道 cooperative attempt 已 settle；retry overlap 有 unit proof。
-- 影响：core API rename 会触及 fake runner type，但不改变 production route behavior。
-- 风险：假 timer/abort listener 泄漏；用 listener count、late rejection 和 fake timer test 阻断。
-- 回滚：单独 revert SCH-002A；legacy adapter 仍支持旧 consumer。
+本片可单独 revert；legacy adapter 仍保留旧 production 行为。
 
 ## Slice SCH-002B：安全 consumer 迁移
 
-### 目标
+### 目的
 
-把能独立判断的 read/sync/probe/chat wrapper 从 legacy timeout 迁出，只留下 `sessions.create` 一个
-allowlisted legacy consumer，交给 SCH-003。
+只迁已有证据支持的 read/sync/chat wrapper。provider probe 不在本片冒险移除 route 5 秒 wrapper。
 
-### 影响文件
+### Session：restore 与 getActive 必须同样保守
 
-- `src/main/routes/sessions/sessionService.ts`
-- `src/main/routes/chat/chatService.ts`
-- `src/main/routes/providers/providerService.ts`
-- `src/main/routes/hotPathPorts.ts`（只在 task factory/signal type 真需要时改）
-- 对应 route service tests、dispatcher integration tests
-- `scripts/architecture-guard.mjs` 或 focused static test：冻结 legacy `timeout(` consumer allowlist
+`SCH-002B` 必须基于 `SES-002` typed availability contract：
 
-### Session migration
+- `restoreSession` 与 `getActiveSession` 都保留最多 `2 attempts`、间隔 `25ms`；
+- 只有前一 attempt 已 settle 为 typed `transient_error` 才启动第二次；
+- `missing`、`unavailable`、validation error、observation deadline 均不 retry；
+- attempt、backoff、deadline、late settlement 期间都不清 binding；
+- `getActive` 只有 SES-002 权威 `missing` terminal result 才能 unbind；
+- `listMessagesPage/listSessions` 使用 idempotent observation，不做 per-row retry；
+- `activate/deactivate` 已同步完成副作用，直接调用，删除无效 timeout，不 retry。
 
-1. 基于 `SES-002` 的 typed availability result 工作，不回退到 null/error-string 分类。
-2. `restoreSession()` 使用 `retryIdempotent`：
-   - overall deadline 5 秒；
-   - immediate typed `transient_error` rejection 可在 25ms 后 retry；
-   - attempt 未 settle、missing、unavailable、validation error、deadline 均不 retry；
-   - attempt late settle 后只 drain，不写 binding。
-3. `listMessagesPage/listSessions/getActive` 使用 `observeIdempotent`；list 不做 per-row retry。
-4. `activate/deactivate` 删除 timeout wrapper，直接调用现有 owner；不增加 retry。
-5. `createSession` 暂时保留 legacy adapter，static allowlist 精确到这一处。
+### Provider：只删已证明无效的 sync wrapper
 
-### Provider migration
+- `listModels()` 两个 getter 在 `Promise.resolve` 前同步执行，改为直接调用；
+- `testConnection()` 暂时保持现状并进入精确 allowlist，绝不 automatic retry；
+- 文档和 test 固定真实语义：
+  - 有 `modelId`：provider completion 与 60 秒 `null` race；60 秒只是 observation，request 可能继续；
+  - 无 `modelId`：直接 `provider.check()`，presenter 没有统一 deadline/cancellation；
+  - 外层 route 5 秒同样只停止等待。
+- 不能写“等待 provider 自有 timeout”，因为代码没有统一保证。
 
-1. `listModels()` 直接调用同步 catalog getter；保留原 output shape。
-2. `testConnection()` 删除 route-level 5 秒 `Promise.race`，等待 provider owner 的真实 check/model timeout。
-3. 不自动 retry provider probe；连续点击治理若有真实问题另立 owner task，不在 Scheduler 猜 cooldown。
-4. test 覆盖 deferred provider check：5 秒时 route 不产生 false `TimeoutError`；最终 owner result 原样返回。
+### Chat
 
-### Chat migration
-
-1. session/agent/message lookup 使用 `observeIdempotent`；route controller abort 后不得继续进入下一 mutation。
-2. `sendMessage/steerActiveTurn/respondToolInteraction` 不再套 observation deadline；等待 domain owner 返回
-   acceptance/result。
-3. send 的 30 分钟 constant 和“generation timeout”假语义删除；不在本片决定 active controller 最终名称。
-4. `stopStream` 保留两项 cleanup 都尝试的 `Promise.allSettled`，但不再用 5 秒 race 宣称 cleanup 已结束。
-5. `cancelGeneration()` 仍只表示 request accepted；现有 AgentRuntime exactly-once settlement tests 必须通过。
+- session/agent/message preflight read 用 `observeIdempotent`，route stop 后不再进入下一 mutation；
+- `sendMessage/steerActiveTurn/respondToolInteraction` 删除 non-cancellable mutation 外层 deadline，等待现有 owner
+  acceptance/result；
+- 删除把 30 分钟常量描述为 generation timeout 的语义；
+- `stopStream` 保持 both-cleanups-attempted；`cancelGeneration()` 仍只表示 request accepted；
+- AgentRuntime exactly-once terminal settlement tests 必须保持通过。
 
 ### Legacy allowlist
 
-SCH-002B 结束后必须满足：
+本片结束时不是“一项”，而是以下两项：
 
 ```text
-legacy OperationRunner.timeout consumer count = 1
-allowed path = SessionService.createSession only
+SessionService.createSession
+ProviderService.testConnection
 ```
 
-guard 只冻结生产 consumer，不阻止 test fixture import compatibility adapter。SCH-003B 删除最后 consumer
-和 adapter。
+guard 精确到 method/path，任何新增 consumer 都 blocking。create 由 003 atomic cutover 删除；provider 由
+`PRV-CAN-001` 删除。
 
-### Focused test matrix
+### Focused tests
 
-| Consumer | Failure/late case |
+| Consumer | 必须证明 |
 | --- | --- |
-| restore immediate transient | attempt 1 settle reject，25ms 后 attempt 2；最大并发 1 |
-| restore deferred past deadline | caller deadline；late settle；attempt 2 永不启动 |
-| restore missing/unavailable | 不 retry，不清错误 binding |
-| list/getActive deadline | late read 不更新 route result；binding 遵守 `SES-*` |
-| activate/deactivate | effect/event exactly once；无 runner 调用 |
-| listModels | 两个 sync getter exactly once；无 timer/runner |
-| provider check >5s | 不在 5 秒返回 false failure；最终 result 返回 |
-| chat stop during preflight | mutation 不启动；cancel request/permission cleanup 各一次 |
-| chat send acceptance | 无 30min runner；pending input 不重复 |
-| stop cleanup one side rejects | 两边都执行；request result contract 不变 |
-| runtime cancellation | single `user_stop` hook；stale run 不覆盖 newer run |
+| restore transient | settle reject -> 25ms -> attempt 2，最大并发 1 |
+| getActive transient | 同上；两次 attempt 全程 binding retained |
+| restore/getActive deferred | deadline 后无 second attempt，binding retained |
+| restore/getActive missing | 仅 SES-002 权威 missing 走对应 missing/unbind 行为 |
+| unavailable/validation | 不 retry，不清 binding |
+| list/page | late result drained，不做 per-row retry |
+| activate/deactivate | effect/event exactly once，无 runner |
+| listModels | getter exactly once，无 timer/runner |
+| provider model/no-model | 固定当前两类 timeout truth，不声称 cancellation、不 retry |
+| chat stop during preflight | mutation 不启动；cleanup request 各一次 |
+| runtime cancellation | single terminal hook，stale run 不覆盖 newer run |
 
-### 自动验证
+### 影响、收益、风险
+
+| 维度 | 影响 | 收益/控制 |
+| --- | --- | --- |
+| Session | transient read 仍可能做第二次 | 不 overlap；短暂读故障恢复策略保留 |
+| Binding | transient/deadline 不再被误作 missing | 避免 active session 被错误解绑 |
+| Provider catalog | 删除无意义 Promise/timer | 路径更直接，性能收益小但确定 |
+| Provider probe | 暂留 false observation deadline | 不把无界 no-model probe 直接暴露成永久 hang；风险被显式登记 |
+| Chat | 真 owner hang 不再被假 deadline 遮住 | 不再向 UI 报“失败”但 mutation 继续 |
+
+### 验证与回滚
 
 ```bash
 pnpm exec vitest run \
@@ -197,275 +253,285 @@ pnpm run lint
 pnpm test
 ```
 
-full suite 与 repository baseline 对比；不得把历史失败计入本片回归。
+可按 session/chat/catalog consumer 小 commit revert；provider probe 本片本来不改行为。
+
+## Dependent slice PRV-CAN-001：Provider owner cancellation
+
+### 为什么另立 slice
+
+route 无法单方面取消 provider SDK request。只有 provider owner 能决定哪些 SDK 接受 signal、哪些 adapter 需要
+显式 teardown、什么状态才算 settle。把这件事塞进 generic runner 会再次制造假 cancellation。
+
+### 工作内容
+
+1. 逐 provider 枚举 `check()`：local-only、network、SDK/model completion；记录各自 signal/timeout 能力。
+2. 让 `ProviderExecutionPort.testConnection` 和 `LLMProviderPresenter.check` 接收 owner-owned cancellation input。
+3. 有 `modelId` 的 60 秒 observation race 改为真实 owner deadline：发送 cancel，并等 physical attempt settle。
+4. 无 `modelId` 的 provider-specific check 要么传播 signal 并有 finite deadline，要么明确返回
+   unsupported，不能无界。
+5. 所有 adapter 完成后才删除 route 5 秒 legacy wrapper；仍不 automatic retry，因为 probe 可能消耗 quota。
+6. 如果此时出现真实 `runCancellable` consumer，再在这个 slice 提出最窄 API；settlement tests 与 consumer 同 PR。
+
+### 收益与 gate
+
+- UI timeout 后不再有 provider request 在后台继续；
+- model/no-model 都有 owner-level finite contract；
+- architecture guard 从两项 legacy consumer 降为 create 一项，或在 003 已合入时降为零。
+
+## Slice SCH-003P：Initial-input acceptance seam
+
+### 目的
+
+让 create journal 能诚实区分“首条输入已被 owner 接收”与“整轮 generation 已结束”。
+
+### 代码真相
+
+- DeepChat `queuePendingInput()` 会创建 SQLite pending-input record，然后后台启动/排空 generation；await 它只等
+  queue acceptance，不等 generation，正好是需要的 seam。
+- fallback `processMessage()` 是完整 processing Promise。直接 await 会让 create 等整轮；fire-and-forget 又没有
+  accepted proof。
+
+### 实施步骤
+
+1. 在 agent/session owner 定义窄返回：`not_required` 或 content-free `acceptedHandle`。
+2. 无首条输入返回 `not_required`。
+3. DeepChat path await `queuePendingInput()` 的 durable record，再返回 accepted；generation 保持后台运行。
+4. fallback owner 提供 start/accepted API：只有 owner 已接管后 resolve，不能把 Promise 创建当 acceptance。
+5. 静态 inventory 证明每个 production agent path 都命中 queue 或 accepted-start；否则 003 merge gate
+   失败。
+6. 不改 generation terminal settlement、不改 cancelGeneration、不把 title generation 放进 acceptance。
+
+### Focused tests
+
+| Case | 必须证明 |
+| --- | --- |
+| no initial input | `not_required`，不启动 message |
+| DeepChat queue success | record durable 后 resolve，generation 可仍 deferred |
+| queue reject | acceptance reject，不能写 accepted stage |
+| fallback start | accepted handle 在 owner 接管后、generation settle 前 resolve |
+| fallback unsupported | typed failure，003 cutover gate失败，不伪造 accepted |
+| duplicate create intent | 同 operation 不重复 enqueue |
 
 ### 影响与收益
 
-| 维度 | 影响 | 收益 |
-| --- | --- | --- |
-| 正确性 | restore timeout 不再自动起第二个 overlapping read | 消除同一 retry loop 的并发 attempt |
-| UX | provider check 可能等待 owner 的真实 timeout，而不是 5 秒假失败 | 不再“界面失败但 provider 仍扣费/运行” |
-| 性能 | 删除 sync getter 的 timer/race；差异很小 | 更少无意义 Promise/timer，主要收益是语义清晰 |
-| Chat | 删除 mutation 外层 deadline；pathological owner hang 不再被假 timeout 遮住 | 不会把仍在运行的 mutation说成失败；真实 hang 会暴露给 owner |
-| 兼容 | session create 暂留旧 adapter | PR 可独立合入，create 行为由下一片处理 |
+- create 不会为了“准确”而等待整轮 LLM generation；
+- journal completed 能代表 session/runtime/input 已被接收，而不是仅仅调用了一个 Promise；
+- fallback 的旧 fire-and-forget 模糊语义被隔离在 owner，不扩散到 operation framework。
 
-### 回滚
+## Atomic delivery SCH-003A + SCH-003B
 
-- 可整体 revert SCH-002B，SCH-002A runner core 仍可保留。
-- 不做 schema migration；回滚无数据转换。
-- 若某 consumer manual smoke 发现 owner 无内部 timeout，单独回滚该 consumer，不恢复 automatic retry。
+### 为什么必须原子交付
 
-## Slice SCH-003A：Session create operation backend
+旧 output 不能表达 `pending`，旧 caller 又没有 operation id。若先 merge backend：
 
-### 目标
+- 无限 compatibility wait 会把 hang 暴露给用户；
+- 继续旧 5 秒 timeout 会保留 unknown-outcome；
+- 提前返回 null 会破坏旧 renderer。
 
-让慢 create 返回可查询的 `pending`，让 late success/cleanup uncertainty 有 operation truth；本片只做
-main/shared contract 和 backend，不改最终 UI。
+三种都不稳定。所以 003A 只作为 backend review commit；003B 集成 renderer 和全部 caller，二者通过后才创建
+一个 production PR。无 operation id 的 compatibility 是“副作用前立即 typed reject”，不是等待策略。
+
+## Development slice SCH-003A：Session create operation backend
 
 ### 影响文件
 
-- `src/shared/contracts/routes/sessions.routes.ts`
-- `src/shared/types/agent-interface.d.ts`（只放 shared operation DTO，避免 main type 泄漏）
-- `src/main/routes/sessions/sessionService.ts`
-- `src/main/routes/index.ts`
-- `src/main/presenter/agentSessionPresenter/index.ts`
-- `src/main/presenter/agentSessionPresenter/sessionManager.ts`
-- `src/main/presenter/sqlitePresenter/schemaCatalog.ts`
-- 新 domain-specific table，例如
-  `src/main/presenter/sqlitePresenter/tables/sessionCreateOperations.ts`
-- focused table/service/dispatcher tests
+- `src/shared/contracts/routes/sessions.routes.ts`：唯一 DTO/schema owner；
+- `src/main/routes/sessions/sessionService.ts`、`src/main/routes/index.ts`；
+- `src/main/presenter/agentSessionPresenter/*`；
+- `src/main/presenter/sqlitePresenter/schemaCatalog.ts` 与 domain-specific table；
+- focused table/service/dispatcher/presenter tests。
 
-### 数据与 owner
+明确不改 `src/shared/types/agent-interface.d.ts` 来承载 operation DTO。
+
+### 数据与 route
+
+只新增 domain-specific `session_create_operations`。最小数据为 operation/session id、fingerprint、state、stage、
+stable error code、dismissed/created/updated timestamps；不保存 prompt、files、title、agent/provider/model 或 payload
+副本。
+
+新增/修改 route：
+
+- `sessions.create`：需要 operation id，返回 operation envelope；
+- `sessions.getCreateOperation`：按已知 id reconcile；
+- `sessions.listIncompleteCreateOperations`：`limit 1..20, default 10`，只返回 content-free identity；
+- dismiss route：只写 `dismissedAt`，不删 session、不清 dedupe identity。
+
+虽然 schema 可为 staged rollout 暂时 parse optional id，handler 必须在副作用前对 missing id 返回
+`OperationIdRequiredError`。production caller guard 必须为零，后续可把 schema 收紧为 required。
+
+### Backend 实施步骤
+
+1. schema validation 后 canonicalize input、计算 DB-only fingerprint、预分配 session id。
+2. 副作用前登记 operation；same id/same fingerprint single-flight；different fingerprint typed conflict。
+3. 按 durable boundary 更新 `record_created`、`runtime_ready`、
+   `input_not_required/input_accepted`、`completed`。
+4. initial-input stage 只调用 `SCH-003P` seam；绝不 await whole generation。
+5. 保留 `5_000ms` 作为 create 首次 observation deadline；到点返回 `pending`，不 abort、不写 failed。
+6. owner failure 收集所有 compensation outcome：全部 settle success 才 `failed`，任一不确定为 `unknown`。
+7. restart：succeeded + readable session 可重建；incomplete pending 转 unknown；不 replay payload。
+8. discovery 只返回未 dismiss 的 pending/unknown，按 `updatedAt DESC, operationId ASC`，同时给 `truncated`。
+9. succeeded row 随 session delete；failed/unknown 用 dismiss 隐藏但保留 dedupe evidence，不加 speculative TTL worker。
+
+### Backend tests
+
+| Case | 必须证明 |
+| --- | --- |
+| fast/no-input create | succeeded，stage completed |
+| input queue deferred | 未 accepted 前不 completed；不等待 generation terminal |
+| deferred record/runtime | deadline 返回 pending，late success 可 query |
+| duplicate pending/succeeded | create/runtime/input count = 1 |
+| same id/different input | conflict，旧 state 不变 |
+| cleanup all success | failed，record 不残留 |
+| one cleanup unknown | unknown，不自动 retry |
+| restart incomplete | pending -> unknown，不 replay payload |
+| missing operation id | typed finite error；所有 mutation count = 0 |
+| invalid limit | Zod reject；DB query count = 0 |
+| discovery | max 20、稳定排序、content-free、truncated 正确 |
+| dismiss | current list 隐藏；identity 保留；session 不删除 |
+| schema ownership | agent-interface 无 operation DTO duplicate |
+
+### 003A 边界
+
+- 独立 backend verifier 可以审核 DB truth、single-flight、compensation 和 data hygiene；
+- commit 不得单独 merge/base deploy；
+- rollback 以整个 003 atomic PR 为单位，不能承诺旧 renderer 能消费 003A output。
+
+## Integration slice SCH-003B：Renderer、restart recovery 与 cutover
+
+### 显式依赖
+
+`SCH-003B depends on SCH-003A + SES-003 + SCH-003P`。它在集成 branch 上包含 003A backend commit，完成后
+只提交一个 atomic production PR。
+
+### Renderer 实施步骤
+
+1. `SessionClient.create()` 每个新 intent 用 `crypto.randomUUID()` 生成 id；transport retry 复用，同一次用户
+   explicit retry 才生成新 id。
+2. store 保存 current intent token；draft 继续由原 draft owner 管理，不复制到 operation state/journal。
+3. pending 只在 current create page 生命周期内 polling：每 `2_000ms` 一次，最多自动查询 `15` 次；之后停
+   timer 并保留手工 Check。页面离开停止观察，不取消 main operation。
+4. succeeded/current 才 upsert + activate/navigate + onboarding；succeeded/stale 只刷新 list。
+5. failed/unknown 保留 draft，不自动 create retry；query transient error 也不换 operation id。
+6. app startup 调 bounded discovery：
+   - 只显示 operation 时间/状态，不展示内容；
+   - 一条或多条都要求用户显式点 `Check`；
+   - 不把 recovery item 关联当前 draft，不自动 activate/navigate；
+   - dismiss 只隐藏 record。
+7. i18n 增加 pending/unknown/discovery/dismiss/error copy，不暴露 internal error/fingerprint。
+8. 同一 atomic PR 更新所有 production caller；guard 证明 missing operation id caller = 0。
+9. 删除 create legacy timeout。若 `PRV-CAN-001` 已完成则删除整个 adapter；否则 adapter 只剩精确 provider
+   项。
+
+### UI 行为
 
 ```text
-renderer operationId
-  -> SessionService (single-flight + observation deadline)
-      -> SessionCreateOperationsTable (durable identity/stage)
-      -> AgentSessionPresenter (actual mutation/compensation)
-      -> NewSessionManager/new_sessions (authoritative session record)
+Current slow intent
++---------------- New Thread ----------------+
+| Creating session...                        |
+| Draft remains here while result is checked.|
++--------------------------------------------+
+
+Restart recovery
++---------------- New Thread ----------------+
+| Unconfirmed creations                      |
+| 10:42  unknown                 [Check]      |
+| 10:39  unknown                 [Check]      |
+|                              [Dismiss]      |
++--------------------------------------------+
+| Current draft is separate.                 |
++--------------------------------------------+
 ```
 
-- `SessionService` 只拥有 operation orchestration，不直接执行 presenter internals。
-- `AgentSessionPresenter` 继续拥有 create/cleanup steps，但要返回可观察的 compensation outcome。
-- journal 只保存 content-free identity/stage/error code；session data 仍由现有 tables 拥有。
+即使只有一条 restart record，也不能自动把当前 draft 接上去。这是 privacy 和 correctness 约束，不是 UI
+偏好。
 
-### 实现步骤
+### Renderer/integration tests
 
-1. Additive route input/output schema：optional `operationId` + operation envelope。
-2. 增加只读 `sessions.getCreateOperation`，输入 operation id，输出相同 envelope。
-3. operation 开始前：
-   - validate input；
-   - canonicalize + SHA-256 fingerprint；
-   - 预分配 session id；
-   - insert journal `accepted/pending`；
-   - 建 per-operation single-flight Promise。
-4. 按 stage 执行 create，并在每个 durable boundary 更新 journal：record、runtime、initial input acceptance、
-   completion。
-5. 观察 deadline 到达：route 返回 `pending`，不 abort operation，不 throw timeout。
-6. duplicate same id/same fingerprint：返回/等待 existing state；different fingerprint：typed conflict。
-7. owner error：收集 ACP clear、runtime destroy、record delete 等 compensation result：
-   - 全部 settle 成功 → `failed`；
-   - 任一 reject/无法证明 → `unknown`。
-8. process startup/reconcile：
-   - persisted succeeded + readable session → reconstruct succeeded；
-   - incomplete stage → unknown；
-   - 不持久化 payload，不自动 replay。
-9. terminal operation row 跟随 session deletion清理；failed/unknown row 保留供 diagnostics/reconcile，本片不
-   增加后台 TTL worker。
-
-### 为什么不加 TTL worker
-
-每次 create 最多一行，规模与 session 数同阶；先在 session delete 时清成功行。failed/unknown 预计低频，
-没有测量证明需要后台清理器。若 DB fixture 以后证明增长显著，再按数据加 bounded maintenance，而不是本片
-预建 timer。
-
-### Focused test matrix
-
-| Case | 断言 |
+| Case | 必须证明 |
 | --- | --- |
-| fast create | succeeded + session；stage completed |
-| deferred before record | deadline 返回 pending；late success 可 query |
-| deferred after record/runtime | pending；只有一个 session/runtime attempt |
-| duplicate same id while pending | 共用 Promise；create count 1 |
-| duplicate same id after success | reconstruct same session；不执行 create |
-| same id/different input | conflict；旧 state 不变 |
-| init failure + cleanup success | terminal failed；record 不残留 |
-| init failure + one cleanup reject | unknown；不自动 retry |
-| restart with succeeded journal | route reconstruct session |
-| restart with incomplete journal | unknown；不 replay input |
-| late resolve after renderer stops waiting | journal success/event exactly once |
-| raw data hygiene | journal 除 fingerprint 外不含 prompt/file path/payload；log 不含 fingerprint/raw payload |
+| fast success | 原 create/navigation/onboarding 一致 |
+| pending -> success/current | draft 到 success 前保留，只导航一次 |
+| pending -> success/stale | 只刷新 list，不抢 route/active session |
+| page leave | polling cleanup，main operation 不取消 |
+| transient reconcile error | 同 id 可重查，不创建新 operation |
+| failed/unknown | draft 保留，无 auto retry |
+| restart one/many | 都需显式选择，不绑定当前 draft |
+| discovery data | UI/API 不出现 prompt/file/title/provider/fingerprint |
+| dismiss | 只隐藏 identity，不删 session |
+| legacy missing id | typed finite error，mutation count 0 |
+| duplicate event + reconcile | upsert/activate/onboarding idempotent |
 
-### 自动验证
+### Manual smoke
+
+1. DeepChat 正常 create：首条输入只入队一次、session 激活、generation 可继续。
+2. ACP/fallback production path：accepted handle 在 generation completion 前返回；没有 seam 就阻止 merge。
+3. 人为延迟 record/runtime/queue 超过 deadline：UI pending、不报失败、不丢 draft，late success 收敛。
+4. pending 后切换已有 session：late success 不抢页面。
+5. compensation 一项失败：unknown，无自动 duplicate create。
+6. pending 时重启：content-free discovery 出现，必须手选；当前 draft 不关联。
+7. 检查 log 和 journal：无 raw prompt/file/payload，log 无 fingerprint。
+
+### 影响、收益、风险
+
+| 维度 | 影响 | 收益/控制 |
+| --- | --- | --- |
+| 用户认知 | 新增 pending/unknown/recovery 状态 | 不再“先失败、后冒出 session” |
+| Draft | cleanup 延后到 confirmed success | 慢请求/restart 不丢当前输入 |
+| 导航 | late success 检查 intent token | 不抢当前页面 |
+| 数据 | 每个 create intent 一条 content-free journal | dedupe/reconcile 有 durable truth |
+| Privacy | recovery 不显示内容，journal 不复制 payload | restart 能找 id，但不扩大敏感数据副本 |
+| Compatibility | backend/renderer 必须同 PR | 没有无限 wait 或旧 5 秒半成品窗口 |
+
+### Atomic rollback
+
+1. 以整个 003 PR 回滚 backend + renderer/client；不能只回滚 renderer 并声称 backend 兼容。
+2. additive journal table 可保留，旧代码忽略；不做 destructive down migration。
+3. 不删除已经创建的 session；operation row 不是 session source of truth。
+4. 回滚前先停止新 create traffic（桌面版本即关闭/重启升级窗口），避免新旧 schema consumer 并存。
+
+## 统一验证清单
+
+### 自动 gate
 
 ```bash
-pnpm exec vitest run \
-  test/main/presenter/sqlitePresenter/sessionCreateOperations.test.ts \
-  test/main/routes/sessionService.test.ts \
-  test/main/routes/dispatcher.test.ts \
-  test/main/presenter/agentSessionPresenter/agentSessionPresenter.test.ts \
-  test/main/presenter/agentSessionPresenter/integration.test.ts
-pnpm run typecheck:node
-pnpm run format:check
-pnpm run lint
-```
-
-### 影响与收益
-
-- 正确性：create caller 和 main 对同一个 operation 有共同 identity，不再猜 late result。
-- 数据：新增 additive table；不复制 raw payload；rollback 留空表不影响旧版本读取。
-- UX：backend 已能表达 pending/unknown，但旧 client 在 SCH-003B 前仍走 compatibility wait。
-- 风险：create stages 跨多个现有 owner；focused deferred/compensation tests 是 merge gate。
-- 回滚：revert backend/runtime code；additive table 保留无害，不做 destructive down migration。
-
-## Slice SCH-003B：Renderer reconciliation 与 legacy cleanup
-
-### 目标
-
-让新 client 真正使用 operation contract，pending/unknown 对用户可理解；然后删除最后 legacy timeout 和
-compatibility allowlist。
-
-### 影响文件
-
-- `src/renderer/api/SessionClient.ts`
-- `src/renderer/src/stores/ui/session.ts`
-- `src/renderer/src/pages/NewThreadPage.vue`（只在状态展示需要时）
-- `src/renderer/src/i18n/*/chat.json` 或归属 locale 文件
-- renderer API/store/component tests
-- `src/main/routes/operationRunner.ts`：删除 legacy `timeout()` adapter
-- legacy static allowlist/architecture baseline
-
-### 实现步骤
-
-1. `SessionClient.create()` 生成/接收 operation id，并解析 operation envelope。
-2. session store 建一个 current create intent token；draft data 保持在现有 draft owner，不复制到 operation
-   store。
-3. pending 时按 bounded polling/reconciliation：
-   - 只在 create page/current intent 仍活跃时轮询；
-   - 页面离开时停止观察，不取消 main operation；
-   - 不因一次 query error 自动创建新 operation。
-4. succeeded：
-   - current intent → upsert、activate/navigate、onboarding；
-   - stale intent → refresh list only。
-5. failed：展示稳定 error mapping，保留 draft，用户显式重试生成新 operation id。
-6. unknown：保留 draft，提供 check again/refresh list；禁止 automatic create retry。
-7. i18n 增加 pending/unknown/failure keys；不显示内部 error/message/fingerprint。
-8. 添加 manual smoke 后，删除 legacy `timeout()` adapter、allowlist 和旧 `SESSION_OPERATION_TIMEOUT_MS` create
-   使用。
-
-### Polling 说明
-
-不新建常驻 polling service。只复用当前 create intent 生命周期中的局部 timer；route success/failure/页面离开
-都会 cleanup。poll 间隔属于 UX 参数，implementation 先使用现有 settings page polling helper 同类的简单
-fixed interval；不引入 exponential-backoff dependency。正确性不依赖轮询间隔，手动 check route 始终可用。
-
-### Renderer test matrix
-
-| Case | 断言 |
-| --- | --- |
-| fast success | 与现有 create/navigation/onboarding 行为一致 |
-| pending then success/current | draft 不清空直到 success；只导航一次 |
-| pending then success/stale | session list 更新，不抢当前 route/active session |
-| pending then page leave | polling cleanup；main operation 不取消 |
-| query transient error | 显示可重查状态；不创建新 id |
-| terminal failed | draft 保留；explicit retry 使用新 id |
-| unknown | 无 false failure/auto retry；check again 可用 |
-| duplicate event + reconciliation | upsert/activate/onboarding idempotent |
-| legacy no-id caller | compatibility path 仍返回 non-null session，直到 allowlist 删除 gate完成 |
-
-### Manual smoke（自动化不能完全替代）
-
-1. 正常创建 DeepChat session，确认首条消息只出现一次、session 激活、onboarding 正常。
-2. 正常创建 ACP session，确认 workdir/runtime 准备与首条输入正常。
-3. 测试 fixture 人为延迟 create 超过 observation deadline：UI 显示 pending，不显示失败、不丢 draft；
-   late success 后当前 intent 导航。
-4. pending 后立刻导航到已有 session：late success 只刷新列表，不抢页面。
-5. 人为让 cleanup 一项失败：显示 unknown，无自动 duplicate session。
-6. pending 期间重启 app：incomplete journal 保守显示 unknown；已有成功 session 仍能从列表打开。
-7. 检查 production log/diagnostics 不出现 raw prompt/file path/fingerprint；DB journal 除 fingerprint 外
-   不复制 raw payload。
-
-### 自动验证
-
-```bash
-pnpm exec vitest run \
-  test/renderer/api/clients.test.ts \
-  test/renderer/stores/sessionStore.test.ts \
-  test/renderer/components/NewThreadPage.test.ts \
-  test/main/routes/operationRunner.test.ts \
-  test/main/routes/sessionService.test.ts \
-  test/main/routes/dispatcher.test.ts
 pnpm run typecheck
 pnpm run format
+pnpm run format:check
 pnpm run i18n
 pnpm run lint
 pnpm test
 ```
 
-### 影响与收益
+每个 slice 还要跑本节列出的 focused tests。full suite 与已记录 baseline 对比，新增失败必须为零。
 
-| 维度 | 影响 | 收益 |
-| --- | --- | --- |
-| 用户认知 | 多一个 pending/unknown 状态 | 不再看到“失败”后又冒出 session |
-| 草稿 | draft cleanup 时机后移到 confirmed success | 慢创建/unknown 不丢输入 |
-| 导航 | late success 要检查 intent token | 不抢用户当前页面/active session |
-| 测试 | 增加 deferred、restart、stale intent matrix | 大改后稳定性有状态机证据，不靠 happy path |
-| 数据 | journal 与 session 同阶增长 | operation 可查、duplicate 可抑制 |
+### Review 必查
 
-### 回滚
-
-- 先回滚 SCH-003B renderer/client，backend compatibility path 仍可服务旧 caller。
-- 如需再回滚 SCH-003A，保留 additive journal table；旧版本忽略它。
-- 不回滚/删除用户已经创建的 session；operation row 不是 session source of truth。
-
-## 全链路验证与稳定性门槛
-
-每个 slice 都必须由独立 verify agent 审查。blocking finding 回到原 develop branch 修复，再重新验证；同一
-agent 不同时承担 develop 和 final verify。
-
-### 自动 gate
-
-- focused unit/integration tests 全绿；
-- `pnpm run typecheck`；
-- `pnpm run format` 后 `pnpm run format:check`；
-- `pnpm run i18n`；
-- `pnpm run lint`；
-- full `pnpm test` 与已记录 baseline 对比；
-- architecture guard 证明 legacy timeout consumer 按 1 → 0 收敛。
-
-### Review 必查项
-
-1. 有没有把 deadline error 当 operation failure？
-2. 有没有在上一 attempt 未 settle 时启动 retry？
-3. 有没有只因 task 接收 signal 就宣称 physically cancellable？
-4. 有没有恢复 cancelGeneration 同步 terminal settlement？
-5. create cleanup 不确定时有没有错误写 failed？
-6. duplicate operation id 是否 single-flight？
-7. renderer stale intent 是否可能抢导航？
-8. journal/log 是否泄露 raw payload？
-9. compatibility adapter 是否有精确 allowlist 和删除条件？
-10. sync DB work 是否被错误描述为 Promise timeout 可中断？
-
-### PR body 必须记录
-
-- scope 与明确 non-goals；
-- code-truth before/after；
-- operation state/attempt timeline；
-- focused/full test counts；
-- manual smoke 完成项与未覆盖平台；
-- compatibility/rollback；
-- 对用户的可见影响；
-- 如果 automation 缺失，给出具体手工步骤和风险，不写“应该没问题”。
+1. deadline 是否被误写成 operation failure？
+2. 上一 attempt 未 settle 时是否可能启动 retry？
+3. restore/getActive 是否都保留 `2 attempts/25ms`，且 transient/deadline 不清 binding？
+4. 是否加入了没有真实 consumer 的 `runCancellable()`？
+5. provider model 60 秒/no-model path 是否被误称为 owner timeout？
+6. initial input accepted 是否误等整轮 generation，或在 fire-and-forget 时提前写 completed？
+7. cleanup uncertainty 是否误写 failed？
+8. restart recovery 是否复制/显示 payload，或自动绑定当前 draft？
+9. 003A 是否被错误当成可独立 merge？003B 是否明确依赖 003A + SES-003？
+10. missing operation id 是否在副作用前 finite reject？
+11. DTO 是否只由 sessions route schema inference 拥有？
+12. 所有 numeric input 是否 finite/nonnegative/bounded validation？
 
 ## 完成判定
 
 `A-04` 只有同时满足以下条件才关闭：
 
-1. legacy `Scheduler.timeout(task: Promise)` 生产 consumer 为 0；
-2. retry overlap tests 证明最大并发 attempt 为 1；
-3. `sessions.create` slow path 返回 pending/unknown envelope 并可 reconcile；
-4. cancelGeneration exactly-once settlement 回归通过；
-5. renderer stale/unknown/draft tests 与 manual smoke 通过；
-6. full suite 没有新增失败。
+1. legacy `Scheduler.timeout(task: Promise)` production consumer 为 `0`；
+2. retry tests 证明 `maxConcurrentAttempts === 1`；
+3. restore/getActive 的 typed transient `2 attempts/25ms` 与 binding retention 全部通过；
+4. provider model/no-model 都有 owner-level finite cancellation/settlement，不能只剩 observation race；
+5. session create slow path 返回 pending/unknown 并可 reconcile；
+6. initial input accepted 不等待 generation terminal，也不提前伪造；
+7. restart discovery content-free、bounded、explicit selection；
+8. 003A/B atomic cutover 完成，missing id caller count = 0；
+9. cancelGeneration exactly-once settlement 回归通过；
+10. renderer stale/unknown/draft/manual smoke 与 full suite 无新增失败。
 
-仅完成 `SCH-002A` core 或仅把 timeout 数值调大，都不能关闭 finding。
+只完成 runner rename、只调大 timeout、只合 backend 或只做 UI，都不能关闭 finding。

--- a/docs/architecture/scheduler-operation-contract/plan.md
+++ b/docs/architecture/scheduler-operation-contract/plan.md
@@ -1,0 +1,471 @@
+# Scheduler Operation Contract Implementation Plan
+
+## 实施原则
+
+本计划不做 big-bang Scheduler rewrite。按“先修 timing primitive，再迁安全 consumer，最后给 create
+mutation 建 operation identity”推进。每个 sub-slice 独立 branch/PR、独立 develop/verify，前一片通过后
+后一片才开始。
+
+```text
+SCH-001 docs
+   |
+   v
+SCH-002A OperationRunner core
+   |
+   v
+SCH-002B safe consumer migration
+   |
+   v
+SCH-003A session create operation backend
+   |
+   v
+SCH-003B renderer reconciliation + legacy cleanup
+```
+
+## 依赖与冲突安排
+
+| 依赖/并行工作 | 安排 |
+| --- | --- |
+| `SES-002` 修改 `SessionService` / session resolution | `SCH-002A` 可并行；`SCH-002B` 的 session slice 必须基于已合入 `SES-002`，不能双边各自改同一语义 |
+| `SES-003` 修改 route/session renderer | `SCH-003B` 在其后 rebase，复用四态字段；不复制 compatibility adapter |
+| `CHAT-001/002` 决定 enqueue/generation owner | SCH 只移除 false mutation deadline、保留 cancel request semantics；generation handle 的增删由 `CHAT-*` 决定 |
+| `PRM-*` / fatal work | 无 contract 依赖；如共同修改 route root，只按 merge 顺序 rebase，不合并目标 |
+
+推荐 merge 顺序：`SES-002` → `SCH-002A` → `SCH-002B` → `SES-003` → `SCH-003A` →
+`SCH-003B`。若 `SES-003` 尚未开始，`SCH-003A` 可先做 backend，但 renderer slice 仍需在最终 session route
+schema 上验证。
+
+## Slice SCH-002A：OperationRunner core
+
+### 目标
+
+只改 timing primitive 和 focused tests，不动 domain behavior。建立可证明的 runner contract，并保留一个
+最小 compatibility adapter 让 consumer migration 能分 PR 完成。
+
+### 影响文件
+
+- `src/main/routes/scheduler.ts`：重命名/收窄为 `operationRunner.ts`，实现新 API。
+- `src/main/routes/index.ts`：composition root 改用 `createNodeOperationRunner()`。
+- `test/main/routes/scheduler.test.ts`：迁移为 capability contract tests。
+- architecture guard/baseline（仅当 rename 触发 tracked path）。
+
+### 实现步骤
+
+1. 定义 typed errors：
+   - `ObservationDeadlineError`：只说明 observer deadline；
+   - `TimeoutError`：仅供 cooperative cancellable attempt abort 后 settle；
+   - `AbortError`：external abort 且 cancellable attempt settle；
+   - 普通 owner error 保留 `cause`，不靠 message 分类。
+2. `observeIdempotent()`：
+   - listener/timer 先于 task factory；
+   - late resolve/reject 都有 drain handler；
+   - deadline/abort 后不会执行任何 callback/retry。
+3. `runCancellable()`：
+   - runner 创建内部 controller；
+   - external signal/deadline 只发一次 abort；
+   - await task settlement 后再映射 timeout/abort；
+   - task 在 abort 后 fulfilled 时也不得把 value 返回 caller。
+4. `retryIdempotent()`：
+   - 单 while loop，attempt 必须 settle 后才 backoff；
+   - `shouldRetry` 默认由 caller 显式传入；
+   - overall deadline/abort 关闭 loop；running attempt late settle 后不得启动下一轮；
+   - backoff 使用 runner `sleep()` 并响应 loop closure。
+5. 暂保留 legacy `timeout()` adapter，但加清晰 deprecated 注释；不改其语义，不让新代码使用。
+6. 不引入 `p-retry`，不新增 queue/registry。
+
+### Focused test matrix
+
+| Case | 断言 |
+| --- | --- |
+| task factory sync throw | timer/listener cleanup；原 error 返回 |
+| signal pre-aborted | task factory 不调用 |
+| idempotent observation deadline | caller 得 `ObservationDeadlineError`；late resolve drained |
+| late reject after observation deadline | 无 unhandled rejection；无 retry |
+| cancellable deadline | task 收到 aborted signal；task settle 前 runner 不 settle |
+| cancellable task resolves after abort | caller 仍得 `TimeoutError`，不返回 stale value |
+| external abort | settle 后 `AbortError`；deadline timer 清理 |
+| immediate transient reject then success | 顺序两次，结果 success |
+| first attempt deferred | second attempt 调用次数为 0，直到 first reject |
+| deadline while attempt deferred | caller 结束；first late reject 后 second 仍为 0 |
+| deadline during backoff | 下一 attempt 永不启动 |
+| retry classifier false | 只调用一次，原 error 返回 |
+| max attempts/backoff | 尝试次数和 delay 序列准确，`maxConcurrentAttempts=1` |
+
+### 自动验证
+
+```bash
+pnpm exec vitest run test/main/routes/operationRunner.test.ts
+pnpm run typecheck:node
+pnpm run format:check
+pnpm run lint:architecture
+pnpm run lint
+```
+
+### 影响与收益
+
+- 收益：以后看到 `TimeoutError` 可以知道 cooperative attempt 已 settle；retry overlap 有 unit proof。
+- 影响：core API rename 会触及 fake runner type，但不改变 production route behavior。
+- 风险：假 timer/abort listener 泄漏；用 listener count、late rejection 和 fake timer test 阻断。
+- 回滚：单独 revert SCH-002A；legacy adapter 仍支持旧 consumer。
+
+## Slice SCH-002B：安全 consumer 迁移
+
+### 目标
+
+把能独立判断的 read/sync/probe/chat wrapper 从 legacy timeout 迁出，只留下 `sessions.create` 一个
+allowlisted legacy consumer，交给 SCH-003。
+
+### 影响文件
+
+- `src/main/routes/sessions/sessionService.ts`
+- `src/main/routes/chat/chatService.ts`
+- `src/main/routes/providers/providerService.ts`
+- `src/main/routes/hotPathPorts.ts`（只在 task factory/signal type 真需要时改）
+- 对应 route service tests、dispatcher integration tests
+- `scripts/architecture-guard.mjs` 或 focused static test：冻结 legacy `timeout(` consumer allowlist
+
+### Session migration
+
+1. 基于 `SES-002` 的 typed availability result 工作，不回退到 null/error-string 分类。
+2. `restoreSession()` 使用 `retryIdempotent`：
+   - overall deadline 5 秒；
+   - immediate typed `transient_error` rejection 可在 25ms 后 retry；
+   - attempt 未 settle、missing、unavailable、validation error、deadline 均不 retry；
+   - attempt late settle 后只 drain，不写 binding。
+3. `listMessagesPage/listSessions/getActive` 使用 `observeIdempotent`；list 不做 per-row retry。
+4. `activate/deactivate` 删除 timeout wrapper，直接调用现有 owner；不增加 retry。
+5. `createSession` 暂时保留 legacy adapter，static allowlist 精确到这一处。
+
+### Provider migration
+
+1. `listModels()` 直接调用同步 catalog getter；保留原 output shape。
+2. `testConnection()` 删除 route-level 5 秒 `Promise.race`，等待 provider owner 的真实 check/model timeout。
+3. 不自动 retry provider probe；连续点击治理若有真实问题另立 owner task，不在 Scheduler 猜 cooldown。
+4. test 覆盖 deferred provider check：5 秒时 route 不产生 false `TimeoutError`；最终 owner result 原样返回。
+
+### Chat migration
+
+1. session/agent/message lookup 使用 `observeIdempotent`；route controller abort 后不得继续进入下一 mutation。
+2. `sendMessage/steerActiveTurn/respondToolInteraction` 不再套 observation deadline；等待 domain owner 返回
+   acceptance/result。
+3. send 的 30 分钟 constant 和“generation timeout”假语义删除；不在本片决定 active controller 最终名称。
+4. `stopStream` 保留两项 cleanup 都尝试的 `Promise.allSettled`，但不再用 5 秒 race 宣称 cleanup 已结束。
+5. `cancelGeneration()` 仍只表示 request accepted；现有 AgentRuntime exactly-once settlement tests 必须通过。
+
+### Legacy allowlist
+
+SCH-002B 结束后必须满足：
+
+```text
+legacy OperationRunner.timeout consumer count = 1
+allowed path = SessionService.createSession only
+```
+
+guard 只冻结生产 consumer，不阻止 test fixture import compatibility adapter。SCH-003B 删除最后 consumer
+和 adapter。
+
+### Focused test matrix
+
+| Consumer | Failure/late case |
+| --- | --- |
+| restore immediate transient | attempt 1 settle reject，25ms 后 attempt 2；最大并发 1 |
+| restore deferred past deadline | caller deadline；late settle；attempt 2 永不启动 |
+| restore missing/unavailable | 不 retry，不清错误 binding |
+| list/getActive deadline | late read 不更新 route result；binding 遵守 `SES-*` |
+| activate/deactivate | effect/event exactly once；无 runner 调用 |
+| listModels | 两个 sync getter exactly once；无 timer/runner |
+| provider check >5s | 不在 5 秒返回 false failure；最终 result 返回 |
+| chat stop during preflight | mutation 不启动；cancel request/permission cleanup 各一次 |
+| chat send acceptance | 无 30min runner；pending input 不重复 |
+| stop cleanup one side rejects | 两边都执行；request result contract 不变 |
+| runtime cancellation | single `user_stop` hook；stale run 不覆盖 newer run |
+
+### 自动验证
+
+```bash
+pnpm exec vitest run \
+  test/main/routes/operationRunner.test.ts \
+  test/main/routes/sessionService.test.ts \
+  test/main/routes/providerService.test.ts \
+  test/main/routes/chatService.test.ts \
+  test/main/routes/dispatcher.test.ts \
+  test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+pnpm run typecheck
+pnpm run format:check
+pnpm run i18n
+pnpm run lint
+pnpm test
+```
+
+full suite 与 repository baseline 对比；不得把历史失败计入本片回归。
+
+### 影响与收益
+
+| 维度 | 影响 | 收益 |
+| --- | --- | --- |
+| 正确性 | restore timeout 不再自动起第二个 overlapping read | 消除同一 retry loop 的并发 attempt |
+| UX | provider check 可能等待 owner 的真实 timeout，而不是 5 秒假失败 | 不再“界面失败但 provider 仍扣费/运行” |
+| 性能 | 删除 sync getter 的 timer/race；差异很小 | 更少无意义 Promise/timer，主要收益是语义清晰 |
+| Chat | 删除 mutation 外层 deadline；pathological owner hang 不再被假 timeout 遮住 | 不会把仍在运行的 mutation说成失败；真实 hang 会暴露给 owner |
+| 兼容 | session create 暂留旧 adapter | PR 可独立合入，create 行为由下一片处理 |
+
+### 回滚
+
+- 可整体 revert SCH-002B，SCH-002A runner core 仍可保留。
+- 不做 schema migration；回滚无数据转换。
+- 若某 consumer manual smoke 发现 owner 无内部 timeout，单独回滚该 consumer，不恢复 automatic retry。
+
+## Slice SCH-003A：Session create operation backend
+
+### 目标
+
+让慢 create 返回可查询的 `pending`，让 late success/cleanup uncertainty 有 operation truth；本片只做
+main/shared contract 和 backend，不改最终 UI。
+
+### 影响文件
+
+- `src/shared/contracts/routes/sessions.routes.ts`
+- `src/shared/types/agent-interface.d.ts`（只放 shared operation DTO，避免 main type 泄漏）
+- `src/main/routes/sessions/sessionService.ts`
+- `src/main/routes/index.ts`
+- `src/main/presenter/agentSessionPresenter/index.ts`
+- `src/main/presenter/agentSessionPresenter/sessionManager.ts`
+- `src/main/presenter/sqlitePresenter/schemaCatalog.ts`
+- 新 domain-specific table，例如
+  `src/main/presenter/sqlitePresenter/tables/sessionCreateOperations.ts`
+- focused table/service/dispatcher tests
+
+### 数据与 owner
+
+```text
+renderer operationId
+  -> SessionService (single-flight + observation deadline)
+      -> SessionCreateOperationsTable (durable identity/stage)
+      -> AgentSessionPresenter (actual mutation/compensation)
+      -> NewSessionManager/new_sessions (authoritative session record)
+```
+
+- `SessionService` 只拥有 operation orchestration，不直接执行 presenter internals。
+- `AgentSessionPresenter` 继续拥有 create/cleanup steps，但要返回可观察的 compensation outcome。
+- journal 只保存 content-free identity/stage/error code；session data 仍由现有 tables 拥有。
+
+### 实现步骤
+
+1. Additive route input/output schema：optional `operationId` + operation envelope。
+2. 增加只读 `sessions.getCreateOperation`，输入 operation id，输出相同 envelope。
+3. operation 开始前：
+   - validate input；
+   - canonicalize + SHA-256 fingerprint；
+   - 预分配 session id；
+   - insert journal `accepted/pending`；
+   - 建 per-operation single-flight Promise。
+4. 按 stage 执行 create，并在每个 durable boundary 更新 journal：record、runtime、initial input acceptance、
+   completion。
+5. 观察 deadline 到达：route 返回 `pending`，不 abort operation，不 throw timeout。
+6. duplicate same id/same fingerprint：返回/等待 existing state；different fingerprint：typed conflict。
+7. owner error：收集 ACP clear、runtime destroy、record delete 等 compensation result：
+   - 全部 settle 成功 → `failed`；
+   - 任一 reject/无法证明 → `unknown`。
+8. process startup/reconcile：
+   - persisted succeeded + readable session → reconstruct succeeded；
+   - incomplete stage → unknown；
+   - 不持久化 payload，不自动 replay。
+9. terminal operation row 跟随 session deletion清理；failed/unknown row 保留供 diagnostics/reconcile，本片不
+   增加后台 TTL worker。
+
+### 为什么不加 TTL worker
+
+每次 create 最多一行，规模与 session 数同阶；先在 session delete 时清成功行。failed/unknown 预计低频，
+没有测量证明需要后台清理器。若 DB fixture 以后证明增长显著，再按数据加 bounded maintenance，而不是本片
+预建 timer。
+
+### Focused test matrix
+
+| Case | 断言 |
+| --- | --- |
+| fast create | succeeded + session；stage completed |
+| deferred before record | deadline 返回 pending；late success 可 query |
+| deferred after record/runtime | pending；只有一个 session/runtime attempt |
+| duplicate same id while pending | 共用 Promise；create count 1 |
+| duplicate same id after success | reconstruct same session；不执行 create |
+| same id/different input | conflict；旧 state 不变 |
+| init failure + cleanup success | terminal failed；record 不残留 |
+| init failure + one cleanup reject | unknown；不自动 retry |
+| restart with succeeded journal | route reconstruct session |
+| restart with incomplete journal | unknown；不 replay input |
+| late resolve after renderer stops waiting | journal success/event exactly once |
+| raw data hygiene | journal 除 fingerprint 外不含 prompt/file path/payload；log 不含 fingerprint/raw payload |
+
+### 自动验证
+
+```bash
+pnpm exec vitest run \
+  test/main/presenter/sqlitePresenter/sessionCreateOperations.test.ts \
+  test/main/routes/sessionService.test.ts \
+  test/main/routes/dispatcher.test.ts \
+  test/main/presenter/agentSessionPresenter/agentSessionPresenter.test.ts \
+  test/main/presenter/agentSessionPresenter/integration.test.ts
+pnpm run typecheck:node
+pnpm run format:check
+pnpm run lint
+```
+
+### 影响与收益
+
+- 正确性：create caller 和 main 对同一个 operation 有共同 identity，不再猜 late result。
+- 数据：新增 additive table；不复制 raw payload；rollback 留空表不影响旧版本读取。
+- UX：backend 已能表达 pending/unknown，但旧 client 在 SCH-003B 前仍走 compatibility wait。
+- 风险：create stages 跨多个现有 owner；focused deferred/compensation tests 是 merge gate。
+- 回滚：revert backend/runtime code；additive table 保留无害，不做 destructive down migration。
+
+## Slice SCH-003B：Renderer reconciliation 与 legacy cleanup
+
+### 目标
+
+让新 client 真正使用 operation contract，pending/unknown 对用户可理解；然后删除最后 legacy timeout 和
+compatibility allowlist。
+
+### 影响文件
+
+- `src/renderer/api/SessionClient.ts`
+- `src/renderer/src/stores/ui/session.ts`
+- `src/renderer/src/pages/NewThreadPage.vue`（只在状态展示需要时）
+- `src/renderer/src/i18n/*/chat.json` 或归属 locale 文件
+- renderer API/store/component tests
+- `src/main/routes/operationRunner.ts`：删除 legacy `timeout()` adapter
+- legacy static allowlist/architecture baseline
+
+### 实现步骤
+
+1. `SessionClient.create()` 生成/接收 operation id，并解析 operation envelope。
+2. session store 建一个 current create intent token；draft data 保持在现有 draft owner，不复制到 operation
+   store。
+3. pending 时按 bounded polling/reconciliation：
+   - 只在 create page/current intent 仍活跃时轮询；
+   - 页面离开时停止观察，不取消 main operation；
+   - 不因一次 query error 自动创建新 operation。
+4. succeeded：
+   - current intent → upsert、activate/navigate、onboarding；
+   - stale intent → refresh list only。
+5. failed：展示稳定 error mapping，保留 draft，用户显式重试生成新 operation id。
+6. unknown：保留 draft，提供 check again/refresh list；禁止 automatic create retry。
+7. i18n 增加 pending/unknown/failure keys；不显示内部 error/message/fingerprint。
+8. 添加 manual smoke 后，删除 legacy `timeout()` adapter、allowlist 和旧 `SESSION_OPERATION_TIMEOUT_MS` create
+   使用。
+
+### Polling 说明
+
+不新建常驻 polling service。只复用当前 create intent 生命周期中的局部 timer；route success/failure/页面离开
+都会 cleanup。poll 间隔属于 UX 参数，implementation 先使用现有 settings page polling helper 同类的简单
+fixed interval；不引入 exponential-backoff dependency。正确性不依赖轮询间隔，手动 check route 始终可用。
+
+### Renderer test matrix
+
+| Case | 断言 |
+| --- | --- |
+| fast success | 与现有 create/navigation/onboarding 行为一致 |
+| pending then success/current | draft 不清空直到 success；只导航一次 |
+| pending then success/stale | session list 更新，不抢当前 route/active session |
+| pending then page leave | polling cleanup；main operation 不取消 |
+| query transient error | 显示可重查状态；不创建新 id |
+| terminal failed | draft 保留；explicit retry 使用新 id |
+| unknown | 无 false failure/auto retry；check again 可用 |
+| duplicate event + reconciliation | upsert/activate/onboarding idempotent |
+| legacy no-id caller | compatibility path 仍返回 non-null session，直到 allowlist 删除 gate完成 |
+
+### Manual smoke（自动化不能完全替代）
+
+1. 正常创建 DeepChat session，确认首条消息只出现一次、session 激活、onboarding 正常。
+2. 正常创建 ACP session，确认 workdir/runtime 准备与首条输入正常。
+3. 测试 fixture 人为延迟 create 超过 observation deadline：UI 显示 pending，不显示失败、不丢 draft；
+   late success 后当前 intent 导航。
+4. pending 后立刻导航到已有 session：late success 只刷新列表，不抢页面。
+5. 人为让 cleanup 一项失败：显示 unknown，无自动 duplicate session。
+6. pending 期间重启 app：incomplete journal 保守显示 unknown；已有成功 session 仍能从列表打开。
+7. 检查 production log/diagnostics 不出现 raw prompt/file path/fingerprint；DB journal 除 fingerprint 外
+   不复制 raw payload。
+
+### 自动验证
+
+```bash
+pnpm exec vitest run \
+  test/renderer/api/clients.test.ts \
+  test/renderer/stores/sessionStore.test.ts \
+  test/renderer/components/NewThreadPage.test.ts \
+  test/main/routes/operationRunner.test.ts \
+  test/main/routes/sessionService.test.ts \
+  test/main/routes/dispatcher.test.ts
+pnpm run typecheck
+pnpm run format
+pnpm run i18n
+pnpm run lint
+pnpm test
+```
+
+### 影响与收益
+
+| 维度 | 影响 | 收益 |
+| --- | --- | --- |
+| 用户认知 | 多一个 pending/unknown 状态 | 不再看到“失败”后又冒出 session |
+| 草稿 | draft cleanup 时机后移到 confirmed success | 慢创建/unknown 不丢输入 |
+| 导航 | late success 要检查 intent token | 不抢用户当前页面/active session |
+| 测试 | 增加 deferred、restart、stale intent matrix | 大改后稳定性有状态机证据，不靠 happy path |
+| 数据 | journal 与 session 同阶增长 | operation 可查、duplicate 可抑制 |
+
+### 回滚
+
+- 先回滚 SCH-003B renderer/client，backend compatibility path 仍可服务旧 caller。
+- 如需再回滚 SCH-003A，保留 additive journal table；旧版本忽略它。
+- 不回滚/删除用户已经创建的 session；operation row 不是 session source of truth。
+
+## 全链路验证与稳定性门槛
+
+每个 slice 都必须由独立 verify agent 审查。blocking finding 回到原 develop branch 修复，再重新验证；同一
+agent 不同时承担 develop 和 final verify。
+
+### 自动 gate
+
+- focused unit/integration tests 全绿；
+- `pnpm run typecheck`；
+- `pnpm run format` 后 `pnpm run format:check`；
+- `pnpm run i18n`；
+- `pnpm run lint`；
+- full `pnpm test` 与已记录 baseline 对比；
+- architecture guard 证明 legacy timeout consumer 按 1 → 0 收敛。
+
+### Review 必查项
+
+1. 有没有把 deadline error 当 operation failure？
+2. 有没有在上一 attempt 未 settle 时启动 retry？
+3. 有没有只因 task 接收 signal 就宣称 physically cancellable？
+4. 有没有恢复 cancelGeneration 同步 terminal settlement？
+5. create cleanup 不确定时有没有错误写 failed？
+6. duplicate operation id 是否 single-flight？
+7. renderer stale intent 是否可能抢导航？
+8. journal/log 是否泄露 raw payload？
+9. compatibility adapter 是否有精确 allowlist 和删除条件？
+10. sync DB work 是否被错误描述为 Promise timeout 可中断？
+
+### PR body 必须记录
+
+- scope 与明确 non-goals；
+- code-truth before/after；
+- operation state/attempt timeline；
+- focused/full test counts；
+- manual smoke 完成项与未覆盖平台；
+- compatibility/rollback；
+- 对用户的可见影响；
+- 如果 automation 缺失，给出具体手工步骤和风险，不写“应该没问题”。
+
+## 完成判定
+
+`A-04` 只有同时满足以下条件才关闭：
+
+1. legacy `Scheduler.timeout(task: Promise)` 生产 consumer 为 0；
+2. retry overlap tests 证明最大并发 attempt 为 1；
+3. `sessions.create` slow path 返回 pending/unknown envelope 并可 reconcile；
+4. cancelGeneration exactly-once settlement 回归通过；
+5. renderer stale/unknown/draft tests 与 manual smoke 通过；
+6. full suite 没有新增失败。
+
+仅完成 `SCH-002A` core 或仅把 timeout 数值调大，都不能关闭 finding。

--- a/docs/architecture/scheduler-operation-contract/spec.md
+++ b/docs/architecture/scheduler-operation-contract/spec.md
@@ -6,8 +6,7 @@
 - Finding：`A-04`
 - 文档类型：Architecture SDD
 - 决策状态：已定稿，无 `[NEEDS CLARIFICATION]`
-- 后续实施：`SCH-002A`、`SCH-002B`、`PRV-CAN-001`、`SCH-003P`、`SCH-003A`、
-  `SCH-003B`
+- 后续实施：`SCH-002A`、`SCH-002B`、`PRV-CAN-001`、`SCH-003A`、`SCH-003B`
 
 ## 先纠正一个分类误区
 
@@ -149,6 +148,14 @@ SessionService.createSession
 
 此外，better-sqlite3 是同步调用。若同步 SQLite 工作阻塞 event loop，deadline timer 本身也不能按时
 运行；Promise race 不能抢占同步 JavaScript/SQLite。
+
+当前 production agent implementation inventory 只有一条实际 runtime owner：constructor 只把
+`agentRuntimeAgent` 注册成 `deepchat`；`resolveAgentImplementation()` 对 catalog type 为 `deepchat` 或 `acp`
+都返回这一个 registered `deepchat` implementation。该 implementation 实现了 `queuePendingInput()`，并在
+SQLite pending-input store 创建 record 后返回；ACP 不是另一个缺少 queue 的 implementation。create 中的
+`else processMessage()` 是 optional interface 的 compatibility fallback，当前没有 production owner 会走到。
+因此后续不为零 consumer 设计 accepted-start API，而是删除 create 的 fallback 并用 static inventory guard
+阻止未来无 queue implementation 静默接入。
 
 ### 4. activate/deactivate 和 provider model timeout 是无效包装
 
@@ -349,7 +356,8 @@ runner 不接受 JavaScript timer 的隐式 coercion。所有数值必须在 tas
 - `deadlineMs`、`overallDeadlineMs`、`initialDelayMs`：有限整数，`0..2_147_483_647`；`0` 表示立即截止；
 - `maxAttempts`：有限正整数；production caller 必须用常量，本轮只允许已评审的 `2`；
 - `backoff`：有限且非负；每次算出的实际 delay 也必须仍是有限整数并在 timer 上限内；
-- discovery `limit`：route schema 约束为整数 `1..20`，默认 `10`；
+- history `limit`：route schema 约束为整数 `1..50`，默认 `20`；cursor `createdAt` 必须是 finite
+  nonnegative integer，cursor `operationId` 复用 UUID/length schema；
 - `NaN`、`Infinity`、负数、小数毫秒、乘法溢出全部 typed reject，且 task/timer 均不得启动。
 
 这些是 correctness validation，不是业务 timeout 调参。`25ms`、`2 attempts` 和 route observation deadline
@@ -411,7 +419,7 @@ waitForGenerationSettlement(runId: string): Promise<GenerationTerminalState>
 
 | Consumer | 代码事实 | 策略/处置 | 实施 owner |
 | --- | --- | --- | --- |
-| `sessions.create` | 多阶段 DB/runtime/binding/input mutation，无 signal | non-cancellable operation；operation id + reconciliation | `SCH-003A/B` |
+| `sessions.create` | 多阶段 DB/runtime/input mutation；当前还提前 bind window；无 signal | non-cancellable operation；operation id + reconciliation；新 backend 不负责 binding | `SCH-003A/B` |
 | `sessions.restore` session read | read-only；`SES-001` 明确保留 bounded transient retry | `retryIdempotent`；overall deadline 后不再启动 attempt | `SCH-002B`，需基于 `SES-002` contract |
 | `sessions.listMessagesPage` | read-only page lookup | `observeIdempotent` | `SCH-002B` |
 | `sessions.list` | record read + runtime state snapshot/cache hydration；无 retry | 只读/idempotent observation；不加 per-row retry | `SCH-002B`，保持 `SES-*` 四态 |
@@ -434,11 +442,24 @@ waitForGenerationSettlement(runId: string): Promise<GenerationTerminalState>
 
 - renderer 每次用户 create intent 用平台 `crypto.randomUUID()` 生成一个 `operationId`；同一 intent 的
   transport retry 必须复用该 id。
+- route schema 使用 `z.string().uuid().length(36)`；empty、非 UUID、前后空白和超长值都在 handler/DB/runtime
+  副作用前失败。history cursor 中的 operation id 复用同一 schema。
 - main 在执行副作用前登记 operation，并预分配 `sessionId`。
 - 同 id + 同 input fingerprint 返回既有 state；同 id + 不同 fingerprint 返回
   `OperationConflictError`，绝不覆盖旧 operation。
+- 新 id 在 insert 前还要查询相同 fingerprint 的所有 `pending/unknown` operation，包括已经 dismiss 的记录。
+  命中时返回 typed `ExistingCreateOperationError` 与 content-free existing operation id/state，不启动新的
+  session/runtime/input。`failed/succeeded` 已 terminal，不阻止用户创建内容相同的新 session。
 - fingerprint 只用于冲突检测，和 session 数据保存在同一 SQLite/SQLCipher database；不得另建
   plaintext sidecar。日志不得记录 message、file path、fingerprint 或 payload。
+
+operation id 是 transport identity，fingerprint 是 restart 后丢失 id 时的 duplicate guard，二者不能互相
+替代。`unknown` 必须先 reconcile：权威 session/runtime/queue 证据能收敛才改成 `succeeded/failed`；仍无法
+证明时继续阻止相同 fingerprint 的新 create。dismiss 不是 abandon，也不授权 retry。
+
+renderer 收到 `ExistingCreateOperationError` 后只显示 content-free “Check existing operation”选择；用户显式
+选择前不把当前 draft 关联旧 operation，也不能换第三个 id继续 create。这样既能找回丢失 id，又不把“相同
+payload”武断等同于“相同用户意图”。
 
 ### 最小 journal
 
@@ -459,7 +480,8 @@ updated_at
 ```
 
 不持久化 create message/files payload 的副本。当前进程中的 single-flight entry 持有原始 input 和 Promise；
-journal 只保存 identity、stage 和结果证据。
+journal 只保存 identity、stage 和结果证据。实现要为 `(input_fingerprint, state)` duplicate lookup 与
+`(created_at, operation_id)` history cursor 建窄索引，避免 operation row 增长后每次 create/recovery 全表扫描。
 
 ### Stage 与 terminal 规则
 
@@ -476,29 +498,21 @@ journal 只保存 identity、stage 和结果证据。
 拿到每个 compensation 结果；否则它没有资格写 `failed`。这不要求把 raw error 暴露 renderer，只记录稳定
 error code 和内部日志。
 
-### Initial input acceptance 是 SCH-003 的前置 seam
+### Initial input acceptance 复用现有 durable queue
 
-当前 create 路径把两种 API 都 fire-and-forget：
+当前 production `deepchat/acp` 都解析到同一个 `agentRuntimeAgent`，它实现 `queuePendingInput()`：先在 SQLite
+pending-input store 创建 record，再在后台调用/排空 `processMessage()`。因此 `SCH-003A` 直接 await 现有
+queue Promise；它 resolve 是“输入已 durable accepted”的证据，不是 generation completed。
 
-- DeepChat `queuePendingInput()` 先在 SQLite pending-input store 创建 record，再在后台调用
-  `processMessage()`；它的 Promise resolve 可以作为“输入已被 durable queue 接收”的证据，但不表示 generation
-  完成。
-- fallback `processMessage()` 的 Promise 表示完整 processing result；await 它会把 session create 错误地变成
-  “等待整轮 generation”，仅创建 Promise 又不能证明 owner 已接收。
+规则：
 
-所以在 journal backend 前先交付 `SCH-003P`：提供一个窄的 initial-input acceptance seam。它只返回
-`not_required` 或带 content-free handle 的 `accepted`，不返回 message payload：
-
-1. 无首条输入时立即返回 `not_required`，journal 可进入 `input_not_required`；
-2. DeepChat path 必须 `await queuePendingInput()` 返回的 durable record，然后写 `input_accepted`；后台
-   `processMessage()` 继续由 runtime owner 管理，create 不等待 generation；
-3. fallback path 必须由对应 agent owner 新增“start 并返回 accepted handle”的 API；handle 只能在 owner 已接管
-   后 resolve，不能用 `void processMessage()` 或 Promise 构造成功冒充 acceptance；
-4. 如果 production fallback 无法提供该 seam，`SCH-003A/B` cutover 阻塞，不能把 stage 写成 completed；
-5. title generation 不属于 input acceptance，也不阻塞 session create operation terminal state。
-
-`SCH-003P` 先用静态 consumer inventory 和 DeepChat/ACP focused tests 证明所有 production agent path 都有
-accepted boundary。它不是 generation settlement API，也不改变 `cancelGeneration()`。
+1. 无首条输入时写 `input_not_required`；
+2. 有输入时 await `queuePendingInput()` 返回 record 后写 `input_accepted`，不等待后台 generation；
+3. 删除 create path 当前 unreachable 的 `else processMessage()`；不新增 separate acceptance slice 或
+   speculative accepted-start API；
+4. static guard 固定 production create implementation 全部具有 queue capability。未来若注册无 queue 的
+   owner，必须先单独写 owner spec 和 durable acceptance contract，不能恢复 fire-and-forget fallback；
+5. title generation 不属于 input acceptance，也不阻塞 operation terminal state。
 
 ### Route compatibility
 
@@ -508,10 +522,12 @@ accepted boundary。它不是 generation settlement API，也不改变 `cancelGe
   可以分 commit、分 develop/verify，但必须在同一个 atomic production PR/cutover 中合入；
 - route schema 在 cutover 中新增 operation envelope；新路径允许 `session: null` + `pending/unknown`；
 - 同一个 PR 把全部 production caller 改为传 `operationId`，静态 guard 要求缺失 caller 为 `0`；
+- `operationId` 必须先通过 UUID/length schema；compatibility missing id 和 malformed id 都在任何副作用前
+  finite reject；
 - 为避免 rollout/test 中的旧调用无限等待或继续留下旧 5 秒 unknown，缺少 `operationId` 的请求在任何副作用
   前立即返回 typed `OperationIdRequiredError`；它是 finite compatibility failure，不启动 create；
 - 不提供“无 id 就一直等”的 adapter，也不伪造可独立合入的 003A compatibility；
-- 新增 `sessions.getCreateOperation`、bounded `sessions.listIncompleteCreateOperations` 和 dismiss route；不新增
+- 新增 `sessions.getCreateOperation`、cursor-paginated `sessions.listCreateOperations` 和 dismiss route；不新增
   第二条 create command。
 
 内部 Electron main/renderer 同版本交付，因此这里选择 atomic cutover，比维持两套长期 create 语义更稳定。
@@ -520,39 +536,55 @@ accepted boundary。它不是 generation settlement API，也不改变 `cancelGe
 ### Restart 后的 content-free recovery identity
 
 renderer 内存中的 current intent token 会随进程消失，仅有 `getCreateOperation(operationId)` 不足以让新
-renderer 找回 operation id。恢复采用 bounded discovery，不持久化 draft/payload：
+renderer 找回 operation id。恢复采用 cursor pagination，不持久化 draft/payload：
 
 ```text
-sessions.listIncompleteCreateOperations({ limit?: 1..20 = 10 })
-  -> items: [{ operationId, sessionId, state, stage, updatedAt }]
-  -> truncated: boolean
+sessions.listCreateOperations({ cursor?, limit?: 1..50 = 20 })
+  -> items: [{ operationId, sessionId, state, stage, createdAt, updatedAt, dismissedAt }]
+  -> nextCursor: { createdAt, operationId } | null
+  -> hasMore: boolean
 ```
 
 规则：
 
-- 只返回未 dismiss 的 `pending/unknown`；按 `updatedAt DESC, operationId ASC` 稳定排序；
+- 返回所有仍保留的 operation identity；按 immutable `createdAt DESC, operationId ASC` 稳定排序，cursor 使用
+  同一复合 key，state/updatedAt/dismiss 变化不会让 row 在翻页间移动，也不能漏掉同毫秒记录；UI recovery 默认
+  关注 `pending/unknown`，但 dismissed/history 仍可翻页查回；
 - route 不返回 prompt、files、title、agent/provider/model、fingerprint、error detail 或任何 input payload；
 - app restart 把 persisted incomplete `pending` 保守转为 `unknown`，不重放 payload；
 - 无论列表只有一条还是多条，UI 都只显示“待确认的创建记录”，必须由用户显式选择“查看结果”；不得把它
   绑定到当前 draft，不得自动 navigate/activate；
-- succeeded operation 不出现在 discovery 中；session 由正常 session list 展示；
-- dismiss 只写 content-free `dismissed_at` 并从 discovery 隐藏，保留 operation identity/fingerprint 以阻止旧
-  transport 重放；它不删除 session，也不把 unknown 改成 failed；
-- succeeded row 随 session 删除清理；failed/unknown row 不用猜测 TTL 删除。记录很小，先以 bounded query
-  和 dismiss 控制 UI，只有测量证明 DB 增长后才设计 maintenance。
+- succeeded session 仍由正常 session list 展示；history row 可用于诊断/去重，直到 session deletion cleanup；
+- dismiss 只写 content-free `dismissed_at`，含义是 UI 折叠。默认 recovery panel 可折叠它，但 history route、
+  fingerprint duplicate query 和 retry guard 都必须继续看见；它不删除 session/identity，不把 unknown 改 failed；
+- failed/unknown row 不用猜测 TTL 删除。cursor pagination 防止一次加载无界；只有测量证明 DB 增长后才设计
+  maintenance。
 
 选择 recovery item 后，UI 只用 operation id 调 `getCreateOperation`。如果状态后来 succeeded，仍按 stale
 intent 处理：刷新 session list，不抢当前页面。当前 draft 永远由现有 draft owner 保存，不能写进 journal，
 也不能附着到 restart 前的 operation。
 
-### Binding 与 renderer 收敛
+### Binding、event 与 renderer 收敛
 
-operation 晚成功时不得让过期 renderer intent 强制导航。renderer store 保留当前 create intent token：
+create backend 不拥有窗口意图，不能调用 `bindWindow()`。当前 create port 的 production caller inventory
+只有 renderer 的 `sessions.create` route；remote-control session 使用独立 remote binding owner，其他 grep
+命中是 tests 或无关同名函数。因此 `SCH-003A` 从 create repository/presenter port 移除 `webContentsId`，不为
+假想 caller 保留自动 binding。
 
-- token 仍是当前 intent：upsert session、activate/navigate、完成 onboarding；
-- 用户已切换/发起另一次 create：只刷新 session list，不覆盖当前页面；
+operation owner 在 terminal success 后只发一次 non-activation `sessions.updated(reason: 'created')` list
+notification，不带 `activeSessionId/webContentsId`。该 event 是 post-commit notification，不是 journal stage；
+renderer restart/history reconciliation 不依赖 event replay。窗口 binding 只由显式 `sessions.activate` 拥有：
+
+- token 仍是 current intent：upsert session，await `sessions.activate(sessionId)`，确认成功后 navigate 并完成
+  onboarding；
+- 用户已切换/发起另一次 create：只刷新 session list，绝不 activate/navigate；
 - `pending`：显示“正在确认创建结果”，不显示失败；
 - `unknown`：保留输入草稿，允许刷新/查询；不自动创建第二个 session。
+
+create 开始前的 binding（已有 session id 或 null）在 record/runtime/queue/pending/late success 全程不变。
+`sessions.activate` 每个 current intent 只调用一次，并只发布一次 `reason: 'activated'` event；create event 不得
+伪装 activation。测试必须分别断言 previous binding retained、stale late success 零 activate、current success
+bind exactly once/event exactly once。
 
 create 保留现有 `5_000ms` 作为第一次 observation deadline，但到点返回 `pending`，不再返回 operation
 failure。current intent 之后每 `2_000ms` 查询一次，最多自动查询 `15` 次；仍未 terminal 就停止自动 timer，
@@ -592,13 +624,14 @@ Unknown
 | Draft remains available; no auto retry.     |
 +--------------------------------------------+
 
-Restart discovery (content-free)
+Restart recovery history (content-free)
 +---------------- New Thread ----------------+
 | Unconfirmed session creations (2)          |
 | 10:42  unknown                 [Check]      |
 | 10:39  unknown                 [Check]      |
-|                              [Dismiss]      |
+|                  [Dismiss] [Show history]   |
 +--------------------------------------------+
+| History: dismissed records remain checkable|
 | Current draft stays separate.              |
 +--------------------------------------------+
 ```
@@ -632,12 +665,16 @@ Restart discovery (content-free)
 
 - deferred create 超过 observation deadline 返回 `pending`，不是 `TimeoutError`。
 - 同 `operationId` 的重复 create 不会创建第二条 session/runtime/input。
-- late DB/runtime/binding/event completion 可用 operation id 查询并收敛。
+- 新 id + 相同 fingerprint 的 pending/unknown（含 dismissed）在副作用前返回 existing operation，不能重复
+  create。
+- late DB/runtime/input completion 可用 operation id 查询并收敛；create backend 全程不改变 window binding。
 - cleanup 失败或 incomplete restart 返回 `unknown`，不伪造 `failed`。
-- initial input stage 只在 durable queue 或 owner accepted handle resolve 后前进，不等待整轮 generation。
-- renderer pending 不丢草稿；stale intent 不抢导航；unknown 不自动 retry。
-- restart discovery bounded/content-free/稳定排序，用户显式选择且绝不绑定当前 draft。
-- legacy no-operation-id caller 在副作用前得到 typed finite error；`SCH-003A/B` atomic merge。
+- initial input stage 只在当前 production durable queue resolve 后前进，不等待整轮 generation；无 speculative
+  fallback API。
+- renderer pending 不丢草稿；stale intent 零 activate；current intent 显式 activate exactly once。
+- restart history cursor-paginated/content-free/稳定排序，dismissed identity 可查回，用户显式选择且绝不绑定
+  当前 draft。
+- missing、empty、malformed、超长 operation id 都在副作用前 finite reject；`SCH-003A/B` atomic merge。
 - journal 不记录 raw prompt/file/payload，日志不输出 fingerprint。
 
 ## 约束
@@ -655,7 +692,7 @@ Restart discovery (content-free)
 
 - 不在 `SCH-001` 改生产代码。
 - 不把所有 repository method 改成 AbortSignal-aware。
-- 不解决 generation settlement owner；`SCH-003P` 只定义 initial-input acceptance。
+- 不解决 generation settlement owner；create 只复用现有 durable pending-input acceptance。
 - 不改变 `cancelGeneration()` 的 request-only semantics。
 - 不给 Cron/Startup/Knowledge scheduler 建共同基类。
 - 不做 cross-device/distributed operation journal。
@@ -680,8 +717,11 @@ Restart discovery (content-free)
 | journal 保存完整 create payload 以自动重放 | 拒绝 | 重复敏感数据且扩大恢复状态机；样板先选择 conservative unknown |
 | 进程重启后看到 partial record 就自动宣称成功 | 拒绝 | 无法证明 initial input 已 accepted，也无法证明 cleanup/remote state |
 | SCH-003A backend 先独立 merge，旧 caller 无 id 就无限等 | 拒绝 | intermediate version 既不能表达 pending，也没有 finite failure；A/B 必须 atomic cutover |
-| restart journal 保存 draft/payload 方便自动恢复 | 拒绝 | 扩大敏感数据副本和错误关联；使用 content-free bounded discovery |
+| restart journal 保存 draft/payload 方便自动恢复 | 拒绝 | 扩大敏感数据副本和错误关联；使用 content-free cursor history |
 | 先实现无人使用的 `runCancellable()` | 拒绝 | 没有 owner settlement proof，unused abstraction 不能证明 cancellation |
+| create backend 为 late result 自动 bind window | 拒绝 | main 不知道 renderer intent 是否仍 current；stale success 会抢 active session |
+| dismiss 删除/排除 operation identity | 拒绝 | 会绕过 retry-before-reconcile 和 fingerprint duplicate guard |
+| 为当前不存在的 no-queue agent 新增 accepted-start API | 拒绝 | deepchat/acp 都使用已有 durable queue；零 consumer abstraction 只扩大状态机 |
 
 ## Open Questions
 

--- a/docs/architecture/scheduler-operation-contract/spec.md
+++ b/docs/architecture/scheduler-operation-contract/spec.md
@@ -445,11 +445,12 @@ waitForGenerationSettlement(runId: string): Promise<GenerationTerminalState>
 - route schema 使用 `z.string().uuid().length(36)`；empty、非 UUID、前后空白和超长值都在 handler/DB/runtime
   副作用前失败。history cursor 中的 operation id 复用同一 schema。
 - main 在执行副作用前登记 operation，并预分配 `sessionId`。
-- 同 id + 同 input fingerprint 返回既有 state；同 id + 不同 fingerprint 返回
-  `OperationConflictError`，绝不覆盖旧 operation。
+- 同 id + 同 input fingerprint 返回既有 state；同 id + 不同 fingerprint 在 service 内可使用 typed
+  `OperationConflictError`，绝不覆盖旧 operation；route 必须把它映射为 serializable `conflict` output。
 - 新 id 在 insert 前还要查询相同 fingerprint 的所有 `pending/unknown` operation，包括已经 dismiss 的记录。
-  命中时返回 typed `ExistingCreateOperationError` 与 content-free existing operation id/state，不启动新的
-  session/runtime/input。`failed/succeeded` 已 terminal，不阻止用户创建内容相同的新 session。
+  命中时 service 可使用 typed `ExistingCreateOperationError`，route 映射为 serializable `existing` output，
+  携带 content-free old operation identity/state，不启动新的 session/runtime/input。`failed/succeeded` 已
+  terminal，不阻止用户创建内容相同的新 session。
 - fingerprint 只用于冲突检测，和 session 数据保存在同一 SQLite/SQLCipher database；不得另建
   plaintext sidecar。日志不得记录 message、file path、fingerprint 或 payload。
 
@@ -457,8 +458,8 @@ operation id 是 transport identity，fingerprint 是 restart 后丢失 id 时�
 替代。`unknown` 必须先 reconcile：权威 session/runtime/queue 证据能收敛才改成 `succeeded/failed`；仍无法
 证明时继续阻止相同 fingerprint 的新 create。dismiss 不是 abandon，也不授权 retry。
 
-renderer 收到 `ExistingCreateOperationError` 后只显示 content-free “Check existing operation”选择；用户显式
-选择前不把当前 draft 关联旧 operation，也不能换第三个 id继续 create。这样既能找回丢失 id，又不把“相同
+renderer 收到 `kind: 'existing'` output 后只显示 content-free “Check existing operation”选择；用户显式选择
+前不把当前 draft 关联旧 operation，也不能换第三个 id继续 create。这样既能找回丢失 id，又不把“相同
 payload”武断等同于“相同用户意图”。
 
 ### 最小 journal
@@ -522,16 +523,64 @@ queue Promise；它 resolve 是“输入已 durable accepted”的证据，不�
   可以分 commit、分 develop/verify，但必须在同一个 atomic production PR/cutover 中合入；
 - route schema 在 cutover 中新增 operation envelope；新路径允许 `session: null` + `pending/unknown`；
 - 同一个 PR 把全部 production caller 改为传 `operationId`，静态 guard 要求缺失 caller 为 `0`；
-- `operationId` 必须先通过 UUID/length schema；compatibility missing id 和 malformed id 都在任何副作用前
-  finite reject；
-- 为避免 rollout/test 中的旧调用无限等待或继续留下旧 5 秒 unknown，缺少 `operationId` 的请求在任何副作用
-  前立即返回 typed `OperationIdRequiredError`；它是 finite compatibility failure，不启动 create；
+- route schema 直接要求 UUID/length-valid `operationId`；missing/malformed 都是 generic validation rejection，
+  在任何副作用前结束，renderer 不按错误类型分支；
 - 不提供“无 id 就一直等”的 adapter，也不伪造可独立合入的 003A compatibility；
 - 新增 `sessions.getCreateOperation`、cursor-paginated `sessions.listCreateOperations` 和 dismiss route；不新增
   第二条 create command。
 
 内部 Electron main/renderer 同版本交付，因此这里选择 atomic cutover，比维持两套长期 create 语义更稳定。
 若 static inventory 仍发现无 id 的 production caller，整个 `SCH-003` 不得 merge。
+
+### Electron IPC output contract
+
+当前 bridge 直接调用 `ipcRenderer.invoke()`；main 的 `ipcMain.handle()` 也直接让 exception 穿过 Electron，
+没有自定义 error envelope。Electron 对 rejected handler 只保证 renderer 得到 error message，不能依赖 custom
+Error class/prototype、`code`、`operationId` 或 `state`。因此 renderer 需要分支的 domain outcome 必须是正常
+route output，不是 throw。
+
+`sessions.create` output 由 `sessions.routes.ts` 的 Zod discriminated union 唯一定义，最小形状如下；字段名可在
+实现中保持同义，但三类语义不能合并：
+
+```ts
+type SessionCreateOutput =
+  | {
+      kind: 'operation'
+      operation: CreateOperationEnvelope
+      session: SessionWithState | null
+    }
+  | {
+      kind: 'existing'
+      code: 'CREATE_OPERATION_EXISTS'
+      operation: ContentFreeCreateOperationSummary
+    }
+  | {
+      kind: 'conflict'
+      code: 'CREATE_OPERATION_CONFLICT'
+      operation: ContentFreeCreateOperationSummary
+    }
+```
+
+规则：
+
+- `operation` 表示新 operation 或同 id/same fingerprint 的既有 operation；state 可以是
+  `pending/succeeded/failed/unknown`，renderer 从 envelope 读取，不从 Error 读取；
+- `existing` 表示新 id 命中 same fingerprint unresolved row；summary 必须带 old `operationId`、`sessionId`、
+  `state`、`stage`、`dismissedAt`，因此 renderer 能显式 Check；
+- `conflict` 表示 requested id 已属于不同 fingerprint；同样返回原 row 的 content-free identity/state，零
+  副作用且可 Check；
+- internal service 可以抛 typed errors，route adapter 只能用 error class/stable internal code 做 exhaustive
+  mapping；禁止按 `error.message` substring 分类；
+- malformed/missing operation id 只走 generic schema validation rejection；正常 bridge caller 会先在 preload
+  `contract.input.parse()` 失败，其他入口也必须在 main schema guard 失败。renderer 不按错误类型分支，因此不必
+  增加 output variant；若未来 UI 需要区分，也必须增加 variant；
+- unexpected infrastructure/programming error 继续 reject，renderer 只能作为 generic failure 展示，不读取
+  custom fields。
+
+boundary test 不能只直接调用 `dispatchDeepchatRoute()`。必须使用 real Electron IPC，或等价 harness：main route
+output 经过 structured serialization/clone，再由 preload `createBridge()` 和 renderer contract parse。测试覆盖
+`operation/existing/conflict` 三种 variant，并有 negative control 证明 thrown custom Error 过 Electron-like
+boundary 后只剩 message，renderer 逻辑仍不依赖丢失字段。
 
 ### Restart 后的 content-free recovery identity
 
@@ -667,6 +716,8 @@ Restart recovery history (content-free)
 - 同 `operationId` 的重复 create 不会创建第二条 session/runtime/input。
 - 新 id + 相同 fingerprint 的 pending/unknown（含 dismissed）在副作用前返回 existing operation，不能重复
   create。
+- operation/existing/conflict 是 sessions route Zod output variants；renderer 所需 id/state/code 经 structured
+  IPC boundary 后仍存在，不依赖 custom Error fields/message。
 - late DB/runtime/input completion 可用 operation id 查询并收敛；create backend 全程不改变 window binding。
 - cleanup 失败或 incomplete restart 返回 `unknown`，不伪造 `failed`。
 - initial input stage 只在当前 production durable queue resolve 后前进，不等待整轮 generation；无 speculative
@@ -722,6 +773,7 @@ Restart recovery history (content-free)
 | create backend 为 late result 自动 bind window | 拒绝 | main 不知道 renderer intent 是否仍 current；stale success 会抢 active session |
 | dismiss 删除/排除 operation identity | 拒绝 | 会绕过 retry-before-reconcile 和 fingerprint duplicate guard |
 | 为当前不存在的 no-queue agent 新增 accepted-start API | 拒绝 | deepchat/acp 都使用已有 durable queue；零 consumer abstraction 只扩大状态机 |
+| renderer 从 custom Error 的 code/operationId/state 分支 | 拒绝 | Electron invoke rejection 只可靠保留 message；domain outcome 必须是 Zod route output |
 
 ## Open Questions
 

--- a/docs/architecture/scheduler-operation-contract/spec.md
+++ b/docs/architecture/scheduler-operation-contract/spec.md
@@ -1,0 +1,570 @@
+# Scheduler Operation Contract
+
+## 状态
+
+- Task：`SCH-001`
+- Finding：`A-04`
+- 文档类型：Architecture SDD
+- 决策状态：已定稿，无 `[NEEDS CLARIFICATION]`
+- 后续实施：`SCH-002A`、`SCH-002B`、`SCH-003A`、`SCH-003B`
+
+## 先纠正一个分类误区
+
+`cancellable`、`idempotent`、`non-cancellable` 不是严格互斥的三种性质。
+
+- `cancellable` 描述“能不能要求正在执行的 attempt 停止，并观察到它已经结束”。
+- `idempotent` 描述“重复执行是否仍然只有同一个业务效果”。
+- `non-cancellable` 是 cancellation capability 的反面，不是 idempotency 的反面。
+
+例如一个只读查询可以同时是 cancellable 和 idempotent；一个写入也可能不可取消但有唯一键，因此
+idempotent。若把三个词直接做成一个 `kind`，调用方会误以为“能取消就能安全 retry”或“幂等就可以并发
+retry”。这两种推导都不成立。
+
+本设计保留审计报告要求的三种**执行策略**，但先按两个维度证明能力，再选择策略：
+
+| 执行策略 | cancellation capability | replay safety | 典型处理 |
+| --- | --- | --- | --- |
+| `cancellable` | owner 能接收 `AbortSignal`，并能证明 attempt 最终 settle | 可幂等也可不幂等 | deadline 发出 abort，等 attempt settle；默认不自动 retry |
+| `idempotent` | 可以不可取消 | owner 已证明重复执行效果相同 | 只在上一 attempt 已 settle 后 retry；deadline 后关闭 retry loop |
+| `non-cancellable` | 不能证明可停止 | 重复有副作用、成本或结果不确定 | operation identity + `pending/unknown` + reconciliation |
+
+选择顺序是：先证明可取消；证明不了时再证明完整幂等；两者都证明不了就按 non-cancellable
+mutation 处理。默认策略是最后一种，不能凭函数名或 HTTP method 猜测。
+
+## 用户需要
+
+当前 route `Scheduler.timeout()` 能让调用方在 deadline 到达时收到 `TimeoutError`，但不能停止底层
+operation。若 operation 是 session create、发送输入或工具交互，界面可能显示失败，而后台稍后成功。
+若外层紧接着 retry，还可能同时运行两个 attempt。
+
+用户需要的是：
+
+1. timeout、cancel、retry 的名字与真实能力一致；
+2. retry 永远不与同一次调用中尚未 settle 的 attempt 重叠；
+3. 不可取消 mutation 不再伪装成确定失败；
+4. 有意的异步 settlement 设计继续保留，不因“看起来反常”被误改；
+5. 改造按小 PR 交付，避免一次重写 session、chat、provider 和 runtime。
+
+## 目标
+
+- 固定 `deadline`、`cancellation request`、`attempt settlement`、`operation settlement` 的不同含义。
+- 把现有 route `Scheduler` 改名并收窄为 `OperationRunner`；它不再假装自己拥有 domain mutation。
+- 为 cancellable 和 idempotent operation 定义不同 API，不提供“万能 `run(kind)`”。
+- 为 non-cancellable mutation 定义 domain-owned operation/reconciliation contract。
+- 给现有每个生产 consumer 一个有代码证据的迁移去向。
+- 保留 `AgentRuntimePresenter.cancelGeneration()` 的 request-only、stream-handler-settlement 设计。
+- 让 `sessions.create` 成为第一个 unknown-outcome mutation 样板。
+
+## 范围澄清：这里说的 Scheduler 是谁
+
+本设计只处理 [`src/main/routes/scheduler.ts`](../../../src/main/routes/scheduler.ts) 的 route operation
+helper。它不是：
+
+- Cron Jobs 的 `SchedulerProcessManager` / utility host；
+- `StartupWorkloadCoordinator` 的 startup task queue；
+- Knowledge Presenter 的 knowledge task scheduler；
+- renderer 的 polling、debounce 或 animation scheduling。
+
+这些模块碰巧也使用 scheduler/task 命名，但有自己的队列、状态机和 owner。本轮不建立全仓统一调度框架，
+也不把它们塞进 `OperationRunner`。
+
+## 代码真相
+
+### 1. 当前 timeout 只结束等待，不结束 operation
+
+[`TimeoutInput`](../../../src/main/routes/scheduler.ts#L9) 接收已经启动的 `Promise<T>`。调用
+`timeout()` 以前，JavaScript 已经求值 `task:` 右侧表达式并启动 operation。
+
+[`timeout()`](../../../src/main/routes/scheduler.ts#L91) 的实际流程是：
+
+```text
+already-started task ────────────────────────────── late resolve/reject
+                  └─ Promise.race ── deadline ── caller gets TimeoutError
+                                      └─ abort timer only
+```
+
+`finally` 中 abort 的是 `node:timers/promises` 的 delay controller，不是底层 operation。外部
+`signal` 也只让 race reject；它没有传给 task。
+
+因此当前 `TimeoutError` 只证明“caller 不等了”，不证明：
+
+- operation 收到 cancel；
+- operation 停止；
+- operation 没有副作用；
+- operation 不会稍后成功。
+
+### 2. 当前 retry 可以在 timed-out attempt 仍运行时启动下一次
+
+[`retry()`](../../../src/main/routes/scheduler.ts#L106) 每轮调用 `task()`，只等待这一层 Promise 的
+结果。`SessionService.restoreSession()` 把 `timeout()` 放进 retry task：
+
+```text
+attempt 1 underlying read ───────────────────────── late settle
+              timeout wrapper ── 5s reject
+                                 25ms
+                                      attempt 2 starts
+```
+
+对应代码在
+[`SessionService.restoreSession()`](../../../src/main/routes/sessions/sessionService.ts#L38)。这不是
+理论推演：wrapper 的 rejection 与 underlying read 的 settlement 是两个不同 Promise。
+
+`SES-001` 已确认 restore read-only retry 是故意保留的产品策略，但该策略只允许 retry 已 settle 的
+transient read；它没有授权 overlapping retry。
+
+### 3. `sessions.create` 是确定的 non-cancellable mutation
+
+当前路径是：
+
+```text
+SessionService.createSession
+  -> Scheduler.timeout(5s, already-started Promise)
+    -> AgentSessionPresenter.createSession
+      -> resolve agent/provider/config
+      -> NewSessionManager.create          # SQLite record/search/environment writes
+      -> initializeSessionRuntime          # runtime/provider initialization
+      -> bindWindow
+      -> publish sessions.updated
+      -> read runtime state
+      -> enqueue initial input             # generation continues separately
+```
+
+证据：
+
+- route timeout：
+  [`sessionService.ts`](../../../src/main/routes/sessions/sessionService.ts#L27)
+- record 创建后才 await runtime 初始化：
+  [`agentSessionPresenter/index.ts`](../../../src/main/presenter/agentSessionPresenter/index.ts#L315)
+- 创建 record 会同步写 `new_sessions`、search document 和 environment：
+  [`sessionManager.ts`](../../../src/main/presenter/agentSessionPresenter/sessionManager.ts#L45)
+- runtime 成功后才 bind window、发 event、读取 state：
+  [`agentSessionPresenter/index.ts`](../../../src/main/presenter/agentSessionPresenter/index.ts#L405)
+- 初始输入在 session result 形成后另行启动：
+  [`agentSessionPresenter/index.ts`](../../../src/main/presenter/agentSessionPresenter/index.ts#L430)
+
+所以 5 秒可能落在 record 已写、runtime 正初始化或即将 binding 的任意位置。caller 收到
+`TimeoutError` 后，这条调用链仍可完成。`createSession()` 没有 `AbortSignal` 参数，也没有 operation id。
+
+此外，better-sqlite3 是同步调用。若同步 SQLite 工作阻塞 event loop，deadline timer 本身也不能按时
+运行；Promise race 不能抢占同步 JavaScript/SQLite。
+
+### 4. activate/deactivate 和 provider model timeout 是无效包装
+
+[`activateSession()` / `deactivateSession()`](../../../src/main/presenter/agentSessionPresenter/index.ts#L1869)
+的方法体没有 `await`：它们同步修改 `windowBindings` 并同步 publish event，随后才返回 resolved
+Promise。`SessionService` 得到 Promise 时副作用已经发生，5 秒 timeout 不可能保护这段工作。
+
+[`ProviderService.listModels()`](../../../src/main/routes/providers/providerService.ts#L16) 更直接：
+
+```ts
+Promise.resolve(providerCatalogPort.getProviderModels(providerId))
+```
+
+`getProviderModels()` 在 `Promise.resolve()` 之前同步执行。这里的两个 timeout 只增加 timer/race，不能
+中断或限制同步 model lookup。
+
+### 5. provider connection test 的 5 秒外层 timeout 会留下真实请求
+
+[`ProviderService.testConnection()`](../../../src/main/routes/providers/providerService.ts#L39) 用 5 秒
+route timeout 包住 `LLMProviderPresenter.check()`。
+
+带 `modelId` 时，`check()` 会发起真实 `provider.completions()`，内部另有 60 秒 race；外层 5 秒先
+返回 `TimeoutError` 后，请求仍会继续，见
+[`llmProviderPresenter/index.ts`](../../../src/main/presenter/llmProviderPresenter/index.ts#L639)。
+
+这类 probe 虽不修改 DeepChat 数据，却可能消耗 provider quota/cost，因此不能只凭“查询”二字认定完整
+幂等，也不能在 5 秒后自动重试。
+
+### 6. ChatService controller 不拥有 generation settlement
+
+[`ChatService`](../../../src/main/routes/chat/chatService.ts#L16) 的 `activeControllers` 只传给 route
+Scheduler race；`ProviderExecutionPort.sendMessage()` 没有 signal 参数。当前 send 实际上通常在 durable
+pending input 被接收后就返回，generation 在 runtime 后台继续。
+
+因此 30 分钟 `CHAT_SEND_TIMEOUT_MS` 不是 generation handle 的 timeout。这个 owner 混淆由 `D-05` 的
+`CHAT-001/002` 决策，不在 SCH 中顺手重写。
+
+### 7. `cancelGeneration()` request-only 是故意的
+
+[`AgentRuntimePresenter.cancelGeneration()`](../../../src/main/presenter/agentRuntimePresenter/index.ts#L2204)
+只 abort controller 并释放 deferred tool/permission controller。它明确不写 terminal block、不发 terminal
+hooks、不设 idle，也不从 active map 提前清理。
+
+这不是遗漏。commit `3ea97717` 为 steer/queue race 修复了重复 settlement：真正的 terminal settlement
+由 in-flight `processMessage()` / stream handler exactly once 完成。对应测试覆盖：
+
+- aborted turn 只发一次 `user_stop` hook；
+- stale aborted run 不覆盖 newer run；
+- cancel 后 terminal block 由 stream completion 写入。
+
+所以 SCH 不会把 `cancelGeneration(): Promise<void>` 重新解释为“generation 已物理结束”。它只表示
+“cancel request 已发出”。如果调用方需要等待 terminal settlement，应由 generation owner 按 `runId`
+提供单独的 observable handle；不能让 route Scheduler 猜。
+
+## 历史意图核验
+
+commit `8ef5c858` 同时引入：
+
+- route `Scheduler` 代码；
+- `SessionService` / `ChatService` / `ProviderService`；
+- 已归档的 `main-kernel-refactor/ports-and-scheduler.md`。
+
+历史文档的目标是统一 timeout/retry/cancel、提高 cleanup 可靠性和 fake scheduler 可测性；它还声称
+cancel owner 需要统一。但同一份建议接口已经把 `TimeoutInput.task` 定义成 `Promise<T>`，使 signal 无法
+传入 operation。
+
+结论：抽出窄 timing port 的意图是故意且合理的；“deadline race 等于 cancellation”不是有证据支持的
+产品语义，而是第一版接口能力与目标冲突。正确处理是保留窄 port/测试 seam，修正 contract，不回退到
+散落 timer，也不引入第三方 retry framework。
+
+commit `9cce714e` 增加 message pagination 时沿用了既有 timeout wrapper，只说明调用方式延续，不能证明
+unknown-outcome 是有意产品行为。
+
+## 术语
+
+| 术语 | 本文定义 |
+| --- | --- |
+| `attempt` | 一次具体 task invocation，从 task function 被调用到它的 Promise settle |
+| `deadline` | caller 最多愿意等待到的时间点；本身不等于 cancellation |
+| `cancellation request` | owner 收到停止请求；不等于 operation 已终止 |
+| `attempt settlement` | attempt Promise fulfilled/rejected，且 owner 声明该 attempt 不再继续产生效果 |
+| `operation settlement` | domain operation 到达 `succeeded` 或确定 `failed` terminal state |
+| `pending` | operation 仍由 owner 跟踪并可能完成 |
+| `unknown` | 当前没有足够证据宣称成功或失败；不得自动开始新 operation |
+| `reconciliation` | 用 operation id 查询权威状态，并将 `pending/unknown` 收敛到可行动状态 |
+
+## 架构决策
+
+### D1. `Scheduler` 重命名为 `OperationRunner`
+
+route helper 不排队、不分配资源，也不拥有 Cron/background task。`OperationRunner` 更准确。它只负责：
+
+- abortable sleep/backoff；
+- idempotent observation deadline；
+- cooperative cancellable attempt；
+- strictly sequential bounded retry。
+
+它不负责：
+
+- domain operation id；
+- session create journal；
+- generation active-run state；
+- compensation/rollback；
+- cross-process recovery。
+
+### D2. 不做万能 `run({ kind })`
+
+分别使用 capability-specific API，避免 caller 用一个字符串绕过类型和 review：
+
+```ts
+interface OperationRunner {
+  sleep(input: SleepInput): Promise<void>
+
+  observeIdempotent<T>(input: {
+    task: () => Promise<T>
+    deadlineMs: number
+    reason: string
+    signal?: AbortSignal
+  }): Promise<T>
+
+  runCancellable<T>(input: {
+    task: (signal: AbortSignal) => Promise<T>
+    deadlineMs: number
+    reason: string
+    signal?: AbortSignal
+  }): Promise<T>
+
+  retryIdempotent<T>(input: {
+    task: (attempt: number) => Promise<T>
+    maxAttempts: number
+    initialDelayMs: number
+    backoff: number
+    overallDeadlineMs: number
+    reason: string
+    signal?: AbortSignal
+    shouldRetry: (error: unknown) => boolean
+  }): Promise<T>
+}
+```
+
+这是 contract 方向，不要求实现照抄属性排列。必须保留的语义是 task factory、overall deadline、
+sequential attempt 和 explicit `shouldRetry`。
+
+### D3. `observeIdempotent` 明确只是 observation deadline
+
+contract：
+
+1. runner 先安装 deadline/abort listener，再调用 task factory；
+2. deadline 到达时 caller 收到 `ObservationDeadlineError`；
+3. 若 task 不支持 cancellation，底层 attempt 可以晚 settle；
+4. runner 必须给 late resolve/reject 安装 handler，不能产生 unhandled rejection；
+5. 此 API 只允许 read-only 或完整 idempotent operation；
+6. 它不自动 retry，也不把 late result 写回 caller state。
+
+`ObservationDeadlineError` 的名字用于阻止上层把它理解成“operation 已失败”。
+
+### D4. `runCancellable` 必须等待 cancellation settlement
+
+contract：
+
+1. task 必须是 `(signal) => Promise<T>`，不能传 already-started Promise；
+2. deadline 或外部 abort 会 abort runner 创建/组合的 signal；
+3. runner 在 task Promise settle 前不启动任何 replacement/retry；
+4. deadline 导致的 abort 只有在 attempt settle 后才映射为 `TimeoutError`；
+5. 外部 abort 只有在 attempt settle 后才映射为 `AbortError`；
+6. task 若忽略 signal 并永不 settle，runner 也不会伪造“已取消”。这是 owner contract violation，不能用
+   第二个 race 掩盖；此类 operation 应重新分类为 non-cancellable。
+
+`TimeoutError` 在新 contract 中因此具有更强含义：cancellation request 已发出，且本 attempt 已 settle。
+它仍不自动授权 retry；retry 还要单独证明 idempotency 或 no-effect failure。
+
+### D5. `retryIdempotent` 只 retry 已 settle 的 rejection
+
+contract：
+
+1. 任意时刻最多一个 attempt running；测试断言 `maxConcurrentAttempts === 1`；
+2. 只有 task Promise 已 reject 且 `shouldRetry(error) === true` 才进入 backoff；
+3. fulfilled 直接返回；`shouldRetry === false` 直接抛出；
+4. overall deadline/外部 abort 到达时关闭 loop，之后绝不启动新 attempt；
+5. 若 deadline 到达时 attempt 仍运行，caller 可结束等待，但 late attempt 只被 drain，不能触发下一轮；
+6. backoff 期间 deadline/abort 立即阻止下一 attempt；
+7. `maxAttempts` 必须是有限正整数；默认不 retry。
+
+`SES-002` 的 restore retry 只对 typed `transient_error` rejection 返回 true。`missing`、`unavailable`、
+validation error、observation deadline 都不 retry。
+
+### D6. non-cancellable mutation 由 domain owner 管理
+
+`OperationRunner` 不接收 non-cancellable mutation。domain contract 至少包含：
+
+```ts
+type OperationState<T> =
+  | { state: 'pending'; operationId: string }
+  | { state: 'succeeded'; operationId: string; value: T }
+  | { state: 'failed'; operationId: string; code: string }
+  | { state: 'unknown'; operationId: string; code: string }
+```
+
+规则：
+
+- observation deadline 返回 `pending`，不是 throw `TimeoutError`；
+- 同一 `operationId` 的重复请求复用同一 attempt/state，不启动第二个；
+- `failed` 只允许在 owner 能证明 attempt settle 且补偿完成时写入；
+- cleanup/compensation 任一结果不确定时必须是 `unknown`；
+- `unknown` 不自动 retry；用户显式 retry 也必须先 reconcile 原 operation；
+- reconciliation 查询权威记录，不按 error message 猜状态；
+- operation result 不因 renderer 停止等待而丢失。
+
+### D7. cancel request 和 settlement handle 分开
+
+以下两个 API 语义不能复用一个 `Promise<void>`：
+
+```ts
+requestGenerationCancel(sessionId: string): Promise<void>
+waitForGenerationSettlement(runId: string): Promise<GenerationTerminalState>
+```
+
+当前 `cancelGeneration()` 保持第一种语义和兼容名称。第二种只有 `CHAT-001/002` 证明真实 consumer 需要时
+才新增；SCH 不预建无 consumer 的 generation abstraction。
+
+## 三类策略的完整 contract
+
+| 项目 | `cancellable` | `idempotent` | `non-cancellable` |
+| --- | --- | --- | --- |
+| task 输入 | `(signal) => Promise<T>` | `() => Promise<T>` | domain command + `operationId` |
+| deadline 到达 | abort signal，等待 settle | caller 停止观察；attempt 可晚 settle | 返回 `pending` |
+| external cancel | 请求 abort，等待 settle | 只停止观察/关闭 retry loop | caller 停止等待；operation 继续 |
+| timeout 后能否称失败 | task settle 后可称 timed out | 不能称 underlying 失败 | 不能；只能 pending/unknown |
+| retry 条件 | settle 后，且另证幂等/no-effect | settle rejection + explicit classifier | 不自动 retry；同 id reconcile |
+| overlap | 禁止 | 禁止 retry overlap | 同 id 永远 single-flight |
+| reconciliation | 通常不需要 | 通常不需要 | 必须 |
+| late result | 已由 settle 消化 | drain 丢弃，不触发 retry | 写 operation state，供查询 |
+
+## 现有 production consumer 的分类与去向
+
+| Consumer | 代码事实 | 策略/处置 | 实施 owner |
+| --- | --- | --- | --- |
+| `sessions.create` | 多阶段 DB/runtime/binding/input mutation，无 signal | non-cancellable operation；operation id + reconciliation | `SCH-003A/B` |
+| `sessions.restore` session read | read-only；`SES-001` 明确保留 bounded transient retry | `retryIdempotent`；overall deadline 后不再启动 attempt | `SCH-002B`，需基于 `SES-002` contract |
+| `sessions.listMessagesPage` | read-only page lookup | `observeIdempotent` | `SCH-002B` |
+| `sessions.list` | record read + runtime state snapshot/cache hydration；无 retry | 只读/idempotent observation；不加 per-row retry | `SCH-002B`，保持 `SES-*` 四态 |
+| `sessions.getActive` | read + 当前 missing 时 unbind；`SES-*` 正在拆四态 | 先落 `SES-002`，再迁 idempotent observation；timeout 不清 binding | `SES-002` → `SCH-002B` |
+| `sessions.activate/deactivate` | 同步 map set/unset + event，Promise 返回前已完成 | 直接 await/call；删除无效 timeout，不 retry | `SCH-002B` |
+| `providers.listModels` | getter 在 `Promise.resolve` 前同步完成 | 直接调用；删除两个无效 timeout | `SCH-002B` |
+| `providers.testConnection` | 真实 network/model probe，外层 5s 不取消请求，可能有 quota cost | 删除 route 5s race；等待 provider owner 的真实结果/自有 timeout；不 retry | `SCH-002B` |
+| Chat preflight session/agent lookup | read-only；stop 可以停止 route 继续进入 mutation | `observeIdempotent` + route wait signal；late read 不继续 mutation | `SCH-002B` |
+| `chat.sendMessage/steer/respond` | durable queue/tool mutation；现有 task 不收 signal | 删除 mutation 外层 deadline，等待 owner acceptance；不自动 retry | `SCH-002B`；generation owner 仍属 `CHAT-*` |
+| `chat.stopStream` cleanup | controller abort + permission clear + cancel request；cancel 不是 terminal settle | 保留 request semantics，直接等待 cleanup request results；不宣称 generation settled | `SCH-002B` / `CHAT-*` |
+
+## `sessions.create` reconciliation 样板
+
+### Operation identity
+
+- renderer 每次用户 create intent 用平台 `crypto.randomUUID()` 生成一个 `operationId`；同一 intent 的
+  transport retry 必须复用该 id。
+- main 在执行副作用前登记 operation，并预分配 `sessionId`。
+- 同 id + 同 input fingerprint 返回既有 state；同 id + 不同 fingerprint 返回
+  `OperationConflictError`，绝不覆盖旧 operation。
+- fingerprint 只用于冲突检测，和 session 数据保存在同一 SQLite/SQLCipher database；不得另建
+  plaintext sidecar。日志不得记录 message、file path、fingerprint 或 payload。
+
+### 最小 journal
+
+`SCH-003A` 使用 domain-specific `session_create_operations`，不建立全仓 generic operation framework。
+最小字段：
+
+```text
+operation_id        primary key
+session_id          unique
+input_fingerprint
+state               pending | succeeded | failed | unknown
+stage               accepted | record_created | runtime_ready | input_accepted | completed
+error_code          nullable, stable/content-free
+created_at
+updated_at
+```
+
+不持久化 create message/files payload 的副本。当前进程中的 single-flight entry 持有原始 input 和 Promise；
+journal 只保存 identity、stage 和结果证据。
+
+### Stage 与 terminal 规则
+
+| 证据 | journal 结果 |
+| --- | --- |
+| operation 已登记，attempt 正在当前进程执行 | `pending` |
+| session record/runtime ready/initial input acceptance 全部完成 | `succeeded` |
+| attempt 已 reject，且 runtime/provider/record compensation 全部完成 | `failed` |
+| cleanup 任一步失败、process 在 incomplete stage 重启、无法证明 initial input 是否 accepted | `unknown` |
+| process 重启后 journal `succeeded` 且 session record 可读 | 重建 result，仍为 `succeeded` |
+| process 重启后 journal incomplete | 保守转 `unknown`；不自动重放 payload |
+
+当前 `cleanupFailedSessionInitialization()` 会吞掉 cleanup error 后删除 record。实施时必须让 operation owner
+拿到每个 compensation 结果；否则它没有资格写 `failed`。这不要求把 raw error 暴露 renderer，只记录稳定
+error code 和内部日志。
+
+### Route compatibility
+
+保留 `sessions.create` 名称，做 additive staged contract：
+
+- input 新增 optional `operationId`；新 `SessionClient` 总是传；旧 caller 不传时走 compatibility wait，
+  但不再使用 false 5s timeout；
+- output 在现有 `session` 基础上增加 operation envelope；新路径允许 `session: null` + `pending/unknown`；
+- 新增只读 `sessions.getCreateOperation` reconciliation route；不新增第二条 create route；
+- compatibility caller 归零后，后续 cleanup 才能把 `operationId` 设为 required。
+
+### Binding 与 renderer 收敛
+
+operation 晚成功时不得让过期 renderer intent 强制导航。renderer store 保留当前 create intent token：
+
+- token 仍是当前 intent：upsert session、activate/navigate、完成 onboarding；
+- 用户已切换/发起另一次 create：只刷新 session list，不覆盖当前页面；
+- `pending`：显示“正在确认创建结果”，不显示失败；
+- `unknown`：保留输入草稿，允许刷新/查询；不自动创建第二个 session。
+
+UI 状态示意：
+
+```text
+Normal (< observation deadline)
++---------------- New Thread ----------------+
+| [prompt draft............................] |
+|                              [Send]        |
++--------------------------------------------+
+                    |
+                    v
++------------------- Chat -------------------+
+| session created and activated              |
++--------------------------------------------+
+
+Slow / pending
++---------------- New Thread ----------------+
+| Creating session...                        |
+| Confirming the result; draft is preserved. |
++--------------------------------------------+
+                    |
+             reconcile by operationId
+              /                     \
+             v                       v
+      succeeded/current       succeeded/stale intent
+      activate + navigate     refresh list only
+
+Unknown
++---------------- New Thread ----------------+
+| Creation result is not confirmed.          |
+| [Check again] [Refresh session list]        |
+| Draft remains available; no auto retry.     |
++--------------------------------------------+
+```
+
+实际 copy 使用 i18n key；ASCII 只定义布局和行为，不锁定最终文案。
+
+## Acceptance Criteria
+
+### SCH-001 文档
+
+- 本目录有 `spec.md`、`plan.md`、`tasks.md`，无 `[NEEDS CLARIFICATION]`。
+- 三种策略的 timeout/retry/settlement/reconciliation contract 全部明确。
+- current consumers、故意的 cancel settlement 和历史意图都有代码/commit 证据。
+- `SCH-002/003` 可以按文档独立开发、验证和回滚。
+
+### SCH-002 implementation
+
+- task factory 在 operation 启动前交给 runner；cancellable task 能收到 signal。
+- `retryIdempotent` 的最大并发 attempt 永远为 1。
+- overall deadline 在 running attempt/backoff 到达后都不会再启动 retry。
+- late rejection 被 drain，无 unhandled rejection。
+- sync provider catalog 不再经过 fake timeout。
+- provider connection probe 不再出现“5 秒报失败、请求继续”的 route-level false timeout。
+- session/chat safe consumers 按 inventory 迁移；`sessions.create` 是唯一临时 legacy exception。
+- `AgentRuntimePresenter` exactly-once cancel settlement tests 不变绿转红。
+
+### SCH-003 implementation
+
+- deferred create 超过 observation deadline 返回 `pending`，不是 `TimeoutError`。
+- 同 `operationId` 的重复 create 不会创建第二条 session/runtime/input。
+- late DB/runtime/binding/event completion 可用 operation id 查询并收敛。
+- cleanup 失败或 incomplete restart 返回 `unknown`，不伪造 `failed`。
+- renderer pending 不丢草稿；stale intent 不抢导航；unknown 不自动 retry。
+- legacy no-operation-id caller 有明确 compatibility test。
+- journal 不记录 raw prompt/file/payload，日志不输出 fingerprint。
+
+## 约束
+
+- 技术标识、type/function/commit 使用英文；用户文案通过 i18n。
+- 不增加第三方 retry/operation dependency；Node timer、AbortController、SQLite 已足够。
+- 不用 feature flag 维持两套长期语义；compatibility 是按 caller allowlist 删除的短期 adapter。
+- 不在 SCH 中重写 Agent runtime generation queue、Cron scheduler 或 startup coordinator。
+- 同步 better-sqlite3 不能被 Promise deadline 抢占；性能问题要靠 query/worker/owner 设计解决，不能靠
+  `Promise.race` 宣称解决。
+- 所有新 error/status 使用 typed contract，不按 message substring 分类。
+
+## Non-goals
+
+- 不在 `SCH-001` 改生产代码。
+- 不把所有 repository method 改成 AbortSignal-aware。
+- 不解决 `D-05` 的最终 enqueue/generation owner 决策。
+- 不改变 `cancelGeneration()` 的 request-only semantics。
+- 不给 Cron/Startup/Knowledge scheduler 建共同基类。
+- 不做 cross-device/distributed operation journal。
+- 不在 journal 复制用户 prompt/file payload。
+- 不自动恢复 incomplete create payload；重启后证据不足时明确 `unknown`。
+- 不用任意 timeout 数值替代 owner contract；现有 5s/30min 只有在对应语义仍成立时保留。
+
+## 已拒绝方案
+
+| 方案 | 结论 | 原因 |
+| --- | --- | --- |
+| 把 `Promise<T>` 改成 `(signal) => Promise<T>` 后一律称可取消 | 拒绝 | task 收到 signal 不等于 owner 会停止/settle |
+| timeout 后固定 sleep 一小段再 retry | 拒绝 | 无法证明上一 attempt 已结束，时间常数不是 correctness proof |
+| 幂等 operation 可以 overlap retry | 拒绝 | requirement 明确禁止；并发读也可能放大负载/cost |
+| 所有 mutation timeout 都改成很长 | 拒绝 | 只降低触发概率，unknown-outcome 仍存在 |
+| timeout 后调用 cleanup 然后立刻报 failed | 拒绝 | cleanup 也可能失败；必须观察 compensation 结果 |
+| 让 generic runner 保存所有 domain operations | 拒绝 | operation state/reconciliation 是 domain truth，会形成新 God object |
+| 引入 `p-retry`/queue framework | 拒绝 | 现有问题是 contract，不是缺少 backoff library |
+| cancel 时同步写 terminal state | 拒绝 | 违背 `3ea97717` exactly-once settlement 修复，会恢复 stale/double settlement |
+| 新建第二个 `sessions.beginCreate` API 家族 | 拒绝 | 可在现有 typed route 上 additive migration，无需永久双轨 |
+| journal 保存完整 create payload 以自动重放 | 拒绝 | 重复敏感数据且扩大恢复状态机；样板先选择 conservative unknown |
+| 进程重启后看到 partial record 就自动宣称成功 | 拒绝 | 无法证明 initial input 已 accepted，也无法证明 cleanup/remote state |
+
+## Open Questions
+
+无。实现参数、兼容顺序和 restart disposition 已在本 SDD 中确定。

--- a/docs/architecture/scheduler-operation-contract/spec.md
+++ b/docs/architecture/scheduler-operation-contract/spec.md
@@ -6,7 +6,8 @@
 - Finding：`A-04`
 - 文档类型：Architecture SDD
 - 决策状态：已定稿，无 `[NEEDS CLARIFICATION]`
-- 后续实施：`SCH-002A`、`SCH-002B`、`SCH-003A`、`SCH-003B`
+- 后续实施：`SCH-002A`、`SCH-002B`、`PRV-CAN-001`、`SCH-003P`、`SCH-003A`、
+  `SCH-003B`
 
 ## 先纠正一个分类误区
 
@@ -49,7 +50,8 @@ operation。若 operation 是 session create、发送输入或工具交互，界
 
 - 固定 `deadline`、`cancellation request`、`attempt settlement`、`operation settlement` 的不同含义。
 - 把现有 route `Scheduler` 改名并收窄为 `OperationRunner`；它不再假装自己拥有 domain mutation。
-- 为 cancellable 和 idempotent operation 定义不同 API，不提供“万能 `run(kind)`”。
+- 为当前有 consumer 的 idempotent operation 定义窄 API；cancellable 只保留 owner-specific future
+  contract，不预建零 consumer API。
 - 为 non-cancellable mutation 定义 domain-owned operation/reconciliation contract。
 - 给现有每个生产 consumer 一个有代码证据的迁移去向。
 - 保留 `AgentRuntimePresenter.cancelGeneration()` 的 request-only、stream-handler-settlement 设计。
@@ -172,6 +174,11 @@ route timeout 包住 `LLMProviderPresenter.check()`。
 返回 `TimeoutError` 后，请求仍会继续，见
 [`llmProviderPresenter/index.ts`](../../../src/main/presenter/llmProviderPresenter/index.ts#L639)。
 
+60 秒也只是 observation deadline：它 resolve `null`，没有把 signal 传给 `provider.completions()`，所以
+不能称 provider owner timeout。未传 `modelId` 时则直接 `await provider.check()`；不同 provider 实现各自
+决定网络/SDK 行为，`LLMProviderPresenter` 没有统一 deadline，更没有统一 cancellation。部分实现可能由 SDK
+内部超时，部分可能无界；在逐 provider 证明前，文档不能概括成“owner 已有 timeout”。
+
 这类 probe 虽不修改 DeepChat 数据，却可能消耗 provider quota/cost，因此不能只凭“查询”二字认定完整
 幂等，也不能在 5 秒后自动重试。
 
@@ -241,7 +248,6 @@ route helper 不排队、不分配资源，也不拥有 Cron/background task。`
 
 - abortable sleep/backoff；
 - idempotent observation deadline；
-- cooperative cancellable attempt；
 - strictly sequential bounded retry。
 
 它不负责：
@@ -267,13 +273,6 @@ interface OperationRunner {
     signal?: AbortSignal
   }): Promise<T>
 
-  runCancellable<T>(input: {
-    task: (signal: AbortSignal) => Promise<T>
-    deadlineMs: number
-    reason: string
-    signal?: AbortSignal
-  }): Promise<T>
-
   retryIdempotent<T>(input: {
     task: (attempt: number) => Promise<T>
     maxAttempts: number
@@ -290,6 +289,11 @@ interface OperationRunner {
 这是 contract 方向，不要求实现照抄属性排列。必须保留的语义是 task factory、overall deadline、
 sequential attempt 和 explicit `shouldRetry`。
 
+当前生产 consumer 中，没有一处同时满足“真实 owner 接收 signal”和“abort 后可观察 physical settlement”。
+因此 `SCH-002A` 不实现 `runCancellable()`，也不把 unused method 放进 port。未来只有真实 consumer 与 owner
+一起证明 cancellation/settlement 后，才建立 owner-specific slice；下面 D4 是该 slice 的验收规则，不是
+本轮待实现接口。
+
 ### D3. `observeIdempotent` 明确只是 observation deadline
 
 contract：
@@ -303,7 +307,7 @@ contract：
 
 `ObservationDeadlineError` 的名字用于阻止上层把它理解成“operation 已失败”。
 
-### D4. `runCancellable` 必须等待 cancellation settlement
+### D4. future cancellable API 必须等待 cancellation settlement
 
 contract：
 
@@ -318,6 +322,10 @@ contract：
 `TimeoutError` 在新 contract 中因此具有更强含义：cancellation request 已发出，且本 attempt 已 settle。
 它仍不自动授权 retry；retry 还要单独证明 idempotency 或 no-effect failure。
 
+该决策现在只冻结语义。`SCH-002A` 不实现、导出或测试 `runCancellable()`；首次真实 consumer 必须在
+owner-specific follow-up slice 中同时补 signal propagation、settlement proof 和 focused tests，不能只在
+generic runner 中加一个无人使用的方法。
+
 ### D5. `retryIdempotent` 只 retry 已 settle 的 rejection
 
 contract：
@@ -330,8 +338,22 @@ contract：
 6. backoff 期间 deadline/abort 立即阻止下一 attempt；
 7. `maxAttempts` 必须是有限正整数；默认不 retry。
 
-`SES-002` 的 restore retry 只对 typed `transient_error` rejection 返回 true。`missing`、`unavailable`、
-validation error、observation deadline 都不 retry。
+`SES-002` 的 restore/getActive 都把 `transient_error` result 转成 typed rejected read attempt，且只有该
+rejection 的 `shouldRetry` 返回 true。`missing`、`unavailable`、validation error、observation deadline 都不
+retry。
+
+### D5.1. 数值输入先验证，再启动 task
+
+runner 不接受 JavaScript timer 的隐式 coercion。所有数值必须在 task factory 调用前验证：
+
+- `deadlineMs`、`overallDeadlineMs`、`initialDelayMs`：有限整数，`0..2_147_483_647`；`0` 表示立即截止；
+- `maxAttempts`：有限正整数；production caller 必须用常量，本轮只允许已评审的 `2`；
+- `backoff`：有限且非负；每次算出的实际 delay 也必须仍是有限整数并在 timer 上限内；
+- discovery `limit`：route schema 约束为整数 `1..20`，默认 `10`；
+- `NaN`、`Infinity`、负数、小数毫秒、乘法溢出全部 typed reject，且 task/timer 均不得启动。
+
+这些是 correctness validation，不是业务 timeout 调参。`25ms`、`2 attempts` 和 route observation deadline
+仍由 consumer contract 固定，caller 不能从未验证的 IPC 值覆盖。
 
 ### D6. non-cancellable mutation 由 domain owner 管理
 
@@ -344,6 +366,11 @@ type OperationState<T> =
   | { state: 'failed'; operationId: string; code: string }
   | { state: 'unknown'; operationId: string; code: string }
 ```
+
+这里的 TypeScript 只是解释状态机。真实 session operation DTO 只由
+`src/shared/contracts/routes/sessions.routes.ts` 的 Zod schema 定义，并从 schema/route contract inference
+得到类型；不得在 `src/shared/types/agent-interface.d.ts` 再定义一份 operation DTO。后者属于 agent/runtime
+消息领域，不是 sessions route contract owner。
 
 规则：
 
@@ -388,13 +415,18 @@ waitForGenerationSettlement(runId: string): Promise<GenerationTerminalState>
 | `sessions.restore` session read | read-only；`SES-001` 明确保留 bounded transient retry | `retryIdempotent`；overall deadline 后不再启动 attempt | `SCH-002B`，需基于 `SES-002` contract |
 | `sessions.listMessagesPage` | read-only page lookup | `observeIdempotent` | `SCH-002B` |
 | `sessions.list` | record read + runtime state snapshot/cache hydration；无 retry | 只读/idempotent observation；不加 per-row retry | `SCH-002B`，保持 `SES-*` 四态 |
-| `sessions.getActive` | read + 当前 missing 时 unbind；`SES-*` 正在拆四态 | 先落 `SES-002`，再迁 idempotent observation；timeout 不清 binding | `SES-002` → `SCH-002B` |
+| `sessions.getActive` | read + 当前 missing 时 unbind；`SES-*` 正在拆四态 | 与 restore 一样保留 typed transient、settled-only `2 attempts/25ms`；attempt/deadline/transient 期间不清 binding | `SES-002` → `SCH-002B` |
 | `sessions.activate/deactivate` | 同步 map set/unset + event，Promise 返回前已完成 | 直接 await/call；删除无效 timeout，不 retry | `SCH-002B` |
 | `providers.listModels` | getter 在 `Promise.resolve` 前同步完成 | 直接调用；删除两个无效 timeout | `SCH-002B` |
-| `providers.testConnection` | 真实 network/model probe，外层 5s 不取消请求，可能有 quota cost | 删除 route 5s race；等待 provider owner 的真实结果/自有 timeout；不 retry | `SCH-002B` |
+| `providers.testConnection` | 真实 probe；route 5s 不取消；model 60s 也只观察；no-model 无统一 bound | `SCH-002B` 暂不改，保留为已知 legacy exception且绝不 retry；真实 owner cancellation 另立 `PRV-CAN-001` | provider owner task 后再迁移 |
 | Chat preflight session/agent lookup | read-only；stop 可以停止 route 继续进入 mutation | `observeIdempotent` + route wait signal；late read 不继续 mutation | `SCH-002B` |
 | `chat.sendMessage/steer/respond` | durable queue/tool mutation；现有 task 不收 signal | 删除 mutation 外层 deadline，等待 owner acceptance；不自动 retry | `SCH-002B`；generation owner 仍属 `CHAT-*` |
 | `chat.stopStream` cleanup | controller abort + permission clear + cancel request；cancel 不是 terminal settle | 保留 request semantics，直接等待 cleanup request results；不宣称 generation settled | `SCH-002B` / `CHAT-*` |
+
+`sessions.restore` 与 `sessions.getActive` 的 retry 数值不是建议值，而是 SES contract：最多 `2 attempts`、
+两次之间 `25ms`，只对已 settle 的 typed `transient_error` retry。尤其 `getActive` 在第一次 transient、backoff、
+第二次 attempt、observation deadline 或 late settlement 期间都必须保留原 binding；只有 SES-002 的权威
+`missing` terminal 结果才有资格 unbind。`unavailable`、deadline 和 transient 都不等于 missing。
 
 ## `sessions.create` reconciliation 样板
 
@@ -418,8 +450,10 @@ operation_id        primary key
 session_id          unique
 input_fingerprint
 state               pending | succeeded | failed | unknown
-stage               accepted | record_created | runtime_ready | input_accepted | completed
+stage               accepted | record_created | runtime_ready | input_not_required |
+                    input_accepted | completed
 error_code          nullable, stable/content-free
+dismissed_at        nullable
 created_at
 updated_at
 ```
@@ -432,7 +466,7 @@ journal 只保存 identity、stage 和结果证据。
 | 证据 | journal 结果 |
 | --- | --- |
 | operation 已登记，attempt 正在当前进程执行 | `pending` |
-| session record/runtime ready/initial input acceptance 全部完成 | `succeeded` |
+| session record/runtime ready/initial input accepted 或明确 not required 全部完成 | `succeeded` |
 | attempt 已 reject，且 runtime/provider/record compensation 全部完成 | `failed` |
 | cleanup 任一步失败、process 在 incomplete stage 重启、无法证明 initial input 是否 accepted | `unknown` |
 | process 重启后 journal `succeeded` 且 session record 可读 | 重建 result，仍为 `succeeded` |
@@ -442,15 +476,74 @@ journal 只保存 identity、stage 和结果证据。
 拿到每个 compensation 结果；否则它没有资格写 `failed`。这不要求把 raw error 暴露 renderer，只记录稳定
 error code 和内部日志。
 
+### Initial input acceptance 是 SCH-003 的前置 seam
+
+当前 create 路径把两种 API 都 fire-and-forget：
+
+- DeepChat `queuePendingInput()` 先在 SQLite pending-input store 创建 record，再在后台调用
+  `processMessage()`；它的 Promise resolve 可以作为“输入已被 durable queue 接收”的证据，但不表示 generation
+  完成。
+- fallback `processMessage()` 的 Promise 表示完整 processing result；await 它会把 session create 错误地变成
+  “等待整轮 generation”，仅创建 Promise 又不能证明 owner 已接收。
+
+所以在 journal backend 前先交付 `SCH-003P`：提供一个窄的 initial-input acceptance seam。它只返回
+`not_required` 或带 content-free handle 的 `accepted`，不返回 message payload：
+
+1. 无首条输入时立即返回 `not_required`，journal 可进入 `input_not_required`；
+2. DeepChat path 必须 `await queuePendingInput()` 返回的 durable record，然后写 `input_accepted`；后台
+   `processMessage()` 继续由 runtime owner 管理，create 不等待 generation；
+3. fallback path 必须由对应 agent owner 新增“start 并返回 accepted handle”的 API；handle 只能在 owner 已接管
+   后 resolve，不能用 `void processMessage()` 或 Promise 构造成功冒充 acceptance；
+4. 如果 production fallback 无法提供该 seam，`SCH-003A/B` cutover 阻塞，不能把 stage 写成 completed；
+5. title generation 不属于 input acceptance，也不阻塞 session create operation terminal state。
+
+`SCH-003P` 先用静态 consumer inventory 和 DeepChat/ACP focused tests 证明所有 production agent path 都有
+accepted boundary。它不是 generation settlement API，也不改变 `cancelGeneration()`。
+
 ### Route compatibility
 
-保留 `sessions.create` 名称，做 additive staged contract：
+保留 `sessions.create` 名称，但不发布一个“backend 已改、renderer 仍旧”的中间版本：
 
-- input 新增 optional `operationId`；新 `SessionClient` 总是传；旧 caller 不传时走 compatibility wait，
-  但不再使用 false 5s timeout；
-- output 在现有 `session` 基础上增加 operation envelope；新路径允许 `session: null` + `pending/unknown`；
-- 新增只读 `sessions.getCreateOperation` reconciliation route；不新增第二条 create route；
-- compatibility caller 归零后，后续 cleanup 才能把 `operationId` 设为 required。
+- `SCH-003A` 是 non-mergeable backend development slice；`SCH-003B` 显式依赖 `SCH-003A + SES-003`；二者
+  可以分 commit、分 develop/verify，但必须在同一个 atomic production PR/cutover 中合入；
+- route schema 在 cutover 中新增 operation envelope；新路径允许 `session: null` + `pending/unknown`；
+- 同一个 PR 把全部 production caller 改为传 `operationId`，静态 guard 要求缺失 caller 为 `0`；
+- 为避免 rollout/test 中的旧调用无限等待或继续留下旧 5 秒 unknown，缺少 `operationId` 的请求在任何副作用
+  前立即返回 typed `OperationIdRequiredError`；它是 finite compatibility failure，不启动 create；
+- 不提供“无 id 就一直等”的 adapter，也不伪造可独立合入的 003A compatibility；
+- 新增 `sessions.getCreateOperation`、bounded `sessions.listIncompleteCreateOperations` 和 dismiss route；不新增
+  第二条 create command。
+
+内部 Electron main/renderer 同版本交付，因此这里选择 atomic cutover，比维持两套长期 create 语义更稳定。
+若 static inventory 仍发现无 id 的 production caller，整个 `SCH-003` 不得 merge。
+
+### Restart 后的 content-free recovery identity
+
+renderer 内存中的 current intent token 会随进程消失，仅有 `getCreateOperation(operationId)` 不足以让新
+renderer 找回 operation id。恢复采用 bounded discovery，不持久化 draft/payload：
+
+```text
+sessions.listIncompleteCreateOperations({ limit?: 1..20 = 10 })
+  -> items: [{ operationId, sessionId, state, stage, updatedAt }]
+  -> truncated: boolean
+```
+
+规则：
+
+- 只返回未 dismiss 的 `pending/unknown`；按 `updatedAt DESC, operationId ASC` 稳定排序；
+- route 不返回 prompt、files、title、agent/provider/model、fingerprint、error detail 或任何 input payload；
+- app restart 把 persisted incomplete `pending` 保守转为 `unknown`，不重放 payload；
+- 无论列表只有一条还是多条，UI 都只显示“待确认的创建记录”，必须由用户显式选择“查看结果”；不得把它
+  绑定到当前 draft，不得自动 navigate/activate；
+- succeeded operation 不出现在 discovery 中；session 由正常 session list 展示；
+- dismiss 只写 content-free `dismissed_at` 并从 discovery 隐藏，保留 operation identity/fingerprint 以阻止旧
+  transport 重放；它不删除 session，也不把 unknown 改成 failed；
+- succeeded row 随 session 删除清理；failed/unknown row 不用猜测 TTL 删除。记录很小，先以 bounded query
+  和 dismiss 控制 UI，只有测量证明 DB 增长后才设计 maintenance。
+
+选择 recovery item 后，UI 只用 operation id 调 `getCreateOperation`。如果状态后来 succeeded，仍按 stale
+intent 处理：刷新 session list，不抢当前页面。当前 draft 永远由现有 draft owner 保存，不能写进 journal，
+也不能附着到 restart 前的 operation。
 
 ### Binding 与 renderer 收敛
 
@@ -460,6 +553,11 @@ operation 晚成功时不得让过期 renderer intent 强制导航。renderer st
 - 用户已切换/发起另一次 create：只刷新 session list，不覆盖当前页面；
 - `pending`：显示“正在确认创建结果”，不显示失败；
 - `unknown`：保留输入草稿，允许刷新/查询；不自动创建第二个 session。
+
+create 保留现有 `5_000ms` 作为第一次 observation deadline，但到点返回 `pending`，不再返回 operation
+failure。current intent 之后每 `2_000ms` 查询一次，最多自动查询 `15` 次；仍未 terminal 就停止自动 timer，
+保留手工“再次检查”。这些是 code-owned UX constants，不从 IPC 接收，正确性不依赖它们；页面离开或 intent
+变化必须立即清理 timer。
 
 UI 状态示意：
 
@@ -493,6 +591,16 @@ Unknown
 | [Check again] [Refresh session list]        |
 | Draft remains available; no auto retry.     |
 +--------------------------------------------+
+
+Restart discovery (content-free)
++---------------- New Thread ----------------+
+| Unconfirmed session creations (2)          |
+| 10:42  unknown                 [Check]      |
+| 10:39  unknown                 [Check]      |
+|                              [Dismiss]      |
++--------------------------------------------+
+| Current draft stays separate.              |
++--------------------------------------------+
 ```
 
 实际 copy 使用 i18n key；ASCII 只定义布局和行为，不锁定最终文案。
@@ -504,17 +612,20 @@ Unknown
 - 本目录有 `spec.md`、`plan.md`、`tasks.md`，无 `[NEEDS CLARIFICATION]`。
 - 三种策略的 timeout/retry/settlement/reconciliation contract 全部明确。
 - current consumers、故意的 cancel settlement 和历史意图都有代码/commit 证据。
-- `SCH-002/003` 可以按文档独立开发、验证和回滚。
+- `SCH-002` 可独立交付；`SCH-003A/B` 可以分段开发验证但明确 atomic merge，文档没有伪造 backend-only
+  compatibility。
 
 ### SCH-002 implementation
 
-- task factory 在 operation 启动前交给 runner；cancellable task 能收到 signal。
+- task factory 在 operation 启动前交给 runner；`SCH-002A` 没有零 consumer 的 cancellable API。
 - `retryIdempotent` 的最大并发 attempt 永远为 1。
 - overall deadline 在 running attempt/backoff 到达后都不会再启动 retry。
 - late rejection 被 drain，无 unhandled rejection。
 - sync provider catalog 不再经过 fake timeout。
-- provider connection probe 不再出现“5 秒报失败、请求继续”的 route-level false timeout。
-- session/chat safe consumers 按 inventory 迁移；`sessions.create` 是唯一临时 legacy exception。
+- provider connection probe 的 route 5 秒 wrapper 被明确保留为 known exception；model 60 秒 observation 与
+  no-model unbounded truth 有 tests，`PRV-CAN-001` 未完成前不假称 owner cancellation。
+- session/chat safe consumers 按 inventory 迁移；legacy allowlist 包含 `sessions.create` 与精确的
+  `providers.testConnection`，不得扩大。
 - `AgentRuntimePresenter` exactly-once cancel settlement tests 不变绿转红。
 
 ### SCH-003 implementation
@@ -523,15 +634,18 @@ Unknown
 - 同 `operationId` 的重复 create 不会创建第二条 session/runtime/input。
 - late DB/runtime/binding/event completion 可用 operation id 查询并收敛。
 - cleanup 失败或 incomplete restart 返回 `unknown`，不伪造 `failed`。
+- initial input stage 只在 durable queue 或 owner accepted handle resolve 后前进，不等待整轮 generation。
 - renderer pending 不丢草稿；stale intent 不抢导航；unknown 不自动 retry。
-- legacy no-operation-id caller 有明确 compatibility test。
+- restart discovery bounded/content-free/稳定排序，用户显式选择且绝不绑定当前 draft。
+- legacy no-operation-id caller 在副作用前得到 typed finite error；`SCH-003A/B` atomic merge。
 - journal 不记录 raw prompt/file/payload，日志不输出 fingerprint。
 
 ## 约束
 
 - 技术标识、type/function/commit 使用英文；用户文案通过 i18n。
 - 不增加第三方 retry/operation dependency；Node timer、AbortController、SQLite 已足够。
-- 不用 feature flag 维持两套长期语义；compatibility 是按 caller allowlist 删除的短期 adapter。
+- 不用 feature flag 维持两套长期语义；create 使用 atomic cutover，无 id compatibility 只做 finite pre-effect
+  rejection。
 - 不在 SCH 中重写 Agent runtime generation queue、Cron scheduler 或 startup coordinator。
 - 同步 better-sqlite3 不能被 Promise deadline 抢占；性能问题要靠 query/worker/owner 设计解决，不能靠
   `Promise.race` 宣称解决。
@@ -541,13 +655,14 @@ Unknown
 
 - 不在 `SCH-001` 改生产代码。
 - 不把所有 repository method 改成 AbortSignal-aware。
-- 不解决 `D-05` 的最终 enqueue/generation owner 决策。
+- 不解决 generation settlement owner；`SCH-003P` 只定义 initial-input acceptance。
 - 不改变 `cancelGeneration()` 的 request-only semantics。
 - 不给 Cron/Startup/Knowledge scheduler 建共同基类。
 - 不做 cross-device/distributed operation journal。
 - 不在 journal 复制用户 prompt/file payload。
 - 不自动恢复 incomplete create payload；重启后证据不足时明确 `unknown`。
-- 不用任意 timeout 数值替代 owner contract；现有 5s/30min 只有在对应语义仍成立时保留。
+- 不用任意 timeout 数值替代 owner contract；provider route 5s 是显式登记、等待 owner task 的遗留观察
+  deadline，不得描述为真实取消或稳定终态。
 
 ## 已拒绝方案
 
@@ -564,6 +679,9 @@ Unknown
 | 新建第二个 `sessions.beginCreate` API 家族 | 拒绝 | 可在现有 typed route 上 additive migration，无需永久双轨 |
 | journal 保存完整 create payload 以自动重放 | 拒绝 | 重复敏感数据且扩大恢复状态机；样板先选择 conservative unknown |
 | 进程重启后看到 partial record 就自动宣称成功 | 拒绝 | 无法证明 initial input 已 accepted，也无法证明 cleanup/remote state |
+| SCH-003A backend 先独立 merge，旧 caller 无 id 就无限等 | 拒绝 | intermediate version 既不能表达 pending，也没有 finite failure；A/B 必须 atomic cutover |
+| restart journal 保存 draft/payload 方便自动恢复 | 拒绝 | 扩大敏感数据副本和错误关联；使用 content-free bounded discovery |
+| 先实现无人使用的 `runCancellable()` | 拒绝 | 没有 owner settlement proof，unused abstraction 不能证明 cancellation |
 
 ## Open Questions
 

--- a/docs/architecture/scheduler-operation-contract/tasks.md
+++ b/docs/architecture/scheduler-operation-contract/tasks.md
@@ -9,6 +9,8 @@
 - [x] 关闭 verifier 对 getActive/restart/legacy/initial-input/provider truth 的 blocking findings。
 - [x] 明确 operation DTO 只由 sessions route Zod/schema inference 拥有。
 - [x] 明确 `SCH-003A/B` 为 atomic production cutover，`SCH-003B depends on SCH-003A + SES-003`。
+- [x] inventory 证明 deepchat/acp 共用 durable queue；删除 speculative acceptance slice。
+- [x] 固定 unbound create、cursor history、dismiss retry guard 与 UUID validation contract。
 - [x] 文档无 `[NEEDS CLARIFICATION]`。
 
 ## SCH-002A：OperationRunner core
@@ -58,58 +60,52 @@
 - [ ] 删除 provider route 5s legacy wrapper 后更新 allowlist。
 - [ ] 独立 provider owner verifier 逐 adapter 检查 signal propagation/settlement。
 
-## SCH-003P：Initial-input acceptance seam
-
-- [ ] 静态枚举所有 production agent create path 是否支持 queue/accepted-start。
-- [ ] 定义 `not_required | accepted` 的 content-free acceptance result。
-- [ ] DeepChat path await durable `queuePendingInput()` record，不等待后台 generation。
-- [ ] fallback path 增加 owner accepted-start handle，不 await whole `processMessage()`。
-- [ ] 禁止用 Promise 创建成功或 fire-and-forget 冒充 accepted。
-- [ ] queue/start reject 时不返回 accepted；无 seam 的 production path 阻止 003 cutover。
-- [ ] title generation 不阻塞 acceptance；不改 generation terminal/cancel owner。
-- [ ] 覆盖 no-input、queue deferred/reject、fallback accepted-before-generation、unsupported、dedupe tests。
-- [ ] 独立 verifier 审查 accepted boundary 与 generation settlement 分离。
-
 ## SCH-003A：Session create backend development slice（不可独立 merge）
 
-- [ ] 建 backend review branch/commit，基于 SCH-002B + SCH-003P。
+- [ ] 建 backend review branch/commit，基于 SCH-002B。
 - [ ] operation schema/DTO 只写在 `sessions.routes.ts` 并通过 schema/route inference取类型。
 - [ ] 加 guard：`agent-interface.d.ts` 不得复制 session operation DTO。
-- [ ] route schema/handler支持 operation envelope；missing id 在任何副作用前 typed finite reject。
+- [ ] operation id schema 使用 UUID + length 36；missing/empty/whitespace/non-UUID/overlength 在任何副作用前
+  reject。
 - [ ] 增加 `sessions.getCreateOperation`。
-- [ ] 增加 bounded `sessions.listIncompleteCreateOperations`：limit int `1..20`、default `10`、稳定排序。
-- [ ] 增加 dismiss route：只写 `dismissedAt`，保留 dedupe identity，不删 session。
+- [ ] 增加 cursor `sessions.listCreateOperations`：limit int `1..50`、default `20`、复合稳定排序、同毫秒不漏。
+- [ ] history 返回所有 identity 与 `dismissedAt`；dismiss 只供 UI 折叠，history/retry guard 仍可查回。
 - [ ] 实现 domain-specific `session_create_operations` additive table。
 - [ ] journal 只存 identity/fingerprint/stage/content-free error/timestamps，不存 raw payload。
-- [ ] operation 开始前登记 identity并预分配 session id。
+- [ ] operation 开始前登记 identity 并预分配 session id。
 - [ ] 同 id/same fingerprint single-flight；same id/different fingerprint conflict。
+- [ ] 新 id + same fingerprint pending/unknown（含 dismissed）返回 existing operation且零副作用。
 - [ ] durable stage 覆盖 record/runtime/input_not_required|input_accepted/completed。
-- [ ] initial input 只调用 SCH-003P seam，不等待 generation terminal。
+- [ ] inventory/guard 固定 deepchat/acp 都 resolve 到有 durable queue 的 `agentRuntimeAgent`。
+- [ ] await 现有 `queuePendingInput()` record；删除 unreachable `processMessage` fallback；不新增 accepted-start API。
 - [ ] observation deadline 返回 pending，不 abort/不 throw false TimeoutError。
-- [ ] create 首次 observation 固定 `5_000ms`；renderer reconciliation 固定 `2_000ms × 15`，到界后只留
-  manual Check，离页/intent 变化清 timer。
+- [ ] create 首次 observation 固定 `5_000ms`。
+- [ ] create port/backend 移除 `webContentsId`/`bindWindow`；record/runtime/queue/late success 全程保留原 binding。
+- [ ] terminal success 只发一次 non-activation `created` list notification，不带 active fields，不作为 journal stage。
 - [ ] compensation 全部 settle success 才 failed；任一不确定为 unknown。
 - [ ] restart succeeded 可重建；incomplete pending -> unknown；不 replay payload。
-- [ ] discovery 只返回 operationId/sessionId/state/stage/updatedAt，不返回内容/配置/fingerprint。
-- [ ] succeeded 随 session delete；failed/unknown 可 dismiss，不加 speculative TTL worker。
-- [ ] 覆盖 fast/deferred/duplicate/conflict/cleanup/restart/discovery/dismiss/data-hygiene tests。
-- [ ] 独立 backend verifier 审查 DB truth/stage/acceptance/no-duplicate/privacy。
+- [ ] history 只返回 content-free identity/status/cursor，不返回内容/配置/fingerprint。
+- [ ] succeeded 随 session delete；failed/unknown 保留 reconcile/dedupe evidence，不加 speculative TTL worker。
+- [ ] 覆盖 validation/fingerprint/dismiss/cursor/unbound/created-event/queue/cleanup/restart/privacy tests。
+- [ ] 独立 backend verifier 审查 DB truth/stage/acceptance/no-duplicate/binding/privacy。
 - [ ] 明确此 commit 不创建独立 production PR、不单独 merge。
 
 ## SCH-003B：Renderer/integration atomic cutover
 
-- [ ] 显式基于 `SCH-003A + SES-003 + SCH-003P` 集成。
+- [ ] 显式基于 `SCH-003A + SES-003` 集成。
 - [ ] SessionClient 每个新 intent 生成 operation id；transport retry 复用，用户 explicit retry 换新 id。
 - [ ] production missing-operation-id caller static count = 0。
 - [ ] store 维护 current intent token，draft 保持在原 owner，不复制到 operation state/journal。
-- [ ] pending 时局部 bounded reconciliation；离页 cleanup observer，不 cancel main operation。
-- [ ] succeeded/current 激活导航；succeeded/stale 只刷新列表。
-- [ ] failed/unknown/query error 均不自动 create retry，draft 保留。
-- [ ] startup bounded discovery；无论一条/多条都需 explicit selection。
+- [ ] pending reconciliation 固定 `2_000ms × 15`；到界只留 manual Check，离页/intent 变化清 timer。
+- [ ] succeeded/current 显式 activate exactly once 后导航；succeeded/stale 只刷新且 activate count = 0。
+- [ ] failed/unknown/query error 均不自动 create retry；unknown 先 reconcile，相同 fingerprint unresolved 不重建。
+- [ ] `ExistingCreateOperationError` 显式 Check，不自动绑定当前 draft、不生成新 id；dismissed row 同样拦截。
+- [ ] startup cursor history 可遍历 pending/unknown/dismissed；无论一条/多条都需 explicit selection。
 - [ ] restart recovery 不绑定当前 draft、不自动 activate/navigate、不显示内容。
-- [ ] dismiss 只隐藏 record，不删除 session/identity。
-- [ ] 增加 pending/unknown/discovery/dismiss/error i18n keys。
-- [ ] 添加 current/stale/page-leave/restart-one-many/privacy/dismiss/duplicate-event tests。
+- [ ] dismiss 只折叠 open panel；history/retry guard 可见，不删除 session/identity。
+- [ ] 增加 pending/unknown/history/dismiss/error i18n keys。
+- [ ] 添加 current/stale activate 1/0、binding retained、cursor pages、dismiss guard、privacy、duplicate event tests。
+- [ ] current activate failure 不 navigate/onboarding、不改 previous binding，created session 仍可从 list 选择。
 - [ ] 删除 create 5s legacy timeout；provider 未完成时 adapter 只剩精确 provider一项。
 - [ ] 003A + 003B 只创建一个 atomic production PR，不发布 backend-only version。
 - [ ] 独立 integration verifier 审查 navigation、draft、poll cleanup、restart、legacy finite semantics。
@@ -126,9 +122,11 @@
 - [ ] restore/getActive 的 `2 attempts/25ms` 与 binding retention 没有退化。
 - [ ] provider truth 没有被概括成不存在的 owner timeout。
 - [ ] 没有改变 request-only `cancelGeneration()` 的 exactly-once settlement owner。
-- [ ] initial input accepted 不等待 whole generation，也不提前伪造。
-- [ ] restart recovery content-free、bounded、explicit selection，不关联当前 draft。
+- [ ] initial input 只 await 当前 durable queue，不等待 whole generation、不保留 speculative fallback。
+- [ ] restart history content-free、cursor-complete、dismissed recoverable、explicit selection，不关联当前 draft。
 - [ ] session operation DTO 没有逃出 sessions route schema owner。
-- [ ] missing operation id finite pre-effect reject；003A/B 未被拆成独立 production merge。
+- [ ] operation id missing/empty/malformed/overlength finite pre-effect reject；003A/B 未拆成独立 production merge。
+- [ ] create backend 不 bind；current/stale activate exactly 1/0；previous/null binding retained。
+- [ ] same fingerprint pending/unknown（含 dismissed）无法绕过 retry-before-reconcile guard。
 - [ ] journal 除 DB-only fingerprint 外不含 raw prompt/file/payload；log 不含 fingerprint/raw payload。
 - [ ] full suite 新增失败数为 0；PR body 有 scope、影响、收益、manual gap、rollback。

--- a/docs/architecture/scheduler-operation-contract/tasks.md
+++ b/docs/architecture/scheduler-operation-contract/tasks.md
@@ -11,6 +11,7 @@
 - [x] 明确 `SCH-003A/B` 为 atomic production cutover，`SCH-003B depends on SCH-003A + SES-003`。
 - [x] inventory 证明 deepchat/acp 共用 durable queue；删除 speculative acceptance slice。
 - [x] 固定 unbound create、cursor history、dismiss retry guard 与 UUID validation contract。
+- [x] 固定 Electron-safe operation/existing/conflict output；renderer 不依赖 custom Error fields。
 - [x] 文档无 `[NEEDS CLARIFICATION]`。
 
 ## SCH-002A：OperationRunner core
@@ -64,6 +65,8 @@
 
 - [ ] 建 backend review branch/commit，基于 SCH-002B。
 - [ ] operation schema/DTO 只写在 `sessions.routes.ts` 并通过 schema/route inference取类型。
+- [ ] `sessions.create` output 是 serializable Zod discriminated union：operation/existing/conflict。
+- [ ] renderer 分支需要的 operationId/sessionId/state/stage/code/dismissedAt 全在 output，不读取 Error fields。
 - [ ] 加 guard：`agent-interface.d.ts` 不得复制 session operation DTO。
 - [ ] operation id schema 使用 UUID + length 36；missing/empty/whitespace/non-UUID/overlength 在任何副作用前
   reject。
@@ -73,8 +76,9 @@
 - [ ] 实现 domain-specific `session_create_operations` additive table。
 - [ ] journal 只存 identity/fingerprint/stage/content-free error/timestamps，不存 raw payload。
 - [ ] operation 开始前登记 identity 并预分配 session id。
-- [ ] 同 id/same fingerprint single-flight；same id/different fingerprint conflict。
-- [ ] 新 id + same fingerprint pending/unknown（含 dismissed）返回 existing operation且零副作用。
+- [ ] 同 id/same fingerprint 返回 operation；same id/different fingerprint 返回 conflict + old checkable identity。
+- [ ] 新 id + same fingerprint pending/unknown（含 dismissed）返回 existing + old checkable identity且零副作用。
+- [ ] internal typed error 由 route adapter按 class/stable code 映射，禁止按 message 分类。
 - [ ] durable stage 覆盖 record/runtime/input_not_required|input_accepted/completed。
 - [ ] inventory/guard 固定 deepchat/acp 都 resolve 到有 durable queue 的 `agentRuntimeAgent`。
 - [ ] await 现有 `queuePendingInput()` record；删除 unreachable `processMessage` fallback；不新增 accepted-start API。
@@ -99,12 +103,14 @@
 - [ ] pending reconciliation 固定 `2_000ms × 15`；到界只留 manual Check，离页/intent 变化清 timer。
 - [ ] succeeded/current 显式 activate exactly once 后导航；succeeded/stale 只刷新且 activate count = 0。
 - [ ] failed/unknown/query error 均不自动 create retry；unknown 先 reconcile，相同 fingerprint unresolved 不重建。
-- [ ] `ExistingCreateOperationError` 显式 Check，不自动绑定当前 draft、不生成新 id；dismissed row 同样拦截。
+- [ ] `kind: existing/conflict` 只读 structured output 并显式 Check，不自动绑定 draft/生成新 id。
 - [ ] startup cursor history 可遍历 pending/unknown/dismissed；无论一条/多条都需 explicit selection。
 - [ ] restart recovery 不绑定当前 draft、不自动 activate/navigate、不显示内容。
 - [ ] dismiss 只折叠 open panel；history/retry guard 可见，不删除 session/identity。
 - [ ] 增加 pending/unknown/history/dismiss/error i18n keys。
 - [ ] 添加 current/stale activate 1/0、binding retained、cursor pages、dismiss guard、privacy、duplicate event tests。
+- [ ] 增加 real IPC 或 structured serialization + `createBridge` boundary test，不接受仅 dispatcher 直调。
+- [ ] boundary test 覆盖 operation/existing/conflict；negative control 证明 custom Error 过界只剩 message。
 - [ ] current activate failure 不 navigate/onboarding、不改 previous binding，created session 仍可从 list 选择。
 - [ ] 删除 create 5s legacy timeout；provider 未完成时 adapter 只剩精确 provider一项。
 - [ ] 003A + 003B 只创建一个 atomic production PR，不发布 backend-only version。
@@ -125,6 +131,7 @@
 - [ ] initial input 只 await 当前 durable queue，不等待 whole generation、不保留 speculative fallback。
 - [ ] restart history content-free、cursor-complete、dismissed recoverable、explicit selection，不关联当前 draft。
 - [ ] session operation DTO 没有逃出 sessions route schema owner。
+- [ ] Electron IPC renderer 分支不依赖 Error prototype/custom code/id/state/message substring。
 - [ ] operation id missing/empty/malformed/overlength finite pre-effect reject；003A/B 未拆成独立 production merge。
 - [ ] create backend 不 bind；current/stale activate exactly 1/0；previous/null binding retained。
 - [ ] same fingerprint pending/unknown（含 dismissed）无法绕过 retry-before-reconcile guard。

--- a/docs/architecture/scheduler-operation-contract/tasks.md
+++ b/docs/architecture/scheduler-operation-contract/tasks.md
@@ -1,0 +1,101 @@
+# Scheduler Operation Contract Tasks
+
+## SCH-001：Decision / SDD
+
+- [x] 从最新 `docs/audit-remediation-plan` 基线建立独立 worktree/branch。
+- [x] 审计 `src/main/routes/scheduler.ts` 的 timeout/retry/abort 实现。
+- [x] 枚举 `SessionService`、`ChatService`、`ProviderService` 的全部 production consumer。
+- [x] 追踪 session create 的 DB/runtime/binding/event/initial input side effects。
+- [x] 追踪 provider model sync getter 和 provider check 的真实 timeout owner。
+- [x] 追踪 Chat route controller 与 Agent runtime generation controller 的 owner 差异。
+- [x] 核验 commit `8ef5c858` 的原始 Scheduler 目标与接口冲突。
+- [x] 核验 commit `3ea97717` 的 request-only cancel / exactly-once settlement 意图。
+- [x] 定义 cancellation capability × replay safety 两轴与三种 execution policy。
+- [x] 定义 deadline、retry、settlement、unknown outcome、reconciliation contract。
+- [x] 设计 `SCH-002A/B`、`SCH-003A/B` 的独立交付顺序、测试和回滚。
+- [x] 定义 pending/unknown renderer 行为与 ASCII UI。
+- [x] 文档无 `[NEEDS CLARIFICATION]`。
+
+## SCH-002A：OperationRunner core
+
+- [ ] 建独立 branch/worktree，基于已合入 SCH-001。
+- [ ] 把 route `Scheduler` 重命名/收窄为 `OperationRunner`。
+- [ ] 实现 `observeIdempotent()`，task 使用 factory，late result 安全 drain。
+- [ ] 实现 `runCancellable()`，signal 传给 owner，abort 后等待 attempt settle。
+- [ ] 实现 `retryIdempotent()`，overall deadline 和 explicit `shouldRetry`。
+- [ ] 保留临时 legacy `timeout()` adapter，仅供 consumer migration。
+- [ ] 增加 pre-abort、late resolve/reject、listener/timer cleanup tests。
+- [ ] 增加 deferred attempt，断言 retry `maxConcurrentAttempts === 1`。
+- [ ] 增加 deadline-in-attempt/backoff，断言之后不启动 attempt。
+- [ ] 独立 verify agent 审查 typed error、abort/settlement 和资源 cleanup。
+- [ ] 运行 focused tests、typecheck:node、format:check、lint:architecture、lint。
+- [ ] PR 记录 automation/manual gap/rollback，merge 后在 base 跑 full regression。
+
+## SCH-002B：Safe consumer migration
+
+- [ ] 确认/合入 `SES-002` 后再修改 `SessionService` availability path。
+- [ ] restore 改用 settled-only typed transient retry；overall deadline 后禁止新 attempt。
+- [ ] session read/list/page/getActive 迁到 idempotent observation，不做 per-row retry。
+- [ ] activate/deactivate 删除无效 timeout wrapper。
+- [ ] provider model getter 删除 `Promise.resolve` + timeout 包装。
+- [ ] provider connection test 删除 route 5 秒 false timeout，不增加 automatic retry。
+- [ ] Chat preflight reads 迁到 idempotent observation，abort 后不进入下一 mutation。
+- [ ] Chat send/steer/respond 删除 non-cancellable mutation 外层 deadline。
+- [ ] stop 保留 both-cleanups-attempted，且不把 cancel request 说成 terminal settlement。
+- [ ] 加 static allowlist：legacy timeout 只允许 `SessionService.createSession` 一处。
+- [ ] 保持 AgentRuntime exactly-once cancel/stale-run tests 全绿。
+- [ ] 独立 verify agent 对每个 consumer 重做 capability 分类，不接受按名称推断。
+- [ ] 跑 focused/full tests、typecheck、format、i18n、lint。
+- [ ] 手工验证 provider slow check、stop during preflight、normal send/restore。
+- [ ] merge 后更新统一审计实施 ledger。
+
+## SCH-003A：Session create operation backend
+
+- [ ] 建独立 architecture/backend branch，基于 SCH-002B。
+- [ ] 定义 additive create operation DTO 和 typed error/status schema。
+- [ ] 增加 optional input `operationId` 与 `sessions.getCreateOperation` route。
+- [ ] 实现 domain-specific `session_create_operations` additive table。
+- [ ] journal 只存 identity/fingerprint/stage/content-free error code，不存 raw payload。
+- [ ] operation 开始前登记 identity 并预分配 session id。
+- [ ] 实现同 id/same fingerprint single-flight，同 id/different fingerprint conflict。
+- [ ] 在 record/runtime/initial-input acceptance/completion 后更新 durable stage。
+- [ ] observation deadline 返回 pending，不 abort/不 throw TimeoutError。
+- [ ] compensation 结果可观察：全成功才 failed；任一不确定则 unknown。
+- [ ] process restart：succeeded 可重建；incomplete 保守 unknown；不 replay payload。
+- [ ] session delete 清理关联 succeeded operation row；不新增 speculative TTL worker。
+- [ ] 覆盖 fast/deferred/duplicate/conflict/cleanup-failure/restart/data-hygiene tests。
+- [ ] 独立 verify agent 审查 DB truth、stage 原子边界和 no-duplicate side effects。
+- [ ] 运行 focused tests、typecheck:node、format:check、lint。
+
+## SCH-003B：Renderer reconciliation / cleanup
+
+- [ ] 基于已合入 `SES-003` route/renderer compatibility 结果 rebase。
+- [ ] SessionClient 为每个新 create intent 生成并复用 operation id。
+- [ ] session store 维护 current intent token，不复制 draft payload。
+- [ ] pending 时局部 reconciliation；页面离开 cleanup observer，不 cancel main operation。
+- [ ] succeeded/current intent 激活导航；succeeded/stale intent 只刷新列表。
+- [ ] failed/unknown 均保留 draft；unknown/check error 不自动 retry。
+- [ ] 增加 pending/unknown/failure i18n keys。
+- [ ] 按 spec ASCII 行为实现 UI state；不暴露内部 error/fingerprint。
+- [ ] 添加 API/store/component tests：current/stale/page-leave/restart/duplicate event。
+- [ ] 删除 legacy `timeout()` adapter、allowlist 和 create 5 秒 constant。
+- [ ] architecture guard 证明 legacy production consumer count = 0。
+- [ ] 独立 verify agent 审查 navigation race、draft lifecycle、poll cleanup、compatibility。
+- [ ] 跑 renderer/main focused tests、typecheck、format、i18n、lint、full tests。
+- [ ] 完成 DeepChat/ACP/slow/stale/unknown/restart/data-hygiene manual smoke。
+- [ ] PR 详细记录未自动覆盖的平台/路径、手工步骤、影响和回滚。
+- [ ] merge 后更新统一审计实施 ledger，满足全部 closure gates 后关闭 A-04。
+
+## 每个 PR 的 blocking gate
+
+- [ ] develop 与 verify 不是同一 agent。
+- [ ] blocking finding 修复后重新完整 verify，不只口头确认。
+- [ ] 没有新增 `[NEEDS CLARIFICATION]`。
+- [ ] 没有新增第三方 retry/operation dependency。
+- [ ] 没有把 signal delivery 误写成 physical cancellation proof。
+- [ ] 没有把 observation deadline 误写成 operation failure。
+- [ ] 没有 retry overlap 或 same-operation duplicate attempt。
+- [ ] 没有改变 request-only `cancelGeneration()` 的 exactly-once settlement owner。
+- [ ] journal 除 fingerprint 外不含 raw prompt/file/payload；log 不含 fingerprint/raw payload。
+- [ ] full suite 新增失败数为 0；历史 baseline failure 单独列出。
+- [ ] PR body 有 scope、影响、收益、自动验证、manual gap、rollback。

--- a/docs/architecture/scheduler-operation-contract/tasks.md
+++ b/docs/architecture/scheduler-operation-contract/tasks.md
@@ -2,18 +2,13 @@
 
 ## SCH-001：Decision / SDD
 
-- [x] 从最新 `docs/audit-remediation-plan` 基线建立独立 worktree/branch。
-- [x] 审计 `src/main/routes/scheduler.ts` 的 timeout/retry/abort 实现。
-- [x] 枚举 `SessionService`、`ChatService`、`ProviderService` 的全部 production consumer。
-- [x] 追踪 session create 的 DB/runtime/binding/event/initial input side effects。
-- [x] 追踪 provider model sync getter 和 provider check 的真实 timeout owner。
-- [x] 追踪 Chat route controller 与 Agent runtime generation controller 的 owner 差异。
-- [x] 核验 commit `8ef5c858` 的原始 Scheduler 目标与接口冲突。
-- [x] 核验 commit `3ea97717` 的 request-only cancel / exactly-once settlement 意图。
-- [x] 定义 cancellation capability × replay safety 两轴与三种 execution policy。
-- [x] 定义 deadline、retry、settlement、unknown outcome、reconciliation contract。
-- [x] 设计 `SCH-002A/B`、`SCH-003A/B` 的独立交付顺序、测试和回滚。
-- [x] 定义 pending/unknown renderer 行为与 ASCII UI。
+- [x] 审计 route Scheduler timeout/retry/abort 的真实能力。
+- [x] 枚举 Session/Chat/Provider production consumers 与 side effects。
+- [x] 核验 Scheduler 历史目标、cancelGeneration request-only/exactly-once settlement 意图。
+- [x] 定义 observation、retry、cancellation、settlement、unknown/reconciliation contract。
+- [x] 关闭 verifier 对 getActive/restart/legacy/initial-input/provider truth 的 blocking findings。
+- [x] 明确 operation DTO 只由 sessions route Zod/schema inference 拥有。
+- [x] 明确 `SCH-003A/B` 为 atomic production cutover，`SCH-003B depends on SCH-003A + SES-003`。
 - [x] 文档无 `[NEEDS CLARIFICATION]`。
 
 ## SCH-002A：OperationRunner core
@@ -21,81 +16,119 @@
 - [ ] 建独立 branch/worktree，基于已合入 SCH-001。
 - [ ] 把 route `Scheduler` 重命名/收窄为 `OperationRunner`。
 - [ ] 实现 `observeIdempotent()`，task 使用 factory，late result 安全 drain。
-- [ ] 实现 `runCancellable()`，signal 传给 owner，abort 后等待 attempt settle。
-- [ ] 实现 `retryIdempotent()`，overall deadline 和 explicit `shouldRetry`。
-- [ ] 保留临时 legacy `timeout()` adapter，仅供 consumer migration。
-- [ ] 增加 pre-abort、late resolve/reject、listener/timer cleanup tests。
-- [ ] 增加 deferred attempt，断言 retry `maxConcurrentAttempts === 1`。
-- [ ] 增加 deadline-in-attempt/backoff，断言之后不启动 attempt。
-- [ ] 独立 verify agent 审查 typed error、abort/settlement 和资源 cleanup。
-- [ ] 运行 focused tests、typecheck:node、format:check、lint:architecture、lint。
-- [ ] PR 记录 automation/manual gap/rollback，merge 后在 base 跑 full regression。
+- [ ] 实现 `retryIdempotent()`，overall deadline、explicit classifier、最大并发 attempt = 1。
+- [ ] 实现 abortable `sleep()`。
+- [ ] 验证 milliseconds finite integer `0..2_147_483_647`、maxAttempts positive integer、backoff
+  finite/nonnegative；invalid input 不启动 task/timer。
+- [ ] 不实现/导出/测试零 production consumer 的 `runCancellable()`。
+- [ ] 保留临时 legacy `timeout()` adapter，仅供 allowlisted migration。
+- [ ] 增加 pre-abort、sync throw、late resolve/reject、listener/timer cleanup tests。
+- [ ] 增加 deferred attempt/deadline-in-attempt/backoff tests，断言无 overlap/no next attempt。
+- [ ] 独立 verify agent 审查 observation/retry/resource cleanup 与 unused abstraction guard。
+- [ ] 跑 focused tests、typecheck:node、format:check、lint:architecture、lint。
 
 ## SCH-002B：Safe consumer migration
 
-- [ ] 确认/合入 `SES-002` 后再修改 `SessionService` availability path。
-- [ ] restore 改用 settled-only typed transient retry；overall deadline 后禁止新 attempt。
-- [ ] session read/list/page/getActive 迁到 idempotent observation，不做 per-row retry。
+- [ ] 等 `SES-002` 合入并 rebase，不复制 availability adapter。
+- [ ] `restore` 保留 typed transient settled-only `2 attempts/25ms`。
+- [ ] `getActive` 同样保留 typed transient settled-only `2 attempts/25ms`。
+- [ ] restore/getActive 的 attempt、backoff、deadline、late settle 期间均保留 binding。
+- [ ] 只有 SES-002 权威 `missing` 允许 getActive unbind；unavailable/transient/deadline 不清 binding。
+- [ ] session list/page 使用 idempotent observation，不做 per-row retry。
 - [ ] activate/deactivate 删除无效 timeout wrapper。
-- [ ] provider model getter 删除 `Promise.resolve` + timeout 包装。
-- [ ] provider connection test 删除 route 5 秒 false timeout，不增加 automatic retry。
-- [ ] Chat preflight reads 迁到 idempotent observation，abort 后不进入下一 mutation。
+- [ ] provider model getters 删除 `Promise.resolve` + timeout wrapper。
+- [ ] `providers.testConnection` 暂不改：精确 legacy allowlist、无 automatic retry、tests 固定 model 60s
+  observation/no-model no-uniform-bound truth。
+- [ ] Chat preflight reads 迁 idempotent observation，abort 后不进入下一 mutation。
 - [ ] Chat send/steer/respond 删除 non-cancellable mutation 外层 deadline。
-- [ ] stop 保留 both-cleanups-attempted，且不把 cancel request 说成 terminal settlement。
-- [ ] 加 static allowlist：legacy timeout 只允许 `SessionService.createSession` 一处。
+- [ ] stop 保留 both-cleanups-attempted，不把 cancel request 说成 terminal settlement。
+- [ ] static allowlist 精确为 `sessions.create` + `providers.testConnection` 两项。
 - [ ] 保持 AgentRuntime exactly-once cancel/stale-run tests 全绿。
-- [ ] 独立 verify agent 对每个 consumer 重做 capability 分类，不接受按名称推断。
+- [ ] 独立 verify agent 对每个 consumer 重做 capability 分类。
 - [ ] 跑 focused/full tests、typecheck、format、i18n、lint。
-- [ ] 手工验证 provider slow check、stop during preflight、normal send/restore。
-- [ ] merge 后更新统一审计实施 ledger。
 
-## SCH-003A：Session create operation backend
+## PRV-CAN-001：Provider owner cancellation（dependent slice）
 
-- [ ] 建独立 architecture/backend branch，基于 SCH-002B。
-- [ ] 定义 additive create operation DTO 和 typed error/status schema。
-- [ ] 增加 optional input `operationId` 与 `sessions.getCreateOperation` route。
+- [ ] 逐 provider inventory `check()`：local/network/SDK/model、signal/timeout 能力。
+- [ ] `ProviderExecutionPort.testConnection` 与 presenter check 接收 owner cancellation input。
+- [ ] model 60s race 改为发送 cancel 并等待 physical settlement。
+- [ ] no-model provider check 全部获得 finite owner deadline/cancellation，或 typed unsupported。
+- [ ] 不 automatic retry provider probe。
+- [ ] 若出现首个真实 cancellable consumer，同 PR 设计最窄 runner API 与 settlement tests。
+- [ ] 删除 provider route 5s legacy wrapper 后更新 allowlist。
+- [ ] 独立 provider owner verifier 逐 adapter 检查 signal propagation/settlement。
+
+## SCH-003P：Initial-input acceptance seam
+
+- [ ] 静态枚举所有 production agent create path 是否支持 queue/accepted-start。
+- [ ] 定义 `not_required | accepted` 的 content-free acceptance result。
+- [ ] DeepChat path await durable `queuePendingInput()` record，不等待后台 generation。
+- [ ] fallback path 增加 owner accepted-start handle，不 await whole `processMessage()`。
+- [ ] 禁止用 Promise 创建成功或 fire-and-forget 冒充 accepted。
+- [ ] queue/start reject 时不返回 accepted；无 seam 的 production path 阻止 003 cutover。
+- [ ] title generation 不阻塞 acceptance；不改 generation terminal/cancel owner。
+- [ ] 覆盖 no-input、queue deferred/reject、fallback accepted-before-generation、unsupported、dedupe tests。
+- [ ] 独立 verifier 审查 accepted boundary 与 generation settlement 分离。
+
+## SCH-003A：Session create backend development slice（不可独立 merge）
+
+- [ ] 建 backend review branch/commit，基于 SCH-002B + SCH-003P。
+- [ ] operation schema/DTO 只写在 `sessions.routes.ts` 并通过 schema/route inference取类型。
+- [ ] 加 guard：`agent-interface.d.ts` 不得复制 session operation DTO。
+- [ ] route schema/handler支持 operation envelope；missing id 在任何副作用前 typed finite reject。
+- [ ] 增加 `sessions.getCreateOperation`。
+- [ ] 增加 bounded `sessions.listIncompleteCreateOperations`：limit int `1..20`、default `10`、稳定排序。
+- [ ] 增加 dismiss route：只写 `dismissedAt`，保留 dedupe identity，不删 session。
 - [ ] 实现 domain-specific `session_create_operations` additive table。
-- [ ] journal 只存 identity/fingerprint/stage/content-free error code，不存 raw payload。
-- [ ] operation 开始前登记 identity 并预分配 session id。
-- [ ] 实现同 id/same fingerprint single-flight，同 id/different fingerprint conflict。
-- [ ] 在 record/runtime/initial-input acceptance/completion 后更新 durable stage。
-- [ ] observation deadline 返回 pending，不 abort/不 throw TimeoutError。
-- [ ] compensation 结果可观察：全成功才 failed；任一不确定则 unknown。
-- [ ] process restart：succeeded 可重建；incomplete 保守 unknown；不 replay payload。
-- [ ] session delete 清理关联 succeeded operation row；不新增 speculative TTL worker。
-- [ ] 覆盖 fast/deferred/duplicate/conflict/cleanup-failure/restart/data-hygiene tests。
-- [ ] 独立 verify agent 审查 DB truth、stage 原子边界和 no-duplicate side effects。
-- [ ] 运行 focused tests、typecheck:node、format:check、lint。
+- [ ] journal 只存 identity/fingerprint/stage/content-free error/timestamps，不存 raw payload。
+- [ ] operation 开始前登记 identity并预分配 session id。
+- [ ] 同 id/same fingerprint single-flight；same id/different fingerprint conflict。
+- [ ] durable stage 覆盖 record/runtime/input_not_required|input_accepted/completed。
+- [ ] initial input 只调用 SCH-003P seam，不等待 generation terminal。
+- [ ] observation deadline 返回 pending，不 abort/不 throw false TimeoutError。
+- [ ] create 首次 observation 固定 `5_000ms`；renderer reconciliation 固定 `2_000ms × 15`，到界后只留
+  manual Check，离页/intent 变化清 timer。
+- [ ] compensation 全部 settle success 才 failed；任一不确定为 unknown。
+- [ ] restart succeeded 可重建；incomplete pending -> unknown；不 replay payload。
+- [ ] discovery 只返回 operationId/sessionId/state/stage/updatedAt，不返回内容/配置/fingerprint。
+- [ ] succeeded 随 session delete；failed/unknown 可 dismiss，不加 speculative TTL worker。
+- [ ] 覆盖 fast/deferred/duplicate/conflict/cleanup/restart/discovery/dismiss/data-hygiene tests。
+- [ ] 独立 backend verifier 审查 DB truth/stage/acceptance/no-duplicate/privacy。
+- [ ] 明确此 commit 不创建独立 production PR、不单独 merge。
 
-## SCH-003B：Renderer reconciliation / cleanup
+## SCH-003B：Renderer/integration atomic cutover
 
-- [ ] 基于已合入 `SES-003` route/renderer compatibility 结果 rebase。
-- [ ] SessionClient 为每个新 create intent 生成并复用 operation id。
-- [ ] session store 维护 current intent token，不复制 draft payload。
-- [ ] pending 时局部 reconciliation；页面离开 cleanup observer，不 cancel main operation。
-- [ ] succeeded/current intent 激活导航；succeeded/stale intent 只刷新列表。
-- [ ] failed/unknown 均保留 draft；unknown/check error 不自动 retry。
-- [ ] 增加 pending/unknown/failure i18n keys。
-- [ ] 按 spec ASCII 行为实现 UI state；不暴露内部 error/fingerprint。
-- [ ] 添加 API/store/component tests：current/stale/page-leave/restart/duplicate event。
-- [ ] 删除 legacy `timeout()` adapter、allowlist 和 create 5 秒 constant。
-- [ ] architecture guard 证明 legacy production consumer count = 0。
-- [ ] 独立 verify agent 审查 navigation race、draft lifecycle、poll cleanup、compatibility。
+- [ ] 显式基于 `SCH-003A + SES-003 + SCH-003P` 集成。
+- [ ] SessionClient 每个新 intent 生成 operation id；transport retry 复用，用户 explicit retry 换新 id。
+- [ ] production missing-operation-id caller static count = 0。
+- [ ] store 维护 current intent token，draft 保持在原 owner，不复制到 operation state/journal。
+- [ ] pending 时局部 bounded reconciliation；离页 cleanup observer，不 cancel main operation。
+- [ ] succeeded/current 激活导航；succeeded/stale 只刷新列表。
+- [ ] failed/unknown/query error 均不自动 create retry，draft 保留。
+- [ ] startup bounded discovery；无论一条/多条都需 explicit selection。
+- [ ] restart recovery 不绑定当前 draft、不自动 activate/navigate、不显示内容。
+- [ ] dismiss 只隐藏 record，不删除 session/identity。
+- [ ] 增加 pending/unknown/discovery/dismiss/error i18n keys。
+- [ ] 添加 current/stale/page-leave/restart-one-many/privacy/dismiss/duplicate-event tests。
+- [ ] 删除 create 5s legacy timeout；provider 未完成时 adapter 只剩精确 provider一项。
+- [ ] 003A + 003B 只创建一个 atomic production PR，不发布 backend-only version。
+- [ ] 独立 integration verifier 审查 navigation、draft、poll cleanup、restart、legacy finite semantics。
 - [ ] 跑 renderer/main focused tests、typecheck、format、i18n、lint、full tests。
 - [ ] 完成 DeepChat/ACP/slow/stale/unknown/restart/data-hygiene manual smoke。
-- [ ] PR 详细记录未自动覆盖的平台/路径、手工步骤、影响和回滚。
-- [ ] merge 后更新统一审计实施 ledger，满足全部 closure gates 后关闭 A-04。
 
 ## 每个 PR 的 blocking gate
 
-- [ ] develop 与 verify 不是同一 agent。
-- [ ] blocking finding 修复后重新完整 verify，不只口头确认。
-- [ ] 没有新增 `[NEEDS CLARIFICATION]`。
-- [ ] 没有新增第三方 retry/operation dependency。
-- [ ] 没有把 signal delivery 误写成 physical cancellation proof。
-- [ ] 没有把 observation deadline 误写成 operation failure。
+- [ ] develop 与 final verify 不是同一 agent。
+- [ ] blocking finding 修复后重新完整 verify。
+- [ ] 没有新增 `[NEEDS CLARIFICATION]` 或第三方 retry/operation dependency。
+- [ ] 没有把 signal delivery/observation deadline 误写成 physical cancellation/operation failure。
 - [ ] 没有 retry overlap 或 same-operation duplicate attempt。
+- [ ] restore/getActive 的 `2 attempts/25ms` 与 binding retention 没有退化。
+- [ ] provider truth 没有被概括成不存在的 owner timeout。
 - [ ] 没有改变 request-only `cancelGeneration()` 的 exactly-once settlement owner。
-- [ ] journal 除 fingerprint 外不含 raw prompt/file/payload；log 不含 fingerprint/raw payload。
-- [ ] full suite 新增失败数为 0；历史 baseline failure 单独列出。
-- [ ] PR body 有 scope、影响、收益、自动验证、manual gap、rollback。
+- [ ] initial input accepted 不等待 whole generation，也不提前伪造。
+- [ ] restart recovery content-free、bounded、explicit selection，不关联当前 draft。
+- [ ] session operation DTO 没有逃出 sessions route schema owner。
+- [ ] missing operation id finite pre-effect reject；003A/B 未被拆成独立 production merge。
+- [ ] journal 除 DB-only fingerprint 外不含 raw prompt/file/payload；log 不含 fingerprint/raw payload。
+- [ ] full suite 新增失败数为 0；PR body 有 scope、影响、收益、manual gap、rollback。


### PR DESCRIPTION
## Scope

This documentation-only PR delivers SCH-001, the architecture contract for route operation deadlines, retries, cancellation capabilities, and non-cancellable session creation.

It does not change production code. It defines the independently reviewable implementation slices:

- SCH-002A: OperationRunner observation and settled-only retry primitives
- SCH-002B: safe session, chat, and synchronous provider-catalog consumer migration
- PRV-CAN-001: provider-owned cancellation and finite probe contracts
- SCH-003A + SCH-003B: one atomic backend/renderer session-create cutover

## Why

The current route Scheduler accepts already-started promises. Its timeout only stops the caller from waiting; it does not stop the operation. Retry can therefore begin while the previous attempt is still running. Session create can write records, initialize runtime state, bind a window, and accept input after the caller has already received TimeoutError.

A direct rewrite would mix timing primitives, session availability, provider requests, renderer navigation, database journaling, and generation settlement. This contract separates those owners and records the exact current behavior before any implementation begins.

## Decisions

- Model cancellation capability and replay safety as separate axes.
- Implement only APIs with real production consumers. SCH-002A does not prebuild runCancellable.
- Retry only after the previous attempt has settled; max concurrent attempts is one.
- Preserve SES-002 restore and getActive behavior: at most two typed transient attempts separated by 25 ms, without clearing the binding during attempt, backoff, deadline, or late settlement.
- Keep provider testConnection as an explicit legacy observation-deadline exception until PRV-CAN-001 supplies owner-level cancellation. The inner 60-second model race is also observation-only; no-model checks have no uniform owner bound today.
- Keep cancelGeneration request-only. Terminal generation settlement remains owned by the in-flight runtime handler.
- Treat session create as a domain-owned non-cancellable operation with operation identity, pending/unknown states, reconciliation, and no automatic replay.
- Keep operation DTOs in the sessions route Zod contract, not the Agent implementation protocol.
- Use an IPC-safe create output discriminated union: operation, existing, or conflict. Renderer decisions never depend on custom Error properties or message parsing.
- Make create backend unbound. A current renderer intent explicitly activates after success; a stale intent only refreshes the list and cannot steal the main window binding.
- Store only content-free operation identity, stage, stable code, and encrypted-database fingerprint metadata. Do not store raw prompt, files, or payload copies.
- Discover operation history with immutable createdAt plus operationId keyset pagination. Dismiss only folds UI; it does not remove reconciliation or deduplication identity.
- Reject missing or invalid operation IDs before any side effect after the atomic cutover.
- Reuse the real durable queuePendingInput acceptance seam. DeepChat and ACP currently resolve to the same runtime owner; no speculative fallback acceptance API is added.
- Merge SCH-003A and SCH-003B as one production PR even if developed as separate review commits.

## Impact

There is no runtime impact in this PR.

The implementation plan reduces stability drift by preventing four false claims:

- an observation deadline is not physical cancellation
- a cancel request is not terminal settlement
- a timed-out mutation is not a confirmed failure
- renderer navigation suppression does not by itself preserve the main binding

The tradeoff is that A-04 remains open until the provider cancellation dependency and the atomic session-create cutover are complete.

## Automated validation

Independent review required three correction rounds and now passes with no blocking or non-blocking findings.

- format check, i18n, lint, typecheck, architecture guard, and diff check passed.
- Relative links and referenced line anchors were checked.
- Focused scheduler/session/provider/chat/runtime/renderer tests passed in the review rounds.
- Code and history review covered the original Scheduler introduction, request-only generation cancellation, session create side effects, SES availability retry semantics, Electron IPC error serialization, current DeepChat/ACP runtime resolution, durable pending-input acceptance, remote binding ownership, and renderer draft persistence.
- The final review specifically verified the IPC-safe output contract through a required real IPC or equivalent structured serialization plus actual bridge and route schema boundary. Direct dispatcher-only tests are not sufficient.

## Manual validation and gaps

No product smoke is meaningful for a decision-only PR. Each implementation slice has explicit manual and automated gates.

Important remaining manual/integration coverage includes:

- slow restore/getActive with transient failures and binding retention
- provider model and no-model probes before and after owner cancellation
- current versus stale create intent, activation failure, and no binding theft
- pending/unknown create reconciliation across app restart
- paginated and dismissed operation history
- cleanup uncertainty and no duplicate session/input side effects
- real Electron IPC serialization of every create output variant
- DeepChat and ACP create/input acceptance
- draft preservation and page-leave polling cleanup

## Rollback

Revert this documentation PR before SCH-002A begins. There is no schema or runtime migration.

After implementation starts, rollback follows slice boundaries. SCH-003A and SCH-003B must roll back together because their production contract is atomic. A rollback must not restore overlapping retry, parse error messages, treat pending as failure, or make create bind the window before the renderer confirms the current intent.
