### PR TITLE
fix(process): bound helper child lifetimes

### DIFF
--- a/docs/issues/fatal-process-tree-governance/spec.md
+++ b/docs/issues/fatal-process-tree-governance/spec.md
@@ -112,7 +112,11 @@ device-query limit, and a five-second skill command-probe limit. These are conse
 ceilings: workspace operations get the largest budget, while local system and availability probes
 align with adjacent five/ten-second probes. A timeout must settle the caller once and must not be
 presented as successful output. Existing public failure semantics remain authoritative: Workspace
-Git APIs converge to `null`, device queries reject, and `hasCommand()` resolves `false`.
+Git APIs converge to `null`, device queries reject, and `hasCommand()` resolves `false` for normal
+absence or a timeout whose direct child has closed. If neither the child handle nor the same-owner
+direct PID fallback can produce a confirmed close within the reap grace period, `hasCommand()`
+rejects `CommandProbeContainmentError`; an unconfirmed containment failure is not an availability
+miss.
 Process-tree containment remains a later PTG slice because a finite caller result alone does not
 prove that descendants stopped.
 
@@ -223,7 +227,8 @@ Each required row runs in real Electron with a disposable profile and unique mar
 - a hung `wmic`/`df` direct child is killed and reaped within 10 seconds plus grace, while the
   public device query keeps its existing rejection semantics;
 - a hung `SkillExecutionService.hasCommand()` direct child is killed and reaped within five seconds
-  plus grace, while the public probe resolves as unavailable;
+  plus grace, then resolves as unavailable; an unconfirmed reap rejects the typed containment error
+  instead of returning `false`;
 - each timeout settles once, clears timers/listeners, and never returns partial output as success;
 - existing successful Git, device-query, and command-availability results remain unchanged; and
 - tests prove the direct timeout behavior without claiming that it governs descendants. Descendant

--- a/docs/issues/fatal-process-tree-governance/spec.md
+++ b/docs/issues/fatal-process-tree-governance/spec.md
@@ -113,10 +113,12 @@ ceilings: workspace operations get the largest budget, while local system and av
 align with adjacent five/ten-second probes. A timeout must settle the caller once and must not be
 presented as successful output. Existing public failure semantics remain authoritative: Workspace
 Git APIs converge to `null`, device queries reject, and `hasCommand()` resolves `false` for normal
-absence or a timeout whose direct child has closed. If neither the child handle nor the same-owner
-direct PID fallback can produce a confirmed close within the reap grace period, `hasCommand()`
-rejects `CommandProbeContainmentError`; an unconfirmed containment failure is not an availability
-miss.
+absence or a timeout whose direct child has closed. Timeout containment uses only the owned
+`ChildProcess` handle and `child.kill('SIGKILL')`; it must never signal a cached raw PID. If the owner
+kill returns `false` or throws, the probe still waits up to the one-second reap grace for `close`.
+`close` resolves ordinary timeout failure as `false`; no confirmed `close` rejects
+`CommandProbeContainmentError`. The exception path reports only that containment is unconfirmed and
+must not claim the child was reaped.
 Process-tree containment remains a later PTG slice because a finite caller result alone does not
 prove that descendants stopped.
 
@@ -227,9 +229,11 @@ Each required row runs in real Electron with a disposable profile and unique mar
 - a hung `wmic`/`df` direct child is killed and reaped within 10 seconds plus grace, while the
   public device query keeps its existing rejection semantics;
 - a hung `SkillExecutionService.hasCommand()` direct child is killed and reaped within five seconds
-  plus grace, then resolves as unavailable; an unconfirmed reap rejects the typed containment error
-  instead of returning `false`;
-- each timeout settles once, clears timers/listeners, and never returns partial output as success;
+  plus grace, then resolves as unavailable; an owner-handle kill that has no confirmed `close`
+  rejects the typed containment error instead of returning `false`, with no raw-PID signal fallback;
+- each timeout settles once, clears its timers, and never returns partial output as success; normal
+  settlement removes listeners immediately, while typed containment rejection retains the ownership
+  listeners only until a late `close` removes them without settling the caller again;
 - existing successful Git, device-query, and command-availability results remain unchanged; and
 - tests prove the direct timeout behavior without claiming that it governs descendants. Descendant
   absence remains part of the later real Electron parent-loss matrix.

--- a/src/main/presenter/devicePresenter/index.ts
+++ b/src/main/presenter/devicePresenter/index.ts
@@ -1,7 +1,7 @@
 import logger from '@shared/logger'
 import { IDevicePresenter, DeviceInfo, MemoryInfo, DiskInfo } from '../../../shared/presenter'
 import os from 'os'
-import { exec } from 'child_process'
+import { execFile } from 'child_process'
 import { promisify } from 'util'
 import fs from 'fs'
 import path from 'path'
@@ -11,7 +11,8 @@ import axios from 'axios'
 import { is } from '@electron-toolkit/utils'
 import { svgSanitizer } from '../../lib/svgSanitizer'
 import { publishDeepchatEvent } from '@/routes/publishDeepchatEvent'
-const execAsync = promisify(exec)
+const execFileAsync = promisify(execFile)
+const DEVICE_QUERY_TIMEOUT_MS = 10_000
 
 type DeviceResetRuntime = {
   closeSqlite?: () => void
@@ -147,7 +148,11 @@ export class DevicePresenter implements IDevicePresenter {
   async getDiskSpace(): Promise<DiskInfo> {
     if (process.platform === 'win32') {
       // Windows implementation
-      const { stdout } = await execAsync('wmic logicaldisk get size,freespace')
+      const { stdout } = await execFileAsync('wmic', ['logicaldisk', 'get', 'size,freespace'], {
+        timeout: DEVICE_QUERY_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
+        windowsHide: true
+      })
       const lines = stdout.trim().split('\n').slice(1)
       let total = 0
       let free = 0
@@ -167,7 +172,11 @@ export class DevicePresenter implements IDevicePresenter {
       }
     } else {
       // Unix-like systems implementation
-      const { stdout } = await execAsync('df -k /')
+      const { stdout } = await execFileAsync('df', ['-k', '/'], {
+        timeout: DEVICE_QUERY_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
+        windowsHide: true
+      })
       const [, line] = stdout.trim().split('\n')
       const [, total, , used, free] = line.split(/\s+/)
 

--- a/src/main/presenter/skillPresenter/skillExecutionService.ts
+++ b/src/main/presenter/skillPresenter/skillExecutionService.ts
@@ -48,6 +48,16 @@ export interface SkillRunOptions {
 
 interface SkillExecutionServiceOptions {
   resolveConversationWorkdir?: (conversationId: string) => Promise<string | null>
+  killDirectProcess?: (pid: number) => boolean
+}
+
+export class CommandProbeContainmentError extends Error {
+  readonly code = 'COMMAND_PROBE_CONTAINMENT_FAILED'
+
+  constructor() {
+    super('Command probe containment could not be confirmed')
+    this.name = 'CommandProbeContainmentError'
+  }
 }
 
 interface SkillExecutionResult {
@@ -77,6 +87,7 @@ export class SkillExecutionService {
   private readonly runtimeHelper = RuntimeHelper.getInstance()
   private readonly configPresenter?: Pick<IConfigPresenter, 'getSetting'>
   private readonly resolveConversationWorkdir?: (conversationId: string) => Promise<string | null>
+  private readonly killDirectProcess: (pid: number) => boolean
 
   constructor(
     private readonly skillPresenter: ISkillPresenter,
@@ -85,6 +96,8 @@ export class SkillExecutionService {
   ) {
     this.configPresenter = configPresenter
     this.resolveConversationWorkdir = options.resolveConversationWorkdir
+    this.killDirectProcess =
+      options.killDirectProcess ?? ((pid: number) => process.kill(pid, 'SIGKILL'))
     this.runtimeHelper.initializeRuntimes()
   }
 
@@ -688,7 +701,7 @@ export class SkillExecutionService {
     args: string[],
     env: Record<string, string>
   ): Promise<boolean> {
-    return await new Promise((resolve) => {
+    return await new Promise((resolve, reject) => {
       const child = spawn(command, args, {
         env,
         stdio: 'ignore',
@@ -698,6 +711,7 @@ export class SkillExecutionService {
       let spawnFailed = false
       let settled = false
       let stopRequested = false
+      let closed = false
       let timeoutId: NodeJS.Timeout | null = null
       let reapTimeoutId: NodeJS.Timeout | null = null
 
@@ -714,53 +728,64 @@ export class SkillExecutionService {
         child.removeListener('close', onClose)
       }
 
-      const settle = (available: boolean, keepChildOwnership = false) => {
+      const settle = (available: boolean) => {
         if (settled) return
         settled = true
-        if (keepChildOwnership) cleanupTimers()
-        else cleanup()
+        cleanup()
         resolve(available)
+      }
+
+      const rejectContainment = () => {
+        if (settled) return
+        settled = true
+        cleanupTimers()
+        reject(new CommandProbeContainmentError())
       }
 
       const requestStop = (reason: 'timeout' | 'child_error') => {
         if (stopRequested || settled) return
         stopRequested = true
 
-        let killSent = false
+        let ownerKillSent = false
+        let fallbackKillSent = false
         try {
-          killSent = child.kill('SIGKILL')
-        } catch (error) {
+          ownerKillSent = child.kill('SIGKILL')
+        } catch {
           logger.error('[SkillExecutionService] Failed to kill command probe', {
-            command,
-            pid: child.pid,
             reason,
-            error
+            phase: 'owner_kill'
           })
+        }
+
+        if (!ownerKillSent && !closed && child.pid != null) {
+          try {
+            fallbackKillSent = this.killDirectProcess(child.pid)
+          } catch {
+            logger.error('[SkillExecutionService] Failed to kill command probe', {
+              reason,
+              phase: 'direct_kill_fallback'
+            })
+          }
         }
 
         reapTimeoutId = setTimeout(() => {
           logger.error('[SkillExecutionService] Command probe termination was not confirmed', {
-            command,
-            pid: child.pid,
             reason,
-            killSent
+            ownerKillSent,
+            fallbackKillSent
           })
-          // Keep the child listeners until a late close confirms reap. The caller remains bounded,
-          // but the still-parented child is not silently abandoned after an unconfirmed kill.
-          settle(false, true)
+          // Keep ownership listeners until a late close confirms reap. Containment failure is not
+          // an ordinary availability miss, so the bounded caller receives a typed rejection.
+          rejectContainment()
         }, COMMAND_PROBE_REAP_GRACE_MS)
       }
 
-      const onError = (error: Error) => {
+      const onError = (_error: Error) => {
         spawnFailed = true
         if (settled) {
           logger.error(
             '[SkillExecutionService] Command probe error after unconfirmed termination',
-            {
-              command,
-              pid: child.pid,
-              error
-            }
+            { phase: 'late_child_error' }
           )
           return
         }
@@ -769,13 +794,12 @@ export class SkillExecutionService {
           return
         }
         logger.error('[SkillExecutionService] Command probe child error', {
-          command,
-          pid: child.pid,
-          error
+          phase: 'child_error'
         })
         requestStop('child_error')
       }
       const onClose = (code: number | null) => {
+        closed = true
         if (settled) {
           cleanup()
           return

--- a/src/main/presenter/skillPresenter/skillExecutionService.ts
+++ b/src/main/presenter/skillPresenter/skillExecutionService.ts
@@ -29,6 +29,7 @@ const FOREGROUND_OFFLOAD_THRESHOLD = 10000
 const FOREGROUND_PREVIEW_CHARS = 12000
 const FOREGROUND_KILL_GRACE_MS = 2000
 const FOREGROUND_FORCE_SETTLE_MS = 500
+const COMMAND_PROBE_TIMEOUT_MS = 5_000
 
 export interface SkillRunRequest {
   skill: string
@@ -690,11 +691,27 @@ export class SkillExecutionService {
       const child = spawn(command, args, {
         env,
         stdio: 'ignore',
-        shell: false
+        shell: false,
+        timeout: COMMAND_PROBE_TIMEOUT_MS,
+        killSignal: 'SIGKILL'
       })
 
-      child.on('error', () => resolve(false))
-      child.on('close', (code) => resolve(code === 0))
+      let spawnFailed = false
+      let settled = false
+
+      const onError = () => {
+        spawnFailed = true
+      }
+      const onClose = (code: number | null) => {
+        if (settled) return
+        settled = true
+        child.removeListener('error', onError)
+        child.removeListener('close', onClose)
+        resolve(!spawnFailed && code === 0)
+      }
+
+      child.once('error', onError)
+      child.once('close', onClose)
     })
   }
 

--- a/src/main/presenter/skillPresenter/skillExecutionService.ts
+++ b/src/main/presenter/skillPresenter/skillExecutionService.ts
@@ -48,7 +48,6 @@ export interface SkillRunOptions {
 
 interface SkillExecutionServiceOptions {
   resolveConversationWorkdir?: (conversationId: string) => Promise<string | null>
-  killDirectProcess?: (pid: number) => boolean
 }
 
 export class CommandProbeContainmentError extends Error {
@@ -87,7 +86,6 @@ export class SkillExecutionService {
   private readonly runtimeHelper = RuntimeHelper.getInstance()
   private readonly configPresenter?: Pick<IConfigPresenter, 'getSetting'>
   private readonly resolveConversationWorkdir?: (conversationId: string) => Promise<string | null>
-  private readonly killDirectProcess: (pid: number) => boolean
 
   constructor(
     private readonly skillPresenter: ISkillPresenter,
@@ -96,8 +94,6 @@ export class SkillExecutionService {
   ) {
     this.configPresenter = configPresenter
     this.resolveConversationWorkdir = options.resolveConversationWorkdir
-    this.killDirectProcess =
-      options.killDirectProcess ?? ((pid: number) => process.kill(pid, 'SIGKILL'))
     this.runtimeHelper.initializeRuntimes()
   }
 
@@ -711,7 +707,6 @@ export class SkillExecutionService {
       let spawnFailed = false
       let settled = false
       let stopRequested = false
-      let closed = false
       let timeoutId: NodeJS.Timeout | null = null
       let reapTimeoutId: NodeJS.Timeout | null = null
 
@@ -747,7 +742,6 @@ export class SkillExecutionService {
         stopRequested = true
 
         let ownerKillSent = false
-        let fallbackKillSent = false
         try {
           ownerKillSent = child.kill('SIGKILL')
         } catch {
@@ -756,23 +750,12 @@ export class SkillExecutionService {
             phase: 'owner_kill'
           })
         }
-
-        if (!ownerKillSent && !closed && child.pid != null) {
-          try {
-            fallbackKillSent = this.killDirectProcess(child.pid)
-          } catch {
-            logger.error('[SkillExecutionService] Failed to kill command probe', {
-              reason,
-              phase: 'direct_kill_fallback'
-            })
-          }
-        }
+        if (settled) return
 
         reapTimeoutId = setTimeout(() => {
           logger.error('[SkillExecutionService] Command probe termination was not confirmed', {
             reason,
-            ownerKillSent,
-            fallbackKillSent
+            ownerKillSent
           })
           // Keep ownership listeners until a late close confirms reap. Containment failure is not
           // an ordinary availability miss, so the bounded caller receives a typed rejection.
@@ -799,7 +782,6 @@ export class SkillExecutionService {
         requestStop('child_error')
       }
       const onClose = (code: number | null) => {
-        closed = true
         if (settled) {
           cleanup()
           return

--- a/src/main/presenter/skillPresenter/skillExecutionService.ts
+++ b/src/main/presenter/skillPresenter/skillExecutionService.ts
@@ -30,6 +30,7 @@ const FOREGROUND_PREVIEW_CHARS = 12000
 const FOREGROUND_KILL_GRACE_MS = 2000
 const FOREGROUND_FORCE_SETTLE_MS = 500
 const COMMAND_PROBE_TIMEOUT_MS = 5_000
+const COMMAND_PROBE_REAP_GRACE_MS = 1_000
 
 export interface SkillRunRequest {
   skill: string
@@ -691,27 +692,100 @@ export class SkillExecutionService {
       const child = spawn(command, args, {
         env,
         stdio: 'ignore',
-        shell: false,
-        timeout: COMMAND_PROBE_TIMEOUT_MS,
-        killSignal: 'SIGKILL'
+        shell: false
       })
 
       let spawnFailed = false
       let settled = false
+      let stopRequested = false
+      let timeoutId: NodeJS.Timeout | null = null
+      let reapTimeoutId: NodeJS.Timeout | null = null
 
-      const onError = () => {
-        spawnFailed = true
+      const cleanupTimers = () => {
+        if (timeoutId) clearTimeout(timeoutId)
+        if (reapTimeoutId) clearTimeout(reapTimeoutId)
+        timeoutId = null
+        reapTimeoutId = null
       }
-      const onClose = (code: number | null) => {
-        if (settled) return
-        settled = true
+
+      const cleanup = () => {
+        cleanupTimers()
         child.removeListener('error', onError)
         child.removeListener('close', onClose)
-        resolve(!spawnFailed && code === 0)
       }
 
-      child.once('error', onError)
+      const settle = (available: boolean, keepChildOwnership = false) => {
+        if (settled) return
+        settled = true
+        if (keepChildOwnership) cleanupTimers()
+        else cleanup()
+        resolve(available)
+      }
+
+      const requestStop = (reason: 'timeout' | 'child_error') => {
+        if (stopRequested || settled) return
+        stopRequested = true
+
+        let killSent = false
+        try {
+          killSent = child.kill('SIGKILL')
+        } catch (error) {
+          logger.error('[SkillExecutionService] Failed to kill command probe', {
+            command,
+            pid: child.pid,
+            reason,
+            error
+          })
+        }
+
+        reapTimeoutId = setTimeout(() => {
+          logger.error('[SkillExecutionService] Command probe termination was not confirmed', {
+            command,
+            pid: child.pid,
+            reason,
+            killSent
+          })
+          // Keep the child listeners until a late close confirms reap. The caller remains bounded,
+          // but the still-parented child is not silently abandoned after an unconfirmed kill.
+          settle(false, true)
+        }, COMMAND_PROBE_REAP_GRACE_MS)
+      }
+
+      const onError = (error: Error) => {
+        spawnFailed = true
+        if (settled) {
+          logger.error(
+            '[SkillExecutionService] Command probe error after unconfirmed termination',
+            {
+              command,
+              pid: child.pid,
+              error
+            }
+          )
+          return
+        }
+        if (child.pid == null) {
+          settle(false)
+          return
+        }
+        logger.error('[SkillExecutionService] Command probe child error', {
+          command,
+          pid: child.pid,
+          error
+        })
+        requestStop('child_error')
+      }
+      const onClose = (code: number | null) => {
+        if (settled) {
+          cleanup()
+          return
+        }
+        settle(!spawnFailed && !stopRequested && code === 0)
+      }
+
+      child.on('error', onError)
       child.once('close', onClose)
+      timeoutId = setTimeout(() => requestStop('timeout'), COMMAND_PROBE_TIMEOUT_MS)
     })
   }
 

--- a/src/main/presenter/workspacePresenter/index.ts
+++ b/src/main/presenter/workspacePresenter/index.ts
@@ -41,6 +41,7 @@ import type {
 } from '@shared/presenter'
 
 const execFileAsync = promisify(execFile)
+const WORKSPACE_GIT_TIMEOUT_MS = 30_000
 
 const TEXT_LIKE_MIME_TYPES = new Set([
   'application/json',
@@ -681,7 +682,9 @@ export class WorkspacePresenter implements IWorkspacePresenter {
       const result = await execFileAsync('git', args, {
         cwd: workspacePath,
         windowsHide: true,
-        maxBuffer: 8 * 1024 * 1024
+        maxBuffer: 8 * 1024 * 1024,
+        timeout: WORKSPACE_GIT_TIMEOUT_MS,
+        killSignal: 'SIGKILL'
       })
       return result.stdout.trimEnd()
     } catch (error) {
@@ -1027,11 +1030,22 @@ export class WorkspacePresenter implements IWorkspacePresenter {
         {
           cwd: workspacePath,
           windowsHide: true,
-          maxBuffer: 8 * 1024 * 1024
+          maxBuffer: 8 * 1024 * 1024,
+          timeout: WORKSPACE_GIT_TIMEOUT_MS,
+          killSignal: 'SIGKILL'
         }
       )
       return result.stdout.trimEnd()
     } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'killed' in error &&
+        (error as { killed?: boolean }).killed === true
+      ) {
+        throw error
+      }
+
       if (
         typeof error === 'object' &&
         error !== null &&

--- a/test/main/lib/processIdentity.ts
+++ b/test/main/lib/processIdentity.ts
@@ -1,0 +1,120 @@
+import { execFile, type ChildProcess } from 'node:child_process'
+import { once } from 'node:events'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const PROCESS_QUERY_TIMEOUT_MS = 5_000
+
+type ProcessSnapshot = {
+  startIdentity: string
+  commandLine: string
+}
+
+export type MarkedProcessIdentity = ProcessSnapshot & {
+  pid: number
+  marker: string
+}
+
+export type ProcessIdentityStatus = 'absent' | 'match' | 'mismatch'
+
+async function queryWindowsProcess(pid: number): Promise<ProcessSnapshot | null> {
+  const script = [
+    `$target = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction Stop`,
+    "if ($null -eq $target) { [PSCustomObject]@{ status = 'absent' } | ConvertTo-Json -Compress }",
+    "else { [PSCustomObject]@{ status = 'present'; startIdentity = $target.CreationDate.ToUniversalTime().ToString('o'); commandLine = [string]$target.CommandLine } | ConvertTo-Json -Compress }"
+  ].join('; ')
+  const { stdout } = await execFileAsync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    {
+      timeout: PROCESS_QUERY_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+      windowsHide: true
+    }
+  )
+  const result = JSON.parse(stdout.trim()) as {
+    status: 'absent' | 'present'
+    startIdentity?: string
+    commandLine?: string
+  }
+  if (result.status === 'absent') return null
+  if (!result.startIdentity || !result.commandLine) {
+    throw new Error(`Incomplete Windows process identity for PID ${pid}`)
+  }
+  return {
+    startIdentity: result.startIdentity,
+    commandLine: result.commandLine
+  }
+}
+
+async function queryPosixProcess(pid: number): Promise<ProcessSnapshot | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'ps',
+      ['-ww', '-p', String(pid), '-o', 'lstart=', '-o', 'command='],
+      {
+        timeout: PROCESS_QUERY_TIMEOUT_MS,
+        killSignal: 'SIGKILL'
+      }
+    )
+    const line = stdout.trim()
+    if (!line) return null
+    const startIdentity = line.slice(0, 24)
+    const commandLine = line.slice(24).trim()
+    if (!startIdentity || !commandLine) {
+      throw new Error(`Incomplete POSIX process identity for PID ${pid}`)
+    }
+    return { startIdentity, commandLine }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException & { code?: number }).code === 1) return null
+    throw error
+  }
+}
+
+async function queryProcess(pid: number): Promise<ProcessSnapshot | null> {
+  if (process.platform === 'win32') return await queryWindowsProcess(pid)
+  if (process.platform === 'darwin' || process.platform === 'linux') {
+    return await queryPosixProcess(pid)
+  }
+  throw new Error(`Unsupported process identity platform: ${process.platform}`)
+}
+
+export async function captureMarkedProcessIdentity(
+  pid: number,
+  marker: string
+): Promise<MarkedProcessIdentity> {
+  const snapshot = await queryProcess(pid)
+  if (!snapshot) throw new Error(`Marked process ${pid} exited before identity capture`)
+  if (!snapshot.commandLine.includes(marker)) {
+    throw new Error(`Process ${pid} does not contain marker ${marker}`)
+  }
+  return { pid, marker, ...snapshot }
+}
+
+export async function getProcessIdentityStatus(
+  identity: MarkedProcessIdentity
+): Promise<ProcessIdentityStatus> {
+  const snapshot = await queryProcess(identity.pid)
+  if (!snapshot) return 'absent'
+  return snapshot.startIdentity === identity.startIdentity &&
+    snapshot.commandLine.includes(identity.marker)
+    ? 'match'
+    : 'mismatch'
+}
+
+export async function killMarkedChildIfStillOwned(
+  child: ChildProcess,
+  identity: MarkedProcessIdentity,
+  graceMs: number
+): Promise<void> {
+  const status = await getProcessIdentityStatus(identity)
+  if (status !== 'match') return
+
+  const closePromise = once(child, 'close')
+  child.kill('SIGKILL')
+  await Promise.race([closePromise, new Promise((resolve) => setTimeout(resolve, graceMs))])
+
+  if ((await getProcessIdentityStatus(identity)) === 'match') {
+    throw new Error(`Marked process ${identity.pid} survived cleanup`)
+  }
+}

--- a/test/main/presenter/devicePresenter.test.ts
+++ b/test/main/presenter/devicePresenter.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import fs from 'fs'
 import { DevicePresenter } from '../../../src/main/presenter/devicePresenter/index'
 
-const publishDeepchatEventMock = vi.hoisted(() => vi.fn())
+const { publishDeepchatEventMock, execFileMock } = vi.hoisted(() => ({
+  publishDeepchatEventMock: vi.fn(),
+  execFileMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock
+}))
 
 vi.mock('@electron-toolkit/utils', () => ({
   is: {
@@ -22,10 +29,14 @@ vi.mock('@/lib/svgSanitizer', () => ({
 }))
 
 describe('DevicePresenter', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
   afterEach(() => {
     vi.useRealTimers()
     vi.restoreAllMocks()
     publishDeepchatEventMock.mockClear()
+    execFileMock.mockReset()
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform)
   })
 
   describe('getDefaultHeaders', () => {
@@ -52,6 +63,83 @@ describe('DevicePresenter', () => {
 
       expect(publishDeepchatEventMock).toHaveBeenCalledTimes(1)
       expect(publishDeepchatEventMock).toHaveBeenCalledWith('appRuntime.dataResetCompleteDev', {})
+    })
+  })
+
+  describe('getDiskSpace', () => {
+    it('uses a bounded direct df child and preserves parsed output', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+      execFileMock.mockImplementation(
+        (
+          _command: string,
+          _args: string[],
+          _options: unknown,
+          callback: (error: Error | null, result?: { stdout: string; stderr: string }) => void
+        ) =>
+          callback(null, {
+            stdout:
+              'Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/disk 100 25 75 25% /\n',
+            stderr: ''
+          })
+      )
+
+      await expect(new DevicePresenter().getDiskSpace()).resolves.toEqual({
+        total: 100 * 1024,
+        free: 25 * 1024,
+        used: 75 * 1024
+      })
+      expect(execFileMock).toHaveBeenCalledWith(
+        'df',
+        ['-k', '/'],
+        expect.objectContaining({ timeout: 10_000, killSignal: 'SIGKILL', windowsHide: true }),
+        expect.any(Function)
+      )
+    })
+
+    it('uses a bounded direct wmic child on Windows', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      execFileMock.mockImplementation(
+        (
+          _command: string,
+          _args: string[],
+          _options: unknown,
+          callback: (error: Error | null, result?: { stdout: string; stderr: string }) => void
+        ) =>
+          callback(null, {
+            stdout: 'FreeSpace  Size\n100  300\n200  500\n',
+            stderr: ''
+          })
+      )
+
+      await expect(new DevicePresenter().getDiskSpace()).resolves.toEqual({
+        total: 800,
+        free: 300,
+        used: 500
+      })
+      expect(execFileMock).toHaveBeenCalledWith(
+        'wmic',
+        ['logicaldisk', 'get', 'size,freespace'],
+        expect.objectContaining({ timeout: 10_000, killSignal: 'SIGKILL', windowsHide: true }),
+        expect.any(Function)
+      )
+    })
+
+    it('preserves rejection when the device query times out', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+      const timeoutError = Object.assign(new Error('Device query timed out'), {
+        killed: true,
+        signal: 'SIGKILL'
+      })
+      execFileMock.mockImplementation(
+        (
+          _command: string,
+          _args: string[],
+          _options: unknown,
+          callback: (error: Error | null) => void
+        ) => callback(timeoutError)
+      )
+
+      await expect(new DevicePresenter().getDiskSpace()).rejects.toBe(timeoutError)
     })
   })
 

--- a/test/main/presenter/helperProcessTimeouts.test.ts
+++ b/test/main/presenter/helperProcessTimeouts.test.ts
@@ -2,46 +2,29 @@ import { execFile, spawn, type ChildProcess } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { once } from 'node:events'
 import { describe, expect, it } from 'vitest'
+import {
+  captureMarkedProcessIdentity,
+  getProcessIdentityStatus,
+  killMarkedChildIfStillOwned,
+  type MarkedProcessIdentity
+} from '../lib/processIdentity'
 
-const DIRECT_CHILD_TIMEOUT_MS = 100
-const TEST_GRACE_MS = 1_000
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
-  }
-}
-
-async function waitForReap(pid: number): Promise<void> {
-  const deadline = Date.now() + TEST_GRACE_MS
-  while (isProcessAlive(pid) && Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, 10))
-  }
-  expect(isProcessAlive(pid)).toBe(false)
-}
-
-async function killMarkedSurvivor(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) return
-  child.kill('SIGKILL')
-  await Promise.race([
-    once(child, 'close'),
-    new Promise((resolve) => setTimeout(resolve, TEST_GRACE_MS))
-  ])
-}
+const DIRECT_CHILD_TIMEOUT_MS = process.platform === 'win32' ? 8_000 : 2_000
+const TEST_GRACE_MS = 2_000
+const SELF_EXIT_MS = DIRECT_CHILD_TIMEOUT_MS + TEST_GRACE_MS * 2
+const HANG_SCRIPT = `setTimeout(() => process.exit(97), ${SELF_EXIT_MS}); setInterval(() => {}, 1000)`
 
 describe('PTG-H0 native direct-child timeout contract', () => {
   it('execFile settles once only after its marked direct child is reaped', async () => {
     const marker = `ptg-h0-exec-file-${randomUUID()}`
     let callbackCount = 0
     let child!: ChildProcess
+    let identity: MarkedProcessIdentity | null = null
 
     const completion = new Promise<Error>((resolve) => {
       child = execFile(
         process.execPath,
-        ['-e', 'setInterval(() => {}, 1000)', marker],
+        ['-e', HANG_SCRIPT, marker],
         { timeout: DIRECT_CHILD_TIMEOUT_MS, killSignal: 'SIGKILL' },
         (error) => {
           callbackCount += 1
@@ -49,61 +32,53 @@ describe('PTG-H0 native direct-child timeout contract', () => {
         }
       )
     })
-    const identity = {
-      pid: child.pid!,
-      marker,
-      startedAtNs: process.hrtime.bigint(),
-      spawnfile: child.spawnfile
-    }
 
     try {
+      identity = await captureMarkedProcessIdentity(child.pid!, marker)
       const error = (await completion) as Error & { killed?: boolean; signal?: string }
-      await waitForReap(identity.pid)
-      await new Promise((resolve) => setTimeout(resolve, DIRECT_CHILD_TIMEOUT_MS + 20))
+      const finalStatus = await getProcessIdentityStatus(identity)
+      await new Promise((resolve) => setTimeout(resolve, 20))
 
-      expect(identity).toEqual({
-        pid: expect.any(Number),
-        marker,
-        startedAtNs: identity.startedAtNs,
-        spawnfile: process.execPath
-      })
-      expect(typeof identity.startedAtNs).toBe('bigint')
+      expect(identity.pid).toBe(child.pid)
+      expect(identity.marker).toBe(marker)
+      expect(identity.startIdentity).not.toBe('')
+      expect(identity.commandLine).toContain(marker)
+      expect(finalStatus).not.toBe('match')
       expect(error.killed).toBe(true)
       expect(error.signal).toBe('SIGKILL')
       expect(callbackCount).toBe(1)
     } finally {
-      await killMarkedSurvivor(child)
+      if (identity) await killMarkedChildIfStillOwned(child, identity, TEST_GRACE_MS)
     }
-  })
+  }, 15_000)
 
   it('spawn emits one close only after its marked direct child is reaped', async () => {
     const marker = `ptg-h0-spawn-${randomUUID()}`
-    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)', marker], {
+    const child = spawn(process.execPath, ['-e', HANG_SCRIPT, marker], {
       stdio: 'ignore',
       timeout: DIRECT_CHILD_TIMEOUT_MS,
       killSignal: 'SIGKILL'
     })
-    const identity = {
-      pid: child.pid!,
-      marker,
-      startedAtNs: process.hrtime.bigint(),
-      spawnfile: child.spawnfile
-    }
+    let identity: MarkedProcessIdentity | null = null
     let closeCount = 0
     child.on('close', () => {
       closeCount += 1
     })
 
     try {
+      identity = await captureMarkedProcessIdentity(child.pid!, marker)
       const [code, signal] = (await once(child, 'close')) as [number | null, string | null]
-      await waitForReap(identity.pid)
-      await new Promise((resolve) => setTimeout(resolve, DIRECT_CHILD_TIMEOUT_MS + 20))
+      const finalStatus = await getProcessIdentityStatus(identity)
+      await new Promise((resolve) => setTimeout(resolve, 20))
 
+      expect(identity.startIdentity).not.toBe('')
+      expect(identity.commandLine).toContain(marker)
+      expect(finalStatus).not.toBe('match')
       expect(code).toBeNull()
       expect(signal).toBe('SIGKILL')
       expect(closeCount).toBe(1)
     } finally {
-      await killMarkedSurvivor(child)
+      if (identity) await killMarkedChildIfStillOwned(child, identity, TEST_GRACE_MS)
     }
-  })
+  }, 15_000)
 })

--- a/test/main/presenter/helperProcessTimeouts.test.ts
+++ b/test/main/presenter/helperProcessTimeouts.test.ts
@@ -1,0 +1,109 @@
+import { execFile, spawn, type ChildProcess } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { once } from 'node:events'
+import { describe, expect, it } from 'vitest'
+
+const DIRECT_CHILD_TIMEOUT_MS = 100
+const TEST_GRACE_MS = 1_000
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+async function waitForReap(pid: number): Promise<void> {
+  const deadline = Date.now() + TEST_GRACE_MS
+  while (isProcessAlive(pid) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  expect(isProcessAlive(pid)).toBe(false)
+}
+
+async function killMarkedSurvivor(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  child.kill('SIGKILL')
+  await Promise.race([
+    once(child, 'close'),
+    new Promise((resolve) => setTimeout(resolve, TEST_GRACE_MS))
+  ])
+}
+
+describe('PTG-H0 native direct-child timeout contract', () => {
+  it('execFile settles once only after its marked direct child is reaped', async () => {
+    const marker = `ptg-h0-exec-file-${randomUUID()}`
+    let callbackCount = 0
+    let child!: ChildProcess
+
+    const completion = new Promise<Error>((resolve) => {
+      child = execFile(
+        process.execPath,
+        ['-e', 'setInterval(() => {}, 1000)', marker],
+        { timeout: DIRECT_CHILD_TIMEOUT_MS, killSignal: 'SIGKILL' },
+        (error) => {
+          callbackCount += 1
+          resolve(error!)
+        }
+      )
+    })
+    const identity = {
+      pid: child.pid!,
+      marker,
+      startedAtNs: process.hrtime.bigint(),
+      spawnfile: child.spawnfile
+    }
+
+    try {
+      const error = (await completion) as Error & { killed?: boolean; signal?: string }
+      await waitForReap(identity.pid)
+      await new Promise((resolve) => setTimeout(resolve, DIRECT_CHILD_TIMEOUT_MS + 20))
+
+      expect(identity).toEqual({
+        pid: expect.any(Number),
+        marker,
+        startedAtNs: identity.startedAtNs,
+        spawnfile: process.execPath
+      })
+      expect(typeof identity.startedAtNs).toBe('bigint')
+      expect(error.killed).toBe(true)
+      expect(error.signal).toBe('SIGKILL')
+      expect(callbackCount).toBe(1)
+    } finally {
+      await killMarkedSurvivor(child)
+    }
+  })
+
+  it('spawn emits one close only after its marked direct child is reaped', async () => {
+    const marker = `ptg-h0-spawn-${randomUUID()}`
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)', marker], {
+      stdio: 'ignore',
+      timeout: DIRECT_CHILD_TIMEOUT_MS,
+      killSignal: 'SIGKILL'
+    })
+    const identity = {
+      pid: child.pid!,
+      marker,
+      startedAtNs: process.hrtime.bigint(),
+      spawnfile: child.spawnfile
+    }
+    let closeCount = 0
+    child.on('close', () => {
+      closeCount += 1
+    })
+
+    try {
+      const [code, signal] = (await once(child, 'close')) as [number | null, string | null]
+      await waitForReap(identity.pid)
+      await new Promise((resolve) => setTimeout(resolve, DIRECT_CHILD_TIMEOUT_MS + 20))
+
+      expect(code).toBeNull()
+      expect(signal).toBe('SIGKILL')
+      expect(closeCount).toBe(1)
+    } finally {
+      await killMarkedSurvivor(child)
+    }
+  })
+})

--- a/test/main/presenter/skillPresenter/skillExecutionService.test.ts
+++ b/test/main/presenter/skillPresenter/skillExecutionService.test.ts
@@ -65,7 +65,7 @@ describe('SkillExecutionService', () => {
   let skillPresenter: ISkillPresenter
   let service: SkillExecutionService
   let resolveConversationWorkdir: ReturnType<typeof vi.fn>
-  let killDirectProcess: ReturnType<typeof vi.fn>
+  let rawProcessKill: ReturnType<typeof vi.spyOn>
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
 
   beforeEach(() => {
@@ -76,6 +76,7 @@ describe('SkillExecutionService', () => {
     vi.mocked(fs.promises.stat).mockResolvedValue({
       isDirectory: () => true
     } as never)
+    rawProcessKill = vi.spyOn(process, 'kill').mockReturnValue(true)
 
     skillPresenter = {
       getActiveSkills: vi.fn().mockResolvedValue(['ocr']),
@@ -107,21 +108,20 @@ describe('SkillExecutionService', () => {
     } as unknown as ISkillPresenter
 
     resolveConversationWorkdir = vi.fn().mockResolvedValue('/workspace/session')
-    killDirectProcess = vi.fn(() => true)
     service = new SkillExecutionService(
       skillPresenter,
       {
         getSetting: vi.fn().mockReturnValue(true)
       } as never,
       {
-        resolveConversationWorkdir,
-        killDirectProcess
+        resolveConversationWorkdir
       }
     )
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    rawProcessKill.mockRestore()
     if (originalPlatform) {
       Object.defineProperty(process, 'platform', originalPlatform)
     }
@@ -299,30 +299,73 @@ describe('SkillExecutionService', () => {
     expect(child.listenerCount('close')).toBe(0)
   })
 
-  it('uses the direct kill fallback and resolves false only after close', async () => {
+  it('resolves false when owner kill returns false but the child closes within grace', async () => {
+    vi.useFakeTimers()
+    const child = new MockProbeChild(123)
+    child.kill.mockImplementation(() => {
+      child.emit('close', null)
+      return false
+    })
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    const resultPromise = (service as never).hasCommand('node', ['--version'], { PATH: '/bin' })
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    await expect(resultPromise).resolves.toBe(false)
+    expect(child.kill).toHaveBeenCalledOnce()
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(rawProcessKill).not.toHaveBeenCalled()
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('rejects with a containment error when owner kill returns false and close is unconfirmed', async () => {
     vi.useFakeTimers()
     const child = new MockProbeChild(123)
     child.kill.mockReturnValue(false)
     vi.mocked(spawn).mockReturnValue(child as never)
 
     const resultPromise = (service as never).hasCommand('node', ['--version'], { PATH: '/bin' })
-    await vi.advanceTimersByTimeAsync(5_000)
-    expect(killDirectProcess).toHaveBeenCalledWith(123)
-    child.emit('close', null)
+    const rejection = expect(resultPromise).rejects.toMatchObject({
+      name: 'CommandProbeContainmentError',
+      code: 'COMMAND_PROBE_CONTAINMENT_FAILED'
+    })
+    await vi.advanceTimersByTimeAsync(6_000)
 
-    await expect(resultPromise).resolves.toBe(false)
-    expect(child.kill).toHaveBeenCalledTimes(1)
-    expect(child.listenerCount('error')).toBe(0)
-    expect(child.listenerCount('close')).toBe(0)
+    await rejection
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(rawProcessKill).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+    expect(child.listenerCount('error')).toBe(1)
+    expect(child.listenerCount('close')).toBe(1)
   })
 
-  it('rejects once when neither kill path can confirm close', async () => {
+  it('rejects with a containment error when owner kill throws and close is unconfirmed', async () => {
+    vi.useFakeTimers()
+    const child = new MockProbeChild(123)
+    child.kill.mockImplementation(() => {
+      throw new Error('owner kill failed')
+    })
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    const resultPromise = (service as never).hasCommand('node', ['--version'], { PATH: '/bin' })
+    const rejection = expect(resultPromise).rejects.toBeInstanceOf(CommandProbeContainmentError)
+    await vi.advanceTimersByTimeAsync(6_000)
+
+    await rejection
+    expect(child.kill).toHaveBeenCalledOnce()
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(rawProcessKill).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+    expect(child.listenerCount('error')).toBe(1)
+    expect(child.listenerCount('close')).toBe(1)
+  })
+
+  it('settles containment once and removes ownership listeners on a late close', async () => {
     vi.useFakeTimers()
     const child = new MockProbeChild(123)
     child.kill.mockReturnValue(false)
-    killDirectProcess.mockImplementation(() => {
-      throw new Error('direct kill failed')
-    })
     const rejected = vi.fn()
     vi.mocked(spawn).mockReturnValue(child as never)
 
@@ -332,23 +375,22 @@ describe('SkillExecutionService', () => {
         rejected(error)
         throw error
       })
-    const rejection = expect(resultPromise).rejects.toMatchObject({
-      name: 'CommandProbeContainmentError',
-      code: 'COMMAND_PROBE_CONTAINMENT_FAILED'
-    })
+    const rejection = expect(resultPromise).rejects.toBeInstanceOf(CommandProbeContainmentError)
     await vi.advanceTimersByTimeAsync(6_000)
 
     await rejection
-    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
-    expect(killDirectProcess).toHaveBeenCalledWith(123)
-    expect(rejected).toHaveBeenCalledTimes(1)
-    expect(rejected.mock.calls[0][0]).toBeInstanceOf(CommandProbeContainmentError)
+    expect(rejected).toHaveBeenCalledOnce()
+    expect(rawProcessKill).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
     expect(child.listenerCount('error')).toBe(1)
     expect(child.listenerCount('close')).toBe(1)
 
     child.emit('close', null)
     child.emit('close', null)
-    expect(rejected).toHaveBeenCalledTimes(1)
+    await vi.runAllTimersAsync()
+
+    expect(rejected).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
     expect(child.listenerCount('error')).toBe(0)
     expect(child.listenerCount('close')).toBe(0)
   })

--- a/test/main/presenter/skillPresenter/skillExecutionService.test.ts
+++ b/test/main/presenter/skillPresenter/skillExecutionService.test.ts
@@ -4,7 +4,10 @@ import os from 'os'
 import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ISkillPresenter } from '../../../../src/shared/types/skill'
-import { SkillExecutionService } from '../../../../src/main/presenter/skillPresenter/skillExecutionService'
+import {
+  CommandProbeContainmentError,
+  SkillExecutionService
+} from '../../../../src/main/presenter/skillPresenter/skillExecutionService'
 
 vi.mock('child_process', () => ({
   spawn: vi.fn()
@@ -62,6 +65,7 @@ describe('SkillExecutionService', () => {
   let skillPresenter: ISkillPresenter
   let service: SkillExecutionService
   let resolveConversationWorkdir: ReturnType<typeof vi.fn>
+  let killDirectProcess: ReturnType<typeof vi.fn>
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
 
   beforeEach(() => {
@@ -103,13 +107,15 @@ describe('SkillExecutionService', () => {
     } as unknown as ISkillPresenter
 
     resolveConversationWorkdir = vi.fn().mockResolvedValue('/workspace/session')
+    killDirectProcess = vi.fn(() => true)
     service = new SkillExecutionService(
       skillPresenter,
       {
         getSetting: vi.fn().mockReturnValue(true)
       } as never,
       {
-        resolveConversationWorkdir
+        resolveConversationWorkdir,
+        killDirectProcess
       }
     )
   })
@@ -293,40 +299,56 @@ describe('SkillExecutionService', () => {
     expect(child.listenerCount('close')).toBe(0)
   })
 
-  it('bounds a kill failure when the command probe never closes', async () => {
+  it('uses the direct kill fallback and resolves false only after close', async () => {
     vi.useFakeTimers()
     const child = new MockProbeChild(123)
     child.kill.mockReturnValue(false)
     vi.mocked(spawn).mockReturnValue(child as never)
 
     const resultPromise = (service as never).hasCommand('node', ['--version'], { PATH: '/bin' })
-    await vi.advanceTimersByTimeAsync(6_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(killDirectProcess).toHaveBeenCalledWith(123)
+    child.emit('close', null)
 
     await expect(resultPromise).resolves.toBe(false)
     expect(child.kill).toHaveBeenCalledTimes(1)
-    expect(child.listenerCount('error')).toBe(1)
-    expect(child.listenerCount('close')).toBe(1)
-
-    child.emit('close', null)
     expect(child.listenerCount('error')).toBe(0)
     expect(child.listenerCount('close')).toBe(0)
   })
 
-  it('bounds a child error when the command probe never closes', async () => {
+  it('rejects once when neither kill path can confirm close', async () => {
     vi.useFakeTimers()
     const child = new MockProbeChild(123)
+    child.kill.mockReturnValue(false)
+    killDirectProcess.mockImplementation(() => {
+      throw new Error('direct kill failed')
+    })
+    const rejected = vi.fn()
     vi.mocked(spawn).mockReturnValue(child as never)
 
-    const resultPromise = (service as never).hasCommand('node', ['--version'], { PATH: '/bin' })
-    child.emit('error', new Error('kill failed'))
-    await vi.advanceTimersByTimeAsync(1_000)
+    const resultPromise = (service as never)
+      .hasCommand('node', ['--version'], { PATH: '/bin' })
+      .catch((error: unknown) => {
+        rejected(error)
+        throw error
+      })
+    const rejection = expect(resultPromise).rejects.toMatchObject({
+      name: 'CommandProbeContainmentError',
+      code: 'COMMAND_PROBE_CONTAINMENT_FAILED'
+    })
+    await vi.advanceTimersByTimeAsync(6_000)
 
-    await expect(resultPromise).resolves.toBe(false)
+    await rejection
     expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(killDirectProcess).toHaveBeenCalledWith(123)
+    expect(rejected).toHaveBeenCalledTimes(1)
+    expect(rejected.mock.calls[0][0]).toBeInstanceOf(CommandProbeContainmentError)
     expect(child.listenerCount('error')).toBe(1)
     expect(child.listenerCount('close')).toBe(1)
 
     child.emit('close', null)
+    child.emit('close', null)
+    expect(rejected).toHaveBeenCalledTimes(1)
     expect(child.listenerCount('error')).toBe(0)
     expect(child.listenerCount('close')).toBe(0)
   })

--- a/test/main/presenter/skillPresenter/skillExecutionService.test.ts
+++ b/test/main/presenter/skillPresenter/skillExecutionService.test.ts
@@ -48,6 +48,16 @@ import { spawn } from 'child_process'
 import * as shellEnvHelper from '../../../../src/main/lib/agentRuntime/shellEnvHelper'
 import { rtkRuntimeService } from '../../../../src/main/lib/agentRuntime/rtkRuntimeService'
 
+class MockProbeChild extends EventEmitter {
+  pid: number | undefined
+  kill = vi.fn(() => true)
+
+  constructor(pid?: number) {
+    super()
+    this.pid = pid
+  }
+}
+
 describe('SkillExecutionService', () => {
   let skillPresenter: ISkillPresenter
   let service: SkillExecutionService
@@ -226,7 +236,8 @@ describe('SkillExecutionService', () => {
   })
 
   it('bounds command probes and preserves successful availability', async () => {
-    const child = new EventEmitter()
+    vi.useFakeTimers()
+    const child = new MockProbeChild(123)
     vi.mocked(spawn).mockReturnValue(child as never)
 
     const resultPromise = (service as never).hasCommand('node', ['--version'], { PATH: '/bin' })
@@ -234,22 +245,25 @@ describe('SkillExecutionService', () => {
     expect(spawn).toHaveBeenCalledWith('node', ['--version'], {
       env: { PATH: '/bin' },
       stdio: 'ignore',
-      shell: false,
-      timeout: 5_000,
-      killSignal: 'SIGKILL'
+      shell: false
     })
     child.emit('close', 0)
 
     await expect(resultPromise).resolves.toBe(true)
+    await vi.advanceTimersByTimeAsync(6_000)
+    expect(child.kill).not.toHaveBeenCalled()
     expect(child.listenerCount('error')).toBe(0)
     expect(child.listenerCount('close')).toBe(0)
   })
 
   it('resolves a timed-out command probe as unavailable after close', async () => {
-    const child = new EventEmitter()
+    vi.useFakeTimers()
+    const child = new MockProbeChild(123)
     vi.mocked(spawn).mockReturnValue(child as never)
 
     const resultPromise = (service as never).hasCommand('node', ['--version'], { PATH: '/bin' })
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
     child.emit('close', null, 'SIGKILL')
 
     await expect(resultPromise).resolves.toBe(false)
@@ -258,7 +272,7 @@ describe('SkillExecutionService', () => {
   })
 
   it('settles a failed command probe once after error and close', async () => {
-    const child = new EventEmitter()
+    const child = new MockProbeChild()
     const settled = vi.fn()
     vi.mocked(spawn).mockReturnValue(child as never)
 
@@ -275,6 +289,44 @@ describe('SkillExecutionService', () => {
 
     await expect(resultPromise).resolves.toBe(false)
     expect(settled).toHaveBeenCalledTimes(1)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+  })
+
+  it('bounds a kill failure when the command probe never closes', async () => {
+    vi.useFakeTimers()
+    const child = new MockProbeChild(123)
+    child.kill.mockReturnValue(false)
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    const resultPromise = (service as never).hasCommand('node', ['--version'], { PATH: '/bin' })
+    await vi.advanceTimersByTimeAsync(6_000)
+
+    await expect(resultPromise).resolves.toBe(false)
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(child.listenerCount('error')).toBe(1)
+    expect(child.listenerCount('close')).toBe(1)
+
+    child.emit('close', null)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+  })
+
+  it('bounds a child error when the command probe never closes', async () => {
+    vi.useFakeTimers()
+    const child = new MockProbeChild(123)
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    const resultPromise = (service as never).hasCommand('node', ['--version'], { PATH: '/bin' })
+    child.emit('error', new Error('kill failed'))
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await expect(resultPromise).resolves.toBe(false)
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(child.listenerCount('error')).toBe(1)
+    expect(child.listenerCount('close')).toBe(1)
+
+    child.emit('close', null)
     expect(child.listenerCount('error')).toBe(0)
     expect(child.listenerCount('close')).toBe(0)
   })

--- a/test/main/presenter/skillPresenter/skillExecutionService.test.ts
+++ b/test/main/presenter/skillPresenter/skillExecutionService.test.ts
@@ -225,6 +225,60 @@ describe('SkillExecutionService', () => {
     ).rejects.toThrow('No compatible Python runtime found for this skill')
   })
 
+  it('bounds command probes and preserves successful availability', async () => {
+    const child = new EventEmitter()
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    const resultPromise = (service as never).hasCommand('node', ['--version'], { PATH: '/bin' })
+
+    expect(spawn).toHaveBeenCalledWith('node', ['--version'], {
+      env: { PATH: '/bin' },
+      stdio: 'ignore',
+      shell: false,
+      timeout: 5_000,
+      killSignal: 'SIGKILL'
+    })
+    child.emit('close', 0)
+
+    await expect(resultPromise).resolves.toBe(true)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+  })
+
+  it('resolves a timed-out command probe as unavailable after close', async () => {
+    const child = new EventEmitter()
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    const resultPromise = (service as never).hasCommand('node', ['--version'], { PATH: '/bin' })
+    child.emit('close', null, 'SIGKILL')
+
+    await expect(resultPromise).resolves.toBe(false)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+  })
+
+  it('settles a failed command probe once after error and close', async () => {
+    const child = new EventEmitter()
+    const settled = vi.fn()
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    const resultPromise = (service as never)
+      .hasCommand('missing', [], { PATH: '/bin' })
+      .then((result: boolean) => {
+        settled(result)
+        return result
+      })
+
+    child.emit('error', new Error('spawn failed'))
+    child.emit('close', null)
+    child.emit('close', 0)
+
+    await expect(resultPromise).resolves.toBe(false)
+    expect(settled).toHaveBeenCalledTimes(1)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+  })
+
   it('switches to shell spawn mode when RTK rewrites the command', async () => {
     vi.mocked(rtkRuntimeService.prepareShellCommand).mockResolvedValueOnce({
       originalCommand: 'node /skills/ocr/scripts/run.py',

--- a/test/main/presenter/workspacePresenter.test.ts
+++ b/test/main/presenter/workspacePresenter.test.ts
@@ -631,3 +631,106 @@ describe('workspacePreviewProtocol helpers', () => {
     expect(resolveWorkspacePreviewRequest(previewUrl)).toBeNull()
   })
 })
+
+describe('WorkspacePresenter Git process limits', () => {
+  let workspacePath: string
+  let presenter: WorkspacePresenter
+
+  beforeEach(async () => {
+    execFileMock.mockReset()
+    workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-workspace-git-'))
+    presenter = new WorkspacePresenter({ prepareFileCompletely: vi.fn() } as any)
+    await presenter.registerWorkspace(workspacePath)
+  })
+
+  afterEach(async () => {
+    await presenter.destroy()
+    fs.rmSync(workspacePath, { recursive: true, force: true })
+  })
+
+  it('preserves Git output and applies the direct-child timeout', async () => {
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        args: string[],
+        _options: unknown,
+        callback: (error: Error | null, result?: { stdout: string; stderr: string }) => void
+      ) => {
+        callback(null, {
+          stdout:
+            args[0] === 'rev-parse'
+              ? `${workspacePath}\n`
+              : '## main...origin/main [ahead 1]\n M src/app.ts\n',
+          stderr: ''
+        })
+      }
+    )
+
+    const result = await presenter.getGitStatus(workspacePath)
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        branch: 'main',
+        ahead: 1,
+        behind: 0,
+        changes: [expect.objectContaining({ relativePath: 'src/app.ts' })]
+      })
+    )
+    for (const call of execFileMock.mock.calls) {
+      expect(call[2]).toEqual(expect.objectContaining({ timeout: 30_000, killSignal: 'SIGKILL' }))
+    }
+  })
+
+  it('returns null after a timed-out Git command settles', async () => {
+    const timeoutError = Object.assign(new Error('Git timed out'), {
+      killed: true,
+      signal: 'SIGKILL'
+    })
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        args: string[],
+        _options: unknown,
+        callback: (error: Error | null, result?: { stdout: string; stderr: string }) => void
+      ) => {
+        if (args[0] === 'rev-parse') {
+          callback(null, { stdout: `${workspacePath}\n`, stderr: '' })
+          return
+        }
+        callback(timeoutError)
+      }
+    )
+
+    await expect(presenter.getGitStatus(workspacePath)).resolves.toBeNull()
+  })
+
+  it('does not turn a timed-out untracked-file diff into partial success', async () => {
+    const filePath = path.join(workspacePath, 'new.txt')
+    fs.writeFileSync(filePath, 'new content')
+    const timeoutError = Object.assign(new Error('Git timed out'), {
+      killed: true,
+      signal: 'SIGKILL'
+    })
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        args: string[],
+        _options: unknown,
+        callback: (error: Error | null, result?: { stdout: string; stderr: string }) => void
+      ) => {
+        if (args[0] === 'rev-parse') {
+          callback(null, { stdout: `${workspacePath}\n`, stderr: '' })
+        } else if (args.includes('--no-index')) {
+          callback(timeoutError)
+        } else if (args[0] === 'ls-files') {
+          callback(null, { stdout: 'new.txt\n', stderr: '' })
+        } else {
+          callback(null, { stdout: '', stderr: '' })
+        }
+      }
+    )
+
+    await expect(presenter.getGitDiff(workspacePath, filePath)).resolves.toBeNull()
+    expect(execFileMock.mock.calls.some((call) => call[1].includes('--no-index'))).toBe(true)
+  })
+})

--- a/test/main/presenter/workspacePresenter.test.ts
+++ b/test/main/presenter/workspacePresenter.test.ts
@@ -709,7 +709,9 @@ describe('WorkspacePresenter Git process limits', () => {
     fs.writeFileSync(filePath, 'new content')
     const timeoutError = Object.assign(new Error('Git timed out'), {
       killed: true,
-      signal: 'SIGKILL'
+      signal: 'SIGKILL',
+      code: 1,
+      stdout: 'partial diff that must not escape\n'
     })
     execFileMock.mockImplementation(
       (


### PR DESCRIPTION
## Scope

This PR delivers PTG-H0 only: finite direct-child lifetimes for three previously unbounded helper paths.

- Workspace Git helpers: 30-second direct execFile timeout with SIGKILL.
- Device disk queries: replace shell exec with direct execFile for wmic or df, with a 10-second timeout and SIGKILL.
- Skill runtime command probes: 5-second owner-handle kill request plus a 1-second close/reap confirmation window.

It does not implement descendant containment, a watchdog, platform process groups, Job Objects, or the broader PTG launcher matrix.

## Why

These helpers could wait forever during healthy operation. That made the later owner-loss matrix ambiguous: a test could not distinguish a process-tree containment defect from a helper that never had a finite local contract.

The change establishes finite direct-child behavior first while preserving each public result contract:

- Workspace failures still converge to null.
- Device query failures still reject.
- Normal command-probe absence or timeout still returns false.
- An unconfirmed command-probe kill is not disguised as false; it rejects with CommandProbeContainmentError.

## Implementation

### Workspace

Every Git execFile path, including diff --no-index, receives the 30-second timeout and SIGKILL. A killed no-index process is checked before the normal Git code-1 partial-output branch, so timeout output cannot be returned as a successful diff.

### Device

wmic and df now run as direct executables with argument arrays. This removes the intermediary shell while preserving stdout parsing and rejection behavior.

### Skill command probe

The probe uses only the owned ChildProcess handle for termination. It never sends a signal to a cached raw PID.

- At five seconds, request child.kill(SIGKILL).
- Resolve false only after close confirms process settlement.
- If close is still unconfirmed after one second, reject typed CommandProbeContainmentError.
- Keep ownership listeners after that rejection so a late close still cleans up without a second settlement.

This exceptional rejection is an OS/process-ownership invariant failure, not ordinary command unavailability.

## Impact

Normal successful results are unchanged. Hung helpers now have explicit owner-level bounds, so renderer/runtime callers no longer wait indefinitely on these three paths.

The command-probe path can now surface a typed containment error in the exceptional case where the owned child does not confirm close after a kill request. That is intentionally stricter than returning false while a process may still be alive.

No descendant behavior is changed. A probed command could theoretically create descendants; PTG-H0 does not claim to govern them.

## Automated validation

Independent verification required three correction rounds and now passes with no finding.

- Focused final verification: 4 files, 48 tests passed.
- Developer focused suite: 46 tests passed.
- typecheck, typecheck:node, format check, i18n, lint, architecture guard, and diff check passed.
- Full developer run: 4,518 tests passed with the same five known baseline failures.
- Real child tests verify execFile callback and spawn close occur after SIGKILL and process absence.
- Test cleanup uses PID plus a UUID command marker plus an OS start identity:
  - macOS/Linux: ps start time and command
  - Windows: CIM CreationDate and CommandLine
- If identity lookup fails, cleanup fails safely and does not fall back to a raw-PID kill.
- Tests cover child.kill false, child.kill throw, self-close within grace, no-close containment rejection, late-close cleanup, exactly-once settlement, listener/timer cleanup, and no-index killed plus code-1 plus partial stdout.

The five baseline failures remain:

- three SpotlightOverlay Pinia setup tests
- one debug mock-session plan-block test
- one AgentSession long converted-steer rebudget test

## Manual validation and gaps

Local real-child evidence was collected on macOS only.

Before PTG-H0 can count toward the broader FTL-002 unlock matrix, native CI or manual runs are still required on Windows and Linux for:

- execFile timeout and callback settlement
- spawn/ChildProcess kill and close settlement
- PowerShell CIM identity lookup on Windows
- ps identity parsing on Linux
- wmic and df argument/output compatibility on supported systems

This PR proves direct-child behavior only. It does not close PTG-001, does not unblock FTL-002 by itself, and does not claim that shells, MCP servers, ACP processes, PTYs, or arbitrary descendants are contained after main-process loss.

## Rollback

Revert the four commits in this PR. There is no data or schema migration.

Rollback restores the prior unbounded helper behavior, so FTL-002 and the PTG implementation must remain blocked. Do not keep the tests while weakening them to accept an unreaped child or raw-PID cleanup.
