### PR TITLE
fix(skills): publish immutable runtime snapshots

### DIFF
--- a/docs/issues/system-prompt-cache-coherence/spec.md
+++ b/docs/issues/system-prompt-cache-coherence/spec.md
@@ -343,6 +343,7 @@ interface PublishedSkillEntry {
   metadata: Readonly<SkillMetadata>
   renderedContent?: string
   allowedTools: readonly string[]
+  linkedFiles?: readonly Readonly<{ path: string; kind: string }>[]
   sourceError?: Readonly<{ code: string; message: string }>
 }
 
@@ -372,17 +373,22 @@ interface SkillRuntimeSnapshotPort {
    `SkillPresenter` 必须从同一次 raw source/config/script snapshot stage 出完整 `ready` entry，再 atomic
    publish；`waitForStableRuntimeSnapshot({ requiredSkillNames })` 负责共享该 readiness stage，reader 不能
    直接从磁盘补 body。
-4. `sourceVersion` 是 staged inputs 的 content digest，至少覆盖 raw `SKILL.md`、normalized extension、
-   normalized runnable script descriptors，以及会影响 path-variable/runtime rendering 的 skill/plugin root、
-   owner id 和 process arch。不能只用 name/mtime。
-5. stable state 使用 even safe integer，publish window 使用 odd integer。应用重启可从 `0` 开始，因为
+4. `skill_view` 的 root `SKILL.md`（包括显式 `filePath: 'SKILL.md'`）是 model/runtime reader：content、
+   metadata 和 linked-file path listing 必须来自同一个 captured `ready` entry，调用期间不 stat、readdir
+   或 read skill source。显式查看非 root linked file 是独立的用户请求，允许在 captured catalog metadata
+   授权的 skill root 内有界读盘，并明确可能观察到比 root LKG 更新的 linked-file bytes；该内容不参与
+   prompt/tool coherent pair，也不会替换 published root snapshot。
+5. `sourceVersion` 是 staged inputs 的 content digest，至少覆盖 raw `SKILL.md`、normalized extension、
+   normalized runnable script descriptors、linked-file path listing，以及会影响 path-variable/runtime
+   rendering 的 skill/plugin root、owner id 和 process arch。不能只用 name/mtime。
+6. stable state 使用 even safe integer，publish window 使用 odd integer。应用重启可从 `0` 开始，因为
    published snapshot 和所有依赖 cache 同时清空。
-6. 进入新的 even epoch 前必须已经选择并 atomic publish 以下三者之一：
+7. 进入新的 even epoch 前必须已经选择并 atomic publish 以下三者之一：
    - fully validated candidate snapshot；
    - previous last-known-good snapshot（可附带新的 diagnostic `sourceError`）；
    - 对没有 last-known-good 的 source 发布 `quarantined/unavailable` 状态，且它不进入 available/active
      prompt 或 `allowedTools`。
-7. published `sourceError` 是 runtime contract 的一部分，只允许稳定、受控、无 source content 的
+8. published `sourceError` 是 runtime contract 的一部分，只允许稳定、受控、无 source content 的
    code/message。raw exception、绝对路径、文件内容和底层错误消息只写 main-process local log，不得进入
    immutable snapshot、IPC 或 renderer cache。
 
@@ -431,6 +437,12 @@ interface SkillRuntimeSnapshotPort {
    stages、diagnostics 和 publish bookkeeping 全部保持不变。owner 应先停止 watcher/阻止新 mutation，等
    active publish settlement 后重试 reset；成功 reset 必须推进单调 observation floor，使 reset 前已经
    stage 的 late result 永远不能在 reset 后重新 publish。
+10. plugin contribution register/unregister API 返回成功前，贡献 map 与 published snapshot 必须收敛。
+    whole-catalog discovery 的 CAS 若被并发 watcher/mutation observation 淘汰，register 使用 bounded
+    per-source stage/CAS publish，unregister 为每个 removed source 推进 observation 并 direct CAS remove；
+    不能把 stale catalog snapshot 当作成功。所有 uninstall cleanup（包括目录已不存在的 `not_found`）也
+    必须先推进 source observation，再在 atomic remove 点 CAS，从而使 cleanup 前已开始的 watcher stage
+    永远不能复活已删除 entry。
 
 #### C3. bounded stable read
 
@@ -594,6 +606,11 @@ prompt/tool orchestration 仍分别等待 `PRM-002B`、`PRM-002C`；本 slice �
       `listSkillScripts()` compatibility API 只读 published snapshot，并用 hard-check 阻止 runtime path 重读
       source disk。
 - [x] 完成 invalid parse、deferred stage、rollback/reconcile、abort/deadline/hung worker tests。
+- [x] 完成最终 mutation lifecycle audit：catalog discovery 使用 catalog observation CAS；root/linked-source
+      watcher 使用 per-source observation CAS；repo-owned save/install/adopt 使用先 stage、再 odd publish
+      window、失败 rollback/reconcile；plugin contribution register/unregister 在 catalog CAS 丢失后逐源收敛；
+      uninstall（含 `not_found` cleanup）先推进 observation 再原子移除。`references`、`templates`、
+      `scripts`、`assets` 的目录变化都重建 linked-file listing snapshot。
 
 ### `PRM-002C` tasks
 
@@ -675,6 +692,13 @@ prompt/tool orchestration 仍分别等待 `PRM-002B`、`PRM-002C`；本 slice �
    candidate 都只从单一 source version publish；
 10. 外部文件先改变、watcher event 尚未送达，以及 event 已送达但 private stage deferred 时，旧 LKG 可继续
    命中；测试明确该 unavoidable observation window 不代表新 disk bytes 已 stable。
+11. root `skill_view`（含显式 `SKILL.md`）从一个 captured ready entry 返回 content/metadata/linked-file
+    listing，期间不 stat/readdir/read source；显式非 root linked-file view 仍可执行有界读盘。
+12. plugin register/unregister 的 catalog CAS 被并发 watcher 淘汰时，API 在逐源 publish/remove 收敛后才
+    返回成功。
+13. `not_found` uninstall cleanup 与已开始但未完成的 watcher stage 交错时，旧 candidate 不得复活 entry。
+14. linked-file 目录新增、删除事件会重建 published listing；linked-file 内容显式查看可读取比 root LKG
+    更新的 bytes，但不替换 root snapshot。
 
 ### Validation commands
 

--- a/docs/issues/system-prompt-cache-coherence/spec.md
+++ b/docs/issues/system-prompt-cache-coherence/spec.md
@@ -439,10 +439,13 @@ interface SkillRuntimeSnapshotPort {
    stage 的 late result 永远不能在 reset 后重新 publish。
 10. plugin contribution register/unregister API 返回成功前，贡献 map 与 published snapshot 必须收敛。
     whole-catalog discovery 的 CAS 若被并发 watcher/mutation observation 淘汰，register 使用 bounded
-    per-source stage/CAS publish，unregister 为每个 removed source 推进 observation 并 direct CAS remove；
-    不能把 stale catalog snapshot 当作成功。所有 uninstall cleanup（包括目录已不存在的 `not_found`）也
-    必须先推进 source observation，再在 atomic remove 点 CAS，从而使 cleanup 前已开始的 watcher stage
-    永远不能复活已删除 entry。
+    per-source stage/CAS publish，并且只有 published `sourceVersion` 与当前 contribution stage 的完整
+    revision（owner/plugin root/body/extension/scripts）一致时才可返回；相同 path/owner 不是 revision
+    identity。unregister 为每个 removed source 推进 observation 并 direct CAS remove，不能把 stale catalog
+    snapshot 当作成功。所有 uninstall（包括目录已不存在的 `not_found`）都先推进 source observation，
+    从而使 cleanup 前已开始的 watcher stage 永远不能复活已删除 entry；只有确实存在 published entry
+    需要移除时才打开 atomic publish window。pure missing no-op 和 management-only cleanup 不推进 runtime
+    epoch。
 
 #### C3. bounded stable read
 
@@ -609,8 +612,9 @@ prompt/tool orchestration 仍分别等待 `PRM-002B`、`PRM-002C`；本 slice �
 - [x] 完成最终 mutation lifecycle audit：catalog discovery 使用 catalog observation CAS；root/linked-source
       watcher 使用 per-source observation CAS；repo-owned save/install/adopt 使用先 stage、再 odd publish
       window、失败 rollback/reconcile；plugin contribution register/unregister 在 catalog CAS 丢失后逐源收敛；
-      uninstall（含 `not_found` cleanup）先推进 observation 再原子移除。`references`、`templates`、
-      `scripts`、`assets` 的目录变化都重建 linked-file listing snapshot。
+      plugin re-register 用完整 `sourceVersion` 证明当前 revision；uninstall（含 `not_found` cleanup）先推进
+      observation，仅在 snapshot 真正变化时推进 epoch。`references`、`templates`、`scripts`、`assets`
+      的目录变化都重建 linked-file listing snapshot。
 
 ### `PRM-002C` tasks
 
@@ -699,6 +703,10 @@ prompt/tool orchestration 仍分别等待 `PRM-002B`、`PRM-002C`；本 slice �
 13. `not_found` uninstall cleanup 与已开始但未完成的 watcher stage 交错时，旧 candidate 不得复活 entry。
 14. linked-file 目录新增、删除事件会重建 published listing；linked-file 内容显式查看可读取比 root LKG
     更新的 bytes，但不替换 root snapshot。
+15. 相同 path/owner 的 plugin 用新 plugin root/body re-register，且 catalog CAS 被无关 watcher 淘汰时，
+    API 必须发布与当前 contribution staged `sourceVersion` 一致的 revision，不能接受旧 entry。
+16. pure missing uninstall 和 management-only missing cleanup 保持 snapshot reference/epoch 不变；两者仍推进
+    per-source observation，使更早开始的 late stage 失效。
 
 ### Validation commands
 

--- a/docs/issues/system-prompt-cache-coherence/spec.md
+++ b/docs/issues/system-prompt-cache-coherence/spec.md
@@ -568,17 +568,17 @@ prompt/tool orchestration 仍分别等待 `PRM-002B`、`PRM-002C`；本 slice �
 
 ### `PRM-002B` tasks
 
-- [ ] 定义 immutable `PublishedSkillEntry`/`SkillRuntimeSnapshot` 与 content-derived `sourceVersion`。
-- [ ] 让 metadata/body/runtime instructions/`allowedTools` 从同一次 staged source version 产生。
-- [ ] 保留 progressive loading：active `metadata_only` entry 必须通过 staged atomic publish 变成 `ready`。
-- [ ] 实现 repo mutation stage → atomic disk replace → atomic snapshot publish；实现 atomic rollback。
-- [ ] 实现 invalid existing/new、rollback-failed LKG/quarantine 和 reconcile state machine。
-- [ ] 实现 odd/even publish epoch、shared settlement barrier 和
+- [x] 定义 immutable `PublishedSkillEntry`/`SkillRuntimeSnapshot` 与 content-derived `sourceVersion`。
+- [x] 让 metadata/body/runtime instructions/`allowedTools` 从同一次 staged source version 产生。
+- [x] 保留 progressive loading：active `metadata_only` entry 必须通过 staged atomic publish 变成 `ready`。
+- [x] 实现 repo mutation stage → atomic disk replace → atomic snapshot publish；实现 atomic rollback。
+- [x] 实现 invalid existing/new、rollback-failed LKG/quarantine 和 reconcile state machine。
+- [x] 实现 odd/even publish epoch、shared settlement barrier 和
       `waitForStableRuntimeSnapshot({ signal, deadlineAt })`。
-- [ ] 让现有 `getMetadataList()`、`loadSkillContent()`、`getActiveSkillsAllowedTools()`、
+- [x] 让现有 `getMetadataList()`、`loadSkillContent()`、`getActiveSkillsAllowedTools()`、
       `listSkillScripts()` compatibility API 只读 published snapshot，并用 hard-check 阻止 runtime path 重读
       source disk。
-- [ ] 完成 invalid parse、deferred stage、rollback/reconcile、abort/deadline/hung worker tests。
+- [x] 完成 invalid parse、deferred stage、rollback/reconcile、abort/deadline/hung worker tests。
 
 ### `PRM-002C` tasks
 
@@ -605,7 +605,7 @@ prompt/tool orchestration 仍分别等待 `PRM-002B`、`PRM-002C`；本 slice �
       failure/reconcile 和 cache hit contract。
 - [x] `PRM-001`: 拆分 `PRM-002A`–`PRM-002C` 的 depends-on、validation 与 rollback order。
 - [x] `PRM-002A`: source snapshots。
-- [ ] `PRM-002B`: skill immutable snapshot/epoch。
+- [x] `PRM-002B`: skill immutable snapshot/epoch。
 - [ ] `PRM-002C`: orchestration cache wiring and final validation。
 
 ## Test design

--- a/docs/issues/system-prompt-cache-coherence/spec.md
+++ b/docs/issues/system-prompt-cache-coherence/spec.md
@@ -382,6 +382,9 @@ interface SkillRuntimeSnapshotPort {
    - previous last-known-good snapshot（可附带新的 diagnostic `sourceError`）；
    - 对没有 last-known-good 的 source 发布 `quarantined/unavailable` 状态，且它不进入 available/active
      prompt 或 `allowedTools`。
+7. published `sourceError` 是 runtime contract 的一部分，只允许稳定、受控、无 source content 的
+   code/message。raw exception、绝对路径、文件内容和底层错误消息只写 main-process local log，不得进入
+   immutable snapshot、IPC 或 renderer cache。
 
 仅仅“disk operation 返回了”或“worker Promise settle 了”不是进入 even 的充分条件。
 
@@ -391,9 +394,11 @@ interface SkillRuntimeSnapshotPort {
    和 script descriptors，计算 `sourceVersion` 并形成 immutable candidate。stage 期间 reader 继续使用旧
    stable snapshot，不会读取正在变化的磁盘。
 2. candidate 完整后才开启很短的 odd publish window，atomic swap snapshot reference，然后进入新的
-   even epoch。每个 stage 带 source observation sequence；publish 按 skill/source 串行 compare-and-swap，
-   旧 stage 不得覆盖已发布的新 observation。重叠 publish 使用 active publish count/shared settlement
-   barrier，直到所有 publish settlement 完成都保持 odd。
+   even epoch。每个 stage 带 source observation sequence；sequence 的 compare-and-swap 与开启 odd
+   publish/update 必须是同一个同步原子步骤，不能先检查、跨越 `await` 后再 publish。discovery 使用
+   catalog observation sequence，并只在该 sequence 仍是最新 observation 时 whole-map replace；其间任一
+   watcher 或 mutation observation 都使旧 discovery result 失效。重叠 publish 使用 active publish
+   count/shared settlement barrier，直到所有 publish settlement 完成都保持 odd。
 3. repo-owned mutation 在写盘前先用 proposed bytes stage/validate candidate。需要写盘时，在第一个
    externally visible write 前进入 odd，使用 temp file + atomic replace；多资源写入失败且已经改变磁盘时，
    必须用 previous raw/config 做 atomic rollback，然后才能选择 previous LKG snapshot 并进入 even。
@@ -419,6 +424,13 @@ interface SkillRuntimeSnapshotPort {
 7. success、完整 rollback、rollback failure 和 invalid candidate 都必须在 `finally` 中关闭 publish
    bookkeeping；但只有 coherent snapshot 已被选定/published 后才能从 odd 进入 even。即使最终仍是旧
    bytes，也进入新的 even epoch；这是可接受的低频 false invalidation。
+8. publication observer/callback 不是 publication truth。snapshot reference 已 swap 后，即使 observer
+   抛错，本次 publication 仍保持成功的 even snapshot；调用方同步收到 observer error，但 shared
+   settlement 必须在 `finally` resolve 并清空，不能留下 even epoch 搭配永久 pending waiter。
+9. `reset()`/`destroy()` 遇到 active publish 时必须原子拒绝：snapshot、observation sequences、readiness
+   stages、diagnostics 和 publish bookkeeping 全部保持不变。owner 应先停止 watcher/阻止新 mutation，等
+   active publish settlement 后重试 reset；成功 reset 必须推进单调 observation floor，使 reset 前已经
+   stage 的 late result 永远不能在 reset 后重新 publish。
 
 #### C3. bounded stable read
 
@@ -426,7 +438,10 @@ interface SkillRuntimeSnapshotPort {
    `AbortSignal` 传给 `waitForStableRuntimeSnapshot()`。retry/rebuild 不得重置 deadline。
 2. required entry 仍是 `metadata_only` 时，wait 启动/复用 shared readiness staging Promise；epoch odd 时
    复用 shared publish settlement Promise。每个 caller 独立 race 自己的 signal/deadline；一个 caller
-   timeout/abort 不取消 shared stage/mutation，也不影响其他 waiter。
+   timeout/abort 不取消 shared stage/mutation，也不影响其他 waiter。shared readiness stage 若得到 invalid
+   candidate 或 read failure：有 previous `ready` LKG 时保留该 LKG 并附稳定 `sourceError`；没有 ready
+   LKG 时 atomic publish `quarantined`。后续 waiter 直接观察同一稳定结果，不重复读盘；只有新的 watcher
+   event、显式 discovery 或下一次 mutation 才能重新触发 staging，不创建 `30s` timer 或后台 retry loop。
 3. signal 先触发时立即抛现有 abort error，不回退 cache。deadline 先到且 required readiness stage 或 odd
    publish 仍 pending/hung 时，抛：
 

--- a/src/main/presenter/skillPresenter/index.ts
+++ b/src/main/presenter/skillPresenter/index.ts
@@ -41,7 +41,11 @@ import {
   SkillScriptDescriptor,
   SkillScriptRuntime,
   SkillViewResult,
-  SkillLinkedFile
+  SkillLinkedFile,
+  PublishedSkillEntry,
+  PublishedSkillSourceError,
+  SkillRuntimeSnapshot,
+  WaitForStableSkillRuntimeOptions
 } from '@shared/types/skill'
 import type {
   SkillManagementItem,
@@ -55,6 +59,14 @@ import { publishDeepchatEvent } from '@/routes/publishDeepchatEvent'
 import logger from '@shared/logger'
 import { normalizeSkillAllowedTools } from './toolNameMapping'
 import { discoverSkillMetadataInWorker, logSkillDiscoveryWorkerWarnings } from './discoveryWorker'
+import {
+  createMetadataOnlyEntry,
+  createSkillSourceVersion,
+  freezeScriptDescriptors,
+  freezeSkillExtension,
+  freezeSkillMetadata,
+  SkillRuntimeSnapshotCoordinator
+} from './runtimeSnapshot'
 
 const execFileAsync = promisify(execFile)
 
@@ -137,6 +149,7 @@ const DRAFT_CONVERSATION_ID_PATTERN = /^[A-Za-z0-9._-]+$/
 const DRAFT_ID_PATTERN = /^[A-Za-z0-9._-]+$/
 const DRAFT_ACTIVITY_MARKER = '.lastActivity'
 const SKILL_MANAGEMENT_STATE_KEY = 'skills.managementState'
+const SKILL_RUNTIME_WAIT_BUDGET_MS = 200
 const DRAFT_INJECTION_PATTERNS = [
   /ignore\s+previous\s+instructions/i,
   /disregard\s+all\s+prior/i,
@@ -231,6 +244,12 @@ export class SkillPresenter implements ISkillPresenter {
   private draftsRoot: string
   private metadataCache: Map<string, SkillMetadata> = new Map()
   private contentCache: Map<string, SkillContent> = new Map()
+  private runtimeContentViews = new WeakMap<PublishedSkillEntry, SkillContent>()
+  private readonly runtimeSnapshots = new SkillRuntimeSnapshotCoordinator({
+    stageEntry: (metadata) => this.stagePublishedSkillEntry(metadata),
+    onPublished: (entries) => this.syncCompatibilityCaches(entries)
+  })
+  private runtimeSnapshotReadDepth = 0
   private pluginSkillContributions: Map<
     string,
     { ownerPluginId: string; skillRoot: string; pluginRoot?: string }
@@ -316,6 +335,181 @@ export class SkillPresenter implements ISkillPresenter {
     return this.skillsDir
   }
 
+  getPublishedRuntimeSnapshot(): SkillRuntimeSnapshot {
+    return this.runtimeSnapshots.snapshot
+  }
+
+  async waitForStableRuntimeSnapshot(
+    options: WaitForStableSkillRuntimeOptions
+  ): Promise<SkillRuntimeSnapshot> {
+    this.seedRuntimeSnapshotFromCompatibilityCache()
+    return await this.runtimeSnapshots.wait(options)
+  }
+
+  private seedRuntimeSnapshotFromCompatibilityCache(): void {
+    this.runtimeSnapshots.seedFromMetadata(this.metadataCache.values())
+  }
+
+  private beginRuntimePublish(): () => void {
+    return this.runtimeSnapshots.beginPublish()
+  }
+
+  private publishRuntimeReplacement(entries: ReadonlyMap<string, PublishedSkillEntry>): void {
+    this.runtimeSnapshots.replace(entries)
+  }
+
+  private publishRuntimeEntry(entry: PublishedSkillEntry, previousName?: string): void {
+    this.runtimeSnapshots.publishEntry(entry, previousName)
+  }
+
+  private publishRuntimeRemoval(name: string): void {
+    this.runtimeSnapshots.remove(name)
+  }
+
+  private publishRuntimeSourceError(
+    name: string,
+    error: { code: string; message: string },
+    sourcePath?: string
+  ): void {
+    this.runtimeSnapshots.publishSourceError(name, error, sourcePath)
+  }
+
+  private syncCompatibilityCaches(entries: ReadonlyMap<string, PublishedSkillEntry>): void {
+    this.metadataCache.clear()
+    this.contentCache.clear()
+    for (const [name, entry] of entries) {
+      if (entry.availability === 'quarantined') continue
+      this.metadataCache.set(name, entry.metadata as SkillMetadata)
+      if (entry.availability === 'ready' && entry.renderedContent !== undefined) {
+        this.contentCache.set(name, this.getRuntimeContentView(entry))
+      }
+    }
+  }
+
+  private getRuntimeContentView(entry: PublishedSkillEntry): SkillContent {
+    const cached = this.runtimeContentViews.get(entry)
+    if (cached) return cached
+    const content = Object.freeze({
+      name: entry.metadata.name,
+      content: entry.renderedContent ?? ''
+    })
+    this.runtimeContentViews.set(entry, content)
+    return content
+  }
+
+  private async stagePublishedSkillEntry(
+    metadataHint: SkillMetadata,
+    options: {
+      rawContent?: string
+      extension?: SkillExtensionConfig
+      scriptSourceRoot?: string
+    } = {}
+  ): Promise<PublishedSkillEntry | null> {
+    this.assertSourceReadAllowed()
+    let rawContent = options.rawContent
+    if (rawContent === undefined) {
+      const stats = await fs.promises.stat(metadataHint.path)
+      if (stats.size > SKILL_CONFIG.SKILL_FILE_MAX_SIZE) {
+        throw new Error(
+          `Skill file too large: ${stats.size} bytes (max: ${SKILL_CONFIG.SKILL_FILE_MAX_SIZE})`
+        )
+      }
+      rawContent = await fs.promises.readFile(metadataHint.path, 'utf-8')
+    }
+
+    const parsed = this.parseSkillMetadataFromContent(
+      rawContent,
+      metadataHint.path,
+      path.basename(metadataHint.skillRoot),
+      metadataHint.ownerPluginId
+    )
+    if (!parsed) {
+      return null
+    }
+
+    const extension = sanitizeSkillExtensionConfig(
+      options.extension ?? (await this.loadSkillExtensionForStage(parsed.name))
+    )
+    const scriptSourceRoot = options.scriptSourceRoot ?? parsed.skillRoot
+    const scripts = await this.collectStagedScriptDescriptors(
+      scriptSourceRoot,
+      parsed.skillRoot,
+      extension
+    )
+    const parsedContent = matter(rawContent).content
+    const renderedBody = this.replacePathVariables(parsedContent, parsed).trim()
+    const runtimeInstructions = this.buildRuntimeInstructionsFromScripts(parsed, scripts)
+    const renderedContent = [renderedBody, runtimeInstructions].filter(Boolean).join('\n\n')
+    const pluginContribution = this.getPluginContributionForSkillRoot(parsed.skillRoot)
+    const frozenMetadata = freezeSkillMetadata(parsed)
+    const frozenExtension = freezeSkillExtension(extension)
+    const frozenScripts = freezeScriptDescriptors(scripts)
+    const allowedTools = Object.freeze([...(frozenMetadata.allowedTools ?? [])])
+    const sourceVersion = createSkillSourceVersion({
+      rawContent,
+      extension: frozenExtension,
+      scripts: frozenScripts.map(({ relativePath, runtime, enabled, description }) => ({
+        relativePath,
+        runtime,
+        enabled,
+        description
+      })),
+      skillRoot: parsed.skillRoot,
+      skillsDir: this.skillsDir,
+      pluginRoot: pluginContribution?.pluginRoot ?? null,
+      ownerPluginId: parsed.ownerPluginId ?? pluginContribution?.ownerPluginId ?? null,
+      processArch: process.arch
+    })
+
+    return Object.freeze({
+      sourceVersion,
+      availability: 'ready' as const,
+      metadata: frozenMetadata,
+      renderedContent,
+      allowedTools,
+      extension: frozenExtension,
+      scripts: frozenScripts
+    })
+  }
+
+  private async collectStagedScriptDescriptors(
+    sourceRoot: string,
+    publishedRoot: string,
+    extension: SkillExtensionConfig
+  ): Promise<SkillScriptDescriptor[]> {
+    const scriptsDir = path.join(sourceRoot, 'scripts')
+    if (!(await this.pathExists(scriptsDir))) {
+      return []
+    }
+    const descriptors = await this.collectScriptDescriptors(scriptsDir, sourceRoot)
+    return descriptors
+      .map((script) => {
+        const override = extension.scriptOverrides[script.relativePath] ?? {}
+        return {
+          ...script,
+          absolutePath: path.join(publishedRoot, script.relativePath),
+          enabled: override.enabled ?? true,
+          description: override.description
+        }
+      })
+      .sort((left, right) => left.relativePath.localeCompare(right.relativePath))
+  }
+
+  private assertSourceReadAllowed(): void {
+    if (this.runtimeSnapshotReadDepth > 0) {
+      throw new Error('Skill source disk read attempted inside a published runtime snapshot read')
+    }
+  }
+
+  private readCapturedRuntimeSnapshot<T>(reader: (snapshot: SkillRuntimeSnapshot) => T): T {
+    this.runtimeSnapshotReadDepth += 1
+    try {
+      return reader(this.runtimeSnapshots.snapshot)
+    } finally {
+      this.runtimeSnapshotReadDepth -= 1
+    }
+  }
+
   /**
    * Initialize the skill system - discover skills and start watching
    */
@@ -333,10 +527,8 @@ export class SkillPresenter implements ISkillPresenter {
    * Discover all skills from the skills directory
    */
   async discoverSkills(): Promise<SkillMetadata[]> {
-    this.metadataCache.clear()
-    this.contentCache.clear()
-
     if (!fs.existsSync(this.skillsDir)) {
+      this.publishRuntimeReplacement(new Map())
       return []
     }
 
@@ -354,21 +546,79 @@ export class SkillPresenter implements ISkillPresenter {
       discoveredSkills = await this.discoverSkillsOnMainThread()
     }
 
+    const previousEntries = this.runtimeSnapshots.snapshot.entries
+    const nextEntries = new Map<string, PublishedSkillEntry>()
+    const observedPaths = new Set<string>()
     for (const metadata of [
       ...discoveredSkills,
       ...(await this.discoverPluginSkillsOnMainThread())
     ]) {
-      if (this.metadataCache.has(metadata.name)) {
+      observedPaths.add(metadata.path)
+      if (nextEntries.has(metadata.name)) {
         logger.warn('[SkillPresenter] Duplicate skill name discovered. Keeping the first entry.', {
           name: metadata.name,
           path: metadata.path
         })
         continue
       }
-      this.metadataCache.set(metadata.name, metadata)
+      const previous = previousEntries.get(metadata.name)
+      if (previous?.availability === 'ready' && previous.metadata.path === metadata.path) {
+        const sequence = this.runtimeSnapshots.nextObservation(metadata.path)
+        try {
+          const staged = await this.stagePublishedSkillEntry(metadata)
+          if (staged && this.runtimeSnapshots.isCurrentObservation(metadata.path, sequence)) {
+            nextEntries.set(staged.metadata.name, staged)
+            continue
+          }
+        } catch (error) {
+          logger.warn('[SkillPresenter] Failed to refresh a ready skill during discovery.', {
+            name: metadata.name,
+            path: metadata.path,
+            error
+          })
+        }
+        nextEntries.set(
+          metadata.name,
+          Object.freeze({
+            ...previous,
+            sourceError: Object.freeze({
+              code: 'DISCOVERY_REFRESH_FAILED',
+              message: 'Discovery could not produce a complete ready candidate'
+            })
+          })
+        )
+        continue
+      }
+      nextEntries.set(metadata.name, createMetadataOnlyEntry(metadata))
     }
 
-    const skills = this.getVisibleMetadataFromCache()
+    for (const [name, previous] of previousEntries) {
+      if (nextEntries.has(name) || observedPaths.has(previous.metadata.path)) {
+        continue
+      }
+      const pluginStillRegistered = previous.metadata.ownerPluginId
+        ? Array.from(this.pluginSkillContributions.values()).some(
+            (contribution) =>
+              contribution.ownerPluginId === previous.metadata.ownerPluginId &&
+              path.join(contribution.skillRoot, 'SKILL.md') === previous.metadata.path
+          )
+        : true
+      if (pluginStillRegistered && fs.existsSync(previous.metadata.path)) {
+        nextEntries.set(
+          name,
+          Object.freeze({
+            ...previous,
+            sourceError: Object.freeze({
+              code: 'INVALID_SOURCE',
+              message: 'Discovery observed an invalid skill source; retaining last-known-good'
+            })
+          })
+        )
+      }
+    }
+
+    this.publishRuntimeReplacement(nextEntries)
+    const skills = this.getVisibleMetadataFromSnapshot(this.runtimeSnapshots.snapshot)
     publishDeepchatEvent('skills.catalog.changed', {
       reason: 'discovered',
       skills,
@@ -442,21 +692,30 @@ export class SkillPresenter implements ISkillPresenter {
   ): Promise<SkillMetadata | null> {
     try {
       const content = await fs.promises.readFile(skillPath, 'utf-8')
-      const { data } = matter(content)
+      return this.parseSkillMetadataFromContent(content, skillPath, dirName, ownerPluginId)
+    } catch (error) {
+      console.error(`[SkillPresenter] Error parsing skill metadata at ${skillPath}:`, error)
+      return null
+    }
+  }
 
-      // Validate required fields
+  private parseSkillMetadataFromContent(
+    content: string,
+    skillPath: string,
+    dirName: string,
+    ownerPluginId?: string
+  ): SkillMetadata | null {
+    try {
+      const { data } = matter(content)
       if (!data.name || !data.description) {
         console.warn(`[SkillPresenter] Skill ${dirName} missing required frontmatter fields`)
         return null
       }
-
-      // Ensure name matches directory name
       if (data.name !== dirName) {
         console.warn(
           `[SkillPresenter] Skill name "${data.name}" doesn't match directory "${dirName}"`
         )
       }
-
       return {
         name: data.name || dirName,
         description: data.description || '',
@@ -471,7 +730,7 @@ export class SkillPresenter implements ISkillPresenter {
             ? (data.metadata as Record<string, unknown>)
             : undefined,
         allowedTools: Array.isArray(data.allowedTools)
-          ? data.allowedTools.filter((t): t is string => typeof t === 'string')
+          ? data.allowedTools.filter((tool): tool is string => typeof tool === 'string')
           : undefined,
         ownerPluginId
       }
@@ -486,7 +745,8 @@ export class SkillPresenter implements ISkillPresenter {
    * Uses discoveryPromise pattern to prevent race conditions
    */
   async getMetadataList(): Promise<SkillMetadata[]> {
-    if (this.metadataCache.size === 0) {
+    this.seedRuntimeSnapshotFromCompatibilityCache()
+    if (this.runtimeSnapshots.snapshot.entries.size === 0) {
       if (!this.discoveryPromise) {
         this.discoveryPromise = this.discoverSkills().finally(() => {
           this.discoveryPromise = null
@@ -494,12 +754,17 @@ export class SkillPresenter implements ISkillPresenter {
       }
       await this.discoveryPromise
     }
-    return this.getVisibleMetadataFromCache()
+    return this.readCapturedRuntimeSnapshot((snapshot) =>
+      this.getVisibleMetadataFromSnapshot(snapshot)
+    )
   }
 
-  private getVisibleMetadataFromCache(): SkillMetadata[] {
+  private getVisibleMetadataFromSnapshot(snapshot: SkillRuntimeSnapshot): SkillMetadata[] {
     return this.sortSkillMetadata(
-      Array.from(this.metadataCache.values()).filter((skill) => this.isSkillVisible(skill))
+      Array.from(snapshot.entries.values())
+        .filter((entry) => entry.availability !== 'quarantined')
+        .map((entry) => entry.metadata as SkillMetadata)
+        .filter((skill) => this.isSkillVisible(skill))
     )
   }
 
@@ -639,22 +904,25 @@ export class SkillPresenter implements ISkillPresenter {
   }
 
   async setSkillDeepChatDisabled(name: string, disabled: boolean): Promise<void> {
-    if (this.metadataCache.size === 0) {
-      await this.discoverSkills()
-    }
-    if (!this.metadataCache.has(name)) {
+    await this.getMetadataList()
+    const metadata = this.runtimeSnapshots.snapshot.entries.get(name)?.metadata
+    if (!metadata) {
       throw new Error(`Skill "${name}" not found`)
     }
 
-    this.updateSkillManagementItem(name, (item) => ({
-      ...item,
-      canonicalPath: this.metadataCache.get(name)?.skillRoot ?? item.canonicalPath,
-      deepchat: {
-        ...item.deepchat,
-        disabled
-      }
-    }))
-    this.contentCache.delete(name)
+    const endPublish = this.beginRuntimePublish()
+    try {
+      this.updateSkillManagementItem(name, (item) => ({
+        ...item,
+        canonicalPath: metadata.skillRoot,
+        deepchat: {
+          ...item.deepchat,
+          disabled
+        }
+      }))
+    } finally {
+      endPublish()
+    }
     publishDeepchatEvent('skills.catalog.changed', {
       reason: 'disabled-updated',
       name,
@@ -663,12 +931,15 @@ export class SkillPresenter implements ISkillPresenter {
   }
 
   async getUnifiedSkillCatalog(): Promise<UnifiedSkillItem[]> {
-    if (this.metadataCache.size === 0) {
-      await this.discoverSkills()
-    }
+    await this.getMetadataList()
 
     const state = this.getStoredManagementState()
-    return this.sortSkillMetadata(Array.from(this.metadataCache.values())).map((skill) => {
+    const metadata = this.readCapturedRuntimeSnapshot((snapshot) =>
+      Array.from(snapshot.entries.values())
+        .filter((entry) => entry.availability !== 'quarantined')
+        .map((entry) => entry.metadata as SkillMetadata)
+    )
+    return this.sortSkillMetadata(metadata).map((skill) => {
       const item = state.skills[skill.name] ?? this.createDefaultManagementItem(skill.name)
       return {
         ...skill,
@@ -726,51 +997,27 @@ export class SkillPresenter implements ISkillPresenter {
    * Load full skill content (lazy loading)
    */
   async loadSkillContent(name: string): Promise<SkillContent | null> {
-    if (this.metadataCache.size === 0) {
-      await this.discoverSkills()
-    }
-
-    // Get metadata to find the path
-    const metadata = this.metadataCache.get(name)
-    if (!metadata || !this.isSkillVisible(metadata)) {
+    await this.getMetadataList()
+    const snapshot = await this.waitForStableRuntimeSnapshot({
+      requiredSkillNames: [name],
+      signal: new AbortController().signal,
+      deadlineAt: Date.now() + SKILL_RUNTIME_WAIT_BUDGET_MS
+    })
+    const entry = snapshot.entries.get(name)
+    if (
+      !entry ||
+      entry.availability !== 'ready' ||
+      entry.renderedContent === undefined ||
+      !this.isSkillVisible(entry.metadata as SkillMetadata)
+    ) {
       console.warn(`[SkillPresenter] Skill not found: ${name}`)
       return null
     }
-
-    // Check content cache after feature visibility so disabled managed skills stay hidden.
-    if (this.contentCache.has(name)) {
-      return this.contentCache.get(name)!
-    }
-
+    this.runtimeSnapshotReadDepth += 1
     try {
-      // Check file size before reading to prevent memory exhaustion
-      const stats = await fs.promises.stat(metadata.path)
-      if (stats.size > SKILL_CONFIG.SKILL_FILE_MAX_SIZE) {
-        console.error(
-          `[SkillPresenter] Skill file too large: ${stats.size} bytes (max: ${SKILL_CONFIG.SKILL_FILE_MAX_SIZE})`
-        )
-        return null
-      }
-
-      const rawContent = await fs.promises.readFile(metadata.path, 'utf-8')
-      const { content } = matter(rawContent)
-      const renderedContent = this.replacePathVariables(content, metadata)
-      const runtimeInstructions = await this.buildRuntimeInstructions(metadata)
-
-      const skillContent: SkillContent = {
-        name,
-        content: [renderedContent.trim(), runtimeInstructions].filter(Boolean).join('\n\n')
-      }
-
-      // Discovery may have refreshed the caches while we were reading from disk;
-      // only cache when this skill's metadata entry is still the one we read from.
-      if (this.metadataCache.get(name) === metadata) {
-        this.contentCache.set(name, skillContent)
-      }
-      return skillContent
-    } catch (error) {
-      console.error(`[SkillPresenter] Error loading skill content for ${name}:`, error)
-      return null
+      return this.getRuntimeContentView(entry)
+    } finally {
+      this.runtimeSnapshotReadDepth -= 1
     }
   }
 
@@ -781,11 +1028,10 @@ export class SkillPresenter implements ISkillPresenter {
       conversationId?: string
     }
   ): Promise<SkillViewResult> {
-    if (this.metadataCache.size === 0) {
-      await this.discoverSkills()
-    }
-
-    const metadata = this.metadataCache.get(name)
+    await this.getMetadataList()
+    const metadata = this.runtimeSnapshots.snapshot.entries.get(name)?.metadata as
+      | SkillMetadata
+      | undefined
     if (!metadata || !this.isSkillVisible(metadata)) {
       return {
         success: false,
@@ -1219,8 +1465,11 @@ export class SkillPresenter implements ISkillPresenter {
       )
   }
 
-  private async buildRuntimeInstructions(metadata: SkillMetadata): Promise<string> {
-    const scripts = (await this.listSkillScripts(metadata.name)).filter((script) => script.enabled)
+  private buildRuntimeInstructionsFromScripts(
+    metadata: SkillMetadata,
+    stagedScripts: readonly SkillScriptDescriptor[]
+  ): string {
+    const scripts = stagedScripts.filter((script) => script.enabled)
     const lines = [
       '## DeepChat Runtime Context',
       `- Skill root: \`${metadata.skillRoot}\`.`,
@@ -1672,11 +1921,7 @@ export class SkillPresenter implements ISkillPresenter {
       skillRoot,
       pluginRoot: input.pluginRoot ? path.resolve(input.pluginRoot) : undefined
     })
-    this.metadataCache.clear()
-    this.contentCache.clear()
-    if (this.initialized) {
-      await this.discoverSkills()
-    }
+    await this.discoverSkills()
   }
 
   async registerAdoptedSkill(input: SkillAdoptionRegistration): Promise<void> {
@@ -1685,28 +1930,40 @@ export class SkillPresenter implements ISkillPresenter {
     if (!metadata || metadata.name !== input.name) {
       throw new Error(`Adopted skill "${input.name}" is invalid`)
     }
+    const candidate = await this.stagePublishedSkillEntry(metadata)
+    if (!candidate) {
+      throw new Error(`Adopted skill "${input.name}" is invalid`)
+    }
 
-    this.metadataCache.set(input.name, metadata)
-    this.contentCache.delete(input.name)
-    this.updateSkillManagementItem(input.name, (item) => ({
-      ...item,
-      canonicalPath: skillRoot,
-      source: {
-        type: 'adopted',
-        agentId: input.agentId,
-        originalPath: input.originalPath,
-        adoptedAt: new Date().toISOString()
-      },
-      agentLinks: {
-        ...item.agentLinks,
-        [input.agentId]: {
-          path: input.agentPath,
-          state: 'linked',
-          createdByDeepChat: true,
-          linkedAt: new Date().toISOString()
+    const previousState = this.getStoredManagementState()
+    const endPublish = this.beginRuntimePublish()
+    try {
+      this.updateSkillManagementItem(input.name, (item) => ({
+        ...item,
+        canonicalPath: skillRoot,
+        source: {
+          type: 'adopted',
+          agentId: input.agentId,
+          originalPath: input.originalPath,
+          adoptedAt: new Date().toISOString()
+        },
+        agentLinks: {
+          ...item.agentLinks,
+          [input.agentId]: {
+            path: input.agentPath,
+            state: 'linked',
+            createdByDeepChat: true,
+            linkedAt: new Date().toISOString()
+          }
         }
-      }
-    }))
+      }))
+      this.publishRuntimeEntry(candidate)
+    } catch (error) {
+      this.saveManagementState(previousState)
+      throw error
+    } finally {
+      endPublish()
+    }
 
     publishDeepchatEvent('skills.catalog.changed', {
       reason: 'installed',
@@ -1717,10 +1974,8 @@ export class SkillPresenter implements ISkillPresenter {
   }
 
   async registerAgentSkillLink(input: SkillAgentLinkRegistration): Promise<void> {
-    if (this.metadataCache.size === 0) {
-      await this.discoverSkills()
-    }
-    const metadata = this.metadataCache.get(input.skillName)
+    await this.getMetadataList()
+    const metadata = this.runtimeSnapshots.snapshot.entries.get(input.skillName)?.metadata
     if (!metadata) {
       throw new Error(`Skill "${input.skillName}" not found`)
     }
@@ -1772,13 +2027,8 @@ export class SkillPresenter implements ISkillPresenter {
       }
     }
 
-    if (changed && this.initialized) {
-      this.metadataCache.clear()
-      this.contentCache.clear()
+    if (changed) {
       await this.discoverSkills()
-    } else if (changed) {
-      this.metadataCache.clear()
-      this.contentCache.clear()
     }
   }
 
@@ -1872,47 +2122,120 @@ export class SkillPresenter implements ISkillPresenter {
         }
       }
 
-      if (fs.existsSync(resolvedTarget)) {
-        if (!options?.overwrite) {
-          return {
-            success: false,
-            error: `Skill "${finalSkillName}" already exists`,
-            errorCode: 'conflict',
-            existingSkillName: finalSkillName
-          }
+      const targetExists = fs.existsSync(resolvedTarget)
+      if (targetExists && !options?.overwrite) {
+        return {
+          success: false,
+          error: `Skill "${finalSkillName}" already exists`,
+          errorCode: 'conflict',
+          existingSkillName: finalSkillName
         }
-        const replaceResult = this.prepareExistingSkillTargetForInstall(
-          finalSkillName,
-          resolvedTarget
-        )
-        if (replaceResult) {
-          return replaceResult
-        }
-        this.metadataCache.delete(finalSkillName)
-        this.contentCache.delete(finalSkillName)
       }
 
-      this.copyDirectory(resolvedSource, resolvedTarget)
+      const stagingDir = path.join(
+        this.skillsDir,
+        `.${finalSkillName}.install-${process.pid}-${randomUUID()}`
+      )
+      this.copyDirectory(resolvedSource, stagingDir)
       if (finalSkillName !== skillName) {
-        this.rewriteSkillManifestName(resolvedTarget, finalSkillName)
+        this.rewriteSkillManifestName(stagingDir, finalSkillName)
       }
-
-      const metadata = await this.parseSkillMetadata(
+      const stagedContent = fs.readFileSync(path.join(stagingDir, 'SKILL.md'), 'utf-8')
+      const metadata = this.parseSkillMetadataFromContent(
+        stagedContent,
         path.join(resolvedTarget, 'SKILL.md'),
         finalSkillName
       )
-      if (metadata) {
-        this.metadataCache.set(finalSkillName, metadata)
+      if (!metadata) {
+        fs.rmSync(stagingDir, { recursive: true, force: true })
+        return { success: false, error: 'Staged skill is invalid', errorCode: 'invalid_skill' }
       }
-      this.updateSkillManagementItem(finalSkillName, (item) => ({
-        ...item,
-        canonicalPath: resolvedTarget,
-        source: {
-          type: sourceType,
-          installedAt: new Date().toISOString(),
-          ...sourcePatch
+      const candidate = await this.stagePublishedSkillEntry(metadata, {
+        rawContent: stagedContent,
+        scriptSourceRoot: stagingDir
+      })
+      if (!candidate || candidate.metadata.name !== finalSkillName) {
+        fs.rmSync(stagingDir, { recursive: true, force: true })
+        return { success: false, error: 'Staged skill is invalid', errorCode: 'invalid_skill' }
+      }
+
+      this.seedRuntimeSnapshotFromCompatibilityCache()
+      const previousEntry = this.runtimeSnapshots.snapshot.entries.get(finalSkillName)
+      const previousState = this.getStoredManagementState()
+      const endPublish = this.beginRuntimePublish()
+      let backupDir: string | null = null
+      let retiredTargetDir: string | null = null
+      let installedTarget = false
+      try {
+        if (targetExists) {
+          if (fs.existsSync(path.join(resolvedTarget, 'SKILL.md'))) {
+            backupDir = this.backupExistingSkill(finalSkillName)
+          } else {
+            retiredTargetDir = path.join(
+              this.skillsDir,
+              `.${finalSkillName}.replaced-${process.pid}-${randomUUID()}`
+            )
+            fs.renameSync(resolvedTarget, retiredTargetDir)
+          }
         }
-      }))
+        fs.renameSync(stagingDir, resolvedTarget)
+        installedTarget = true
+        this.updateSkillManagementItem(finalSkillName, (item) => ({
+          ...item,
+          canonicalPath: resolvedTarget,
+          source: {
+            type: sourceType,
+            installedAt: new Date().toISOString(),
+            ...sourcePatch
+          }
+        }))
+        this.publishRuntimeEntry(candidate)
+      } catch (error) {
+        let rollbackFailed = false
+        try {
+          if (installedTarget) {
+            fs.rmSync(resolvedTarget, { recursive: true, force: true })
+          }
+          if (backupDir) {
+            fs.renameSync(backupDir, resolvedTarget)
+          } else if (retiredTargetDir) {
+            fs.renameSync(retiredTargetDir, resolvedTarget)
+          }
+          this.saveManagementState(previousState)
+          if (previousEntry) {
+            this.publishRuntimeSourceError(finalSkillName, {
+              code: 'MUTATION_ROLLED_BACK',
+              message: error instanceof Error ? error.message : String(error)
+            })
+          }
+        } catch (rollbackError) {
+          rollbackFailed = true
+          logger.warn('[SkillPresenter] Failed to rollback skill installation.', {
+            name: finalSkillName,
+            error,
+            rollbackError
+          })
+          await this.reconcileUnknownSkillSource(finalSkillName, metadata, previousEntry)
+        }
+        const failure = this.createTargetOperationFailure(
+          finalSkillName,
+          resolvedTarget,
+          'replace',
+          error
+        )
+        if (rollbackFailed) {
+          failure.error = `${failure.error} (rollback failed)`
+        }
+        return failure
+      } finally {
+        endPublish()
+        if (fs.existsSync(stagingDir)) {
+          fs.rmSync(stagingDir, { recursive: true, force: true })
+        }
+      }
+      if (retiredTargetDir) {
+        fs.rmSync(retiredTargetDir, { recursive: true, force: true })
+      }
 
       publishDeepchatEvent('skills.catalog.changed', {
         reason: 'installed',
@@ -1927,37 +2250,12 @@ export class SkillPresenter implements ISkillPresenter {
     }
   }
 
-  private prepareExistingSkillTargetForInstall(
-    skillName: string,
-    targetDir: string
-  ): SkillInstallResult | null {
-    try {
-      const existingSkillPath = path.join(targetDir, 'SKILL.md')
-      if (fs.existsSync(existingSkillPath)) {
-        this.backupExistingSkill(skillName)
-      } else {
-        fs.rmSync(targetDir, { recursive: true, force: true })
-        if (fs.existsSync(targetDir)) {
-          return this.createTargetLockedFailure(skillName, targetDir, 'replace')
-        }
-      }
-      return null
-    } catch (error) {
-      return this.createTargetOperationFailure(skillName, targetDir, 'replace', error)
-    }
-  }
-
   private backupExistingSkill(skillName: string): string {
     const sourceDir = path.join(this.skillsDir, skillName)
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
     const backupRoot = path.join(app.getPath('home'), '.deepchat', 'backups', 'skill-installs')
     fs.mkdirSync(backupRoot, { recursive: true })
-    let backupDir = path.join(backupRoot, `${skillName}-${timestamp}`)
-    let counter = 0
-    while (fs.existsSync(backupDir)) {
-      counter += 1
-      backupDir = path.join(backupRoot, `${skillName}-${timestamp}-${counter}`)
-    }
+    const backupDir = path.join(backupRoot, `${skillName}-${timestamp}-${randomUUID()}`)
     fs.renameSync(sourceDir, backupDir)
     return backupDir
   }
@@ -2365,20 +2663,62 @@ export class SkillPresenter implements ISkillPresenter {
    * Uninstall a skill
    */
   async uninstallSkill(name: string): Promise<SkillInstallResult> {
+    this.seedRuntimeSnapshotFromCompatibilityCache()
+    const previousEntry = this.runtimeSnapshots.snapshot.entries.get(name)
+    const previousState = this.getStoredManagementState()
+    const skillDir = path.join(this.skillsDir, name)
+    const trashDir = path.join(this.skillsDir, `.${name}.uninstall-${process.pid}-${randomUUID()}`)
     try {
-      const skillDir = path.join(this.skillsDir, name)
-
       if (!fs.existsSync(skillDir)) {
         this.cleanupUninstalledSkillState(name)
         return { success: false, error: `Skill "${name}" not found`, errorCode: 'not_found' }
       }
 
-      fs.rmSync(skillDir, { recursive: true, force: true })
-      if (fs.existsSync(skillDir)) {
-        return this.createTargetLockedFailure(name, skillDir, 'remove')
+      const endPublish = this.beginRuntimePublish()
+      try {
+        fs.renameSync(skillDir, trashDir)
+        this.cleanupUninstalledSkillState(name)
+      } catch (error) {
+        try {
+          if (fs.existsSync(trashDir)) {
+            fs.renameSync(trashDir, skillDir)
+          }
+          this.saveManagementState(previousState)
+          if (previousEntry) {
+            this.publishRuntimeEntry(previousEntry)
+          }
+        } catch (rollbackError) {
+          logger.warn('[SkillPresenter] Failed to rollback skill uninstall.', {
+            name,
+            error,
+            rollbackError
+          })
+          if (previousEntry) {
+            this.publishRuntimeEntry(
+              Object.freeze({
+                ...previousEntry,
+                sourceError: Object.freeze({
+                  code: 'RECONCILE_REQUIRED',
+                  message: 'Skill uninstall outcome is unknown'
+                })
+              })
+            )
+          }
+        }
+        return this.createTargetOperationFailure(name, skillDir, 'remove', error)
+      } finally {
+        endPublish()
       }
 
-      this.cleanupUninstalledSkillState(name)
+      try {
+        fs.rmSync(trashDir, { recursive: true, force: true })
+      } catch (error) {
+        logger.warn('[SkillPresenter] Failed to remove retired skill directory.', {
+          name,
+          path: trashDir,
+          error
+        })
+      }
 
       publishDeepchatEvent('skills.catalog.changed', {
         reason: 'uninstalled',
@@ -2409,8 +2749,9 @@ export class SkillPresenter implements ISkillPresenter {
       }
     }
 
-    this.metadataCache.delete(name)
-    this.contentCache.delete(name)
+    if (this.runtimeSnapshots.snapshot.entries.has(name)) {
+      this.publishRuntimeRemoval(name)
+    }
   }
 
   private isSafeSkillName(name: string): boolean {
@@ -2421,25 +2762,52 @@ export class SkillPresenter implements ISkillPresenter {
    * Update a skill's SKILL.md content
    */
   async updateSkillFile(name: string, content: string): Promise<SkillInstallResult> {
+    await this.getMetadataList()
+    const previousEntry = this.runtimeSnapshots.snapshot.entries.get(name)
+    const metadata = previousEntry?.metadata as SkillMetadata | undefined
+    if (!metadata) {
+      return { success: false, error: `Skill "${name}" not found` }
+    }
+
+    const sequence = this.runtimeSnapshots.nextObservation(metadata.path)
+    const candidate = await this.stagePublishedSkillEntry(metadata, { rawContent: content })
+    if (
+      !candidate ||
+      candidate.metadata.name !== name ||
+      !this.runtimeSnapshots.isCurrentObservation(metadata.path, sequence)
+    ) {
+      return { success: false, error: `Skill "${name}" content is invalid` }
+    }
+
+    const previousContent = await this.readSkillFile(name)
+    const endPublish = this.beginRuntimePublish()
+    let wroteSource = false
     try {
-      const metadata = this.metadataCache.get(name)
-      if (!metadata) {
-        return { success: false, error: `Skill "${name}" not found` }
-      }
-
-      fs.writeFileSync(metadata.path, content, 'utf-8')
-
-      // Invalidate caches
-      this.contentCache.delete(name)
-      const newMetadata = await this.parseSkillMetadata(metadata.path, name)
-      if (newMetadata) {
-        this.metadataCache.set(name, newMetadata)
-      }
-
+      this.atomicWriteFile(metadata.path, content)
+      wroteSource = true
+      this.publishRuntimeEntry(candidate)
       return { success: true, skillName: name }
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error)
-      return { success: false, error: errorMsg }
+      let rollbackError: unknown
+      if (wroteSource) {
+        try {
+          this.atomicWriteFile(metadata.path, previousContent)
+          this.publishRuntimeSourceError(name, {
+            code: 'MUTATION_ROLLED_BACK',
+            message: errorMsg
+          })
+        } catch (rollbackFailure) {
+          rollbackError = rollbackFailure
+          await this.reconcileUnknownSkillSource(name, metadata, previousEntry)
+        }
+      }
+      const rollbackMessage = rollbackError
+        ? ` (rollback failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)})`
+        : ''
+      return { success: false, error: `${errorMsg}${rollbackMessage}` }
+    } finally {
+      endPublish()
     }
   }
 
@@ -2449,65 +2817,75 @@ export class SkillPresenter implements ISkillPresenter {
     config: SkillExtensionConfig
   ): Promise<SkillInstallResult> {
     this.ensureSkillsDir()
-    if (this.metadataCache.size === 0) {
-      await this.discoverSkills()
-    }
-
-    const metadata = this.metadataCache.get(name)
+    await this.getMetadataList()
+    const previousEntry = this.runtimeSnapshots.snapshot.entries.get(name)
+    const metadata = previousEntry?.metadata as SkillMetadata | undefined
     if (!metadata) {
       return { success: false, error: `Skill "${name}" not found` }
     }
 
-    const previousSkillContent = fs.readFileSync(metadata.path, 'utf-8')
+    const previousSkillContent = await this.readSkillFile(name)
     const previousState = this.getStoredManagementState()
     const sanitized = sanitizeSkillExtensionConfig(config)
+    const sequence = this.runtimeSnapshots.nextObservation(metadata.path)
+    const candidate = await this.stagePublishedSkillEntry(metadata, {
+      rawContent: content,
+      extension: sanitized
+    })
+    if (
+      !candidate ||
+      candidate.metadata.name !== name ||
+      !this.runtimeSnapshots.isCurrentObservation(metadata.path, sequence)
+    ) {
+      return { success: false, error: `Skill "${name}" content is invalid` }
+    }
 
+    const endPublish = this.beginRuntimePublish()
+    let wroteSource = false
     try {
-      fs.writeFileSync(metadata.path, content, 'utf-8')
+      this.atomicWriteFile(metadata.path, content)
+      wroteSource = true
       this.updateSkillManagementItem(name, (item) => ({
         ...item,
         canonicalPath: metadata.skillRoot,
         extension: sanitized
       }))
 
-      this.contentCache.delete(name)
-      const newMetadata = await this.parseSkillMetadata(metadata.path, name)
-      if (newMetadata) {
-        this.metadataCache.set(name, newMetadata)
-      }
-
+      this.publishRuntimeEntry(candidate)
       return { success: true, skillName: name }
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error)
-
+      let rollbackError: unknown
       try {
-        fs.writeFileSync(metadata.path, previousSkillContent, 'utf-8')
+        if (wroteSource) {
+          this.atomicWriteFile(metadata.path, previousSkillContent)
+        }
         this.saveManagementState(previousState)
-      } catch (rollbackError) {
-        const rollbackMessage =
-          rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+        this.publishRuntimeSourceError(name, {
+          code: 'MUTATION_ROLLED_BACK',
+          message: errorMsg
+        })
+      } catch (rollbackFailure) {
+        rollbackError = rollbackFailure
         logger.warn('[SkillPresenter] Failed to rollback combined skill save', {
           name,
           error,
-          rollbackError
+          rollbackError: rollbackFailure
         })
-        return {
-          success: false,
-          error: `${errorMsg} (rollback failed: ${rollbackMessage})`
-        }
+        await this.reconcileUnknownSkillSource(name, metadata, previousEntry)
       }
-
-      this.contentCache.delete(name)
-      return { success: false, error: errorMsg }
+      const rollbackMessage = rollbackError
+        ? ` (rollback failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)})`
+        : ''
+      return { success: false, error: `${errorMsg}${rollbackMessage}` }
+    } finally {
+      endPublish()
     }
   }
 
   async readSkillFile(name: string): Promise<string> {
-    if (this.metadataCache.size === 0) {
-      await this.discoverSkills()
-    }
-
-    const metadata = this.metadataCache.get(name)
+    await this.getMetadataList()
+    const metadata = this.runtimeSnapshots.snapshot.entries.get(name)?.metadata
     if (!metadata) {
       throw new Error(`Skill "${name}" not found`)
     }
@@ -2522,11 +2900,65 @@ export class SkillPresenter implements ISkillPresenter {
     return await fs.promises.readFile(metadata.path, 'utf-8')
   }
 
+  private async reconcileUnknownSkillSource(
+    name: string,
+    metadata: SkillMetadata,
+    previousEntry?: PublishedSkillEntry
+  ): Promise<void> {
+    const reconcileError: PublishedSkillSourceError = {
+      code: 'RECONCILE_REQUIRED',
+      message: 'Skill source rollback failed; runtime retained a coherent published state'
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      const staged = this.stagePublishedSkillEntry(metadata)
+      const candidate = await Promise.race([
+        staged,
+        new Promise<null>((resolve) => {
+          timer = setTimeout(() => resolve(null), SKILL_RUNTIME_WAIT_BUDGET_MS)
+        })
+      ])
+      if (candidate && candidate.metadata.name === name) {
+        this.publishRuntimeEntry(candidate)
+        return
+      }
+    } catch (error) {
+      logger.warn('[SkillPresenter] Immediate skill reconcile failed.', { name, error })
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+
+    if (previousEntry) {
+      this.publishRuntimeEntry(
+        Object.freeze({
+          ...previousEntry,
+          sourceError: Object.freeze(reconcileError)
+        })
+      )
+      return
+    }
+
+    const quarantinedMetadata = freezeSkillMetadata(metadata)
+    this.publishRuntimeEntry(
+      Object.freeze({
+        sourceVersion: createSkillSourceVersion({
+          metadata: quarantinedMetadata,
+          quarantine: true
+        }),
+        availability: 'quarantined' as const,
+        metadata: quarantinedMetadata,
+        allowedTools: Object.freeze([]),
+        sourceError: Object.freeze(reconcileError)
+      })
+    )
+  }
+
   /**
    * Get folder tree for a skill
    */
   async getSkillFolderTree(name: string): Promise<SkillFolderNode[]> {
-    const metadata = this.metadataCache.get(name)
+    await this.getMetadataList()
+    const metadata = this.runtimeSnapshots.snapshot.entries.get(name)?.metadata
     if (!metadata) {
       return []
     }
@@ -2589,6 +3021,23 @@ export class SkillPresenter implements ISkillPresenter {
   }
 
   async getSkillExtension(name: string): Promise<SkillExtensionConfig> {
+    await this.getMetadataList()
+    if (this.runtimeSnapshots.snapshot.entries.has(name)) {
+      const snapshot = await this.waitForStableRuntimeSnapshot({
+        requiredSkillNames: [name],
+        signal: new AbortController().signal,
+        deadlineAt: Date.now() + SKILL_RUNTIME_WAIT_BUDGET_MS
+      })
+      const extension = snapshot.entries.get(name)?.extension
+      if (extension) {
+        return structuredClone(extension) as SkillExtensionConfig
+      }
+    }
+    return await this.loadSkillExtensionForStage(name)
+  }
+
+  private async loadSkillExtensionForStage(name: string): Promise<SkillExtensionConfig> {
+    this.assertSourceReadAllowed()
     this.ensureSkillsDir()
     const item = this.getStoredManagementState().skills[name]
     if (item) {
@@ -2641,53 +3090,74 @@ export class SkillPresenter implements ISkillPresenter {
 
   async saveSkillExtension(name: string, config: SkillExtensionConfig): Promise<void> {
     this.ensureSkillsDir()
-    if (this.metadataCache.size === 0) {
-      await this.discoverSkills()
-    }
-
-    if (!this.metadataCache.has(name)) {
+    await this.getMetadataList()
+    const previousEntry = this.runtimeSnapshots.snapshot.entries.get(name)
+    const metadata = previousEntry?.metadata as SkillMetadata | undefined
+    if (!metadata) {
       throw new Error(`Skill "${name}" not found`)
     }
 
     const sanitized = sanitizeSkillExtensionConfig(config)
-    const metadata = this.metadataCache.get(name)
-    this.updateSkillManagementItem(name, (item) => ({
-      ...item,
-      canonicalPath: metadata?.skillRoot ?? item.canonicalPath,
-      extension: sanitized
-    }))
-    this.contentCache.delete(name)
+    const previousState = this.getStoredManagementState()
+    const sequence = this.runtimeSnapshots.nextObservation(metadata.path)
+    const candidate = await this.stagePublishedSkillEntry(metadata, { extension: sanitized })
+    if (
+      !candidate ||
+      candidate.metadata.name !== name ||
+      !this.runtimeSnapshots.isCurrentObservation(metadata.path, sequence)
+    ) {
+      throw new Error(`Skill "${name}" source is invalid`)
+    }
+
+    const endPublish = this.beginRuntimePublish()
+    try {
+      this.updateSkillManagementItem(name, (item) => ({
+        ...item,
+        canonicalPath: metadata.skillRoot,
+        extension: sanitized
+      }))
+      this.publishRuntimeEntry(candidate)
+    } catch (error) {
+      try {
+        this.saveManagementState(previousState)
+        this.publishRuntimeSourceError(name, {
+          code: 'MUTATION_ROLLED_BACK',
+          message: error instanceof Error ? error.message : String(error)
+        })
+      } catch (rollbackError) {
+        logger.warn('[SkillPresenter] Failed to rollback skill extension save.', {
+          name,
+          error,
+          rollbackError
+        })
+        await this.reconcileUnknownSkillSource(name, metadata, previousEntry)
+      }
+      throw error
+    } finally {
+      endPublish()
+    }
   }
 
   async listSkillScripts(name: string): Promise<SkillScriptDescriptor[]> {
-    if (this.metadataCache.size === 0) {
-      await this.discoverSkills()
-    }
-
-    const metadata = this.metadataCache.get(name)
-    if (!metadata) {
+    await this.getMetadataList()
+    if (!this.runtimeSnapshots.snapshot.entries.has(name)) {
       return []
     }
-
-    const scriptsDir = path.join(metadata.skillRoot, 'scripts')
-    if (!(await this.pathExists(scriptsDir))) {
+    const snapshot = await this.waitForStableRuntimeSnapshot({
+      requiredSkillNames: [name],
+      signal: new AbortController().signal,
+      deadlineAt: Date.now() + SKILL_RUNTIME_WAIT_BUDGET_MS
+    })
+    const entry = snapshot.entries.get(name)
+    if (entry?.availability !== 'ready') {
       return []
     }
-
-    const extension = await this.getSkillExtension(name)
-    const descriptors = (await this.collectScriptDescriptors(scriptsDir, metadata.skillRoot)).map(
-      (script) => {
-        const override = extension.scriptOverrides[script.relativePath] ?? {}
-        return {
-          ...script,
-          enabled: override.enabled ?? true,
-          description: override.description
-        }
-      }
-    )
-
-    descriptors.sort((left, right) => left.relativePath.localeCompare(right.relativePath))
-    return descriptors
+    this.runtimeSnapshotReadDepth += 1
+    try {
+      return (entry.scripts ?? []).map((script) => ({ ...script }))
+    } finally {
+      this.runtimeSnapshotReadDepth -= 1
+    }
   }
 
   private async isNewAgentSession(conversationId: string): Promise<boolean> {
@@ -2827,18 +3297,28 @@ export class SkillPresenter implements ISkillPresenter {
     conversationId: string,
     activeSkillNamesOverride?: string[]
   ): Promise<string[]> {
-    if (this.metadataCache.size === 0) {
-      await this.discoverSkills()
-    }
-
+    await this.getMetadataList()
     const activeSkills = activeSkillNamesOverride ?? (await this.getActiveSkills(conversationId))
+    const snapshot = await this.waitForStableRuntimeSnapshot({
+      requiredSkillNames: activeSkills,
+      signal: new AbortController().signal,
+      deadlineAt: Date.now() + SKILL_RUNTIME_WAIT_BUDGET_MS
+    })
     const allowedTools: Set<string> = new Set()
 
-    for (const skillName of activeSkills) {
-      const metadata = this.metadataCache.get(skillName)
-      if (metadata?.allowedTools && this.isSkillVisible(metadata)) {
-        metadata.allowedTools.forEach((tool) => allowedTools.add(tool))
+    this.runtimeSnapshotReadDepth += 1
+    try {
+      for (const skillName of activeSkills) {
+        const entry = snapshot.entries.get(skillName)
+        if (
+          entry?.availability === 'ready' &&
+          this.isSkillVisible(entry.metadata as SkillMetadata)
+        ) {
+          entry.allowedTools.forEach((tool) => allowedTools.add(tool))
+        }
       }
+    } finally {
+      this.runtimeSnapshotReadDepth -= 1
     }
 
     const result = normalizeSkillAllowedTools(Array.from(allowedTools))
@@ -2930,6 +3410,9 @@ export class SkillPresenter implements ISkillPresenter {
 
     for (const event of batch.events) {
       if (!this.isWatchedSkillMarkdownPath(event.path)) {
+        if (event.type === 'create' || event.type === 'update' || event.type === 'delete') {
+          await this.handlePublishedSkillAuxiliarySourceChanged(event.path)
+        }
         continue
       }
 
@@ -2977,83 +3460,177 @@ export class SkillPresenter implements ISkillPresenter {
     const segments = relativePath.split(/[\\/]+/).filter(Boolean)
     return (
       !segments.includes(SKILL_CONFIG.SIDECAR_DIR) &&
+      !segments.slice(0, -1).some((segment) => this.shouldIgnoreSkillsRootEntry(segment)) &&
       segments.length - 1 <= SKILL_CONFIG.FOLDER_TREE_MAX_DEPTH
     )
   }
 
   private async handleSkillFileChanged(filePath: string): Promise<void> {
+    this.seedRuntimeSnapshotFromCompatibilityCache()
     const previousName = this.findSkillNameByPath(filePath) ?? path.basename(path.dirname(filePath))
-    this.contentCache.delete(previousName)
-
-    const metadata = await this.parseSkillMetadata(filePath, path.basename(path.dirname(filePath)))
-    if (!metadata) {
+    const previousEntry = this.runtimeSnapshots.snapshot.entries.get(previousName)
+    const hint =
+      (previousEntry?.metadata as SkillMetadata | undefined) ??
+      this.createStageMetadataHint(filePath, previousName)
+    const sequence = this.runtimeSnapshots.nextObservation(filePath)
+    let candidate: PublishedSkillEntry | null
+    try {
+      candidate = await this.stagePublishedSkillEntry(hint)
+    } catch (error) {
+      this.publishRuntimeSourceError(
+        previousName,
+        {
+          code: 'SOURCE_READ_FAILED',
+          message: error instanceof Error ? error.message : String(error)
+        },
+        filePath
+      )
+      return
+    }
+    if (!this.runtimeSnapshots.isCurrentObservation(filePath, sequence)) {
+      return
+    }
+    if (!candidate) {
+      this.publishRuntimeSourceError(
+        previousName,
+        { code: 'INVALID_SOURCE', message: 'Watcher observed an invalid skill source' },
+        filePath
+      )
       return
     }
 
-    const existingMetadata = this.metadataCache.get(metadata.name)
-    if (existingMetadata && existingMetadata.path !== metadata.path) {
+    const existingEntry = this.runtimeSnapshots.snapshot.entries.get(candidate.metadata.name)
+    if (existingEntry && existingEntry.metadata.path !== candidate.metadata.path) {
       logger.warn('[SkillPresenter] Duplicate skill name discovered. Keeping the first entry.', {
-        name: metadata.name,
-        path: metadata.path,
-        existingPath: existingMetadata.path
+        name: candidate.metadata.name,
+        path: candidate.metadata.path,
+        existingPath: existingEntry.metadata.path
       })
-      const previousMetadata = this.metadataCache.get(previousName)
-      if (previousName !== metadata.name && previousMetadata?.path === metadata.path) {
-        this.metadataCache.delete(previousName)
-      }
+      this.publishRuntimeSourceError(previousName, {
+        code: 'DUPLICATE_SKILL_NAME',
+        message: `Skill source renamed to duplicate name "${candidate.metadata.name}"`
+      })
       return
     }
 
-    if (previousName !== metadata.name) {
-      const previousMetadata = this.metadataCache.get(previousName)
-      if (previousMetadata?.path === metadata.path) {
-        this.metadataCache.delete(previousName)
-      }
-    }
-
-    this.metadataCache.set(metadata.name, metadata)
+    this.publishRuntimeEntry(candidate, previousName)
+    this.runtimeSnapshots.deleteDiagnostic(filePath)
     publishDeepchatEvent('skills.catalog.changed', {
       reason: 'metadata-updated',
-      name: metadata.name,
-      skill: metadata,
+      name: candidate.metadata.name,
+      skill: candidate.metadata,
       version: Date.now()
     })
   }
 
   private async handleSkillFileAdded(filePath: string): Promise<void> {
-    const metadata = await this.parseSkillMetadata(filePath, path.basename(path.dirname(filePath)))
-    if (!metadata) {
+    this.seedRuntimeSnapshotFromCompatibilityCache()
+    const hint = this.createStageMetadataHint(filePath, path.basename(path.dirname(filePath)))
+    const sequence = this.runtimeSnapshots.nextObservation(filePath)
+    let candidate: PublishedSkillEntry | null
+    try {
+      candidate = await this.stagePublishedSkillEntry(hint)
+    } catch (error) {
+      this.runtimeSnapshots.setDiagnostic(
+        filePath,
+        Object.freeze({
+          code: 'SOURCE_READ_FAILED',
+          message: error instanceof Error ? error.message : String(error)
+        })
+      )
+      return
+    }
+    if (!this.runtimeSnapshots.isCurrentObservation(filePath, sequence)) {
+      return
+    }
+    if (!candidate) {
+      this.runtimeSnapshots.setDiagnostic(
+        filePath,
+        Object.freeze({ code: 'INVALID_SOURCE', message: 'Watcher observed an invalid new skill' })
+      )
       return
     }
 
-    const existingMetadata = this.metadataCache.get(metadata.name)
-    if (existingMetadata && existingMetadata.path !== metadata.path) {
+    const existingEntry = this.runtimeSnapshots.snapshot.entries.get(candidate.metadata.name)
+    if (existingEntry && existingEntry.metadata.path !== candidate.metadata.path) {
       logger.warn('[SkillPresenter] Duplicate skill name discovered. Keeping the first entry.', {
-        name: metadata.name,
-        path: metadata.path,
-        existingPath: existingMetadata.path
+        name: candidate.metadata.name,
+        path: candidate.metadata.path,
+        existingPath: existingEntry.metadata.path
       })
       return
     }
 
-    this.metadataCache.set(metadata.name, metadata)
+    this.publishRuntimeEntry(candidate)
+    this.runtimeSnapshots.deleteDiagnostic(filePath)
     publishDeepchatEvent('skills.catalog.changed', {
       reason: 'installed',
-      name: metadata.name,
-      skill: metadata,
+      name: candidate.metadata.name,
+      skill: candidate.metadata,
       version: Date.now()
     })
   }
 
   private handleSkillFileDeleted(filePath: string): void {
+    this.seedRuntimeSnapshotFromCompatibilityCache()
     const skillName = this.findSkillNameByPath(filePath) ?? path.basename(path.dirname(filePath))
-    this.metadataCache.delete(skillName)
-    this.contentCache.delete(skillName)
+    this.runtimeSnapshots.nextObservation(filePath)
+    this.publishRuntimeRemoval(skillName)
+    this.runtimeSnapshots.deleteDiagnostic(filePath)
     publishDeepchatEvent('skills.catalog.changed', {
       reason: 'uninstalled',
       name: skillName,
       version: Date.now()
     })
+  }
+
+  private createStageMetadataHint(filePath: string, name: string): SkillMetadata {
+    return {
+      name,
+      description: '',
+      path: filePath,
+      skillRoot: path.dirname(filePath),
+      category: this.deriveSkillCategory(path.dirname(filePath))
+    }
+  }
+
+  private async handlePublishedSkillAuxiliarySourceChanged(filePath: string): Promise<void> {
+    const entry = Array.from(this.runtimeSnapshots.snapshot.entries.values()).find((candidate) => {
+      const relativePath = path.relative(candidate.metadata.skillRoot, filePath)
+      return (
+        relativePath !== '' &&
+        !relativePath.startsWith('..') &&
+        !path.isAbsolute(relativePath) &&
+        relativePath.split(/[\\/]+/)[0] === 'scripts'
+      )
+    })
+    if (!entry) {
+      return
+    }
+
+    const sourcePath = entry.metadata.path
+    const sequence = this.runtimeSnapshots.nextObservation(sourcePath)
+    if (entry.availability !== 'ready') {
+      return
+    }
+    try {
+      const candidate = await this.stagePublishedSkillEntry(entry.metadata as SkillMetadata)
+      if (candidate && this.runtimeSnapshots.isCurrentObservation(sourcePath, sequence)) {
+        this.publishRuntimeEntry(candidate)
+      } else if (this.runtimeSnapshots.isCurrentObservation(sourcePath, sequence)) {
+        this.publishRuntimeSourceError(entry.metadata.name, {
+          code: 'INVALID_SOURCE',
+          message: 'Watcher observed an invalid skill source'
+        })
+      }
+    } catch (error) {
+      if (this.runtimeSnapshots.isCurrentObservation(sourcePath, sequence)) {
+        this.publishRuntimeSourceError(entry.metadata.name, {
+          code: 'SOURCE_READ_FAILED',
+          message: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
   }
 
   /**
@@ -3086,8 +3663,10 @@ export class SkillPresenter implements ISkillPresenter {
    */
   async destroy(): Promise<void> {
     await this.stopWatching()
+    this.runtimeSnapshots.reset()
     this.metadataCache.clear()
     this.contentCache.clear()
+    this.runtimeContentViews = new WeakMap()
     this.discoveryPromise = null
     this.initialized = false
   }
@@ -3456,8 +4035,14 @@ export class SkillPresenter implements ISkillPresenter {
       path.dirname(targetPath),
       `.${path.basename(targetPath)}.${process.pid}.${Date.now()}.tmp`
     )
-    fs.writeFileSync(tempPath, content, 'utf-8')
-    fs.renameSync(tempPath, targetPath)
+    try {
+      fs.writeFileSync(tempPath, content, 'utf-8')
+      fs.renameSync(tempPath, targetPath)
+    } finally {
+      if (fs.existsSync(tempPath)) {
+        fs.rmSync(tempPath, { force: true })
+      }
+    }
   }
 
   private cleanupExpiredDrafts(): void {
@@ -3493,9 +4078,9 @@ export class SkillPresenter implements ISkillPresenter {
   }
 
   private findSkillNameByPath(skillPath: string): string | null {
-    for (const metadata of this.metadataCache.values()) {
-      if (metadata.path === skillPath) {
-        return metadata.name
+    for (const entry of this.runtimeSnapshots.snapshot.entries.values()) {
+      if (entry.metadata.path === skillPath) {
+        return entry.metadata.name
       }
     }
     return null

--- a/src/main/presenter/skillPresenter/index.ts
+++ b/src/main/presenter/skillPresenter/index.ts
@@ -11,6 +11,7 @@ import {
   createWatcherRequestId,
   getFileWatcherService,
   type IFileWatcherService,
+  type WatchEventType,
   type WatcherEventBatch,
   type WatcherStatus,
   type WatchHandle
@@ -380,10 +381,6 @@ export class SkillPresenter implements ISkillPresenter {
     return this.runtimeSnapshots.publishEntryIfCurrent(sourcePath, sequence, entry, previousName)
   }
 
-  private publishRuntimeRemoval(name: string): void {
-    this.runtimeSnapshots.remove(name)
-  }
-
   private publishRuntimeSourceError(
     name: string,
     error: { code: string; message: string },
@@ -463,6 +460,7 @@ export class SkillPresenter implements ISkillPresenter {
       parsed.skillRoot,
       extension
     )
+    const linkedFiles = await this.listSkillLinkedFiles(scriptSourceRoot)
     const parsedContent = matter(rawContent).content
     const renderedBody = this.replacePathVariables(parsedContent, parsed).trim()
     const runtimeInstructions = this.buildRuntimeInstructionsFromScripts(parsed, scripts)
@@ -471,6 +469,9 @@ export class SkillPresenter implements ISkillPresenter {
     const frozenMetadata = freezeSkillMetadata(parsed)
     const frozenExtension = freezeSkillExtension(extension)
     const frozenScripts = freezeScriptDescriptors(scripts)
+    const frozenLinkedFiles = Object.freeze(
+      linkedFiles.map((linkedFile) => Object.freeze({ ...linkedFile }))
+    )
     const allowedTools = Object.freeze([...(frozenMetadata.allowedTools ?? [])])
     const sourceVersion = createSkillSourceVersion({
       rawContent,
@@ -481,6 +482,7 @@ export class SkillPresenter implements ISkillPresenter {
         enabled,
         description
       })),
+      linkedFiles: frozenLinkedFiles,
       skillRoot: parsed.skillRoot,
       skillsDir: this.skillsDir,
       pluginRoot: pluginContribution?.pluginRoot ?? null,
@@ -495,7 +497,8 @@ export class SkillPresenter implements ISkillPresenter {
       renderedContent,
       allowedTools,
       extension: frozenExtension,
-      scripts: frozenScripts
+      scripts: frozenScripts,
+      linkedFiles: frozenLinkedFiles
     })
   }
 
@@ -1062,30 +1065,30 @@ export class SkillPresenter implements ISkillPresenter {
       }
     }
 
-    const pinnedSkills = options?.conversationId
-      ? await this.getActiveSkills(options.conversationId)
-      : []
-    const isPinned = pinnedSkills.includes(metadata.name)
+    const requestedFilePath = options?.filePath?.trim()
+    const requestedPath = requestedFilePath
+      ? this.resolveSkillRelativePath(metadata.skillRoot, requestedFilePath)
+      : metadata.path
+    const isRootView =
+      requestedPath !== null && path.resolve(requestedPath) === path.resolve(metadata.path)
 
-    if (options?.filePath?.trim()) {
+    if (requestedFilePath && !isRootView) {
       try {
-        const requestedFilePath = options.filePath.trim()
-        const resolvedPath = this.resolveSkillRelativePath(metadata.skillRoot, requestedFilePath)
-        if (!resolvedPath) {
+        if (!requestedPath) {
           return {
             success: false,
             error: 'Requested skill file is outside the skill root'
           }
         }
 
-        if (!(await this.pathExists(resolvedPath))) {
+        if (!(await this.pathExists(requestedPath))) {
           return {
             success: false,
             error: `Skill file not found: ${requestedFilePath}`
           }
         }
 
-        const stats = await fs.promises.stat(resolvedPath)
+        const stats = await fs.promises.stat(requestedPath)
         if (!stats.isFile()) {
           return {
             success: false,
@@ -1098,29 +1101,32 @@ export class SkillPresenter implements ISkillPresenter {
             error: 'Requested skill file is too large to load inline'
           }
         }
-        if (this.isBinaryLikeFile(resolvedPath)) {
+        if (this.isBinaryLikeFile(requestedPath)) {
           return {
             success: false,
             error: 'Binary skill files cannot be loaded with skill_view'
           }
         }
 
+        const pinnedSkills = options?.conversationId
+          ? await this.getActiveSkills(options.conversationId)
+          : []
         return {
           success: true,
           name: metadata.name,
           category: metadata.category ?? null,
           skillRoot: metadata.skillRoot,
-          filePath: path.relative(metadata.skillRoot, resolvedPath),
-          content: await fs.promises.readFile(resolvedPath, 'utf-8'),
+          filePath: path.relative(metadata.skillRoot, requestedPath),
+          content: await fs.promises.readFile(requestedPath, 'utf-8'),
           platforms: metadata.platforms,
           metadata: metadata.metadata,
-          isPinned
+          isPinned: pinnedSkills.includes(metadata.name)
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error)
         console.error('[SkillPresenter] Failed to load requested skill file for skill_view:', {
           name: metadata.name,
-          filePath: options.filePath.trim(),
+          filePath: requestedFilePath,
           error
         })
         return {
@@ -1130,42 +1136,44 @@ export class SkillPresenter implements ISkillPresenter {
       }
     }
 
-    try {
-      const stats = await fs.promises.stat(metadata.path)
-      if (stats.size > SKILL_CONFIG.SKILL_FILE_MAX_SIZE) {
-        const errorMessage = `[SkillPresenter] Skill file too large: ${stats.size} bytes (max: ${SKILL_CONFIG.SKILL_FILE_MAX_SIZE})`
-        console.error(errorMessage)
-        return {
-          success: false,
-          error: errorMessage
-        }
-      }
-
-      const rawContent = await fs.promises.readFile(metadata.path, 'utf-8')
-      const { content } = matter(rawContent)
-      return {
-        success: true,
-        name: metadata.name,
-        category: metadata.category ?? null,
-        skillRoot: metadata.skillRoot,
-        filePath: null,
-        content: this.replacePathVariables(content, metadata),
-        platforms: metadata.platforms,
-        metadata: metadata.metadata,
-        linkedFiles: await this.listSkillLinkedFiles(metadata.skillRoot),
-        isPinned
-      }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      console.error('[SkillPresenter] Failed to load skill_view content:', {
-        name: metadata.name,
-        path: metadata.path,
-        error
-      })
+    const snapshot = await this.waitForStableRuntimeSnapshot({
+      requiredSkillNames: [name],
+      signal: new AbortController().signal,
+      deadlineAt: Date.now() + SKILL_RUNTIME_WAIT_BUDGET_MS
+    })
+    const entry = snapshot.entries.get(name)
+    if (
+      !entry ||
+      entry.availability !== 'ready' ||
+      entry.renderedContent === undefined ||
+      !this.isSkillVisible(entry.metadata as SkillMetadata)
+    ) {
       return {
         success: false,
-        error: `Failed to load skill view: ${errorMessage}`
+        error: `Skill "${name}" not found`
       }
+    }
+
+    const pinnedSkills = options?.conversationId
+      ? await this.getActiveSkills(options.conversationId)
+      : []
+    const capturedMetadata = entry.metadata as SkillMetadata
+    this.runtimeSnapshotReadDepth += 1
+    try {
+      return {
+        success: true,
+        name: capturedMetadata.name,
+        category: capturedMetadata.category ?? null,
+        skillRoot: capturedMetadata.skillRoot,
+        filePath: null,
+        content: entry.renderedContent,
+        platforms: capturedMetadata.platforms,
+        metadata: capturedMetadata.metadata,
+        linkedFiles: (entry.linkedFiles ?? []).map((linkedFile) => ({ ...linkedFile })),
+        isPinned: pinnedSkills.includes(capturedMetadata.name)
+      }
+    } finally {
+      this.runtimeSnapshotReadDepth -= 1
     }
   }
 
@@ -1939,12 +1947,63 @@ export class SkillPresenter implements ISkillPresenter {
       throw new Error(`Plugin skill "${input.id}" is missing SKILL.md`)
     }
 
-    this.pluginSkillContributions.set(`${input.ownerPluginId}:${input.id}`, {
+    const contribution = {
       ownerPluginId: input.ownerPluginId,
       skillRoot,
       pluginRoot: input.pluginRoot ? path.resolve(input.pluginRoot) : undefined
-    })
+    }
+    this.pluginSkillContributions.set(`${input.ownerPluginId}:${input.id}`, contribution)
     await this.discoverSkills()
+    await this.ensurePluginContributionPublished(contribution)
+  }
+
+  private async ensurePluginContributionPublished(contribution: {
+    ownerPluginId: string
+    skillRoot: string
+    pluginRoot?: string
+  }): Promise<void> {
+    const skillPath = path.join(contribution.skillRoot, 'SKILL.md')
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const current = Array.from(this.runtimeSnapshots.snapshot.entries.values()).find(
+        (entry) =>
+          entry.metadata.path === skillPath &&
+          entry.metadata.ownerPluginId === contribution.ownerPluginId
+      )
+      if (current) return
+
+      const sequence = this.runtimeSnapshots.nextObservation(skillPath)
+      const metadata = await this.parseSkillMetadata(
+        skillPath,
+        path.basename(contribution.skillRoot),
+        contribution.ownerPluginId
+      )
+      if (!metadata) {
+        throw new Error(`Plugin skill at "${contribution.skillRoot}" is invalid`)
+      }
+      const candidate = await this.stagePublishedSkillEntry(metadata)
+      if (!candidate) {
+        throw new Error(`Plugin skill at "${contribution.skillRoot}" is invalid`)
+      }
+
+      const conflict = this.runtimeSnapshots.snapshot.entries.get(candidate.metadata.name)
+      if (conflict && conflict.metadata.path !== skillPath) {
+        throw new Error(`Plugin skill name "${candidate.metadata.name}" is already registered`)
+      }
+      const previousName = Array.from(this.runtimeSnapshots.snapshot.entries.entries()).find(
+        ([, entry]) => entry.metadata.path === skillPath
+      )?.[0]
+      if (this.publishRuntimeEntryIfCurrent(skillPath, sequence, candidate, previousName)) {
+        publishDeepchatEvent('skills.catalog.changed', {
+          reason: 'installed',
+          name: candidate.metadata.name,
+          skill: candidate.metadata,
+          version: Date.now()
+        })
+        return
+      }
+    }
+
+    throw new Error(`Plugin skill at "${contribution.skillRoot}" changed during registration`)
   }
 
   async registerAdoptedSkill(input: SkillAdoptionRegistration): Promise<void> {
@@ -2046,16 +2105,45 @@ export class SkillPresenter implements ISkillPresenter {
   }
 
   async unregisterPluginSkillsByOwner(ownerPluginId: string): Promise<void> {
-    let changed = false
+    const removedContributions: Array<{
+      ownerPluginId: string
+      skillRoot: string
+      pluginRoot?: string
+    }> = []
     for (const [key, contribution] of this.pluginSkillContributions.entries()) {
       if (contribution.ownerPluginId === ownerPluginId) {
+        removedContributions.push(contribution)
         this.pluginSkillContributions.delete(key)
-        changed = true
       }
     }
 
-    if (changed) {
-      await this.discoverSkills()
+    if (removedContributions.length === 0) return
+    await this.discoverSkills()
+
+    let removedPublishedEntry = false
+    for (const contribution of removedContributions) {
+      const skillPath = path.join(contribution.skillRoot, 'SKILL.md')
+      const sequence = this.runtimeSnapshots.nextObservation(skillPath)
+      const names = Array.from(this.runtimeSnapshots.snapshot.entries.entries())
+        .filter(
+          ([, entry]) =>
+            entry.metadata.path === skillPath && entry.metadata.ownerPluginId === ownerPluginId
+        )
+        .map(([name]) => name)
+      for (const name of names) {
+        if (!this.runtimeSnapshots.removeIfCurrent(skillPath, sequence, name)) {
+          throw new Error(`Plugin skill "${name}" changed during unregistration`)
+        }
+        removedPublishedEntry = true
+      }
+    }
+
+    if (removedPublishedEntry) {
+      publishDeepchatEvent('skills.catalog.changed', {
+        reason: 'uninstalled',
+        ownerPluginId,
+        version: Date.now()
+      })
     }
   }
 
@@ -2704,21 +2792,29 @@ export class SkillPresenter implements ISkillPresenter {
     const previousState = this.getStoredManagementState()
     const skillDir = path.join(this.skillsDir, name)
     const trashDir = path.join(this.skillsDir, `.${name}.uninstall-${process.pid}-${randomUUID()}`)
+    const sourcePath = previousEntry?.metadata.path ?? path.join(skillDir, 'SKILL.md')
+    const sequence = this.runtimeSnapshots.nextObservation(sourcePath)
     try {
       if (!fs.existsSync(skillDir)) {
-        this.cleanupUninstalledSkillState(name)
+        const endPublish = this.beginRuntimePublishIfCurrent(sourcePath, sequence)
+        if (!endPublish) {
+          return { success: false, error: `Skill "${name}" changed before cleanup` }
+        }
+        try {
+          this.cleanupUninstalledSkillState(name, sourcePath, sequence)
+        } finally {
+          endPublish()
+        }
         return { success: false, error: `Skill "${name}" not found`, errorCode: 'not_found' }
       }
 
-      const sourcePath = previousEntry?.metadata.path ?? path.join(skillDir, 'SKILL.md')
-      const sequence = this.runtimeSnapshots.nextObservation(sourcePath)
       const endPublish = this.beginRuntimePublishIfCurrent(sourcePath, sequence)
       if (!endPublish) {
         return { success: false, error: `Skill "${name}" changed before uninstall` }
       }
       try {
         fs.renameSync(skillDir, trashDir)
-        this.cleanupUninstalledSkillState(name)
+        this.cleanupUninstalledSkillState(name, sourcePath, sequence)
       } catch (error) {
         try {
           if (fs.existsSync(trashDir)) {
@@ -2775,7 +2871,10 @@ export class SkillPresenter implements ISkillPresenter {
     }
   }
 
-  private cleanupUninstalledSkillState(name: string): void {
+  private cleanupUninstalledSkillState(name: string, sourcePath: string, sequence: number): void {
+    if (!this.runtimeSnapshots.isCurrentObservation(sourcePath, sequence)) {
+      throw new Error(`Skill "${name}" changed before cleanup`)
+    }
     if (this.isSafeSkillName(name)) {
       try {
         this.deleteSkillManagementItem(name)
@@ -2788,7 +2887,9 @@ export class SkillPresenter implements ISkillPresenter {
     }
 
     if (this.runtimeSnapshots.snapshot.entries.has(name)) {
-      this.publishRuntimeRemoval(name)
+      if (!this.runtimeSnapshots.removeIfCurrent(sourcePath, sequence, name)) {
+        throw new Error(`Skill "${name}" changed before cleanup`)
+      }
     }
   }
 
@@ -3442,7 +3543,7 @@ export class SkillPresenter implements ISkillPresenter {
     for (const event of batch.events) {
       if (!this.isWatchedSkillMarkdownPath(event.path)) {
         if (event.type === 'create' || event.type === 'update' || event.type === 'delete') {
-          await this.handlePublishedSkillAuxiliarySourceChanged(event.path)
+          await this.handlePublishedSkillAuxiliarySourceChanged(event.path, event.type)
         }
         continue
       }
@@ -3620,14 +3721,21 @@ export class SkillPresenter implements ISkillPresenter {
     }
   }
 
-  private async handlePublishedSkillAuxiliarySourceChanged(filePath: string): Promise<void> {
+  private async handlePublishedSkillAuxiliarySourceChanged(
+    filePath: string,
+    eventType: WatchEventType
+  ): Promise<void> {
     const entry = Array.from(this.runtimeSnapshots.snapshot.entries.values()).find((candidate) => {
       const relativePath = path.relative(candidate.metadata.skillRoot, filePath)
+      const sourceDirectory = relativePath.split(/[\\/]+/)[0]
+      const affectsPublishedSnapshot =
+        sourceDirectory === 'scripts' ||
+        (eventType !== 'update' && ['assets', 'references', 'templates'].includes(sourceDirectory))
       return (
         relativePath !== '' &&
         !relativePath.startsWith('..') &&
         !path.isAbsolute(relativePath) &&
-        relativePath.split(/[\\/]+/)[0] === 'scripts'
+        affectsPublishedSnapshot
       )
     })
     if (!entry) {

--- a/src/main/presenter/skillPresenter/index.ts
+++ b/src/main/presenter/skillPresenter/index.ts
@@ -1964,13 +1964,6 @@ export class SkillPresenter implements ISkillPresenter {
   }): Promise<void> {
     const skillPath = path.join(contribution.skillRoot, 'SKILL.md')
     for (let attempt = 0; attempt < 2; attempt += 1) {
-      const current = Array.from(this.runtimeSnapshots.snapshot.entries.values()).find(
-        (entry) =>
-          entry.metadata.path === skillPath &&
-          entry.metadata.ownerPluginId === contribution.ownerPluginId
-      )
-      if (current) return
-
       const sequence = this.runtimeSnapshots.nextObservation(skillPath)
       const metadata = await this.parseSkillMetadata(
         skillPath,
@@ -1989,6 +1982,18 @@ export class SkillPresenter implements ISkillPresenter {
       if (conflict && conflict.metadata.path !== skillPath) {
         throw new Error(`Plugin skill name "${candidate.metadata.name}" is already registered`)
       }
+      const current = Array.from(this.runtimeSnapshots.snapshot.entries.values()).find(
+        (entry) =>
+          entry.metadata.path === skillPath &&
+          entry.metadata.ownerPluginId === contribution.ownerPluginId
+      )
+      if (
+        current?.sourceVersion === candidate.sourceVersion &&
+        this.runtimeSnapshots.isCurrentObservation(skillPath, sequence)
+      ) {
+        return
+      }
+
       const previousName = Array.from(this.runtimeSnapshots.snapshot.entries.entries()).find(
         ([, entry]) => entry.metadata.path === skillPath
       )?.[0]
@@ -2796,6 +2801,11 @@ export class SkillPresenter implements ISkillPresenter {
     const sequence = this.runtimeSnapshots.nextObservation(sourcePath)
     try {
       if (!fs.existsSync(skillDir)) {
+        if (!previousEntry) {
+          if (previousState.skills[name]) this.cleanupUninstalledSkillManagementState(name)
+          return { success: false, error: `Skill "${name}" not found`, errorCode: 'not_found' }
+        }
+
         const endPublish = this.beginRuntimePublishIfCurrent(sourcePath, sequence)
         if (!endPublish) {
           return { success: false, error: `Skill "${name}" changed before cleanup` }
@@ -2875,6 +2885,16 @@ export class SkillPresenter implements ISkillPresenter {
     if (!this.runtimeSnapshots.isCurrentObservation(sourcePath, sequence)) {
       throw new Error(`Skill "${name}" changed before cleanup`)
     }
+    this.cleanupUninstalledSkillManagementState(name)
+
+    if (this.runtimeSnapshots.snapshot.entries.has(name)) {
+      if (!this.runtimeSnapshots.removeIfCurrent(sourcePath, sequence, name)) {
+        throw new Error(`Skill "${name}" changed before cleanup`)
+      }
+    }
+  }
+
+  private cleanupUninstalledSkillManagementState(name: string): void {
     if (this.isSafeSkillName(name)) {
       try {
         this.deleteSkillManagementItem(name)
@@ -2883,12 +2903,6 @@ export class SkillPresenter implements ISkillPresenter {
           name,
           error
         })
-      }
-    }
-
-    if (this.runtimeSnapshots.snapshot.entries.has(name)) {
-      if (!this.runtimeSnapshots.removeIfCurrent(sourcePath, sequence, name)) {
-        throw new Error(`Skill "${name}" changed before cleanup`)
       }
     }
   }

--- a/src/main/presenter/skillPresenter/index.ts
+++ b/src/main/presenter/skillPresenter/index.ts
@@ -60,12 +60,14 @@ import logger from '@shared/logger'
 import { normalizeSkillAllowedTools } from './toolNameMapping'
 import { discoverSkillMetadataInWorker, logSkillDiscoveryWorkerWarnings } from './discoveryWorker'
 import {
+  createQuarantinedEntry,
   createMetadataOnlyEntry,
   createSkillSourceVersion,
   freezeScriptDescriptors,
   freezeSkillExtension,
   freezeSkillMetadata,
-  SkillRuntimeSnapshotCoordinator
+  SkillRuntimeSnapshotCoordinator,
+  withPublishedSourceError
 } from './runtimeSnapshot'
 
 const execFileAsync = promisify(execFile)
@@ -247,7 +249,14 @@ export class SkillPresenter implements ISkillPresenter {
   private runtimeContentViews = new WeakMap<PublishedSkillEntry, SkillContent>()
   private readonly runtimeSnapshots = new SkillRuntimeSnapshotCoordinator({
     stageEntry: (metadata) => this.stagePublishedSkillEntry(metadata),
-    onPublished: (entries) => this.syncCompatibilityCaches(entries)
+    onPublished: (entries) => this.syncCompatibilityCaches(entries),
+    onStageError: (metadata, error) => {
+      logger.warn('[SkillPresenter] Failed to stage skill runtime source.', {
+        name: metadata.name,
+        path: metadata.path,
+        error
+      })
+    }
   })
   private runtimeSnapshotReadDepth = 0
   private pluginSkillContributions: Map<
@@ -354,12 +363,21 @@ export class SkillPresenter implements ISkillPresenter {
     return this.runtimeSnapshots.beginPublish()
   }
 
-  private publishRuntimeReplacement(entries: ReadonlyMap<string, PublishedSkillEntry>): void {
-    this.runtimeSnapshots.replace(entries)
+  private beginRuntimePublishIfCurrent(sourcePath: string, sequence: number): (() => void) | null {
+    return this.runtimeSnapshots.beginPublishIfCurrent(sourcePath, sequence)
   }
 
   private publishRuntimeEntry(entry: PublishedSkillEntry, previousName?: string): void {
     this.runtimeSnapshots.publishEntry(entry, previousName)
+  }
+
+  private publishRuntimeEntryIfCurrent(
+    sourcePath: string,
+    sequence: number,
+    entry: PublishedSkillEntry,
+    previousName?: string
+  ): boolean {
+    return this.runtimeSnapshots.publishEntryIfCurrent(sourcePath, sequence, entry, previousName)
   }
 
   private publishRuntimeRemoval(name: string): void {
@@ -372,6 +390,15 @@ export class SkillPresenter implements ISkillPresenter {
     sourcePath?: string
   ): void {
     this.runtimeSnapshots.publishSourceError(name, error, sourcePath)
+  }
+
+  private publishRuntimeSourceErrorIfCurrent(
+    sourcePath: string,
+    sequence: number,
+    name: string,
+    error: { code: string; message: string }
+  ): boolean {
+    return this.runtimeSnapshots.publishSourceErrorIfCurrent(sourcePath, sequence, name, error)
   }
 
   private syncCompatibilityCaches(entries: ReadonlyMap<string, PublishedSkillEntry>): void {
@@ -527,8 +554,9 @@ export class SkillPresenter implements ISkillPresenter {
    * Discover all skills from the skills directory
    */
   async discoverSkills(): Promise<SkillMetadata[]> {
+    const discoveryObservation = this.runtimeSnapshots.beginCatalogObservation()
     if (!fs.existsSync(this.skillsDir)) {
-      this.publishRuntimeReplacement(new Map())
+      this.runtimeSnapshots.replaceIfCatalogCurrent(discoveryObservation, new Map())
       return []
     }
 
@@ -563,10 +591,9 @@ export class SkillPresenter implements ISkillPresenter {
       }
       const previous = previousEntries.get(metadata.name)
       if (previous?.availability === 'ready' && previous.metadata.path === metadata.path) {
-        const sequence = this.runtimeSnapshots.nextObservation(metadata.path)
         try {
           const staged = await this.stagePublishedSkillEntry(metadata)
-          if (staged && this.runtimeSnapshots.isCurrentObservation(metadata.path, sequence)) {
+          if (staged) {
             nextEntries.set(staged.metadata.name, staged)
             continue
           }
@@ -579,12 +606,9 @@ export class SkillPresenter implements ISkillPresenter {
         }
         nextEntries.set(
           metadata.name,
-          Object.freeze({
-            ...previous,
-            sourceError: Object.freeze({
-              code: 'DISCOVERY_REFRESH_FAILED',
-              message: 'Discovery could not produce a complete ready candidate'
-            })
+          withPublishedSourceError(previous, {
+            code: 'DISCOVERY_REFRESH_FAILED',
+            message: 'Skill discovery could not refresh the source'
           })
         )
         continue
@@ -606,18 +630,17 @@ export class SkillPresenter implements ISkillPresenter {
       if (pluginStillRegistered && fs.existsSync(previous.metadata.path)) {
         nextEntries.set(
           name,
-          Object.freeze({
-            ...previous,
-            sourceError: Object.freeze({
-              code: 'INVALID_SOURCE',
-              message: 'Discovery observed an invalid skill source; retaining last-known-good'
-            })
+          withPublishedSourceError(previous, {
+            code: 'INVALID_SOURCE',
+            message: 'Skill source is invalid'
           })
         )
       }
     }
 
-    this.publishRuntimeReplacement(nextEntries)
+    if (!this.runtimeSnapshots.replaceIfCatalogCurrent(discoveryObservation, nextEntries)) {
+      return this.getVisibleMetadataFromSnapshot(this.runtimeSnapshots.snapshot)
+    }
     const skills = this.getVisibleMetadataFromSnapshot(this.runtimeSnapshots.snapshot)
     publishDeepchatEvent('skills.catalog.changed', {
       reason: 'discovered',
@@ -1930,13 +1953,17 @@ export class SkillPresenter implements ISkillPresenter {
     if (!metadata || metadata.name !== input.name) {
       throw new Error(`Adopted skill "${input.name}" is invalid`)
     }
+    const sequence = this.runtimeSnapshots.nextObservation(metadata.path)
     const candidate = await this.stagePublishedSkillEntry(metadata)
     if (!candidate) {
       throw new Error(`Adopted skill "${input.name}" is invalid`)
     }
 
     const previousState = this.getStoredManagementState()
-    const endPublish = this.beginRuntimePublish()
+    const endPublish = this.beginRuntimePublishIfCurrent(metadata.path, sequence)
+    if (!endPublish) {
+      throw new Error(`Adopted skill "${input.name}" changed while registration was staged`)
+    }
     try {
       this.updateSkillManagementItem(input.name, (item) => ({
         ...item,
@@ -2150,6 +2177,7 @@ export class SkillPresenter implements ISkillPresenter {
         fs.rmSync(stagingDir, { recursive: true, force: true })
         return { success: false, error: 'Staged skill is invalid', errorCode: 'invalid_skill' }
       }
+      const sequence = this.runtimeSnapshots.nextObservation(metadata.path)
       const candidate = await this.stagePublishedSkillEntry(metadata, {
         rawContent: stagedContent,
         scriptSourceRoot: stagingDir
@@ -2162,7 +2190,15 @@ export class SkillPresenter implements ISkillPresenter {
       this.seedRuntimeSnapshotFromCompatibilityCache()
       const previousEntry = this.runtimeSnapshots.snapshot.entries.get(finalSkillName)
       const previousState = this.getStoredManagementState()
-      const endPublish = this.beginRuntimePublish()
+      const endPublish = this.beginRuntimePublishIfCurrent(metadata.path, sequence)
+      if (!endPublish) {
+        fs.rmSync(stagingDir, { recursive: true, force: true })
+        return {
+          success: false,
+          error: `Skill "${finalSkillName}" changed while installation was staged`,
+          errorCode: 'conflict'
+        }
+      }
       let backupDir: string | null = null
       let retiredTargetDir: string | null = null
       let installedTarget = false
@@ -2674,7 +2710,12 @@ export class SkillPresenter implements ISkillPresenter {
         return { success: false, error: `Skill "${name}" not found`, errorCode: 'not_found' }
       }
 
-      const endPublish = this.beginRuntimePublish()
+      const sourcePath = previousEntry?.metadata.path ?? path.join(skillDir, 'SKILL.md')
+      const sequence = this.runtimeSnapshots.nextObservation(sourcePath)
+      const endPublish = this.beginRuntimePublishIfCurrent(sourcePath, sequence)
+      if (!endPublish) {
+        return { success: false, error: `Skill "${name}" changed before uninstall` }
+      }
       try {
         fs.renameSync(skillDir, trashDir)
         this.cleanupUninstalledSkillState(name)
@@ -2695,12 +2736,9 @@ export class SkillPresenter implements ISkillPresenter {
           })
           if (previousEntry) {
             this.publishRuntimeEntry(
-              Object.freeze({
-                ...previousEntry,
-                sourceError: Object.freeze({
-                  code: 'RECONCILE_REQUIRED',
-                  message: 'Skill uninstall outcome is unknown'
-                })
+              withPublishedSourceError(previousEntry, {
+                code: 'RECONCILE_REQUIRED',
+                message: 'Skill source requires reconciliation'
               })
             )
           }
@@ -2771,16 +2809,15 @@ export class SkillPresenter implements ISkillPresenter {
 
     const sequence = this.runtimeSnapshots.nextObservation(metadata.path)
     const candidate = await this.stagePublishedSkillEntry(metadata, { rawContent: content })
-    if (
-      !candidate ||
-      candidate.metadata.name !== name ||
-      !this.runtimeSnapshots.isCurrentObservation(metadata.path, sequence)
-    ) {
+    if (!candidate || candidate.metadata.name !== name) {
       return { success: false, error: `Skill "${name}" content is invalid` }
     }
 
     const previousContent = await this.readSkillFile(name)
-    const endPublish = this.beginRuntimePublish()
+    const endPublish = this.beginRuntimePublishIfCurrent(metadata.path, sequence)
+    if (!endPublish) {
+      return { success: false, error: `Skill "${name}" changed while the update was staged` }
+    }
     let wroteSource = false
     try {
       this.atomicWriteFile(metadata.path, content)
@@ -2832,15 +2869,14 @@ export class SkillPresenter implements ISkillPresenter {
       rawContent: content,
       extension: sanitized
     })
-    if (
-      !candidate ||
-      candidate.metadata.name !== name ||
-      !this.runtimeSnapshots.isCurrentObservation(metadata.path, sequence)
-    ) {
+    if (!candidate || candidate.metadata.name !== name) {
       return { success: false, error: `Skill "${name}" content is invalid` }
     }
 
-    const endPublish = this.beginRuntimePublish()
+    const endPublish = this.beginRuntimePublishIfCurrent(metadata.path, sequence)
+    if (!endPublish) {
+      return { success: false, error: `Skill "${name}" changed while the update was staged` }
+    }
     let wroteSource = false
     try {
       this.atomicWriteFile(metadata.path, content)
@@ -2905,9 +2941,10 @@ export class SkillPresenter implements ISkillPresenter {
     metadata: SkillMetadata,
     previousEntry?: PublishedSkillEntry
   ): Promise<void> {
+    const sequence = this.runtimeSnapshots.nextObservation(metadata.path)
     const reconcileError: PublishedSkillSourceError = {
       code: 'RECONCILE_REQUIRED',
-      message: 'Skill source rollback failed; runtime retained a coherent published state'
+      message: 'Skill source requires reconciliation'
     }
     let timer: ReturnType<typeof setTimeout> | undefined
     try {
@@ -2919,7 +2956,7 @@ export class SkillPresenter implements ISkillPresenter {
         })
       ])
       if (candidate && candidate.metadata.name === name) {
-        this.publishRuntimeEntry(candidate)
+        this.publishRuntimeEntryIfCurrent(metadata.path, sequence, candidate)
         return
       }
     } catch (error) {
@@ -2928,28 +2965,23 @@ export class SkillPresenter implements ISkillPresenter {
       if (timer) clearTimeout(timer)
     }
 
+    if (!this.runtimeSnapshots.isCurrentObservation(metadata.path, sequence)) {
+      return
+    }
+
     if (previousEntry) {
-      this.publishRuntimeEntry(
-        Object.freeze({
-          ...previousEntry,
-          sourceError: Object.freeze(reconcileError)
-        })
+      this.publishRuntimeEntryIfCurrent(
+        metadata.path,
+        sequence,
+        withPublishedSourceError(previousEntry, reconcileError)
       )
       return
     }
 
-    const quarantinedMetadata = freezeSkillMetadata(metadata)
-    this.publishRuntimeEntry(
-      Object.freeze({
-        sourceVersion: createSkillSourceVersion({
-          metadata: quarantinedMetadata,
-          quarantine: true
-        }),
-        availability: 'quarantined' as const,
-        metadata: quarantinedMetadata,
-        allowedTools: Object.freeze([]),
-        sourceError: Object.freeze(reconcileError)
-      })
+    this.publishRuntimeEntryIfCurrent(
+      metadata.path,
+      sequence,
+      createQuarantinedEntry(metadata, reconcileError)
     )
   }
 
@@ -3101,15 +3133,14 @@ export class SkillPresenter implements ISkillPresenter {
     const previousState = this.getStoredManagementState()
     const sequence = this.runtimeSnapshots.nextObservation(metadata.path)
     const candidate = await this.stagePublishedSkillEntry(metadata, { extension: sanitized })
-    if (
-      !candidate ||
-      candidate.metadata.name !== name ||
-      !this.runtimeSnapshots.isCurrentObservation(metadata.path, sequence)
-    ) {
+    if (!candidate || candidate.metadata.name !== name) {
       throw new Error(`Skill "${name}" source is invalid`)
     }
 
-    const endPublish = this.beginRuntimePublish()
+    const endPublish = this.beginRuntimePublishIfCurrent(metadata.path, sequence)
+    if (!endPublish) {
+      throw new Error(`Skill "${name}" changed while the extension was staged`)
+    }
     try {
       this.updateSkillManagementItem(name, (item) => ({
         ...item,
@@ -3477,25 +3508,22 @@ export class SkillPresenter implements ISkillPresenter {
     try {
       candidate = await this.stagePublishedSkillEntry(hint)
     } catch (error) {
-      this.publishRuntimeSourceError(
-        previousName,
-        {
-          code: 'SOURCE_READ_FAILED',
-          message: error instanceof Error ? error.message : String(error)
-        },
-        filePath
-      )
-      return
-    }
-    if (!this.runtimeSnapshots.isCurrentObservation(filePath, sequence)) {
+      logger.warn('[SkillPresenter] Failed to stage watcher skill update.', {
+        name: previousName,
+        path: filePath,
+        error
+      })
+      this.publishRuntimeSourceErrorIfCurrent(filePath, sequence, previousName, {
+        code: 'SOURCE_READ_FAILED',
+        message: 'Skill source could not be read'
+      })
       return
     }
     if (!candidate) {
-      this.publishRuntimeSourceError(
-        previousName,
-        { code: 'INVALID_SOURCE', message: 'Watcher observed an invalid skill source' },
-        filePath
-      )
+      this.publishRuntimeSourceErrorIfCurrent(filePath, sequence, previousName, {
+        code: 'INVALID_SOURCE',
+        message: 'Skill source is invalid'
+      })
       return
     }
 
@@ -3506,14 +3534,14 @@ export class SkillPresenter implements ISkillPresenter {
         path: candidate.metadata.path,
         existingPath: existingEntry.metadata.path
       })
-      this.publishRuntimeSourceError(previousName, {
+      this.publishRuntimeSourceErrorIfCurrent(filePath, sequence, previousName, {
         code: 'DUPLICATE_SKILL_NAME',
-        message: `Skill source renamed to duplicate name "${candidate.metadata.name}"`
+        message: 'Skill source conflicts with an existing skill name'
       })
       return
     }
 
-    this.publishRuntimeEntry(candidate, previousName)
+    if (!this.publishRuntimeEntryIfCurrent(filePath, sequence, candidate, previousName)) return
     this.runtimeSnapshots.deleteDiagnostic(filePath)
     publishDeepchatEvent('skills.catalog.changed', {
       reason: 'metadata-updated',
@@ -3531,23 +3559,21 @@ export class SkillPresenter implements ISkillPresenter {
     try {
       candidate = await this.stagePublishedSkillEntry(hint)
     } catch (error) {
-      this.runtimeSnapshots.setDiagnostic(
-        filePath,
-        Object.freeze({
-          code: 'SOURCE_READ_FAILED',
-          message: error instanceof Error ? error.message : String(error)
-        })
-      )
-      return
-    }
-    if (!this.runtimeSnapshots.isCurrentObservation(filePath, sequence)) {
+      logger.warn('[SkillPresenter] Failed to stage watcher skill addition.', {
+        path: filePath,
+        error
+      })
+      this.runtimeSnapshots.setDiagnosticIfCurrent(filePath, sequence, {
+        code: 'SOURCE_READ_FAILED',
+        message: 'Skill source could not be read'
+      })
       return
     }
     if (!candidate) {
-      this.runtimeSnapshots.setDiagnostic(
-        filePath,
-        Object.freeze({ code: 'INVALID_SOURCE', message: 'Watcher observed an invalid new skill' })
-      )
+      this.runtimeSnapshots.setDiagnosticIfCurrent(filePath, sequence, {
+        code: 'INVALID_SOURCE',
+        message: 'Skill source is invalid'
+      })
       return
     }
 
@@ -3561,7 +3587,7 @@ export class SkillPresenter implements ISkillPresenter {
       return
     }
 
-    this.publishRuntimeEntry(candidate)
+    if (!this.publishRuntimeEntryIfCurrent(filePath, sequence, candidate)) return
     this.runtimeSnapshots.deleteDiagnostic(filePath)
     publishDeepchatEvent('skills.catalog.changed', {
       reason: 'installed',
@@ -3574,8 +3600,8 @@ export class SkillPresenter implements ISkillPresenter {
   private handleSkillFileDeleted(filePath: string): void {
     this.seedRuntimeSnapshotFromCompatibilityCache()
     const skillName = this.findSkillNameByPath(filePath) ?? path.basename(path.dirname(filePath))
-    this.runtimeSnapshots.nextObservation(filePath)
-    this.publishRuntimeRemoval(skillName)
+    const sequence = this.runtimeSnapshots.nextObservation(filePath)
+    if (!this.runtimeSnapshots.removeIfCurrent(filePath, sequence, skillName)) return
     this.runtimeSnapshots.deleteDiagnostic(filePath)
     publishDeepchatEvent('skills.catalog.changed', {
       reason: 'uninstalled',
@@ -3615,21 +3641,24 @@ export class SkillPresenter implements ISkillPresenter {
     }
     try {
       const candidate = await this.stagePublishedSkillEntry(entry.metadata as SkillMetadata)
-      if (candidate && this.runtimeSnapshots.isCurrentObservation(sourcePath, sequence)) {
-        this.publishRuntimeEntry(candidate)
-      } else if (this.runtimeSnapshots.isCurrentObservation(sourcePath, sequence)) {
-        this.publishRuntimeSourceError(entry.metadata.name, {
+      if (candidate) {
+        this.publishRuntimeEntryIfCurrent(sourcePath, sequence, candidate)
+      } else {
+        this.publishRuntimeSourceErrorIfCurrent(sourcePath, sequence, entry.metadata.name, {
           code: 'INVALID_SOURCE',
-          message: 'Watcher observed an invalid skill source'
+          message: 'Skill source is invalid'
         })
       }
     } catch (error) {
-      if (this.runtimeSnapshots.isCurrentObservation(sourcePath, sequence)) {
-        this.publishRuntimeSourceError(entry.metadata.name, {
-          code: 'SOURCE_READ_FAILED',
-          message: error instanceof Error ? error.message : String(error)
-        })
-      }
+      logger.warn('[SkillPresenter] Failed to stage watcher script update.', {
+        name: entry.metadata.name,
+        path: filePath,
+        error
+      })
+      this.publishRuntimeSourceErrorIfCurrent(sourcePath, sequence, entry.metadata.name, {
+        code: 'SOURCE_READ_FAILED',
+        message: 'Skill source could not be read'
+      })
     }
   }
 

--- a/src/main/presenter/skillPresenter/runtimeSnapshot.ts
+++ b/src/main/presenter/skillPresenter/runtimeSnapshot.ts
@@ -1,0 +1,460 @@
+import { createHash } from 'node:crypto'
+import {
+  SkillRuntimeUpdatingError,
+  type PublishedSkillEntry,
+  type PublishedSkillSourceError,
+  type SkillExtensionConfig,
+  type SkillMetadata,
+  type SkillRuntimeSnapshot,
+  type SkillScriptDescriptor,
+  type WaitForStableSkillRuntimeOptions
+} from '@shared/types/skill'
+
+export function stableSerialize(value: unknown): string {
+  if (value === undefined) return 'undefined'
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableSerialize(item)).join(',')}]`
+  }
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, item]) => `${JSON.stringify(key)}:${stableSerialize(item)}`)
+    .join(',')}}`
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value
+  for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested)
+  return Object.freeze(value)
+}
+
+export function createSkillSourceVersion(value: unknown): string {
+  return createHash('sha256').update(stableSerialize(value)).digest('hex')
+}
+
+export function freezeSkillMetadata(metadata: SkillMetadata): Readonly<SkillMetadata> {
+  return deepFreeze(structuredClone(metadata))
+}
+
+export function freezeSkillExtension(config: SkillExtensionConfig): Readonly<SkillExtensionConfig> {
+  return deepFreeze(structuredClone(config))
+}
+
+export function freezeScriptDescriptors(
+  scripts: SkillScriptDescriptor[]
+): readonly Readonly<SkillScriptDescriptor>[] {
+  return deepFreeze(structuredClone(scripts))
+}
+
+export function createMetadataOnlyEntry(
+  metadata: SkillMetadata,
+  sourceError?: PublishedSkillSourceError
+): PublishedSkillEntry {
+  const frozenMetadata = freezeSkillMetadata(metadata)
+  return Object.freeze({
+    sourceVersion: createSkillSourceVersion({
+      availability: 'metadata_only',
+      metadata: frozenMetadata,
+      processArch: process.arch
+    }),
+    availability: 'metadata_only' as const,
+    metadata: frozenMetadata,
+    allowedTools: Object.freeze([...(frozenMetadata.allowedTools ?? [])]),
+    sourceError: sourceError ? Object.freeze({ ...sourceError }) : undefined
+  })
+}
+
+class ImmutableMapView<K, V> implements ReadonlyMap<K, V> {
+  readonly #entries: Map<K, V>
+
+  constructor(entries: ReadonlyMap<K, V>) {
+    this.#entries = new Map(entries)
+    Object.freeze(this)
+  }
+
+  get size(): number {
+    return this.#entries.size
+  }
+
+  get(key: K): V | undefined {
+    return this.#entries.get(key)
+  }
+
+  has(key: K): boolean {
+    return this.#entries.has(key)
+  }
+
+  entries(): MapIterator<[K, V]> {
+    return this.#entries.entries()
+  }
+
+  keys(): MapIterator<K> {
+    return this.#entries.keys()
+  }
+
+  values(): MapIterator<V> {
+    return this.#entries.values()
+  }
+
+  forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: unknown): void {
+    for (const [key, value] of this.#entries) {
+      callbackfn.call(thisArg, value, key, this)
+    }
+  }
+
+  [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.#entries[Symbol.iterator]()
+  }
+
+  get [Symbol.toStringTag](): string {
+    return 'ImmutableMapView'
+  }
+}
+
+export interface SkillRuntimePublishHandle {
+  update(updater: (entries: Map<string, PublishedSkillEntry>) => void): void
+  end(): void
+}
+
+export class SkillRuntimeSnapshotState {
+  #epoch = 0
+  #snapshot: SkillRuntimeSnapshot = this.#createSnapshot(0, new Map())
+  #pendingEntries: Map<string, PublishedSkillEntry> | null = null
+  #activePublishCount = 0
+  #settlementPromise: Promise<void> | null = null
+  #resolveSettlement: (() => void) | null = null
+
+  get epoch(): number {
+    return this.#epoch
+  }
+
+  get snapshot(): SkillRuntimeSnapshot {
+    return this.#snapshot
+  }
+
+  get isPublishing(): boolean {
+    return this.#epoch % 2 === 1
+  }
+
+  get settlementPromise(): Promise<void> | null {
+    return this.#settlementPromise
+  }
+
+  beginPublish(
+    onPublished: (entries: ReadonlyMap<string, PublishedSkillEntry>) => void
+  ): SkillRuntimePublishHandle {
+    if (this.#activePublishCount === 0) {
+      if (this.#epoch % 2 !== 0) {
+        throw new Error('Skill runtime publish entered from an unstable epoch')
+      }
+      this.#advanceEpoch()
+      this.#pendingEntries = new Map(this.#snapshot.entries)
+      this.#settlementPromise = new Promise<void>((resolve) => {
+        this.#resolveSettlement = resolve
+      })
+    }
+    this.#activePublishCount += 1
+    let ended = false
+
+    return {
+      update: (updater) => {
+        if (ended || !this.#pendingEntries || !this.isPublishing) {
+          throw new Error('Skill runtime entries can only change inside an active publish window')
+        }
+        updater(this.#pendingEntries)
+      },
+      end: () => {
+        if (ended) return
+        ended = true
+        this.#activePublishCount -= 1
+        if (this.#activePublishCount > 0) return
+
+        const entries = this.#pendingEntries ?? new Map(this.#snapshot.entries)
+        const epoch = this.#advanceEpoch()
+        this.#snapshot = this.#createSnapshot(epoch, entries)
+        this.#pendingEntries = null
+        onPublished(this.#snapshot.entries)
+        const resolve = this.#resolveSettlement
+        this.#resolveSettlement = null
+        this.#settlementPromise = null
+        resolve?.()
+      }
+    }
+  }
+
+  replace(
+    entries: ReadonlyMap<string, PublishedSkillEntry>,
+    onPublished: (published: ReadonlyMap<string, PublishedSkillEntry>) => void
+  ): void {
+    const publish = this.beginPublish(onPublished)
+    try {
+      publish.update((pending) => {
+        pending.clear()
+        for (const [name, entry] of entries) {
+          pending.set(name, entry)
+        }
+      })
+    } finally {
+      publish.end()
+    }
+  }
+
+  reset(): void {
+    if (this.#activePublishCount !== 0) {
+      throw new Error('Cannot reset skill runtime snapshot during publication')
+    }
+    this.#epoch = 0
+    this.#snapshot = this.#createSnapshot(0, new Map())
+    this.#pendingEntries = null
+    this.#settlementPromise = null
+    this.#resolveSettlement = null
+  }
+
+  #advanceEpoch(): number {
+    if (this.#epoch >= Number.MAX_SAFE_INTEGER) {
+      throw new Error('Skill mutation epoch exhausted')
+    }
+    this.#epoch += 1
+    return this.#epoch
+  }
+
+  #createSnapshot(
+    epoch: number,
+    entries: ReadonlyMap<string, PublishedSkillEntry>
+  ): SkillRuntimeSnapshot {
+    return Object.freeze({
+      epoch,
+      entries: new ImmutableMapView(entries)
+    })
+  }
+}
+
+interface SkillRuntimeSnapshotCoordinatorOptions {
+  stageEntry(metadata: SkillMetadata): Promise<PublishedSkillEntry | null>
+  onPublished(entries: ReadonlyMap<string, PublishedSkillEntry>): void
+}
+
+export class SkillRuntimeSnapshotCoordinator {
+  readonly #state = new SkillRuntimeSnapshotState()
+  readonly #readinessStages = new Map<string, Promise<void>>()
+  readonly #sourceObservationSequences = new Map<string, number>()
+  readonly #sourceDiagnostics = new Map<string, PublishedSkillSourceError>()
+  readonly #publishHandles: SkillRuntimePublishHandle[] = []
+
+  constructor(private readonly options: SkillRuntimeSnapshotCoordinatorOptions) {}
+
+  get snapshot(): SkillRuntimeSnapshot {
+    return this.#state.snapshot
+  }
+
+  async wait(options: WaitForStableSkillRuntimeOptions): Promise<SkillRuntimeSnapshot> {
+    this.#throwIfAborted(options.signal)
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const requiredStages = options.requiredSkillNames
+        .map((name) => this.#ensureReady(name))
+        .filter((stage): stage is Promise<void> => Boolean(stage))
+      const pendingPublish = this.#state.isPublishing ? this.#state.settlementPromise : null
+      const pending = [...requiredStages, ...(pendingPublish ? [pendingPublish] : [])]
+      if (pending.length > 0) {
+        await this.#waitForPreparation(Promise.all(pending), options)
+      }
+
+      this.#throwIfAborted(options.signal)
+      const epochBefore = this.#state.epoch
+      const snapshot = this.#state.snapshot
+      const epochAfter = this.#state.epoch
+      const requiredStillStaging = options.requiredSkillNames.some(
+        (name) => snapshot.entries.get(name)?.availability === 'metadata_only'
+      )
+      if (
+        epochBefore === epochAfter &&
+        epochBefore % 2 === 0 &&
+        snapshot.epoch === epochBefore &&
+        !requiredStillStaging
+      ) {
+        return snapshot
+      }
+    }
+    throw new SkillRuntimeUpdatingError()
+  }
+
+  seedFromMetadata(metadata: Iterable<SkillMetadata>): void {
+    if (this.snapshot.entries.size > 0) return
+    const entries = new Map<string, PublishedSkillEntry>()
+    for (const item of metadata) entries.set(item.name, createMetadataOnlyEntry(item))
+    if (entries.size > 0) this.replace(entries)
+  }
+
+  beginPublish(): () => void {
+    const handle = this.#state.beginPublish(this.options.onPublished)
+    this.#publishHandles.push(handle)
+    return () => {
+      const index = this.#publishHandles.lastIndexOf(handle)
+      if (index >= 0) this.#publishHandles.splice(index, 1)
+      handle.end()
+    }
+  }
+
+  replace(entries: ReadonlyMap<string, PublishedSkillEntry>): void {
+    const end = this.beginPublish()
+    try {
+      this.#update((pending) => {
+        pending.clear()
+        for (const [name, entry] of entries) pending.set(name, entry)
+      })
+    } finally {
+      end()
+    }
+  }
+
+  publishEntry(entry: PublishedSkillEntry, previousName?: string): void {
+    const end = this.beginPublish()
+    try {
+      this.#update((entries) => {
+        if (previousName && previousName !== entry.metadata.name) entries.delete(previousName)
+        entries.set(entry.metadata.name, entry)
+      })
+    } finally {
+      end()
+    }
+  }
+
+  remove(name: string): void {
+    const end = this.beginPublish()
+    try {
+      this.#update((entries) => entries.delete(name))
+    } finally {
+      end()
+    }
+  }
+
+  publishSourceError(name: string, error: PublishedSkillSourceError, sourcePath?: string): void {
+    const current = this.snapshot.entries.get(name)
+    if (!current) {
+      if (sourcePath) this.setDiagnostic(sourcePath, error)
+      return
+    }
+    this.publishEntry(
+      Object.freeze({
+        ...current,
+        sourceError: Object.freeze({ ...error })
+      })
+    )
+  }
+
+  nextObservation(sourcePath: string): number {
+    const next = (this.#sourceObservationSequences.get(sourcePath) ?? 0) + 1
+    this.#sourceObservationSequences.set(sourcePath, next)
+    return next
+  }
+
+  currentObservation(sourcePath: string): number {
+    return this.#sourceObservationSequences.get(sourcePath) ?? 0
+  }
+
+  isCurrentObservation(sourcePath: string, sequence: number): boolean {
+    return this.currentObservation(sourcePath) === sequence
+  }
+
+  setDiagnostic(sourcePath: string, error: PublishedSkillSourceError): void {
+    this.#sourceDiagnostics.set(sourcePath, Object.freeze({ ...error }))
+  }
+
+  deleteDiagnostic(sourcePath: string): void {
+    this.#sourceDiagnostics.delete(sourcePath)
+  }
+
+  reset(): void {
+    this.#sourceObservationSequences.clear()
+    this.#readinessStages.clear()
+    this.#sourceDiagnostics.clear()
+    this.#publishHandles.splice(0)
+    this.#state.reset()
+  }
+
+  #update(updater: (entries: Map<string, PublishedSkillEntry>) => void): void {
+    const handle = this.#publishHandles.at(-1)
+    if (!handle) throw new Error('Skill runtime entries can only change inside a publish window')
+    handle.update(updater)
+  }
+
+  #ensureReady(name: string): Promise<void> | null {
+    const entry = this.snapshot.entries.get(name)
+    if (!entry || entry.availability !== 'metadata_only') return null
+    const existingStage = this.#readinessStages.get(name)
+    if (existingStage) return existingStage
+
+    const sourcePath = entry.metadata.path
+    const sequence = this.currentObservation(sourcePath)
+    const stage = (async () => {
+      try {
+        const candidate = await this.options.stageEntry(entry.metadata as SkillMetadata)
+        if (!this.isCurrentObservation(sourcePath, sequence)) return
+        if (!candidate || candidate.metadata.name !== name) {
+          this.publishSourceError(
+            name,
+            { code: 'INVALID_SOURCE', message: 'Skill source did not produce a valid entry' },
+            sourcePath
+          )
+          return
+        }
+        this.publishEntry(candidate)
+      } catch (error) {
+        if (!this.isCurrentObservation(sourcePath, sequence)) return
+        this.publishSourceError(
+          name,
+          {
+            code: 'SOURCE_READ_FAILED',
+            message: error instanceof Error ? error.message : String(error)
+          },
+          sourcePath
+        )
+      }
+    })()
+    this.#readinessStages.set(name, stage)
+    void stage.finally(() => {
+      if (this.#readinessStages.get(name) === stage) this.#readinessStages.delete(name)
+    })
+    return stage
+  }
+
+  #throwIfAborted(signal: AbortSignal): void {
+    if (!signal.aborted) return
+    if (signal.reason instanceof Error) throw signal.reason
+    throw new DOMException('This operation was aborted', 'AbortError')
+  }
+
+  async #waitForPreparation(
+    pending: Promise<unknown>,
+    options: WaitForStableSkillRuntimeOptions
+  ): Promise<void> {
+    this.#throwIfAborted(options.signal)
+    const remainingMs = Math.max(0, options.deadlineAt - Date.now())
+    if (remainingMs === 0) throw new SkillRuntimeUpdatingError()
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false
+      const settle = (action: () => void) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        options.signal.removeEventListener('abort', onAbort)
+        action()
+      }
+      const onAbort = () =>
+        settle(() => {
+          if (options.signal.reason instanceof Error) reject(options.signal.reason)
+          else reject(new DOMException('This operation was aborted', 'AbortError'))
+        })
+      const timeout = setTimeout(
+        () => settle(() => reject(new SkillRuntimeUpdatingError())),
+        remainingMs
+      )
+      options.signal.addEventListener('abort', onAbort, { once: true })
+      void pending.then(
+        () => settle(resolve),
+        (error) => settle(() => reject(error))
+      )
+    })
+  }
+}

--- a/src/main/presenter/skillPresenter/runtimeSnapshot.ts
+++ b/src/main/presenter/skillPresenter/runtimeSnapshot.ts
@@ -46,6 +46,28 @@ export function freezeScriptDescriptors(
   return deepFreeze(structuredClone(scripts))
 }
 
+const PUBLISHED_SOURCE_ERROR_MESSAGES: Readonly<Record<string, string>> = Object.freeze({
+  DISCOVERY_REFRESH_FAILED: 'Skill discovery could not refresh the source',
+  DUPLICATE_SKILL_NAME: 'Skill source conflicts with an existing skill name',
+  INVALID_SOURCE: 'Skill source is invalid',
+  MUTATION_ROLLED_BACK: 'Skill source mutation was rolled back',
+  RECONCILE_REQUIRED: 'Skill source requires reconciliation',
+  SOURCE_READ_FAILED: 'Skill source could not be read',
+  SOURCE_UNAVAILABLE: 'Skill source is unavailable'
+})
+
+export function freezePublishedSourceError(
+  error: PublishedSkillSourceError
+): Readonly<PublishedSkillSourceError> {
+  const code = Object.hasOwn(PUBLISHED_SOURCE_ERROR_MESSAGES, error.code)
+    ? error.code
+    : 'SOURCE_UNAVAILABLE'
+  return Object.freeze({
+    code,
+    message: PUBLISHED_SOURCE_ERROR_MESSAGES[code]
+  })
+}
+
 export function createMetadataOnlyEntry(
   metadata: SkillMetadata,
   sourceError?: PublishedSkillSourceError
@@ -60,7 +82,37 @@ export function createMetadataOnlyEntry(
     availability: 'metadata_only' as const,
     metadata: frozenMetadata,
     allowedTools: Object.freeze([...(frozenMetadata.allowedTools ?? [])]),
-    sourceError: sourceError ? Object.freeze({ ...sourceError }) : undefined
+    sourceError: sourceError ? freezePublishedSourceError(sourceError) : undefined
+  })
+}
+
+export function createQuarantinedEntry(
+  metadata: SkillMetadata,
+  sourceError: PublishedSkillSourceError
+): PublishedSkillEntry {
+  const frozenMetadata = freezeSkillMetadata(metadata)
+  const frozenSourceError = freezePublishedSourceError(sourceError)
+  return Object.freeze({
+    sourceVersion: createSkillSourceVersion({
+      availability: 'quarantined',
+      metadata: frozenMetadata,
+      sourceError: frozenSourceError,
+      processArch: process.arch
+    }),
+    availability: 'quarantined' as const,
+    metadata: frozenMetadata,
+    allowedTools: Object.freeze([]),
+    sourceError: frozenSourceError
+  })
+}
+
+export function withPublishedSourceError(
+  entry: PublishedSkillEntry,
+  sourceError: PublishedSkillSourceError
+): PublishedSkillEntry {
+  return Object.freeze({
+    ...entry,
+    sourceError: freezePublishedSourceError(sourceError)
   })
 }
 
@@ -173,11 +225,14 @@ export class SkillRuntimeSnapshotState {
         const epoch = this.#advanceEpoch()
         this.#snapshot = this.#createSnapshot(epoch, entries)
         this.#pendingEntries = null
-        onPublished(this.#snapshot.entries)
         const resolve = this.#resolveSettlement
-        this.#resolveSettlement = null
-        this.#settlementPromise = null
-        resolve?.()
+        try {
+          onPublished(this.#snapshot.entries)
+        } finally {
+          this.#resolveSettlement = null
+          this.#settlementPromise = null
+          resolve?.()
+        }
       }
     }
   }
@@ -232,6 +287,7 @@ export class SkillRuntimeSnapshotState {
 interface SkillRuntimeSnapshotCoordinatorOptions {
   stageEntry(metadata: SkillMetadata): Promise<PublishedSkillEntry | null>
   onPublished(entries: ReadonlyMap<string, PublishedSkillEntry>): void
+  onStageError?(metadata: SkillMetadata, error: unknown): void
 }
 
 export class SkillRuntimeSnapshotCoordinator {
@@ -240,6 +296,8 @@ export class SkillRuntimeSnapshotCoordinator {
   readonly #sourceObservationSequences = new Map<string, number>()
   readonly #sourceDiagnostics = new Map<string, PublishedSkillSourceError>()
   readonly #publishHandles: SkillRuntimePublishHandle[] = []
+  #observationSequence = 0
+  #observationFloor = 0
 
   constructor(private readonly options: SkillRuntimeSnapshotCoordinatorOptions) {}
 
@@ -281,7 +339,10 @@ export class SkillRuntimeSnapshotCoordinator {
   seedFromMetadata(metadata: Iterable<SkillMetadata>): void {
     if (this.snapshot.entries.size > 0) return
     const entries = new Map<string, PublishedSkillEntry>()
-    for (const item of metadata) entries.set(item.name, createMetadataOnlyEntry(item))
+    for (const item of metadata) {
+      this.nextObservation(item.path)
+      entries.set(item.name, createMetadataOnlyEntry(item))
+    }
     if (entries.size > 0) this.replace(entries)
   }
 
@@ -293,6 +354,15 @@ export class SkillRuntimeSnapshotCoordinator {
       if (index >= 0) this.#publishHandles.splice(index, 1)
       handle.end()
     }
+  }
+
+  beginPublishIfCurrent(sourcePath: string, sequence: number): (() => void) | null {
+    if (!this.isCurrentObservation(sourcePath, sequence)) return null
+    return this.beginPublish()
+  }
+
+  beginCatalogObservation(): number {
+    return this.#advanceObservationSequence()
   }
 
   replace(entries: ReadonlyMap<string, PublishedSkillEntry>): void {
@@ -307,6 +377,25 @@ export class SkillRuntimeSnapshotCoordinator {
     }
   }
 
+  replaceIfCatalogCurrent(
+    sequence: number,
+    entries: ReadonlyMap<string, PublishedSkillEntry>
+  ): boolean {
+    if (this.#observationSequence !== sequence) return false
+    const nextFloor = this.#nextObservationSequence()
+    const previousEpoch = this.snapshot.epoch
+    try {
+      this.replace(entries)
+    } finally {
+      if (this.snapshot.epoch !== previousEpoch) {
+        this.#observationSequence = nextFloor
+        this.#observationFloor = nextFloor
+        this.#sourceObservationSequences.clear()
+      }
+    }
+    return true
+  }
+
   publishEntry(entry: PublishedSkillEntry, previousName?: string): void {
     const end = this.beginPublish()
     try {
@@ -319,6 +408,17 @@ export class SkillRuntimeSnapshotCoordinator {
     }
   }
 
+  publishEntryIfCurrent(
+    sourcePath: string,
+    sequence: number,
+    entry: PublishedSkillEntry,
+    previousName?: string
+  ): boolean {
+    if (!this.isCurrentObservation(sourcePath, sequence)) return false
+    this.publishEntry(entry, previousName)
+    return true
+  }
+
   remove(name: string): void {
     const end = this.beginPublish()
     try {
@@ -328,28 +428,44 @@ export class SkillRuntimeSnapshotCoordinator {
     }
   }
 
+  removeIfCurrent(sourcePath: string, sequence: number, name: string): boolean {
+    if (!this.isCurrentObservation(sourcePath, sequence)) return false
+    this.remove(name)
+    return true
+  }
+
   publishSourceError(name: string, error: PublishedSkillSourceError, sourcePath?: string): void {
     const current = this.snapshot.entries.get(name)
     if (!current) {
       if (sourcePath) this.setDiagnostic(sourcePath, error)
       return
     }
-    this.publishEntry(
-      Object.freeze({
-        ...current,
-        sourceError: Object.freeze({ ...error })
-      })
-    )
+    if (current.availability === 'metadata_only') {
+      this.publishEntry(createQuarantinedEntry(current.metadata as SkillMetadata, error))
+      return
+    }
+    this.publishEntry(withPublishedSourceError(current, error))
+  }
+
+  publishSourceErrorIfCurrent(
+    sourcePath: string,
+    sequence: number,
+    name: string,
+    error: PublishedSkillSourceError
+  ): boolean {
+    if (!this.isCurrentObservation(sourcePath, sequence)) return false
+    this.publishSourceError(name, error, sourcePath)
+    return true
   }
 
   nextObservation(sourcePath: string): number {
-    const next = (this.#sourceObservationSequences.get(sourcePath) ?? 0) + 1
+    const next = this.#advanceObservationSequence()
     this.#sourceObservationSequences.set(sourcePath, next)
     return next
   }
 
   currentObservation(sourcePath: string): number {
-    return this.#sourceObservationSequences.get(sourcePath) ?? 0
+    return this.#sourceObservationSequences.get(sourcePath) ?? this.#observationFloor
   }
 
   isCurrentObservation(sourcePath: string, sequence: number): boolean {
@@ -357,7 +473,17 @@ export class SkillRuntimeSnapshotCoordinator {
   }
 
   setDiagnostic(sourcePath: string, error: PublishedSkillSourceError): void {
-    this.#sourceDiagnostics.set(sourcePath, Object.freeze({ ...error }))
+    this.#sourceDiagnostics.set(sourcePath, freezePublishedSourceError(error))
+  }
+
+  setDiagnosticIfCurrent(
+    sourcePath: string,
+    sequence: number,
+    error: PublishedSkillSourceError
+  ): boolean {
+    if (!this.isCurrentObservation(sourcePath, sequence)) return false
+    this.setDiagnostic(sourcePath, error)
+    return true
   }
 
   deleteDiagnostic(sourcePath: string): void {
@@ -365,11 +491,14 @@ export class SkillRuntimeSnapshotCoordinator {
   }
 
   reset(): void {
+    const nextFloor = this.#nextObservationSequence()
+    this.#state.reset()
+    this.#observationSequence = nextFloor
+    this.#observationFloor = nextFloor
     this.#sourceObservationSequences.clear()
     this.#readinessStages.clear()
     this.#sourceDiagnostics.clear()
     this.#publishHandles.splice(0)
-    this.#state.reset()
   }
 
   #update(updater: (entries: Map<string, PublishedSkillEntry>) => void): void {
@@ -387,35 +516,48 @@ export class SkillRuntimeSnapshotCoordinator {
     const sourcePath = entry.metadata.path
     const sequence = this.currentObservation(sourcePath)
     const stage = (async () => {
+      let candidate: PublishedSkillEntry | null
       try {
-        const candidate = await this.options.stageEntry(entry.metadata as SkillMetadata)
-        if (!this.isCurrentObservation(sourcePath, sequence)) return
-        if (!candidate || candidate.metadata.name !== name) {
-          this.publishSourceError(
-            name,
-            { code: 'INVALID_SOURCE', message: 'Skill source did not produce a valid entry' },
-            sourcePath
-          )
-          return
-        }
-        this.publishEntry(candidate)
+        candidate = await this.options.stageEntry(entry.metadata as SkillMetadata)
       } catch (error) {
-        if (!this.isCurrentObservation(sourcePath, sequence)) return
-        this.publishSourceError(
-          name,
-          {
-            code: 'SOURCE_READ_FAILED',
-            message: error instanceof Error ? error.message : String(error)
-          },
-          sourcePath
-        )
+        this.options.onStageError?.(entry.metadata as SkillMetadata, error)
+        this.publishSourceErrorIfCurrent(sourcePath, sequence, name, {
+          code: 'SOURCE_READ_FAILED',
+          message: 'Skill source could not be read'
+        })
+        return
       }
+      if (!candidate || candidate.metadata.name !== name) {
+        this.publishSourceErrorIfCurrent(sourcePath, sequence, name, {
+          code: 'INVALID_SOURCE',
+          message: 'Skill source is invalid'
+        })
+        return
+      }
+      this.publishEntryIfCurrent(sourcePath, sequence, candidate)
     })()
     this.#readinessStages.set(name, stage)
-    void stage.finally(() => {
-      if (this.#readinessStages.get(name) === stage) this.#readinessStages.delete(name)
-    })
+    void stage.then(
+      () => {
+        if (this.#readinessStages.get(name) === stage) this.#readinessStages.delete(name)
+      },
+      () => {
+        if (this.#readinessStages.get(name) === stage) this.#readinessStages.delete(name)
+      }
+    )
     return stage
+  }
+
+  #nextObservationSequence(): number {
+    if (this.#observationSequence >= Number.MAX_SAFE_INTEGER) {
+      throw new Error('Skill source observation sequence exhausted')
+    }
+    return this.#observationSequence + 1
+  }
+
+  #advanceObservationSequence(): number {
+    this.#observationSequence = this.#nextObservationSequence()
+    return this.#observationSequence
   }
 
   #throwIfAborted(signal: AbortSignal): void {

--- a/src/shared/types/skill.ts
+++ b/src/shared/types/skill.ts
@@ -48,6 +48,45 @@ export interface SkillContent {
   content: string
 }
 
+export type PublishedSkillAvailability = 'metadata_only' | 'ready' | 'quarantined'
+
+export interface PublishedSkillSourceError {
+  code: string
+  message: string
+}
+
+export interface PublishedSkillEntry {
+  sourceVersion: string
+  availability: PublishedSkillAvailability
+  metadata: Readonly<SkillMetadata>
+  renderedContent?: string
+  allowedTools: readonly string[]
+  extension?: Readonly<SkillExtensionConfig>
+  scripts?: readonly Readonly<SkillScriptDescriptor>[]
+  sourceError?: Readonly<PublishedSkillSourceError>
+}
+
+export interface SkillRuntimeSnapshot {
+  epoch: number
+  entries: ReadonlyMap<string, PublishedSkillEntry>
+}
+
+export interface WaitForStableSkillRuntimeOptions {
+  requiredSkillNames: readonly string[]
+  signal: AbortSignal
+  deadlineAt: number
+}
+
+export class SkillRuntimeUpdatingError extends Error {
+  readonly code = 'SKILL_RUNTIME_UPDATING'
+  readonly retryable = true
+
+  constructor(message: string = 'Skill runtime is still updating') {
+    super(message)
+    this.name = 'SkillRuntimeUpdatingError'
+  }
+}
+
 export type SkillRuntimePreference = 'auto' | 'system' | 'builtin'
 
 export interface SkillRuntimePolicy {
@@ -272,6 +311,10 @@ export interface ISkillPresenter {
   getMetadataPrompt(): Promise<string>
   getSkillManagementState(): Promise<SkillManagementState>
   setSkillDeepChatDisabled(name: string, disabled: boolean): Promise<void>
+  getPublishedRuntimeSnapshot(): SkillRuntimeSnapshot
+  waitForStableRuntimeSnapshot(
+    options: WaitForStableSkillRuntimeOptions
+  ): Promise<SkillRuntimeSnapshot>
 
   // Content loading
   loadSkillContent(name: string): Promise<SkillContent | null>

--- a/src/shared/types/skill.ts
+++ b/src/shared/types/skill.ts
@@ -63,6 +63,7 @@ export interface PublishedSkillEntry {
   allowedTools: readonly string[]
   extension?: Readonly<SkillExtensionConfig>
   scripts?: readonly Readonly<SkillScriptDescriptor>[]
+  linkedFiles?: readonly Readonly<SkillLinkedFile>[]
   sourceError?: Readonly<PublishedSkillSourceError>
 }
 

--- a/test/main/presenter/skillPresenter/runtimeSnapshot.test.ts
+++ b/test/main/presenter/skillPresenter/runtimeSnapshot.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { PublishedSkillEntry, SkillMetadata } from '@shared/types/skill'
-import { SkillRuntimeSnapshotState } from '@/presenter/skillPresenter/runtimeSnapshot'
+import {
+  SkillRuntimeSnapshotCoordinator,
+  SkillRuntimeSnapshotState
+} from '@/presenter/skillPresenter/runtimeSnapshot'
 
 function createEntry(name: string): PublishedSkillEntry {
   const metadata: SkillMetadata = {
@@ -15,6 +18,14 @@ function createEntry(name: string): PublishedSkillEntry {
     metadata: Object.freeze(metadata),
     allowedTools: Object.freeze([])
   })
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
 }
 
 describe('SkillRuntimeSnapshotState', () => {
@@ -60,5 +71,134 @@ describe('SkillRuntimeSnapshotState', () => {
     expect(() => publish.update((entries) => entries.clear())).toThrow(
       'Skill runtime entries can only change inside an active publish window'
     )
+  })
+
+  it('settles publication bookkeeping even when a compatibility observer throws', async () => {
+    const state = new SkillRuntimeSnapshotState()
+    const publish = state.beginPublish(() => {
+      throw new Error('compatibility observer failed')
+    })
+    publish.update((entries) => entries.set('a', createEntry('a')))
+    const settlement = state.settlementPromise
+    let settled = false
+    void settlement?.then(() => {
+      settled = true
+    })
+
+    expect(() => publish.end()).toThrow('compatibility observer failed')
+    await Promise.resolve()
+
+    expect(settled).toBe(true)
+    expect(state.settlementPromise).toBeNull()
+    expect(state.epoch).toBe(2)
+    expect(state.snapshot.entries.has('a')).toBe(true)
+
+    const next = state.beginPublish(() => {})
+    next.end()
+    expect(state.epoch).toBe(4)
+  })
+})
+
+describe('SkillRuntimeSnapshotCoordinator', () => {
+  it('quarantines invalid metadata-only readiness once for all current and later callers', async () => {
+    const metadata = createEntry('invalid').metadata as SkillMetadata
+    const stageEntry = vi.fn().mockResolvedValue(null)
+    const coordinator = new SkillRuntimeSnapshotCoordinator({
+      stageEntry,
+      onPublished: vi.fn(),
+      onStageError: vi.fn()
+    })
+    coordinator.seedFromMetadata([metadata])
+
+    const createWait = () =>
+      coordinator.wait({
+        requiredSkillNames: ['invalid'],
+        signal: new AbortController().signal,
+        deadlineAt: Date.now() + 1_000
+      })
+    const [first, second] = await Promise.all([createWait(), createWait()])
+    const third = await createWait()
+
+    expect(stageEntry).toHaveBeenCalledTimes(1)
+    expect(first).toBe(second)
+    expect(third.entries.get('invalid')).toMatchObject({
+      availability: 'quarantined',
+      allowedTools: [],
+      sourceError: {
+        code: 'INVALID_SOURCE',
+        message: 'Skill source is invalid'
+      }
+    })
+  })
+
+  it('keeps raw readiness errors local and publishes only stable diagnostics', async () => {
+    const metadata = createEntry('invalid').metadata as SkillMetadata
+    const rawError = new Error('/private/skill/SKILL.md included secret body')
+    const onStageError = vi.fn()
+    const coordinator = new SkillRuntimeSnapshotCoordinator({
+      stageEntry: vi.fn().mockRejectedValue(rawError),
+      onPublished: vi.fn(),
+      onStageError
+    })
+    coordinator.seedFromMetadata([metadata])
+
+    const snapshot = await coordinator.wait({
+      requiredSkillNames: ['invalid'],
+      signal: new AbortController().signal,
+      deadlineAt: Date.now() + 1_000
+    })
+
+    expect(onStageError).toHaveBeenCalledWith(metadata, rawError)
+    expect(snapshot.entries.get('invalid')?.sourceError).toEqual({
+      code: 'SOURCE_READ_FAILED',
+      message: 'Skill source could not be read'
+    })
+    expect(JSON.stringify(snapshot.entries.get('invalid')?.sourceError)).not.toContain('/private')
+    expect(JSON.stringify(snapshot.entries.get('invalid')?.sourceError)).not.toContain('secret')
+  })
+
+  it('rejects reset atomically while a publication is active', () => {
+    const coordinator = new SkillRuntimeSnapshotCoordinator({
+      stageEntry: vi.fn(),
+      onPublished: vi.fn(),
+      onStageError: vi.fn()
+    })
+    const sourcePath = '/skills/a/SKILL.md'
+    const observation = coordinator.nextObservation(sourcePath)
+    const end = coordinator.beginPublish()
+    coordinator.publishEntry(createEntry('a'))
+
+    expect(() => coordinator.reset()).toThrow(
+      'Cannot reset skill runtime snapshot during publication'
+    )
+    expect(coordinator.currentObservation(sourcePath)).toBe(observation)
+
+    end()
+    expect(coordinator.snapshot.entries.has('a')).toBe(true)
+    coordinator.reset()
+    expect(coordinator.snapshot.entries.size).toBe(0)
+  })
+
+  it('invalidates a readiness stage that settles after reset', async () => {
+    const metadata = createEntry('late').metadata as SkillMetadata
+    const deferred = createDeferred<PublishedSkillEntry | null>()
+    const coordinator = new SkillRuntimeSnapshotCoordinator({
+      stageEntry: vi.fn().mockReturnValue(deferred.promise),
+      onPublished: vi.fn(),
+      onStageError: vi.fn()
+    })
+    coordinator.seedFromMetadata([metadata])
+    const waiting = coordinator.wait({
+      requiredSkillNames: ['late'],
+      signal: new AbortController().signal,
+      deadlineAt: Date.now() + 1_000
+    })
+    await Promise.resolve()
+
+    coordinator.reset()
+    deferred.resolve(createEntry('late'))
+
+    await expect(waiting).resolves.toMatchObject({ epoch: 0 })
+    expect(coordinator.snapshot.entries.has('late')).toBe(false)
   })
 })

--- a/test/main/presenter/skillPresenter/runtimeSnapshot.test.ts
+++ b/test/main/presenter/skillPresenter/runtimeSnapshot.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PublishedSkillEntry, SkillMetadata } from '@shared/types/skill'
+import { SkillRuntimeSnapshotState } from '@/presenter/skillPresenter/runtimeSnapshot'
+
+function createEntry(name: string): PublishedSkillEntry {
+  const metadata: SkillMetadata = {
+    name,
+    description: name,
+    path: `/skills/${name}/SKILL.md`,
+    skillRoot: `/skills/${name}`
+  }
+  return Object.freeze({
+    sourceVersion: name,
+    availability: 'metadata_only' as const,
+    metadata: Object.freeze(metadata),
+    allowedTools: Object.freeze([])
+  })
+}
+
+describe('SkillRuntimeSnapshotState', () => {
+  it('keeps the epoch odd until every overlapping publication settles', async () => {
+    const state = new SkillRuntimeSnapshotState()
+    const onPublished = vi.fn()
+    const first = state.beginPublish(onPublished)
+    first.update((entries) => entries.set('a', createEntry('a')))
+    const settlement = state.settlementPromise
+    const second = state.beginPublish(onPublished)
+    second.update((entries) => entries.set('b', createEntry('b')))
+
+    expect(state.epoch).toBe(1)
+    expect(state.snapshot.epoch).toBe(0)
+    expect(state.snapshot.entries.size).toBe(0)
+    first.end()
+    expect(state.epoch).toBe(1)
+    expect(onPublished).not.toHaveBeenCalled()
+
+    second.end()
+    await settlement
+    expect(state.epoch).toBe(2)
+    expect(state.snapshot.epoch).toBe(2)
+    expect([...state.snapshot.entries.keys()]).toEqual(['a', 'b'])
+    expect(onPublished).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not expose mutating map methods from a published snapshot', () => {
+    const state = new SkillRuntimeSnapshotState()
+    state.replace(new Map([['a', createEntry('a')]]), () => {})
+    const entries = state.snapshot.entries as Map<string, PublishedSkillEntry>
+
+    expect(() => entries.set('b', createEntry('b'))).toThrow(TypeError)
+    expect(() => entries.delete('a')).toThrow(TypeError)
+    expect([...state.snapshot.entries.keys()]).toEqual(['a'])
+  })
+
+  it('rejects updates through a settled publication handle', () => {
+    const state = new SkillRuntimeSnapshotState()
+    const publish = state.beginPublish(() => {})
+    publish.end()
+
+    expect(() => publish.update((entries) => entries.clear())).toThrow(
+      'Skill runtime entries can only change inside an active publish window'
+    )
+  })
+})

--- a/test/main/presenter/skillPresenter/skillPresenter.test.ts
+++ b/test/main/presenter/skillPresenter/skillPresenter.test.ts
@@ -1143,7 +1143,7 @@ describe('SkillPresenter', () => {
       )
     })
 
-    it('rejects oversized skill markdown files before loading content', async () => {
+    it('quarantines oversized root skill sources during snapshot staging', async () => {
       ;(fs.statSync as Mock).mockReturnValue({
         isFile: () => true,
         size: 6 * 1024 * 1024,
@@ -1155,7 +1155,11 @@ describe('SkillPresenter', () => {
 
       expect(result).toEqual({
         success: false,
-        error: '[SkillPresenter] Skill file too large: 6291456 bytes (max: 5242880)'
+        error: 'Skill "test-skill" not found'
+      })
+      expect(skillPresenter.getPublishedRuntimeSnapshot().entries.get('test-skill')).toMatchObject({
+        availability: 'quarantined',
+        sourceError: { code: 'SOURCE_READ_FAILED' }
       })
       expect(fs.readFileSync).not.toHaveBeenCalledWith(
         expect.stringContaining('/test-skill/SKILL.md'),
@@ -1196,7 +1200,7 @@ describe('SkillPresenter', () => {
       })
     })
 
-    it('returns a structured error when main skill content access throws', async () => {
+    it('returns stable unavailable state when root snapshot staging fails', async () => {
       ;(fs.readFileSync as Mock).mockImplementation((target: string) => {
         if (String(target).endsWith('/test-skill/SKILL.md')) {
           throw new Error('Read failure')
@@ -1208,7 +1212,11 @@ describe('SkillPresenter', () => {
 
       expect(result).toEqual({
         success: false,
-        error: 'Failed to load skill view: Read failure'
+        error: 'Skill "test-skill" not found'
+      })
+      expect(skillPresenter.getPublishedRuntimeSnapshot().entries.get('test-skill')).toMatchObject({
+        availability: 'quarantined',
+        sourceError: { code: 'SOURCE_READ_FAILED' }
       })
     })
   })

--- a/test/main/presenter/skillPresenter/skillPresenter.test.ts
+++ b/test/main/presenter/skillPresenter/skillPresenter.test.ts
@@ -2857,8 +2857,12 @@ describe('SkillPresenter', () => {
       const originalMetadata = createSkillMetadata('skill-a', 'skill-a')
       const existingDuplicate = createSkillMetadata('skill-b', 'skill-b')
 
-      metadataCache.set(originalMetadata.name, originalMetadata)
-      metadataCache.set(existingDuplicate.name, existingDuplicate)
+      ;(skillPresenter as any).runtimeSnapshots.publishEntry(
+        createPublishedSkillEntry(originalMetadata)
+      )
+      ;(skillPresenter as any).runtimeSnapshots.publishEntry(
+        createPublishedSkillEntry(existingDuplicate)
+      )
       ;(skillPresenter as any).stagePublishedSkillEntry = vi
         .fn()
         .mockResolvedValue(createPublishedSkillEntry(createSkillMetadata('skill-b', 'skill-a')))

--- a/test/main/presenter/skillPresenter/skillPresenter.test.ts
+++ b/test/main/presenter/skillPresenter/skillPresenter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, Mock, afterEach } from 'vitest'
 import type { IConfigPresenter } from '../../../../src/shared/presenter'
-import type { SkillMetadata } from '../../../../src/shared/types/skill'
+import type { PublishedSkillEntry, SkillMetadata } from '../../../../src/shared/types/skill'
 import { app } from 'electron'
 
 const DEFAULT_SKILLS_DIR = '/mock/home/.deepchat/skills'
@@ -144,7 +144,8 @@ vi.mock('node:child_process', () => ({
   )
 }))
 
-vi.mock('node:crypto', () => ({
+vi.mock('node:crypto', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:crypto')>()),
   randomUUID: vi.fn().mockReturnValue('12345678-1234-1234-1234-123456789abc')
 }))
 
@@ -244,6 +245,23 @@ function createSkillMetadata(name: string, dirName: string): SkillMetadata {
     path: `${DEFAULT_SKILLS_DIR}/${dirName}/SKILL.md`,
     skillRoot: `${DEFAULT_SKILLS_DIR}/${dirName}`,
     category: null
+  }
+}
+
+function createPublishedSkillEntry(metadata: SkillMetadata): PublishedSkillEntry {
+  return {
+    sourceVersion: `source-${metadata.name}`,
+    availability: 'ready',
+    metadata,
+    renderedContent: `# ${metadata.name}`,
+    allowedTools: metadata.allowedTools ?? [],
+    extension: {
+      version: 1,
+      env: {},
+      runtimePolicy: { python: 'auto', node: 'auto' },
+      scriptOverrides: {}
+    },
+    scripts: []
   }
 }
 
@@ -1411,7 +1429,11 @@ describe('SkillPresenter', () => {
       })
       expect(fs.copyFileSync).toHaveBeenCalledWith(
         `${draftPath}/SKILL.md`,
-        `${DEFAULT_SKILLS_DIR}/draft-skill/SKILL.md`
+        expect.stringContaining('/.draft-skill.install-')
+      )
+      expect(fs.renameSync).toHaveBeenCalledWith(
+        expect.stringContaining('/.draft-skill.install-'),
+        `${DEFAULT_SKILLS_DIR}/draft-skill`
       )
       expect(fs.rmSync).toHaveBeenCalledWith(draftPath, { recursive: true, force: true })
     })
@@ -1598,7 +1620,7 @@ describe('SkillPresenter', () => {
       expect(result.error).toContain('already exists')
     })
 
-    it('should reinstall over stale residue without backup rename', async () => {
+    it('should atomically retire stale residue without creating a permanent backup', async () => {
       const targetDir = `${DEFAULT_SKILLS_DIR}/reloaded-skill`
       let removed = false
       ;(fs.existsSync as Mock).mockImplementation((target: string) => {
@@ -1622,8 +1644,14 @@ describe('SkillPresenter', () => {
       const result = await skillPresenter.installFromFolder('/source/reloaded', { overwrite: true })
 
       expect(result).toMatchObject({ success: true, skillName: 'reloaded-skill' })
-      expect(fs.rmSync).toHaveBeenCalledWith(targetDir, { recursive: true, force: true })
-      expect(fs.renameSync).not.toHaveBeenCalled()
+      expect(fs.renameSync).toHaveBeenCalledWith(
+        targetDir,
+        expect.stringContaining('/.reloaded-skill.replaced-')
+      )
+      expect(fs.renameSync).not.toHaveBeenCalledWith(
+        targetDir,
+        expect.stringContaining('/backups/skill-installs/')
+      )
     })
 
     it('should return target_locked when overwrite backup rename is denied', async () => {
@@ -1764,6 +1792,7 @@ describe('SkillPresenter', () => {
     })
 
     it('installs a conflicting Git skill with the rename strategy and records provenance', async () => {
+      let rewrittenManifest = ''
       ;(fs.existsSync as Mock).mockImplementation((target: string) => {
         if (target.endsWith('/SKILL.md')) return true
         if (target === `${DEFAULT_SKILLS_DIR}/guizang-ppt-skill`) return true
@@ -1771,6 +1800,26 @@ describe('SkillPresenter', () => {
         return true
       })
       ;(fs.readdirSync as Mock).mockReturnValue([createFileEntry('SKILL.md')])
+      ;(fs.readFileSync as Mock).mockImplementation((target: string) => {
+        if (target.includes('/.guizang-ppt-skill-1.install-') && rewrittenManifest) {
+          return rewrittenManifest
+        }
+        return '---\nname: guizang-ppt-skill\ndescription: PPT\n---\n# PPT'
+      })
+      ;(fs.writeFileSync as Mock).mockImplementation((target: string, content: string) => {
+        if (target.includes('/.guizang-ppt-skill-1.install-')) {
+          rewrittenManifest = content
+        }
+      })
+      ;(matter as unknown as Mock).mockImplementation((content: string) => ({
+        data: {
+          name: content.includes('name: guizang-ppt-skill-1')
+            ? 'guizang-ppt-skill-1'
+            : 'guizang-ppt-skill',
+          description: 'Create PPT files'
+        },
+        content: '# PPT'
+      }))
 
       const results = await skillPresenter.installSkillsFromGit({
         repoUrl: 'https://github.com/op7418/guizang-ppt-skill',
@@ -1787,7 +1836,7 @@ describe('SkillPresenter', () => {
       ])
       expect(fs.copyFileSync).toHaveBeenCalledWith(
         expect.stringContaining('/SKILL.md'),
-        `${DEFAULT_SKILLS_DIR}/guizang-ppt-skill-1/SKILL.md`
+        expect.stringContaining('/.guizang-ppt-skill-1.install-')
       )
       expect((matter as any).stringify).toHaveBeenCalledWith(
         '# PPT',
@@ -2078,8 +2127,8 @@ describe('SkillPresenter', () => {
         content: 'content'
       })
       ;(fs.existsSync as Mock).mockImplementation((target: string) => target === skillDir)
-      ;(fs.rmSync as Mock).mockImplementation(() => {
-        throw lockError
+      ;(fs.renameSync as Mock).mockImplementation((source: string) => {
+        if (source === skillDir) throw lockError
       })
       publishDeepchatEventMock.mockClear()
 
@@ -2092,7 +2141,7 @@ describe('SkillPresenter', () => {
         targetPath: skillDir
       })
       expect((skillPresenter as any).metadataCache.has('locked-skill')).toBe(true)
-      expect((skillPresenter as any).contentCache.has('locked-skill')).toBe(true)
+      expect(skillPresenter.getPublishedRuntimeSnapshot().entries.has('locked-skill')).toBe(true)
       expect(publishDeepchatEventMock).not.toHaveBeenCalled()
     })
   })
@@ -2159,9 +2208,13 @@ describe('SkillPresenter', () => {
 
       expect(result).toEqual({ success: true, skillName: 'test-skill' })
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringContaining('/test-skill/SKILL.md'),
+        expect.stringContaining('/test-skill/.SKILL.md.'),
         'new content',
         'utf-8'
+      )
+      expect(fs.renameSync).toHaveBeenCalledWith(
+        expect.stringContaining('/test-skill/.SKILL.md.'),
+        expect.stringContaining('/test-skill/SKILL.md')
       )
       const state = configSettings.get('skills.managementState') as any
       expect(state.skills['test-skill'].extension).toEqual(extension)
@@ -2187,7 +2240,7 @@ describe('SkillPresenter', () => {
       expect(result.success).toBe(false)
       expect(result.error).toContain('management state write failed')
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringContaining('/test-skill/SKILL.md'),
+        expect.stringContaining('/test-skill/.SKILL.md.'),
         'old skill content',
         'utf-8'
       )
@@ -2806,17 +2859,20 @@ describe('SkillPresenter', () => {
 
       metadataCache.set(originalMetadata.name, originalMetadata)
       metadataCache.set(existingDuplicate.name, existingDuplicate)
-      ;(skillPresenter as any).parseSkillMetadata = vi
+      ;(skillPresenter as any).stagePublishedSkillEntry = vi
         .fn()
-        .mockResolvedValue(createSkillMetadata('skill-b', 'skill-a'))
+        .mockResolvedValue(createPublishedSkillEntry(createSkillMetadata('skill-b', 'skill-a')))
 
       await skillPresenter.watchSkillFiles()
       const watcher = fakeWatcherService.watchers.at(-1)
 
       await watcher?.emit([{ type: 'update', path: originalMetadata.path }])
 
-      expect(metadataCache.has('skill-a')).toBe(false)
+      expect(metadataCache.has('skill-a')).toBe(true)
       expect(metadataCache.get('skill-b')).toEqual(existingDuplicate)
+      expect(
+        skillPresenter.getPublishedRuntimeSnapshot().entries.get('skill-a')?.sourceError
+      ).toEqual(expect.objectContaining({ code: 'DUPLICATE_SKILL_NAME' }))
       expect(logger.warn).toHaveBeenCalledWith(
         '[SkillPresenter] Duplicate skill name discovered. Keeping the first entry.',
         expect.objectContaining({
@@ -2834,7 +2890,9 @@ describe('SkillPresenter', () => {
       const renamedMetadata = createSkillMetadata('skill-c', 'skill-a')
 
       metadataCache.set(originalMetadata.name, originalMetadata)
-      ;(skillPresenter as any).parseSkillMetadata = vi.fn().mockResolvedValue(renamedMetadata)
+      ;(skillPresenter as any).stagePublishedSkillEntry = vi
+        .fn()
+        .mockResolvedValue(createPublishedSkillEntry(renamedMetadata))
 
       await skillPresenter.watchSkillFiles()
       const watcher = fakeWatcherService.watchers.at(-1)
@@ -2860,7 +2918,9 @@ describe('SkillPresenter', () => {
       const duplicateMetadata = createSkillMetadata('skill-b', 'skill-candidate')
 
       metadataCache.set(existingMetadata.name, existingMetadata)
-      ;(skillPresenter as any).parseSkillMetadata = vi.fn().mockResolvedValue(duplicateMetadata)
+      ;(skillPresenter as any).stagePublishedSkillEntry = vi
+        .fn()
+        .mockResolvedValue(createPublishedSkillEntry(duplicateMetadata))
 
       await skillPresenter.watchSkillFiles()
       const watcher = fakeWatcherService.watchers.at(-1)

--- a/test/main/presenter/skillPresenter/skillRuntimeSnapshot.test.ts
+++ b/test/main/presenter/skillPresenter/skillRuntimeSnapshot.test.ts
@@ -181,6 +181,8 @@ describe('SkillPresenter runtime snapshots', () => {
     expect(Object.isFrozen(publishedEntry?.extension?.runtimePolicy)).toBe(true)
     expect(Object.isFrozen(publishedEntry?.scripts)).toBe(true)
     expect(Object.isFrozen(publishedEntry?.scripts?.[0])).toBe(true)
+    expect(Object.isFrozen(publishedEntry?.linkedFiles)).toBe(true)
+    expect(Object.isFrozen(publishedEntry?.linkedFiles?.[0])).toBe(true)
 
     const mutableEntries = published.entries as Map<string, unknown>
     expect(() => mutableEntries.set('injected', {})).toThrow(TypeError)
@@ -218,6 +220,147 @@ describe('SkillPresenter runtime snapshots', () => {
     await (presenter as any).handleSkillFileAdded(path.join(root, 'invalid-new', 'SKILL.md'))
 
     expect(presenter.getPublishedRuntimeSnapshot().entries.has('invalid-new')).toBe(false)
+  })
+
+  it('serves root skill views from one captured snapshot while linked-file views stay explicit', async () => {
+    writeSkill(root, 'review', { description: 'Version A', body: '# Body A' })
+    const referencesDir = path.join(root, 'review', 'references')
+    fs.mkdirSync(referencesDir, { recursive: true })
+    fs.writeFileSync(path.join(referencesDir, 'guide.md'), '# Guide A', 'utf-8')
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+
+    writeSkill(root, 'review', { description: 'Version B', body: '# Body B' })
+    fs.writeFileSync(path.join(referencesDir, 'guide.md'), '# Guide B', 'utf-8')
+    const readFile = vi.spyOn(fs.promises, 'readFile')
+    const stat = vi.spyOn(fs.promises, 'stat')
+    const readdir = vi.spyOn(fs.promises, 'readdir')
+
+    const rootView = await presenter.viewSkill('review', { filePath: 'SKILL.md' })
+
+    expect(rootView).toMatchObject({
+      success: true,
+      name: 'review',
+      filePath: null,
+      content: expect.stringContaining('# Body A'),
+      linkedFiles: [{ kind: 'reference', path: 'references/guide.md' }]
+    })
+    expect(rootView.content).not.toContain('# Body B')
+    expect(readFile).not.toHaveBeenCalled()
+    expect(stat).not.toHaveBeenCalled()
+    expect(readdir).not.toHaveBeenCalled()
+
+    const linkedView = await presenter.viewSkill('review', {
+      filePath: 'references/guide.md'
+    })
+    expect(linkedView).toMatchObject({
+      success: true,
+      filePath: 'references/guide.md',
+      content: '# Guide B'
+    })
+    expect(readFile).toHaveBeenCalledWith(path.join(referencesDir, 'guide.md'), 'utf-8')
+
+    const newReferencePath = path.join(referencesDir, 'new.md')
+    fs.writeFileSync(newReferencePath, '# New reference', 'utf-8')
+    await (presenter as any).handlePublishedSkillAuxiliarySourceChanged(newReferencePath, 'create')
+    await expect(presenter.viewSkill('review')).resolves.toMatchObject({
+      success: true,
+      content: expect.stringContaining('# Body B'),
+      linkedFiles: [
+        { kind: 'reference', path: 'references/guide.md' },
+        { kind: 'reference', path: 'references/new.md' }
+      ]
+    })
+  })
+
+  it('publishes a plugin registration after a watcher invalidates catalog discovery', async () => {
+    writeSkill(root, 'regular', { description: 'Regular A', body: '# Regular A' })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('regular')
+    const pluginBase = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-plugin-runtime-'))
+    const pluginSkillRoot = path.join(pluginBase, 'plugin-skill')
+    writeSkill(pluginBase, 'plugin-skill', {
+      description: 'Plugin',
+      body: '# Plugin body'
+    })
+    const pluginPath = path.join(pluginSkillRoot, 'SKILL.md')
+    const parseStarted = createDeferred<void>()
+    const releaseParse = createDeferred<void>()
+    const originalParse = (presenter as any).parseSkillMetadata.bind(presenter)
+    let heldPluginParse = false
+    vi.spyOn(presenter as any, 'parseSkillMetadata').mockImplementation(
+      async (skillPath: string, ...args: unknown[]) => {
+        if (skillPath === pluginPath && !heldPluginParse) {
+          heldPluginParse = true
+          parseStarted.resolve()
+          await releaseParse.promise
+        }
+        return await originalParse(skillPath, ...args)
+      }
+    )
+
+    try {
+      const registration = presenter.registerPluginSkill({
+        ownerPluginId: 'plugin.fixture',
+        id: 'plugin-skill',
+        skillRoot: pluginSkillRoot,
+        pluginRoot: pluginBase
+      })
+      await parseStarted.promise
+      writeSkill(root, 'regular', { description: 'Regular B', body: '# Regular B' })
+      await (presenter as any).handleSkillFileChanged(path.join(root, 'regular', 'SKILL.md'))
+      releaseParse.resolve()
+      await registration
+
+      expect(presenter.getPublishedRuntimeSnapshot().entries.get('plugin-skill')).toMatchObject({
+        availability: 'ready',
+        metadata: {
+          path: pluginPath,
+          ownerPluginId: 'plugin.fixture'
+        },
+        renderedContent: expect.stringContaining('# Plugin body')
+      })
+    } finally {
+      fs.rmSync(pluginBase, { recursive: true, force: true })
+    }
+  })
+
+  it('removes plugin snapshots after a watcher invalidates unregister discovery', async () => {
+    const pluginBase = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-plugin-runtime-'))
+    const pluginSkillRoot = path.join(pluginBase, 'plugin-skill')
+    writeSkill(pluginBase, 'plugin-skill', {
+      description: 'Plugin',
+      body: '# Plugin body'
+    })
+    const pluginPath = path.join(pluginSkillRoot, 'SKILL.md')
+
+    try {
+      await presenter.registerPluginSkill({
+        ownerPluginId: 'plugin.fixture',
+        id: 'plugin-skill',
+        skillRoot: pluginSkillRoot,
+        pluginRoot: pluginBase
+      })
+      await presenter.loadSkillContent('plugin-skill')
+      const discoveryStarted = createDeferred<void>()
+      const releaseDiscovery = createDeferred<void>()
+      discoveryWorkerMock.discoverSkillMetadataInWorker.mockImplementationOnce(async () => {
+        discoveryStarted.resolve()
+        await releaseDiscovery.promise
+        return { skills: [], warnings: [] }
+      })
+
+      const unregister = presenter.unregisterPluginSkillsByOwner('plugin.fixture')
+      await discoveryStarted.promise
+      await (presenter as any).handleSkillFileChanged(pluginPath)
+      releaseDiscovery.resolve()
+      await unregister
+
+      expect(presenter.getPublishedRuntimeSnapshot().entries.has('plugin-skill')).toBe(false)
+      expect(await presenter.getMetadataList()).toEqual([])
+    } finally {
+      fs.rmSync(pluginBase, { recursive: true, force: true })
+    }
   })
 
   it('rejects repo-owned parse-null before writing the source file', async () => {
@@ -451,6 +594,33 @@ describe('SkillPresenter runtime snapshots', () => {
     endPublish()
     await presenter.destroy()
     expect(presenter.getPublishedRuntimeSnapshot().entries.size).toBe(0)
+  })
+
+  it('does not let a late watcher revive a missing skill after uninstall cleanup', async () => {
+    writeSkill(root, 'review', { description: 'Version A', body: '# Body A' })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const skillPath = path.join(root, 'review', 'SKILL.md')
+    const metadata = presenter.getPublishedRuntimeSnapshot().entries.get('review')!.metadata as any
+    const watcherCandidate = await (presenter as any).stagePublishedSkillEntry(metadata)
+    const stageStarted = createDeferred<void>()
+    const deferredStage = createDeferred<typeof watcherCandidate>()
+    vi.spyOn(presenter as any, 'stagePublishedSkillEntry').mockImplementationOnce(async () => {
+      stageStarted.resolve()
+      return await deferredStage.promise
+    })
+
+    const staleWatcher = (presenter as any).handleSkillFileChanged(skillPath) as Promise<void>
+    await stageStarted.promise
+    fs.rmSync(path.join(root, 'review'), { recursive: true, force: true })
+    await expect(presenter.uninstallSkill('review')).resolves.toMatchObject({
+      success: false,
+      errorCode: 'not_found'
+    })
+    deferredStage.resolve(watcherCandidate)
+    await staleWatcher
+
+    expect(presenter.getPublishedRuntimeSnapshot().entries.has('review')).toBe(false)
   })
 
   it('serves compatibility runtime APIs from a captured ready snapshot without source disk reads', async () => {

--- a/test/main/presenter/skillPresenter/skillRuntimeSnapshot.test.ts
+++ b/test/main/presenter/skillPresenter/skillRuntimeSnapshot.test.ts
@@ -1,0 +1,427 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { IConfigPresenter } from '../../../../src/shared/presenter'
+import type { IFileWatcherService } from '../../../../src/main/lib/fileWatcher'
+import {
+  SkillRuntimeUpdatingError,
+  type SkillManagementState
+} from '../../../../src/shared/types/skill'
+
+const discoveryWorkerMock = vi.hoisted(() => ({
+  discoverSkillMetadataInWorker: vi.fn(),
+  logSkillDiscoveryWorkerWarnings: vi.fn()
+}))
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return { ...actual, default: actual }
+})
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+  return { ...actual, default: actual }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((name: string) => (name === 'home' ? os.homedir() : os.tmpdir())),
+    getAppPath: vi.fn(() => process.cwd()),
+    isPackaged: false
+  },
+  shell: { openPath: vi.fn().mockResolvedValue('') }
+}))
+
+vi.mock('@/routes/publishDeepchatEvent', () => ({
+  publishDeepchatEvent: vi.fn()
+}))
+
+vi.mock('../../../../src/main/presenter/skillPresenter/discoveryWorker', () => discoveryWorkerMock)
+
+import { SkillPresenter } from '../../../../src/main/presenter/skillPresenter'
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function createSessionStatePort() {
+  return {
+    hasNewSession: vi.fn().mockResolvedValue(true),
+    getPersistedNewSessionSkills: vi.fn().mockReturnValue([]),
+    setPersistedNewSessionSkills: vi.fn(),
+    repairImportedLegacySessionSkills: vi.fn().mockResolvedValue([])
+  }
+}
+
+function writeSkill(
+  root: string,
+  name: string,
+  input: { description: string; body: string; allowedTools?: string[]; script?: string }
+) {
+  const skillRoot = path.join(root, name)
+  fs.mkdirSync(skillRoot, { recursive: true })
+  const allowedTools = input.allowedTools?.length
+    ? `allowedTools:\n${input.allowedTools.map((tool) => `  - ${tool}`).join('\n')}\n`
+    : ''
+  fs.writeFileSync(
+    path.join(skillRoot, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${input.description}\n${allowedTools}---\n\n${input.body}`,
+    'utf-8'
+  )
+  if (input.script) {
+    const scriptsDir = path.join(skillRoot, 'scripts')
+    fs.mkdirSync(scriptsDir, { recursive: true })
+    fs.writeFileSync(path.join(scriptsDir, input.script), 'print("ok")', 'utf-8')
+  }
+}
+
+describe('SkillPresenter runtime snapshots', () => {
+  let root: string
+  let presenter: SkillPresenter
+  let settings: Map<string, unknown>
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-skill-runtime-'))
+    settings = new Map()
+    discoveryWorkerMock.discoverSkillMetadataInWorker.mockRejectedValue(new Error('test fallback'))
+    const config = {
+      getSkillsPath: vi.fn(() => root),
+      getSetting: vi.fn((key: string) => settings.get(key)),
+      setSetting: vi.fn((key: string, value: unknown) => settings.set(key, value))
+    } as unknown as IConfigPresenter
+    presenter = new SkillPresenter(config, createSessionStatePort(), {
+      watch: vi.fn()
+    } as unknown as IFileWatcherService)
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    await presenter.destroy()
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('publishes metadata, body, scripts and allowed tools from one staged source version', async () => {
+    writeSkill(root, 'review', {
+      description: 'Version A',
+      body: '# Body A',
+      allowedTools: ['read_file'],
+      script: 'run.py'
+    })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const previous = presenter.getPublishedRuntimeSnapshot()
+    const previousEntry = previous.entries.get('review')
+    expect(previousEntry).toMatchObject({
+      availability: 'ready',
+      metadata: { description: 'Version A' },
+      allowedTools: ['read_file']
+    })
+    expect(previousEntry?.renderedContent).toContain('# Body A')
+    expect(previousEntry?.scripts?.map((script) => script.relativePath)).toEqual(['scripts/run.py'])
+
+    writeSkill(root, 'review', {
+      description: 'Version B',
+      body: '# Body B',
+      allowedTools: ['write_file'],
+      script: 'check.js'
+    })
+    fs.rmSync(path.join(root, 'review', 'scripts', 'run.py'))
+
+    const deferredRead = createDeferred<string>()
+    const originalReadFile = fs.promises.readFile.bind(fs.promises)
+    let deferManifestRead = true
+    vi.spyOn(fs.promises, 'readFile').mockImplementation(async (target, options) => {
+      if (deferManifestRead && target === path.join(root, 'review', 'SKILL.md')) {
+        deferManifestRead = false
+        return await deferredRead.promise
+      }
+      return await originalReadFile(target, options as BufferEncoding)
+    })
+
+    const watcherUpdate = (presenter as any).handleSkillFileChanged(
+      path.join(root, 'review', 'SKILL.md')
+    ) as Promise<void>
+    await Promise.resolve()
+
+    const duringStage = presenter.getPublishedRuntimeSnapshot()
+    expect(duringStage.epoch).toBe(previous.epoch)
+    expect(duringStage.entries.get('review')).toBe(previousEntry)
+    expect((await presenter.loadSkillContent('review'))?.content).toContain('# Body A')
+
+    deferredRead.resolve(fs.readFileSync(path.join(root, 'review', 'SKILL.md'), 'utf-8'))
+    await watcherUpdate
+
+    const published = presenter.getPublishedRuntimeSnapshot()
+    const publishedEntry = published.entries.get('review')
+    expect(published.epoch).toBeGreaterThan(previous.epoch)
+    expect(published.epoch % 2).toBe(0)
+    expect(publishedEntry?.sourceVersion).not.toBe(previousEntry?.sourceVersion)
+    expect(publishedEntry).toMatchObject({
+      availability: 'ready',
+      metadata: { description: 'Version B' },
+      allowedTools: ['write_file']
+    })
+    expect(publishedEntry?.renderedContent).toContain('# Body B')
+    expect(publishedEntry?.renderedContent).not.toContain('# Body A')
+    expect(publishedEntry?.scripts?.map((script) => script.relativePath)).toEqual([
+      'scripts/check.js'
+    ])
+    expect(Object.isFrozen(publishedEntry)).toBe(true)
+    expect(Object.isFrozen(publishedEntry?.metadata)).toBe(true)
+    expect(Object.isFrozen(publishedEntry?.allowedTools)).toBe(true)
+    expect(Object.isFrozen(publishedEntry?.extension)).toBe(true)
+    expect(Object.isFrozen(publishedEntry?.extension?.runtimePolicy)).toBe(true)
+    expect(Object.isFrozen(publishedEntry?.scripts)).toBe(true)
+    expect(Object.isFrozen(publishedEntry?.scripts?.[0])).toBe(true)
+
+    const mutableEntries = published.entries as Map<string, unknown>
+    expect(() => mutableEntries.set('injected', {})).toThrow(TypeError)
+    expect(() => mutableEntries.delete('review')).toThrow(TypeError)
+    expect(presenter.getPublishedRuntimeSnapshot().entries.has('injected')).toBe(false)
+    expect(presenter.getPublishedRuntimeSnapshot().entries.has('review')).toBe(true)
+  })
+
+  it('keeps the complete LKG on an invalid watcher update and ignores an invalid new skill', async () => {
+    writeSkill(root, 'review', {
+      description: 'Valid',
+      body: '# Valid body',
+      allowedTools: ['read_file']
+    })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const previousEntry = presenter.getPublishedRuntimeSnapshot().entries.get('review')
+
+    fs.writeFileSync(path.join(root, 'review', 'SKILL.md'), '---\nname: review\n---\nBroken')
+    await (presenter as any).handleSkillFileChanged(path.join(root, 'review', 'SKILL.md'))
+
+    const retained = presenter.getPublishedRuntimeSnapshot().entries.get('review')
+    expect(retained?.metadata).toBe(previousEntry?.metadata)
+    expect(retained?.renderedContent).toBe(previousEntry?.renderedContent)
+    expect(retained?.allowedTools).toBe(previousEntry?.allowedTools)
+    expect(retained?.sourceVersion).toBe(previousEntry?.sourceVersion)
+    expect(retained?.sourceError?.code).toBe('INVALID_SOURCE')
+
+    fs.mkdirSync(path.join(root, 'invalid-new'), { recursive: true })
+    fs.writeFileSync(path.join(root, 'invalid-new', 'SKILL.md'), '---\nname: invalid-new\n---')
+    await (presenter as any).handleSkillFileAdded(path.join(root, 'invalid-new', 'SKILL.md'))
+
+    expect(presenter.getPublishedRuntimeSnapshot().entries.has('invalid-new')).toBe(false)
+  })
+
+  it('rejects repo-owned parse-null before writing the source file', async () => {
+    writeSkill(root, 'review', { description: 'Valid', body: '# Original' })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const skillPath = path.join(root, 'review', 'SKILL.md')
+    const original = fs.readFileSync(skillPath, 'utf-8')
+    const atomicWrite = vi.spyOn(presenter as any, 'atomicWriteFile')
+
+    const result = await presenter.updateSkillFile('review', '---\nname: review\n---\nInvalid')
+
+    expect(result.success).toBe(false)
+    expect(atomicWrite).not.toHaveBeenCalled()
+    expect(fs.readFileSync(skillPath, 'utf-8')).toBe(original)
+    expect(
+      presenter.getPublishedRuntimeSnapshot().entries.get('review')?.renderedContent
+    ).toContain('# Original')
+  })
+
+  it('keeps repo-owned writes behind the shared odd publish barrier', async () => {
+    writeSkill(root, 'review', { description: 'Old', body: '# Old' })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const previous = presenter.getPublishedRuntimeSnapshot()
+    const originalAtomicWrite = (presenter as any).atomicWriteFile.bind(presenter)
+    let waitingForPublish: Promise<unknown> | undefined
+    vi.spyOn(presenter as any, 'atomicWriteFile').mockImplementation(
+      (target: string, content: string) => {
+        expect(presenter.getPublishedRuntimeSnapshot()).toBe(previous)
+        waitingForPublish = presenter.waitForStableRuntimeSnapshot({
+          requiredSkillNames: ['review'],
+          signal: new AbortController().signal,
+          deadlineAt: Date.now() + 1_000
+        })
+        return originalAtomicWrite(target, content)
+      }
+    )
+
+    const result = await presenter.updateSkillFile(
+      'review',
+      '---\nname: review\ndescription: New\n---\n\n# New'
+    )
+
+    expect(result).toEqual({ success: true, skillName: 'review' })
+    const published = await waitingForPublish
+    expect(published).toBe(presenter.getPublishedRuntimeSnapshot())
+    expect(presenter.getPublishedRuntimeSnapshot().epoch).toBe(previous.epoch + 2)
+    expect(
+      presenter.getPublishedRuntimeSnapshot().entries.get('review')?.renderedContent
+    ).toContain('# New')
+  })
+
+  it('bounds a hung readiness stage and aborts each waiter independently', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-10T00:00:00.000Z'))
+    writeSkill(root, 'review', { description: 'Valid', body: '# Body' })
+    await presenter.discoverSkills()
+    const never = createDeferred<never>()
+    vi.spyOn(presenter as any, 'stagePublishedSkillEntry').mockReturnValue(never.promise)
+    const sharedStage = presenter.waitForStableRuntimeSnapshot({
+      requiredSkillNames: ['review'],
+      signal: new AbortController().signal,
+      deadlineAt: Date.now() + 200
+    })
+    const abortController = new AbortController()
+    const abortedWaiter = presenter.waitForStableRuntimeSnapshot({
+      requiredSkillNames: ['review'],
+      signal: abortController.signal,
+      deadlineAt: Date.now() + 200
+    })
+
+    abortController.abort()
+    await expect(abortedWaiter).rejects.toMatchObject({ name: 'AbortError' })
+    await vi.advanceTimersByTimeAsync(199)
+    let settled = false
+    void sharedStage.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    await vi.advanceTimersByTimeAsync(1)
+    await expect(sharedStage).rejects.toBeInstanceOf(SkillRuntimeUpdatingError)
+  })
+
+  it('bounds a hung odd publish window without exposing its pending entries', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-10T00:00:00.000Z'))
+    writeSkill(root, 'review', { description: 'Valid', body: '# Body' })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const previous = presenter.getPublishedRuntimeSnapshot()
+    const endPublish = (presenter as any).beginRuntimePublish() as () => void
+    const wait = presenter.waitForStableRuntimeSnapshot({
+      requiredSkillNames: ['review'],
+      signal: new AbortController().signal,
+      deadlineAt: Date.now() + 200
+    })
+    const waitRejection = expect(wait).rejects.toBeInstanceOf(SkillRuntimeUpdatingError)
+
+    expect(presenter.getPublishedRuntimeSnapshot()).toBe(previous)
+    await vi.advanceTimersByTimeAsync(199)
+    expect(presenter.getPublishedRuntimeSnapshot()).toBe(previous)
+    await vi.advanceTimersByTimeAsync(1)
+    await waitRejection
+    endPublish()
+    expect(presenter.getPublishedRuntimeSnapshot().epoch).toBe(previous.epoch + 2)
+  })
+
+  it('serves compatibility runtime APIs from a captured ready snapshot without source disk reads', async () => {
+    writeSkill(root, 'review', {
+      description: 'Valid',
+      body: '# Body',
+      allowedTools: ['read_file'],
+      script: 'run.py'
+    })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const readSpy = vi.spyOn(fs.promises, 'readFile')
+    const statSpy = vi.spyOn(fs.promises, 'stat')
+    const readdirSpy = vi.spyOn(fs.promises, 'readdir')
+
+    expect((await presenter.getMetadataList()).map((skill) => skill.name)).toEqual(['review'])
+    expect((await presenter.loadSkillContent('review'))?.content).toContain('# Body')
+    expect((await presenter.listSkillScripts('review')).map((script) => script.name)).toEqual([
+      'run.py'
+    ])
+    expect(await presenter.getActiveSkillsAllowedTools('conversation', ['review'])).toEqual([
+      'read'
+    ])
+    expect(readSpy).not.toHaveBeenCalled()
+    expect(statSpy).not.toHaveBeenCalled()
+    expect(readdirSpy).not.toHaveBeenCalled()
+  })
+
+  it('publishes reconciled disk state after rollback leaves the disk outcome unknown', async () => {
+    writeSkill(root, 'review', { description: 'Old', body: '# Old' })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const state = (settings.get('skills.managementState') as SkillManagementState | undefined) ?? {
+      version: 1,
+      skills: {}
+    }
+    settings.set('skills.managementState', state)
+    const config = (presenter as any).configPresenter as IConfigPresenter
+    vi.spyOn(config, 'setSetting')
+      .mockImplementationOnce(() => {
+        throw new Error('extension write failed')
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('extension rollback failed')
+      })
+    const originalAtomicWrite = (presenter as any).atomicWriteFile.bind(presenter)
+    vi.spyOn(presenter as any, 'atomicWriteFile').mockImplementation(
+      (target: string, content: string) => {
+        if (content.includes('# Old')) {
+          throw new Error('source rollback failed')
+        }
+        return originalAtomicWrite(target, content)
+      }
+    )
+
+    const result = await presenter.saveSkillWithExtension(
+      'review',
+      '---\nname: review\ndescription: New\nallowedTools:\n  - write_file\n---\n\n# New',
+      {
+        version: 1,
+        env: {},
+        runtimePolicy: { python: 'auto', node: 'auto' },
+        scriptOverrides: {}
+      }
+    )
+
+    expect(result.success).toBe(false)
+    const reconciled = presenter.getPublishedRuntimeSnapshot().entries.get('review')
+    expect(reconciled?.availability).toBe('ready')
+    expect(reconciled?.metadata.description).toBe('New')
+    expect(reconciled?.renderedContent).toContain('# New')
+    expect(reconciled?.allowedTools).toEqual(['write_file'])
+    expect(reconciled?.sourceError).toBeUndefined()
+  })
+
+  it('quarantines an unknown source outcome when no LKG can be reconciled', async () => {
+    vi.useFakeTimers()
+    const metadata = {
+      name: 'new-skill',
+      description: 'New',
+      path: path.join(root, 'new-skill', 'SKILL.md'),
+      skillRoot: path.join(root, 'new-skill')
+    }
+    const stage = vi.spyOn(presenter as any, 'stagePublishedSkillEntry').mockResolvedValue(null)
+
+    await (presenter as any).reconcileUnknownSkillSource('new-skill', metadata, undefined)
+
+    const quarantined = presenter.getPublishedRuntimeSnapshot().entries.get('new-skill')
+    expect(quarantined).toMatchObject({
+      availability: 'quarantined',
+      allowedTools: [],
+      sourceError: { code: 'RECONCILE_REQUIRED' }
+    })
+    expect(await presenter.getMetadataList()).toEqual([])
+    expect(await presenter.loadSkillContent('new-skill')).toBeNull()
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(stage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/main/presenter/skillPresenter/skillRuntimeSnapshot.test.ts
+++ b/test/main/presenter/skillPresenter/skillRuntimeSnapshot.test.ts
@@ -325,6 +325,80 @@ describe('SkillPresenter runtime snapshots', () => {
     }
   })
 
+  it('publishes the current plugin revision when re-registration loses catalog CAS', async () => {
+    writeSkill(root, 'regular', { description: 'Regular A', body: '# Regular A' })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('regular')
+    const pluginBase = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-plugin-runtime-'))
+    const pluginSkillRoot = path.join(pluginBase, 'plugin-skill')
+    const firstPluginRoot = path.join(pluginBase, 'runtime-a')
+    const secondPluginRoot = path.join(pluginBase, 'runtime-b')
+    writeSkill(pluginBase, 'plugin-skill', {
+      description: 'Plugin A',
+      body: '# Plugin A\n\nPlugin root: `${PLUGIN_ROOT}`.'
+    })
+    const pluginPath = path.join(pluginSkillRoot, 'SKILL.md')
+
+    try {
+      await presenter.registerPluginSkill({
+        ownerPluginId: 'plugin.fixture',
+        id: 'plugin-skill',
+        skillRoot: pluginSkillRoot,
+        pluginRoot: firstPluginRoot
+      })
+      await presenter.loadSkillContent('plugin-skill')
+      const previousVersion = presenter
+        .getPublishedRuntimeSnapshot()
+        .entries.get('plugin-skill')!.sourceVersion
+
+      writeSkill(pluginBase, 'plugin-skill', {
+        description: 'Plugin B',
+        body: '# Plugin B\n\nPlugin root: `${PLUGIN_ROOT}`.'
+      })
+      const parseStarted = createDeferred<void>()
+      const releaseParse = createDeferred<void>()
+      const originalParse = (presenter as any).parseSkillMetadata.bind(presenter)
+      let heldPluginParse = false
+      vi.spyOn(presenter as any, 'parseSkillMetadata').mockImplementation(
+        async (skillPath: string, ...args: unknown[]) => {
+          if (skillPath === pluginPath && !heldPluginParse) {
+            heldPluginParse = true
+            parseStarted.resolve()
+            await releaseParse.promise
+          }
+          return await originalParse(skillPath, ...args)
+        }
+      )
+
+      const registration = presenter.registerPluginSkill({
+        ownerPluginId: 'plugin.fixture',
+        id: 'plugin-skill',
+        skillRoot: pluginSkillRoot,
+        pluginRoot: secondPluginRoot
+      })
+      await parseStarted.promise
+      writeSkill(root, 'regular', { description: 'Regular B', body: '# Regular B' })
+      await (presenter as any).handleSkillFileChanged(path.join(root, 'regular', 'SKILL.md'))
+      releaseParse.resolve()
+      await registration
+
+      const current = presenter.getPublishedRuntimeSnapshot().entries.get('plugin-skill')
+      expect(current).toMatchObject({
+        availability: 'ready',
+        metadata: {
+          description: 'Plugin B',
+          path: pluginPath,
+          ownerPluginId: 'plugin.fixture'
+        },
+        renderedContent: expect.stringContaining('# Plugin B')
+      })
+      expect(current?.renderedContent).toContain(`Plugin root: \`${secondPluginRoot}\`.`)
+      expect(current?.sourceVersion).not.toBe(previousVersion)
+    } finally {
+      fs.rmSync(pluginBase, { recursive: true, force: true })
+    }
+  })
+
   it('removes plugin snapshots after a watcher invalidates unregister discovery', async () => {
     const pluginBase = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-plugin-runtime-'))
     const pluginSkillRoot = path.join(pluginBase, 'plugin-skill')
@@ -621,6 +695,64 @@ describe('SkillPresenter runtime snapshots', () => {
     await staleWatcher
 
     expect(presenter.getPublishedRuntimeSnapshot().entries.has('review')).toBe(false)
+  })
+
+  it('keeps the runtime epoch stable while invalidating a pure missing late stage', async () => {
+    writeSkill(root, 'missing', { description: 'Missing', body: '# Missing' })
+    const skillPath = path.join(root, 'missing', 'SKILL.md')
+    const hint = (presenter as any).createStageMetadataHint(skillPath, 'missing')
+    const candidate = await (presenter as any).stagePublishedSkillEntry(hint)
+    fs.rmSync(path.join(root, 'missing'), { recursive: true, force: true })
+    const stageStarted = createDeferred<void>()
+    const deferredStage = createDeferred<typeof candidate>()
+    vi.spyOn(presenter as any, 'stagePublishedSkillEntry').mockImplementationOnce(async () => {
+      stageStarted.resolve()
+      return await deferredStage.promise
+    })
+
+    const staleAddition = (presenter as any).handleSkillFileAdded(skillPath) as Promise<void>
+    await stageStarted.promise
+    const before = presenter.getPublishedRuntimeSnapshot()
+
+    await expect(presenter.uninstallSkill('missing')).resolves.toMatchObject({
+      success: false,
+      errorCode: 'not_found'
+    })
+    deferredStage.resolve(candidate)
+    await staleAddition
+
+    expect(presenter.getPublishedRuntimeSnapshot()).toBe(before)
+    expect(presenter.getPublishedRuntimeSnapshot().entries.has('missing')).toBe(false)
+    expect(settings.has('skills.managementState')).toBe(false)
+  })
+
+  it('cleans management-only missing state without publishing a runtime epoch', async () => {
+    settings.set('skills.managementState', {
+      version: 1,
+      skills: {
+        missing: {
+          name: 'missing',
+          canonicalPath: path.join(root, 'missing'),
+          deepchat: { disabled: true },
+          extension: {
+            version: 1,
+            env: {},
+            runtimePolicy: { python: 'auto', node: 'auto' },
+            scriptOverrides: {}
+          },
+          source: { type: 'created' }
+        }
+      }
+    })
+    const before = presenter.getPublishedRuntimeSnapshot()
+
+    await expect(presenter.uninstallSkill('missing')).resolves.toMatchObject({
+      success: false,
+      errorCode: 'not_found'
+    })
+
+    expect(presenter.getPublishedRuntimeSnapshot()).toBe(before)
+    expect((settings.get('skills.managementState') as any).skills.missing).toBeUndefined()
   })
 
   it('serves compatibility runtime APIs from a captured ready snapshot without source disk reads', async () => {

--- a/test/main/presenter/skillPresenter/skillRuntimeSnapshot.test.ts
+++ b/test/main/presenter/skillPresenter/skillRuntimeSnapshot.test.ts
@@ -207,7 +207,11 @@ describe('SkillPresenter runtime snapshots', () => {
     expect(retained?.renderedContent).toBe(previousEntry?.renderedContent)
     expect(retained?.allowedTools).toBe(previousEntry?.allowedTools)
     expect(retained?.sourceVersion).toBe(previousEntry?.sourceVersion)
-    expect(retained?.sourceError?.code).toBe('INVALID_SOURCE')
+    expect(retained?.sourceError).toEqual({
+      code: 'INVALID_SOURCE',
+      message: 'Skill source is invalid'
+    })
+    expect(JSON.stringify(retained?.sourceError)).not.toContain('Broken')
 
     fs.mkdirSync(path.join(root, 'invalid-new'), { recursive: true })
     fs.writeFileSync(path.join(root, 'invalid-new', 'SKILL.md'), '---\nname: invalid-new\n---')
@@ -232,6 +236,107 @@ describe('SkillPresenter runtime snapshots', () => {
     expect(
       presenter.getPublishedRuntimeSnapshot().entries.get('review')?.renderedContent
     ).toContain('# Original')
+  })
+
+  it('does not let an update overwrite a newer watcher observation after an awaited read', async () => {
+    writeSkill(root, 'review', { description: 'Old', body: '# Old' })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const skillPath = path.join(root, 'review', 'SKILL.md')
+    const oldContent = fs.readFileSync(skillPath, 'utf-8')
+    const readStarted = createDeferred<void>()
+    const previousRead = createDeferred<string>()
+    vi.spyOn(presenter, 'readSkillFile').mockImplementationOnce(async () => {
+      readStarted.resolve()
+      return await previousRead.promise
+    })
+
+    const staleUpdate = presenter.updateSkillFile(
+      'review',
+      '---\nname: review\ndescription: Update A\n---\n\n# Update A'
+    )
+    await readStarted.promise
+
+    writeSkill(root, 'review', { description: 'Watcher B', body: '# Watcher B' })
+    await (presenter as any).handleSkillFileChanged(skillPath)
+    previousRead.resolve(oldContent)
+
+    await expect(staleUpdate).resolves.toMatchObject({ success: false })
+    const published = presenter.getPublishedRuntimeSnapshot().entries.get('review')
+    expect(published?.metadata.description).toBe('Watcher B')
+    expect(published?.renderedContent).toContain('# Watcher B')
+    expect(fs.readFileSync(skillPath, 'utf-8')).toContain('# Watcher B')
+  })
+
+  it('does not let a stale watcher stage overwrite a newer watcher publication', async () => {
+    writeSkill(root, 'review', { description: 'Old', body: '# Old' })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const skillPath = path.join(root, 'review', 'SKILL.md')
+    const metadata = presenter.getPublishedRuntimeSnapshot().entries.get('review')!.metadata as any
+
+    writeSkill(root, 'review', { description: 'Watcher A', body: '# Watcher A' })
+    const watcherCandidateA = await (presenter as any).stagePublishedSkillEntry(metadata)
+    const stageStarted = createDeferred<void>()
+    const deferredStage = createDeferred<typeof watcherCandidateA>()
+    const originalStage = (presenter as any).stagePublishedSkillEntry.bind(presenter)
+    vi.spyOn(presenter as any, 'stagePublishedSkillEntry')
+      .mockImplementationOnce(async () => {
+        stageStarted.resolve()
+        return await deferredStage.promise
+      })
+      .mockImplementation(originalStage)
+
+    const staleWatcher = (presenter as any).handleSkillFileChanged(skillPath) as Promise<void>
+    await stageStarted.promise
+    writeSkill(root, 'review', { description: 'Watcher B', body: '# Watcher B' })
+    await (presenter as any).handleSkillFileChanged(skillPath)
+    deferredStage.resolve(watcherCandidateA)
+    await staleWatcher
+
+    const published = presenter.getPublishedRuntimeSnapshot().entries.get('review')
+    expect(published?.metadata.description).toBe('Watcher B')
+    expect(published?.renderedContent).toContain('# Watcher B')
+  })
+
+  it('does not let a stale whole-catalog discovery replace a newer watcher publication', async () => {
+    writeSkill(root, 'review', { description: 'Old', body: '# Old' })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const skillPath = path.join(root, 'review', 'SKILL.md')
+
+    writeSkill(root, 'review', { description: 'Discovery A', body: '# Discovery A' })
+    await (presenter as any).handleSkillFileChanged(skillPath)
+    const discoveryCandidate = presenter.getPublishedRuntimeSnapshot().entries.get('review')!
+
+    writeSkill(root, 'review', { description: 'Old', body: '# Old' })
+    await (presenter as any).handleSkillFileChanged(skillPath)
+    const metadata = presenter.getPublishedRuntimeSnapshot().entries.get('review')!.metadata as any
+    discoveryWorkerMock.discoverSkillMetadataInWorker.mockResolvedValue({
+      skills: [metadata],
+      warnings: []
+    })
+
+    const stageStarted = createDeferred<void>()
+    const deferredStage = createDeferred<typeof discoveryCandidate>()
+    const originalStage = (presenter as any).stagePublishedSkillEntry.bind(presenter)
+    vi.spyOn(presenter as any, 'stagePublishedSkillEntry')
+      .mockImplementationOnce(async () => {
+        stageStarted.resolve()
+        return await deferredStage.promise
+      })
+      .mockImplementation(originalStage)
+
+    const discovery = presenter.discoverSkills()
+    await stageStarted.promise
+    writeSkill(root, 'review', { description: 'Watcher B', body: '# Watcher B' })
+    await (presenter as any).handleSkillFileChanged(skillPath)
+    deferredStage.resolve(discoveryCandidate)
+    await discovery
+
+    const published = presenter.getPublishedRuntimeSnapshot().entries.get('review')
+    expect(published?.metadata.description).toBe('Watcher B')
+    expect(published?.renderedContent).toContain('# Watcher B')
   })
 
   it('keeps repo-owned writes behind the shared odd publish barrier', async () => {
@@ -326,6 +431,26 @@ describe('SkillPresenter runtime snapshots', () => {
     await waitRejection
     endPublish()
     expect(presenter.getPublishedRuntimeSnapshot().epoch).toBe(previous.epoch + 2)
+  })
+
+  it('rejects destroy without partially resetting an active publication', async () => {
+    writeSkill(root, 'review', { description: 'Valid', body: '# Body' })
+    await presenter.discoverSkills()
+    await presenter.loadSkillContent('review')
+    const previousEntry = presenter.getPublishedRuntimeSnapshot().entries.get('review')
+    const sourcePath = previousEntry!.metadata.path
+    const observation = (presenter as any).runtimeSnapshots.nextObservation(sourcePath)
+    const endPublish = (presenter as any).beginRuntimePublish() as () => void
+
+    await expect(presenter.destroy()).rejects.toThrow(
+      'Cannot reset skill runtime snapshot during publication'
+    )
+    expect((presenter as any).runtimeSnapshots.currentObservation(sourcePath)).toBe(observation)
+    expect(presenter.getPublishedRuntimeSnapshot().entries.get('review')).toBe(previousEntry)
+
+    endPublish()
+    await presenter.destroy()
+    expect(presenter.getPublishedRuntimeSnapshot().entries.size).toBe(0)
   })
 
   it('serves compatibility runtime APIs from a captured ready snapshot without source disk reads', async () => {


### PR DESCRIPTION
## Scope

This PR delivers PRM-002B only: one immutable, published runtime snapshot for skill metadata, rendered root content, allowed tools, extension policy, script descriptors, and linked-file listing.

It changes the SkillPresenter lifecycle and its internal snapshot state machine, but intentionally does not wire the skill epoch into the outer system-prompt cache or tool-profile cache. That orchestration remains PRM-002C, and P-07 stays open.

## Why

The previous skill APIs could read metadata, content, tools, scripts, and extension state at different times. A watcher or mutation between those reads could expose a mixed pair to the runtime: for example, new skill content with old allowed tools.

This is a high-risk area, so the implementation was held through repeated independent review instead of relying on broad green tests. The final design publishes complete immutable entries behind an odd/even epoch and keeps the last known good entry until a complete replacement is ready.

## Implementation

### Immutable publication

- Each published entry includes one sourceVersion covering rendered inputs: raw body, metadata, allowed tools, extension, scripts, linked-file listing, roots/owner, and architecture.
- Metadata, extension, scripts, linked files, entry objects, and the exposed map view are runtime-immutable.
- Publication moves through an odd epoch and exposes a new even snapshot only when all overlapping publish handles settle.
- Waiters share readiness work, have caller-local abort/deadline behavior, and never receive a mixed snapshot.
- Observer failures are exception-safe: an already published even snapshot remains valid and settlement bookkeeping is always closed.

### Last-known-good and quarantine

- Existing ready entries remain fully usable when a refresh is invalid or transiently fails.
- A new metadata-only entry that cannot produce a complete runtime candidate becomes stable quarantined state instead of rereading disk on every caller.
- Published source diagnostics use stable, content-free code/message pairs. Raw errors and paths remain main-local logs.

### Concurrency and lifecycle

- Per-source observation CAS is checked at the atomic publish/update boundary.
- Whole-catalog discovery uses a catalog observation token and does not overwrite a later watcher/mutation publication.
- Reset/destroy rejects atomically during an active publication and uses a monotonic observation floor to prevent late-worker ABA.
- Repo update, install, adopt, uninstall, plugin registration, plugin unregistration, extension/script changes, and watcher paths all converge through the published snapshot contract.
- Plugin re-registration stages the current complete candidate and verifies sourceVersion, plugin root, owner, and observation before accepting an existing entry.
- Missing uninstall invalidates late watcher work but does not advance the epoch when neither the snapshot nor runtime-visible state changes.
- Root skill_view reads the captured ready snapshot and performs no source-disk reread. Explicit linked-file view remains a bounded file read by contract.

### Compatibility

Existing SkillPresenter string/list APIs remain available but read from the published snapshot on runtime paths. AgentRuntime and ToolPresenter orchestration fingerprints are unchanged in this slice.

## Impact

For the same stable sources, user-visible skill content and tool behavior remain compatible.

The benefit is coherence: prompt-visible skill instructions, allowed tools, extension policy, scripts, and root view come from one revision. Invalid updates retain the previous working skill instead of exposing partial state.

Cold staging and mutations do more deliberate validation before publication. Runtime reads become snapshot-only and avoid repeated source I/O. Epoch changes occur only for runtime-visible changes.

## Automated validation

Independent review required four implementation correction rounds and the final verifier reports no blocking or non-blocking finding.

Final evidence:

- Focused final review: 3 files, 136 tests passed.
- Developer focused suite: 20 tests passed.
- Related suite: 184 tests passed.
- Full suite: 4,531 passed, 5 known baseline failures, 135 skipped.
- typecheck, typecheck:node, format, format check, i18n, lint, architecture guard, and diff check passed.

The test matrix covers:

- runtime Map and deep-object mutation attacks
- odd/even overlapping publication
- observer throw settlement
- hung readiness at deadline boundaries
- independent waiter abort
- metadata-only quarantine and no repeated source read
- last-known-good retention
- active reset/destroy and late worker ABA
- update/watcher and whole-catalog controlled races
- install/rollback/reconcile
- plugin register/re-register/unregister CAS races
- uninstall missing/management-only/no-op epoch behavior
- extension, scripts, linked-file listing, root view, and allowed-tools coherence
- compatibility AgentRuntime and ToolPresenter paths

The five failures remain the repository baseline:

- three SpotlightOverlay Pinia setup tests
- one debug mock-session plan-block test
- one AgentSession long converted-steer rebudget test

## Manual validation and gaps

Recommended manual smoke before release:

1. Open a chat with an active skill and confirm its root view, prompt instructions, and allowed tools agree.
2. Edit SKILL.md, extension settings, scripts, and linked files while the session is open; confirm the runtime switches only after a complete valid update.
3. Save invalid frontmatter and restore it; confirm the last working skill remains available and diagnostics recover.
4. Install, overwrite, uninstall, and re-register a plugin skill; confirm catalog, scripts, and tool exposure converge.
5. Repeat the watcher smoke on macOS, Windows, and Linux because filesystem event ordering and rename behavior vary by platform.

The automated suite does not measure unbounded source-path cardinality over a very long-lived process. Observation and diagnostic maps are process-local; capacity monitoring remains a follow-up concern.

PRM-002C must still validate end-to-end prompt/tool coherence with the outer cache fingerprint. This PR alone does not close P-07.

## Rollback

Revert the four commits in this PR before PRM-002C merges. There is no database or file-format migration.

Compatibility APIs and the old outer cache key still exist, so rollback is local to SkillPresenter. After PRM-002C merges, rollback must occur in reverse dependency order: C first, then B.
