### PR TITLE
fix(session): classify availability

### DIFF
--- a/docs/issues/session-availability-resolution/spec.md
+++ b/docs/issues/session-availability-resolution/spec.md
@@ -455,9 +455,10 @@ The migration inventory is fixed before implementation:
 | tests and third-party Presenter mocks | legacy methods remain type-compatible; new contract tests target `resolve*` directly |
 
 `SES-002` uses a TypeScript AST/type/provenance guard rather than a text grep. It follows direct property access,
-local aliases, local assignment chains, variable/parameter/assignment object destructuring and bound method
-references rooted in the repository-owned `IAgentSessionPresenter` type, including `Pick`, `Partial`, constrained
-type parameters and local type aliases. The real `Presenter.agentSessionPresenter` property is covered through
+local aliases, local assignment chains, variable/parameter/assignment object destructuring (including local
+object-rest bindings) and bound method references rooted in the repository-owned `IAgentSessionPresenter` type,
+including `Pick`, `Partial`, constrained type parameters and local type aliases. The real
+`Presenter.agentSessionPresenter` property is covered through
 that type source, not by trusting the property name. Positive and negative fixtures prove these forms are
 distinguished from unrelated `any` values and classes that happen to expose the same nested property or method
 names. This is intentionally not full JavaScript dataflow: computed assignments, re-exports and values that have

--- a/docs/issues/session-availability-resolution/spec.md
+++ b/docs/issues/session-availability-resolution/spec.md
@@ -890,13 +890,13 @@ semantics and smaller regression ambiguity before later AgentRuntime refactors.
 
 ### Implementation (`SES-002`)
 
-- [ ] Add failing main tests from this spec.
-- [ ] Implement Presenter-port four-state `resolve*` APIs plus typed legacy adapters.
-- [ ] Migrate the fixed consumer inventory, enforce the legacy allowlist and preserve list isolation.
-- [ ] Remove unsafe cast and preserve the built-in registry fast path.
-- [ ] Fix window and remote binding decisions without adding a deletion reverse index.
-- [ ] Activate bounded transient read retry.
-- [ ] Enforce terminal-only diagnostics, keep legacy route shapes and run repository validation.
+- [x] Add failing main tests from this spec.
+- [x] Implement Presenter-port four-state `resolve*` APIs plus typed legacy adapters.
+- [x] Migrate the fixed consumer inventory, enforce the legacy allowlist and preserve list isolation.
+- [x] Remove unsafe cast and preserve the built-in registry fast path.
+- [x] Fix window and remote binding decisions without adding a deletion reverse index.
+- [x] Activate bounded transient read retry.
+- [x] Enforce terminal-only diagnostics, keep legacy route shapes and run repository validation.
 
 ### Renderer contract (`SES-003`)
 

--- a/docs/issues/session-availability-resolution/spec.md
+++ b/docs/issues/session-availability-resolution/spec.md
@@ -455,12 +455,14 @@ The migration inventory is fixed before implementation:
 | tests and third-party Presenter mocks | legacy methods remain type-compatible; new contract tests target `resolve*` directly |
 
 `SES-002` uses a TypeScript AST/type/provenance guard rather than a text grep. It follows direct property access,
-local aliases, local assignment chains, object destructuring and bound method references rooted in the
-repository-owned `IAgentSessionPresenter` type, including `Pick`, `Partial` and local type aliases. The real
-`Presenter.agentSessionPresenter` property is covered through that type source, not by trusting the property
-name. Positive and negative fixtures prove these forms are distinguished from unrelated `any` values and classes
-that happen to expose the same nested property or method names. After migration, the allowlist names the owning
-method and adapter exactly; the floating button's
+local aliases, local assignment chains, variable/parameter/assignment object destructuring and bound method
+references rooted in the repository-owned `IAgentSessionPresenter` type, including `Pick`, `Partial`, constrained
+type parameters and local type aliases. The real `Presenter.agentSessionPresenter` property is covered through
+that type source, not by trusting the property name. Positive and negative fixtures prove these forms are
+distinguished from unrelated `any` values and classes that happen to expose the same nested property or method
+names. This is intentionally not full JavaScript dataflow: computed assignments, re-exports and values that have
+already been erased to `any` remain outside the guard. After migration, the allowlist names the owning method and
+adapter exactly; the floating button's
 `loadSessions#getSessionList` boundary is the sole production entry. An unexplained legacy reference is a failing
 test, not an implicit compatibility decision.
 

--- a/docs/issues/session-availability-resolution/spec.md
+++ b/docs/issues/session-availability-resolution/spec.md
@@ -455,10 +455,12 @@ The migration inventory is fixed before implementation:
 | tests and third-party Presenter mocks | legacy methods remain type-compatible; new contract tests target `resolve*` directly |
 
 `SES-002` uses a TypeScript AST/type/provenance guard rather than a text grep. It follows direct property access,
-local aliases, alias chains, object destructuring and bound method references rooted at
-`agentSessionPresenter`; typed `IAgentSessionPresenter` references are also covered. Positive and negative
-fixtures prove these forms are distinguished from unrelated classes that happen to define a method named
-`getSession`. After migration, the allowlist names the owning method and adapter exactly; the floating button's
+local aliases, local assignment chains, object destructuring and bound method references rooted in the
+repository-owned `IAgentSessionPresenter` type, including `Pick`, `Partial` and local type aliases. The real
+`Presenter.agentSessionPresenter` property is covered through that type source, not by trusting the property
+name. Positive and negative fixtures prove these forms are distinguished from unrelated `any` values and classes
+that happen to expose the same nested property or method names. After migration, the allowlist names the owning
+method and adapter exactly; the floating button's
 `loadSessions#getSessionList` boundary is the sole production entry. An unexplained legacy reference is a failing
 test, not an implicit compatibility decision.
 

--- a/docs/issues/session-availability-resolution/spec.md
+++ b/docs/issues/session-availability-resolution/spec.md
@@ -454,9 +454,13 @@ The migration inventory is fixed before implementation:
 | floating-button full list | intentionally remains on available-only `getSessionList` until that secondary renderer has an availability UI; it is the sole production list-adapter allowlist entry |
 | tests and third-party Presenter mocks | legacy methods remain type-compatible; new contract tests target `resolve*` directly |
 
-`SES-002` must grep direct calls and bound references before commit. After migration, the allowlist names every
-remaining production legacy-adapter call site; an unexplained `getSession*` call is a failing test, not an implicit
-compatibility decision.
+`SES-002` uses a TypeScript AST/type/provenance guard rather than a text grep. It follows direct property access,
+local aliases, alias chains, object destructuring and bound method references rooted at
+`agentSessionPresenter`; typed `IAgentSessionPresenter` references are also covered. Positive and negative
+fixtures prove these forms are distinguished from unrelated classes that happen to define a method named
+`getSession`. After migration, the allowlist names the owning method and adapter exactly; the floating button's
+`loadSessions#getSessionList` boundary is the sole production entry. An unexplained legacy reference is a failing
+test, not an implicit compatibility decision.
 
 ### `getActive`
 
@@ -621,18 +625,22 @@ accepted the result as terminal:
 
 Each terminal non-available lookup records one structured diagnostic:
 
+- stable operation name
 - `sessionId`
-- `agentId` when a record exists
 - `availability`
 - `stage`
 - stable error `code`
+- stable `retryable` flag
 - attempt count when retry ran
-- original `cause` through the existing logger object path for transient errors only
 
-Unavailable/missing diagnostics infer their stable stage (`agent_lookup` / `record_read`) and have no fabricated
-cause. List isolation must avoid duplicate warnings from both classifier and adapter. One failed row produces one
-terminal diagnostic per list request, not one per layer or retry attempt. Tests spy on the shared helper/logger to
-prove a transient-first/success-second retry emits no terminal error and an exhausted retry emits exactly one.
+The original `cause` exists only in the in-memory classified result so typed owners can decide whether a settled
+read is retryable. It is discarded at the terminal logging boundary. No raw `Error`, message, stack, configured
+Agent identity, absolute path, SQL text, command, environment data or provider secret is passed to
+`electron-log`. Unavailable/missing diagnostics infer their stable stage (`agent_lookup` / `record_read`) without
+fabricating a cause. List isolation must avoid duplicate warnings from both classifier and adapter. One failed row
+produces one terminal diagnostic per list request, not one per layer or retry attempt. Tests spy on the shared
+helper/logger to prove a transient-first/success-second retry emits no terminal error, an exhausted retry emits
+exactly one, and injected secret/path text is absent from every logger argument.
 
 ### Renderer payload
 
@@ -722,8 +730,9 @@ all four public states are testable without production fault injection.
 - [ ] `getSessionList()` remains available-only for the allowlisted floating button, while
       `resolveSessionList()` returns unknown/transient rows in original order.
 - [ ] Terminal diagnostic spy proves transient-first/success-second logs none and exhausted transient logs once.
-- [ ] Source/type guard proves the unsafe fake-null cast is absent and no unallowlisted production call site uses
-      legacy `getSession*`.
+- [ ] AST/type/provenance guard fixtures prove direct, aliased, destructured and bound legacy references fail
+      closed, unrelated same-name methods remain allowed, the unsafe fake-null cast is absent, and floating
+      `loadSessions#getSessionList` is the only production allowlist entry.
 
 ### `SES-003`
 

--- a/src/main/presenter/agentSessionPresenter/index.ts
+++ b/src/main/presenter/agentSessionPresenter/index.ts
@@ -48,6 +48,7 @@ import type {
 } from '@shared/types/tape-replay'
 import type {
   AcpConfigState,
+  ActiveSessionResolution,
   IConfigPresenter,
   HistorySearchHit,
   HistorySearchOptions,
@@ -55,6 +56,8 @@ import type {
   HistorySearchMessageHit,
   ILlmProviderPresenter,
   ISkillPresenter,
+  SessionResolutionListFilters,
+  SessionResolutionResult,
   CONVERSATION
 } from '@shared/presenter'
 import type { SQLitePresenter } from '../sqlitePresenter'
@@ -88,6 +91,7 @@ import {
 import { rtkRuntimeService } from '@/lib/agentRuntime/rtkRuntimeService'
 import { resolveAcpAgentAlias } from '../configPresenter/acpRegistryConstants'
 import type { ProviderSessionPort, SessionPermissionPort, SessionUiPort } from '../runtimePorts'
+import { getAvailableSession, reportTerminalSessionResolution } from './sessionResolution'
 
 type SearchableSessionRow = {
   id: string
@@ -638,7 +642,7 @@ export class AgentSessionPresenter {
           throw new Error(`Subagent session not found after creation: ${sessionId}`)
         }
 
-        const session = (await this.buildSessionWithState(record)) as SessionWithState
+        const session = await this.buildSessionWithState(record)
         this.emitSessionListUpdated({
           sessionIds: [session.id],
           reason: 'created'
@@ -1057,23 +1061,33 @@ export class AgentSessionPresenter {
     }
   }
 
-  async getSessionList(filters?: {
-    agentId?: string
-    projectDir?: string
-    includeSubagents?: boolean
-    parentSessionId?: string
-  }): Promise<SessionWithState[]> {
+  async resolveSessionList(
+    filters?: SessionResolutionListFilters
+  ): Promise<SessionResolutionResult[]> {
     const records = this.sessionManager.list(filters)
-    const enriched: SessionWithState[] = []
+    const resolutions: SessionResolutionResult[] = []
 
     for (const record of records) {
-      const session = await this.tryBuildSessionWithState(record, 'list')
+      resolutions.push(await this.resolveSessionRecord(record, 'list'))
+    }
+
+    return resolutions
+  }
+
+  async getSessionList(filters?: SessionResolutionListFilters): Promise<SessionWithState[]> {
+    const resolutions = await this.resolveSessionList(filters)
+    const sessions: SessionWithState[] = []
+
+    for (const resolution of resolutions) {
+      const session = getAvailableSession(resolution)
       if (session) {
-        enriched.push(session)
+        sessions.push(session)
+      } else {
+        reportTerminalSessionResolution('legacy.getSessionList', resolution)
       }
     }
 
-    return enriched
+    return sessions
   }
 
   async getLightweightSessionList(options?: {
@@ -1118,10 +1132,28 @@ export class AgentSessionPresenter {
     )
   }
 
+  async resolveSession(sessionId: string): Promise<SessionResolutionResult> {
+    let record: SessionRecord | null
+    try {
+      record = this.sessionManager.get(sessionId)
+    } catch (cause) {
+      return this.buildTransientResolution(sessionId, null, 'record_read', cause)
+    }
+
+    if (!record) {
+      return { availability: 'missing', sessionId }
+    }
+
+    return await this.resolveSessionRecord(record)
+  }
+
   async getSession(sessionId: string): Promise<SessionWithState | null> {
-    const record = this.sessionManager.get(sessionId)
-    if (!record) return null
-    return await this.tryBuildSessionWithState(record)
+    const resolution = await this.resolveSession(sessionId)
+    const session = getAvailableSession(resolution)
+    if (!session) {
+      reportTerminalSessionResolution('legacy.getSession', resolution)
+    }
+    return session
   }
 
   async getMessages(sessionId: string): Promise<ChatMessageRecord[]> {
@@ -1886,12 +1918,32 @@ export class AgentSessionPresenter {
     })
   }
 
-  async getActiveSession(webContentsId: number): Promise<SessionWithState | null> {
+  async resolveActiveSession(webContentsId: number): Promise<ActiveSessionResolution> {
     const sessionId = this.sessionManager.getActiveSessionId(webContentsId)
-    if (!sessionId) return null
-    const session = await this.getSession(sessionId)
-    if (!session) {
+    if (!sessionId) {
+      return { binding: 'none' }
+    }
+
+    const resolution = await this.resolveSession(sessionId)
+    if (
+      resolution.availability === 'missing' &&
+      this.sessionManager.getActiveSessionId(webContentsId) === sessionId
+    ) {
       this.sessionManager.unbindWindow(webContentsId)
+    }
+
+    return { binding: 'bound', sessionId, resolution }
+  }
+
+  async getActiveSession(webContentsId: number): Promise<SessionWithState | null> {
+    const active = await this.resolveActiveSession(webContentsId)
+    if (active.binding === 'none') {
+      return null
+    }
+
+    const session = getAvailableSession(active.resolution)
+    if (!session) {
+      reportTerminalSessionResolution('legacy.getActiveSession', active.resolution)
     }
     return session
   }
@@ -2324,12 +2376,7 @@ export class AgentSessionPresenter {
       sessionIds: [sessionId],
       reason: 'updated'
     })
-    const sessionWithState = await this.tryBuildSessionWithState(updated)
-    if (!sessionWithState) {
-      throw new Error(`Failed to build session state for sessionId: ${sessionId}`)
-    }
-
-    return sessionWithState
+    return await this.buildSessionWithState(updated)
   }
 
   async setSessionModel(
@@ -2410,11 +2457,7 @@ export class AgentSessionPresenter {
       sessionIds: [sessionId],
       reason: 'updated'
     })
-    const sessionWithState = await this.tryBuildSessionWithState(updated)
-    if (!sessionWithState) {
-      throw new Error(`Failed to build session state after project update: ${sessionId}`)
-    }
-    return sessionWithState
+    return await this.buildSessionWithState(updated)
   }
 
   async getSessionGenerationSettings(sessionId: string): Promise<SessionGenerationSettings | null> {
@@ -2665,18 +2708,76 @@ export class AgentSessionPresenter {
     return true
   }
 
-  private async tryBuildSessionWithState(
+  private async resolveSessionRecord(
     record: SessionRecord,
     mode: 'full' | 'list' = 'full'
-  ): Promise<SessionWithState> {
+  ): Promise<SessionResolutionResult> {
+    const resolvedAgentId = resolveAcpAgentAlias(record.agentId)
+    let agent: IAgentImplementation
+
     try {
-      return await this.buildSessionWithState(record, mode)
-    } catch (error) {
-      console.warn(
-        `[AgentSessionPresenter] Skipping unavailable session id=${record.id} agent=${record.agentId}:`,
-        error
-      )
-      return null as unknown as SessionWithState
+      if (this.agentRegistry.has(resolvedAgentId)) {
+        agent = this.agentRegistry.resolve(resolvedAgentId)
+      } else {
+        let agentType: 'deepchat' | 'acp' | null
+        try {
+          agentType = await this.getAgentType(resolvedAgentId)
+        } catch (cause) {
+          return this.buildTransientResolution(record.id, record, 'agent_lookup', cause)
+        }
+
+        if (agentType !== 'deepchat' && agentType !== 'acp') {
+          return {
+            availability: 'unavailable',
+            sessionId: record.id,
+            record,
+            reason: 'agent_unknown'
+          }
+        }
+
+        agent = this.agentRegistry.resolve('deepchat')
+      }
+    } catch (cause) {
+      return this.buildTransientResolution(record.id, record, 'runtime_resolution', cause)
+    }
+
+    try {
+      const state =
+        mode === 'list' && agent.getSessionListState
+          ? await agent.getSessionListState(record.id)
+          : await agent.getSessionState(record.id)
+      const status = state?.status ?? 'idle'
+      this.sessionStatusSnapshots.set(record.id, status)
+      return {
+        availability: 'available',
+        session: {
+          ...record,
+          status,
+          providerId: state?.providerId ?? '',
+          modelId: state?.modelId ?? ''
+        }
+      }
+    } catch (cause) {
+      return this.buildTransientResolution(record.id, record, 'state_read', cause)
+    }
+  }
+
+  private buildTransientResolution(
+    sessionId: string,
+    record: SessionRecord | null,
+    stage: 'record_read' | 'agent_lookup' | 'runtime_resolution' | 'state_read',
+    cause: unknown
+  ): SessionResolutionResult {
+    return {
+      availability: 'transient_error',
+      sessionId,
+      record,
+      error: {
+        code: 'SESSION_RESOLUTION_FAILED',
+        stage,
+        retryable: true,
+        cause
+      }
     }
   }
 
@@ -2965,10 +3066,7 @@ export class AgentSessionPresenter {
       throw new Error(`Session not found after transfer: ${sessionId}`)
     }
 
-    const sessionWithState = await this.tryBuildSessionWithState(updated)
-    if (!sessionWithState) {
-      throw new Error(`Failed to build session state after transfer: ${sessionId}`)
-    }
+    const sessionWithState = await this.buildSessionWithState(updated)
 
     if (previousAcpBacked) {
       try {

--- a/src/main/presenter/agentSessionPresenter/sessionResolution.ts
+++ b/src/main/presenter/agentSessionPresenter/sessionResolution.ts
@@ -1,0 +1,91 @@
+import logger from '@shared/logger'
+import type {
+  SessionResolutionResult,
+  SessionResolutionStage
+} from '@shared/types/presenters/agent-session.presenter'
+import type { SessionRecord, SessionWithState } from '@shared/types/agent-interface'
+
+export type TerminalSessionResolution = Exclude<
+  SessionResolutionResult,
+  { availability: 'available' }
+>
+
+export class SessionResolutionError extends Error {
+  readonly code: 'SESSION_MISSING' | 'SESSION_UNAVAILABLE' | 'SESSION_RESOLUTION_FAILED'
+  readonly availability: TerminalSessionResolution['availability']
+  readonly sessionId: string
+  readonly stage: SessionResolutionStage
+  readonly retryable: boolean
+
+  constructor(operation: string, resolution: TerminalSessionResolution) {
+    const metadata = getTerminalSessionResolutionMetadata(resolution)
+    super(`${metadata.code}: ${operation} (${resolution.sessionId})`)
+    this.name = 'SessionResolutionError'
+    this.code = metadata.code
+    this.availability = resolution.availability
+    this.sessionId = resolution.sessionId
+    this.stage = metadata.stage
+    this.retryable = resolution.availability === 'transient_error'
+  }
+}
+
+export function getAvailableSession(resolution: SessionResolutionResult): SessionWithState | null {
+  return resolution.availability === 'available' ? resolution.session : null
+}
+
+export function getResolutionRecord(resolution: SessionResolutionResult): SessionRecord | null {
+  if (resolution.availability === 'available') {
+    return resolution.session
+  }
+  return 'record' in resolution ? resolution.record : null
+}
+
+export function requireAvailableSession(
+  operation: string,
+  resolution: SessionResolutionResult,
+  attemptCount: number = 1
+): SessionWithState {
+  if (resolution.availability === 'available') {
+    return resolution.session
+  }
+
+  reportTerminalSessionResolution(operation, resolution, attemptCount)
+  throw new SessionResolutionError(operation, resolution)
+}
+
+export function reportTerminalSessionResolution(
+  operation: string,
+  resolution: SessionResolutionResult,
+  attemptCount: number = 1
+): void {
+  if (resolution.availability === 'available') {
+    return
+  }
+
+  const metadata = getTerminalSessionResolutionMetadata(resolution)
+  logger.warn('[SessionResolution] Terminal lookup', {
+    operation,
+    sessionId: resolution.sessionId,
+    agentId: 'record' in resolution ? resolution.record?.agentId : undefined,
+    availability: resolution.availability,
+    stage: metadata.stage,
+    code: metadata.code,
+    retryable: resolution.availability === 'transient_error',
+    attemptCount,
+    ...(resolution.availability === 'transient_error' ? { cause: resolution.error.cause } : {})
+  })
+}
+
+function getTerminalSessionResolutionMetadata(resolution: TerminalSessionResolution): {
+  code: 'SESSION_MISSING' | 'SESSION_UNAVAILABLE' | 'SESSION_RESOLUTION_FAILED'
+  stage: SessionResolutionStage
+} {
+  switch (resolution.availability) {
+    case 'missing':
+      return { code: 'SESSION_MISSING', stage: 'record_read' }
+    case 'unavailable':
+      return { code: 'SESSION_UNAVAILABLE', stage: 'agent_lookup' }
+    case 'transient_error':
+      return { code: resolution.error.code, stage: resolution.error.stage }
+  }
+}

--- a/src/main/presenter/agentSessionPresenter/sessionResolution.ts
+++ b/src/main/presenter/agentSessionPresenter/sessionResolution.ts
@@ -66,13 +66,11 @@ export function reportTerminalSessionResolution(
   logger.warn('[SessionResolution] Terminal lookup', {
     operation,
     sessionId: resolution.sessionId,
-    agentId: 'record' in resolution ? resolution.record?.agentId : undefined,
     availability: resolution.availability,
     stage: metadata.stage,
     code: metadata.code,
     retryable: resolution.availability === 'transient_error',
-    attemptCount,
-    ...(resolution.availability === 'transient_error' ? { cause: resolution.error.cause } : {})
+    attemptCount
   })
 }
 

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -68,6 +68,12 @@ import { HooksNotificationsService } from './hooksNotifications'
 import { NewSessionHooksBridge } from './hooksNotifications/newSessionBridge'
 import { CronJobsService } from './cronJobs'
 import { AgentSessionPresenter } from './agentSessionPresenter'
+import {
+  SessionResolutionError,
+  getResolutionRecord,
+  reportTerminalSessionResolution,
+  requireAvailableSession
+} from './agentSessionPresenter/sessionResolution'
 import { AgentRuntimePresenter } from './agentRuntimePresenter'
 import { MemoryPresenter, isSafeAgentId } from './memoryPresenter'
 import { MemoryVectorStore } from './memoryPresenter/infra/memoryVectorStore'
@@ -240,26 +246,27 @@ export class Presenter implements IPresenter {
 
     const agentToolRuntime: AgentToolRuntimePort = {
       resolveConversationWorkdir: async (conversationId) => {
-        try {
-          const session = await this.agentSessionPresenter?.getSession(conversationId)
-          const normalized = session?.projectDir?.trim()
-          if (normalized) {
-            return normalized
-          }
-        } catch (error) {
-          console.warn('[Presenter] Failed to resolve new session workdir:', {
-            conversationId,
-            error
-          })
-        }
-
-        return null
-      },
-      resolveConversationSessionInfo: async (conversationId) => {
-        const session = await this.agentSessionPresenter?.getSession(conversationId)
-        if (!session) {
+        if (!this.agentSessionPresenter) {
           return null
         }
+
+        const resolution = await this.agentSessionPresenter.resolveSession(conversationId)
+        const record = getResolutionRecord(resolution)
+        if (resolution.availability !== 'available') {
+          reportTerminalSessionResolution('tools.resolveConversationWorkdir', resolution)
+        }
+        if (!record && resolution.availability === 'transient_error') {
+          throw new SessionResolutionError('tools.resolveConversationWorkdir', resolution)
+        }
+
+        return record?.projectDir?.trim() || null
+      },
+      resolveConversationSessionInfo: async (conversationId) => {
+        if (!this.agentSessionPresenter) {
+          return null
+        }
+        const resolution = await this.agentSessionPresenter.resolveSession(conversationId)
+        const session = requireAvailableSession('tools.resolveConversationSessionInfo', resolution)
 
         const agent = await this.configPresenter.getAgent(session.agentId)
         const agentType = await this.configPresenter.getAgentType(session.agentId)
@@ -440,11 +447,22 @@ export class Presenter implements IPresenter {
 
     const skillSessionStatePort: SkillSessionStatePort = {
       hasNewSession: async (conversationId) => {
-        try {
-          return Boolean(await this.agentSessionPresenter?.getSession(conversationId))
-        } catch {
+        if (!this.agentSessionPresenter) {
           return false
         }
+        const resolution = await this.agentSessionPresenter.resolveSession(conversationId)
+        if (resolution.availability === 'available') {
+          return true
+        }
+
+        reportTerminalSessionResolution('skills.hasNewSession', resolution)
+        if (resolution.availability === 'missing') {
+          return false
+        }
+        if (resolution.availability === 'unavailable' || resolution.record) {
+          return true
+        }
+        throw new SessionResolutionError('skills.hasNewSession', resolution)
       },
       getPersistedNewSessionSkills: (conversationId) =>
         (
@@ -676,7 +694,16 @@ export class Presenter implements IPresenter {
 
     // Update hooksNotifications with actual dependencies now that agentSessionPresenter is ready
     this.hooksNotifications = new HooksNotificationsService(this.configPresenter, {
-      getSession: this.agentSessionPresenter.getSession.bind(this.agentSessionPresenter),
+      getSession: async (sessionId) => {
+        const resolution = await this.agentSessionPresenter.resolveSession(sessionId)
+        if (resolution.availability === 'available') {
+          return resolution.session
+        }
+
+        reportTerminalSessionResolution('hooks.getSession', resolution)
+        const record = getResolutionRecord(resolution)
+        return record ? { projectDir: record.projectDir } : null
+      },
       getMessage: this.agentSessionPresenter.getMessage.bind(this.agentSessionPresenter)
     })
 

--- a/src/main/presenter/mcpPresenter/inMemoryServers/conversationSearchServer.ts
+++ b/src/main/presenter/mcpPresenter/inMemoryServers/conversationSearchServer.ts
@@ -6,6 +6,10 @@ import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { presenter } from '@/presenter' // 导入全局的 presenter 对象
 import { isSafeRegexPattern } from '@shared/regexValidator'
+import {
+  SessionResolutionError,
+  requireAvailableSession
+} from '../../agentSessionPresenter/sessionResolution'
 
 // Schema definitions
 const SearchConversationsArgsSchema = z.object({
@@ -266,10 +270,8 @@ export class ConversationSearchServer {
   // 获取对话历史
   private async getConversationHistory(conversationId: string, includeSystem: boolean = false) {
     try {
-      const session = await presenter.agentSessionPresenter.getSession(conversationId)
-      if (!session) {
-        throw new Error(`Session not found: ${conversationId}`)
-      }
+      const resolution = await presenter.agentSessionPresenter.resolveSession(conversationId)
+      const session = requireAvailableSession('mcp.conversationHistory', resolution)
       const records = await presenter.agentSessionPresenter.getMessages(conversationId)
 
       const filteredMessages = includeSystem
@@ -296,6 +298,9 @@ export class ConversationSearchServer {
         }))
       }
     } catch (error) {
+      if (error instanceof SessionResolutionError) {
+        throw error
+      }
       console.error('Error getting conversation history:', error)
       throw new Error(
         `Failed to get conversation history: ${error instanceof Error ? error.message : String(error)}`

--- a/src/main/presenter/mcpPresenter/toolManager.ts
+++ b/src/main/presenter/mcpPresenter/toolManager.ts
@@ -18,6 +18,10 @@ import { getErrorMessageLabels } from '@shared/i18n'
 import { presenter } from '@/presenter'
 import { getPluginToolPolicy } from '@/presenter/pluginPresenter/toolPolicyStore'
 import { publishDeepchatEvent } from '@/routes/publishDeepchatEvent'
+import {
+  reportTerminalSessionResolution,
+  requireAvailableSession
+} from '../agentSessionPresenter/sessionResolution'
 
 const CUA_PLUGIN_ID = 'com.deepchat.plugins.cua'
 
@@ -381,23 +385,22 @@ export class ToolManager {
       return null
     }
 
-    try {
-      const session = await presenter.agentSessionPresenter.getSession(sessionId)
-      const agentId = session?.agentId?.trim()
-      const providerId = session?.providerId?.trim()
-      if (session && providerId === 'acp' && agentId) {
-        return {
+    const resolution = await presenter.agentSessionPresenter.resolveSession(sessionId)
+    if (resolution.availability === 'missing') {
+      reportTerminalSessionResolution('mcp.resolveAcpSessionContext', resolution)
+      return null
+    }
+
+    const session = requireAvailableSession('mcp.resolveAcpSessionContext', resolution)
+    const agentId = session.agentId.trim()
+    const providerId = session.providerId.trim()
+    return providerId === 'acp' && agentId
+      ? {
           agentId,
           providerId,
           projectDir: session.projectDir?.trim() || null
         }
-      }
-
-      return null
-    } catch (error) {
-      console.warn('[ToolManager] Failed to resolve new session MCP context:', error)
-      return null
-    }
+      : null
   }
 
   // 检查工具调用权限

--- a/src/main/presenter/remoteControlPresenter/services/remoteConversationRunner.ts
+++ b/src/main/presenter/remoteControlPresenter/services/remoteConversationRunner.ts
@@ -47,6 +47,11 @@ import {
 } from './remoteBlockRenderer'
 import { RemoteBindingStore } from './remoteBindingStore'
 import { collectPendingInteraction } from './remoteInteraction'
+import {
+  getAvailableSession,
+  reportTerminalSessionResolution,
+  requireAvailableSession
+} from '../../agentSessionPresenter/sessionResolution'
 
 const sleep = async (ms: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms))
@@ -484,13 +489,14 @@ export class RemoteConversationRunner {
       return null
     }
 
-    const session = await this.deps.agentSessionPresenter.getSession(binding.sessionId)
-    if (!session) {
+    const resolution = await this.deps.agentSessionPresenter.resolveSession(binding.sessionId)
+    if (resolution.availability === 'missing') {
+      reportTerminalSessionResolution('remote.getCurrentSession', resolution)
       this.bindingStore.clearBinding(endpointKey)
       return null
     }
 
-    return session
+    return requireAvailableSession('remote.getCurrentSession', resolution)
   }
 
   async ensureBoundSession(
@@ -516,9 +522,18 @@ export class RemoteConversationRunner {
 
   async listSessions(endpointKey: string): Promise<SessionWithState[]> {
     const agentId = await this.resolveSessionListAgentId(endpointKey)
-    const sessions = await this.deps.agentSessionPresenter.getSessionList({
+    const resolutions = await this.deps.agentSessionPresenter.resolveSessionList({
       agentId
     })
+    const sessions: SessionWithState[] = []
+    for (const resolution of resolutions) {
+      const session = getAvailableSession(resolution)
+      if (session) {
+        sessions.push(session)
+      } else {
+        reportTerminalSessionResolution('remote.listSessions', resolution)
+      }
+    }
     const sorted = [...sessions]
       .sort((left, right) => right.updatedAt - left.updatedAt)
       .slice(0, TELEGRAM_RECENT_SESSION_LIMIT)
@@ -544,10 +559,12 @@ export class RemoteConversationRunner {
       throw new Error('Session index is out of range.')
     }
 
-    const session = await this.deps.agentSessionPresenter.getSession(sessionId)
-    if (!session) {
+    const resolution = await this.deps.agentSessionPresenter.resolveSession(sessionId)
+    if (resolution.availability === 'missing') {
+      reportTerminalSessionResolution('remote.useSessionByIndex', resolution)
       throw new Error('Selected session no longer exists.')
     }
+    const session = requireAvailableSession('remote.useSessionByIndex', resolution)
 
     if (bindingMeta) {
       this.bindingStore.setBinding(endpointKey, session.id, bindingMeta)
@@ -1091,8 +1108,9 @@ export class RemoteConversationRunner {
       ignoreMessageId: string | null
     }
   ): Promise<RemoteConversationSnapshot> {
-    const session = await this.deps.agentSessionPresenter.getSession(sessionId)
-    if (!session) {
+    const resolution = await this.deps.agentSessionPresenter.resolveSession(sessionId)
+    if (resolution.availability === 'missing') {
+      reportTerminalSessionResolution('remote.getConversationSnapshot', resolution)
       this.bindingStore.clearBinding(endpointKey)
       return {
         messageId: null,
@@ -1108,6 +1126,7 @@ export class RemoteConversationRunner {
         pendingInteraction: null
       }
     }
+    const session = requireAvailableSession('remote.getConversationSnapshot', resolution)
 
     const activeGeneration = this.deps.agentRuntimePresenter.getActiveGeneration(sessionId)
     const trackedMessage = await this.resolveTrackedAssistantMessage(

--- a/src/main/routes/chat/chatService.ts
+++ b/src/main/routes/chat/chatService.ts
@@ -7,6 +7,7 @@ import type {
   SessionRepository
 } from '../hotPathPorts'
 import type { Scheduler } from '../scheduler'
+import { requireAvailableSession } from '@/presenter/agentSessionPresenter/sessionResolution'
 
 const CHAT_LOOKUP_TIMEOUT_MS = 5_000
 const CHAT_SEND_TIMEOUT_MS = 30 * 60 * 1_000
@@ -43,15 +44,12 @@ export class ChatService {
     this.activeControllers.set(sessionId, controller)
 
     try {
-      const session = await this.deps.scheduler.timeout({
-        task: this.deps.sessionRepository.get(sessionId),
+      const resolution = await this.deps.scheduler.timeout({
+        task: this.deps.sessionRepository.resolve(sessionId),
         ms: CHAT_LOOKUP_TIMEOUT_MS,
         reason: `chat.sendMessage:${sessionId}:session`
       })
-
-      if (!session) {
-        throw new Error(`Session not found: ${sessionId}`)
-      }
+      const session = requireAvailableSession('chat.sendMessage', resolution)
 
       const agentType = await this.deps.scheduler.timeout({
         task: this.deps.providerCatalogPort.getAgentType(session.agentId),
@@ -108,15 +106,12 @@ export class ChatService {
     sessionId: string,
     content: string | SendMessageInput
   ): Promise<{ accepted: true }> {
-    const session = await this.deps.scheduler.timeout({
-      task: this.deps.sessionRepository.get(sessionId),
+    const resolution = await this.deps.scheduler.timeout({
+      task: this.deps.sessionRepository.resolve(sessionId),
       ms: CHAT_LOOKUP_TIMEOUT_MS,
       reason: `chat.steerActiveTurn:${sessionId}:session`
     })
-
-    if (!session) {
-      throw new Error(`Session not found: ${sessionId}`)
-    }
+    requireAvailableSession('chat.steerActiveTurn', resolution)
 
     await this.deps.scheduler.timeout({
       task: this.deps.providerExecutionPort.steerActiveTurn(sessionId, content),

--- a/src/main/routes/hotPathPorts.ts
+++ b/src/main/routes/hotPathPorts.ts
@@ -1,7 +1,10 @@
 import type {
   IAgentSessionPresenter,
   IConfigPresenter,
-  ILlmProviderPresenter
+  ILlmProviderPresenter,
+  ActiveSessionResolution,
+  SessionResolutionListFilters,
+  SessionResolutionResult
 } from '@shared/presenter'
 import type { DeepchatEventName, DeepchatEventPayload } from '@shared/contracts/events'
 import type {
@@ -21,20 +24,15 @@ import type {
 } from '../presenter/runtimePorts'
 import { publishDeepchatEvent } from './publishDeepchatEvent'
 
-export type SessionListFilters = {
-  agentId?: string
-  projectDir?: string
-  includeSubagents?: boolean
-  parentSessionId?: string
-}
+export type SessionListFilters = SessionResolutionListFilters
 
 export interface SessionRepository {
   create(input: CreateSessionInput, webContentsId: number): Promise<SessionWithState>
-  get(sessionId: string): Promise<SessionWithState | null>
-  list(filters?: SessionListFilters): Promise<SessionWithState[]>
+  resolve(sessionId: string): Promise<SessionResolutionResult>
+  resolveList(filters?: SessionListFilters): Promise<SessionResolutionResult[]>
   activate(webContentsId: number, sessionId: string): Promise<void>
   deactivate(webContentsId: number): Promise<void>
-  getActive(webContentsId: number): Promise<SessionWithState | null>
+  resolveActive(webContentsId: number): Promise<ActiveSessionResolution>
 }
 
 export interface MessageRepository {
@@ -83,11 +81,11 @@ export function createPresenterHotPathPorts(deps: {
   agentSessionPresenter: Pick<
     IAgentSessionPresenter,
     | 'createSession'
-    | 'getSession'
-    | 'getSessionList'
+    | 'resolveSession'
+    | 'resolveSessionList'
     | 'activateSession'
     | 'deactivateSession'
-    | 'getActiveSession'
+    | 'resolveActiveSession'
     | 'getMessages'
     | 'listMessagesPage'
     | 'getMessage'
@@ -112,14 +110,14 @@ export function createPresenterHotPathPorts(deps: {
     sessionRepository: {
       create: async (input, webContentsId) =>
         await deps.agentSessionPresenter.createSession(input, webContentsId),
-      get: async (sessionId) => await deps.agentSessionPresenter.getSession(sessionId),
-      list: async (filters) => await deps.agentSessionPresenter.getSessionList(filters),
+      resolve: async (sessionId) => await deps.agentSessionPresenter.resolveSession(sessionId),
+      resolveList: async (filters) => await deps.agentSessionPresenter.resolveSessionList(filters),
       activate: async (webContentsId, sessionId) =>
         await deps.agentSessionPresenter.activateSession(webContentsId, sessionId),
       deactivate: async (webContentsId) =>
         await deps.agentSessionPresenter.deactivateSession(webContentsId),
-      getActive: async (webContentsId) =>
-        await deps.agentSessionPresenter.getActiveSession(webContentsId)
+      resolveActive: async (webContentsId) =>
+        await deps.agentSessionPresenter.resolveActiveSession(webContentsId)
     },
     messageRepository: {
       listBySession: async (sessionId) => await deps.agentSessionPresenter.getMessages(sessionId),

--- a/src/main/routes/sessions/sessionService.ts
+++ b/src/main/routes/sessions/sessionService.ts
@@ -4,11 +4,29 @@ import type {
   MessagePageCursor,
   SessionWithState
 } from '@shared/types/agent-interface'
+import type { ActiveSessionResolution, SessionResolutionResult } from '@shared/presenter'
+import {
+  getAvailableSession,
+  reportTerminalSessionResolution
+} from '@/presenter/agentSessionPresenter/sessionResolution'
 import type { MessageRepository, SessionListFilters, SessionRepository } from '../hotPathPorts'
 import type { Scheduler } from '../scheduler'
 
 const SESSION_OPERATION_TIMEOUT_MS = 5_000
 const DEFAULT_RESTORE_MESSAGE_LIMIT = 100
+
+class RetryableSessionReadError extends Error {
+  constructor(
+    readonly resolution: Extract<SessionResolutionResult, { availability: 'transient_error' }>
+  ) {
+    super('Session resolution read is retryable')
+    this.name = 'RetryableSessionReadError'
+  }
+}
+
+class NonRetryableSessionReadFailure {
+  constructor(readonly error: unknown) {}
+}
 
 export type SessionRouteContext = {
   webContentsId: number
@@ -44,20 +62,14 @@ export class SessionService {
     } & ChatMessagePageResult
   > {
     const effectiveLimit = limit ?? DEFAULT_RESTORE_MESSAGE_LIMIT
-    const session = await this.deps.scheduler.retry({
-      task: async () =>
-        await this.deps.scheduler.timeout({
-          task: this.deps.sessionRepository.get(sessionId),
-          ms: SESSION_OPERATION_TIMEOUT_MS,
-          reason: `sessions.restore:${sessionId}:session`
-        }),
-      maxAttempts: 2,
-      initialDelayMs: 25,
-      backoff: 1,
-      reason: `sessions.restore:${sessionId}`
-    })
+    const { resolution, attemptCount } = await this.resolveSessionWithRetry(
+      sessionId,
+      `sessions.restore:${sessionId}`
+    )
+    const session = getAvailableSession(resolution)
 
     if (!session) {
+      reportTerminalSessionResolution('sessions.restore', resolution, attemptCount)
       return {
         session: null,
         messages: [],
@@ -95,11 +107,22 @@ export class SessionService {
   }
 
   async listSessions(filters?: SessionListFilters) {
-    return await this.deps.scheduler.timeout({
-      task: this.deps.sessionRepository.list(filters),
+    const resolutions = await this.deps.scheduler.timeout({
+      task: this.deps.sessionRepository.resolveList(filters),
       ms: SESSION_OPERATION_TIMEOUT_MS,
       reason: 'sessions.list'
     })
+
+    const sessions: SessionWithState[] = []
+    for (const resolution of resolutions) {
+      const session = getAvailableSession(resolution)
+      if (session) {
+        sessions.push(session)
+      } else {
+        reportTerminalSessionResolution('sessions.list', resolution)
+      }
+    }
+    return sessions
   }
 
   async activateSession(context: SessionRouteContext, sessionId: string): Promise<void> {
@@ -119,10 +142,101 @@ export class SessionService {
   }
 
   async getActiveSession(context: SessionRouteContext): Promise<SessionWithState | null> {
-    return await this.deps.scheduler.timeout({
-      task: this.deps.sessionRepository.getActive(context.webContentsId),
-      ms: SESSION_OPERATION_TIMEOUT_MS,
-      reason: 'sessions.getActive'
-    })
+    let attemptCount = 0
+    let active: ActiveSessionResolution
+
+    try {
+      const read = await this.deps.scheduler.retry<
+        ActiveSessionResolution | NonRetryableSessionReadFailure
+      >({
+        task: async () => {
+          attemptCount += 1
+          let result: ActiveSessionResolution
+          try {
+            result = await this.deps.scheduler.timeout({
+              task: this.deps.sessionRepository.resolveActive(context.webContentsId),
+              ms: SESSION_OPERATION_TIMEOUT_MS,
+              reason: 'sessions.getActive'
+            })
+          } catch (error) {
+            return new NonRetryableSessionReadFailure(error)
+          }
+          if (result.binding === 'bound' && result.resolution.availability === 'transient_error') {
+            throw new RetryableSessionReadError(result.resolution)
+          }
+          return result
+        },
+        maxAttempts: 2,
+        initialDelayMs: 25,
+        backoff: 1,
+        reason: 'sessions.getActive'
+      })
+      if (read instanceof NonRetryableSessionReadFailure) {
+        throw read.error
+      }
+      active = read
+    } catch (error) {
+      if (!(error instanceof RetryableSessionReadError)) {
+        throw error
+      }
+      active = {
+        binding: 'bound',
+        sessionId: error.resolution.sessionId,
+        resolution: error.resolution
+      }
+    }
+
+    if (active.binding === 'none') {
+      return null
+    }
+
+    const session = getAvailableSession(active.resolution)
+    if (!session) {
+      reportTerminalSessionResolution('sessions.getActive', active.resolution, attemptCount)
+    }
+    return session
+  }
+
+  private async resolveSessionWithRetry(
+    sessionId: string,
+    reason: string
+  ): Promise<{ resolution: SessionResolutionResult; attemptCount: number }> {
+    let attemptCount = 0
+    try {
+      const read = await this.deps.scheduler.retry<
+        SessionResolutionResult | NonRetryableSessionReadFailure
+      >({
+        task: async () => {
+          attemptCount += 1
+          let result: SessionResolutionResult
+          try {
+            result = await this.deps.scheduler.timeout({
+              task: this.deps.sessionRepository.resolve(sessionId),
+              ms: SESSION_OPERATION_TIMEOUT_MS,
+              reason: `${reason}:session`
+            })
+          } catch (error) {
+            return new NonRetryableSessionReadFailure(error)
+          }
+          if (result.availability === 'transient_error') {
+            throw new RetryableSessionReadError(result)
+          }
+          return result
+        },
+        maxAttempts: 2,
+        initialDelayMs: 25,
+        backoff: 1,
+        reason
+      })
+      if (read instanceof NonRetryableSessionReadFailure) {
+        throw read.error
+      }
+      return { resolution: read, attemptCount }
+    } catch (error) {
+      if (!(error instanceof RetryableSessionReadError)) {
+        throw error
+      }
+      return { resolution: error.resolution, attemptCount }
+    }
   }
 }

--- a/src/shared/types/presenters/agent-session.presenter.d.ts
+++ b/src/shared/types/presenters/agent-session.presenter.d.ts
@@ -7,6 +7,7 @@ import type {
   ChatMessagePageResult,
   CreateSessionInput,
   CreateDetachedSessionInput,
+  SessionRecord,
   SessionWithState,
   ChatMessageRecord,
   MessageTraceRecord,
@@ -58,6 +59,54 @@ export interface HistorySearchMessageHit {
 
 export type HistorySearchHit = HistorySearchSessionHit | HistorySearchMessageHit
 
+export interface SessionResolutionListFilters {
+  agentId?: string
+  projectDir?: string
+  includeSubagents?: boolean
+  parentSessionId?: string
+}
+
+export type SessionResolutionStage =
+  | 'record_read'
+  | 'agent_lookup'
+  | 'runtime_resolution'
+  | 'state_read'
+
+export type SessionResolutionResult =
+  | {
+      availability: 'available'
+      session: SessionWithState
+    }
+  | {
+      availability: 'unavailable'
+      sessionId: string
+      record: SessionRecord
+      reason: 'agent_unknown'
+    }
+  | {
+      availability: 'transient_error'
+      sessionId: string
+      record: SessionRecord | null
+      error: {
+        code: 'SESSION_RESOLUTION_FAILED'
+        stage: SessionResolutionStage
+        retryable: true
+        cause: unknown
+      }
+    }
+  | {
+      availability: 'missing'
+      sessionId: string
+    }
+
+export type ActiveSessionResolution =
+  | { binding: 'none' }
+  | {
+      binding: 'bound'
+      sessionId: string
+      resolution: SessionResolutionResult
+    }
+
 export interface IAgentSessionPresenter {
   createSession(input: CreateSessionInput, webContentsId: number): Promise<SessionWithState>
   createDetachedSession(input: CreateDetachedSessionInput): Promise<SessionWithState>
@@ -98,12 +147,10 @@ export interface IAgentSessionPresenter {
     targetMessageId: string,
     newTitle?: string
   ): Promise<SessionWithState>
-  getSessionList(filters?: {
-    agentId?: string
-    projectDir?: string
-    includeSubagents?: boolean
-    parentSessionId?: string
-  }): Promise<SessionWithState[]>
+  resolveSession(sessionId: string): Promise<SessionResolutionResult>
+  resolveSessionList(filters?: SessionResolutionListFilters): Promise<SessionResolutionResult[]>
+  resolveActiveSession(webContentsId: number): Promise<ActiveSessionResolution>
+  getSessionList(filters?: SessionResolutionListFilters): Promise<SessionWithState[]>
   getSession(sessionId: string): Promise<SessionWithState | null>
   getMessages(sessionId: string): Promise<ChatMessageRecord[]>
   listMessagesPage(

--- a/src/shared/types/presenters/index.d.ts
+++ b/src/shared/types/presenters/index.d.ts
@@ -102,10 +102,14 @@ export type {
 // New agent architecture types
 export type {
   IAgentSessionPresenter,
+  ActiveSessionResolution,
   HistorySearchHit,
   HistorySearchMessageHit,
   HistorySearchOptions,
-  HistorySearchSessionHit
+  HistorySearchSessionHit,
+  SessionResolutionListFilters,
+  SessionResolutionResult,
+  SessionResolutionStage
 } from './agent-session.presenter'
 export type { IProjectPresenter } from './project.presenter'
 export type {

--- a/test/fixtures/sessionResolutionGuard/negative.ts
+++ b/test/fixtures/sessionResolutionGuard/negative.ts
@@ -1,0 +1,20 @@
+class UnrelatedSessionCache {
+  getSession(): unknown {
+    return null
+  }
+
+  getSessionList(): unknown[] {
+    return []
+  }
+
+  getActiveSession(): unknown {
+    return null
+  }
+}
+
+export function unrelatedReferences(cache: UnrelatedSessionCache): unknown[] {
+  const alias = cache
+  const { getActiveSession } = alias
+  const bound = alias.getSession.bind(alias)
+  return [bound(), alias.getSessionList(), getActiveSession.call(alias)]
+}

--- a/test/fixtures/sessionResolutionGuard/negative.ts
+++ b/test/fixtures/sessionResolutionGuard/negative.ts
@@ -31,6 +31,12 @@ export function unrelatedNestedAny(container: any): unknown {
   return container.agentSessionPresenter.getSession()
 }
 
+export function unrelatedAnyDestructuring(container: any): unknown {
+  let getSession: () => unknown
+  ;({ getSession } = container.agentSessionPresenter)
+  return getSession()
+}
+
 interface IAgentSessionPresenter {
   getSession(): unknown
 }
@@ -39,4 +45,18 @@ export function unrelatedSameNamedPort(
   sessionPresenter: Pick<IAgentSessionPresenter, 'getSession'>
 ): unknown {
   return sessionPresenter.getSession()
+}
+
+export function unrelatedParameterDestructuring({
+  getSession
+}: Pick<IAgentSessionPresenter, 'getSession'>): unknown {
+  return getSession()
+}
+
+export function unrelatedAssignmentDestructuring(
+  sessionPresenter: Pick<IAgentSessionPresenter, 'getSession'>
+): unknown {
+  let getSession: () => unknown
+  ;({ getSession } = sessionPresenter)
+  return getSession()
 }

--- a/test/fixtures/sessionResolutionGuard/negative.ts
+++ b/test/fixtures/sessionResolutionGuard/negative.ts
@@ -37,6 +37,16 @@ export function unrelatedAnyDestructuring(container: any): unknown {
   return getSession()
 }
 
+export function unrelatedClassRest(cache: UnrelatedSessionCache): unknown {
+  const { ...rest } = cache
+  return rest.getSession()
+}
+
+export function unrelatedAnyRest(container: any): unknown {
+  const { ...rest } = container
+  return rest.getSession()
+}
+
 interface IAgentSessionPresenter {
   getSession(): unknown
 }
@@ -53,10 +63,22 @@ export function unrelatedParameterDestructuring({
   return getSession()
 }
 
+export function unrelatedParameterRest({
+  ...rest
+}: Pick<IAgentSessionPresenter, 'getSession'>): unknown {
+  return rest.getSession()
+}
+
 export function unrelatedAssignmentDestructuring(
   sessionPresenter: Pick<IAgentSessionPresenter, 'getSession'>
 ): unknown {
   let getSession: () => unknown
   ;({ getSession } = sessionPresenter)
   return getSession()
+}
+
+export function unrelatedAssignmentRest(cache: UnrelatedSessionCache): unknown {
+  let rest
+  ;({ ...rest } = cache)
+  return rest.getSession()
 }

--- a/test/fixtures/sessionResolutionGuard/negative.ts
+++ b/test/fixtures/sessionResolutionGuard/negative.ts
@@ -18,3 +18,25 @@ export function unrelatedReferences(cache: UnrelatedSessionCache): unknown[] {
   const bound = alias.getSession.bind(alias)
   return [bound(), alias.getSessionList(), getActiveSession.call(alias)]
 }
+
+class UnrelatedContainer {
+  agentSessionPresenter = new UnrelatedSessionCache()
+}
+
+export function unrelatedNestedClass(container: UnrelatedContainer): unknown {
+  return container.agentSessionPresenter.getSession()
+}
+
+export function unrelatedNestedAny(container: any): unknown {
+  return container.agentSessionPresenter.getSession()
+}
+
+interface IAgentSessionPresenter {
+  getSession(): unknown
+}
+
+export function unrelatedSameNamedPort(
+  sessionPresenter: Pick<IAgentSessionPresenter, 'getSession'>
+): unknown {
+  return sessionPresenter.getSession()
+}

--- a/test/fixtures/sessionResolutionGuard/positive.ts
+++ b/test/fixtures/sessionResolutionGuard/positive.ts
@@ -1,0 +1,53 @@
+interface SessionPresenterPort {
+  resolveSession(sessionId: string): Promise<unknown>
+  resolveSessionList(): Promise<unknown>
+  resolveActiveSession(webContentsId: number): Promise<unknown>
+  getSession(sessionId: string): Promise<unknown>
+  getSessionList(): Promise<unknown>
+  getActiveSession(webContentsId: number): Promise<unknown>
+}
+
+declare const presenter: { agentSessionPresenter: SessionPresenterPort }
+
+export function directReference(): Promise<unknown> {
+  return presenter.agentSessionPresenter.getSession('session-1')
+}
+
+export function aliasedReference(): Promise<unknown> {
+  const sessionPresenter = presenter.agentSessionPresenter as Pick<
+    SessionPresenterPort,
+    'getSessionList'
+  >
+  const alias = sessionPresenter
+  return alias.getSessionList()
+}
+
+export function destructuredReference(): Promise<unknown> {
+  const sessionPresenter = presenter.agentSessionPresenter as Pick<
+    SessionPresenterPort,
+    'getActiveSession'
+  >
+  const { getActiveSession } = sessionPresenter
+  return getActiveSession(1)
+}
+
+export function boundReference(): (sessionId: string) => Promise<unknown> {
+  const sessionPresenter = presenter.agentSessionPresenter as Pick<
+    SessionPresenterPort,
+    'getSession'
+  >
+  return sessionPresenter.getSession.bind(sessionPresenter)
+}
+
+export function destructuredRootReference(): Promise<unknown> {
+  const { agentSessionPresenter } = presenter
+  return agentSessionPresenter.getSession('session-1')
+}
+
+export function typedReference(sessionPresenter: SessionPresenterPort): Promise<unknown> {
+  return sessionPresenter.getSessionList()
+}
+
+export function computedReference(method: keyof SessionPresenterPort): unknown {
+  return presenter.agentSessionPresenter[method]
+}

--- a/test/fixtures/sessionResolutionGuard/positive.ts
+++ b/test/fixtures/sessionResolutionGuard/positive.ts
@@ -50,10 +50,25 @@ export function parameterDestructuredReference({
   return getSession('session-1')
 }
 
+export function parameterRestReference({ ...sessionPresenter }: FullPort): Promise<unknown> {
+  return sessionPresenter.getSession('session-1')
+}
+
+export function variableRestReference(): Promise<unknown> {
+  const { ...sessionPresenter } = presenter.agentSessionPresenter
+  return sessionPresenter.getSession('session-1')
+}
+
 export function assignmentDestructuredReference(): Promise<unknown> {
   let getSession: FullPort['getSession']
   ;({ getSession } = presenter.agentSessionPresenter)
   return getSession('session-1')
+}
+
+export function assignmentRestReference(): Promise<unknown> {
+  let sessionPresenter
+  ;({ ...sessionPresenter } = presenter.agentSessionPresenter)
+  return (sessionPresenter as any).getSession('session-1')
 }
 
 type SessionListPort = Partial<Pick<FullPort, 'getSessionList'>>

--- a/test/fixtures/sessionResolutionGuard/positive.ts
+++ b/test/fixtures/sessionResolutionGuard/positive.ts
@@ -38,6 +38,24 @@ export function pickReference(sessionPresenter: Pick<FullPort, 'getSession'>): P
   return sessionPresenter.getSession('session-1')
 }
 
+export function constrainedTypeParameterReference<T extends Pick<FullPort, 'getSession'>>(
+  sessionPresenter: T
+): Promise<unknown> {
+  return sessionPresenter.getSession('session-1')
+}
+
+export function parameterDestructuredReference({
+  getSession
+}: Pick<FullPort, 'getSession'>): Promise<unknown> {
+  return getSession('session-1')
+}
+
+export function assignmentDestructuredReference(): Promise<unknown> {
+  let getSession: FullPort['getSession']
+  ;({ getSession } = presenter.agentSessionPresenter)
+  return getSession('session-1')
+}
+
 type SessionListPort = Partial<Pick<FullPort, 'getSessionList'>>
 
 export function typeAliasReference(

--- a/test/fixtures/sessionResolutionGuard/positive.ts
+++ b/test/fixtures/sessionResolutionGuard/positive.ts
@@ -1,41 +1,27 @@
-interface SessionPresenterPort {
-  resolveSession(sessionId: string): Promise<unknown>
-  resolveSessionList(): Promise<unknown>
-  resolveActiveSession(webContentsId: number): Promise<unknown>
-  getSession(sessionId: string): Promise<unknown>
-  getSessionList(): Promise<unknown>
-  getActiveSession(webContentsId: number): Promise<unknown>
-}
+import type { IAgentSessionPresenter as FullPort } from '../../../src/shared/types/presenters/agent-session.presenter'
 
-declare const presenter: { agentSessionPresenter: SessionPresenterPort }
+declare const presenter: { agentSessionPresenter: FullPort }
 
 export function directReference(): Promise<unknown> {
   return presenter.agentSessionPresenter.getSession('session-1')
 }
 
 export function aliasedReference(): Promise<unknown> {
-  const sessionPresenter = presenter.agentSessionPresenter as Pick<
-    SessionPresenterPort,
-    'getSessionList'
-  >
+  const sessionPresenter = presenter.agentSessionPresenter as Pick<FullPort, 'getSessionList'>
   const alias = sessionPresenter
   return alias.getSessionList()
 }
 
-export function destructuredReference(): Promise<unknown> {
-  const sessionPresenter = presenter.agentSessionPresenter as Pick<
-    SessionPresenterPort,
-    'getActiveSession'
+export function destructuredReference(): Promise<unknown> | undefined {
+  const sessionPresenter = presenter.agentSessionPresenter as Partial<
+    Pick<FullPort, 'getActiveSession'>
   >
   const { getActiveSession } = sessionPresenter
-  return getActiveSession(1)
+  return getActiveSession?.(1)
 }
 
 export function boundReference(): (sessionId: string) => Promise<unknown> {
-  const sessionPresenter = presenter.agentSessionPresenter as Pick<
-    SessionPresenterPort,
-    'getSession'
-  >
+  const sessionPresenter = presenter.agentSessionPresenter as Pick<FullPort, 'getSession'>
   return sessionPresenter.getSession.bind(sessionPresenter)
 }
 
@@ -44,10 +30,38 @@ export function destructuredRootReference(): Promise<unknown> {
   return agentSessionPresenter.getSession('session-1')
 }
 
-export function typedReference(sessionPresenter: SessionPresenterPort): Promise<unknown> {
+export function typedReference(sessionPresenter: FullPort): Promise<unknown> {
   return sessionPresenter.getSessionList()
 }
 
-export function computedReference(method: keyof SessionPresenterPort): unknown {
+export function pickReference(sessionPresenter: Pick<FullPort, 'getSession'>): Promise<unknown> {
+  return sessionPresenter.getSession('session-1')
+}
+
+type SessionListPort = Partial<Pick<FullPort, 'getSessionList'>>
+
+export function typeAliasReference(
+  sessionPresenter: SessionListPort
+): Promise<unknown> | undefined {
+  return sessionPresenter.getSessionList?.()
+}
+
+export function typedAssignmentReference(): Promise<unknown> {
+  let first: Pick<FullPort, 'getSessionList'>
+  let second: Pick<FullPort, 'getSessionList'>
+  first = presenter.agentSessionPresenter
+  second = first
+  return second.getSessionList()
+}
+
+export function untypedAssignmentReference(): Promise<unknown> {
+  let first
+  let second
+  first = presenter.agentSessionPresenter as unknown
+  second = first
+  return (second as any).getActiveSession(1)
+}
+
+export function computedReference(method: keyof FullPort): unknown {
   return presenter.agentSessionPresenter[method]
 }

--- a/test/main/presenter/agentSessionPresenter/agentSessionPresenter.test.ts
+++ b/test/main/presenter/agentSessionPresenter/agentSessionPresenter.test.ts
@@ -1635,8 +1635,7 @@ describe('AgentSessionPresenter', () => {
       expect(sessions[0].modelId).toBe('gpt-4')
     })
 
-    it('skips sessions whose agent implementation cannot be resolved', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    it('classifies an unknown agent without hiding later healthy sessions', async () => {
       sqlitePresenter.newSessionsTable.list.mockReturnValue([
         {
           id: 'missing-agent',
@@ -1658,19 +1657,24 @@ describe('AgentSessionPresenter', () => {
         }
       ])
 
-      const sessions = await presenter.getSessionList()
+      const resolutions = await presenter.resolveSessionList()
 
-      expect(sessions).toHaveLength(1)
-      expect(sessions[0].id).toBe('s1')
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[AgentSessionPresenter] Skipping unavailable session id=missing-agent agent=disabled-agent:',
-        expect.any(Error)
-      )
-      warnSpy.mockRestore()
+      expect(resolutions).toHaveLength(2)
+      expect(resolutions[0]).toMatchObject({
+        availability: 'unavailable',
+        sessionId: 'missing-agent',
+        reason: 'agent_unknown'
+      })
+      expect(resolutions[1]).toMatchObject({
+        availability: 'available',
+        session: { id: 's1' }
+      })
+      await expect(presenter.getSessionList()).resolves.toEqual([
+        expect.objectContaining({ id: 's1' })
+      ])
     })
 
-    it('skips sessions whose state loading fails', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    it('isolates transient state reads without retrying list rows', async () => {
       sqlitePresenter.newSessionsTable.list.mockReturnValue([
         {
           id: 'broken-state',
@@ -1703,15 +1707,57 @@ describe('AgentSessionPresenter', () => {
         }
       })
 
-      const sessions = await presenter.getSessionList()
+      const resolutions = await presenter.resolveSessionList()
 
-      expect(sessions).toHaveLength(1)
-      expect(sessions[0].id).toBe('healthy-state')
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[AgentSessionPresenter] Skipping unavailable session id=broken-state agent=deepchat:',
-        expect.any(Error)
-      )
-      warnSpy.mockRestore()
+      expect(resolutions[0]).toMatchObject({
+        availability: 'transient_error',
+        sessionId: 'broken-state',
+        error: { stage: 'state_read', retryable: true }
+      })
+      expect(resolutions[1]).toMatchObject({
+        availability: 'available',
+        session: { id: 'healthy-state' }
+      })
+      expect(deepChatAgent.getSessionListState).toHaveBeenCalledTimes(2)
+    })
+
+    it('rejects the whole classified list when the record query fails', async () => {
+      const listError = new Error('list query failed')
+      sqlitePresenter.newSessionsTable.list.mockImplementation(() => {
+        throw listError
+      })
+
+      await expect(presenter.resolveSessionList()).rejects.toBe(listError)
+      expect(deepChatAgent.getSessionListState).not.toHaveBeenCalled()
+    })
+
+    it('keeps the lightweight list record-only for unknown agents', async () => {
+      sqlitePresenter.newSessionsTable.listPage.mockReturnValue({
+        rows: [
+          {
+            id: 'unknown-agent-session',
+            agent_id: 'removed-agent',
+            title: 'Historical session',
+            project_dir: null,
+            is_pinned: 0,
+            is_draft: 0,
+            session_kind: 'regular',
+            parent_session_id: null,
+            subagent_enabled: 0,
+            subagent_meta_json: null,
+            created_at: 1000,
+            updated_at: 2000
+          }
+        ],
+        hasMore: false
+      })
+
+      await expect(presenter.getLightweightSessionList()).resolves.toMatchObject({
+        items: [{ id: 'unknown-agent-session', agentId: 'removed-agent', status: 'idle' }]
+      })
+      expect(configPresenter.getAgentType).not.toHaveBeenCalled()
+      expect(deepChatAgent.getSessionState).not.toHaveBeenCalled()
+      expect(deepChatAgent.getSessionListState).not.toHaveBeenCalled()
     })
   })
 
@@ -1737,8 +1783,7 @@ describe('AgentSessionPresenter', () => {
       expect(await presenter.getSession('unknown')).toBeNull()
     })
 
-    it('returns null when session agent is unavailable', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    it('classifies unknown agents and keeps the legacy adapter nullable', async () => {
       sqlitePresenter.newSessionsTable.get.mockReturnValue({
         id: 's-disabled',
         agent_id: 'disabled-agent',
@@ -1749,12 +1794,123 @@ describe('AgentSessionPresenter', () => {
         updated_at: 2000
       })
 
-      expect(await presenter.getSession('s-disabled')).toBeNull()
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[AgentSessionPresenter] Skipping unavailable session id=s-disabled agent=disabled-agent:',
-        expect.any(Error)
-      )
-      warnSpy.mockRestore()
+      await expect(presenter.resolveSession('s-disabled')).resolves.toMatchObject({
+        availability: 'unavailable',
+        sessionId: 's-disabled',
+        reason: 'agent_unknown'
+      })
+      await expect(presenter.getSession('s-disabled')).resolves.toBeNull()
+    })
+
+    it('classifies catalog and state read failures without matching error text', async () => {
+      sqlitePresenter.newSessionsTable.get.mockReturnValue({
+        id: 's-custom',
+        agent_id: 'custom-agent',
+        title: 'Custom',
+        project_dir: null,
+        is_pinned: 0,
+        created_at: 1000,
+        updated_at: 2000
+      })
+      configPresenter.getAgentType.mockRejectedValueOnce(new Error('Agent not found'))
+
+      await expect(presenter.resolveSession('s-custom')).resolves.toMatchObject({
+        availability: 'transient_error',
+        error: { stage: 'agent_lookup' }
+      })
+
+      sqlitePresenter.newSessionsTable.get.mockReturnValue({
+        id: 's1',
+        agent_id: 'deepchat',
+        title: 'Built in',
+        project_dir: null,
+        is_pinned: 0,
+        created_at: 1000,
+        updated_at: 2000
+      })
+      deepChatAgent.getSessionState.mockRejectedValueOnce(new Error('unavailable'))
+      await expect(presenter.resolveSession('s1')).resolves.toMatchObject({
+        availability: 'transient_error',
+        error: { stage: 'state_read' }
+      })
+    })
+
+    it('keeps the built-in fast path catalog-free and accepts a null runtime state', async () => {
+      sqlitePresenter.newSessionsTable.get.mockReturnValue({
+        id: 's1',
+        agent_id: 'deepchat',
+        title: 'Built in',
+        project_dir: null,
+        is_pinned: 0,
+        created_at: 1000,
+        updated_at: 2000
+      })
+      configPresenter.getAgentType.mockRejectedValue(new Error('catalog unavailable'))
+      deepChatAgent.getSessionState.mockResolvedValue(null)
+
+      await expect(presenter.resolveSession('s1')).resolves.toMatchObject({
+        availability: 'available',
+        session: {
+          id: 's1',
+          status: 'idle',
+          providerId: '',
+          modelId: ''
+        }
+      })
+      expect(configPresenter.getAgentType).not.toHaveBeenCalled()
+    })
+
+    it('normalizes ACP aliases and resolves known disabled agent identities', async () => {
+      const row = {
+        id: 's-custom',
+        agent_id: 'kimi-cli',
+        title: 'Legacy ACP',
+        project_dir: null,
+        is_pinned: 0,
+        created_at: 1000,
+        updated_at: 2000
+      }
+      sqlitePresenter.newSessionsTable.get.mockReturnValue(row)
+      configPresenter.getAgentType.mockImplementation(async (agentId: string) => {
+        if (agentId === 'kimi') return 'acp'
+        return agentId === 'disabled-but-known' ? 'deepchat' : null
+      })
+
+      await expect(presenter.resolveSession('s-custom')).resolves.toMatchObject({
+        availability: 'available',
+        session: { id: 's-custom' }
+      })
+      expect(configPresenter.getAgentType).toHaveBeenCalledWith('kimi')
+
+      sqlitePresenter.newSessionsTable.get.mockReturnValue({
+        ...row,
+        id: 's-disabled',
+        agent_id: 'disabled-but-known'
+      })
+      await expect(presenter.resolveSession('s-disabled')).resolves.toMatchObject({
+        availability: 'available',
+        session: { id: 's-disabled', agentId: 'disabled-but-known' }
+      })
+    })
+
+    it('classifies registry implementation failures as transient runtime resolution', async () => {
+      sqlitePresenter.newSessionsTable.get.mockReturnValue({
+        id: 's1',
+        agent_id: 'deepchat',
+        title: 'Built in',
+        project_dir: null,
+        is_pinned: 0,
+        created_at: 1000,
+        updated_at: 2000
+      })
+      vi.spyOn((presenter as any).agentRegistry, 'resolve').mockImplementation(() => {
+        throw new Error('registry invariant failed')
+      })
+
+      await expect(presenter.resolveSession('s1')).resolves.toMatchObject({
+        availability: 'transient_error',
+        error: { stage: 'runtime_resolution' }
+      })
     })
   })
 
@@ -2085,7 +2241,7 @@ describe('AgentSessionPresenter', () => {
   })
 
   describe('setSessionSubagentEnabled', () => {
-    it('throws when the updated session state cannot be rebuilt', async () => {
+    it('propagates the runtime read error when the updated session state cannot be rebuilt', async () => {
       const row = {
         id: 's1',
         agent_id: 'deepchat',
@@ -2109,7 +2265,7 @@ describe('AgentSessionPresenter', () => {
       deepChatAgent.getSessionState.mockRejectedValueOnce(new Error('state unavailable'))
 
       await expect(presenter.setSessionSubagentEnabled('s1', true)).rejects.toThrow(
-        'Failed to build session state for sessionId: s1'
+        'state unavailable'
       )
 
       expect(sqlitePresenter.newSessionsTable.update).toHaveBeenCalledWith('s1', {
@@ -2963,11 +3119,9 @@ describe('AgentSessionPresenter', () => {
       expect(session!.id).toBe('s1')
     })
 
-    it('returns null and clears binding when bound session becomes unavailable', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
+    it('retains binding when the bound session agent is unavailable', async () => {
       await presenter.activateSession(1, 's-disabled')
-      sqlitePresenter.newSessionsTable.get.mockReturnValueOnce({
+      sqlitePresenter.newSessionsTable.get.mockReturnValue({
         id: 's-disabled',
         agent_id: 'disabled-agent',
         title: 'Disabled',
@@ -2978,22 +3132,62 @@ describe('AgentSessionPresenter', () => {
       })
 
       await expect(presenter.getActiveSession(1)).resolves.toBeNull()
+      expect(presenter.getActiveSessionId(1)).toBe('s-disabled')
+      await expect(presenter.resolveActiveSession(1)).resolves.toMatchObject({
+        binding: 'bound',
+        sessionId: 's-disabled',
+        resolution: { availability: 'unavailable' }
+      })
+    })
 
-      sqlitePresenter.newSessionsTable.get.mockReturnValue({
-        id: 's-disabled',
+    it('retains binding on transient reads and clears it only on a record miss', async () => {
+      await presenter.activateSession(1, 's1')
+      sqlitePresenter.newSessionsTable.get.mockImplementation(() => {
+        throw new Error('SQLITE_BUSY')
+      })
+
+      await expect(presenter.resolveActiveSession(1)).resolves.toMatchObject({
+        binding: 'bound',
+        resolution: {
+          availability: 'transient_error',
+          error: { stage: 'record_read' }
+        }
+      })
+      expect(presenter.getActiveSessionId(1)).toBe('s1')
+
+      sqlitePresenter.newSessionsTable.get.mockReturnValue(undefined)
+      await expect(presenter.resolveActiveSession(1)).resolves.toMatchObject({
+        binding: 'bound',
+        resolution: { availability: 'missing' }
+      })
+      expect(presenter.getActiveSessionId(1)).toBeNull()
+    })
+
+    it('converges a deleted binding on the next missing lookup without deactivation event', async () => {
+      const record = {
+        id: 's1',
         agent_id: 'deepchat',
-        title: 'Recovered',
+        title: 'Deleted',
         project_dir: null,
         is_pinned: 0,
         created_at: 1000,
         updated_at: 2000
+      }
+      await presenter.activateSession(1, 's1')
+      sqlitePresenter.newSessionsTable.get.mockReturnValue(record)
+      await presenter.deleteSession('s1')
+      sqlitePresenter.newSessionsTable.get.mockReturnValue(undefined)
+      vi.mocked(publishDeepchatEvent).mockClear()
+
+      await expect(presenter.resolveActiveSession(1)).resolves.toMatchObject({
+        binding: 'bound',
+        resolution: { availability: 'missing', sessionId: 's1' }
       })
-      await expect(presenter.getActiveSession(1)).resolves.toBeNull()
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[AgentSessionPresenter] Skipping unavailable session id=s-disabled agent=disabled-agent:',
-        expect.any(Error)
+      expect(presenter.getActiveSessionId(1)).toBeNull()
+      expect(publishDeepchatEvent).not.toHaveBeenCalledWith(
+        'sessions.updated',
+        expect.objectContaining({ reason: 'deactivated' })
       )
-      warnSpy.mockRestore()
     })
   })
 })

--- a/test/main/presenter/agentSessionPresenter/sessionResolutionContract.test.ts
+++ b/test/main/presenter/agentSessionPresenter/sessionResolutionContract.test.ts
@@ -1,51 +1,235 @@
-import fs from 'node:fs/promises'
 import path from 'node:path'
+import * as ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 
 const MAIN_ROOT = path.resolve('src/main')
+const FIXTURE_ROOT = path.resolve('test/fixtures/sessionResolutionGuard')
+const LEGACY_METHODS = new Set(['getSession', 'getSessionList', 'getActiveSession'])
+const PRODUCTION_ALLOWLIST = new Set([
+  'src/main/presenter/floatingButtonPresenter/index.ts#loadSessions#getSessionList'
+])
 
-const listTypeScriptFiles = async (directory: string): Promise<string[]> => {
-  const entries = await fs.readdir(directory, { withFileTypes: true })
-  const nested = await Promise.all(
-    entries.map(async (entry) => {
-      const entryPath = path.join(directory, entry.name)
-      if (entry.isDirectory()) {
-        return await listTypeScriptFiles(entryPath)
-      }
-      return entry.isFile() && entry.name.endsWith('.ts') ? [entryPath] : []
-    })
-  )
-  return nested.flat()
+const toProjectPath = (file: string): string =>
+  path.relative(process.cwd(), file).split(path.sep).join('/')
+
+const createProgram = (rootNames?: string[]): ts.Program => {
+  const configPath = path.resolve('tsconfig.node.json')
+  const config = ts.readConfigFile(configPath, ts.sys.readFile)
+  if (config.error) {
+    throw new Error(ts.flattenDiagnosticMessageText(config.error.messageText, '\n'))
+  }
+  const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, path.dirname(configPath))
+  if (parsed.errors.length > 0) {
+    throw new Error(
+      parsed.errors
+        .map((error) => ts.flattenDiagnosticMessageText(error.messageText, '\n'))
+        .join('\n')
+    )
+  }
+  return ts.createProgram({
+    rootNames: rootNames ?? parsed.fileNames,
+    options: rootNames ? { ...parsed.options, composite: false, noEmit: true } : parsed.options
+  })
 }
 
-describe('session resolution source contract', () => {
-  it('keeps only the floating button on a production legacy session adapter', async () => {
-    const files = await listTypeScriptFiles(MAIN_ROOT)
-    const callPattern = /agentSessionPresenter\??\.(getSession|getSessionList|getActiveSession)\b/g
-    const callers: string[] = []
+const unwrap = (expression: ts.Expression): ts.Expression => {
+  let current = expression
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isSatisfiesExpression(current)
+  ) {
+    current = current.expression
+  }
+  return current
+}
 
-    for (const file of files) {
-      const source = await fs.readFile(file, 'utf8')
-      for (const match of source.matchAll(callPattern)) {
-        callers.push(`${path.relative(process.cwd(), file)}:${match[1]}`)
+const staticName = (name: ts.PropertyName | undefined): string | null => {
+  if (name && (ts.isIdentifier(name) || ts.isStringLiteralLike(name))) {
+    return name.text
+  }
+  return null
+}
+
+const elementName = (node: ts.ElementAccessExpression): string | null => {
+  const argument = node.argumentExpression && unwrap(node.argumentExpression)
+  return argument && ts.isStringLiteralLike(argument) ? argument.text : null
+}
+
+const hasPresenterShape = (type: ts.Type): boolean => {
+  if (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Never)) {
+    return false
+  }
+  if (type.isUnionOrIntersection()) {
+    return type.types.some(hasPresenterShape)
+  }
+  return ['resolveSession', 'resolveSessionList', 'resolveActiveSession'].every((method) =>
+    type.getProperty(method)
+  )
+}
+
+const isPresenterExpression = (
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  seen: ReadonlySet<ts.Symbol> = new Set()
+): boolean => {
+  const current = unwrap(expression)
+  if (hasPresenterShape(checker.getTypeAtLocation(current))) {
+    return true
+  }
+  if (
+    (ts.isPropertyAccessExpression(current) && current.name.text === 'agentSessionPresenter') ||
+    (ts.isElementAccessExpression(current) && elementName(current) === 'agentSessionPresenter')
+  ) {
+    return true
+  }
+  if (ts.isIdentifier(current)) {
+    const symbol = checker.getSymbolAtLocation(current)
+    if (!symbol || seen.has(symbol)) {
+      return false
+    }
+    const nextSeen = new Set(seen).add(symbol)
+    return Boolean(
+      symbol.declarations?.some((declaration) => {
+        if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+          return isPresenterExpression(declaration.initializer, checker, nextSeen)
+        }
+        return (
+          ts.isBindingElement(declaration) &&
+          staticName(declaration.propertyName ?? declaration.name) === 'agentSessionPresenter'
+        )
+      })
+    )
+  }
+  if (ts.isConditionalExpression(current)) {
+    return (
+      isPresenterExpression(current.whenTrue, checker, seen) ||
+      isPresenterExpression(current.whenFalse, checker, seen)
+    )
+  }
+  if (
+    ts.isBinaryExpression(current) &&
+    [
+      ts.SyntaxKind.QuestionQuestionToken,
+      ts.SyntaxKind.BarBarToken,
+      ts.SyntaxKind.AmpersandAmpersandToken
+    ].includes(current.operatorToken.kind)
+  ) {
+    return (
+      isPresenterExpression(current.left, checker, seen) ||
+      isPresenterExpression(current.right, checker, seen)
+    )
+  }
+  return false
+}
+
+const ownerName = (node: ts.Node): string => {
+  for (let current: ts.Node | undefined = node; current; current = current.parent) {
+    if (
+      ts.isMethodDeclaration(current) ||
+      ts.isGetAccessorDeclaration(current) ||
+      ts.isSetAccessorDeclaration(current)
+    ) {
+      return staticName(current.name) ?? '<computed-owner>'
+    }
+    if (ts.isFunctionDeclaration(current)) {
+      return current.name?.text ?? '<anonymous-function>'
+    }
+    if (
+      (ts.isArrowFunction(current) || ts.isFunctionExpression(current)) &&
+      ts.isVariableDeclaration(current.parent) &&
+      ts.isIdentifier(current.parent.name)
+    ) {
+      return current.parent.name.text
+    }
+  }
+  return '<module>'
+}
+
+const scanLegacyReferences = (program: ts.Program, sourceFiles: ts.SourceFile[]): string[] => {
+  const checker = program.getTypeChecker()
+  const references = new Set<string>()
+  const record = (node: ts.Node, method: string): void => {
+    references.add(`${toProjectPath(node.getSourceFile().fileName)}#${ownerName(node)}#${method}`)
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      LEGACY_METHODS.has(node.name.text) &&
+      isPresenterExpression(node.expression, checker)
+    ) {
+      record(node, node.name.text)
+    } else if (
+      ts.isElementAccessExpression(node) &&
+      isPresenterExpression(node.expression, checker)
+    ) {
+      const method = elementName(node)
+      if (method === null || LEGACY_METHODS.has(method)) {
+        record(node, method ?? '<computed-access>')
+      }
+    } else if (
+      ts.isVariableDeclaration(node) &&
+      ts.isObjectBindingPattern(node.name) &&
+      node.initializer &&
+      isPresenterExpression(node.initializer, checker)
+    ) {
+      for (const element of node.name.elements) {
+        const method = staticName(element.propertyName ?? element.name)
+        if (method === null || LEGACY_METHODS.has(method)) {
+          record(element, method ?? '<computed-destructure>')
+        }
       }
     }
+    ts.forEachChild(node, visit)
+  }
 
-    expect([...new Set(callers)]).toEqual([
-      'src/main/presenter/floatingButtonPresenter/index.ts:getSessionList'
+  sourceFiles.forEach(visit)
+  return [...references].sort()
+}
+
+const sourceFilesUnder = (program: ts.Program, root: string): ts.SourceFile[] =>
+  program
+    .getSourceFiles()
+    .filter((sourceFile) => path.resolve(sourceFile.fileName).startsWith(`${root}${path.sep}`))
+
+describe('session resolution source contract', () => {
+  it('keeps only the exact floating-button boundary on a production legacy adapter', () => {
+    const program = createProgram()
+    const sourceFiles = sourceFilesUnder(program, MAIN_ROOT)
+    const references = scanLegacyReferences(program, sourceFiles)
+
+    expect(references.filter((reference) => PRODUCTION_ALLOWLIST.has(reference))).toEqual([
+      ...PRODUCTION_ALLOWLIST
+    ])
+    expect(references.filter((reference) => !PRODUCTION_ALLOWLIST.has(reference))).toEqual([])
+  })
+
+  it('catches aliased legacy references but ignores unrelated same-name methods', () => {
+    const program = createProgram([
+      path.join(FIXTURE_ROOT, 'positive.ts'),
+      path.join(FIXTURE_ROOT, 'negative.ts')
+    ])
+    const references = scanLegacyReferences(program, sourceFilesUnder(program, FIXTURE_ROOT))
+
+    expect(references).toEqual([
+      'test/fixtures/sessionResolutionGuard/positive.ts#aliasedReference#getSessionList',
+      'test/fixtures/sessionResolutionGuard/positive.ts#boundReference#getSession',
+      'test/fixtures/sessionResolutionGuard/positive.ts#computedReference#<computed-access>',
+      'test/fixtures/sessionResolutionGuard/positive.ts#destructuredReference#getActiveSession',
+      'test/fixtures/sessionResolutionGuard/positive.ts#destructuredRootReference#getSession',
+      'test/fixtures/sessionResolutionGuard/positive.ts#directReference#getSession',
+      'test/fixtures/sessionResolutionGuard/positive.ts#typedReference#getSessionList'
     ])
   })
 
-  it('does not fake a nullable session into SessionWithState', async () => {
-    const files = await listTypeScriptFiles(MAIN_ROOT)
-    const violations: string[] = []
-
-    for (const file of files) {
-      const source = await fs.readFile(file, 'utf8')
-      if (/null\s+as\s+unknown\s+as\s+SessionWithState/.test(source)) {
-        violations.push(path.relative(process.cwd(), file))
-      }
-    }
+  it('does not fake a nullable session into SessionWithState', () => {
+    const program = createProgram()
+    const violations = sourceFilesUnder(program, MAIN_ROOT)
+      .filter((sourceFile) => /null\s+as\s+unknown\s+as\s+SessionWithState/.test(sourceFile.text))
+      .map((sourceFile) => toProjectPath(sourceFile.fileName))
 
     expect(violations).toEqual([])
   })

--- a/test/main/presenter/agentSessionPresenter/sessionResolutionContract.test.ts
+++ b/test/main/presenter/agentSessionPresenter/sessionResolutionContract.test.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const MAIN_ROOT = path.resolve('src/main')
+
+const listTypeScriptFiles = async (directory: string): Promise<string[]> => {
+  const entries = await fs.readdir(directory, { withFileTypes: true })
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directory, entry.name)
+      if (entry.isDirectory()) {
+        return await listTypeScriptFiles(entryPath)
+      }
+      return entry.isFile() && entry.name.endsWith('.ts') ? [entryPath] : []
+    })
+  )
+  return nested.flat()
+}
+
+describe('session resolution source contract', () => {
+  it('keeps only the floating button on a production legacy session adapter', async () => {
+    const files = await listTypeScriptFiles(MAIN_ROOT)
+    const callPattern = /agentSessionPresenter\??\.(getSession|getSessionList|getActiveSession)\b/g
+    const callers: string[] = []
+
+    for (const file of files) {
+      const source = await fs.readFile(file, 'utf8')
+      for (const match of source.matchAll(callPattern)) {
+        callers.push(`${path.relative(process.cwd(), file)}:${match[1]}`)
+      }
+    }
+
+    expect([...new Set(callers)]).toEqual([
+      'src/main/presenter/floatingButtonPresenter/index.ts:getSessionList'
+    ])
+  })
+
+  it('does not fake a nullable session into SessionWithState', async () => {
+    const files = await listTypeScriptFiles(MAIN_ROOT)
+    const violations: string[] = []
+
+    for (const file of files) {
+      const source = await fs.readFile(file, 'utf8')
+      if (/null\s+as\s+unknown\s+as\s+SessionWithState/.test(source)) {
+        violations.push(path.relative(process.cwd(), file))
+      }
+    }
+
+    expect(violations).toEqual([])
+  })
+})

--- a/test/main/presenter/agentSessionPresenter/sessionResolutionContract.test.ts
+++ b/test/main/presenter/agentSessionPresenter/sessionResolutionContract.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 const MAIN_ROOT = path.resolve('src/main')
 const FIXTURE_ROOT = path.resolve('test/fixtures/sessionResolutionGuard')
+const PRESENTER_TYPE_FILE = path.resolve('src/shared/types/presenters/agent-session.presenter.d.ts')
 const LEGACY_METHODS = new Set(['getSession', 'getSessionList', 'getActiveSession'])
 const PRODUCTION_ALLOWLIST = new Set([
   'src/main/presenter/floatingButtonPresenter/index.ts#loadSessions#getSessionList'
@@ -58,31 +59,89 @@ const elementName = (node: ts.ElementAccessExpression): string | null => {
   return argument && ts.isStringLiteralLike(argument) ? argument.text : null
 }
 
-const hasPresenterShape = (type: ts.Type): boolean => {
+const isPresenterTypeSymbol = (
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+  seen: Set<ts.Symbol>
+): boolean => {
+  if (!symbol || seen.has(symbol)) {
+    return false
+  }
+  seen.add(symbol)
+
+  const resolved = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
+  if (
+    resolved.name === 'IAgentSessionPresenter' &&
+    resolved.declarations?.some(
+      (declaration) => path.resolve(declaration.getSourceFile().fileName) === PRESENTER_TYPE_FILE
+    )
+  ) {
+    return true
+  }
+
+  return Boolean(
+    resolved.declarations?.some((declaration) => {
+      if (!ts.isTypeAliasDeclaration(declaration)) {
+        return false
+      }
+      let found = false
+      const visit = (node: ts.Node): void => {
+        if (found) return
+        if (
+          ts.isTypeReferenceNode(node) &&
+          isPresenterTypeSymbol(checker.getSymbolAtLocation(node.typeName), checker, seen)
+        ) {
+          found = true
+          return
+        }
+        ts.forEachChild(node, visit)
+      }
+      visit(declaration.type)
+      return found
+    })
+  )
+}
+
+const hasPresenterType = (
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  seen: Set<ts.Type> = new Set()
+): boolean => {
   if (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Never)) {
     return false
   }
-  if (type.isUnionOrIntersection()) {
-    return type.types.some(hasPresenterShape)
+  if (seen.has(type)) {
+    return false
   }
-  return ['resolveSession', 'resolveSessionList', 'resolveActiveSession'].every((method) =>
-    type.getProperty(method)
-  )
+  seen.add(type)
+  if (
+    isPresenterTypeSymbol(type.aliasSymbol, checker, new Set()) ||
+    isPresenterTypeSymbol(type.getSymbol(), checker, new Set())
+  ) {
+    return true
+  }
+  if (type.isUnionOrIntersection()) {
+    return type.types.some((member) => hasPresenterType(member, checker, seen))
+  }
+  if (type.aliasTypeArguments?.some((argument) => hasPresenterType(argument, checker, seen))) {
+    return true
+  }
+  if (type.flags & ts.TypeFlags.Object) {
+    return checker
+      .getTypeArguments(type as ts.TypeReference)
+      .some((argument) => hasPresenterType(argument, checker, seen))
+  }
+  return false
 }
 
 const isPresenterExpression = (
   expression: ts.Expression,
   checker: ts.TypeChecker,
+  assignments: ReadonlyMap<ts.Symbol, readonly ts.Expression[]>,
   seen: ReadonlySet<ts.Symbol> = new Set()
 ): boolean => {
   const current = unwrap(expression)
-  if (hasPresenterShape(checker.getTypeAtLocation(current))) {
-    return true
-  }
-  if (
-    (ts.isPropertyAccessExpression(current) && current.name.text === 'agentSessionPresenter') ||
-    (ts.isElementAccessExpression(current) && elementName(current) === 'agentSessionPresenter')
-  ) {
+  if (hasPresenterType(checker.getTypeAtLocation(current), checker)) {
     return true
   }
   if (ts.isIdentifier(current)) {
@@ -94,19 +153,19 @@ const isPresenterExpression = (
     return Boolean(
       symbol.declarations?.some((declaration) => {
         if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
-          return isPresenterExpression(declaration.initializer, checker, nextSeen)
+          return isPresenterExpression(declaration.initializer, checker, assignments, nextSeen)
         }
-        return (
-          ts.isBindingElement(declaration) &&
-          staticName(declaration.propertyName ?? declaration.name) === 'agentSessionPresenter'
-        )
-      })
+        return false
+      }) ||
+      assignments
+        .get(symbol)
+        ?.some((source) => isPresenterExpression(source, checker, assignments, nextSeen))
     )
   }
   if (ts.isConditionalExpression(current)) {
     return (
-      isPresenterExpression(current.whenTrue, checker, seen) ||
-      isPresenterExpression(current.whenFalse, checker, seen)
+      isPresenterExpression(current.whenTrue, checker, assignments, seen) ||
+      isPresenterExpression(current.whenFalse, checker, assignments, seen)
     )
   }
   if (
@@ -118,8 +177,8 @@ const isPresenterExpression = (
     ].includes(current.operatorToken.kind)
   ) {
     return (
-      isPresenterExpression(current.left, checker, seen) ||
-      isPresenterExpression(current.right, checker, seen)
+      isPresenterExpression(current.left, checker, assignments, seen) ||
+      isPresenterExpression(current.right, checker, assignments, seen)
     )
   }
   return false
@@ -150,21 +209,39 @@ const ownerName = (node: ts.Node): string => {
 
 const scanLegacyReferences = (program: ts.Program, sourceFiles: ts.SourceFile[]): string[] => {
   const checker = program.getTypeChecker()
+  const assignments = new Map<ts.Symbol, ts.Expression[]>()
   const references = new Set<string>()
   const record = (node: ts.Node, method: string): void => {
     references.add(`${toProjectPath(node.getSourceFile().fileName)}#${ownerName(node)}#${method}`)
   }
 
+  const collectAssignments = (node: ts.Node): void => {
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(unwrap(node.left))
+    ) {
+      const symbol = checker.getSymbolAtLocation(unwrap(node.left))
+      if (symbol) {
+        const sources = assignments.get(symbol) ?? []
+        sources.push(node.right)
+        assignments.set(symbol, sources)
+      }
+    }
+    ts.forEachChild(node, collectAssignments)
+  }
+  sourceFiles.forEach(collectAssignments)
+
   const visit = (node: ts.Node): void => {
     if (
       ts.isPropertyAccessExpression(node) &&
       LEGACY_METHODS.has(node.name.text) &&
-      isPresenterExpression(node.expression, checker)
+      isPresenterExpression(node.expression, checker, assignments)
     ) {
       record(node, node.name.text)
     } else if (
       ts.isElementAccessExpression(node) &&
-      isPresenterExpression(node.expression, checker)
+      isPresenterExpression(node.expression, checker, assignments)
     ) {
       const method = elementName(node)
       if (method === null || LEGACY_METHODS.has(method)) {
@@ -174,7 +251,7 @@ const scanLegacyReferences = (program: ts.Program, sourceFiles: ts.SourceFile[])
       ts.isVariableDeclaration(node) &&
       ts.isObjectBindingPattern(node.name) &&
       node.initializer &&
-      isPresenterExpression(node.initializer, checker)
+      isPresenterExpression(node.initializer, checker, assignments)
     ) {
       for (const element of node.name.elements) {
         const method = staticName(element.propertyName ?? element.name)
@@ -221,7 +298,11 @@ describe('session resolution source contract', () => {
       'test/fixtures/sessionResolutionGuard/positive.ts#destructuredReference#getActiveSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#destructuredRootReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#directReference#getSession',
-      'test/fixtures/sessionResolutionGuard/positive.ts#typedReference#getSessionList'
+      'test/fixtures/sessionResolutionGuard/positive.ts#pickReference#getSession',
+      'test/fixtures/sessionResolutionGuard/positive.ts#typeAliasReference#getSessionList',
+      'test/fixtures/sessionResolutionGuard/positive.ts#typedAssignmentReference#getSessionList',
+      'test/fixtures/sessionResolutionGuard/positive.ts#typedReference#getSessionList',
+      'test/fixtures/sessionResolutionGuard/positive.ts#untypedAssignmentReference#getActiveSession'
     ])
   })
 

--- a/test/main/presenter/agentSessionPresenter/sessionResolutionContract.test.ts
+++ b/test/main/presenter/agentSessionPresenter/sessionResolutionContract.test.ts
@@ -159,6 +159,19 @@ const isPresenterExpression = (
         if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
           return isPresenterExpression(declaration.initializer, checker, assignments, nextSeen)
         }
+        if (
+          ts.isBindingElement(declaration) &&
+          declaration.dotDotDotToken &&
+          ts.isObjectBindingPattern(declaration.parent)
+        ) {
+          const owner = declaration.parent.parent
+          if (ts.isParameter(owner)) {
+            return hasPresenterType(checker.getTypeAtLocation(owner), checker)
+          }
+          if (ts.isVariableDeclaration(owner) && owner.initializer) {
+            return isPresenterExpression(owner.initializer, checker, assignments, nextSeen)
+          }
+        }
         return false
       }) ||
       assignments
@@ -220,16 +233,24 @@ const scanLegacyReferences = (program: ts.Program, sourceFiles: ts.SourceFile[])
   }
 
   const collectAssignments = (node: ts.Node): void => {
-    if (
-      ts.isBinaryExpression(node) &&
-      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-      ts.isIdentifier(unwrap(node.left))
-    ) {
-      const symbol = checker.getSymbolAtLocation(unwrap(node.left))
-      if (symbol) {
-        const sources = assignments.get(symbol) ?? []
-        sources.push(node.right)
-        assignments.set(symbol, sources)
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      const left = unwrap(node.left)
+      const targets = ts.isIdentifier(left)
+        ? [left]
+        : ts.isObjectLiteralExpression(left)
+          ? left.properties.flatMap((property) =>
+              ts.isSpreadAssignment(property) && ts.isIdentifier(unwrap(property.expression))
+                ? [unwrap(property.expression) as ts.Identifier]
+                : []
+            )
+          : []
+      for (const target of targets) {
+        const symbol = checker.getSymbolAtLocation(target)
+        if (symbol) {
+          const sources = assignments.get(symbol) ?? []
+          sources.push(node.right)
+          assignments.set(symbol, sources)
+        }
       }
     }
     ts.forEachChild(node, collectAssignments)
@@ -281,6 +302,9 @@ const scanLegacyReferences = (program: ts.Program, sourceFiles: ts.SourceFile[])
       isPresenterExpression(node.right, checker, assignments)
     ) {
       for (const property of unwrap(node.left).properties) {
+        if (ts.isSpreadAssignment(property)) {
+          continue
+        }
         const method =
           ts.isShorthandPropertyAssignment(property) || ts.isPropertyAssignment(property)
             ? staticName(property.name)
@@ -324,6 +348,7 @@ describe('session resolution source contract', () => {
     expect(references).toEqual([
       'test/fixtures/sessionResolutionGuard/positive.ts#aliasedReference#getSessionList',
       'test/fixtures/sessionResolutionGuard/positive.ts#assignmentDestructuredReference#getSession',
+      'test/fixtures/sessionResolutionGuard/positive.ts#assignmentRestReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#boundReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#computedReference#<computed-access>',
       'test/fixtures/sessionResolutionGuard/positive.ts#constrainedTypeParameterReference#getSession',
@@ -331,11 +356,13 @@ describe('session resolution source contract', () => {
       'test/fixtures/sessionResolutionGuard/positive.ts#destructuredRootReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#directReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#parameterDestructuredReference#getSession',
+      'test/fixtures/sessionResolutionGuard/positive.ts#parameterRestReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#pickReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#typeAliasReference#getSessionList',
       'test/fixtures/sessionResolutionGuard/positive.ts#typedAssignmentReference#getSessionList',
       'test/fixtures/sessionResolutionGuard/positive.ts#typedReference#getSessionList',
-      'test/fixtures/sessionResolutionGuard/positive.ts#untypedAssignmentReference#getActiveSession'
+      'test/fixtures/sessionResolutionGuard/positive.ts#untypedAssignmentReference#getActiveSession',
+      'test/fixtures/sessionResolutionGuard/positive.ts#variableRestReference#getSession'
     ])
   })
 

--- a/test/main/presenter/agentSessionPresenter/sessionResolutionContract.test.ts
+++ b/test/main/presenter/agentSessionPresenter/sessionResolutionContract.test.ts
@@ -120,6 +120,10 @@ const hasPresenterType = (
   ) {
     return true
   }
+  const baseConstraint = checker.getBaseConstraintOfType(type)
+  if (baseConstraint && hasPresenterType(baseConstraint, checker, seen)) {
+    return true
+  }
   if (type.isUnionOrIntersection()) {
     return type.types.some((member) => hasPresenterType(member, checker, seen))
   }
@@ -259,6 +263,32 @@ const scanLegacyReferences = (program: ts.Program, sourceFiles: ts.SourceFile[])
           record(element, method ?? '<computed-destructure>')
         }
       }
+    } else if (
+      ts.isParameter(node) &&
+      ts.isObjectBindingPattern(node.name) &&
+      hasPresenterType(checker.getTypeAtLocation(node), checker)
+    ) {
+      for (const element of node.name.elements) {
+        const method = staticName(element.propertyName ?? element.name)
+        if (method === null || LEGACY_METHODS.has(method)) {
+          record(element, method ?? '<computed-destructure>')
+        }
+      }
+    } else if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isObjectLiteralExpression(unwrap(node.left)) &&
+      isPresenterExpression(node.right, checker, assignments)
+    ) {
+      for (const property of unwrap(node.left).properties) {
+        const method =
+          ts.isShorthandPropertyAssignment(property) || ts.isPropertyAssignment(property)
+            ? staticName(property.name)
+            : null
+        if (method === null || LEGACY_METHODS.has(method)) {
+          record(property, method ?? '<computed-destructure>')
+        }
+      }
     }
     ts.forEachChild(node, visit)
   }
@@ -293,11 +323,14 @@ describe('session resolution source contract', () => {
 
     expect(references).toEqual([
       'test/fixtures/sessionResolutionGuard/positive.ts#aliasedReference#getSessionList',
+      'test/fixtures/sessionResolutionGuard/positive.ts#assignmentDestructuredReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#boundReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#computedReference#<computed-access>',
+      'test/fixtures/sessionResolutionGuard/positive.ts#constrainedTypeParameterReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#destructuredReference#getActiveSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#destructuredRootReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#directReference#getSession',
+      'test/fixtures/sessionResolutionGuard/positive.ts#parameterDestructuredReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#pickReference#getSession',
       'test/fixtures/sessionResolutionGuard/positive.ts#typeAliasReference#getSessionList',
       'test/fixtures/sessionResolutionGuard/positive.ts#typedAssignmentReference#getSessionList',

--- a/test/main/presenter/mcpPresenter/toolManager.test.ts
+++ b/test/main/presenter/mcpPresenter/toolManager.test.ts
@@ -8,9 +8,14 @@ const eventBusMocks = vi.hoisted(() => ({
 
 const presenterMocks = vi.hoisted(() => ({
   agentSessionPresenter: {
-    getSession: vi.fn()
+    resolveSession: vi.fn()
   }
 }))
+
+const available = (session: Record<string, unknown>) => ({
+  availability: 'available' as const,
+  session
+})
 
 vi.mock('@/eventbus', () => ({
   eventBus: eventBusMocks
@@ -182,19 +187,21 @@ describe('ToolManager', () => {
     configPresenter.getAcpAgents.mockResolvedValue([{ id: 'agent-1', name: 'Agent 1' }])
     configPresenter.getAgentMcpSelections.mockResolvedValue([])
 
-    presenterMocks.agentSessionPresenter.getSession.mockResolvedValue({
-      id: 'session-1',
-      agentId: 'agent-1',
-      title: 'New Chat',
-      projectDir: '/workspace/acp',
-      isPinned: false,
-      isDraft: false,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-      status: 'idle',
-      providerId: 'acp',
-      modelId: 'agent-1'
-    })
+    presenterMocks.agentSessionPresenter.resolveSession.mockResolvedValue(
+      available({
+        id: 'session-1',
+        agentId: 'agent-1',
+        title: 'New Chat',
+        projectDir: '/workspace/acp',
+        isPinned: false,
+        isDraft: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        status: 'idle',
+        providerId: 'acp',
+        modelId: 'agent-1'
+      })
+    )
 
     const manager = new ToolManager(
       configPresenter as never,
@@ -320,7 +327,10 @@ describe('ToolManager', () => {
   it('skips ACP session resolution when provider hint is non-ACP', async () => {
     const client = createClient('open-server')
     const configPresenter = createConfigPresenter('open-server')
-    presenterMocks.agentSessionPresenter.getSession.mockResolvedValue(null)
+    presenterMocks.agentSessionPresenter.resolveSession.mockResolvedValue({
+      availability: 'missing',
+      sessionId: 'conv-1'
+    })
 
     const manager = new ToolManager(
       configPresenter as never,
@@ -341,7 +351,7 @@ describe('ToolManager', () => {
     expect(result.isError).toBe(false)
     expect(result.content).toBe('ok')
     expect(client.callTool).toHaveBeenCalledWith('echo', {})
-    expect(presenterMocks.agentSessionPresenter.getSession).not.toHaveBeenCalled()
+    expect(presenterMocks.agentSessionPresenter.resolveSession).not.toHaveBeenCalled()
     expect(configPresenter.getAgentMcpSelections).not.toHaveBeenCalled()
     expect(
       warnSpy.mock.calls.some((call) =>
@@ -354,19 +364,21 @@ describe('ToolManager', () => {
     const client = createClient('open-server')
     const configPresenter = createConfigPresenter('open-server')
 
-    presenterMocks.agentSessionPresenter.getSession.mockResolvedValue({
-      id: 'session-2',
-      agentId: 'deepchat',
-      title: 'Normal Chat',
-      projectDir: null,
-      isPinned: false,
-      isDraft: false,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-      status: 'idle',
-      providerId: 'openai',
-      modelId: 'gpt-4'
-    })
+    presenterMocks.agentSessionPresenter.resolveSession.mockResolvedValue(
+      available({
+        id: 'session-2',
+        agentId: 'deepchat',
+        title: 'Normal Chat',
+        projectDir: null,
+        isPinned: false,
+        isDraft: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        status: 'idle',
+        providerId: 'openai',
+        modelId: 'gpt-4'
+      })
+    )
 
     const manager = new ToolManager(
       configPresenter as never,
@@ -446,7 +458,10 @@ describe('ToolManager', () => {
   it('treats missing provider hint as a fallback to new session resolution', async () => {
     const client = createClient('open-server')
     const configPresenter = createConfigPresenter('open-server')
-    presenterMocks.agentSessionPresenter.getSession.mockResolvedValue(null)
+    presenterMocks.agentSessionPresenter.resolveSession.mockResolvedValue({
+      availability: 'missing',
+      sessionId: 'conv-fallback'
+    })
 
     const manager = new ToolManager(
       configPresenter as never,
@@ -466,7 +481,9 @@ describe('ToolManager', () => {
     expect(result.isError).toBe(false)
     expect(result.content).toBe('ok')
     expect(client.callTool).toHaveBeenCalledWith('echo', {})
-    expect(presenterMocks.agentSessionPresenter.getSession).toHaveBeenCalledWith('conv-fallback')
+    expect(presenterMocks.agentSessionPresenter.resolveSession).toHaveBeenCalledWith(
+      'conv-fallback'
+    )
     expect(configPresenter.getAgentMcpSelections).not.toHaveBeenCalled()
   })
 })

--- a/test/main/presenter/remoteControlPresenter/remoteConversationRunner.test.ts
+++ b/test/main/presenter/remoteControlPresenter/remoteConversationRunner.test.ts
@@ -21,6 +21,11 @@ const createSession = (overrides: Record<string, unknown> = {}) => ({
   ...overrides
 })
 
+const available = (session: ReturnType<typeof createSession>) => ({
+  availability: 'available' as const,
+  session
+})
+
 const createConfigPresenter = (overrides: Record<string, unknown> = {}) => ({
   getAgentType: vi.fn(async (agentId: string) => (agentId === 'acp-agent' ? 'acp' : 'deepchat')),
   getDefaultProjectPath: vi.fn(() => null),
@@ -64,6 +69,82 @@ describe('RemoteConversationRunner', () => {
     expect(bindingStore.setBinding).toHaveBeenCalledWith('telegram:100:0', session.id)
   })
 
+  it.each([
+    {
+      availability: 'unavailable' as const,
+      sessionId: 'session-bound',
+      record: createSession({ id: 'session-bound' }),
+      reason: 'agent_unknown' as const
+    },
+    {
+      availability: 'transient_error' as const,
+      sessionId: 'session-bound',
+      record: createSession({ id: 'session-bound' }),
+      error: {
+        code: 'SESSION_RESOLUTION_FAILED' as const,
+        stage: 'state_read' as const,
+        retryable: true as const,
+        cause: new Error('temporary state read failure')
+      }
+    }
+  ])('retains remote binding for $availability resolution', async (resolution) => {
+    const bindingStore = {
+      getBinding: vi.fn().mockReturnValue({
+        sessionId: 'session-bound',
+        updatedAt: 1
+      }),
+      clearBinding: vi.fn()
+    }
+    const runner = new RemoteConversationRunner(
+      {
+        configPresenter: createConfigPresenter() as any,
+        agentSessionPresenter: {
+          resolveSession: vi.fn().mockResolvedValue(resolution)
+        } as any,
+        agentRuntimePresenter: {} as any,
+        windowPresenter: {} as any,
+        tabPresenter: {} as any,
+        resolveDefaultAgentId: vi.fn()
+      },
+      bindingStore as any
+    )
+
+    await expect(runner.getCurrentSession('telegram:100:0')).rejects.toMatchObject({
+      name: 'SessionResolutionError',
+      availability: resolution.availability
+    })
+    expect(bindingStore.clearBinding).not.toHaveBeenCalled()
+  })
+
+  it('clears remote binding only after an authoritative record miss', async () => {
+    const bindingStore = {
+      getBinding: vi.fn().mockReturnValue({
+        sessionId: 'session-bound',
+        updatedAt: 1
+      }),
+      clearBinding: vi.fn()
+    }
+    const runner = new RemoteConversationRunner(
+      {
+        configPresenter: createConfigPresenter() as any,
+        agentSessionPresenter: {
+          resolveSession: vi.fn().mockResolvedValue({
+            availability: 'missing',
+            sessionId: 'session-bound'
+          })
+        } as any,
+        agentRuntimePresenter: {} as any,
+        windowPresenter: {} as any,
+        tabPresenter: {} as any,
+        resolveDefaultAgentId: vi.fn()
+      },
+      bindingStore as any
+    )
+
+    await expect(runner.getCurrentSession('telegram:100:0')).resolves.toBeNull()
+    expect(bindingStore.clearBinding).toHaveBeenCalledWith('telegram:100:0')
+  })
+
   it('creates a new bound session after the default agent changes', async () => {
     const agentSessionPresenter = {
       createDetachedSession: vi.fn().mockResolvedValue(
@@ -72,11 +153,13 @@ describe('RemoteConversationRunner', () => {
           agentId: 'deepchat-new'
         })
       ),
-      getSession: vi.fn().mockResolvedValue(
-        createSession({
-          id: 'session-legacy',
-          agentId: 'deepchat-legacy'
-        })
+      resolveSession: vi.fn().mockResolvedValue(
+        available(
+          createSession({
+            id: 'session-legacy',
+            agentId: 'deepchat-legacy'
+          })
+        )
       ),
       getMessages: vi.fn().mockResolvedValue([]),
       sendMessage: vi.fn().mockResolvedValue(undefined),
@@ -140,7 +223,7 @@ describe('RemoteConversationRunner', () => {
       projectDir: workspace
     })
     const agentSessionPresenter = {
-      getSession: vi.fn().mockResolvedValue(session),
+      resolveSession: vi.fn().mockResolvedValue(available(session)),
       getMessages: vi.fn().mockResolvedValue([]),
       sendMessage: vi.fn().mockResolvedValue(undefined),
       getMessage: vi.fn().mockResolvedValue(null)
@@ -217,7 +300,7 @@ describe('RemoteConversationRunner', () => {
       projectDir: workspace
     })
     const agentSessionPresenter = {
-      getSession: vi.fn().mockResolvedValue(session),
+      resolveSession: vi.fn().mockResolvedValue(available(session)),
       getMessages: vi.fn().mockResolvedValue([]),
       sendMessage: vi.fn().mockResolvedValue(undefined),
       getMessage: vi.fn().mockResolvedValue(null)
@@ -318,7 +401,7 @@ describe('RemoteConversationRunner', () => {
       projectDir: workspace
     })
     const agentSessionPresenter = {
-      getSession: vi.fn().mockResolvedValue(session),
+      resolveSession: vi.fn().mockResolvedValue(available(session)),
       getMessages: vi.fn().mockResolvedValue([]),
       sendMessage: vi.fn().mockResolvedValue(undefined),
       getMessage: vi.fn().mockResolvedValue(null)
@@ -411,7 +494,7 @@ describe('RemoteConversationRunner', () => {
       projectDir: workspace
     })
     const agentSessionPresenter = {
-      getSession: vi.fn().mockResolvedValue(session),
+      resolveSession: vi.fn().mockResolvedValue(available(session)),
       getMessages: vi.fn().mockResolvedValue([]),
       sendMessage: vi.fn().mockResolvedValue(undefined),
       getMessage: vi.fn().mockResolvedValue(null)
@@ -491,7 +574,7 @@ describe('RemoteConversationRunner', () => {
       projectDir: workspace
     })
     const agentSessionPresenter = {
-      getSession: vi.fn().mockResolvedValue(session),
+      resolveSession: vi.fn().mockResolvedValue(available(session)),
       getMessages: vi.fn().mockResolvedValue([]),
       sendMessage: vi.fn().mockResolvedValue(undefined),
       getMessage: vi.fn().mockResolvedValue(null)
@@ -678,7 +761,7 @@ describe('RemoteConversationRunner', () => {
       projectDir: workspace
     })
     const agentSessionPresenter = {
-      getSession: vi.fn().mockResolvedValue(session),
+      resolveSession: vi.fn().mockResolvedValue(available(session)),
       getMessages: vi.fn().mockResolvedValueOnce([]).mockResolvedValue([assistantMessage]),
       sendMessage: vi.fn().mockResolvedValue(undefined),
       getMessage: vi.fn().mockResolvedValue(assistantMessage),
@@ -773,7 +856,7 @@ describe('RemoteConversationRunner', () => {
       projectDir: null
     })
     const agentSessionPresenter = {
-      getSession: vi.fn().mockResolvedValue(session),
+      resolveSession: vi.fn().mockResolvedValue(available(session)),
       getMessages: vi.fn().mockResolvedValueOnce([]).mockResolvedValue([assistantMessage]),
       sendMessage: vi.fn().mockResolvedValue(undefined),
       getMessage: vi.fn().mockResolvedValue(assistantMessage),
@@ -820,23 +903,29 @@ describe('RemoteConversationRunner', () => {
 
   it('lists recent sessions for the currently bound agent before falling back to default agent', async () => {
     const agentSessionPresenter = {
-      getSession: vi.fn().mockResolvedValue(
-        createSession({
-          id: 'session-bound',
-          agentId: 'deepchat-bound'
-        })
+      resolveSession: vi.fn().mockResolvedValue(
+        available(
+          createSession({
+            id: 'session-bound',
+            agentId: 'deepchat-bound'
+          })
+        )
       ),
-      getSessionList: vi.fn().mockResolvedValue([
-        createSession({
-          id: 'session-a',
-          agentId: 'deepchat-bound',
-          updatedAt: 5
-        }),
-        createSession({
-          id: 'session-b',
-          agentId: 'deepchat-bound',
-          updatedAt: 10
-        })
+      resolveSessionList: vi.fn().mockResolvedValue([
+        available(
+          createSession({
+            id: 'session-a',
+            agentId: 'deepchat-bound',
+            updatedAt: 5
+          })
+        ),
+        available(
+          createSession({
+            id: 'session-b',
+            agentId: 'deepchat-bound',
+            updatedAt: 10
+          })
+        )
       ])
     }
     const bindingStore = {
@@ -860,7 +949,7 @@ describe('RemoteConversationRunner', () => {
 
     const sessions = await runner.listSessions('telegram:100:0')
 
-    expect(agentSessionPresenter.getSessionList).toHaveBeenCalledWith({
+    expect(agentSessionPresenter.resolveSessionList).toHaveBeenCalledWith({
       agentId: 'deepchat-bound'
     })
     expect(sessions.map((session) => session.id)).toEqual(['session-b', 'session-a'])
@@ -872,11 +961,13 @@ describe('RemoteConversationRunner', () => {
 
   it('delegates remote model switching to the bound session', async () => {
     const agentSessionPresenter = {
-      getSession: vi.fn().mockResolvedValue(
-        createSession({
-          id: 'session-bound',
-          agentId: 'deepchat-bound'
-        })
+      resolveSession: vi.fn().mockResolvedValue(
+        available(
+          createSession({
+            id: 'session-bound',
+            agentId: 'deepchat-bound'
+          })
+        )
       ),
       setSessionModel: vi.fn().mockResolvedValue(
         createSession({
@@ -920,7 +1011,7 @@ describe('RemoteConversationRunner', () => {
       {
         configPresenter: createConfigPresenter() as any,
         agentSessionPresenter: {
-          getSession: vi.fn()
+          resolveSession: vi.fn()
         } as any,
         agentRuntimePresenter: {} as any,
         windowPresenter: {
@@ -952,7 +1043,7 @@ describe('RemoteConversationRunner', () => {
       {
         configPresenter: createConfigPresenter() as any,
         agentSessionPresenter: {
-          getSession: vi.fn().mockResolvedValue(createSession()),
+          resolveSession: vi.fn().mockResolvedValue(available(createSession())),
           activateSession
         } as any,
         agentRuntimePresenter: {} as any,
@@ -1001,7 +1092,7 @@ describe('RemoteConversationRunner', () => {
       {
         configPresenter: createConfigPresenter() as any,
         agentSessionPresenter: {
-          getSession: vi.fn().mockResolvedValue(session),
+          resolveSession: vi.fn().mockResolvedValue(available(session)),
           activateSession
         } as any,
         agentRuntimePresenter: {} as any,
@@ -1050,7 +1141,7 @@ describe('RemoteConversationRunner', () => {
     }
 
     const agentSessionPresenter = {
-      getSession: vi.fn().mockResolvedValue(session),
+      resolveSession: vi.fn().mockResolvedValue(available(session)),
       getMessages: vi
         .fn()
         .mockResolvedValueOnce([
@@ -1128,7 +1219,7 @@ describe('RemoteConversationRunner', () => {
       {
         configPresenter: createConfigPresenter() as any,
         agentSessionPresenter: {
-          getSession: vi.fn().mockResolvedValue(createSession()),
+          resolveSession: vi.fn().mockResolvedValue(available(createSession())),
           sendMessage: vi.fn().mockResolvedValue(undefined),
           getMessages: vi.fn().mockResolvedValue([
             {
@@ -1210,7 +1301,7 @@ describe('RemoteConversationRunner', () => {
       {
         configPresenter: createConfigPresenter() as any,
         agentSessionPresenter: {
-          getSession: vi.fn().mockResolvedValue(createSession()),
+          resolveSession: vi.fn().mockResolvedValue(available(createSession())),
           getMessages: vi.fn().mockResolvedValue([
             {
               id: 'assistant-1',
@@ -1289,7 +1380,7 @@ describe('RemoteConversationRunner', () => {
       ])
     })
     const agentSessionPresenter = {
-      getSession: vi.fn().mockResolvedValue(createSession()),
+      resolveSession: vi.fn().mockResolvedValue(available(createSession())),
       getMessages: vi
         .fn()
         .mockResolvedValueOnce([

--- a/test/main/routes/chatService.test.ts
+++ b/test/main/routes/chatService.test.ts
@@ -1,6 +1,11 @@
 import { ChatService } from '@/routes/chat/chatService'
 
 describe('ChatService', () => {
+  const availableSession = <T extends Record<string, unknown>>(session: T) => ({
+    availability: 'available' as const,
+    session
+  })
+
   const createScheduler = () => ({
     sleep: vi.fn(),
     timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task),
@@ -10,10 +15,12 @@ describe('ChatService', () => {
   it('sends messages through the scheduler after resolving the session owner', async () => {
     const scheduler = createScheduler()
     const sessionRepository = {
-      get: vi.fn().mockResolvedValue({
-        id: 'session-1',
-        agentId: 'deepchat'
-      })
+      resolve: vi.fn().mockResolvedValue(
+        availableSession({
+          id: 'session-1',
+          agentId: 'deepchat'
+        })
+      )
     }
     const messageRepository = {
       listBySession: vi.fn(),
@@ -52,20 +59,76 @@ describe('ChatService', () => {
       messageId: null
     })
 
-    expect(sessionRepository.get).toHaveBeenCalledWith('session-1')
+    expect(sessionRepository.resolve).toHaveBeenCalledWith('session-1')
     expect(providerCatalogPort.getAgentType).toHaveBeenCalledWith('deepchat')
     expect(providerExecutionPort.sendMessage).toHaveBeenCalledWith('session-1', 'hello')
     expect(messageRepository.listBySession).not.toHaveBeenCalled()
     expect(scheduler.timeout).toHaveBeenCalledTimes(3)
   })
 
+  it.each([
+    {
+      availability: 'missing' as const,
+      sessionId: 'session-1'
+    },
+    {
+      availability: 'unavailable' as const,
+      sessionId: 'session-1',
+      record: { id: 'session-1', agentId: 'removed-agent' },
+      reason: 'agent_unknown' as const
+    },
+    {
+      availability: 'transient_error' as const,
+      sessionId: 'session-1',
+      record: null,
+      error: {
+        code: 'SESSION_RESOLUTION_FAILED' as const,
+        stage: 'record_read' as const,
+        retryable: true as const,
+        cause: new Error('temporary read failure')
+      }
+    }
+  ])('does not start a send for $availability resolution', async (resolution) => {
+    const providerExecutionPort = {
+      sendMessage: vi.fn(),
+      steerActiveTurn: vi.fn(),
+      cancelGeneration: vi.fn(),
+      respondToolInteraction: vi.fn()
+    }
+    const service = new ChatService({
+      sessionRepository: {
+        resolve: vi.fn().mockResolvedValue(resolution)
+      } as any,
+      messageRepository: {
+        listBySession: vi.fn(),
+        get: vi.fn()
+      } as any,
+      providerExecutionPort,
+      providerCatalogPort: {
+        getAgentType: vi.fn()
+      } as any,
+      sessionPermissionPort: {
+        clearSessionPermissions: vi.fn()
+      },
+      scheduler: createScheduler() as any
+    })
+
+    await expect(service.sendMessage('session-1', 'hello')).rejects.toMatchObject({
+      name: 'SessionResolutionError',
+      availability: resolution.availability
+    })
+    expect(providerExecutionPort.sendMessage).not.toHaveBeenCalled()
+  })
+
   it('steers the active turn without claiming the normal send lock', async () => {
     const scheduler = createScheduler()
     const sessionRepository = {
-      get: vi.fn().mockResolvedValue({
-        id: 'session-1',
-        agentId: 'deepchat'
-      })
+      resolve: vi.fn().mockResolvedValue(
+        availableSession({
+          id: 'session-1',
+          agentId: 'deepchat'
+        })
+      )
     }
     const providerExecutionPort = {
       sendMessage: vi.fn(),
@@ -94,7 +157,7 @@ describe('ChatService', () => {
       accepted: true
     })
 
-    expect(sessionRepository.get).toHaveBeenCalledWith('session-1')
+    expect(sessionRepository.resolve).toHaveBeenCalledWith('session-1')
     expect(providerExecutionPort.steerActiveTurn).toHaveBeenCalledWith('session-1', 'refine this')
     expect(scheduler.timeout).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -106,7 +169,7 @@ describe('ChatService', () => {
   it('resolves stopStream by request id and clears permissions before cancelling', async () => {
     const scheduler = createScheduler()
     const sessionRepository = {
-      get: vi.fn()
+      resolve: vi.fn()
     }
     const messageRepository = {
       listBySession: vi.fn(),
@@ -148,7 +211,7 @@ describe('ChatService', () => {
   it('attempts both stopStream cleanups even if clearing permissions fails', async () => {
     const scheduler = createScheduler()
     const sessionRepository = {
-      get: vi.fn()
+      resolve: vi.fn()
     }
     const messageRepository = {
       listBySession: vi.fn(),
@@ -200,7 +263,7 @@ describe('ChatService', () => {
 
     const service = new ChatService({
       sessionRepository: {
-        get: vi.fn()
+        resolve: vi.fn()
       } as any,
       messageRepository: {
         listBySession: vi.fn(),
@@ -254,10 +317,12 @@ describe('ChatService', () => {
     const timeoutError = new Error('timed out')
     timeoutError.name = 'TimeoutError'
     const sessionRepository = {
-      get: vi.fn().mockResolvedValue({
-        id: 'session-1',
-        agentId: 'deepchat'
-      })
+      resolve: vi.fn().mockResolvedValue(
+        availableSession({
+          id: 'session-1',
+          agentId: 'deepchat'
+        })
+      )
     }
     const messageRepository = {
       listBySession: vi.fn().mockResolvedValue([]),
@@ -335,11 +400,17 @@ describe('ChatService', () => {
       ),
       retry: vi.fn()
     }
-    let resolveSession!: (value: { id: string; agentId: string }) => void
+    let resolveSession!: (value: {
+      availability: 'available'
+      session: { id: string; agentId: string }
+    }) => void
     const sessionRepository = {
-      get: vi.fn().mockImplementation(
+      resolve: vi.fn().mockImplementation(
         async () =>
-          await new Promise<{ id: string; agentId: string }>((resolve) => {
+          await new Promise<{
+            availability: 'available'
+            session: { id: string; agentId: string }
+          }>((resolve) => {
             resolveSession = resolve
           })
       )
@@ -377,10 +448,12 @@ describe('ChatService', () => {
       stopped: true
     })
 
-    resolveSession({
-      id: 'session-1',
-      agentId: 'deepchat'
-    })
+    resolveSession(
+      availableSession({
+        id: 'session-1',
+        agentId: 'deepchat'
+      })
+    )
 
     await expect(pendingSend).rejects.toMatchObject({
       name: 'AbortError'
@@ -392,10 +465,12 @@ describe('ChatService', () => {
   it('rejects a new send while another stream is still active for the session', async () => {
     const scheduler = createScheduler()
     const sessionRepository = {
-      get: vi.fn().mockResolvedValue({
-        id: 'session-1',
-        agentId: 'deepchat'
-      })
+      resolve: vi.fn().mockResolvedValue(
+        availableSession({
+          id: 'session-1',
+          agentId: 'deepchat'
+        })
+      )
     }
     const messageRepository = {
       listBySession: vi.fn(),

--- a/test/main/routes/dispatcher.test.ts
+++ b/test/main/routes/dispatcher.test.ts
@@ -470,6 +470,26 @@ function createRuntime() {
       providerId: 'openai',
       modelId: 'gpt-5.4'
     }),
+    resolveSession: vi.fn().mockResolvedValue({
+      availability: 'available',
+      session: {
+        id: 'session-1',
+        agentId: 'deepchat',
+        title: 'Restored',
+        projectDir: '/workspace',
+        isPinned: false,
+        isDraft: false,
+        sessionKind: 'regular',
+        parentSessionId: null,
+        subagentEnabled: false,
+        subagentMeta: null,
+        createdAt: 1,
+        updatedAt: 2,
+        status: 'idle',
+        providerId: 'openai',
+        modelId: 'gpt-5.4'
+      }
+    }),
     getMessages: vi.fn().mockResolvedValue([
       {
         id: 'message-1',
@@ -485,7 +505,9 @@ function createRuntime() {
       }
     ]),
     getSessionList: vi.fn().mockResolvedValue([]),
+    resolveSessionList: vi.fn().mockResolvedValue([]),
     getActiveSession: vi.fn().mockResolvedValue(null),
+    resolveActiveSession: vi.fn().mockResolvedValue({ binding: 'none' }),
     activateSession: vi.fn().mockResolvedValue(undefined),
     deactivateSession: vi.fn().mockResolvedValue(undefined),
     getSessionGenerationSettings: vi.fn().mockResolvedValue({
@@ -3915,23 +3937,32 @@ describe('dispatchDeepchatRoute', () => {
 
   it('activates, deactivates, and reads the active session through typed routes', async () => {
     const { runtime, agentSessionPresenter } = createRuntime()
-    ;(agentSessionPresenter.getActiveSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      id: 'session-1',
-      agentId: 'deepchat',
-      title: 'Restored',
-      projectDir: '/workspace',
-      isPinned: false,
-      isDraft: false,
-      sessionKind: 'regular',
-      parentSessionId: null,
-      subagentEnabled: false,
-      subagentMeta: null,
-      createdAt: 1,
-      updatedAt: 2,
-      status: 'idle',
-      providerId: 'openai',
-      modelId: 'gpt-5.4'
-    })
+    ;(agentSessionPresenter.resolveActiveSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      {
+        binding: 'bound',
+        sessionId: 'session-1',
+        resolution: {
+          availability: 'available',
+          session: {
+            id: 'session-1',
+            agentId: 'deepchat',
+            title: 'Restored',
+            projectDir: '/workspace',
+            isPinned: false,
+            isDraft: false,
+            sessionKind: 'regular',
+            parentSessionId: null,
+            subagentEnabled: false,
+            subagentMeta: null,
+            createdAt: 1,
+            updatedAt: 2,
+            status: 'idle',
+            providerId: 'openai',
+            modelId: 'gpt-5.4'
+          }
+        }
+      }
+    )
 
     const activateResult = await dispatchDeepchatRoute(
       runtime,
@@ -3967,7 +3998,7 @@ describe('dispatchDeepchatRoute', () => {
 
     expect(agentSessionPresenter.activateSession).toHaveBeenCalledWith(88, 'session-1')
     expect(agentSessionPresenter.deactivateSession).toHaveBeenCalledWith(88)
-    expect(agentSessionPresenter.getActiveSession).toHaveBeenCalledWith(88)
+    expect(agentSessionPresenter.resolveActiveSession).toHaveBeenCalledWith(88)
     expect(activateResult).toEqual({ activated: true })
     expect(deactivateResult).toEqual({ deactivated: true })
     expect(activeResult).toEqual({

--- a/test/main/routes/sessionService.test.ts
+++ b/test/main/routes/sessionService.test.ts
@@ -1,5 +1,6 @@
 import logger from '@shared/logger'
 import { SessionService } from '@/routes/sessions/sessionService'
+import { reportTerminalSessionResolution } from '@/presenter/agentSessionPresenter/sessionResolution'
 
 vi.mock('@shared/logger', () => ({
   default: {
@@ -156,6 +157,54 @@ describe('SessionService', () => {
       '[SessionResolution] Terminal lookup',
       expect.objectContaining({ operation: 'sessions.restore', attemptCount: 2 })
     )
+  })
+
+  it('logs only stable metadata and discards transient secrets and paths', () => {
+    const cause = new Error('provider-secret at /Users/alice/private/provider.json')
+    cause.stack = 'provider-secret stack at /Users/alice/private/provider.json'
+
+    reportTerminalSessionResolution(
+      'sessions.restore',
+      {
+        availability: 'transient_error',
+        sessionId: 'session-1',
+        record: {
+          id: 'session-1',
+          agentId: 'configured-agent-secret',
+          title: 'private session',
+          projectDir: '/Users/alice/private',
+          isPinned: false,
+          sessionKind: 'regular',
+          subagentEnabled: false,
+          createdAt: 1,
+          updatedAt: 1
+        },
+        error: {
+          code: 'SESSION_RESOLUTION_FAILED',
+          stage: 'state_read',
+          retryable: true,
+          cause
+        }
+      },
+      2
+    )
+
+    expect(logger.warn).toHaveBeenCalledWith('[SessionResolution] Terminal lookup', {
+      operation: 'sessions.restore',
+      sessionId: 'session-1',
+      availability: 'transient_error',
+      stage: 'state_read',
+      code: 'SESSION_RESOLUTION_FAILED',
+      retryable: true,
+      attemptCount: 2
+    })
+
+    const serializedArguments = JSON.stringify(vi.mocked(logger.warn).mock.calls)
+    expect(serializedArguments).not.toContain('provider-secret')
+    expect(serializedArguments).not.toContain('/Users/alice/private/provider.json')
+    expect(serializedArguments).not.toContain('configured-agent-secret')
+    expect(serializedArguments).not.toContain('cause')
+    expect(serializedArguments).not.toContain('stack')
   })
 
   it('does not retry an unsettled timeout as a classified transient result', async () => {

--- a/test/main/routes/sessionService.test.ts
+++ b/test/main/routes/sessionService.test.ts
@@ -1,76 +1,110 @@
+import logger from '@shared/logger'
 import { SessionService } from '@/routes/sessions/sessionService'
 
+vi.mock('@shared/logger', () => ({
+  default: {
+    warn: vi.fn()
+  }
+}))
+
+const available = (session: Record<string, unknown>) => ({
+  availability: 'available' as const,
+  session
+})
+
+const transient = (sessionId: string) => ({
+  availability: 'transient_error' as const,
+  sessionId,
+  record: null,
+  error: {
+    code: 'SESSION_RESOLUTION_FAILED' as const,
+    stage: 'record_read' as const,
+    retryable: true as const,
+    cause: new Error('temporary read failure')
+  }
+})
+
+const createScheduler = () => ({
+  sleep: vi.fn(),
+  timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task),
+  retry: vi.fn(
+    async <T>({
+      task,
+      maxAttempts
+    }: {
+      task: () => Promise<T>
+      maxAttempts: number
+    }): Promise<T> => {
+      let lastError: unknown
+      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        try {
+          return await task()
+        } catch (error) {
+          lastError = error
+        }
+      }
+      throw lastError
+    }
+  )
+})
+
+const createMessageRepository = () => ({
+  listBySession: vi.fn(),
+  listPageBySession: vi.fn().mockResolvedValue({
+    messages: [{ id: 'message-1', sessionId: 'session-1' }],
+    nextCursor: null,
+    hasMore: false
+  }),
+  get: vi.fn()
+})
+
+const createSessionRepository = () => ({
+  create: vi.fn(),
+  resolve: vi.fn(),
+  resolveList: vi.fn(),
+  activate: vi.fn(),
+  deactivate: vi.fn(),
+  resolveActive: vi.fn()
+})
+
 describe('SessionService', () => {
-  const createScheduler = () => ({
-    sleep: vi.fn(),
-    timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task),
-    retry: vi.fn(async <T>({ task }: { task: () => Promise<T> }) => await task())
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
-  it('restores session snapshots through the scheduler and repositories', async () => {
+  it('restores an available session through the scheduler and repositories', async () => {
     const scheduler = createScheduler()
-    const sessionRepository = {
-      create: vi.fn(),
-      get: vi.fn().mockResolvedValue({
-        id: 'session-1'
-      }),
-      list: vi.fn(),
-      activate: vi.fn(),
-      deactivate: vi.fn(),
-      getActive: vi.fn()
-    }
-    const messageRepository = {
-      listBySession: vi.fn(),
-      listPageBySession: vi.fn().mockResolvedValue({
-        messages: [{ id: 'message-1', sessionId: 'session-1' }],
-        nextCursor: null,
-        hasMore: false
-      }),
-      get: vi.fn()
-    }
-
+    const sessionRepository = createSessionRepository()
+    sessionRepository.resolve.mockResolvedValue(available({ id: 'session-1' }))
+    const messageRepository = createMessageRepository()
     const service = new SessionService({
-      sessionRepository,
-      messageRepository,
-      scheduler
+      sessionRepository: sessionRepository as any,
+      messageRepository: messageRepository as any,
+      scheduler: scheduler as any
     })
 
-    const result = await service.restoreSession('session-1')
-
-    expect(scheduler.retry).toHaveBeenCalledTimes(1)
-    expect(scheduler.timeout).toHaveBeenCalledTimes(2)
-    expect(sessionRepository.get).toHaveBeenCalledWith('session-1')
-    expect(messageRepository.listPageBySession).toHaveBeenCalledWith('session-1', {
-      limit: 100
-    })
-    expect(result).toEqual({
+    await expect(service.restoreSession('session-1')).resolves.toEqual({
       session: { id: 'session-1' },
       messages: [{ id: 'message-1', sessionId: 'session-1' }],
       nextCursor: null,
       hasMore: false
     })
+    expect(sessionRepository.resolve).toHaveBeenCalledTimes(1)
+    expect(messageRepository.listPageBySession).toHaveBeenCalledWith('session-1', { limit: 100 })
   })
 
-  it('returns an empty restore payload when the session no longer exists', async () => {
+  it('does not retry an authoritative missing result', async () => {
     const scheduler = createScheduler()
-    const sessionRepository = {
-      create: vi.fn(),
-      get: vi.fn().mockResolvedValue(null),
-      list: vi.fn(),
-      activate: vi.fn(),
-      deactivate: vi.fn(),
-      getActive: vi.fn()
-    }
-    const messageRepository = {
-      listBySession: vi.fn(),
-      listPageBySession: vi.fn(),
-      get: vi.fn()
-    }
-
+    const sessionRepository = createSessionRepository()
+    sessionRepository.resolve.mockResolvedValue({
+      availability: 'missing',
+      sessionId: 'missing-session'
+    })
+    const messageRepository = createMessageRepository()
     const service = new SessionService({
-      sessionRepository,
-      messageRepository,
-      scheduler
+      sessionRepository: sessionRepository as any,
+      messageRepository: messageRepository as any,
+      scheduler: scheduler as any
     })
 
     await expect(service.restoreSession('missing-session')).resolves.toEqual({
@@ -79,6 +113,140 @@ describe('SessionService', () => {
       nextCursor: null,
       hasMore: false
     })
+    expect(sessionRepository.resolve).toHaveBeenCalledTimes(1)
     expect(messageRepository.listPageBySession).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a transient restore once and does not log if it recovers', async () => {
+    const scheduler = createScheduler()
+    const sessionRepository = createSessionRepository()
+    sessionRepository.resolve
+      .mockResolvedValueOnce(transient('session-1'))
+      .mockResolvedValueOnce(available({ id: 'session-1' }))
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: createMessageRepository() as any,
+      scheduler: scheduler as any
+    })
+
+    await expect(service.restoreSession('session-1')).resolves.toMatchObject({
+      session: { id: 'session-1' }
+    })
+    expect(sessionRepository.resolve).toHaveBeenCalledTimes(2)
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('logs an exhausted transient restore exactly once', async () => {
+    const scheduler = createScheduler()
+    const sessionRepository = createSessionRepository()
+    sessionRepository.resolve.mockResolvedValue(transient('session-1'))
+    const messageRepository = createMessageRepository()
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: messageRepository as any,
+      scheduler: scheduler as any
+    })
+
+    await expect(service.restoreSession('session-1')).resolves.toMatchObject({ session: null })
+    expect(sessionRepository.resolve).toHaveBeenCalledTimes(2)
+    expect(messageRepository.listPageBySession).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[SessionResolution] Terminal lookup',
+      expect.objectContaining({ operation: 'sessions.restore', attemptCount: 2 })
+    )
+  })
+
+  it('does not retry an unsettled timeout as a classified transient result', async () => {
+    const scheduler = createScheduler()
+    const timeoutError = new Error('lookup timed out')
+    timeoutError.name = 'TimeoutError'
+    scheduler.timeout.mockRejectedValue(timeoutError)
+    const sessionRepository = createSessionRepository()
+    sessionRepository.resolve.mockReturnValue(new Promise(() => {}))
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: createMessageRepository() as any,
+      scheduler: scheduler as any
+    })
+
+    await expect(service.restoreSession('session-1')).rejects.toBe(timeoutError)
+    expect(sessionRepository.resolve).toHaveBeenCalledTimes(1)
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('uses the same bounded retry for active-session reads', async () => {
+    const scheduler = createScheduler()
+    const sessionRepository = createSessionRepository()
+    sessionRepository.resolveActive
+      .mockResolvedValueOnce({
+        binding: 'bound',
+        sessionId: 'session-1',
+        resolution: transient('session-1')
+      })
+      .mockResolvedValueOnce({
+        binding: 'bound',
+        sessionId: 'session-1',
+        resolution: available({ id: 'session-1' })
+      })
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: createMessageRepository() as any,
+      scheduler: scheduler as any
+    })
+
+    await expect(service.getActiveSession({ webContentsId: 7, windowId: null })).resolves.toEqual({
+      id: 'session-1'
+    })
+    expect(sessionRepository.resolveActive).toHaveBeenCalledTimes(2)
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('logs an exhausted active-session transient exactly once', async () => {
+    const scheduler = createScheduler()
+    const sessionRepository = createSessionRepository()
+    sessionRepository.resolveActive.mockResolvedValue({
+      binding: 'bound',
+      sessionId: 'session-1',
+      resolution: transient('session-1')
+    })
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: createMessageRepository() as any,
+      scheduler: scheduler as any
+    })
+
+    await expect(service.getActiveSession({ webContentsId: 7, windowId: null })).resolves.toBeNull()
+    expect(sessionRepository.resolveActive).toHaveBeenCalledTimes(2)
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[SessionResolution] Terminal lookup',
+      expect.objectContaining({ operation: 'sessions.getActive', attemptCount: 2 })
+    )
+  })
+
+  it('does not retry individual non-available list rows', async () => {
+    const scheduler = createScheduler()
+    const sessionRepository = createSessionRepository()
+    sessionRepository.resolveList.mockResolvedValue([
+      {
+        availability: 'unavailable',
+        sessionId: 'unknown',
+        record: { id: 'unknown', agentId: 'removed' },
+        reason: 'agent_unknown'
+      },
+      available({ id: 'healthy' })
+    ])
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: createMessageRepository() as any,
+      scheduler: scheduler as any
+    })
+
+    await expect(service.listSessions()).resolves.toEqual([{ id: 'healthy' }])
+    expect(sessionRepository.resolveList).toHaveBeenCalledTimes(1)
+    expect(scheduler.retry).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Scope

This PR delivers `SES-002`: the internal four-state session-resolution contract and the safe migration of fixed main-process consumers.

It deliberately keeps the existing public route and renderer shapes. Public availability fields and UI states remain the separate `SES-003` slice.

## Why

The previous contract collapsed four different facts into `null`:

- the session is available;
- the persisted Agent is permanently unavailable;
- a catalog/runtime/state read failed transiently;
- the session record is authoritatively missing.

That ambiguity could remove an active binding during a temporary failure, silently omit records, and make bounded read retry impossible because the error was already swallowed.

## What changed

- Added typed `available`, `unavailable`, `transient_error` and `missing` results.
- Added classified `resolveSession`, `resolveSessionList` and `resolveActiveSession` authority methods.
- Preserved the registered built-in Agent fast path without adding a catalog lookup.
- Treats fulfilled catalog absence as `unavailable`, thrown catalog/runtime/state reads as `transient_error`, and only an authoritative record miss as `missing`.
- Keeps fulfilled null state compatible as an available idle session.
- Clears window and remote bindings only for `missing`; transient and unavailable results retain the binding.
- Makes restore and get-active reads use two settled attempts with a 25ms delay only for typed transient results. Timeout/throw paths do not start an overlapping attempt.
- Keeps full-list outer query failures as failures while isolating per-row availability results in original order. List rows are not retried individually.
- Migrates Chat, Remote, MCP search/tool, Hook, Skill and route hot-path consumers to the classified API.
- Keeps legacy adapters only at compatibility boundaries; the floating-button full list remains the sole production allowlist entry.
- Emits terminal diagnostics once, with stable fields only. Raw cause, message, stack, Agent identity, project path, commands and secrets are not written to electron-log.
- Replaces the old text grep with a TypeScript type/provenance contract test rooted in the canonical `IAgentSessionPresenter` declaration. It covers direct, aliased, destructured, bound, computed, generic-constrained, assignment-chain and local object-rest references without treating unrelated same-name types as the presenter.

## User and runtime impact

- Temporary session-resolution failures no longer make the active conversation disappear or unbind its window.
- An authoritatively deleted session still converges by clearing the stale binding.
- Restore/get-active may perform one additional read after 25ms on a settled transient failure.
- Full session lists do not add per-row retries, so a large list cannot create a retry storm.
- Existing routes and renderers still receive their previous available-only/null shapes in this slice.
- There is no database, settings, IPC or renderer schema migration.

## Security and privacy

The original error cause remains main-process in-memory evidence for retry classification only. The terminal logger receives operation, session id, availability, stage, stable code, retryability and attempt count. Tests inject secret text, absolute paths and stack data and assert none reaches logger arguments.

## Automated verification

- Focused changed tests: 7 files, 206/206 passed.
- Full suite: 4,570 passed / 5 failed / 135 skipped.
- The five failures exactly match the existing baseline: SpotlightOverlay Pinia x3, AgentSession steer rebudget x1 and debug mock session x1.
- `pnpm run typecheck` passed.
- `pnpm run format:check` passed.
- `pnpm run i18n` passed.
- `pnpm run lint` passed, including architecture and cleanup guards.
- `git diff --check` passed.
- Independent verification replayed partial typed ports, generic constraints, variable/parameter/assignment destructuring, local object-rest, typed and erased assignment chains, computed access and negative same-name types.

## Manual validation and remaining work

Automation does not add the public unavailable/retryable UI:

- `SES-003` must migrate route schemas and renderer/floating compatibility before users can see all four states directly.
- Packaged fault injection can still be used to inspect restore/get-active behavior, but no production fault-injection artifact is included.
- A whole-list database/query failure remains a terminal list failure by contract; only row hydration is isolated.
- The provenance guard intentionally covers local TypeScript type and assignment provenance, not arbitrary cross-function JavaScript dataflow, computed assignment graphs or re-export analysis.

## Rollback

There is no persisted format migration. Reverting this PR restores the legacy internal null behavior and consumers. `SES-003` must not be merged without this contract; if it is later present, revert it before reverting `SES-002`.