### PR TITLE
fix(runtime): synchronize prompt tool snapshots

### DIFF
--- a/docs/issues/system-prompt-cache-coherence/spec.md
+++ b/docs/issues/system-prompt-cache-coherence/spec.md
@@ -743,12 +743,17 @@ git diff --check
 
 2026-07-11 automated evidence：
 
-- source snapshot、runtime orchestration、SkillPresenter、SkillTools 和 AgentToolManager focused suite：
-  `428 passed / 2 skipped`；其中 raw persisted-pin regression 覆盖 imported legacy empty pin、typed
-  read failure、process/manual compaction/resume 三条 production entry 和 failed-pair cache exclusion；
+- source snapshot、runtime orchestration、SkillPresenter、SkillTools 和 AgentToolManager non-native
+  focused suite：`348 passed`；普通 Node ABI 另有 5 个 native SQLite cases skipped；
+- Electron 40 ABI 下 raw persisted-pin target 为 `5 passed`，`test:main:native-sqlite` 等价的四文件
+  suite 为 `120 passed`；覆盖 normalized rows 优先、legacy JSON、fresh/missing/empty、non-array、
+  corrupt JSON，以及 process/manual compaction/resume 三条 production entry 和 failed-pair cache
+  exclusion。`DEEPCHAT_REQUIRE_NATIVE_SQLITE=1` 在 native harness 不可用时会显式失败，不会 skip；
 - `pnpm run typecheck`、`pnpm run format`、`pnpm run i18n`、`pnpm run lint`、
   `git diff --check`：通过；
-- full suite：`4629 passed / 5 failed / 136 skipped`。5 个失败与合入前 baseline 相同：
+- full suite：`4629 passed / 5 failed / 139 skipped`。相对原 135 skips 的净增 4 来自同一
+  `newSessionsTable` native fixture 从 1 例扩为 5 例；新增 5 例已全部由上述 Electron ABI suite
+  实际执行。5 个失败与合入前 baseline 相同：
   `SpotlightOverlay.test.ts` 3 个、`agentSessionPresenter/integration.test.ts` 1 个、
   `createMockChatSession.test.ts` 1 个。
 

--- a/docs/issues/system-prompt-cache-coherence/spec.md
+++ b/docs/issues/system-prompt-cache-coherence/spec.md
@@ -618,11 +618,11 @@ prompt/tool orchestration 仍分别等待 `PRM-002B`、`PRM-002C`；本 slice �
 
 ### `PRM-002C` tasks
 
-- [ ] 先写真实 outer + A/B source owner 的 failing integration tests。
-- [ ] 把 stable skill lookup 接入 A 已建立的 absolute `200ms` pre-stream source deadline；三者保持并行。
-- [ ] 从同一个 immutable skill snapshot 构造 metadata/content/tool pair。
-- [ ] composed prompt/tool profile cache entry 与 fingerprint 加入 source revisions/stable epoch。
-- [ ] 实现一次 bounded rebuild、fully matching previous stable fallback 和 typed
+- [x] 先写真实 outer + A/B source owner 的 failing integration tests。
+- [x] 把 stable skill lookup 接入 A 已建立的 absolute `200ms` pre-stream source deadline；三者保持并行。
+- [x] 从同一个 immutable skill snapshot 构造 metadata/content/tool pair。
+- [x] composed prompt/tool profile cache entry 与 fingerprint 加入 source revisions/stable epoch。
+- [x] 实现一次 bounded rebuild、fully matching previous stable fallback 和 typed
       `SkillRuntimeUpdatingError` propagation。
 - [ ] 完成 latency upper-bound、full baseline、manual validation；仅在 C 验证完成后关闭 P-07。
 

--- a/docs/issues/system-prompt-cache-coherence/spec.md
+++ b/docs/issues/system-prompt-cache-coherence/spec.md
@@ -498,6 +498,9 @@ AND same stable-even skillMutationEpoch
 1. pre-stream source preparation 只创建一个 `deadlineAt = startedAt + 200ms`。env snapshot、verification
    snapshot 和 stable skill snapshot wait 立即并行启动并共享该 absolute deadline/`AbortSignal`；禁止先等
    env `200ms`，再等 verification `200ms`，再为 skill 创建新 budget。
+   `processMessage()`、manual compaction 和 resume 在进入该 orchestration 前只允许读取 session 持久化的
+   raw skill pins；该读取不得调用 metadata validation/discovery。raw names 必须在同一个 bounded immutable
+   skill snapshot 中完成 availability/policy filter，避免在 `deadlineAt` 创建前先做一次无界 source discovery。
 2. env/verification snapshots 和 stable skill epoch 必须在 cache hit 判定前取得。两个 file snapshot
    都 pending 时，wall-clock upper bound 是 overall `200ms` 加微小同步 compose/hash 开销，不是 `400ms`。
 3. cache entry 记录使用的 revisions/epoch，便于测试和 debug；日志不得输出 `AGENTS.md`、
@@ -515,6 +518,10 @@ AND same stable-even skillMutationEpoch
 `resolveToolProfile()` fingerprint 同样加入 stable even `skillMutationEpoch`。理由不是所有 skill content
 都改变 tool schema，而是 `allowedTools` 与 metadata/content 共用 `SKILL.md` mutation window。tool
 definitions 与 composed prompt 必须来自 C 中同一次 seqlock read；不能各自采样 epoch 后拼成半更新状态。
+
+tool definition build 的 transient failure 必须传播并终止本次 pre-stream/activation refresh。失败前已经存在
+的完整 prompt/tool pair 可以继续留在 cache 中供后续 fully matching fallback 判断，但本次失败不得写入空
+tool list、不得把旧 prompt 与空 tools 拼成新 pair；下一 turn 必须重新尝试 build。
 
 MCP 自身仍由 `toolRegistryRevision` 管理；不合并两种 revision owner。
 
@@ -559,6 +566,9 @@ MCP 自身仍由 `toolRegistryRevision` 管理；不合并两种 revision owner�
       retryable `SkillRuntimeUpdatingError`。
 - [ ] env、verification、odd skill 同时 pending 时仍只消耗同一个 `200ms` overall deadline，不出现
       source fallback 后重新给 skill wait 计时的 `400ms+` 路径。
+- [ ] `processMessage()`、manual compaction 和 resume 的 active-skill prelude 只读取 raw persisted pins，
+      不在 deadline 创建前触发 metadata discovery；slow/hung discovery 在三条生产入口都受同一 signal/
+      absolute `200ms` deadline 约束。
 - [ ] stable read 中途 epoch 变化时丢弃 candidate并在原 deadline 内最多重建一次；持续变化不写长期
       cache，也不发送已知 mixed pair。
 - [ ] watcher 外部编辑在 event 被观察前，以及 observed event 的 private staging 期间，允许继续命中旧
@@ -568,6 +578,8 @@ MCP 自身仍由 `toolRegistryRevision` 管理；不合并两种 revision owner�
       `AGENTS.md` disk read 次数在 `30s` 内保持为一，skill body 直接来自 immutable published snapshot。
 - [ ] fresh env/verification snapshot lookup 不执行 source content read 或重复 `.git` ancestor marker
       scan；修复没有把原本按天发生的同步文件系统检查放大到每个 turn。
+- [ ] ordinary tool build transient failure 不写 prompt/tool cache，下一 turn 会 retry；skill activation 后的
+      pair refresh failure 终止 turn，并保留此前完整 pair，不把 tools 替换为 `[]`。
 - [ ] 现有 base prompt、project dir、model、active skill names 和 natural-day invalidation 测试继续通过。
 - [ ] 本规格中的 contract 均有明确 owner、时序和 failure semantics，不留未决实现选择。
 
@@ -624,7 +636,8 @@ prompt/tool orchestration 仍分别等待 `PRM-002B`、`PRM-002C`；本 slice �
 - [x] composed prompt/tool profile cache entry 与 fingerprint 加入 source revisions/stable epoch。
 - [x] 实现一次 bounded rebuild、fully matching previous stable fallback 和 typed
       `SkillRuntimeUpdatingError` propagation。
-- [ ] 完成 latency upper-bound、full baseline、manual validation；仅在 C 验证完成后关闭 P-07。
+- [x] 完成 latency upper-bound automated coverage 和 full baseline 对比。
+- [ ] 完成 manual validation；仅在 C 验证完成后关闭 P-07。
 
 ### Rollout order
 
@@ -722,6 +735,16 @@ pnpm run lint
 pnpm test -- --reporter=dot
 git diff --check
 ```
+
+2026-07-11 automated evidence：
+
+- source snapshot、runtime orchestration、SkillPresenter、SkillTools 和 AgentToolManager focused suite：
+  `403 passed`；
+- `pnpm run typecheck`、`pnpm run format`、`pnpm run i18n`、`pnpm run lint`、
+  `git diff --check`：通过；
+- full suite：`4564 passed / 5 failed / 135 skipped`。5 个失败与合入前 baseline 相同：
+  `SpotlightOverlay.test.ts` 3 个、`agentSessionPresenter/integration.test.ts` 1 个、
+  `createMockChatSession.test.ts` 1 个。
 
 ### Manual validation
 

--- a/docs/issues/system-prompt-cache-coherence/spec.md
+++ b/docs/issues/system-prompt-cache-coherence/spec.md
@@ -744,10 +744,11 @@ git diff --check
 2026-07-11 automated evidence：
 
 - source snapshot、runtime orchestration、SkillPresenter、SkillTools 和 AgentToolManager focused suite：
-  `403 passed`；
+  `428 passed / 2 skipped`；其中 raw persisted-pin regression 覆盖 imported legacy empty pin、typed
+  read failure、process/manual compaction/resume 三条 production entry 和 failed-pair cache exclusion；
 - `pnpm run typecheck`、`pnpm run format`、`pnpm run i18n`、`pnpm run lint`、
   `git diff --check`：通过；
-- full suite：`4564 passed / 5 failed / 135 skipped`。5 个失败与合入前 baseline 相同：
+- full suite：`4629 passed / 5 failed / 136 skipped`。5 个失败与合入前 baseline 相同：
   `SpotlightOverlay.test.ts` 3 个、`agentSessionPresenter/integration.test.ts` 1 个、
   `createMockChatSession.test.ts` 1 个。
 

--- a/docs/issues/system-prompt-cache-coherence/spec.md
+++ b/docs/issues/system-prompt-cache-coherence/spec.md
@@ -501,6 +501,9 @@ AND same stable-even skillMutationEpoch
    `processMessage()`、manual compaction 和 resume 在进入该 orchestration 前只允许读取 session 持久化的
    raw skill pins；该读取不得调用 metadata validation/discovery。raw names 必须在同一个 bounded immutable
    skill snapshot 中完成 availability/policy filter，避免在 `deadlineAt` 创建前先做一次无界 source discovery。
+   raw API 只读当前 session 的 normalized pin rows 或 legacy JSON column；authoritative missing/empty 返回
+   `[]`，DB/read/parse failure 以 retryable typed error 传播，不能伪装成 empty。imported legacy 全库 repair
+   只保留在 compatibility `getActiveSkills()` 和明确 migration lifecycle，不得进入 runtime prelude。
 2. env/verification snapshots 和 stable skill epoch 必须在 cache hit 判定前取得。两个 file snapshot
    都 pending 时，wall-clock upper bound 是 overall `200ms` 加微小同步 compose/hash 开销，不是 `400ms`。
 3. cache entry 记录使用的 revisions/epoch，便于测试和 debug；日志不得输出 `AGENTS.md`、
@@ -569,6 +572,8 @@ MCP 自身仍由 `toolRegistryRevision` 管理；不合并两种 revision owner�
 - [ ] `processMessage()`、manual compaction 和 resume 的 active-skill prelude 只读取 raw persisted pins，
       不在 deadline 创建前触发 metadata discovery；slow/hung discovery 在三条生产入口都受同一 signal/
       absolute `200ms` deadline 约束。
+- [ ] imported legacy empty pins 不触发全库 repair；raw DB/read/parse failure typed 传播，三条生产入口均不把
+      failure 当作 `[]`，也不缓存由 failure 产生的 prompt/tool pair。
 - [ ] stable read 中途 epoch 变化时丢弃 candidate并在原 deadline 内最多重建一次；持续变化不写长期
       cache，也不发送已知 mixed pair。
 - [ ] watcher 外部编辑在 event 被观察前，以及 observed event 的 private staging 期间，允许继续命中旧

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preinstall": "npx only-allow pnpm",
     "test": "vitest",
     "test:main": "vitest --config vitest.config.ts test/main",
-    "test:main:native-sqlite": "cross-env DEEPCHAT_REQUIRE_NATIVE_SQLITE=1 vitest --config vitest.config.ts test/main/presenter/agentMemoryTable.test.ts test/main/presenter/agentRuntimePresenter/tapeService.test.ts test/main/presenter/memoryRetrieval.eval.test.ts",
+    "test:main:native-sqlite": "cross-env DEEPCHAT_REQUIRE_NATIVE_SQLITE=1 vitest --config vitest.config.ts test/main/presenter/agentMemoryTable.test.ts test/main/presenter/agentRuntimePresenter/tapeService.test.ts test/main/presenter/memoryRetrieval.eval.test.ts test/main/presenter/sqlitePresenter/newSessionsTable.test.ts",
     "test:renderer": "vitest --config vitest.config.renderer.ts test/renderer",
     "test:coverage": "vitest --coverage",
     "test:watch": "vitest --watch",

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -4864,21 +4864,31 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       }
     }
 
-    // The first metadata lookup completes discovery. The lookup between the two stable samples
-    // captures visibility from the same epoch; it is intentionally a second compatibility-cache
-    // read, bounded by the caller's original deadline, rather than a source-disk read.
-    await this.waitForRuntimePreparation(
+    // Discovery and the initial readiness wait share the caller's source-preparation start time.
+    // After both settle, the lookup between stable samples captures visibility from the same
+    // epoch; it is intentionally a compatibility-cache read, bounded by the original deadline,
+    // rather than a source-disk read.
+    const initialSnapshotPromise = skillPresenter.waitForStableRuntimeSnapshot({
+      requiredSkillNames: options.requiredSkillNames,
+      signal: options.signal,
+      deadlineAt: options.deadlineAt
+    })
+    const discoveryPromise = this.waitForRuntimePreparation(
       skillPresenter.getMetadataList(),
       options.signal,
       options.deadlineAt
     )
+    const [initialSnapshot] = await Promise.all([initialSnapshotPromise, discoveryPromise])
 
     for (let attempt = 0; attempt < 2; attempt += 1) {
-      const snapshot = await skillPresenter.waitForStableRuntimeSnapshot({
-        requiredSkillNames: options.requiredSkillNames,
-        signal: options.signal,
-        deadlineAt: options.deadlineAt
-      })
+      const snapshot =
+        attempt === 0
+          ? initialSnapshot
+          : await skillPresenter.waitForStableRuntimeSnapshot({
+              requiredSkillNames: options.requiredSkillNames,
+              signal: options.signal,
+              deadlineAt: options.deadlineAt
+            })
       const visibleMetadata = await this.waitForRuntimePreparation(
         skillPresenter.getMetadataList(),
         options.signal,

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -7082,19 +7082,11 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       return []
     }
 
-    try {
-      const policy = await this.resolveAgentExtensionPolicy(sessionId)
-      return this.filterSkillNamesByPolicy(
-        this.normalizeSkillNames(await this.skillPresenter.getPinnedActiveSkills(sessionId)),
-        policy
-      )
-    } catch (error) {
-      console.warn(
-        `[DeepChatAgent] Failed to load active skills for tool profile in session ${sessionId}:`,
-        error
-      )
-      return []
-    }
+    const policy = await this.resolveAgentExtensionPolicy(sessionId)
+    return this.filterSkillNamesByPolicy(
+      this.normalizeSkillNames(await this.skillPresenter.getPinnedActiveSkills(sessionId)),
+      policy
+    )
   }
 
   private async resolveAgentExtensionPolicy(sessionId: string): Promise<AgentExtensionPolicy> {

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -655,7 +655,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
   private readonly skillPresenter?: Pick<
     ISkillPresenter,
     | 'getMetadataList'
-    | 'getActiveSkills'
+    | 'getPinnedActiveSkills'
     | 'getPublishedRuntimeSnapshot'
     | 'waitForStableRuntimeSnapshot'
     | 'loadSkillContent'
@@ -681,7 +681,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       skillPresenter?: Pick<
         ISkillPresenter,
         | 'getMetadataList'
-        | 'getActiveSkills'
+        | 'getPinnedActiveSkills'
         | 'getPublishedRuntimeSnapshot'
         | 'waitForStableRuntimeSnapshot'
         | 'loadSkillContent'
@@ -5015,21 +5015,16 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     }
 
     const agentId = this.getSessionAgentId(params.sessionId) ?? 'deepchat'
-    try {
-      return await this.toolPresenter.getAllToolDefinitions({
-        agentId,
-        enabledPluginIds: params.extensionPolicy.enabledPluginIds ?? undefined,
-        disabledAgentTools: this.getDisabledAgentTools(params.sessionId),
-        chatMode: 'agent',
-        conversationId: params.sessionId,
-        agentWorkspacePath: params.projectDir,
-        activeSkillNames: params.activeSkillNames,
-        skillRuntimeSnapshot: params.skillSnapshot
-      })
-    } catch (error) {
-      console.error('[DeepChatAgent] failed to fetch tool definitions:', error)
-      return []
-    }
+    return await this.toolPresenter.getAllToolDefinitions({
+      agentId,
+      enabledPluginIds: params.extensionPolicy.enabledPluginIds ?? undefined,
+      disabledAgentTools: this.getDisabledAgentTools(params.sessionId),
+      chatMode: 'agent',
+      conversationId: params.sessionId,
+      agentWorkspacePath: params.projectDir,
+      activeSkillNames: params.activeSkillNames,
+      skillRuntimeSnapshot: params.skillSnapshot
+    })
   }
 
   private resolveMatchingRuntimePairFallback(params: {
@@ -7037,11 +7032,8 @@ export class AgentRuntimePresenter implements IAgentImplementation {
 
       return tools
     } catch (error) {
-      if (error instanceof SkillRuntimeUpdatingError || this.isAbortError(error)) {
-        throw error
-      }
       console.error('[DeepChatAgent] failed to fetch tool definitions:', error)
-      return []
+      throw error
     }
   }
 
@@ -7086,14 +7078,14 @@ export class AgentRuntimePresenter implements IAgentImplementation {
   }
 
   private async resolveActiveSkillNamesForToolProfile(sessionId: string): Promise<string[]> {
-    if (!this.configPresenter.getSkillsEnabled() || !this.skillPresenter?.getActiveSkills) {
+    if (!this.configPresenter.getSkillsEnabled() || !this.skillPresenter?.getPinnedActiveSkills) {
       return []
     }
 
     try {
       const policy = await this.resolveAgentExtensionPolicy(sessionId)
       return this.filterSkillNamesByPolicy(
-        this.normalizeSkillNames(await this.skillPresenter.getActiveSkills(sessionId)),
+        this.normalizeSkillNames(await this.skillPresenter.getPinnedActiveSkills(sessionId)),
         policy
       )
     } catch (error) {

--- a/src/main/presenter/agentRuntimePresenter/index.ts
+++ b/src/main/presenter/agentRuntimePresenter/index.ts
@@ -84,9 +84,18 @@ import { eventBus } from '@/eventbus'
 import { MCP_EVENTS } from '@/events'
 import {
   buildRuntimeCapabilitiesPrompt,
-  buildSystemEnvPrompt
+  buildSystemEnvPromptSnapshot,
+  type SystemEnvPromptSnapshot
 } from '@/lib/agentRuntime/systemEnvPromptBuilder'
-import { buildVerificationPolicyPrompt } from '@/lib/agentRuntime/verificationPolicyPromptBuilder'
+import {
+  buildVerificationPolicySnapshot,
+  type VerificationPolicySnapshot
+} from '@/lib/agentRuntime/verificationPolicyPromptBuilder'
+import {
+  SkillRuntimeUpdatingError,
+  type PublishedSkillEntry,
+  type SkillRuntimeSnapshot
+} from '@shared/types/skill'
 import type { ContextBuildMetadata } from './contextBuilder'
 import {
   buildTapeChatView,
@@ -507,6 +516,10 @@ type SystemPromptCacheEntry = {
   prompt: string
   dayKey: string
   fingerprint: string
+  envRevision: string
+  verificationPolicyRevision: string
+  skillMutationEpoch: number
+  pairFingerprint?: string
 }
 
 type ToolProfileKind = 'code' | 'research' | 'analysis' | 'general'
@@ -515,6 +528,29 @@ type ToolProfileCacheEntry = {
   profile: ToolProfileKind
   fingerprint: string
   tools: MCPToolDefinition[]
+  skillMutationEpoch: number
+  pairFingerprint?: string
+}
+
+type StableSkillRuntimeView = {
+  snapshot: SkillRuntimeSnapshot
+  visibleSkillNames: ReadonlySet<string>
+}
+
+type RuntimeSourceSnapshots = {
+  env: SystemEnvPromptSnapshot
+  verificationPolicy: VerificationPolicySnapshot
+  skills: StableSkillRuntimeView
+}
+
+type RuntimePromptToolPair = {
+  systemPrompt: string
+  tools: MCPToolDefinition[]
+}
+
+type ToolProfileResolution = {
+  kind: ToolProfileKind
+  fingerprint: string
 }
 
 type ActiveGeneration = {
@@ -620,6 +656,8 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     ISkillPresenter,
     | 'getMetadataList'
     | 'getActiveSkills'
+    | 'getPublishedRuntimeSnapshot'
+    | 'waitForStableRuntimeSnapshot'
     | 'loadSkillContent'
     | 'viewDraftSkill'
     | 'installDraftSkill'
@@ -644,6 +682,8 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         ISkillPresenter,
         | 'getMetadataList'
         | 'getActiveSkills'
+        | 'getPublishedRuntimeSnapshot'
+        | 'waitForStableRuntimeSnapshot'
         | 'loadSkillContent'
         | 'viewDraftSkill'
         | 'installDraftSkill'
@@ -1266,21 +1306,19 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       )
       this.logSlowPreStreamStep(sessionId, 'active-skills', stepStartedAt)
       stepStartedAt = Date.now()
-      const tools = await this.loadToolDefinitionsForSession(
+      const runtimePair = await this.buildRuntimePromptToolPair(
         sessionId,
+        generationSettings.systemPrompt,
         projectDir,
-        effectiveActiveSkillNames
+        effectiveActiveSkillNames,
+        preStreamAbortSignal
       )
+      const tools = runtimePair.tools
       this.logSlowPreStreamStep(sessionId, 'tool-definitions', stepStartedAt)
       const toolReserveTokens = estimateToolReserveTokens(tools)
       this.throwIfAbortRequested(preStreamAbortSignal)
       stepStartedAt = Date.now()
-      const baseSystemPrompt = await this.buildSystemPromptWithSkills(
-        sessionId,
-        generationSettings.systemPrompt,
-        tools,
-        effectiveActiveSkillNames
-      )
+      const baseSystemPrompt = runtimePair.systemPrompt
       this.logSlowPreStreamStep(sessionId, 'system-prompt', stepStartedAt)
       this.throwIfAbortRequested(preStreamAbortSignal)
       const tapeReady = this.tapeService.ensureSessionTapeReady(sessionId, this.messageStore)
@@ -1423,13 +1461,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         tools,
         baseSystemPrompt,
         maxProviderRounds: context?.maxProviderRounds,
-        refreshSystemPrompt: async (activeSkillNames, refreshedTools) => {
-          const refreshedBasePrompt = await this.buildSystemPromptWithSkills(
-            sessionId,
-            generationSettings.systemPrompt,
-            refreshedTools,
-            activeSkillNames ?? effectiveActiveSkillNames
-          )
+        decorateRefreshedSystemPrompt: async (refreshedBasePrompt) => {
           return await this.appendMemoryInjection(
             sessionId,
             appendReconstructionAnchorStateSection(
@@ -3107,18 +3139,16 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       const maxTokens = capAgentRequestMaxTokens(generationSettings.maxTokens, contextBudgetLength)
       const activeSkillNames = await this.resolveActiveSkillNamesForToolProfile(sessionId)
       const projectDir = this.resolveProjectDir(sessionId)
-      const tools = await this.loadToolDefinitionsForSession(
-        sessionId,
-        projectDir,
-        activeSkillNames
-      )
-      const toolReserveTokens = estimateToolReserveTokens(tools)
-      const baseSystemPrompt = await this.buildSystemPromptWithSkills(
+      const runtimePair = await this.buildRuntimePromptToolPair(
         sessionId,
         generationSettings.systemPrompt,
-        tools,
-        activeSkillNames
+        projectDir,
+        activeSkillNames,
+        new AbortController().signal
       )
+      const tools = runtimePair.tools
+      const toolReserveTokens = estimateToolReserveTokens(tools)
+      const baseSystemPrompt = runtimePair.systemPrompt
       const tapeReady = this.tapeService.ensureSessionTapeReady(sessionId, this.messageStore)
 
       const intent = await this.compactionService.prepareForManualCompaction({
@@ -3293,10 +3323,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     promptPreview?: string
     interleavedReasoning?: InterleavedReasoningConfig
     viewContext?: PendingTapeViewContext
-    refreshSystemPrompt?: (
-      activeSkillNames: string[] | undefined,
-      toolDefinitions: MCPToolDefinition[]
-    ) => Promise<string>
+    decorateRefreshedSystemPrompt?: (baseSystemPrompt: string) => Promise<string>
     maxProviderRounds?: number
     preStreamStartedAt?: number
     onRunRegistered?: (runId: string) => void
@@ -3312,7 +3339,7 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       promptPreview,
       interleavedReasoning: providedInterleavedReasoning,
       viewContext,
-      refreshSystemPrompt,
+      decorateRefreshedSystemPrompt,
       maxProviderRounds,
       preStreamStartedAt,
       onRunRegistered
@@ -3460,26 +3487,21 @@ export class AgentRuntimePresenter implements IAgentImplementation {
           reviewConversationMessages = nextMessages
         },
         maxProviderRounds,
-        refreshTools: async (activeSkillNames) =>
-          await this.loadToolDefinitionsForSession(
-            sessionId,
-            projectDir,
-            getEffectiveRuntimeSkillNames(activeSkillNames)
-          ),
-        refreshSystemPrompt: async (activeSkillNames, refreshedTools) => {
-          if (refreshSystemPrompt) {
-            return await refreshSystemPrompt(
-              getEffectiveRuntimeSkillNames(activeSkillNames),
-              refreshedTools
-            )
-          }
-          const refreshedBasePrompt = await this.buildSystemPromptWithSkills(
+        refreshRuntimePair: async (activeSkillNames) => {
+          const refreshedPair = await this.buildRuntimePromptToolPair(
             sessionId,
             generationSettings.systemPrompt,
-            refreshedTools,
-            getEffectiveRuntimeSkillNames(activeSkillNames)
+            projectDir,
+            getEffectiveRuntimeSkillNames(activeSkillNames),
+            abortController.signal
           )
-          return refreshedBasePrompt
+          if (!decorateRefreshedSystemPrompt) {
+            return refreshedPair
+          }
+          return {
+            tools: refreshedPair.tools,
+            systemPrompt: await decorateRefreshedSystemPrompt(refreshedPair.systemPrompt)
+          }
         },
         toolPresenter: this.toolPresenter,
         coreStream: async function* (
@@ -4422,19 +4444,17 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       const maxTokens = capAgentRequestMaxTokens(generationSettings.maxTokens, contextBudgetLength)
       const projectDir = this.resolveProjectDir(sessionId)
       const activeSkillNames = await this.resolveActiveSkillNamesForToolProfile(sessionId)
-      const tools = await this.loadToolDefinitionsForSession(
-        sessionId,
-        projectDir,
-        activeSkillNames
-      )
-      const toolReserveTokens = estimateToolReserveTokens(tools)
-      this.throwIfAbortRequested(preStreamAbortSignal)
-      const baseSystemPrompt = await this.buildSystemPromptWithSkills(
+      const runtimePair = await this.buildRuntimePromptToolPair(
         sessionId,
         generationSettings.systemPrompt,
-        tools,
-        activeSkillNames
+        projectDir,
+        activeSkillNames,
+        preStreamAbortSignal
       )
+      const tools = runtimePair.tools
+      const toolReserveTokens = estimateToolReserveTokens(tools)
+      this.throwIfAbortRequested(preStreamAbortSignal)
+      const baseSystemPrompt = runtimePair.systemPrompt
       this.throwIfAbortRequested(preStreamAbortSignal)
       const tapeReady = this.tapeService.ensureSessionTapeReady(sessionId, this.messageStore)
       const resumeTargetOrderSeq =
@@ -4589,37 +4609,356 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     }
   }
 
-  private async buildSystemPromptWithSkills(
+  private async buildRuntimePromptToolPair(
     sessionId: string,
     basePrompt: string,
-    toolDefinitions: MCPToolDefinition[],
-    activeSkillNamesOverride?: string[]
-  ): Promise<string> {
+    projectDir: string | null,
+    activeSkillNames: string[],
+    signal: AbortSignal
+  ): Promise<RuntimePromptToolPair> {
     const normalizedBase = basePrompt?.trim() ?? ''
     const state = this.runtimeState.get(sessionId)
     const providerId = state?.providerId?.trim() || 'unknown-provider'
     const modelId = state?.modelId?.trim() || 'unknown-model'
     if (this.isAcpBackedSubagentSession(sessionId, providerId)) {
-      return normalizedBase
+      return { systemPrompt: normalizedBase, tools: [] }
     }
 
-    const workdir = this.resolveProjectDir(sessionId)
+    const workdir = projectDir?.trim() || null
     const now = new Date()
     const dayKey = this.buildLocalDayKey(now)
-
     const skillsEnabled = this.configPresenter.getSkillsEnabled()
+    const extensionPolicy = await this.resolveAgentExtensionPolicy(sessionId)
+    const requestedActiveSkillNames = this.filterSkillNamesByPolicy(
+      this.normalizeSkillNames(activeSkillNames),
+      extensionPolicy
+    )
+    const deadlineAt = Date.now() + SYSTEM_PROMPT_SOURCE_LOOKUP_BUDGET_MS
+    const envPromise = buildSystemEnvPromptSnapshot({
+      providerId,
+      modelId,
+      workdir,
+      now,
+      modelLookup: this.providerCatalogPort,
+      signal,
+      deadlineAt
+    })
+    const verificationPolicyPromise = buildVerificationPolicySnapshot({
+      workdir,
+      signal,
+      deadlineAt
+    })
+    const skillsPromise = this.captureStableSkillRuntimeView({
+      requiredSkillNames: skillsEnabled ? requestedActiveSkillNames : [],
+      signal,
+      deadlineAt,
+      skillsEnabled
+    })
+
+    let sources: RuntimeSourceSnapshots
+    try {
+      const [env, verificationPolicy, skills] = await Promise.all([
+        envPromise,
+        verificationPolicyPromise,
+        skillsPromise
+      ])
+      sources = { env, verificationPolicy, skills }
+    } catch (error) {
+      if (!(error instanceof SkillRuntimeUpdatingError)) {
+        throw error
+      }
+      const [env, verificationPolicy] = await Promise.all([envPromise, verificationPolicyPromise])
+      return this.resolveMatchingRuntimePairFallback({
+        sessionId,
+        providerId,
+        modelId,
+        workdir,
+        basePrompt: normalizedBase,
+        dayKey,
+        skillsEnabled,
+        requestedActiveSkillNames,
+        extensionPolicy,
+        env,
+        verificationPolicy
+      })
+    }
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const skillContext = this.buildSkillPromptContext(
+        sources.skills,
+        requestedActiveSkillNames,
+        extensionPolicy,
+        skillsEnabled
+      )
+      const toolProfile = await this.resolveToolProfile(
+        sessionId,
+        workdir,
+        skillContext.activeSkillNames,
+        extensionPolicy,
+        sources.skills.snapshot.epoch
+      )
+      const cachedTools = this.toolProfileCache.get(sessionId)
+      const tools =
+        cachedTools &&
+        cachedTools.profile === toolProfile.kind &&
+        cachedTools.fingerprint === toolProfile.fingerprint
+          ? [...cachedTools.tools]
+          : await this.buildToolDefinitionsFromSnapshot({
+              sessionId,
+              projectDir: workdir,
+              activeSkillNames: skillContext.activeSkillNames,
+              extensionPolicy,
+              skillSnapshot: sources.skills.snapshot
+            })
+      if (
+        cachedTools?.profile === toolProfile.kind &&
+        cachedTools.fingerprint === toolProfile.fingerprint
+      ) {
+        this.toolPresenter?.syncAgentToolContext?.({
+          chatMode: 'agent',
+          agentWorkspacePath: workdir
+        })
+      }
+      const promptFingerprint = this.buildSystemPromptFingerprint({
+        providerId,
+        modelId,
+        workdir,
+        basePrompt: normalizedBase,
+        skillsEnabled,
+        availableSkillNames: skillContext.availableSkills.map((skill) => skill.name),
+        activeSkillNames: skillContext.activeSkillNames,
+        toolSignature: this.buildToolSignature(tools),
+        skillDraftSuggestionsEnabled:
+          this.configPresenter.getSkillDraftSuggestionsEnabled?.() ?? false,
+        envRevision: sources.env.revision,
+        verificationPolicyRevision: sources.verificationPolicy.revision,
+        skillMutationEpoch: sources.skills.snapshot.epoch
+      })
+      const cachedPrompt = this.systemPromptCache.get(sessionId)
+      if (
+        cachedPrompt?.dayKey === dayKey &&
+        cachedPrompt.fingerprint === promptFingerprint &&
+        cachedTools?.profile === toolProfile.kind &&
+        cachedTools.fingerprint === toolProfile.fingerprint
+      ) {
+        return { systemPrompt: cachedPrompt.prompt, tools }
+      }
+
+      const systemPrompt = this.buildSystemPromptWithSkills({
+        sessionId,
+        basePrompt: normalizedBase,
+        toolDefinitions: tools,
+        availableSkills: skillContext.availableSkills,
+        activeSkillNames: skillContext.activeSkillNames,
+        skillSnapshot: sources.skills.snapshot,
+        envPrompt: sources.env.prompt,
+        verificationPolicyPrompt: sources.verificationPolicy.prompt,
+        skillsEnabled
+      })
+
+      let confirmedSkills: StableSkillRuntimeView
+      try {
+        const confirmedSnapshot =
+          skillsEnabled && this.skillPresenter
+            ? await this.skillPresenter.waitForStableRuntimeSnapshot({
+                requiredSkillNames: requestedActiveSkillNames,
+                signal,
+                deadlineAt
+              })
+            : sources.skills.snapshot
+        confirmedSkills =
+          confirmedSnapshot.epoch === sources.skills.snapshot.epoch
+            ? sources.skills
+            : await this.captureStableSkillRuntimeView({
+                requiredSkillNames: skillsEnabled ? requestedActiveSkillNames : [],
+                signal,
+                deadlineAt,
+                skillsEnabled
+              })
+      } catch (error) {
+        if (!(error instanceof SkillRuntimeUpdatingError)) {
+          throw error
+        }
+        return this.resolveMatchingRuntimePairFallback({
+          sessionId,
+          providerId,
+          modelId,
+          workdir,
+          basePrompt: normalizedBase,
+          dayKey,
+          skillsEnabled,
+          requestedActiveSkillNames,
+          extensionPolicy,
+          env: sources.env,
+          verificationPolicy: sources.verificationPolicy
+        })
+      }
+
+      if (confirmedSkills.snapshot.epoch !== sources.skills.snapshot.epoch) {
+        if (attempt === 0) {
+          sources = { ...sources, skills: confirmedSkills }
+          continue
+        }
+        return this.resolveMatchingRuntimePairFallback({
+          sessionId,
+          providerId,
+          modelId,
+          workdir,
+          basePrompt: normalizedBase,
+          dayKey,
+          skillsEnabled,
+          requestedActiveSkillNames,
+          extensionPolicy,
+          env: sources.env,
+          verificationPolicy: sources.verificationPolicy
+        })
+      }
+
+      const pairFingerprint = this.buildRuntimePairFingerprint({
+        providerId,
+        modelId,
+        workdir,
+        basePrompt: normalizedBase,
+        dayKey,
+        skillsEnabled,
+        requestedActiveSkillNames,
+        extensionPolicy,
+        envRevision: sources.env.revision,
+        verificationPolicyRevision: sources.verificationPolicy.revision,
+        skillMutationEpoch: sources.skills.snapshot.epoch,
+        sessionId
+      })
+      this.toolProfileCache.set(sessionId, {
+        profile: toolProfile.kind,
+        fingerprint: toolProfile.fingerprint,
+        tools,
+        skillMutationEpoch: sources.skills.snapshot.epoch,
+        pairFingerprint
+      })
+      this.systemPromptCache.set(sessionId, {
+        prompt: systemPrompt,
+        dayKey,
+        fingerprint: promptFingerprint,
+        envRevision: sources.env.revision,
+        verificationPolicyRevision: sources.verificationPolicy.revision,
+        skillMutationEpoch: sources.skills.snapshot.epoch,
+        pairFingerprint
+      })
+      return { systemPrompt, tools }
+    }
+
+    throw new SkillRuntimeUpdatingError()
+  }
+
+  private async captureStableSkillRuntimeView(options: {
+    requiredSkillNames: string[]
+    signal: AbortSignal
+    deadlineAt: number
+    skillsEnabled: boolean
+  }): Promise<StableSkillRuntimeView> {
     const skillPresenter = this.skillPresenter
-    const availableSkills: Array<{
+    if (!options.skillsEnabled || !skillPresenter) {
+      return {
+        snapshot: Object.freeze({ epoch: 0, entries: new Map<string, PublishedSkillEntry>() }),
+        visibleSkillNames: new Set()
+      }
+    }
+
+    // The first metadata lookup completes discovery. The lookup between the two stable samples
+    // captures visibility from the same epoch; it is intentionally a second compatibility-cache
+    // read, bounded by the caller's original deadline, rather than a source-disk read.
+    await this.waitForRuntimePreparation(
+      skillPresenter.getMetadataList(),
+      options.signal,
+      options.deadlineAt
+    )
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const snapshot = await skillPresenter.waitForStableRuntimeSnapshot({
+        requiredSkillNames: options.requiredSkillNames,
+        signal: options.signal,
+        deadlineAt: options.deadlineAt
+      })
+      const visibleMetadata = await this.waitForRuntimePreparation(
+        skillPresenter.getMetadataList(),
+        options.signal,
+        options.deadlineAt
+      )
+      const confirmed = await skillPresenter.waitForStableRuntimeSnapshot({
+        requiredSkillNames: options.requiredSkillNames,
+        signal: options.signal,
+        deadlineAt: options.deadlineAt
+      })
+      if (confirmed.epoch === snapshot.epoch) {
+        return {
+          snapshot: confirmed,
+          visibleSkillNames: new Set(
+            visibleMetadata.map((metadata) => metadata.name?.trim()).filter(Boolean)
+          )
+        }
+      }
+      if (attempt === 1) {
+        break
+      }
+    }
+
+    throw new SkillRuntimeUpdatingError()
+  }
+
+  private async waitForRuntimePreparation<T>(
+    pending: Promise<T>,
+    signal: AbortSignal,
+    deadlineAt: number
+  ): Promise<T> {
+    this.throwIfAbortRequested(signal)
+    const remainingMs = Math.max(0, deadlineAt - Date.now())
+    if (remainingMs === 0) {
+      throw new SkillRuntimeUpdatingError()
+    }
+
+    return await new Promise<T>((resolve, reject) => {
+      let settled = false
+      const finish = (action: () => void) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        signal.removeEventListener('abort', onAbort)
+        action()
+      }
+      const onAbort = () => finish(() => reject(signal.reason ?? createAbortError()))
+      const timeout = setTimeout(
+        () => finish(() => reject(new SkillRuntimeUpdatingError())),
+        remainingMs
+      )
+      signal.addEventListener('abort', onAbort, { once: true })
+      if (signal.aborted) {
+        onAbort()
+      }
+      void pending.then(
+        (value) => finish(() => resolve(value)),
+        (error) => finish(() => reject(error))
+      )
+    })
+  }
+
+  private buildSkillPromptContext(
+    runtimeView: StableSkillRuntimeView,
+    requestedActiveSkillNames: string[],
+    extensionPolicy: AgentExtensionPolicy,
+    skillsEnabled: boolean
+  ): {
+    availableSkills: Array<{
       name: string
       description: string
       category?: string | null
       platforms?: string[]
-    }> = []
-    const activeSkillNames: string[] = activeSkillNamesOverride ? [...activeSkillNamesOverride] : []
-    const skillDraftSuggestionsEnabled =
-      this.configPresenter.getSkillDraftSuggestionsEnabled?.() ?? false
+    }>
+    activeSkillNames: string[]
+  } {
+    if (!skillsEnabled) {
+      return { availableSkills: [], activeSkillNames: [] }
+    }
 
-    const extensionPolicy = await this.resolveAgentExtensionPolicy(sessionId)
     const allowedSkillNameSet =
       extensionPolicy.enabledSkillNames === null || extensionPolicy.enabledSkillNames === undefined
         ? null
@@ -4628,86 +4967,166 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       extensionPolicy.enabledPluginIds === null || extensionPolicy.enabledPluginIds === undefined
         ? null
         : new Set(this.normalizeSkillNames(extensionPolicy.enabledPluginIds))
+    const availableSkills = Array.from(runtimeView.snapshot.entries.values())
+      .filter((entry) => entry.availability !== 'quarantined')
+      .map((entry) => entry.metadata)
+      .filter((metadata) => {
+        const name = metadata.name?.trim()
+        const ownerPluginId = metadata.ownerPluginId?.trim()
+        return (
+          Boolean(name) &&
+          runtimeView.visibleSkillNames.has(name) &&
+          (!allowedSkillNameSet || allowedSkillNameSet.has(name)) &&
+          (!ownerPluginId || !allowedPluginIdSet || allowedPluginIdSet.has(ownerPluginId))
+        )
+      })
+      .map((metadata) => ({
+        name: metadata.name.trim(),
+        description: metadata.description?.trim() || '',
+        category: metadata.category ?? null,
+        platforms: metadata.platforms ? [...metadata.platforms] : undefined
+      }))
+    const availableNames = new Set(availableSkills.map((skill) => skill.name))
+    return {
+      availableSkills,
+      activeSkillNames: requestedActiveSkillNames.filter((name) => availableNames.has(name))
+    }
+  }
 
-    if (skillsEnabled && skillPresenter) {
-      if (skillPresenter.getMetadataList) {
-        const stepStartedAt = Date.now()
-        try {
-          const metadataList = await skillPresenter.getMetadataList()
-          for (const metadata of metadataList) {
-            const skillName = metadata?.name?.trim()
-            const ownerPluginId = metadata?.ownerPluginId?.trim()
-            if (
-              skillName &&
-              (!allowedSkillNameSet || allowedSkillNameSet.has(skillName)) &&
-              (!ownerPluginId || !allowedPluginIdSet || allowedPluginIdSet.has(ownerPluginId))
-            ) {
-              availableSkills.push({
-                name: skillName,
-                description: metadata.description?.trim() || '',
-                category: metadata.category ?? null,
-                platforms: metadata.platforms
-              })
-            }
-          }
-        } catch (error) {
-          console.warn(
-            `[DeepChatAgent] Failed to load skills metadata for session ${sessionId}:`,
-            error
-          )
-        }
-        this.logSlowPreStreamStep(sessionId, 'system-prompt.skills-metadata-load', stepStartedAt)
-      }
-
-      if (!activeSkillNamesOverride && skillPresenter.getActiveSkills) {
-        const stepStartedAt = Date.now()
-        try {
-          const activeSkills = await skillPresenter.getActiveSkills(sessionId)
-          for (const skillName of activeSkills) {
-            const normalizedName = skillName?.trim()
-            if (normalizedName) {
-              activeSkillNames.push(normalizedName)
-            }
-          }
-        } catch (error) {
-          console.warn(
-            `[DeepChatAgent] Failed to load active skills for session ${sessionId}:`,
-            error
-          )
-        }
-        this.logSlowPreStreamStep(sessionId, 'system-prompt.active-skills-load', stepStartedAt)
-      }
+  private async buildToolDefinitionsFromSnapshot(params: {
+    sessionId: string
+    projectDir: string | null
+    activeSkillNames: string[]
+    extensionPolicy: AgentExtensionPolicy
+    skillSnapshot: SkillRuntimeSnapshot
+  }): Promise<MCPToolDefinition[]> {
+    if (!this.toolPresenter) {
+      return []
     }
 
+    const agentId = this.getSessionAgentId(params.sessionId) ?? 'deepchat'
+    try {
+      return await this.toolPresenter.getAllToolDefinitions({
+        agentId,
+        enabledPluginIds: params.extensionPolicy.enabledPluginIds ?? undefined,
+        disabledAgentTools: this.getDisabledAgentTools(params.sessionId),
+        chatMode: 'agent',
+        conversationId: params.sessionId,
+        agentWorkspacePath: params.projectDir,
+        activeSkillNames: params.activeSkillNames,
+        skillRuntimeSnapshot: params.skillSnapshot
+      })
+    } catch (error) {
+      console.error('[DeepChatAgent] failed to fetch tool definitions:', error)
+      return []
+    }
+  }
+
+  private resolveMatchingRuntimePairFallback(params: {
+    sessionId: string
+    providerId: string
+    modelId: string
+    workdir: string | null
+    basePrompt: string
+    dayKey: string
+    skillsEnabled: boolean
+    requestedActiveSkillNames: string[]
+    extensionPolicy: AgentExtensionPolicy
+    env: SystemEnvPromptSnapshot
+    verificationPolicy: VerificationPolicySnapshot
+  }): RuntimePromptToolPair {
+    const skillMutationEpoch = this.skillPresenter?.getPublishedRuntimeSnapshot().epoch ?? 0
+    const pairFingerprint = this.buildRuntimePairFingerprint({
+      ...params,
+      envRevision: params.env.revision,
+      verificationPolicyRevision: params.verificationPolicy.revision,
+      skillMutationEpoch
+    })
+    const prompt = this.systemPromptCache.get(params.sessionId)
+    const tools = this.toolProfileCache.get(params.sessionId)
+    if (
+      prompt?.dayKey === params.dayKey &&
+      prompt.envRevision === params.env.revision &&
+      prompt.verificationPolicyRevision === params.verificationPolicy.revision &&
+      prompt.skillMutationEpoch === skillMutationEpoch &&
+      prompt.pairFingerprint === pairFingerprint &&
+      tools?.skillMutationEpoch === skillMutationEpoch &&
+      tools.pairFingerprint === pairFingerprint
+    ) {
+      return { systemPrompt: prompt.prompt, tools: [...tools.tools] }
+    }
+    throw new SkillRuntimeUpdatingError()
+  }
+
+  private buildRuntimePairFingerprint(params: {
+    sessionId: string
+    providerId: string
+    modelId: string
+    workdir: string | null
+    basePrompt: string
+    dayKey: string
+    skillsEnabled: boolean
+    requestedActiveSkillNames: string[]
+    extensionPolicy: AgentExtensionPolicy
+    envRevision: string
+    verificationPolicyRevision: string
+    skillMutationEpoch: number
+  }): string {
+    return JSON.stringify({
+      providerId: params.providerId,
+      modelId: params.modelId,
+      workdir: params.workdir ?? '',
+      basePrompt: params.basePrompt,
+      dayKey: params.dayKey,
+      skillsEnabled: params.skillsEnabled,
+      requestedActiveSkillNames: params.requestedActiveSkillNames,
+      enabledPluginIds: this.normalizeNullablePolicyList(params.extensionPolicy.enabledPluginIds),
+      enabledSkillNames: this.normalizeNullablePolicyList(params.extensionPolicy.enabledSkillNames),
+      disabledAgentTools: this.getDisabledAgentTools(params.sessionId).sort((left, right) =>
+        left.localeCompare(right)
+      ),
+      skillDraftSuggestionsEnabled:
+        this.configPresenter.getSkillDraftSuggestionsEnabled?.() ?? false,
+      toolRegistryRevision: this.toolRegistryRevision,
+      envRevision: params.envRevision,
+      verificationPolicyRevision: params.verificationPolicyRevision,
+      skillMutationEpoch: params.skillMutationEpoch
+    })
+  }
+
+  private buildSystemPromptWithSkills(params: {
+    sessionId: string
+    basePrompt: string
+    toolDefinitions: MCPToolDefinition[]
+    availableSkills: Array<{
+      name: string
+      description: string
+      category?: string | null
+      platforms?: string[]
+    }>
+    activeSkillNames: string[]
+    skillSnapshot: SkillRuntimeSnapshot
+    envPrompt: string
+    verificationPolicyPrompt: string
+    skillsEnabled: boolean
+  }): string {
+    const {
+      sessionId,
+      basePrompt: normalizedBase,
+      toolDefinitions,
+      availableSkills,
+      activeSkillNames,
+      skillSnapshot,
+      envPrompt,
+      verificationPolicyPrompt,
+      skillsEnabled
+    } = params
+    const skillDraftSuggestionsEnabled =
+      this.configPresenter.getSkillDraftSuggestionsEnabled?.() ?? false
     let stepStartedAt = Date.now()
     const normalizedAvailableSkills = this.normalizeSkillMetadata(availableSkills)
-    const availableSkillNames = new Set(normalizedAvailableSkills.map((skill) => skill.name))
-    const normalizedActiveSkills = this.filterSkillNamesByPolicy(
-      activeSkillNames.filter((skillName) => availableSkillNames.has(skillName)),
-      extensionPolicy
-    )
+    const normalizedActiveSkills = this.normalizeSkillNames(activeSkillNames)
     const agentToolNames = this.getAgentToolNames(toolDefinitions)
-    const fingerprint = this.buildSystemPromptFingerprint({
-      providerId,
-      modelId,
-      workdir,
-      basePrompt: normalizedBase,
-      skillsEnabled,
-      availableSkillNames: normalizedAvailableSkills.map((skill) => skill.name),
-      activeSkillNames: normalizedActiveSkills,
-      toolSignature: this.buildToolSignature(toolDefinitions),
-      skillDraftSuggestionsEnabled
-    })
-    this.logSlowPreStreamStep(sessionId, 'system-prompt.fingerprint', stepStartedAt)
-
-    const cachedPrompt = this.systemPromptCache.get(sessionId)
-    if (
-      cachedPrompt &&
-      cachedPrompt.dayKey === dayKey &&
-      cachedPrompt.fingerprint === fingerprint
-    ) {
-      return cachedPrompt.prompt
-    }
 
     const runtimePrompt = buildRuntimeCapabilitiesPrompt({
       hasYoBrowser: toolDefinitions.some(
@@ -4730,62 +5149,19 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       : ''
 
     let skillsPrompt = ''
-    if (skillsEnabled && skillPresenter?.loadSkillContent && normalizedActiveSkills.length > 0) {
+    if (skillsEnabled && normalizedActiveSkills.length > 0) {
       stepStartedAt = Date.now()
       const skillSections: string[] = []
       for (const skillName of normalizedActiveSkills) {
-        try {
-          const skill = await skillPresenter.loadSkillContent(skillName)
-          const content = skill?.content?.trim()
-          if (content) {
-            skillSections.push(`### ${skillName}\n${content}`)
-          }
-        } catch (error) {
-          console.warn(
-            `[DeepChatAgent] Failed to load skill content for "${skillName}" in session ${sessionId}:`,
-            error
-          )
+        const entry = skillSnapshot.entries.get(skillName)
+        const content = entry?.availability === 'ready' ? entry.renderedContent?.trim() : undefined
+        if (content) {
+          skillSections.push(`### ${skillName}\n${content}`)
         }
       }
       skillsPrompt = this.buildPinnedSkillsPrompt(skillSections)
       this.logSlowPreStreamStep(sessionId, 'system-prompt.pinned-skills-load', stepStartedAt)
     }
-
-    const sourceLookupDeadlineAt = Date.now() + SYSTEM_PROMPT_SOURCE_LOOKUP_BUDGET_MS
-    const envPromptStartedAt = Date.now()
-    const envPromptPromise = buildSystemEnvPrompt({
-      providerId,
-      modelId,
-      workdir,
-      now,
-      modelLookup: this.providerCatalogPort,
-      deadlineAt: sourceLookupDeadlineAt
-    }).then(
-      (prompt) => {
-        this.logSlowPreStreamStep(sessionId, 'system-prompt.env-prompt', envPromptStartedAt)
-        return prompt
-      },
-      (error) => {
-        console.warn(`[DeepChatAgent] Failed to build env prompt for session ${sessionId}:`, error)
-        return ''
-      }
-    )
-    const verificationPolicyStartedAt = Date.now()
-    const verificationPolicyPromptPromise = buildVerificationPolicyPrompt(workdir, {
-      deadlineAt: sourceLookupDeadlineAt
-    }).then((prompt) => {
-      this.logSlowPreStreamStep(
-        sessionId,
-        'system-prompt.verification-policy',
-        verificationPolicyStartedAt
-      )
-      return prompt
-    })
-
-    const [envPrompt, verificationPolicyPrompt] = await Promise.all([
-      envPromptPromise,
-      verificationPolicyPromptPromise
-    ])
 
     let toolingPrompt = ''
     if (this.toolPresenter) {
@@ -4816,12 +5192,6 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       verificationPolicyPrompt
     ])
     this.logSlowPreStreamStep(sessionId, 'system-prompt.compose', stepStartedAt)
-
-    this.systemPromptCache.set(sessionId, {
-      prompt: composedPrompt,
-      dayKey,
-      fingerprint
-    })
 
     return composedPrompt
   }
@@ -5052,6 +5422,9 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     activeSkillNames: string[]
     toolSignature: string[]
     skillDraftSuggestionsEnabled: boolean
+    envRevision: string
+    verificationPolicyRevision: string
+    skillMutationEpoch: number
   }): string {
     return JSON.stringify({
       providerId: params.providerId,
@@ -5062,7 +5435,10 @@ export class AgentRuntimePresenter implements IAgentImplementation {
       availableSkillNames: params.availableSkillNames,
       activeSkillNames: params.activeSkillNames,
       toolSignature: params.toolSignature,
-      skillDraftSuggestionsEnabled: params.skillDraftSuggestionsEnabled
+      skillDraftSuggestionsEnabled: params.skillDraftSuggestionsEnabled,
+      envRevision: params.envRevision,
+      verificationPolicyRevision: params.verificationPolicyRevision,
+      skillMutationEpoch: params.skillMutationEpoch
     })
   }
 
@@ -6595,17 +6971,31 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     }
 
     try {
-      const agentId = this.getSessionAgentId(sessionId) ?? 'deepchat'
       const policy = await this.resolveAgentExtensionPolicy(sessionId)
       const effectiveActiveSkillNames =
         activeSkillNamesOverride === undefined
           ? await this.resolveActiveSkillNamesForToolProfile(sessionId)
           : this.filterSkillNamesByPolicy(activeSkillNamesOverride, policy)
+      const signal = new AbortController().signal
+      const skillsEnabled = this.configPresenter.getSkillsEnabled()
+      const runtimeView = await this.captureStableSkillRuntimeView({
+        requiredSkillNames: skillsEnabled ? effectiveActiveSkillNames : [],
+        signal,
+        deadlineAt: Date.now() + SYSTEM_PROMPT_SOURCE_LOOKUP_BUDGET_MS,
+        skillsEnabled
+      })
+      const skillContext = this.buildSkillPromptContext(
+        runtimeView,
+        effectiveActiveSkillNames,
+        policy,
+        skillsEnabled
+      )
       const profile = await this.resolveToolProfile(
         sessionId,
         projectDir,
-        effectiveActiveSkillNames,
-        policy
+        skillContext.activeSkillNames,
+        policy,
+        runtimeView.snapshot.epoch
       )
       const cachedProfile = this.toolProfileCache.get(sessionId)
       if (
@@ -6620,24 +7010,26 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         return cachedProfile.tools
       }
 
-      const tools = await this.toolPresenter.getAllToolDefinitions({
-        agentId,
-        enabledPluginIds: policy.enabledPluginIds ?? undefined,
-        disabledAgentTools: this.getDisabledAgentTools(sessionId),
-        chatMode: 'agent',
-        conversationId: sessionId,
-        agentWorkspacePath: projectDir,
-        activeSkillNames: effectiveActiveSkillNames
+      const tools = await this.buildToolDefinitionsFromSnapshot({
+        sessionId,
+        projectDir,
+        activeSkillNames: skillContext.activeSkillNames,
+        extensionPolicy: policy,
+        skillSnapshot: runtimeView.snapshot
       })
 
       this.toolProfileCache.set(sessionId, {
         profile: profile.kind,
         fingerprint: profile.fingerprint,
-        tools
+        tools,
+        skillMutationEpoch: runtimeView.snapshot.epoch
       })
 
       return tools
     } catch (error) {
+      if (error instanceof SkillRuntimeUpdatingError || this.isAbortError(error)) {
+        throw error
+      }
       console.error('[DeepChatAgent] failed to fetch tool definitions:', error)
       return []
     }
@@ -6647,8 +7039,9 @@ export class AgentRuntimePresenter implements IAgentImplementation {
     sessionId: string,
     projectDir: string | null,
     activeSkillNamesOverride?: string[],
-    extensionPolicy?: AgentExtensionPolicy
-  ): Promise<{ kind: ToolProfileKind; fingerprint: string }> {
+    extensionPolicy?: AgentExtensionPolicy,
+    skillMutationEpoch: number = 0
+  ): Promise<ToolProfileResolution> {
     const normalizedProjectDir = projectDir?.trim() || null
     const skillsEnabled = this.configPresenter.getSkillsEnabled()
     const policy = extensionPolicy ?? (await this.resolveAgentExtensionPolicy(sessionId))
@@ -6676,7 +7069,8 @@ export class AgentRuntimePresenter implements IAgentImplementation {
         enabledPluginIds: this.normalizeNullablePolicyList(policy.enabledPluginIds),
         enabledSkillNames: this.normalizeNullablePolicyList(policy.enabledSkillNames),
         skillsEnabled,
-        activeSkillNames
+        activeSkillNames,
+        skillMutationEpoch
       })
     }
   }

--- a/src/main/presenter/agentRuntimePresenter/process.ts
+++ b/src/main/presenter/agentRuntimePresenter/process.ts
@@ -520,26 +520,10 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
 
       if (executed.toolsChanged) {
         const activeSkillNames = hooks?.getActiveSkillNames?.()
-        if (params.refreshTools) {
-          try {
-            currentTools = await params.refreshTools(activeSkillNames)
-          } catch (error) {
-            console.warn('[ProcessStream] failed to refresh tools after skill activation:', error)
-          }
-        }
-        if (params.refreshSystemPrompt) {
-          try {
-            const refreshedSystemPrompt = await params.refreshSystemPrompt(
-              activeSkillNames,
-              currentTools
-            )
-            replaceLeadingSystemMessage(conversationMessages, refreshedSystemPrompt)
-          } catch (error) {
-            console.warn(
-              '[ProcessStream] failed to refresh system prompt after skill activation:',
-              error
-            )
-          }
+        if (params.refreshRuntimePair) {
+          const refreshedPair = await params.refreshRuntimePair(activeSkillNames)
+          currentTools = refreshedPair.tools
+          replaceLeadingSystemMessage(conversationMessages, refreshedPair.systemPrompt)
         }
       }
     }

--- a/src/main/presenter/agentRuntimePresenter/types.ts
+++ b/src/main/presenter/agentRuntimePresenter/types.ts
@@ -192,11 +192,10 @@ export interface ProcessResult {
 export interface ProcessParams {
   messages: ChatMessage[]
   tools: MCPToolDefinition[]
-  refreshTools?: (activeSkillNames?: string[]) => Promise<MCPToolDefinition[]>
-  refreshSystemPrompt?: (
-    activeSkillNames: string[] | undefined,
-    toolDefinitions: MCPToolDefinition[]
-  ) => Promise<string>
+  refreshRuntimePair?: (activeSkillNames?: string[]) => Promise<{
+    tools: MCPToolDefinition[]
+    systemPrompt: string
+  }>
   toolPresenter: IToolPresenter | null
   coreStream: (
     messages: ChatMessage[],

--- a/src/main/presenter/index.ts
+++ b/src/main/presenter/index.ts
@@ -464,10 +464,15 @@ export class Presenter implements IPresenter {
         }
         throw new SessionResolutionError('skills.hasNewSession', resolution)
       },
-      getPersistedNewSessionSkills: (conversationId) =>
-        (
+      getPersistedNewSessionSkills: (conversationId) => {
+        const table = (
           this.sqlitePresenter as unknown as import('./sqlitePresenter').SQLitePresenter
-        ).newSessionsTable?.getActiveSkills(conversationId) ?? [],
+        ).newSessionsTable
+        if (!table) {
+          throw new Error('New sessions table is not initialized')
+        }
+        return table.getPersistedActiveSkillPins(conversationId)
+      },
       setPersistedNewSessionSkills: (conversationId, skills) => {
         const sqlitePresenter = this
           .sqlitePresenter as unknown as import('./sqlitePresenter').SQLitePresenter

--- a/src/main/presenter/skillPresenter/index.ts
+++ b/src/main/presenter/skillPresenter/index.ts
@@ -46,7 +46,8 @@ import {
   PublishedSkillEntry,
   PublishedSkillSourceError,
   SkillRuntimeSnapshot,
-  WaitForStableSkillRuntimeOptions
+  WaitForStableSkillRuntimeOptions,
+  PersistedSkillPinsReadError
 } from '@shared/types/skill'
 import type {
   SkillManagementItem,
@@ -3351,18 +3352,20 @@ export class SkillPresenter implements ISkillPresenter {
    * Runtime callers validate these names against one bounded immutable snapshot.
    */
   async getPinnedActiveSkills(conversationId: string): Promise<string[]> {
-    if (await this.isNewAgentSession(conversationId)) {
-      return await this.loadNewSessionSkills(conversationId)
+    try {
+      return this.sessionStatePort.getPersistedNewSessionSkills(conversationId)
+    } catch (error) {
+      throw new PersistedSkillPinsReadError(conversationId, error)
     }
-
-    return []
   }
 
   /**
    * Get active skills for a conversation
    */
   async getActiveSkills(conversationId: string): Promise<string[]> {
-    const skills = await this.getPinnedActiveSkills(conversationId)
+    const skills = (await this.isNewAgentSession(conversationId))
+      ? await this.loadNewSessionSkills(conversationId)
+      : []
     const validSkills = await this.validateSkillNames(skills)
     if (!this.areSkillListsEqual(validSkills, skills)) {
       this.setPersistedNewSessionSkills(conversationId, validSkills)

--- a/src/main/presenter/skillPresenter/index.ts
+++ b/src/main/presenter/skillPresenter/index.ts
@@ -3347,19 +3347,27 @@ export class SkillPresenter implements ISkillPresenter {
   }
 
   /**
-   * Get active skills for a conversation
+   * Get persisted skill pins without triggering catalog discovery.
+   * Runtime callers validate these names against one bounded immutable snapshot.
    */
-  async getActiveSkills(conversationId: string): Promise<string[]> {
+  async getPinnedActiveSkills(conversationId: string): Promise<string[]> {
     if (await this.isNewAgentSession(conversationId)) {
-      const skills = await this.loadNewSessionSkills(conversationId)
-      const validSkills = await this.validateSkillNames(skills)
-      if (!this.areSkillListsEqual(validSkills, skills)) {
-        this.setPersistedNewSessionSkills(conversationId, validSkills)
-      }
-      return validSkills
+      return await this.loadNewSessionSkills(conversationId)
     }
 
     return []
+  }
+
+  /**
+   * Get active skills for a conversation
+   */
+  async getActiveSkills(conversationId: string): Promise<string[]> {
+    const skills = await this.getPinnedActiveSkills(conversationId)
+    const validSkills = await this.validateSkillNames(skills)
+    if (!this.areSkillListsEqual(validSkills, skills)) {
+      this.setPersistedNewSessionSkills(conversationId, validSkills)
+    }
+    return validSkills
   }
 
   /**

--- a/src/main/presenter/sqlitePresenter/tables/newSessions.ts
+++ b/src/main/presenter/sqlitePresenter/tables/newSessions.ts
@@ -344,14 +344,7 @@ export class NewSessionsTable extends BaseTable {
   }
 
   getActiveSkills(id: string): string[] {
-    const normalizedRows = this.db
-      .prepare(
-        `SELECT skill_name
-         FROM new_session_active_skills
-         WHERE session_id = ?
-         ORDER BY ordinal`
-      )
-      .all(id) as Array<{ skill_name: string }>
+    const normalizedRows = this.listActiveSkillRows(id)
     if (normalizedRows.length > 0) {
       return normalizedRows.map((row) => row.skill_name)
     }
@@ -360,6 +353,18 @@ export class NewSessionsTable extends BaseTable {
       | { active_skills?: string | null }
       | undefined
     return this.parseActiveSkills(row?.active_skills)
+  }
+
+  getPersistedActiveSkillPins(id: string): string[] {
+    const normalizedRows = this.listActiveSkillRows(id)
+    if (normalizedRows.length > 0) {
+      return normalizedRows.map((row) => row.skill_name)
+    }
+
+    const row = this.db.prepare('SELECT active_skills FROM new_sessions WHERE id = ?').get(id) as
+      | { active_skills?: string | null }
+      | undefined
+    return this.parsePersistedStringArray(row?.active_skills)
   }
 
   updateActiveSkills(id: string, activeSkills: string[]): void {
@@ -437,6 +442,17 @@ export class NewSessionsTable extends BaseTable {
     return this.parseStringArray(raw)
   }
 
+  private listActiveSkillRows(id: string): Array<{ skill_name: string }> {
+    return this.db
+      .prepare(
+        `SELECT skill_name
+         FROM new_session_active_skills
+         WHERE session_id = ?
+         ORDER BY ordinal`
+      )
+      .all(id) as Array<{ skill_name: string }>
+  }
+
   private replaceActiveSkillsRows(sessionId: string, activeSkills: string[]): void {
     const insert = this.db.prepare(
       `INSERT INTO new_session_active_skills (
@@ -486,5 +502,17 @@ export class NewSessionsTable extends BaseTable {
     } catch {
       return []
     }
+  }
+
+  private parsePersistedStringArray(raw: string | null | undefined): string[] {
+    if (!raw) {
+      return []
+    }
+
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== 'string')) {
+      throw new TypeError('Persisted skill pins must be a JSON string array')
+    }
+    return parsed
   }
 }

--- a/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
+++ b/src/main/presenter/toolPresenter/agentTools/agentToolManager.ts
@@ -8,7 +8,7 @@ import { app, nativeImage } from 'electron'
 import logger from '@shared/logger'
 import type { ChatMessage } from '@shared/types/core/chat-message'
 import type { ToolCallImagePreview } from '@shared/types/core/mcp'
-import type { SkillManageResult } from '@shared/types/skill'
+import type { SkillManageResult, SkillRuntimeSnapshot } from '@shared/types/skill'
 import { buildBinaryReadGuidance, shouldRejectAgentBinaryRead } from '@/lib/binaryReadGuard'
 import { AgentFileSystemHandler } from './agentFileSystemHandler'
 import { AgentBashHandler } from './agentBashHandler'
@@ -22,6 +22,7 @@ import {
 import { FffSearchService, type FffSearchMetadata } from '@/lib/agentRuntime/fffSearchService'
 import { SkillTools } from '../../skillPresenter/skillTools'
 import { SkillExecutionService } from '../../skillPresenter/skillExecutionService'
+import { normalizeSkillAllowedTools } from '../../skillPresenter/toolNameMapping'
 import { questionToolSchema, QUESTION_TOOL_NAME } from '@/lib/agentRuntime/questionTool'
 import {
   ChatSettingsToolHandler,
@@ -367,6 +368,7 @@ export class AgentToolManager {
     agentWorkspacePath: string | null
     conversationId?: string
     activeSkillNames?: string[]
+    skillRuntimeSnapshot?: SkillRuntimeSnapshot
   }): Promise<MCPToolDefinition[]> {
     const defs: MCPToolDefinition[] = []
     const isAgentMode = context.chatMode === 'agent'
@@ -447,7 +449,11 @@ export class AgentToolManager {
 
       if (
         context.conversationId &&
-        (await this.hasRunnableSkillScripts(context.conversationId, context.activeSkillNames))
+        (await this.hasRunnableSkillScripts(
+          context.conversationId,
+          context.activeSkillNames,
+          context.skillRuntimeSnapshot
+        ))
       ) {
         defs.push(this.getSkillRunToolDefinition())
       }
@@ -460,10 +466,12 @@ export class AgentToolManager {
           context.activeSkillNames ??
           (await this.getSkillPresenter().getActiveSkills(context.conversationId))
         if (activeSkills.includes(CHAT_SETTINGS_SKILL_NAME)) {
-          const allowedTools = await this.getSkillPresenter().getActiveSkillsAllowedTools(
-            context.conversationId,
-            activeSkills
-          )
+          const allowedTools = context.skillRuntimeSnapshot
+            ? this.getAllowedToolsFromRuntimeSnapshot(context.skillRuntimeSnapshot, activeSkills)
+            : await this.getSkillPresenter().getActiveSkillsAllowedTools(
+                context.conversationId,
+                activeSkills
+              )
           const requiredSettingsTools = Object.values(CHAT_SETTINGS_TOOL_NAMES)
           const nonOpenSettingsTools = requiredSettingsTools.filter(
             (tool) => tool !== CHAT_SETTINGS_TOOL_NAMES.open
@@ -1940,11 +1948,17 @@ export class AgentToolManager {
 
   private async hasRunnableSkillScripts(
     conversationId: string,
-    activeSkillNames?: string[]
+    activeSkillNames?: string[],
+    skillRuntimeSnapshot?: SkillRuntimeSnapshot
   ): Promise<boolean> {
     try {
       const activeSkills =
         activeSkillNames ?? (await this.getSkillPresenter().getActiveSkills(conversationId))
+      if (skillRuntimeSnapshot) {
+        return activeSkills.some((skillName) =>
+          skillRuntimeSnapshot.entries.get(skillName)?.scripts?.some((script) => script.enabled)
+        )
+      }
       for (const skillName of activeSkills) {
         const scripts = await this.getSkillPresenter().listSkillScripts(skillName)
         if (scripts.some((script) => script.enabled)) {
@@ -1959,6 +1973,21 @@ export class AgentToolManager {
     }
 
     return false
+  }
+
+  private getAllowedToolsFromRuntimeSnapshot(
+    snapshot: SkillRuntimeSnapshot,
+    activeSkillNames: string[]
+  ): string[] {
+    const allowedTools = activeSkillNames.flatMap((skillName) => {
+      const entry = snapshot.entries.get(skillName)
+      return entry?.availability === 'ready' ? [...entry.allowedTools] : []
+    })
+    const normalized = normalizeSkillAllowedTools(allowedTools)
+    for (const warning of normalized.warnings) {
+      logger.warn(warning)
+    }
+    return normalized.tools
   }
 
   /**

--- a/src/main/presenter/toolPresenter/index.ts
+++ b/src/main/presenter/toolPresenter/index.ts
@@ -7,6 +7,7 @@ import type {
 } from '@shared/presenter'
 import type { AgentToolProgressUpdate } from '@shared/types/presenters/tool.presenter'
 import type { PermissionMode } from '@shared/types/agent-interface'
+import type { SkillRuntimeSnapshot } from '@shared/types/skill'
 import { resolveToolOffloadTemplatePath } from '@/lib/agentRuntime/sessionPaths'
 import { QUESTION_TOOL_NAME } from '@/lib/agentRuntime/questionTool'
 import { ToolMapper, type ToolSource } from './toolMapper'
@@ -67,6 +68,7 @@ export interface IToolPresenter {
     agentWorkspacePath?: string | null
     conversationId?: string
     activeSkillNames?: string[]
+    skillRuntimeSnapshot?: SkillRuntimeSnapshot
   }): Promise<MCPToolDefinition[]>
   syncAgentToolContext?(context: {
     chatMode?: 'agent' | 'acp agent'
@@ -192,6 +194,7 @@ export class ToolPresenter implements IToolPresenter {
     agentWorkspacePath?: string | null
     conversationId?: string
     activeSkillNames?: string[]
+    skillRuntimeSnapshot?: SkillRuntimeSnapshot
   }): Promise<MCPToolDefinition[]> {
     const defs: MCPToolDefinition[] = []
     const mapper = this.resolveMapper(context.conversationId)
@@ -235,7 +238,8 @@ export class ToolPresenter implements IToolPresenter {
           supportsVision,
           agentWorkspacePath,
           conversationId: context.conversationId,
-          activeSkillNames: context.activeSkillNames
+          activeSkillNames: context.activeSkillNames,
+          skillRuntimeSnapshot: context.skillRuntimeSnapshot
         }),
         'agent'
       )

--- a/src/shared/types/presenters/tool.presenter.d.ts
+++ b/src/shared/types/presenters/tool.presenter.d.ts
@@ -6,6 +6,7 @@
 import type { MCPToolDefinition, MCPToolCall, MCPToolResponse } from '../core/mcp'
 import type { PermissionMode } from '../agent-interface'
 import type { AgentPlanSnapshot } from '../agent-plan'
+import type { SkillRuntimeSnapshot } from '../skill'
 
 export type AgentToolProgressUpdate =
   | {
@@ -40,6 +41,7 @@ export interface IToolPresenter {
     agentWorkspacePath?: string | null
     conversationId?: string
     activeSkillNames?: string[]
+    skillRuntimeSnapshot?: SkillRuntimeSnapshot
   }): Promise<MCPToolDefinition[]>
 
   /**

--- a/src/shared/types/skill.ts
+++ b/src/shared/types/skill.ts
@@ -88,6 +88,19 @@ export class SkillRuntimeUpdatingError extends Error {
   }
 }
 
+export class PersistedSkillPinsReadError extends Error {
+  readonly code = 'PERSISTED_SKILL_PINS_READ_FAILED'
+  readonly retryable = true
+
+  constructor(
+    readonly conversationId: string,
+    readonly cause: unknown
+  ) {
+    super(`Failed to read persisted skill pins for ${conversationId}`)
+    this.name = 'PersistedSkillPinsReadError'
+  }
+}
+
 export type SkillRuntimePreference = 'auto' | 'system' | 'builtin'
 
 export interface SkillRuntimePolicy {

--- a/src/shared/types/skill.ts
+++ b/src/shared/types/skill.ts
@@ -377,6 +377,7 @@ export interface ISkillPresenter {
   listSkillScripts(name: string): Promise<SkillScriptDescriptor[]>
 
   // Session state management
+  getPinnedActiveSkills(conversationId: string): Promise<string[]>
   getActiveSkills(conversationId: string): Promise<string[]>
   setActiveSkills(conversationId: string, skills: string[]): Promise<string[]>
   clearNewAgentSessionSkills?(conversationId: string): Promise<void>

--- a/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
@@ -59,6 +59,8 @@ vi.mock('@/presenter', () => ({
     skillPresenter: {
       getMetadataList: vi.fn().mockResolvedValue([]),
       getActiveSkills: vi.fn().mockResolvedValue([]),
+      getPublishedRuntimeSnapshot: vi.fn(),
+      waitForStableRuntimeSnapshot: vi.fn(),
       loadSkillContent: vi.fn().mockResolvedValue(null),
       viewDraftSkill: vi.fn(),
       installDraftSkill: vi.fn(),
@@ -78,7 +80,7 @@ vi.mock('@/presenter', () => ({
 
 vi.mock('@/lib/agentRuntime/systemEnvPromptBuilder', () => ({
   buildRuntimeCapabilitiesPrompt: vi.fn(() => 'RUNTIME_CAPABILITIES'),
-  buildSystemEnvPrompt: vi.fn(
+  buildSystemEnvPromptSnapshot: vi.fn(
     async (options?: {
       providerId?: string
       modelId?: string
@@ -88,18 +90,22 @@ vi.mock('@/lib/agentRuntime/systemEnvPromptBuilder', () => ({
       const providerId = options?.providerId || 'unknown-provider'
       const modelId = options?.modelId || 'unknown-model'
       const dateText = (options?.now ?? new Date()).toDateString()
-      return [
+      const prompt = [
         'ENV_BLOCK',
         `MODEL:${providerId}/${modelId}`,
         `WORKDIR:${options?.workdir ?? ''}`,
         `DATE:${dateText}`
       ].join('\n')
+      return { prompt, revision: prompt }
     }
   )
 }))
 
 vi.mock('@/lib/agentRuntime/verificationPolicyPromptBuilder', () => ({
-  buildVerificationPolicyPrompt: vi.fn(async () => '## Verification Policy')
+  buildVerificationPolicySnapshot: vi.fn(async () => ({
+    prompt: '## Verification Policy',
+    revision: 'verification-policy'
+  }))
 }))
 
 // Mock processStream to avoid timer/async complexity
@@ -113,9 +119,9 @@ import { eventBus } from '@/eventbus'
 import { publishDeepchatEvent } from '@/routes/publishDeepchatEvent'
 import {
   buildRuntimeCapabilitiesPrompt,
-  buildSystemEnvPrompt
+  buildSystemEnvPromptSnapshot
 } from '@/lib/agentRuntime/systemEnvPromptBuilder'
-import { buildVerificationPolicyPrompt } from '@/lib/agentRuntime/verificationPolicyPromptBuilder'
+import { buildVerificationPolicySnapshot } from '@/lib/agentRuntime/verificationPolicyPromptBuilder'
 
 function getPublishedPayloads(eventName: string): any[] {
   return (publishDeepchatEvent as ReturnType<typeof vi.fn>).mock.calls
@@ -153,6 +159,8 @@ function getSkillPresenterMock() {
   return presenter.skillPresenter as {
     getMetadataList: ReturnType<typeof vi.fn>
     getActiveSkills: ReturnType<typeof vi.fn>
+    getPublishedRuntimeSnapshot: ReturnType<typeof vi.fn>
+    waitForStableRuntimeSnapshot: ReturnType<typeof vi.fn>
     loadSkillContent: ReturnType<typeof vi.fn>
     viewDraftSkill: ReturnType<typeof vi.fn>
     installDraftSkill: ReturnType<typeof vi.fn>
@@ -646,6 +654,37 @@ describe('AgentRuntimePresenter', () => {
     skillPresenter.getMetadataList.mockResolvedValue([])
     skillPresenter.getActiveSkills.mockResolvedValue([])
     skillPresenter.loadSkillContent.mockResolvedValue(null)
+    let publishedSkillSnapshot = { epoch: 0, entries: new Map<string, any>() }
+    skillPresenter.getPublishedRuntimeSnapshot.mockImplementation(() => publishedSkillSnapshot)
+    skillPresenter.waitForStableRuntimeSnapshot.mockImplementation(
+      async ({ requiredSkillNames }: { requiredSkillNames: string[] }) => {
+        const metadataList = await skillPresenter.getMetadataList()
+        const entries = new Map<string, any>()
+        for (const metadata of metadataList) {
+          const name = metadata.name?.trim()
+          if (!name) continue
+          const content = requiredSkillNames.includes(name)
+            ? await skillPresenter.loadSkillContent(name)
+            : null
+          entries.set(name, {
+            sourceVersion: `${name}:${content?.content ?? 'metadata'}`,
+            availability: content ? 'ready' : 'metadata_only',
+            metadata: {
+              description: '',
+              path: `/tmp/${name}/SKILL.md`,
+              skillRoot: `/tmp/${name}`,
+              ...metadata,
+              name
+            },
+            renderedContent: content?.content,
+            allowedTools: metadata.allowedTools ?? [],
+            scripts: []
+          })
+        }
+        publishedSkillSnapshot = { epoch: 0, entries }
+        return publishedSkillSnapshot
+      }
+    )
     skillPresenter.viewDraftSkill.mockResolvedValue({ success: false, action: 'view', draftId: '' })
     skillPresenter.installDraftSkill.mockResolvedValue({
       success: false,
@@ -2506,13 +2545,13 @@ describe('AgentRuntimePresenter', () => {
     it('reuses cached system prompt within the same day', async () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-03-05T08:00:00.000Z'))
-      const envBuilder = buildSystemEnvPrompt as ReturnType<typeof vi.fn>
+      const envBuilder = buildSystemEnvPromptSnapshot as ReturnType<typeof vi.fn>
 
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
       await agent.processMessage('s1', 'First message')
       await agent.processMessage('s1', 'Second message')
 
-      expect(envBuilder).toHaveBeenCalledTimes(1)
+      expect(envBuilder).toHaveBeenCalledTimes(2)
       expect(toolPresenter.getAllToolDefinitions).toHaveBeenCalledTimes(1)
 
       const firstCallArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
@@ -2524,29 +2563,37 @@ describe('AgentRuntimePresenter', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-03-05T08:00:00.000Z'))
       const startedAt = Date.now()
-      const envBuilder = buildSystemEnvPrompt as ReturnType<typeof vi.fn>
-      const verificationBuilder = buildVerificationPolicyPrompt as ReturnType<typeof vi.fn>
+      const envBuilder = buildSystemEnvPromptSnapshot as ReturnType<typeof vi.fn>
+      const verificationBuilder = buildVerificationPolicySnapshot as ReturnType<typeof vi.fn>
       const envStarted = deferred<void>()
       let envDeadlineAt: number | undefined
       let verificationDeadlineAt: number | undefined
 
       envBuilder.mockImplementationOnce(
         async (options: { deadlineAt?: number }) =>
-          new Promise<string>((resolve) => {
+          new Promise<{ prompt: string; revision: string }>((resolve) => {
             envDeadlineAt = options.deadlineAt
             envStarted.resolve()
             setTimeout(
-              () => resolve('ENV_DEADLINE_FALLBACK'),
+              () =>
+                resolve({
+                  prompt: 'ENV_DEADLINE_FALLBACK',
+                  revision: 'env-deadline-fallback'
+                }),
               Math.max(0, (options.deadlineAt ?? Date.now()) - Date.now())
             )
           })
       )
       verificationBuilder.mockImplementationOnce(
-        async (_workdir: string | null, options: { deadlineAt?: number }) =>
-          new Promise<string>((resolve) => {
+        async (options: { deadlineAt?: number }) =>
+          new Promise<{ prompt: string; revision: string }>((resolve) => {
             verificationDeadlineAt = options.deadlineAt
             setTimeout(
-              () => resolve('## Verification Policy\nVERIFICATION_DEADLINE_FALLBACK'),
+              () =>
+                resolve({
+                  prompt: '## Verification Policy\nVERIFICATION_DEADLINE_FALLBACK',
+                  revision: 'verification-deadline-fallback'
+                }),
               Math.max(0, (options.deadlineAt ?? Date.now()) - Date.now())
             )
           })
@@ -2606,7 +2653,7 @@ describe('AgentRuntimePresenter', () => {
     it('invalidates cached prompt after system prompt update', async () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-03-05T08:00:00.000Z'))
-      const envBuilder = buildSystemEnvPrompt as ReturnType<typeof vi.fn>
+      const envBuilder = buildSystemEnvPromptSnapshot as ReturnType<typeof vi.fn>
 
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
       await agent.processMessage('s1', 'Before update')
@@ -2623,7 +2670,7 @@ describe('AgentRuntimePresenter', () => {
     it('invalidates cached prompt after session project directory update', async () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-03-05T08:00:00.000Z'))
-      const envBuilder = buildSystemEnvPrompt as ReturnType<typeof vi.fn>
+      const envBuilder = buildSystemEnvPromptSnapshot as ReturnType<typeof vi.fn>
 
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
       await agent.processMessage('s1', 'Before project update')
@@ -2667,7 +2714,7 @@ describe('AgentRuntimePresenter', () => {
 
     it('invalidates cached prompt across natural days', async () => {
       vi.useFakeTimers()
-      const envBuilder = buildSystemEnvPrompt as ReturnType<typeof vi.fn>
+      const envBuilder = buildSystemEnvPromptSnapshot as ReturnType<typeof vi.fn>
 
       vi.setSystemTime(new Date('2026-03-05T08:00:00.000Z'))
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
@@ -2687,7 +2734,7 @@ describe('AgentRuntimePresenter', () => {
     it('invalidates cached prompt when pinned skills change', async () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-03-05T08:00:00.000Z'))
-      const envBuilder = buildSystemEnvPrompt as ReturnType<typeof vi.fn>
+      const envBuilder = buildSystemEnvPromptSnapshot as ReturnType<typeof vi.fn>
       const skillPresenter = presenter.skillPresenter as {
         getMetadataList: ReturnType<typeof vi.fn>
         getActiveSkills: ReturnType<typeof vi.fn>
@@ -3059,7 +3106,7 @@ describe('AgentRuntimePresenter', () => {
       expect(toolPresenter.getAllToolDefinitions).not.toHaveBeenCalled()
       expect(toolPresenter.buildToolSystemPrompt).not.toHaveBeenCalled()
       expect(buildRuntimeCapabilitiesPrompt).not.toHaveBeenCalled()
-      expect(buildSystemEnvPrompt).not.toHaveBeenCalled()
+      expect(buildSystemEnvPromptSnapshot).not.toHaveBeenCalled()
 
       const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
       expect(callArgs.tools).toEqual([])
@@ -3111,7 +3158,7 @@ describe('AgentRuntimePresenter', () => {
         })
       )
       expect(buildRuntimeCapabilitiesPrompt).toHaveBeenCalled()
-      expect(buildSystemEnvPrompt).toHaveBeenCalled()
+      expect(buildSystemEnvPromptSnapshot).toHaveBeenCalled()
       expect(toolPresenter.buildToolSystemPrompt).toHaveBeenCalled()
 
       const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]

--- a/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
@@ -58,6 +58,7 @@ vi.mock('@/presenter', () => ({
   presenter: {
     skillPresenter: {
       getMetadataList: vi.fn().mockResolvedValue([]),
+      getPinnedActiveSkills: vi.fn().mockResolvedValue([]),
       getActiveSkills: vi.fn().mockResolvedValue([]),
       getPublishedRuntimeSnapshot: vi.fn(),
       waitForStableRuntimeSnapshot: vi.fn(),
@@ -158,6 +159,7 @@ function deferred<T>() {
 function getSkillPresenterMock() {
   return presenter.skillPresenter as {
     getMetadataList: ReturnType<typeof vi.fn>
+    getPinnedActiveSkills: ReturnType<typeof vi.fn>
     getActiveSkills: ReturnType<typeof vi.fn>
     getPublishedRuntimeSnapshot: ReturnType<typeof vi.fn>
     waitForStableRuntimeSnapshot: ReturnType<typeof vi.fn>
@@ -652,7 +654,7 @@ describe('AgentRuntimePresenter', () => {
     ;(processStream as ReturnType<typeof vi.fn>).mockResolvedValue({ status: 'completed' })
     const skillPresenter = getSkillPresenterMock()
     skillPresenter.getMetadataList.mockResolvedValue([])
-    skillPresenter.getActiveSkills.mockResolvedValue([])
+    skillPresenter.getPinnedActiveSkills.mockResolvedValue([])
     skillPresenter.loadSkillContent.mockResolvedValue(null)
     let publishedSkillSnapshot = { epoch: 0, entries: new Map<string, any>() }
     skillPresenter.getPublishedRuntimeSnapshot.mockImplementation(() => publishedSkillSnapshot)
@@ -2623,6 +2625,97 @@ describe('AgentRuntimePresenter', () => {
       expect(callArgs.messages[0].content).toContain('VERIFICATION_DEADLINE_FALLBACK')
     })
 
+    it('bounds catalog discovery from the real processMessage pre-stream entry', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-03-05T08:00:00.000Z'))
+      const startedAt = Date.now()
+      const skillPresenter = getSkillPresenterMock()
+      const discoveryStarted = deferred<void>()
+      const metadata = {
+        name: 'review',
+        description: 'Review changes',
+        path: '/skills/review/SKILL.md',
+        skillRoot: '/skills/review'
+      }
+      const snapshot = {
+        epoch: 2,
+        entries: new Map([
+          [
+            'review',
+            {
+              sourceVersion: 'review-v1',
+              availability: 'ready',
+              metadata,
+              renderedContent: 'REVIEW BODY',
+              allowedTools: [],
+              scripts: []
+            }
+          ]
+        ])
+      }
+      skillPresenter.getPinnedActiveSkills.mockResolvedValue(['review'])
+      skillPresenter.getActiveSkills.mockRejectedValue(
+        new Error('validated lookup would discover outside the runtime deadline')
+      )
+      skillPresenter.getPublishedRuntimeSnapshot.mockReturnValue(snapshot)
+      skillPresenter.waitForStableRuntimeSnapshot.mockResolvedValue(snapshot)
+      skillPresenter.getMetadataList.mockImplementation(() => {
+        discoveryStarted.resolve()
+        return new Promise(() => undefined)
+      })
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      const processing = agent.processMessage('s1', 'First message')
+      await discoveryStarted.promise
+
+      expect(buildSystemEnvPromptSnapshot).toHaveBeenCalledTimes(1)
+      expect(skillPresenter.getActiveSkills).not.toHaveBeenCalled()
+      expect(skillPresenter.waitForStableRuntimeSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({ deadlineAt: startedAt + 200 })
+      )
+      await vi.advanceTimersByTimeAsync(199)
+      expect(processStream).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      await processing
+      expect(Date.now()).toBe(startedAt + 200)
+      expect(processStream).not.toHaveBeenCalled()
+      expect((await agent.getSessionState('s1'))?.status).toBe('error')
+    })
+
+    it('retries a transient tool-definition failure on the next real turn', async () => {
+      toolPresenter.getAllToolDefinitions
+        .mockRejectedValueOnce(new Error('transient tool registry failure'))
+        .mockResolvedValueOnce([
+          {
+            type: 'function',
+            source: 'agent',
+            function: {
+              name: 'read',
+              description: 'read',
+              parameters: { type: 'object', properties: {} }
+            },
+            server: { name: 'agent-filesystem', icons: '', description: '' }
+          }
+        ])
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      await agent.processMessage('s1', 'First message')
+
+      expect(toolPresenter.getAllToolDefinitions).toHaveBeenCalledTimes(1)
+      expect(processStream).not.toHaveBeenCalled()
+      expect((agent as any).systemPromptCache.has('s1')).toBe(false)
+      expect((agent as any).toolProfileCache.has('s1')).toBe(false)
+
+      await agent.processMessage('s1', 'Second message')
+
+      expect(toolPresenter.getAllToolDefinitions).toHaveBeenCalledTimes(2)
+      expect(processStream).toHaveBeenCalledTimes(1)
+      expect((processStream as ReturnType<typeof vi.fn>).mock.calls[0][0].tools).toEqual([
+        expect.objectContaining({ function: expect.objectContaining({ name: 'read' }) })
+      ])
+    })
+
     it('invalidates cached tools when the MCP client list changes', async () => {
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
       await agent.processMessage('s1', 'Before MCP update')
@@ -2737,13 +2830,13 @@ describe('AgentRuntimePresenter', () => {
       const envBuilder = buildSystemEnvPromptSnapshot as ReturnType<typeof vi.fn>
       const skillPresenter = presenter.skillPresenter as {
         getMetadataList: ReturnType<typeof vi.fn>
-        getActiveSkills: ReturnType<typeof vi.fn>
+        getPinnedActiveSkills: ReturnType<typeof vi.fn>
         loadSkillContent: ReturnType<typeof vi.fn>
       }
 
       skillPresenter.getMetadataList.mockResolvedValue([{ name: 'skill-a' }])
-      skillPresenter.getActiveSkills.mockResolvedValue(['skill-a'])
-      skillPresenter.getActiveSkills.mockResolvedValueOnce([])
+      skillPresenter.getPinnedActiveSkills.mockResolvedValue(['skill-a'])
+      skillPresenter.getPinnedActiveSkills.mockResolvedValueOnce([])
       skillPresenter.loadSkillContent.mockResolvedValue({ content: 'Skill A instructions' })
 
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
@@ -2761,12 +2854,12 @@ describe('AgentRuntimePresenter', () => {
     it('does not load stale skill pins when the skill is absent from available metadata', async () => {
       const skillPresenter = presenter.skillPresenter as {
         getMetadataList: ReturnType<typeof vi.fn>
-        getActiveSkills: ReturnType<typeof vi.fn>
+        getPinnedActiveSkills: ReturnType<typeof vi.fn>
         loadSkillContent: ReturnType<typeof vi.fn>
       }
 
       skillPresenter.getMetadataList.mockResolvedValue([])
-      skillPresenter.getActiveSkills.mockResolvedValue(['plugin-skill'])
+      skillPresenter.getPinnedActiveSkills.mockResolvedValue(['plugin-skill'])
 
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
       await agent.processMessage('s1', 'Click a native app button')
@@ -2783,7 +2876,7 @@ describe('AgentRuntimePresenter', () => {
       vi.setSystemTime(new Date('2026-03-05T08:00:00.000Z'))
       const skillPresenter = presenter.skillPresenter as {
         getMetadataList: ReturnType<typeof vi.fn>
-        getActiveSkills: ReturnType<typeof vi.fn>
+        getPinnedActiveSkills: ReturnType<typeof vi.fn>
         loadSkillContent: ReturnType<typeof vi.fn>
       }
       toolPresenter.getAllToolDefinitions.mockResolvedValueOnce([
@@ -2820,7 +2913,7 @@ describe('AgentRuntimePresenter', () => {
       ])
       toolPresenter.buildToolSystemPrompt.mockReturnValue('TOOLING_BLOCK')
       skillPresenter.getMetadataList.mockResolvedValue([{ name: 'skill-a', description: 'desc-a' }])
-      skillPresenter.getActiveSkills.mockResolvedValue(['skill-a'])
+      skillPresenter.getPinnedActiveSkills.mockResolvedValue(['skill-a'])
       skillPresenter.loadSkillContent.mockResolvedValue({ content: 'Skill A body' })
 
       await agent.initSession('s1', {
@@ -2905,12 +2998,12 @@ describe('AgentRuntimePresenter', () => {
     it('omits skill metadata when skill management tools are unavailable', async () => {
       const skillPresenter = presenter.skillPresenter as {
         getMetadataList: ReturnType<typeof vi.fn>
-        getActiveSkills: ReturnType<typeof vi.fn>
+        getPinnedActiveSkills: ReturnType<typeof vi.fn>
         loadSkillContent: ReturnType<typeof vi.fn>
       }
 
       skillPresenter.getMetadataList.mockResolvedValue([{ name: 'skill-a' }])
-      skillPresenter.getActiveSkills.mockResolvedValue([])
+      skillPresenter.getPinnedActiveSkills.mockResolvedValue([])
       toolPresenter.getAllToolDefinitions.mockResolvedValueOnce([
         {
           type: 'function',
@@ -5635,6 +5728,10 @@ describe('AgentRuntimePresenter', () => {
     })
 
     it('manually compacts without creating a user turn or streaming', async () => {
+      const skillPresenter = getSkillPresenterMock()
+      skillPresenter.getActiveSkills.mockRejectedValue(
+        new Error('manual compaction must not trigger unbounded catalog discovery')
+      )
       configPresenter.resolveDeepChatAgentConfig.mockResolvedValue({
         autoCompactionEnabled: false,
         autoCompactionRetainRecentPairs: 1
@@ -5661,6 +5758,8 @@ describe('AgentRuntimePresenter', () => {
       })
       expect(llmProvider.generateText).toHaveBeenCalledTimes(1)
       expect(processStream).not.toHaveBeenCalled()
+      expect(skillPresenter.getPinnedActiveSkills).toHaveBeenCalledWith('s1')
+      expect(skillPresenter.getActiveSkills).not.toHaveBeenCalled()
 
       const insertRows = sqlitePresenter.deepchatMessagesTable.insert.mock.calls.map(
         ([row]: any[]) => row
@@ -6044,6 +6143,10 @@ describe('AgentRuntimePresenter', () => {
     }
 
     it('handles question_option and resumes assistant message', async () => {
+      const skillPresenter = getSkillPresenterMock()
+      skillPresenter.getActiveSkills.mockRejectedValue(
+        new Error('resume must not trigger unbounded catalog discovery')
+      )
       const prepareForResumeTurn = vi.spyOn(
         (agent as any).compactionService,
         'prepareForResumeTurn'
@@ -6097,6 +6200,8 @@ describe('AgentRuntimePresenter', () => {
         })
       )
       expect(processStream).toHaveBeenCalledTimes(1)
+      expect(skillPresenter.getPinnedActiveSkills).toHaveBeenCalledWith('s1')
+      expect(skillPresenter.getActiveSkills).not.toHaveBeenCalled()
     })
 
     it('inserts resume compaction indicators before the assistant message being resumed', async () => {

--- a/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/agentRuntimePresenter.test.ts
@@ -18,6 +18,7 @@ import {
   getUsableContextLength
 } from '@/presenter/agentRuntimePresenter/contextBudget'
 import { appendMessageRecordToTape } from '@/presenter/agentRuntimePresenter/tapeFacts'
+import { PersistedSkillPinsReadError } from '@shared/types/skill'
 
 vi.mock('nanoid', () => ({ nanoid: vi.fn(() => 'mock-msg-id') }))
 
@@ -1387,6 +1388,31 @@ describe('AgentRuntimePresenter', () => {
   })
 
   describe('processMessage', () => {
+    it('does not cache a prompt/tool pair when persisted pin reads fail', async () => {
+      const skillPresenter = getSkillPresenterMock()
+      const readError = new PersistedSkillPinsReadError('s1', new Error('database unavailable'))
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      skillPresenter.getPinnedActiveSkills
+        .mockRejectedValueOnce(readError)
+        .mockResolvedValueOnce([])
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      await agent.processMessage('s1', 'First message')
+
+      expect(consoleError).toHaveBeenCalledWith('[DeepChatAgent] processMessage error:', readError)
+      expect((agent as any).systemPromptCache.has('s1')).toBe(false)
+      expect((agent as any).toolProfileCache.has('s1')).toBe(false)
+      expect(toolPresenter.getAllToolDefinitions).not.toHaveBeenCalled()
+      expect(processStream).not.toHaveBeenCalled()
+
+      await agent.processMessage('s1', 'Second message')
+
+      expect(skillPresenter.getPinnedActiveSkills.mock.calls.length).toBeGreaterThanOrEqual(2)
+      expect(toolPresenter.getAllToolDefinitions).toHaveBeenCalledTimes(1)
+      expect(processStream).toHaveBeenCalledTimes(1)
+      consoleError.mockRestore()
+    })
+
     it('creates user and assistant messages with correct order_seq', async () => {
       sqlitePresenter.deepchatMessagesTable.getMaxOrderSeq
         .mockReturnValueOnce(0) // user message: seq 1
@@ -2654,9 +2680,7 @@ describe('AgentRuntimePresenter', () => {
         ])
       }
       skillPresenter.getPinnedActiveSkills.mockResolvedValue(['review'])
-      skillPresenter.getActiveSkills.mockRejectedValue(
-        new Error('validated lookup would discover outside the runtime deadline')
-      )
+      skillPresenter.getActiveSkills.mockImplementation(() => new Promise(() => undefined))
       skillPresenter.getPublishedRuntimeSnapshot.mockReturnValue(snapshot)
       skillPresenter.waitForStableRuntimeSnapshot.mockResolvedValue(snapshot)
       skillPresenter.getMetadataList.mockImplementation(() => {
@@ -5727,11 +5751,27 @@ describe('AgentRuntimePresenter', () => {
       ])
     })
 
+    it('propagates persisted pin read failures from manual compaction without caching a pair', async () => {
+      const skillPresenter = getSkillPresenterMock()
+      const readError = new PersistedSkillPinsReadError('s1', new Error('database unavailable'))
+      skillPresenter.getPinnedActiveSkills.mockRejectedValueOnce(readError)
+
+      await agent.initSession('s1', {
+        providerId: 'openai',
+        modelId: 'gpt-4',
+        generationSettings: { contextLength: 128000, maxTokens: 4096 }
+      })
+
+      await expect(agent.compactSession('s1')).rejects.toBe(readError)
+      expect((agent as any).systemPromptCache.has('s1')).toBe(false)
+      expect((agent as any).toolProfileCache.has('s1')).toBe(false)
+      expect(toolPresenter.getAllToolDefinitions).not.toHaveBeenCalled()
+      expect((agent as any).runtimeState.get('s1').status).toBe('idle')
+    })
+
     it('manually compacts without creating a user turn or streaming', async () => {
       const skillPresenter = getSkillPresenterMock()
-      skillPresenter.getActiveSkills.mockRejectedValue(
-        new Error('manual compaction must not trigger unbounded catalog discovery')
-      )
+      skillPresenter.getActiveSkills.mockImplementation(() => new Promise(() => undefined))
       configPresenter.resolveDeepChatAgentConfig.mockResolvedValue({
         autoCompactionEnabled: false,
         autoCompactionRetainRecentPairs: 1
@@ -6142,11 +6182,59 @@ describe('AgentRuntimePresenter', () => {
       return row
     }
 
+    it('propagates persisted pin read failures from resume without caching a pair', async () => {
+      const skillPresenter = getSkillPresenterMock()
+      const readError = new PersistedSkillPinsReadError('s1', new Error('database unavailable'))
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      skillPresenter.getPinnedActiveSkills.mockRejectedValueOnce(readError)
+      skillPresenter.getActiveSkills.mockImplementation(() => new Promise(() => undefined))
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      makeAssistantRow({
+        blocks: [
+          {
+            type: 'tool_call',
+            status: 'pending',
+            timestamp: 1,
+            tool_call: { id: 'tc1', name: 'ask_question', params: '{}', response: '' }
+          },
+          {
+            type: 'action',
+            action_type: 'question_request',
+            status: 'pending',
+            timestamp: 2,
+            content: 'Pick one',
+            tool_call: { id: 'tc1', name: 'ask_question', params: '{}' },
+            extra: {
+              needsUserAction: true,
+              questionText: 'Pick one',
+              questionOptions: [{ label: 'A' }]
+            }
+          }
+        ]
+      })
+
+      await expect(
+        agent.respondToolInteraction('s1', 'm1', 'tc1', {
+          kind: 'question_option',
+          optionLabel: 'A'
+        })
+      ).rejects.toBe(readError)
+      expect(consoleError).toHaveBeenCalledWith(
+        '[DeepChatAgent] resumeAssistantMessage error:',
+        readError
+      )
+      expect(skillPresenter.getActiveSkills).not.toHaveBeenCalled()
+      expect((agent as any).systemPromptCache.has('s1')).toBe(false)
+      expect((agent as any).toolProfileCache.has('s1')).toBe(false)
+      expect(toolPresenter.getAllToolDefinitions).not.toHaveBeenCalled()
+      expect((agent as any).runtimeState.get('s1').status).toBe('error')
+      consoleError.mockRestore()
+    })
+
     it('handles question_option and resumes assistant message', async () => {
       const skillPresenter = getSkillPresenterMock()
-      skillPresenter.getActiveSkills.mockRejectedValue(
-        new Error('resume must not trigger unbounded catalog discovery')
-      )
+      skillPresenter.getActiveSkills.mockImplementation(() => new Promise(() => undefined))
       const prepareForResumeTurn = vi.spyOn(
         (agent as any).compactionService,
         'prepareForResumeTurn'

--- a/test/main/presenter/agentRuntimePresenter/process.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/process.test.ts
@@ -545,10 +545,10 @@ describe('processStream', () => {
       return [...activeSkillNames]
     })
     const getActiveSkillNames = vi.fn(() => [...activeSkillNames])
-    const refreshTools = vi
-      .fn()
-      .mockResolvedValue([makeTool('skill_view'), makeTool('deepchat_settings_set_theme')])
-    const refreshSystemPrompt = vi.fn().mockResolvedValue('refreshed skill prompt')
+    const refreshRuntimePair = vi.fn().mockResolvedValue({
+      tools: [makeTool('skill_view'), makeTool('deepchat_settings_set_theme')],
+      systemPrompt: 'refreshed skill prompt'
+    })
 
     const coreStream = vi.fn(
       function (messages, _modelId, _modelConfig, _temperature, _maxTokens, tools) {
@@ -600,8 +600,7 @@ describe('processStream', () => {
       coreStream,
       toolPresenter,
       tools: [makeTool('skill_view')],
-      refreshTools,
-      refreshSystemPrompt,
+      refreshRuntimePair,
       hooks: {
         activateSkill,
         getActiveSkillNames
@@ -614,18 +613,8 @@ describe('processStream', () => {
 
     expect(activateSkill).toHaveBeenCalledWith('deepchat-settings')
     expect(getActiveSkillNames).toHaveBeenCalled()
-    expect(refreshTools).toHaveBeenCalledTimes(1)
-    expect(refreshTools).toHaveBeenCalledWith(['deepchat-settings'])
-    expect(refreshSystemPrompt).toHaveBeenCalledTimes(1)
-    expect(refreshSystemPrompt).toHaveBeenCalledWith(
-      ['deepchat-settings'],
-      [
-        expect.objectContaining({ function: expect.objectContaining({ name: 'skill_view' }) }),
-        expect.objectContaining({
-          function: expect.objectContaining({ name: 'deepchat_settings_set_theme' })
-        })
-      ]
-    )
+    expect(refreshRuntimePair).toHaveBeenCalledTimes(1)
+    expect(refreshRuntimePair).toHaveBeenCalledWith(['deepchat-settings'])
     expect(coreStream).toHaveBeenCalledTimes(3)
     expect(toolPresenter.callTool).toHaveBeenCalledTimes(2)
   })
@@ -649,7 +638,10 @@ describe('processStream', () => {
         }
       })
     } as unknown as IToolPresenter
-    const refreshTools = vi.fn().mockResolvedValue([makeTool('deepchat_settings_set_theme')])
+    const refreshRuntimePair = vi.fn().mockResolvedValue({
+      tools: [makeTool('deepchat_settings_set_theme')],
+      systemPrompt: 'unused'
+    })
 
     const coreStream = vi.fn(
       function (_messages, _modelId, _modelConfig, _temperature, _maxTokens, tools) {
@@ -683,14 +675,14 @@ describe('processStream', () => {
       coreStream,
       toolPresenter,
       tools: [makeTool('skill_view')],
-      refreshTools
+      refreshRuntimePair
     })
 
     const promise = processStream(params)
     await vi.runAllTimersAsync()
     await promise
 
-    expect(refreshTools).not.toHaveBeenCalled()
+    expect(refreshRuntimePair).not.toHaveBeenCalled()
     expect(coreStream).toHaveBeenCalledTimes(2)
   })
 

--- a/test/main/presenter/agentRuntimePresenter/process.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/process.test.ts
@@ -619,6 +619,65 @@ describe('processStream', () => {
     expect(toolPresenter.callTool).toHaveBeenCalledTimes(2)
   })
 
+  it('terminates the turn when the atomic runtime pair refresh fails after skill activation', async () => {
+    const toolPresenter = {
+      ...createMockToolPresenter(),
+      callTool: vi.fn().mockResolvedValue({
+        content:
+          '{"success":true,"name":"deepchat-settings","activeForCurrentMessage":true,"activatedForMessage":true}',
+        rawData: {
+          toolCallId: 'tc1',
+          content: '{"success":true}',
+          isError: false,
+          toolResult: {
+            activationApplied: true,
+            activationSource: 'skill_md',
+            activatedSkill: 'deepchat-settings'
+          }
+        }
+      })
+    } as unknown as IToolPresenter
+    const coreStream = vi.fn(() =>
+      (async function* () {
+        yield {
+          type: 'tool_call_start',
+          tool_call_id: 'tc1',
+          tool_call_name: 'skill_view'
+        } as LLMCoreStreamEvent
+        yield {
+          type: 'tool_call_end',
+          tool_call_id: 'tc1',
+          tool_call_arguments_complete: '{"name":"deepchat-settings"}'
+        } as LLMCoreStreamEvent
+        yield { type: 'stop', stop_reason: 'tool_use' } as LLMCoreStreamEvent
+      })()
+    ) as unknown as ProcessParams['coreStream']
+    const refreshRuntimePair = vi
+      .fn()
+      .mockRejectedValue(new Error('activation refresh registry failure'))
+    const params = createParams({
+      coreStream,
+      toolPresenter,
+      tools: [makeTool('skill_view')],
+      refreshRuntimePair,
+      hooks: {
+        activateSkill: vi.fn(async () => ['deepchat-settings']),
+        getActiveSkillNames: vi.fn(() => ['deepchat-settings'])
+      }
+    })
+
+    const promise = processStream(params)
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toMatchObject({
+      status: 'error',
+      stopReason: 'error',
+      errorMessage: 'activation refresh registry failure'
+    })
+    expect(refreshRuntimePair).toHaveBeenCalledWith(['deepchat-settings'])
+    expect(coreStream).toHaveBeenCalledTimes(1)
+  })
+
   it('does not refresh tools after linked-file skill_view reads', async () => {
     let callCount = 0
     const toolPresenter = {

--- a/test/main/presenter/agentRuntimePresenter/systemPromptCacheCoherence.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/systemPromptCacheCoherence.test.ts
@@ -329,7 +329,8 @@ describe('system prompt cache coherence orchestration', () => {
     expect(starts).toMatchObject({
       env: startedAt,
       verification: startedAt,
-      skillDiscovery: startedAt
+      skillDiscovery: startedAt,
+      skillStable: startedAt
     })
     await vi.advanceTimersByTimeAsync(50)
     envRead.resolve('PROJECT RULE')
@@ -337,11 +338,60 @@ describe('system prompt cache coherence orchestration', () => {
     discovery.resolve([metadata])
     await pending
 
-    expect(starts.skillStable).toBe(startedAt + 50)
+    expect(starts.skillStable).toBe(startedAt)
     const allDeadlines = skillPresenter.waitForStableRuntimeSnapshot.mock.calls.map(
       ([options]) => options.deadlineAt
     )
     expect(new Set(allDeadlines)).toEqual(new Set([startedAt + 200]))
+  })
+
+  it('reuses an odd-epoch readiness wait while slow discovery consumes the shared budget', async () => {
+    vi.useFakeTimers()
+    const startedAt = Date.now()
+    const metadata: SkillMetadata = {
+      name: 'review',
+      description: 'Review changes',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const snapshot = createSkillSnapshot(2, createSkillEntry(metadata, 'BODY', ['read']))
+    const skillPresenter = createSkillPresenter(snapshot)
+    const discovery = deferred<SkillMetadata[]>()
+    skillPresenter.getMetadataList.mockImplementationOnce(() => discovery.promise)
+    let stableWaitCount = 0
+    skillPresenter.waitForStableRuntimeSnapshot.mockImplementation(
+      (options: { deadlineAt: number }) => {
+        stableWaitCount += 1
+        if (stableWaitCount > 1) {
+          return Promise.resolve(snapshot)
+        }
+        return new Promise<SkillRuntimeSnapshot>((resolve, reject) => {
+          setTimeout(() => {
+            if (Date.now() >= options.deadlineAt) {
+              reject(new SkillRuntimeUpdatingError())
+              return
+            }
+            resolve(snapshot)
+          }, 150)
+        })
+      }
+    )
+    const runtime = createRuntime({ skillPresenter })
+
+    const pending = buildPair(runtime, tempDir)
+    await flushMicrotasks()
+    expect(stableWaitCount).toBe(1)
+    await vi.advanceTimersByTimeAsync(100)
+    discovery.resolve([metadata])
+    await flushMicrotasks()
+    expect(stableWaitCount).toBe(1)
+    await vi.advanceTimersByTimeAsync(50)
+
+    await expect(pending).resolves.toMatchObject({
+      systemPrompt: expect.stringContaining('BODY')
+    })
+    expect(Date.now()).toBe(startedAt + 150)
+    expect(stableWaitCount).toBe(3)
   })
 
   it('rebuilds once when publication changes during tool construction and returns only the new pair', async () => {

--- a/test/main/presenter/agentRuntimePresenter/systemPromptCacheCoherence.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/systemPromptCacheCoherence.test.ts
@@ -1,0 +1,538 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { AgentRuntimePresenter } from '@/presenter/agentRuntimePresenter'
+import { SkillRuntimeUpdatingError } from '@shared/types/skill'
+import type { PublishedSkillEntry, SkillMetadata, SkillRuntimeSnapshot } from '@shared/types/skill'
+import type { MCPToolDefinition } from '@shared/types/core/mcp'
+
+vi.mock('fs', async () => await vi.importActual('fs'))
+vi.mock('path', async () => await vi.importActual('path'))
+vi.mock('@/eventbus', () => ({ eventBus: { on: vi.fn() } }))
+vi.mock('@/routes/publishDeepchatEvent', () => ({ publishDeepchatEvent: vi.fn() }))
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve()
+  }
+}
+
+function createSkillEntry(
+  metadata: SkillMetadata,
+  content: string,
+  allowedTools: string[]
+): PublishedSkillEntry {
+  return Object.freeze({
+    sourceVersion: `${metadata.name}:${content}:${allowedTools.join(',')}`,
+    availability: 'ready' as const,
+    metadata: Object.freeze({ ...metadata, allowedTools: [...allowedTools] }),
+    renderedContent: content,
+    allowedTools: Object.freeze([...allowedTools]),
+    scripts: Object.freeze([])
+  })
+}
+
+function createSkillSnapshot(epoch: number, entry?: PublishedSkillEntry): SkillRuntimeSnapshot {
+  return Object.freeze({
+    epoch,
+    entries: new Map(entry ? [[entry.metadata.name, entry]] : [])
+  })
+}
+
+function createSqlitePresenter() {
+  return {
+    deepchatMessagesTable: { getByStatus: vi.fn(() => []) },
+    deepchatPendingInputsTable: { listClaimed: vi.fn(() => []) },
+    deepchatSessionsTable: { get: vi.fn(() => null) },
+    newSessionsTable: {
+      get: vi.fn(() => null),
+      getDisabledAgentTools: vi.fn(() => [])
+    }
+  } as any
+}
+
+function createConfigPresenter() {
+  return {
+    getSkillsEnabled: vi.fn(() => true),
+    getSkillDraftSuggestionsEnabled: vi.fn(() => false),
+    resolveDeepChatAgentConfig: vi.fn(async () => ({})),
+    getSetting: vi.fn(() => false),
+    getProviderModels: vi.fn(() => []),
+    getCustomModels: vi.fn(() => [])
+  } as any
+}
+
+function createSkillPresenter(initialSnapshot: SkillRuntimeSnapshot) {
+  let snapshot = initialSnapshot
+  const presenter = {
+    getMetadataList: vi.fn(async () =>
+      Array.from(snapshot.entries.values()).map((entry) => entry.metadata as SkillMetadata)
+    ),
+    getActiveSkills: vi.fn(async () => Array.from(snapshot.entries.keys())),
+    getPublishedRuntimeSnapshot: vi.fn(() => snapshot),
+    waitForStableRuntimeSnapshot: vi.fn(async () => snapshot),
+    loadSkillContent: vi.fn(),
+    viewDraftSkill: vi.fn(),
+    installDraftSkill: vi.fn(),
+    discardDraftSkill: vi.fn(),
+    setSnapshot(next: SkillRuntimeSnapshot) {
+      snapshot = next
+    }
+  }
+  return presenter
+}
+
+function createToolPresenter(
+  onBuild?: (context: {
+    activeSkillNames?: string[]
+    skillRuntimeSnapshot?: SkillRuntimeSnapshot
+  }) => void | Promise<void>
+) {
+  return {
+    getAllToolDefinitions: vi.fn(
+      async (context: {
+        activeSkillNames?: string[]
+        skillRuntimeSnapshot?: SkillRuntimeSnapshot
+      }): Promise<MCPToolDefinition[]> => {
+        await onBuild?.(context)
+        const allowedTools = (context.activeSkillNames ?? []).flatMap(
+          (name) => context.skillRuntimeSnapshot?.entries.get(name)?.allowedTools ?? []
+        )
+        return ['skill_view', ...allowedTools].map((name) => ({
+          type: 'function' as const,
+          source: 'agent' as const,
+          function: { name, description: name, parameters: { type: 'object', properties: {} } },
+          server: { name: 'agent-skills', icons: '', description: '' }
+        }))
+      }
+    ),
+    buildToolSystemPrompt: vi.fn(() => ''),
+    syncAgentToolContext: vi.fn()
+  }
+}
+
+function createRuntime(options: {
+  skillPresenter: ReturnType<typeof createSkillPresenter>
+  toolPresenter?: ReturnType<typeof createToolPresenter>
+}) {
+  const runtime = new AgentRuntimePresenter(
+    {} as any,
+    createConfigPresenter(),
+    createSqlitePresenter(),
+    (options.toolPresenter ?? createToolPresenter()) as any,
+    undefined,
+    { skillPresenter: options.skillPresenter as any }
+  )
+  ;(runtime as any).runtimeState.set('session-1', {
+    status: 'idle',
+    providerId: 'openai',
+    modelId: 'gpt-4',
+    permissionMode: 'full_access'
+  })
+  ;(runtime as any).sessionAgentIds.set('session-1', 'deepchat')
+  return runtime
+}
+
+async function buildPair(
+  runtime: AgentRuntimePresenter,
+  workdir: string,
+  activeSkillNames: string[] = ['review']
+) {
+  return await (runtime as any).buildRuntimePromptToolPair(
+    'session-1',
+    'BASE',
+    workdir,
+    activeSkillNames,
+    new AbortController().signal
+  )
+}
+
+describe('system prompt cache coherence orchestration', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'deepchat-prm-002c-'))
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    await fs.promises.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('observes a late real AGENTS.md source result on the next outer-cache lookup', async () => {
+    vi.useFakeTimers()
+    const metadata: SkillMetadata = {
+      name: 'review',
+      description: 'Review changes',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const skillPresenter = createSkillPresenter(
+      createSkillSnapshot(2, createSkillEntry(metadata, 'SKILL A', ['read']))
+    )
+    const runtime = createRuntime({ skillPresenter })
+    const agentsRead = deferred<string>()
+    const agentsReadStarted = deferred<void>()
+    const originalReadFile = fs.promises.readFile.bind(fs.promises)
+    let agentsReadCount = 0
+    vi.spyOn(fs.promises, 'readFile').mockImplementation(async (sourcePath, ...args) => {
+      if (path.resolve(String(sourcePath)) === path.join(tempDir, 'AGENTS.md')) {
+        agentsReadCount += 1
+        agentsReadStarted.resolve()
+        return (await agentsRead.promise) as any
+      }
+      return await (originalReadFile as any)(sourcePath, ...args)
+    })
+
+    const firstPair = buildPair(runtime, tempDir)
+    await agentsReadStarted.promise
+    await vi.advanceTimersByTimeAsync(199)
+    let settled = false
+    void firstPair.then(() => {
+      settled = true
+    })
+    expect(settled).toBe(false)
+    await vi.advanceTimersByTimeAsync(1)
+    expect((await firstPair).systemPrompt).not.toContain('LATE INSTRUCTIONS')
+
+    agentsRead.resolve('LATE INSTRUCTIONS')
+    await vi.waitFor(() => expect(agentsReadCount).toBe(1))
+    await Promise.resolve()
+
+    const secondPair = await buildPair(runtime, tempDir)
+    expect(secondPair.systemPrompt).toContain('LATE INSTRUCTIONS')
+    expect(agentsReadCount).toBe(1)
+  })
+
+  it('invalidates the outer prompt when the real verification snapshot revision changes', async () => {
+    vi.useFakeTimers()
+    const metadata: SkillMetadata = {
+      name: 'review',
+      description: 'Review changes',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const skillPresenter = createSkillPresenter(
+      createSkillSnapshot(2, createSkillEntry(metadata, 'BODY', ['read']))
+    )
+    const runtime = createRuntime({ skillPresenter })
+    const first = await buildPair(runtime, tempDir)
+    expect(first.systemPrompt).not.toContain('`project-check`')
+
+    await fs.promises.writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'fixture', scripts: { 'project-check': 'vitest' } })
+    )
+    await vi.advanceTimersByTimeAsync(30_000)
+    const staleTurn = await buildPair(runtime, tempDir)
+    expect(staleTurn.systemPrompt).not.toContain('`project-check`')
+    await vi.waitFor(async () => {
+      const refreshed = await buildPair(runtime, tempDir)
+      expect(refreshed.systemPrompt).toContain('`project-check`')
+    })
+  })
+
+  it('uses one immutable skill snapshot for prompt content and skill-derived tools', async () => {
+    const metadata: SkillMetadata = {
+      name: 'review',
+      description: 'Review A',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const firstSnapshot = createSkillSnapshot(2, createSkillEntry(metadata, 'BODY A', ['read']))
+    const skillPresenter = createSkillPresenter(firstSnapshot)
+    const toolPresenter = createToolPresenter()
+    const runtime = createRuntime({ skillPresenter, toolPresenter })
+
+    const first = await buildPair(runtime, tempDir)
+    expect(first.systemPrompt).toContain('BODY A')
+    expect(first.tools.map((tool) => tool.function.name)).toEqual(['skill_view', 'read'])
+    expect(toolPresenter.getAllToolDefinitions.mock.calls[0][0].skillRuntimeSnapshot).toBe(
+      firstSnapshot
+    )
+    expect(skillPresenter.loadSkillContent).not.toHaveBeenCalled()
+
+    const secondSnapshot = createSkillSnapshot(
+      4,
+      createSkillEntry({ ...metadata, description: 'Review B' }, 'BODY B', ['exec'])
+    )
+    skillPresenter.setSnapshot(secondSnapshot)
+    const second = await buildPair(runtime, tempDir)
+
+    expect(second.systemPrompt).toContain('BODY B')
+    expect(second.systemPrompt).toContain('Review B')
+    expect(second.tools.map((tool) => tool.function.name)).toEqual(['skill_view', 'exec'])
+    expect(toolPresenter.getAllToolDefinitions.mock.calls[1][0].skillRuntimeSnapshot).toBe(
+      secondSnapshot
+    )
+  })
+
+  it('starts all three source chains together and keeps one absolute deadline through discovery', async () => {
+    await fs.promises.writeFile(path.join(tempDir, 'AGENTS.md'), 'PROJECT RULE')
+    await fs.promises.writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'fixture', scripts: { test: 'vitest' } })
+    )
+    vi.useFakeTimers()
+    const startedAt = Date.now()
+    const metadata: SkillMetadata = {
+      name: 'review',
+      description: 'Review changes',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const snapshot = createSkillSnapshot(2, createSkillEntry(metadata, 'BODY', ['read']))
+    const skillPresenter = createSkillPresenter(snapshot)
+    const discovery = deferred<SkillMetadata[]>()
+    const starts: Record<string, number> = {}
+    skillPresenter.getMetadataList.mockImplementationOnce(() => {
+      starts.skillDiscovery = Date.now()
+      return discovery.promise
+    })
+    skillPresenter.waitForStableRuntimeSnapshot.mockImplementation(async (options) => {
+      starts.skillStable ??= Date.now()
+      expect(options.deadlineAt).toBe(startedAt + 200)
+      return snapshot
+    })
+    const originalReadFile = fs.promises.readFile.bind(fs.promises)
+    const envRead = deferred<string>()
+    const verificationRead = deferred<string>()
+    vi.spyOn(fs.promises, 'readFile').mockImplementation(async (sourcePath, ...args) => {
+      const resolved = path.resolve(String(sourcePath))
+      if (resolved === path.join(tempDir, 'AGENTS.md')) {
+        starts.env = Date.now()
+        return (await envRead.promise) as any
+      }
+      if (resolved === path.join(tempDir, 'package.json')) {
+        starts.verification = Date.now()
+        return (await verificationRead.promise) as any
+      }
+      return await (originalReadFile as any)(sourcePath, ...args)
+    })
+    const runtime = createRuntime({ skillPresenter })
+
+    const pending = buildPair(runtime, tempDir)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(starts).toMatchObject({
+      env: startedAt,
+      verification: startedAt,
+      skillDiscovery: startedAt
+    })
+    await vi.advanceTimersByTimeAsync(50)
+    envRead.resolve('PROJECT RULE')
+    verificationRead.resolve(JSON.stringify({ name: 'fixture', scripts: { test: 'vitest' } }))
+    discovery.resolve([metadata])
+    await pending
+
+    expect(starts.skillStable).toBe(startedAt + 50)
+    const allDeadlines = skillPresenter.waitForStableRuntimeSnapshot.mock.calls.map(
+      ([options]) => options.deadlineAt
+    )
+    expect(new Set(allDeadlines)).toEqual(new Set([startedAt + 200]))
+  })
+
+  it('rebuilds once when publication changes during tool construction and returns only the new pair', async () => {
+    const metadata: SkillMetadata = {
+      name: 'review',
+      description: 'Review changes',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const snapshotA = createSkillSnapshot(2, createSkillEntry(metadata, 'BODY A', ['read']))
+    const snapshotB = createSkillSnapshot(4, createSkillEntry(metadata, 'BODY B', ['exec']))
+    const skillPresenter = createSkillPresenter(snapshotA)
+    let buildCount = 0
+    const toolPresenter = createToolPresenter(() => {
+      buildCount += 1
+      if (buildCount === 1) {
+        skillPresenter.setSnapshot(snapshotB)
+      }
+    })
+    const runtime = createRuntime({ skillPresenter, toolPresenter })
+
+    const pair = await buildPair(runtime, tempDir)
+
+    expect(buildCount).toBe(2)
+    expect(pair.systemPrompt).toContain('BODY B')
+    expect(pair.systemPrompt).not.toContain('BODY A')
+    expect(pair.tools.map((tool) => tool.function.name)).toEqual(['skill_view', 'exec'])
+  })
+
+  it('retries when discovery metadata is published between the two stable samples', async () => {
+    const metadata: SkillMetadata = {
+      name: 'review',
+      description: 'Review changes',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const snapshotA = createSkillSnapshot(2, createSkillEntry(metadata, 'BODY A', ['read']))
+    const snapshotB = createSkillSnapshot(4, createSkillEntry(metadata, 'BODY B', ['exec']))
+    const skillPresenter = createSkillPresenter(snapshotA)
+    let metadataReadCount = 0
+    skillPresenter.getMetadataList.mockImplementation(async () => {
+      metadataReadCount += 1
+      if (metadataReadCount === 2) {
+        skillPresenter.setSnapshot(snapshotB)
+      }
+      const current = skillPresenter.getPublishedRuntimeSnapshot()
+      return Array.from(current.entries.values()).map((entry) => entry.metadata as SkillMetadata)
+    })
+    const runtime = createRuntime({ skillPresenter })
+
+    const pair = await buildPair(runtime, tempDir)
+
+    expect(metadataReadCount).toBeGreaterThanOrEqual(3)
+    expect(pair.systemPrompt).toContain('BODY B')
+    expect(pair.systemPrompt).not.toContain('BODY A')
+    expect(pair.tools.map((tool) => tool.function.name)).toEqual(['skill_view', 'exec'])
+  })
+
+  it('rejects after one rebuild when publication changes twice without resetting the deadline', async () => {
+    const metadata: SkillMetadata = {
+      name: 'review',
+      description: 'Review changes',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const snapshots = [
+      createSkillSnapshot(2, createSkillEntry(metadata, 'BODY A', ['read'])),
+      createSkillSnapshot(4, createSkillEntry(metadata, 'BODY B', ['exec'])),
+      createSkillSnapshot(6, createSkillEntry(metadata, 'BODY C', ['process']))
+    ]
+    const skillPresenter = createSkillPresenter(snapshots[0])
+    let buildCount = 0
+    const toolPresenter = createToolPresenter(() => {
+      buildCount += 1
+      skillPresenter.setSnapshot(snapshots[buildCount])
+    })
+    const runtime = createRuntime({ skillPresenter, toolPresenter })
+
+    await expect(buildPair(runtime, tempDir)).rejects.toBeInstanceOf(SkillRuntimeUpdatingError)
+    expect(buildCount).toBe(2)
+    const deadlines = skillPresenter.waitForStableRuntimeSnapshot.mock.calls.map(
+      ([options]) => options.deadlineAt
+    )
+    expect(new Set(deadlines).size).toBe(1)
+  })
+
+  it('bounds discovery under the shared deadline and rejects an unmatched late snapshot', async () => {
+    vi.useFakeTimers()
+    const emptySnapshot = createSkillSnapshot(0)
+    const skillPresenter = createSkillPresenter(emptySnapshot)
+    const discovery = deferred<SkillMetadata[]>()
+    skillPresenter.getMetadataList.mockImplementationOnce(() => discovery.promise)
+    const runtime = createRuntime({ skillPresenter })
+
+    const pending = buildPair(runtime, tempDir)
+    let settled = false
+    void pending.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+    const pendingRejection = expect(pending).rejects.toBeInstanceOf(SkillRuntimeUpdatingError)
+    await vi.advanceTimersByTimeAsync(199)
+    expect(settled).toBe(false)
+    await vi.advanceTimersByTimeAsync(1)
+    await pendingRejection
+
+    const metadata: SkillMetadata = {
+      name: 'review',
+      description: 'Late review',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const lateSnapshot = createSkillSnapshot(2, createSkillEntry(metadata, 'LATE BODY', ['read']))
+    skillPresenter.setSnapshot(lateSnapshot)
+    discovery.resolve([metadata])
+    await Promise.resolve()
+
+    const recovered = await buildPair(runtime, tempDir)
+    expect(recovered.systemPrompt).toContain('LATE BODY')
+  })
+
+  it('aborts runtime preparation both before registration and inside the listener window', async () => {
+    const skillPresenter = createSkillPresenter(createSkillSnapshot(0))
+    const runtime = createRuntime({ skillPresenter }) as any
+    const alreadyAborted = new AbortController()
+    alreadyAborted.abort(new DOMException('already aborted', 'AbortError'))
+    await expect(
+      runtime.waitForRuntimePreparation(
+        new Promise(() => undefined),
+        alreadyAborted.signal,
+        Date.now() + 10_000
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    const windowAbort = new AbortController()
+    const originalAddEventListener = windowAbort.signal.addEventListener.bind(windowAbort.signal)
+    vi.spyOn(windowAbort.signal, 'addEventListener').mockImplementation(((
+      ...args: Parameters<AbortSignal['addEventListener']>
+    ) => {
+      windowAbort.abort(new DOMException('window abort', 'AbortError'))
+      return originalAddEventListener(...args)
+    }) as AbortSignal['addEventListener'])
+    await expect(
+      runtime.waitForRuntimePreparation(
+        new Promise(() => undefined),
+        windowAbort.signal,
+        Date.now() + 10_000
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('falls back only when both cached halves match every source revision and skill epoch', async () => {
+    const metadata: SkillMetadata = {
+      name: 'review',
+      description: 'Review changes',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const stableSnapshot = createSkillSnapshot(
+      2,
+      createSkillEntry(metadata, 'STABLE BODY', ['read'])
+    )
+    const skillPresenter = createSkillPresenter(stableSnapshot)
+    const runtime = createRuntime({ skillPresenter })
+    const stablePair = await buildPair(runtime, tempDir)
+
+    vi.useFakeTimers()
+    skillPresenter.waitForStableRuntimeSnapshot.mockImplementation(
+      (options: { deadlineAt: number }) =>
+        new Promise<SkillRuntimeSnapshot>((_resolve, reject) => {
+          setTimeout(
+            () => reject(new SkillRuntimeUpdatingError()),
+            Math.max(0, options.deadlineAt - Date.now())
+          )
+        })
+    )
+    const fallback = buildPair(runtime, tempDir)
+    await flushMicrotasks()
+    await vi.advanceTimersByTimeAsync(200)
+    await expect(fallback).resolves.toEqual(stablePair)
+
+    const promptCache = (runtime as any).systemPromptCache.get('session-1')
+    promptCache.envRevision = 'mismatched-env-revision'
+    const rejected = buildPair(runtime, tempDir)
+    const rejection = expect(rejected).rejects.toBeInstanceOf(SkillRuntimeUpdatingError)
+    await flushMicrotasks()
+    await vi.advanceTimersByTimeAsync(200)
+    await rejection
+  })
+})

--- a/test/main/presenter/agentRuntimePresenter/systemPromptCacheCoherence.test.ts
+++ b/test/main/presenter/agentRuntimePresenter/systemPromptCacheCoherence.test.ts
@@ -79,6 +79,7 @@ function createSkillPresenter(initialSnapshot: SkillRuntimeSnapshot) {
     getMetadataList: vi.fn(async () =>
       Array.from(snapshot.entries.values()).map((entry) => entry.metadata as SkillMetadata)
     ),
+    getPinnedActiveSkills: vi.fn(async () => Array.from(snapshot.entries.keys())),
     getActiveSkills: vi.fn(async () => Array.from(snapshot.entries.keys())),
     getPublishedRuntimeSnapshot: vi.fn(() => snapshot),
     waitForStableRuntimeSnapshot: vi.fn(async () => snapshot),
@@ -277,6 +278,87 @@ describe('system prompt cache coherence orchestration', () => {
     expect(toolPresenter.getAllToolDefinitions.mock.calls[1][0].skillRuntimeSnapshot).toBe(
       secondSnapshot
     )
+  })
+
+  it('does not cache an empty pair when an ordinary tool build fails transiently', async () => {
+    const metadata: SkillMetadata = {
+      name: 'review',
+      description: 'Review changes',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const snapshot = createSkillSnapshot(2, createSkillEntry(metadata, 'BODY', ['read']))
+    const skillPresenter = createSkillPresenter(snapshot)
+    const toolPresenter = createToolPresenter()
+    toolPresenter.getAllToolDefinitions
+      .mockRejectedValueOnce(new Error('transient tool registry failure'))
+      .mockResolvedValueOnce([
+        {
+          type: 'function',
+          source: 'agent',
+          function: {
+            name: 'read',
+            description: 'read',
+            parameters: { type: 'object', properties: {} }
+          },
+          server: { name: 'agent-filesystem', icons: '', description: '' }
+        }
+      ])
+    const runtime = createRuntime({ skillPresenter, toolPresenter }) as any
+
+    await expect(buildPair(runtime, tempDir)).rejects.toThrow('transient tool registry failure')
+    expect(runtime.systemPromptCache.has('session-1')).toBe(false)
+    expect(runtime.toolProfileCache.has('session-1')).toBe(false)
+
+    await expect(buildPair(runtime, tempDir)).resolves.toMatchObject({
+      systemPrompt: expect.stringContaining('BODY'),
+      tools: [expect.objectContaining({ function: expect.objectContaining({ name: 'read' }) })]
+    })
+    expect(toolPresenter.getAllToolDefinitions).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the previous complete pair when skill activation tool refresh fails', async () => {
+    const metadataA: SkillMetadata = {
+      name: 'review',
+      description: 'Review changes',
+      path: path.join(tempDir, 'review', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'review')
+    }
+    const metadataB: SkillMetadata = {
+      ...metadataA,
+      name: 'deploy',
+      description: 'Deploy changes',
+      path: path.join(tempDir, 'deploy', 'SKILL.md'),
+      skillRoot: path.join(tempDir, 'deploy')
+    }
+    const snapshotA = createSkillSnapshot(2, createSkillEntry(metadataA, 'REVIEW BODY', ['read']))
+    const snapshotB = createSkillSnapshot(4, createSkillEntry(metadataB, 'DEPLOY BODY', ['write']))
+    const skillPresenter = createSkillPresenter(snapshotA)
+    const toolPresenter = createToolPresenter()
+    const runtime = createRuntime({ skillPresenter, toolPresenter }) as any
+    const previous = await buildPair(runtime, tempDir, ['review'])
+    const previousPromptCache = runtime.systemPromptCache.get('session-1')
+    const previousToolCache = runtime.toolProfileCache.get('session-1')
+
+    skillPresenter.setSnapshot(snapshotB)
+    toolPresenter.getAllToolDefinitions.mockRejectedValueOnce(
+      new Error('activation refresh registry failure')
+    )
+    await expect(buildPair(runtime, tempDir, ['deploy'])).rejects.toThrow(
+      'activation refresh registry failure'
+    )
+
+    expect(runtime.systemPromptCache.get('session-1')).toBe(previousPromptCache)
+    expect(runtime.toolProfileCache.get('session-1')).toBe(previousToolCache)
+    expect(previous.systemPrompt).toContain('REVIEW BODY')
+    expect(previous.tools.map((tool: MCPToolDefinition) => tool.function.name)).toContain('read')
+
+    await expect(buildPair(runtime, tempDir, ['deploy'])).resolves.toMatchObject({
+      systemPrompt: expect.stringContaining('DEPLOY BODY'),
+      tools: expect.arrayContaining([
+        expect.objectContaining({ function: expect.objectContaining({ name: 'write' }) })
+      ])
+    })
   })
 
   it('starts all three source chains together and keeps one absolute deadline through discovery', async () => {

--- a/test/main/presenter/skillPresenter/skillPresenter.test.ts
+++ b/test/main/presenter/skillPresenter/skillPresenter.test.ts
@@ -2456,6 +2456,19 @@ describe('SkillPresenter', () => {
   })
 
   describe('getActiveSkills', () => {
+    it('reads persisted pins without triggering catalog discovery', async () => {
+      ;(skillSessionStatePort.hasNewSession as Mock).mockResolvedValue(true)
+      newSessionActiveSkillsStore.set('new-session-raw-pins', ['available', 'not-yet-discovered'])
+      const discoverySpy = vi
+        .spyOn(skillPresenter, 'getMetadataList')
+        .mockRejectedValue(new Error('catalog discovery must stay inside runtime deadline'))
+
+      const pinned = await skillPresenter.getPinnedActiveSkills('new-session-raw-pins')
+
+      expect(pinned).toEqual(['available', 'not-yet-discovered'])
+      expect(discoverySpy).not.toHaveBeenCalled()
+    })
+
     it('should return empty skills for new agent sessions', async () => {
       ;(skillSessionStatePort.hasNewSession as Mock).mockResolvedValue(true)
 

--- a/test/main/presenter/skillPresenter/skillPresenter.test.ts
+++ b/test/main/presenter/skillPresenter/skillPresenter.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi, Mock, afterEach } from 'vitest'
 import type { IConfigPresenter } from '../../../../src/shared/presenter'
-import type { PublishedSkillEntry, SkillMetadata } from '../../../../src/shared/types/skill'
+import {
+  PersistedSkillPinsReadError,
+  type PublishedSkillEntry,
+  type SkillMetadata
+} from '../../../../src/shared/types/skill'
 import { app } from 'electron'
 
 const DEFAULT_SKILLS_DIR = '/mock/home/.deepchat/skills'
@@ -2467,6 +2471,38 @@ describe('SkillPresenter', () => {
 
       expect(pinned).toEqual(['available', 'not-yet-discovered'])
       expect(discoverySpy).not.toHaveBeenCalled()
+    })
+
+    it('returns authoritative empty pins without starting imported legacy repair', async () => {
+      ;(skillSessionStatePort.hasNewSession as Mock).mockResolvedValue(true)
+      ;(skillSessionStatePort.repairImportedLegacySessionSkills as Mock).mockImplementation(
+        () => new Promise(() => undefined)
+      )
+
+      await expect(
+        skillPresenter.getPinnedActiveSkills('legacy-session-empty-pins')
+      ).resolves.toEqual([])
+      expect(skillSessionStatePort.hasNewSession).not.toHaveBeenCalled()
+      expect(skillSessionStatePort.repairImportedLegacySessionSkills).not.toHaveBeenCalled()
+    })
+
+    it('propagates persisted pin read failures as retryable typed errors', async () => {
+      const cause = new Error('database unavailable')
+      ;(skillSessionStatePort.getPersistedNewSessionSkills as Mock).mockImplementationOnce(() => {
+        throw cause
+      })
+
+      const pending = skillPresenter.getPinnedActiveSkills('legacy-session-db-error')
+
+      await expect(pending).rejects.toMatchObject({
+        name: 'PersistedSkillPinsReadError',
+        code: 'PERSISTED_SKILL_PINS_READ_FAILED',
+        retryable: true,
+        conversationId: 'legacy-session-db-error',
+        cause
+      })
+      await expect(pending).rejects.toBeInstanceOf(PersistedSkillPinsReadError)
+      expect(skillSessionStatePort.repairImportedLegacySessionSkills).not.toHaveBeenCalled()
     })
 
     it('should return empty skills for new agent sessions', async () => {

--- a/test/main/presenter/sqlitePresenter/newSessionsTable.test.ts
+++ b/test/main/presenter/sqlitePresenter/newSessionsTable.test.ts
@@ -20,7 +20,7 @@ const DatabaseCtor = Database!
 const NewSessionsTableCtor = NewSessionsTable!
 const describeIfSqlite = sqliteAvailable && NewSessionsTable ? describe : describe.skip
 
-describeIfSqlite('NewSessionsTable clearProjectDir', () => {
+describeIfSqlite('NewSessionsTable', () => {
   let db: InstanceType<typeof DatabaseCtor> | null
   let table: InstanceType<typeof NewSessionsTableCtor>
 
@@ -77,5 +77,19 @@ describeIfSqlite('NewSessionsTable clearProjectDir', () => {
       project_dir: '/work/app',
       updated_at: 400
     })
+  })
+
+  it('strictly reads persisted active skill pins without hiding corrupt legacy JSON', () => {
+    table.create('session-valid', 'agent', 'Valid', null, { activeSkills: ['review'] })
+    expect(table.getPersistedActiveSkillPins('session-valid')).toEqual(['review'])
+    expect(table.getPersistedActiveSkillPins('session-missing')).toEqual([])
+
+    table.create('session-corrupt', 'agent', 'Corrupt', null)
+    db!
+      .prepare('UPDATE new_sessions SET active_skills = ? WHERE id = ?')
+      .run('{not-json', 'session-corrupt')
+
+    expect(() => table.getPersistedActiveSkillPins('session-corrupt')).toThrow(SyntaxError)
+    expect(table.getActiveSkills('session-corrupt')).toEqual([])
   })
 })

--- a/test/main/presenter/sqlitePresenter/newSessionsTable.test.ts
+++ b/test/main/presenter/sqlitePresenter/newSessionsTable.test.ts
@@ -4,8 +4,19 @@ const sqliteModule = await import('better-sqlite3-multiple-ciphers').catch(() =>
 const tableModule = sqliteModule
   ? await import('@/presenter/sqlitePresenter/tables/newSessions').catch(() => null)
   : null
+const activeSkillsTableModule = sqliteModule
+  ? await import('@/presenter/sqlitePresenter/tables/newSessionActiveSkills').catch(() => null)
+  : null
+const disabledToolsTableModule = sqliteModule
+  ? await import('@/presenter/sqlitePresenter/tables/newSessionDisabledAgentTools').catch(
+      () => null
+    )
+  : null
 const Database = sqliteModule?.default
 const NewSessionsTable = tableModule?.NewSessionsTable
+const NewSessionActiveSkillsTable = activeSkillsTableModule?.NewSessionActiveSkillsTable
+const NewSessionDisabledAgentToolsTable =
+  disabledToolsTableModule?.NewSessionDisabledAgentToolsTable
 let sqliteAvailable = false
 if (Database) {
   try {
@@ -18,7 +29,24 @@ if (Database) {
 }
 const DatabaseCtor = Database!
 const NewSessionsTableCtor = NewSessionsTable!
-const describeIfSqlite = sqliteAvailable && NewSessionsTable ? describe : describe.skip
+const NewSessionActiveSkillsTableCtor = NewSessionActiveSkillsTable!
+const NewSessionDisabledAgentToolsTableCtor = NewSessionDisabledAgentToolsTable!
+const requireNativeSqlite = process.env.DEEPCHAT_REQUIRE_NATIVE_SQLITE === '1'
+const sqliteHarnessAvailable =
+  sqliteAvailable &&
+  NewSessionsTable &&
+  NewSessionActiveSkillsTable &&
+  NewSessionDisabledAgentToolsTable
+const describeIfSqlite = sqliteHarnessAvailable
+  ? describe
+  : requireNativeSqlite
+    ? (name: string, _suite: () => void) =>
+        describe(name, () => {
+          it('requires native SQLite support', () => {
+            throw new Error('Native SQLite NewSessionsTable harness is unavailable')
+          })
+        })
+    : describe.skip
 
 describeIfSqlite('NewSessionsTable', () => {
   let db: InstanceType<typeof DatabaseCtor> | null
@@ -26,6 +54,8 @@ describeIfSqlite('NewSessionsTable', () => {
 
   beforeEach(() => {
     db = new DatabaseCtor(':memory:')
+    new NewSessionActiveSkillsTableCtor(db).createTable()
+    new NewSessionDisabledAgentToolsTableCtor(db).createTable()
     table = new NewSessionsTableCtor(db)
     table.createTable()
   })
@@ -79,17 +109,48 @@ describeIfSqlite('NewSessionsTable', () => {
     })
   })
 
-  it('strictly reads persisted active skill pins without hiding corrupt legacy JSON', () => {
-    table.create('session-valid', 'agent', 'Valid', null, { activeSkills: ['review'] })
-    expect(table.getPersistedActiveSkillPins('session-valid')).toEqual(['review'])
+  it('prefers normalized active skill rows over corrupt legacy JSON', () => {
+    table.create('session-normalized', 'agent', 'Normalized', null, {
+      activeSkills: ['review']
+    })
+    db!
+      .prepare('UPDATE new_sessions SET active_skills = ? WHERE id = ?')
+      .run('{not-json', 'session-normalized')
+
+    expect(table.getPersistedActiveSkillPins('session-normalized')).toEqual(['review'])
+  })
+
+  it('reads valid legacy active skill JSON when normalized rows are absent', () => {
+    table.create('session-legacy', 'agent', 'Legacy', null)
+    db!
+      .prepare('UPDATE new_sessions SET active_skills = ? WHERE id = ?')
+      .run('["review","debug"]', 'session-legacy')
+
+    expect(table.getPersistedActiveSkillPins('session-legacy')).toEqual(['review', 'debug'])
+  })
+
+  it('returns no persisted pins for fresh, missing, and empty sessions', () => {
+    table.create('session-fresh', 'agent', 'Fresh', null)
+    table.create('session-empty', 'agent', 'Empty', null)
+    db!.prepare('UPDATE new_sessions SET active_skills = ? WHERE id = ?').run('', 'session-empty')
+
+    expect(table.getPersistedActiveSkillPins('session-fresh')).toEqual([])
     expect(table.getPersistedActiveSkillPins('session-missing')).toEqual([])
+    expect(table.getPersistedActiveSkillPins('session-empty')).toEqual([])
+  })
+
+  it('rejects non-array and corrupt legacy active skill JSON with typed errors', () => {
+    table.create('session-non-array', 'agent', 'Non-array', null)
+    db!
+      .prepare('UPDATE new_sessions SET active_skills = ? WHERE id = ?')
+      .run('{"skill":"review"}', 'session-non-array')
 
     table.create('session-corrupt', 'agent', 'Corrupt', null)
     db!
       .prepare('UPDATE new_sessions SET active_skills = ? WHERE id = ?')
       .run('{not-json', 'session-corrupt')
 
+    expect(() => table.getPersistedActiveSkillPins('session-non-array')).toThrow(TypeError)
     expect(() => table.getPersistedActiveSkillPins('session-corrupt')).toThrow(SyntaxError)
-    expect(table.getActiveSkills('session-corrupt')).toEqual([])
   })
 })

--- a/test/main/presenter/toolPresenter/agentTools/agentToolManagerSettings.test.ts
+++ b/test/main/presenter/toolPresenter/agentTools/agentToolManagerSettings.test.ts
@@ -167,6 +167,57 @@ describe('AgentToolManager DeepChat settings tool gating', () => {
     expect(defs.map((def) => def.function.name)).toContain('skill_run')
   })
 
+  it('derives skill-gated definitions only from the captured runtime snapshot', async () => {
+    skillPresenter.getActiveSkills.mockResolvedValue([])
+    skillPresenter.getActiveSkillsAllowedTools.mockResolvedValue([])
+    skillPresenter.listSkillScripts.mockResolvedValue([])
+    const manager = buildManager()
+    const metadata = {
+      name: CHAT_SETTINGS_SKILL_NAME,
+      description: 'DeepChat settings',
+      path: '/tmp/deepchat-settings/SKILL.md',
+      skillRoot: '/tmp/deepchat-settings'
+    }
+
+    const defs = await manager.getAllToolDefinitions({
+      chatMode: 'agent',
+      supportsVision: false,
+      agentWorkspacePath: null,
+      conversationId: 'conv-1',
+      activeSkillNames: [CHAT_SETTINGS_SKILL_NAME],
+      skillRuntimeSnapshot: {
+        epoch: 2,
+        entries: new Map([
+          [
+            CHAT_SETTINGS_SKILL_NAME,
+            {
+              sourceVersion: 'captured-v2',
+              availability: 'ready',
+              metadata,
+              renderedContent: '# DeepChat settings',
+              allowedTools: [CHAT_SETTINGS_TOOL_NAMES.toggle],
+              scripts: [
+                {
+                  name: 'apply.js',
+                  relativePath: 'scripts/apply.js',
+                  absolutePath: '/tmp/deepchat-settings/scripts/apply.js',
+                  runtime: 'node',
+                  enabled: true
+                }
+              ]
+            }
+          ]
+        ])
+      }
+    })
+
+    const names = defs.map((def) => def.function.name)
+    expect(names).toContain(CHAT_SETTINGS_TOOL_NAMES.toggle)
+    expect(names).toContain('skill_run')
+    expect(skillPresenter.getActiveSkillsAllowedTools).not.toHaveBeenCalled()
+    expect(skillPresenter.listSkillScripts).not.toHaveBeenCalled()
+  })
+
   it('exposes skill inspection and draft tools without skill_control', async () => {
     skillPresenter.getActiveSkills.mockResolvedValue([])
     skillPresenter.getActiveSkillsAllowedTools.mockResolvedValue([])


### PR DESCRIPTION
## Scope

This PR delivers `PRM-002C`, the orchestration wiring on top of the already merged source snapshots (`PRM-002A`) and immutable skill runtime snapshots (`PRM-002B`).

It makes one pre-stream operation build an atomic `{ systemPrompt, tools }` pair from explicit source revisions and one immutable skill epoch.

## Why

The previous daily outer prompt cache could preserve an early 200ms fallback long after a late `AGENTS.md` or verification-policy read had completed. Prompt skill content and skill-derived tools were also rebuilt through separate live reads, so one turn could observe new instructions with old allowed tools or scripts.

The fix must retain the intentional 200ms startup budget and existing source caches without sending a mixed prompt/tool pair.

## What changed

- Starts environment, verification, skill discovery and the initial stable skill wait together under one absolute 200ms deadline and the caller AbortSignal.
- Uses discovery plus stable-snapshot/visibility/stable-snapshot confirmation as a bounded seqlock.
- Builds skill metadata, rendered body, allowed tools and runnable script exposure from the same immutable `SkillRuntimeSnapshot`.
- Returns prompt and tools as one runtime pair and refreshes them atomically after `skill_view` activation.
- Adds `envRevision`, `verificationPolicyRevision` and `skillMutationEpoch` to the outer prompt/tool fingerprints.
- Allows at most one rebuild when the skill epoch changes during construction. A second change writes no candidate cache.
- Allows fallback only when both cached halves and all structural inputs, revisions, epoch and tool-registry revision match.
- Propagates transient ToolPresenter failures instead of caching an empty tool set. The next turn retries; activation refresh failure terminates the current turn before a mixed pair can reach the provider.
- Adds a true raw persisted-pin API for runtime preparation. It reads only the current session rows/legacy JSON and never triggers legacy full-database repair or skill discovery before the deadline.
- Keeps legacy repair and validation in the compatibility `getActiveSkills` path.
- Propagates database/JSON pin-read failures as retryable `PersistedSkillPinsReadError`; only authoritative missing/empty state becomes `[]`.
- Applies the same preparation contract to normal process, manual compaction and resume entry points.
- Extends the native SQLite gate so the raw-pin fixture cannot be silently skipped when native SQLite is required.

## Correctness and failure behavior

- Late environment or verification results affect the next turn, not an already-started provider request.
- A skill epoch change during tool construction discards the candidate and rebuilds once from the new snapshot.
- A continuously changing or hung skill publication returns only a fully matching previous pair; otherwise it fails visibly with the typed updating error.
- A tool-definition failure never becomes a successful long-lived empty cache entry.
- A failed mid-stream pair refresh stops that tool loop instead of updating tools and prompt independently.
- Abort wins over stable fallback and does not cancel the shared source publication.

## Performance impact

- The three source chains share one overall 200ms wall-clock budget; no stage receives a fresh 200ms timeout.
- Fresh env and verification snapshot lookups reuse their existing source-owner cache and do not re-read content on every turn.
- Stable skill capture performs discovery plus a second compatibility metadata read between epoch samples. The second call is a compatibility-cache read, not a skill source-disk read, but it is not claimed to be zero-cost.
- The global skill epoch causes one prompt/tool rebuild per affected session after any skill publication. This is an accepted low-frequency false invalidation; no speculative per-skill dependency graph is added.
- The process-local source maps still have no eviction. Long-running, high-workspace-churn capacity remains a follow-up measurement, not part of this correctness PR.

## Automated verification

- Non-native focused suites: 348/348 passed.
- Electron 40 native SQLite raw-pin target: 5/5 passed.
- Native SQLite four-file suite: 120/120 passed.
- Full suite: 4,629 passed / 5 failed / 139 skipped.
- The five failures exactly match the baseline: SpotlightOverlay Pinia x3, AgentSession steer rebudget x1 and debug mock session x1.
- The skip count increased from 135 to 139 because the existing native-only `newSessionsTable` fixture expanded from one case to five. All five cases were executed under Electron ABI; they are not unverified logic.
- `DEEPCHAT_REQUIRE_NATIVE_SQLITE=1` fails explicitly when the native harness is unavailable instead of skipping.
- `pnpm run typecheck` passed.
- `pnpm run format:check` and the development format pass completed.
- `pnpm run i18n` passed.
- `pnpm run lint` passed, including the 62-site launcher inventory guard.
- `git diff --check` passed.
- Independent verification replayed t=0 concurrency, abort registration, late source settlement, A to B to C epoch changes, matching fallback, tool failure retry, activation refresh failure, ACP behavior and all three production entry points.

## Manual validation still required

This PR does not mark P-07 complete yet. The following real-app checks remain in the maintained spec and should be attached before final closure:

1. Modify `AGENTS.md` in the same session, cross the 30s refresh boundary and confirm the next post-settlement turn uses the new instructions.
2. Edit an active same-name skill body and confirm the next turn uses it without restart.
3. Change that skill allowed tools/scripts and confirm prompt and tool exposure change together.
4. Add/remove relevant `package.json` verification scripts and confirm the policy refreshes without unrelated prompt churn.
5. Confirm logs contain timing/cache metadata but no instruction, package or skill content.

Windows/Linux watcher timing and long-lived source-map capacity are also not proven by this PR.

## Compatibility and migration

- No database schema migration is added. The raw-pin reader consumes the existing normalized rows and legacy JSON column.
- No renderer, preload, IPC or settings shape changes are introduced.
- ACP-backed subagent sessions retain their existing local-tool bypass contract.

## Rollback

Revert this PR first to restore the old orchestration while leaving `PRM-002A` and `PRM-002B` owner invariants in place. Only after C is reverted may B and then A be considered for reverse-order rollback. There is no persisted migration to undo.