### PR TITLE
refactor(routes): migrate scheduler consumers

### DIFF
--- a/docs/architecture/scheduler-operation-contract/plan.md
+++ b/docs/architecture/scheduler-operation-contract/plan.md
@@ -209,8 +209,9 @@ SessionService.createSession
 ProviderService.testConnection
 ```
 
-guard 精确到 method/path，任何新增 consumer 都 blocking。create 由 003 atomic cutover 删除；provider 由
-`PRV-CAN-001` 删除。
+旧 `retry()` 在本片迁移后已没有 production caller，因此同时删除 interface、factory adapter 与 legacy input；
+settled-only retry 只保留语义明确的 `retryIdempotent()`。`timeout()` guard 精确到 method/path，任何新增
+consumer 都 blocking。create 由 003 atomic cutover 删除；provider 由 `PRV-CAN-001` 删除。
 
 ### Focused tests
 

--- a/docs/architecture/scheduler-operation-contract/plan.md
+++ b/docs/architecture/scheduler-operation-contract/plan.md
@@ -193,7 +193,9 @@ pnpm run lint
 
 ### Chat
 
-- session/agent/message preflight read 用 `observeIdempotent`，route stop 后不再进入下一 mutation；
+- session/agent/message preflight read 用 `observeIdempotent`；同 session 的 send 与全部并发 steer preflight
+  都注册到 stop fence。stop 只 abort 尚未进入 owner mutation 的 wait；late read 不再调用 owner。steer 不占
+  send lock，旧 preflight cleanup 不得删除 stop 后新建的 fence；
 - `sendMessage/steerActiveTurn/respondToolInteraction` 删除 non-cancellable mutation 外层 deadline，等待现有 owner
   acceptance/result；
 - 删除把 30 分钟常量描述为 generation timeout 的语义；
@@ -226,7 +228,7 @@ consumer 都 blocking。create 由 003 atomic cutover 删除；provider 由 `PRV
 | activate/deactivate | effect/event exactly once，无 runner |
 | listModels | getter exactly once，无 timer/runner |
 | provider model/no-model | 固定当前两类 timeout truth，不声称 cancellation、不 retry |
-| chat stop during preflight | mutation 不启动；cleanup request 各一次 |
+| chat stop during preflight | 同 session 全部 send/steer preflight 被 fence，mutation 不启动；cleanup request 各一次；stop 后新 steer 正常 |
 | runtime cancellation | single terminal hook，stale run 不覆盖 newer run |
 
 ### 影响、收益、风险

--- a/docs/architecture/scheduler-operation-contract/spec.md
+++ b/docs/architecture/scheduler-operation-contract/spec.md
@@ -427,7 +427,7 @@ waitForGenerationSettlement(runId: string): Promise<GenerationTerminalState>
 | `sessions.activate/deactivate` | 同步 map set/unset + event，Promise 返回前已完成 | 直接 await/call；删除无效 timeout，不 retry | `SCH-002B` |
 | `providers.listModels` | getter 在 `Promise.resolve` 前同步完成 | 直接调用；删除两个无效 timeout | `SCH-002B` |
 | `providers.testConnection` | 真实 probe；route 5s 不取消；model 60s 也只观察；no-model 无统一 bound | `SCH-002B` 暂不改，保留为已知 legacy exception且绝不 retry；真实 owner cancellation 另立 `PRV-CAN-001` | provider owner task 后再迁移 |
-| Chat preflight session/agent lookup | read-only；stop 可以停止 route 继续进入 mutation | `observeIdempotent` + route wait signal；late read 不继续 mutation | `SCH-002B` |
+| Chat preflight session/agent lookup | read-only；stop 可以停止 route 继续进入 mutation | `observeIdempotent` + route wait signal；同 session 的 send 与全部并发 steer preflight 都纳入 stop fence，late read 不继续 mutation | `SCH-002B` |
 | `chat.sendMessage/steer/respond` | durable queue/tool mutation；现有 task 不收 signal | 删除 mutation 外层 deadline，等待 owner acceptance；不自动 retry | `SCH-002B`；generation owner 仍属 `CHAT-*` |
 | `chat.stopStream` cleanup | controller abort + permission clear + cancel request；cancel 不是 terminal settle | 保留 request semantics，直接等待 cleanup request results；不宣称 generation settled | `SCH-002B` / `CHAT-*` |
 

--- a/docs/architecture/scheduler-operation-contract/spec.md
+++ b/docs/architecture/scheduler-operation-contract/spec.md
@@ -708,6 +708,8 @@ Restart recovery history (content-free)
   no-model unbounded truth 有 tests，`PRV-CAN-001` 未完成前不假称 owner cancellation。
 - session/chat safe consumers 按 inventory 迁移；legacy allowlist 包含 `sessions.create` 与精确的
   `providers.testConnection`，不得扩大。
+- production legacy retry caller 为零，`retry()` surface/adapter/input 已删除；settled-only retry 只经
+  `retryIdempotent()` 暴露。
 - `AgentRuntimePresenter` exactly-once cancel settlement tests 不变绿转红。
 
 ### SCH-003 implementation

--- a/docs/architecture/scheduler-operation-contract/tasks.md
+++ b/docs/architecture/scheduler-operation-contract/tasks.md
@@ -32,23 +32,33 @@
 
 ## SCH-002B：Safe consumer migration
 
-- [ ] 等 `SES-002` 合入并 rebase，不复制 availability adapter。
-- [ ] `restore` 保留 typed transient settled-only `2 attempts/25ms`。
-- [ ] `getActive` 同样保留 typed transient settled-only `2 attempts/25ms`。
-- [ ] restore/getActive 的 attempt、backoff、deadline、late settle 期间均保留 binding。
-- [ ] 只有 SES-002 权威 `missing` 允许 getActive unbind；unavailable/transient/deadline 不清 binding。
-- [ ] session list/page 使用 idempotent observation，不做 per-row retry。
-- [ ] activate/deactivate 删除无效 timeout wrapper。
-- [ ] provider model getters 删除 `Promise.resolve` + timeout wrapper。
-- [ ] `providers.testConnection` 暂不改：精确 legacy allowlist、无 automatic retry、tests 固定 model 60s
+- [x] 等 `SES-002` 合入并 rebase，不复制 availability adapter。
+- [x] `restore` 保留 typed transient settled-only `2 attempts/25ms`。
+- [x] `getActive` 同样保留 typed transient settled-only `2 attempts/25ms`。
+- [x] restore/getActive 的 attempt、backoff、deadline、late settle 期间均保留 binding。
+- [x] 只有 SES-002 权威 `missing` 允许 getActive unbind；unavailable/transient/deadline 不清 binding。
+- [x] session list/page 使用 idempotent observation，不做 per-row retry。
+- [x] activate/deactivate 删除无效 timeout wrapper。
+- [x] provider model getters 删除 `Promise.resolve` + timeout wrapper。
+- [x] `providers.testConnection` 暂不改：精确 legacy allowlist、无 automatic retry、tests 固定 model 60s
   observation/no-model no-uniform-bound truth。
-- [ ] Chat preflight reads 迁 idempotent observation，abort 后不进入下一 mutation。
-- [ ] Chat send/steer/respond 删除 non-cancellable mutation 外层 deadline。
-- [ ] stop 保留 both-cleanups-attempted，不把 cancel request 说成 terminal settlement。
-- [ ] static allowlist 精确为 `sessions.create` + `providers.testConnection` 两项。
-- [ ] 保持 AgentRuntime exactly-once cancel/stale-run tests 全绿。
+- [x] Chat preflight reads 迁 idempotent observation，abort 后不进入下一 mutation。
+- [x] Chat send/steer/respond 删除 non-cancellable mutation 外层 deadline。
+- [x] stop 保留 both-cleanups-attempted，不把 cancel request 说成 terminal settlement。
+- [x] static allowlist 精确为 `sessions.create` + `providers.testConnection` 两项。
+- [x] production legacy retry caller 归零后删除 `retry()` interface/factory adapter/input。
+- [x] 保持 AgentRuntime exactly-once cancel/stale-run tests 全绿。
 - [ ] 独立 verify agent 对每个 consumer 重做 capability 分类。
-- [ ] 跑 focused/full tests、typecheck、format、i18n、lint。
+- [x] 跑 focused/full tests、typecheck、format、i18n、lint。
+
+SCH-002B development 验证记录：
+
+- route/runner/guard/provider presenter focused：`107 passed`；session binding 与 AgentRuntime focused：
+  `276 passed`。
+- `typecheck`、`format`、`i18n`、`lint` 全部通过。
+- single-worker full：`472` files，`4726 passed / 5 failed / 140 skipped`；在未修改的基线
+  `fe126bf3` 上重跑失败文件得到完全相同的 `5` 个失败，新增失败数为 `0`。基线失败属于
+  long-steer rebudget、debug mock plan block 与 Spotlight Pinia setup，不在 SCH-002B scope。
 
 ## PRV-CAN-001：Provider owner cancellation（dependent slice）
 

--- a/docs/architecture/scheduler-operation-contract/tasks.md
+++ b/docs/architecture/scheduler-operation-contract/tasks.md
@@ -43,9 +43,11 @@
 - [x] `providers.testConnection` 暂不改：精确 legacy allowlist、无 automatic retry、tests 固定 model 60s
   observation/no-model no-uniform-bound truth。
 - [x] Chat preflight reads 迁 idempotent observation，abort 后不进入下一 mutation。
+- [x] verifier repair：stop fence 覆盖同 session 全部并发 steer preflight；旧 cleanup 不删新 fence。
 - [x] Chat send/steer/respond 删除 non-cancellable mutation 外层 deadline。
 - [x] stop 保留 both-cleanups-attempted，不把 cancel request 说成 terminal settlement。
 - [x] static allowlist 精确为 `sessions.create` + `providers.testConnection` 两项。
+- [x] verifier repair：禁止 production namespace import 绕过 OperationRunner provenance guard，并补 alias 负测。
 - [x] production legacy retry caller 归零后删除 `retry()` interface/factory adapter/input。
 - [x] 保持 AgentRuntime exactly-once cancel/stale-run tests 全绿。
 - [ ] 独立 verify agent 对每个 consumer 重做 capability 分类。
@@ -59,6 +61,9 @@ SCH-002B development 验证记录：
 - single-worker full：`472` files，`4726 passed / 5 failed / 140 skipped`；在未修改的基线
   `fe126bf3` 上重跑失败文件得到完全相同的 `5` 个失败，新增失败数为 `0`。基线失败属于
   long-steer rebudget、debug mock plan block 与 Spotlight Pinia setup，不在 SCH-002B scope。
+- verifier repair focused：Chat stop/steer fence 与 architecture adversarial guard 共 `46 passed`；namespace
+  factory/type/destructure、factory/property alias、local type alias、routes 外与 renamed owner 均有负测。
+  repair 后 `typecheck`、`format`、`i18n`、`lint` 全部通过；combined full 留给 final verifier/merge gate。
 
 ## PRV-CAN-001：Provider owner cancellation（dependent slice）
 

--- a/docs/architecture/scheduler-operation-contract/tasks.md
+++ b/docs/architecture/scheduler-operation-contract/tasks.md
@@ -50,7 +50,7 @@
 - [x] verifier repair：禁止 production namespace import 绕过 OperationRunner provenance guard，并补 alias 负测。
 - [x] production legacy retry caller 归零后删除 `retry()` interface/factory adapter/input。
 - [x] 保持 AgentRuntime exactly-once cancel/stale-run tests 全绿。
-- [ ] 独立 verify agent 对每个 consumer 重做 capability 分类。
+- [x] 独立 verify agent 对每个 consumer 重做 capability 分类。
 - [x] 跑 focused/full tests、typecheck、format、i18n、lint。
 
 SCH-002B development 验证记录：
@@ -61,6 +61,8 @@ SCH-002B development 验证记录：
 - single-worker full：`472` files，`4726 passed / 5 failed / 140 skipped`；在未修改的基线
   `fe126bf3` 上重跑失败文件得到完全相同的 `5` 个失败，新增失败数为 `0`。基线失败属于
   long-steer rebudget、debug mock plan block 与 Spotlight Pinia setup，不在 SCH-002B scope。
+- final independent focused：`9` files，`438 passed`；额外 adversarial `46 passed`，闭合并发 steer
+  preflight stop fence、stale cleanup/new fence 和 operation-runner namespace/type/alias guard 绕过。
 - verifier repair focused：Chat stop/steer fence 与 architecture adversarial guard 共 `46 passed`；namespace
   factory/type/destructure、factory/property alias、local type alias、routes 外与 renamed owner 均有负测。
   repair 后 `typecheck`、`format`、`i18n`、`lint` 全部通过；combined full 留给 final verifier/merge gate。

--- a/scripts/architecture-guard.mjs
+++ b/scripts/architecture-guard.mjs
@@ -151,25 +151,10 @@ const OPERATION_RUNNER_ALLOWED_METHODS = new Set([
   'sleep',
   'observeIdempotent',
   'retryIdempotent',
-  'timeout',
-  'retry'
+  'timeout'
 ])
 const LEGACY_OPERATION_RUNNER_ALLOWLIST = new Map([
   ['src/main/routes/sessions/sessionService.ts#createSession#timeout', 1],
-  ['src/main/routes/sessions/sessionService.ts#restoreSession#timeout', 1],
-  ['src/main/routes/sessions/sessionService.ts#listMessagesPage#timeout', 1],
-  ['src/main/routes/sessions/sessionService.ts#listSessions#timeout', 1],
-  ['src/main/routes/sessions/sessionService.ts#activateSession#timeout', 1],
-  ['src/main/routes/sessions/sessionService.ts#deactivateSession#timeout', 1],
-  ['src/main/routes/sessions/sessionService.ts#getActiveSession#timeout', 1],
-  ['src/main/routes/sessions/sessionService.ts#getActiveSession#retry', 1],
-  ['src/main/routes/sessions/sessionService.ts#resolveSessionWithRetry#timeout', 1],
-  ['src/main/routes/sessions/sessionService.ts#resolveSessionWithRetry#retry', 1],
-  ['src/main/routes/chat/chatService.ts#sendMessage#timeout', 3],
-  ['src/main/routes/chat/chatService.ts#steerActiveTurn#timeout', 2],
-  ['src/main/routes/chat/chatService.ts#stopStream#timeout', 2],
-  ['src/main/routes/chat/chatService.ts#respondToolInteraction#timeout', 1],
-  ['src/main/routes/providers/providerService.ts#listModels#timeout', 2],
   ['src/main/routes/providers/providerService.ts#testConnection#timeout', 1]
 ])
 

--- a/scripts/architecture-guard.mjs
+++ b/scripts/architecture-guard.mjs
@@ -273,6 +273,21 @@ function importedOperationRunnerSymbols(sourceFile) {
       if (importedName === 'createNodeOperationRunner') factoryNames.add(element.name.text)
     }
   }
+
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const statement of sourceFile.statements) {
+      if (
+        ts.isTypeAliasDeclaration(statement) &&
+        typeReferencesOperationRunner(statement.type, typeNames) &&
+        !typeNames.has(statement.name.text)
+      ) {
+        typeNames.add(statement.name.text)
+        changed = true
+      }
+    }
+  }
   return { typeNames, factoryNames }
 }
 
@@ -376,6 +391,14 @@ function collectOperationRunnerLegacyCalls(sourceFile) {
           changed = true
         }
         const initializer = ts.skipParentheses(declaration.initializer)
+        if (
+          ts.isIdentifier(initializer) &&
+          runnerFactories.has(initializer.text) &&
+          !runnerFactories.has(declaration.name.text)
+        ) {
+          runnerFactories.add(declaration.name.text)
+          changed = true
+        }
         if (
           ts.isIdentifier(initializer) &&
           legacyCallables.has(initializer.text) &&
@@ -483,6 +506,19 @@ async function checkOperationRunnerContract(fileSet, violations) {
     if (!isUnder(filePath, MAIN_SOURCE_ROOT) || path.extname(filePath) === '.vue') continue
     const source = await fs.readFile(filePath, 'utf8')
     const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true)
+    for (const statement of sourceFile.statements) {
+      if (
+        ts.isImportDeclaration(statement) &&
+        ts.isStringLiteral(statement.moduleSpecifier) &&
+        /(?:^|\/)operationRunner$/.test(statement.moduleSpecifier.text) &&
+        statement.importClause?.namedBindings &&
+        ts.isNamespaceImport(statement.importClause.namedBindings)
+      ) {
+        violations.push(
+          `[operation-runner-namespace-import] ${relativePath(filePath)} must use named imports from operationRunner`
+        )
+      }
+    }
     for (const { api, owner } of collectOperationRunnerLegacyCalls(sourceFile)) {
       const key = `${relativePath(filePath)}#${owner}#${api}`
       actualLegacyCalls.set(key, (actualLegacyCalls.get(key) ?? 0) + 1)

--- a/src/main/routes/chat/chatService.ts
+++ b/src/main/routes/chat/chatService.ts
@@ -10,9 +10,6 @@ import type { OperationRunner } from '../operationRunner'
 import { requireAvailableSession } from '@/presenter/agentSessionPresenter/sessionResolution'
 
 const CHAT_LOOKUP_TIMEOUT_MS = 5_000
-const CHAT_SEND_TIMEOUT_MS = 30 * 60 * 1_000
-const CHAT_STOP_TIMEOUT_MS = 5_000
-const CHAT_INTERACTION_TIMEOUT_MS = CHAT_SEND_TIMEOUT_MS
 
 export class ChatService {
   private readonly activeControllers = new Map<string, AbortController>()
@@ -44,57 +41,32 @@ export class ChatService {
     this.activeControllers.set(sessionId, controller)
 
     try {
-      const resolution = await this.deps.scheduler.timeout({
-        task: this.deps.sessionRepository.resolve(sessionId),
-        ms: CHAT_LOOKUP_TIMEOUT_MS,
-        reason: `chat.sendMessage:${sessionId}:session`
+      const resolution = await this.deps.scheduler.observeIdempotent({
+        task: async () => await this.deps.sessionRepository.resolve(sessionId),
+        deadlineMs: CHAT_LOOKUP_TIMEOUT_MS,
+        reason: `chat.sendMessage:${sessionId}:session`,
+        signal: controller.signal
       })
       const session = requireAvailableSession('chat.sendMessage', resolution)
 
-      const agentType = await this.deps.scheduler.timeout({
-        task: this.deps.providerCatalogPort.getAgentType(session.agentId),
-        ms: CHAT_LOOKUP_TIMEOUT_MS,
-        reason: `chat.sendMessage:${sessionId}:agentType`
+      const agentType = await this.deps.scheduler.observeIdempotent({
+        task: async () => await this.deps.providerCatalogPort.getAgentType(session.agentId),
+        deadlineMs: CHAT_LOOKUP_TIMEOUT_MS,
+        reason: `chat.sendMessage:${sessionId}:agentType`,
+        signal: controller.signal
       })
 
       if (!agentType) {
         throw new Error(`Agent type not found: ${session.agentId}`)
       }
 
-      const result = await this.deps.scheduler.timeout({
-        task: this.deps.providerExecutionPort.sendMessage(sessionId, content),
-        ms: CHAT_SEND_TIMEOUT_MS,
-        reason: `chat.sendMessage:${sessionId}`,
-        signal: controller.signal
-      })
+      const result = await this.deps.providerExecutionPort.sendMessage(sessionId, content)
 
       return {
         accepted: true,
         requestId: result.requestId,
         messageId: result.messageId
       }
-    } catch (error) {
-      if (error instanceof Error && error.name === 'TimeoutError') {
-        const cleanupResults = await Promise.allSettled([
-          Promise.resolve(this.deps.sessionPermissionPort.clearSessionPermissions(sessionId)),
-          this.deps.providerExecutionPort.cancelGeneration(sessionId)
-        ])
-        const clearPermissionsResult = cleanupResults[0]
-        if (clearPermissionsResult?.status === 'rejected') {
-          console.warn(
-            `[ChatService] Failed to clear session permissions after send timeout for ${sessionId}:`,
-            clearPermissionsResult.reason
-          )
-        }
-        const cancelGenerationResult = cleanupResults[1]
-        if (cancelGenerationResult?.status === 'rejected') {
-          console.warn(
-            `[ChatService] Failed to cancel generation after send timeout for ${sessionId}:`,
-            cancelGenerationResult.reason
-          )
-        }
-      }
-      throw error
     } finally {
       if (this.activeControllers.get(sessionId) === controller) {
         this.activeControllers.delete(sessionId)
@@ -106,18 +78,14 @@ export class ChatService {
     sessionId: string,
     content: string | SendMessageInput
   ): Promise<{ accepted: true }> {
-    const resolution = await this.deps.scheduler.timeout({
-      task: this.deps.sessionRepository.resolve(sessionId),
-      ms: CHAT_LOOKUP_TIMEOUT_MS,
+    const resolution = await this.deps.scheduler.observeIdempotent({
+      task: async () => await this.deps.sessionRepository.resolve(sessionId),
+      deadlineMs: CHAT_LOOKUP_TIMEOUT_MS,
       reason: `chat.steerActiveTurn:${sessionId}:session`
     })
     requireAvailableSession('chat.steerActiveTurn', resolution)
 
-    await this.deps.scheduler.timeout({
-      task: this.deps.providerExecutionPort.steerActiveTurn(sessionId, content),
-      ms: CHAT_SEND_TIMEOUT_MS,
-      reason: `chat.steerActiveTurn:${sessionId}`
-    })
+    await this.deps.providerExecutionPort.steerActiveTurn(sessionId, content)
 
     return { accepted: true }
   }
@@ -127,12 +95,13 @@ export class ChatService {
     requestId?: string
   }): Promise<{ stopped: boolean }> {
     let targetSessionId = input.sessionId ?? null
+    const requestId = input.requestId
 
-    if (!targetSessionId && input.requestId) {
-      const message = await this.deps.scheduler.timeout({
-        task: this.deps.messageRepository.get(input.requestId),
-        ms: CHAT_LOOKUP_TIMEOUT_MS,
-        reason: `chat.stopStream:${input.requestId}:message`
+    if (!targetSessionId && requestId) {
+      const message = await this.deps.scheduler.observeIdempotent({
+        task: async () => await this.deps.messageRepository.get(requestId),
+        deadlineMs: CHAT_LOOKUP_TIMEOUT_MS,
+        reason: `chat.stopStream:${requestId}:message`
       })
       targetSessionId = message?.sessionId ?? null
     }
@@ -147,34 +116,29 @@ export class ChatService {
       this.activeControllers.delete(targetSessionId)
     }
 
-    await this.deps.scheduler.timeout({
-      task: Promise.allSettled([
-        Promise.resolve().then(() =>
-          this.deps.sessionPermissionPort.clearSessionPermissions(targetSessionId)
-        ),
-        Promise.resolve().then(() =>
-          this.deps.providerExecutionPort.cancelGeneration(targetSessionId)
-        )
-      ]).then((results) => {
-        const clearPermissionsResult = results[0]
-        if (clearPermissionsResult?.status === 'rejected') {
-          console.warn(
-            `[ChatService] Failed to clear session permissions during stop for ${targetSessionId}:`,
-            clearPermissionsResult.reason
-          )
-        }
+    const cleanupResults = await Promise.allSettled([
+      Promise.resolve().then(() =>
+        this.deps.sessionPermissionPort.clearSessionPermissions(targetSessionId)
+      ),
+      Promise.resolve().then(() =>
+        this.deps.providerExecutionPort.cancelGeneration(targetSessionId)
+      )
+    ])
+    const clearPermissionsResult = cleanupResults[0]
+    if (clearPermissionsResult?.status === 'rejected') {
+      console.warn(
+        `[ChatService] Failed to clear session permissions during stop for ${targetSessionId}:`,
+        clearPermissionsResult.reason
+      )
+    }
 
-        const cancelGenerationResult = results[1]
-        if (cancelGenerationResult?.status === 'rejected') {
-          console.warn(
-            `[ChatService] Failed to cancel generation during stop for ${targetSessionId}:`,
-            cancelGenerationResult.reason
-          )
-        }
-      }),
-      ms: CHAT_STOP_TIMEOUT_MS,
-      reason: `chat.stopStream:${targetSessionId}`
-    })
+    const cancelGenerationResult = cleanupResults[1]
+    if (cancelGenerationResult?.status === 'rejected') {
+      console.warn(
+        `[ChatService] Failed to cancel generation during stop for ${targetSessionId}:`,
+        cancelGenerationResult.reason
+      )
+    }
 
     return { stopped: true }
   }
@@ -190,16 +154,12 @@ export class ChatService {
     waitingForUserMessage?: boolean
     handledInline?: boolean
   }> {
-    const result = await this.deps.scheduler.timeout({
-      task: this.deps.providerExecutionPort.respondToolInteraction(
-        input.sessionId,
-        input.messageId,
-        input.toolCallId,
-        input.response
-      ),
-      ms: CHAT_INTERACTION_TIMEOUT_MS,
-      reason: `chat.respondToolInteraction:${input.sessionId}:${input.toolCallId}`
-    })
+    const result = await this.deps.providerExecutionPort.respondToolInteraction(
+      input.sessionId,
+      input.messageId,
+      input.toolCallId,
+      input.response
+    )
 
     return {
       accepted: true,

--- a/src/main/routes/chat/chatService.ts
+++ b/src/main/routes/chat/chatService.ts
@@ -13,6 +13,7 @@ const CHAT_LOOKUP_TIMEOUT_MS = 5_000
 
 export class ChatService {
   private readonly activeControllers = new Map<string, AbortController>()
+  private readonly steerPreflightControllers = new Map<string, Set<AbortController>>()
 
   constructor(
     private readonly deps: {
@@ -78,12 +79,25 @@ export class ChatService {
     sessionId: string,
     content: string | SendMessageInput
   ): Promise<{ accepted: true }> {
-    const resolution = await this.deps.scheduler.observeIdempotent({
-      task: async () => await this.deps.sessionRepository.resolve(sessionId),
-      deadlineMs: CHAT_LOOKUP_TIMEOUT_MS,
-      reason: `chat.steerActiveTurn:${sessionId}:session`
-    })
-    requireAvailableSession('chat.steerActiveTurn', resolution)
+    const controller = new AbortController()
+    const controllers = this.steerPreflightControllers.get(sessionId) ?? new Set<AbortController>()
+    controllers.add(controller)
+    this.steerPreflightControllers.set(sessionId, controllers)
+
+    try {
+      const resolution = await this.deps.scheduler.observeIdempotent({
+        task: async () => await this.deps.sessionRepository.resolve(sessionId),
+        deadlineMs: CHAT_LOOKUP_TIMEOUT_MS,
+        reason: `chat.steerActiveTurn:${sessionId}:session`,
+        signal: controller.signal
+      })
+      requireAvailableSession('chat.steerActiveTurn', resolution)
+    } finally {
+      controllers.delete(controller)
+      if (controllers.size === 0 && this.steerPreflightControllers.get(sessionId) === controllers) {
+        this.steerPreflightControllers.delete(sessionId)
+      }
+    }
 
     await this.deps.providerExecutionPort.steerActiveTurn(sessionId, content)
 
@@ -114,6 +128,14 @@ export class ChatService {
     if (controller) {
       controller.abort()
       this.activeControllers.delete(targetSessionId)
+    }
+
+    const steerControllers = this.steerPreflightControllers.get(targetSessionId)
+    if (steerControllers) {
+      this.steerPreflightControllers.delete(targetSessionId)
+      for (const steerController of steerControllers) {
+        steerController.abort()
+      }
     }
 
     const cleanupResults = await Promise.allSettled([

--- a/src/main/routes/operationRunner.ts
+++ b/src/main/routes/operationRunner.ts
@@ -31,15 +31,6 @@ export interface LegacyTimeoutInput<T> {
   signal?: AbortSignal
 }
 
-export interface LegacyRetryInput<T> {
-  task: () => Promise<T>
-  maxAttempts: number
-  initialDelayMs: number
-  backoff: number
-  reason: string
-  signal?: AbortSignal
-}
-
 export interface OperationRunner {
   sleep(input: SleepInput): Promise<void>
   observeIdempotent<T>(input: ObserveIdempotentInput<T>): Promise<T>
@@ -47,9 +38,6 @@ export interface OperationRunner {
 
   /** @deprecated Migrate the allowlisted consumer to a capability-specific operation. */
   timeout<T>(input: LegacyTimeoutInput<T>): Promise<T>
-
-  /** @deprecated Migrate the allowlisted consumer to retryIdempotent. */
-  retry<T>(input: LegacyRetryInput<T>): Promise<T>
 }
 
 export class OperationRunnerValidationError extends TypeError {
@@ -326,14 +314,6 @@ export function createNodeOperationRunner(): OperationRunner {
     sleep,
     observeIdempotent,
     retryIdempotent,
-    timeout: legacyTimeout,
-    retry(input) {
-      return retryIdempotent({
-        ...input,
-        task: () => input.task(),
-        overallDeadlineMs: MAX_TIMER_MS,
-        shouldRetry: () => true
-      })
-    }
+    timeout: legacyTimeout
   }
 }

--- a/src/main/routes/providers/providerService.ts
+++ b/src/main/routes/providers/providerService.ts
@@ -17,18 +17,8 @@ export class ProviderService {
     providerModels: ReturnType<ProviderCatalogPort['getProviderModels']>
     customModels: ReturnType<ProviderCatalogPort['getCustomModels']>
   }> {
-    const [providerModels, customModels] = await Promise.all([
-      this.deps.scheduler.timeout({
-        task: Promise.resolve(this.deps.providerCatalogPort.getProviderModels(providerId)),
-        ms: PROVIDER_QUERY_TIMEOUT_MS,
-        reason: `providers.listModels:${providerId}:provider`
-      }),
-      this.deps.scheduler.timeout({
-        task: Promise.resolve(this.deps.providerCatalogPort.getCustomModels(providerId)),
-        ms: PROVIDER_QUERY_TIMEOUT_MS,
-        reason: `providers.listModels:${providerId}:custom`
-      })
-    ])
+    const providerModels = this.deps.providerCatalogPort.getProviderModels(providerId)
+    const customModels = this.deps.providerCatalogPort.getCustomModels(providerId)
 
     return {
       providerModels,

--- a/src/main/routes/sessions/sessionService.ts
+++ b/src/main/routes/sessions/sessionService.ts
@@ -25,10 +25,6 @@ class RetryableSessionReadError extends Error {
   }
 }
 
-class NonRetryableSessionReadFailure {
-  constructor(readonly error: unknown) {}
-}
-
 function toPublicSessionResolution(resolution: SessionResolutionResult): PublicSessionResolution {
   switch (resolution.availability) {
     case 'available':
@@ -114,11 +110,12 @@ export class SessionService {
       }
     }
 
-    const page = await this.deps.scheduler.timeout({
-      task: this.deps.messageRepository.listPageBySession(sessionId, {
-        limit: effectiveLimit
-      }),
-      ms: SESSION_OPERATION_TIMEOUT_MS,
+    const page = await this.deps.scheduler.observeIdempotent({
+      task: async () =>
+        await this.deps.messageRepository.listPageBySession(sessionId, {
+          limit: effectiveLimit
+        }),
+      deadlineMs: SESSION_OPERATION_TIMEOUT_MS,
       reason: `sessions.restore:${sessionId}:messages`
     })
 
@@ -136,9 +133,9 @@ export class SessionService {
       cursor?: MessagePageCursor | null
     }
   ): Promise<ChatMessagePageResult> {
-    return await this.deps.scheduler.timeout({
-      task: this.deps.messageRepository.listPageBySession(sessionId, options),
-      ms: SESSION_OPERATION_TIMEOUT_MS,
+    return await this.deps.scheduler.observeIdempotent({
+      task: async () => await this.deps.messageRepository.listPageBySession(sessionId, options),
+      deadlineMs: SESSION_OPERATION_TIMEOUT_MS,
       reason: `sessions.listMessagesPage:${sessionId}`
     })
   }
@@ -146,9 +143,9 @@ export class SessionService {
   async listSessions(
     filters?: SessionListFilters
   ): Promise<{ sessions: SessionWithState[]; results: PublicSessionResolution[] }> {
-    const resolutions = await this.deps.scheduler.timeout({
-      task: this.deps.sessionRepository.resolveList(filters),
-      ms: SESSION_OPERATION_TIMEOUT_MS,
+    const resolutions = await this.deps.scheduler.observeIdempotent({
+      task: async () => await this.deps.sessionRepository.resolveList(filters),
+      deadlineMs: SESSION_OPERATION_TIMEOUT_MS,
       reason: 'sessions.list'
     })
 
@@ -168,19 +165,11 @@ export class SessionService {
   }
 
   async activateSession(context: SessionRouteContext, sessionId: string): Promise<void> {
-    await this.deps.scheduler.timeout({
-      task: this.deps.sessionRepository.activate(context.webContentsId, sessionId),
-      ms: SESSION_OPERATION_TIMEOUT_MS,
-      reason: `sessions.activate:${sessionId}`
-    })
+    await this.deps.sessionRepository.activate(context.webContentsId, sessionId)
   }
 
   async deactivateSession(context: SessionRouteContext): Promise<void> {
-    await this.deps.scheduler.timeout({
-      task: this.deps.sessionRepository.deactivate(context.webContentsId),
-      ms: SESSION_OPERATION_TIMEOUT_MS,
-      reason: 'sessions.deactivate'
-    })
+    await this.deps.sessionRepository.deactivate(context.webContentsId)
   }
 
   async getActiveSession(
@@ -190,21 +179,10 @@ export class SessionService {
     let active: ActiveSessionResolution
 
     try {
-      const read = await this.deps.scheduler.retry<
-        ActiveSessionResolution | NonRetryableSessionReadFailure
-      >({
+      active = await this.deps.scheduler.retryIdempotent({
         task: async () => {
           attemptCount += 1
-          let result: ActiveSessionResolution
-          try {
-            result = await this.deps.scheduler.timeout({
-              task: this.deps.sessionRepository.resolveActive(context.webContentsId),
-              ms: SESSION_OPERATION_TIMEOUT_MS,
-              reason: 'sessions.getActive'
-            })
-          } catch (error) {
-            return new NonRetryableSessionReadFailure(error)
-          }
+          const result = await this.deps.sessionRepository.resolveActive(context.webContentsId)
           if (result.binding === 'bound' && result.resolution.availability === 'transient_error') {
             throw new RetryableSessionReadError(result.resolution)
           }
@@ -213,12 +191,10 @@ export class SessionService {
         maxAttempts: 2,
         initialDelayMs: 25,
         backoff: 1,
+        overallDeadlineMs: SESSION_OPERATION_TIMEOUT_MS,
+        shouldRetry: (error) => error instanceof RetryableSessionReadError,
         reason: 'sessions.getActive'
       })
-      if (read instanceof NonRetryableSessionReadFailure) {
-        throw read.error
-      }
-      active = read
     } catch (error) {
       if (!(error instanceof RetryableSessionReadError)) {
         throw error
@@ -250,21 +226,10 @@ export class SessionService {
   ): Promise<{ resolution: SessionResolutionResult; attemptCount: number }> {
     let attemptCount = 0
     try {
-      const read = await this.deps.scheduler.retry<
-        SessionResolutionResult | NonRetryableSessionReadFailure
-      >({
+      const read = await this.deps.scheduler.retryIdempotent({
         task: async () => {
           attemptCount += 1
-          let result: SessionResolutionResult
-          try {
-            result = await this.deps.scheduler.timeout({
-              task: this.deps.sessionRepository.resolve(sessionId),
-              ms: SESSION_OPERATION_TIMEOUT_MS,
-              reason: `${reason}:session`
-            })
-          } catch (error) {
-            return new NonRetryableSessionReadFailure(error)
-          }
+          const result = await this.deps.sessionRepository.resolve(sessionId)
           if (result.availability === 'transient_error') {
             throw new RetryableSessionReadError(result)
           }
@@ -273,11 +238,10 @@ export class SessionService {
         maxAttempts: 2,
         initialDelayMs: 25,
         backoff: 1,
+        overallDeadlineMs: SESSION_OPERATION_TIMEOUT_MS,
+        shouldRetry: (error) => error instanceof RetryableSessionReadError,
         reason
       })
-      if (read instanceof NonRetryableSessionReadFailure) {
-        throw read.error
-      }
       return { resolution: read, attemptCount }
     } catch (error) {
       if (!(error instanceof RetryableSessionReadError)) {

--- a/test/main/presenter/llmProviderPresenter.test.ts
+++ b/test/main/presenter/llmProviderPresenter.test.ts
@@ -17,6 +17,16 @@ const {
   mockRunAiSdkGenerateText: vi.fn().mockResolvedValue({ content: 'mock completion' })
 }))
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
 // Ensure electron is mocked for this suite to avoid CJS named export issues
 vi.mock('electron', () => {
   return {
@@ -323,6 +333,73 @@ describe('LLMProviderPresenter Integration Tests', () => {
       expect(result).toHaveProperty('errorMsg')
       expect(result.isOk).toBe(true)
     }, 10000)
+
+    it('keeps the model-specific connection check as a 60-second observation', async () => {
+      vi.useFakeTimers()
+      const completion = deferred<{ content: string }>()
+      const provider = {
+        completions: vi.fn().mockReturnValue(completion.promise),
+        check: vi.fn()
+      }
+      vi.spyOn(llmProviderPresenter, 'getProviderInstance').mockReturnValue(provider as any)
+
+      try {
+        let settled = false
+        const checking = llmProviderPresenter.check('mock-openai-api', 'mock-model')
+        void checking.finally(() => {
+          settled = true
+        })
+
+        await vi.advanceTimersByTimeAsync(59_999)
+        expect(settled).toBe(false)
+        expect(provider.completions).toHaveBeenCalledWith(
+          [{ role: 'user', content: 'hi' }],
+          'mock-model',
+          0.1,
+          10
+        )
+
+        await vi.advanceTimersByTimeAsync(1)
+        await expect(checking).resolves.toEqual({
+          isOk: false,
+          errorMsg: 'Model response is invalid'
+        })
+
+        completion.resolve({ content: 'late owner response' })
+        await Promise.resolve()
+        expect(provider.completions).toHaveBeenCalledOnce()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('keeps the provider-native connection check without a uniform route deadline', async () => {
+      vi.useFakeTimers()
+      const nativeCheck = deferred<{ isOk: boolean; errorMsg: string | null }>()
+      const provider = {
+        completions: vi.fn(),
+        check: vi.fn().mockReturnValue(nativeCheck.promise)
+      }
+      vi.spyOn(llmProviderPresenter, 'getProviderInstance').mockReturnValue(provider as any)
+
+      try {
+        let settled = false
+        const checking = llmProviderPresenter.check('mock-openai-api')
+        void checking.finally(() => {
+          settled = true
+        })
+
+        expect(vi.getTimerCount()).toBe(0)
+        await vi.advanceTimersByTimeAsync(600_000)
+        expect(settled).toBe(false)
+        expect(provider.check).toHaveBeenCalledOnce()
+
+        nativeCheck.resolve({ isOk: true, errorMsg: null })
+        await expect(checking).resolves.toEqual({ isOk: true, errorMsg: null })
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   describe('Non-stream Completion', () => {

--- a/test/main/routes/chatService.test.ts
+++ b/test/main/routes/chatService.test.ts
@@ -1,4 +1,15 @@
 import { ChatService } from '@/routes/chat/chatService'
+import { createNodeOperationRunner } from '@/routes/operationRunner'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
 
 describe('ChatService', () => {
   const availableSession = <T extends Record<string, unknown>>(session: T) => ({
@@ -8,8 +19,9 @@ describe('ChatService', () => {
 
   const createScheduler = () => ({
     sleep: vi.fn(),
-    timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task),
-    retry: vi.fn()
+    observeIdempotent: vi.fn(async <T>({ task }: { task: () => Promise<T> }) => await task()),
+    retryIdempotent: vi.fn(),
+    timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task)
   })
 
   it('sends messages through the scheduler after resolving the session owner', async () => {
@@ -63,7 +75,8 @@ describe('ChatService', () => {
     expect(providerCatalogPort.getAgentType).toHaveBeenCalledWith('deepchat')
     expect(providerExecutionPort.sendMessage).toHaveBeenCalledWith('session-1', 'hello')
     expect(messageRepository.listBySession).not.toHaveBeenCalled()
-    expect(scheduler.timeout).toHaveBeenCalledTimes(3)
+    expect(scheduler.observeIdempotent).toHaveBeenCalledTimes(2)
+    expect(scheduler.timeout).not.toHaveBeenCalled()
   })
 
   it.each([
@@ -159,11 +172,12 @@ describe('ChatService', () => {
 
     expect(sessionRepository.resolve).toHaveBeenCalledWith('session-1')
     expect(providerExecutionPort.steerActiveTurn).toHaveBeenCalledWith('session-1', 'refine this')
-    expect(scheduler.timeout).toHaveBeenCalledWith(
+    expect(scheduler.observeIdempotent).toHaveBeenCalledWith(
       expect.objectContaining({
-        reason: 'chat.steerActiveTurn:session-1'
+        reason: 'chat.steerActiveTurn:session-1:session'
       })
     )
+    expect(scheduler.timeout).not.toHaveBeenCalled()
   })
 
   it('resolves stopStream by request id and clears permissions before cancelling', async () => {
@@ -304,15 +318,10 @@ describe('ChatService', () => {
         granted: true
       }
     )
-    expect(scheduler.timeout).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ms: 30 * 60 * 1_000,
-        reason: 'chat.respondToolInteraction:session-1:tool-1'
-      })
-    )
+    expect(scheduler.timeout).not.toHaveBeenCalled()
   })
 
-  it('attempts both timeout cleanups even if clearing permissions fails', async () => {
+  it('does not reinterpret an owner TimeoutError as a route observation timeout', async () => {
     const scheduler = createScheduler()
     const timeoutError = new Error('timed out')
     timeoutError.name = 'TimeoutError'
@@ -352,54 +361,12 @@ describe('ChatService', () => {
 
     await expect(service.sendMessage('session-1', 'hello')).rejects.toBe(timeoutError)
 
-    expect(sessionPermissionPort.clearSessionPermissions).toHaveBeenCalledWith('session-1')
-    expect(providerExecutionPort.cancelGeneration).toHaveBeenCalledWith('session-1')
+    expect(sessionPermissionPort.clearSessionPermissions).not.toHaveBeenCalled()
+    expect(providerExecutionPort.cancelGeneration).not.toHaveBeenCalled()
   })
 
   it('aborts a pending send when stopStream races during preflight', async () => {
-    const createAbortError = (reason: string) => {
-      const error = new Error(reason)
-      error.name = 'AbortError'
-      return error
-    }
-    const scheduler = {
-      sleep: vi.fn(),
-      timeout: vi.fn(
-        async <T>({
-          task,
-          signal,
-          reason
-        }: {
-          task: Promise<T>
-          signal?: AbortSignal
-          reason: string
-        }) => {
-          if (signal?.aborted) {
-            throw createAbortError(reason)
-          }
-
-          return await new Promise<T>((resolve, reject) => {
-            const onAbort = () => {
-              signal?.removeEventListener('abort', onAbort)
-              reject(createAbortError(reason))
-            }
-
-            signal?.addEventListener('abort', onAbort, { once: true })
-            task.then(
-              (value) => {
-                signal?.removeEventListener('abort', onAbort)
-                resolve(value)
-              },
-              (error) => {
-                signal?.removeEventListener('abort', onAbort)
-                reject(error)
-              }
-            )
-          })
-        }
-      ),
-      retry: vi.fn()
-    }
+    const scheduler = createNodeOperationRunner()
     let resolveSession!: (value: {
       availability: 'available'
       session: { id: string; agentId: string }
@@ -458,6 +425,8 @@ describe('ChatService', () => {
     await expect(pendingSend).rejects.toMatchObject({
       name: 'AbortError'
     })
+    expect(providerCatalogPort.getAgentType).not.toHaveBeenCalled()
+    expect(providerExecutionPort.sendMessage).not.toHaveBeenCalled()
     expect(sessionPermissionPort.clearSessionPermissions).toHaveBeenCalledWith('session-1')
     expect(providerExecutionPort.cancelGeneration).toHaveBeenCalledWith('session-1')
   })
@@ -525,5 +494,75 @@ describe('ChatService', () => {
       requestId: 'assistant-1',
       messageId: 'assistant-1'
     })
+  })
+
+  it('does not claim physical cancellation after the owner mutation has started', async () => {
+    const scheduler = createNodeOperationRunner()
+    const sessionRepository = {
+      resolve: vi.fn().mockResolvedValue(
+        availableSession({
+          id: 'session-1',
+          agentId: 'deepchat'
+        })
+      )
+    }
+    const firstOwnerMutation = deferred<{ requestId: string; messageId: string }>()
+    const providerExecutionPort = {
+      sendMessage: vi
+        .fn()
+        .mockReturnValueOnce(firstOwnerMutation.promise)
+        .mockResolvedValueOnce({ requestId: 'assistant-2', messageId: 'assistant-2' }),
+      steerActiveTurn: vi.fn(),
+      cancelGeneration: vi.fn().mockResolvedValue(undefined),
+      respondToolInteraction: vi.fn()
+    }
+    const sessionPermissionPort = {
+      clearSessionPermissions: vi.fn().mockResolvedValue(undefined)
+    }
+    const service = new ChatService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: {
+        listBySession: vi.fn(),
+        get: vi.fn()
+      } as any,
+      providerExecutionPort,
+      providerCatalogPort: {
+        getAgentType: vi.fn().mockResolvedValue('deepchat')
+      } as any,
+      sessionPermissionPort,
+      scheduler
+    })
+
+    const firstSend = service.sendMessage('session-1', 'first')
+    await vi.waitFor(() => {
+      expect(providerExecutionPort.sendMessage).toHaveBeenCalledTimes(1)
+    })
+    let firstSettled = false
+    void firstSend.finally(() => {
+      firstSettled = true
+    })
+
+    await expect(service.stopStream({ sessionId: 'session-1' })).resolves.toEqual({
+      stopped: true
+    })
+    await Promise.resolve()
+
+    expect(firstSettled).toBe(false)
+    expect(sessionPermissionPort.clearSessionPermissions).toHaveBeenCalledOnce()
+    expect(providerExecutionPort.cancelGeneration).toHaveBeenCalledOnce()
+
+    await expect(service.sendMessage('session-1', 'second')).resolves.toEqual({
+      accepted: true,
+      requestId: 'assistant-2',
+      messageId: 'assistant-2'
+    })
+
+    firstOwnerMutation.resolve({ requestId: 'assistant-1', messageId: 'assistant-1' })
+    await expect(firstSend).resolves.toEqual({
+      accepted: true,
+      requestId: 'assistant-1',
+      messageId: 'assistant-1'
+    })
+    expect(providerExecutionPort.sendMessage).toHaveBeenCalledTimes(2)
   })
 })

--- a/test/main/routes/chatService.test.ts
+++ b/test/main/routes/chatService.test.ts
@@ -565,4 +565,152 @@ describe('ChatService', () => {
     })
     expect(providerExecutionPort.sendMessage).toHaveBeenCalledTimes(2)
   })
+
+  it('aborts every concurrent steer preflight for the stopped session', async () => {
+    const scheduler = createNodeOperationRunner()
+    const firstRead = deferred<ReturnType<typeof availableSession>>()
+    const secondRead = deferred<ReturnType<typeof availableSession>>()
+    const sessionRepository = {
+      resolve: vi
+        .fn()
+        .mockReturnValueOnce(firstRead.promise)
+        .mockReturnValueOnce(secondRead.promise)
+    }
+    const providerExecutionPort = {
+      sendMessage: vi.fn(),
+      steerActiveTurn: vi.fn(),
+      cancelGeneration: vi.fn().mockResolvedValue(undefined),
+      respondToolInteraction: vi.fn()
+    }
+    const sessionPermissionPort = {
+      clearSessionPermissions: vi.fn().mockResolvedValue(undefined)
+    }
+    const service = new ChatService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: { listBySession: vi.fn(), get: vi.fn() } as any,
+      providerExecutionPort,
+      providerCatalogPort: { getAgentType: vi.fn() } as any,
+      sessionPermissionPort,
+      scheduler
+    })
+
+    const firstSteer = service.steerActiveTurn('session-1', 'first')
+    const secondSteer = service.steerActiveTurn('session-1', 'second')
+    const firstAborted = expect(firstSteer).rejects.toMatchObject({ name: 'AbortError' })
+    const secondAborted = expect(secondSteer).rejects.toMatchObject({ name: 'AbortError' })
+    expect(sessionRepository.resolve).toHaveBeenCalledTimes(2)
+
+    await expect(service.stopStream({ sessionId: 'session-1' })).resolves.toEqual({
+      stopped: true
+    })
+    await Promise.all([firstAborted, secondAborted])
+
+    firstRead.resolve(availableSession({ id: 'session-1', agentId: 'deepchat' }))
+    secondRead.resolve(availableSession({ id: 'session-1', agentId: 'deepchat' }))
+    await Promise.resolve()
+    expect(providerExecutionPort.steerActiveTurn).not.toHaveBeenCalled()
+    expect(sessionPermissionPort.clearSessionPermissions).toHaveBeenCalledOnce()
+    expect(providerExecutionPort.cancelGeneration).toHaveBeenCalledOnce()
+  })
+
+  it('does not let stale steer cleanup delete a newer preflight fence', async () => {
+    const scheduler = createNodeOperationRunner()
+    const firstRead = deferred<ReturnType<typeof availableSession>>()
+    const secondRead = deferred<ReturnType<typeof availableSession>>()
+    const sessionRepository = {
+      resolve: vi
+        .fn()
+        .mockReturnValueOnce(firstRead.promise)
+        .mockReturnValueOnce(secondRead.promise)
+    }
+    const providerExecutionPort = {
+      sendMessage: vi.fn(),
+      steerActiveTurn: vi.fn(),
+      cancelGeneration: vi.fn().mockResolvedValue(undefined),
+      respondToolInteraction: vi.fn()
+    }
+    const sessionPermissionPort = {
+      clearSessionPermissions: vi.fn().mockResolvedValue(undefined)
+    }
+    const service = new ChatService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: { listBySession: vi.fn(), get: vi.fn() } as any,
+      providerExecutionPort,
+      providerCatalogPort: { getAgentType: vi.fn() } as any,
+      sessionPermissionPort,
+      scheduler
+    })
+
+    const oldSteer = service.steerActiveTurn('session-1', 'old')
+    const oldAborted = expect(oldSteer).rejects.toMatchObject({ name: 'AbortError' })
+    const firstStop = service.stopStream({ sessionId: 'session-1' })
+    const newSteer = service.steerActiveTurn('session-1', 'new')
+    const newAborted = expect(newSteer).rejects.toMatchObject({ name: 'AbortError' })
+
+    await firstStop
+    await oldAborted
+    await service.stopStream({ sessionId: 'session-1' })
+
+    firstRead.resolve(availableSession({ id: 'session-1', agentId: 'deepchat' }))
+    secondRead.resolve(availableSession({ id: 'session-1', agentId: 'deepchat' }))
+    await newAborted
+    expect(providerExecutionPort.steerActiveTurn).not.toHaveBeenCalled()
+    expect(sessionPermissionPort.clearSessionPermissions).toHaveBeenCalledTimes(2)
+    expect(providerExecutionPort.cancelGeneration).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps an owner-started steer pending while stop only requests cancellation', async () => {
+    const scheduler = createNodeOperationRunner()
+    const firstOwnerMutation = deferred<void>()
+    const providerExecutionPort = {
+      sendMessage: vi.fn().mockResolvedValue({ requestId: null, messageId: null }),
+      steerActiveTurn: vi
+        .fn()
+        .mockReturnValueOnce(firstOwnerMutation.promise)
+        .mockResolvedValueOnce(undefined),
+      cancelGeneration: vi.fn().mockResolvedValue(undefined),
+      respondToolInteraction: vi.fn()
+    }
+    const sessionPermissionPort = {
+      clearSessionPermissions: vi.fn().mockResolvedValue(undefined)
+    }
+    const service = new ChatService({
+      sessionRepository: {
+        resolve: vi
+          .fn()
+          .mockResolvedValue(availableSession({ id: 'session-1', agentId: 'deepchat' }))
+      } as any,
+      messageRepository: { listBySession: vi.fn(), get: vi.fn() } as any,
+      providerExecutionPort,
+      providerCatalogPort: { getAgentType: vi.fn().mockResolvedValue('deepchat') } as any,
+      sessionPermissionPort,
+      scheduler
+    })
+
+    const firstSteer = service.steerActiveTurn('session-1', 'first')
+    await vi.waitFor(() => {
+      expect(providerExecutionPort.steerActiveTurn).toHaveBeenCalledOnce()
+    })
+    let firstSettled = false
+    void firstSteer.finally(() => {
+      firstSettled = true
+    })
+
+    await expect(service.sendMessage('session-1', 'send')).resolves.toMatchObject({
+      accepted: true
+    })
+    await service.stopStream({ sessionId: 'session-1' })
+    await Promise.resolve()
+    expect(firstSettled).toBe(false)
+    expect(sessionPermissionPort.clearSessionPermissions).toHaveBeenCalledOnce()
+    expect(providerExecutionPort.cancelGeneration).toHaveBeenCalledOnce()
+
+    await expect(service.steerActiveTurn('session-1', 'second')).resolves.toEqual({
+      accepted: true
+    })
+
+    firstOwnerMutation.resolve()
+    await expect(firstSteer).resolves.toEqual({ accepted: true })
+    expect(providerExecutionPort.steerActiveTurn).toHaveBeenCalledTimes(2)
+  })
 })

--- a/test/main/routes/operationRunner.test.ts
+++ b/test/main/routes/operationRunner.test.ts
@@ -436,8 +436,16 @@ describe('createNodeOperationRunner', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
-  it('keeps the allowlisted legacy timeout and retry behavior during migration', async () => {
+  it('keeps the allowlisted legacy timeout behavior during migration', async () => {
     const runner = createNodeOperationRunner()
+    expect(Object.keys(runner).sort()).toEqual([
+      'observeIdempotent',
+      'retryIdempotent',
+      'sleep',
+      'timeout'
+    ])
+    expect('retry' in runner).toBe(false)
+
     const legacyTimeout = runner.timeout({
       task: new Promise<void>(() => {}),
       ms: 10,
@@ -447,19 +455,6 @@ describe('createNodeOperationRunner', () => {
 
     await vi.advanceTimersByTimeAsync(10)
     await timeout
-
-    const task = vi.fn().mockRejectedValueOnce(new Error('first')).mockResolvedValueOnce('ok')
-    const legacyRetry = runner.retry({
-      task,
-      maxAttempts: 2,
-      initialDelayMs: 1,
-      backoff: 1,
-      reason: 'legacy-retry'
-    })
-    await vi.advanceTimersByTimeAsync(1)
-
-    await expect(legacyRetry).resolves.toBe('ok')
-    expect(task).toHaveBeenCalledTimes(2)
     expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/test/main/routes/providerService.test.ts
+++ b/test/main/routes/providerService.test.ts
@@ -3,8 +3,9 @@ import { ProviderService } from '@/routes/providers/providerService'
 describe('ProviderService', () => {
   const createScheduler = () => ({
     sleep: vi.fn(),
-    timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task),
-    retry: vi.fn()
+    observeIdempotent: vi.fn(),
+    retryIdempotent: vi.fn(),
+    timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task)
   })
 
   it('lists provider and custom models through the provider catalog port', async () => {
@@ -59,7 +60,9 @@ describe('ProviderService', () => {
 
     expect(providerCatalogPort.getProviderModels).toHaveBeenCalledWith('openai')
     expect(providerCatalogPort.getCustomModels).toHaveBeenCalledWith('openai')
-    expect(scheduler.timeout).toHaveBeenCalledTimes(2)
+    expect(scheduler.timeout).not.toHaveBeenCalled()
+    expect(scheduler.observeIdempotent).not.toHaveBeenCalled()
+    expect(scheduler.retryIdempotent).not.toHaveBeenCalled()
   })
 
   it('tests provider connections through the provider execution port', async () => {
@@ -92,5 +95,6 @@ describe('ProviderService', () => {
 
     expect(providerExecutionPort.testConnection).toHaveBeenCalledWith('openai', 'gpt-5.4')
     expect(scheduler.timeout).toHaveBeenCalledTimes(1)
+    expect(scheduler.retryIdempotent).not.toHaveBeenCalled()
   })
 })

--- a/test/main/routes/sessionService.test.ts
+++ b/test/main/routes/sessionService.test.ts
@@ -1,5 +1,7 @@
 import logger from '@shared/logger'
+import type { ChatMessagePageResult } from '@shared/types/agent-interface'
 import { SessionService } from '@/routes/sessions/sessionService'
+import { createNodeOperationRunner } from '@/routes/operationRunner'
 import { reportTerminalSessionResolution } from '@/presenter/agentSessionPresenter/sessionResolution'
 
 vi.mock('@shared/logger', () => ({
@@ -27,27 +29,39 @@ const transient = (sessionId: string) => ({
 
 const createScheduler = () => ({
   sleep: vi.fn(),
-  timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task),
-  retry: vi.fn(
+  observeIdempotent: vi.fn(async <T>({ task }: { task: () => Promise<T> }) => await task()),
+  retryIdempotent: vi.fn(
     async <T>({
       task,
-      maxAttempts
+      maxAttempts,
+      shouldRetry
     }: {
-      task: () => Promise<T>
+      task: (attempt: number) => Promise<T>
       maxAttempts: number
+      shouldRetry: (error: unknown) => boolean
     }): Promise<T> => {
-      let lastError: unknown
-      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
         try {
-          return await task()
+          return await task(attempt)
         } catch (error) {
-          lastError = error
+          if (attempt >= maxAttempts || !shouldRetry(error)) throw error
         }
       }
-      throw lastError
+      throw new Error('unreachable')
     }
-  )
+  ),
+  timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task)
 })
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
 
 const createMessageRepository = () => ({
   listBySession: vi.fn(),
@@ -143,6 +157,15 @@ describe('SessionService', () => {
       session: { id: 'session-1' }
     })
     expect(sessionRepository.resolve).toHaveBeenCalledTimes(2)
+    expect(scheduler.retryIdempotent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxAttempts: 2,
+        initialDelayMs: 25,
+        backoff: 1,
+        overallDeadlineMs: 5_000,
+        shouldRetry: expect.any(Function)
+      })
+    )
     expect(logger.warn).not.toHaveBeenCalled()
   })
 
@@ -196,7 +219,6 @@ describe('SessionService', () => {
       },
       2
     )
-
     expect(logger.warn).toHaveBeenCalledWith('[SessionResolution] Terminal lookup', {
       operation: 'sessions.restore',
       sessionId: 'session-1',
@@ -215,22 +237,33 @@ describe('SessionService', () => {
     expect(serializedArguments).not.toContain('stack')
   })
 
-  it('does not retry an unsettled timeout as a classified transient result', async () => {
-    const scheduler = createScheduler()
-    const timeoutError = new Error('lookup timed out')
-    timeoutError.name = 'TimeoutError'
-    scheduler.timeout.mockRejectedValue(timeoutError)
+  it('does not retry a read that settles after the overall observation deadline', async () => {
+    vi.useFakeTimers()
+    const scheduler = createNodeOperationRunner()
+    const read = deferred<ReturnType<typeof transient>>()
     const sessionRepository = createSessionRepository()
-    sessionRepository.resolve.mockReturnValue(new Promise(() => {}))
+    sessionRepository.resolve.mockReturnValue(read.promise)
     const service = new SessionService({
       sessionRepository: sessionRepository as any,
       messageRepository: createMessageRepository() as any,
-      scheduler: scheduler as any
+      scheduler
     })
 
-    await expect(service.restoreSession('session-1')).rejects.toBe(timeoutError)
-    expect(sessionRepository.resolve).toHaveBeenCalledTimes(1)
-    expect(logger.warn).not.toHaveBeenCalled()
+    try {
+      const restoring = service.restoreSession('session-1')
+      const deadline = expect(restoring).rejects.toMatchObject({
+        name: 'ObservationDeadlineError'
+      })
+      await vi.advanceTimersByTimeAsync(5_000)
+      await deadline
+
+      read.resolve(transient('session-1'))
+      await vi.advanceTimersByTimeAsync(100)
+      expect(sessionRepository.resolve).toHaveBeenCalledTimes(1)
+      expect(logger.warn).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('uses the same bounded retry for active-session reads', async () => {
@@ -261,6 +294,15 @@ describe('SessionService', () => {
       }
     })
     expect(sessionRepository.resolveActive).toHaveBeenCalledTimes(2)
+    expect(scheduler.retryIdempotent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxAttempts: 2,
+        initialDelayMs: 25,
+        backoff: 1,
+        overallDeadlineMs: 5_000,
+        shouldRetry: expect.any(Function)
+      })
+    )
     expect(logger.warn).not.toHaveBeenCalled()
   })
 
@@ -334,8 +376,256 @@ describe('SessionService', () => {
       ]
     })
     expect(sessionRepository.resolveList).toHaveBeenCalledTimes(1)
-    expect(scheduler.retry).not.toHaveBeenCalled()
+    expect(scheduler.retryIdempotent).not.toHaveBeenCalled()
     expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits 25ms after a settled transient restore and never overlaps attempts', async () => {
+    vi.useFakeTimers()
+    const scheduler = createNodeOperationRunner()
+    const first = deferred<ReturnType<typeof transient>>()
+    const sessionRepository = createSessionRepository()
+    let concurrent = 0
+    let maxConcurrent = 0
+    sessionRepository.resolve
+      .mockImplementationOnce(async () => {
+        concurrent += 1
+        maxConcurrent = Math.max(maxConcurrent, concurrent)
+        try {
+          return await first.promise
+        } finally {
+          concurrent -= 1
+        }
+      })
+      .mockImplementationOnce(async () => {
+        concurrent += 1
+        maxConcurrent = Math.max(maxConcurrent, concurrent)
+        try {
+          return available({ id: 'session-1' })
+        } finally {
+          concurrent -= 1
+        }
+      })
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: createMessageRepository() as any,
+      scheduler
+    })
+
+    try {
+      const restoring = service.restoreSession('session-1')
+      await vi.advanceTimersByTimeAsync(100)
+      expect(sessionRepository.resolve).toHaveBeenCalledTimes(1)
+
+      first.resolve(transient('session-1'))
+      await vi.advanceTimersByTimeAsync(24)
+      expect(sessionRepository.resolve).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(1)
+
+      await expect(restoring).resolves.toMatchObject({ session: { id: 'session-1' } })
+      expect(sessionRepository.resolve).toHaveBeenCalledTimes(2)
+      expect(maxConcurrent).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps active binding reads sequential through transient settlement and backoff', async () => {
+    vi.useFakeTimers()
+    const scheduler = createNodeOperationRunner()
+    const first = deferred<{
+      binding: 'bound'
+      sessionId: string
+      resolution: ReturnType<typeof transient>
+    }>()
+    const sessionRepository = createSessionRepository()
+    let concurrent = 0
+    let maxConcurrent = 0
+    sessionRepository.resolveActive
+      .mockImplementationOnce(async () => {
+        concurrent += 1
+        maxConcurrent = Math.max(maxConcurrent, concurrent)
+        try {
+          return await first.promise
+        } finally {
+          concurrent -= 1
+        }
+      })
+      .mockImplementationOnce(async () => {
+        concurrent += 1
+        maxConcurrent = Math.max(maxConcurrent, concurrent)
+        try {
+          return {
+            binding: 'bound',
+            sessionId: 'session-1',
+            resolution: available({ id: 'session-1' })
+          }
+        } finally {
+          concurrent -= 1
+        }
+      })
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: createMessageRepository() as any,
+      scheduler
+    })
+
+    try {
+      const reading = service.getActiveSession({ webContentsId: 7, windowId: null })
+      await vi.advanceTimersByTimeAsync(100)
+      expect(sessionRepository.resolveActive).toHaveBeenCalledTimes(1)
+      expect(sessionRepository.deactivate).not.toHaveBeenCalled()
+
+      first.resolve({
+        binding: 'bound',
+        sessionId: 'session-1',
+        resolution: transient('session-1')
+      })
+      await vi.advanceTimersByTimeAsync(24)
+      expect(sessionRepository.resolveActive).toHaveBeenCalledTimes(1)
+      expect(sessionRepository.deactivate).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1)
+
+      await expect(reading).resolves.toMatchObject({ session: { id: 'session-1' } })
+      expect(sessionRepository.resolveActive).toHaveBeenCalledTimes(2)
+      expect(sessionRepository.deactivate).not.toHaveBeenCalled()
+      expect(maxConcurrent).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retains the active binding when a deferred read settles after its deadline', async () => {
+    vi.useFakeTimers()
+    const scheduler = createNodeOperationRunner()
+    const first = deferred<{
+      binding: 'bound'
+      sessionId: string
+      resolution: ReturnType<typeof transient>
+    }>()
+    const sessionRepository = createSessionRepository()
+    sessionRepository.resolveActive.mockReturnValue(first.promise)
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: createMessageRepository() as any,
+      scheduler
+    })
+
+    try {
+      const reading = service.getActiveSession({ webContentsId: 7, windowId: null })
+      const deadline = expect(reading).rejects.toMatchObject({
+        name: 'ObservationDeadlineError'
+      })
+      await vi.advanceTimersByTimeAsync(5_000)
+      await deadline
+      expect(sessionRepository.deactivate).not.toHaveBeenCalled()
+
+      first.resolve({
+        binding: 'bound',
+        sessionId: 'session-1',
+        resolution: transient('session-1')
+      })
+      await vi.advanceTimersByTimeAsync(100)
+      expect(sessionRepository.resolveActive).toHaveBeenCalledTimes(1)
+      expect(sessionRepository.deactivate).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it.each([
+    {
+      availability: 'missing' as const,
+      sessionId: 'session-1'
+    },
+    {
+      availability: 'unavailable' as const,
+      sessionId: 'session-1',
+      record: { id: 'session-1', agentId: 'removed-agent' },
+      reason: 'agent_unknown' as const
+    }
+  ])('does not retry an authoritative active $availability result', async (resolution) => {
+    const scheduler = createScheduler()
+    const sessionRepository = createSessionRepository()
+    sessionRepository.resolveActive.mockResolvedValue({
+      binding: 'bound',
+      sessionId: 'session-1',
+      resolution
+    })
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: createMessageRepository() as any,
+      scheduler: scheduler as any
+    })
+
+    await expect(
+      service.getActiveSession({ webContentsId: 7, windowId: null })
+    ).resolves.toMatchObject({
+      session: null,
+      resolution: { availability: resolution.availability }
+    })
+    expect(sessionRepository.resolveActive).toHaveBeenCalledTimes(1)
+  })
+
+  it('drains late list and page reads without retrying them', async () => {
+    vi.useFakeTimers()
+    const scheduler = createNodeOperationRunner()
+    const list = deferred<ReturnType<typeof available>[]>()
+    const page = deferred<ChatMessagePageResult>()
+    const sessionRepository = createSessionRepository()
+    sessionRepository.resolveList.mockReturnValue(list.promise)
+    const messageRepository = createMessageRepository()
+    messageRepository.listPageBySession.mockReturnValue(page.promise)
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: messageRepository as any,
+      scheduler
+    })
+
+    try {
+      const listing = service.listSessions()
+      const listDeadline = expect(listing).rejects.toMatchObject({
+        name: 'ObservationDeadlineError'
+      })
+      await vi.advanceTimersByTimeAsync(5_000)
+      await listDeadline
+      list.resolve([available({ id: 'late' })])
+      await Promise.resolve()
+      expect(sessionRepository.resolveList).toHaveBeenCalledTimes(1)
+
+      const paging = service.listMessagesPage('session-1')
+      const pageDeadline = expect(paging).rejects.toMatchObject({
+        name: 'ObservationDeadlineError'
+      })
+      await vi.advanceTimersByTimeAsync(5_000)
+      await pageDeadline
+      page.resolve({ messages: [], nextCursor: null, hasMore: false })
+      await Promise.resolve()
+      expect(messageRepository.listPageBySession).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('activates and deactivates exactly once without an operation runner wrapper', async () => {
+    const scheduler = createScheduler()
+    const sessionRepository = createSessionRepository()
+    sessionRepository.activate.mockResolvedValue(undefined)
+    sessionRepository.deactivate.mockResolvedValue(undefined)
+    const service = new SessionService({
+      sessionRepository: sessionRepository as any,
+      messageRepository: createMessageRepository() as any,
+      scheduler: scheduler as any
+    })
+
+    await service.activateSession({ webContentsId: 7, windowId: null }, 'session-1')
+    await service.deactivateSession({ webContentsId: 7, windowId: null })
+
+    expect(sessionRepository.activate).toHaveBeenCalledOnce()
+    expect(sessionRepository.deactivate).toHaveBeenCalledOnce()
+    expect(scheduler.observeIdempotent).not.toHaveBeenCalled()
+    expect(scheduler.retryIdempotent).not.toHaveBeenCalled()
+    expect(scheduler.timeout).not.toHaveBeenCalled()
   })
 
   it('removes the internal transient cause from public route results', async () => {

--- a/test/main/scripts/architectureGuard.test.ts
+++ b/test/main/scripts/architectureGuard.test.ts
@@ -152,6 +152,99 @@ describe.sequential('architecture guard', () => {
     expect(result.status).toBe(0)
   })
 
+  it.each([
+    [
+      'namespace factory',
+      OPERATION_RUNNER_FIXTURE_PATH,
+      `
+        import * as runnerApi from './operationRunner'
+        const runner = runnerApi.createNodeOperationRunner()
+        export const load = () => runner.timeout({ task: Promise.resolve(), ms: 1, reason: 'new' })
+      `
+    ],
+    [
+      'namespace type',
+      OPERATION_RUNNER_FIXTURE_PATH,
+      `
+        import * as runnerApi from './operationRunner'
+        export class Fixture {
+          constructor(private readonly runner: runnerApi.OperationRunner) {}
+          load() {
+            return this.runner.timeout({ task: Promise.resolve(), ms: 1, reason: 'new' })
+          }
+        }
+      `
+    ],
+    [
+      'namespace destructure and method alias outside routes',
+      MAIN_OPERATION_RUNNER_FIXTURE_PATH,
+      `
+        import * as runnerApi from './routes/operationRunner'
+        const { createNodeOperationRunner: makeRunner } = runnerApi
+        const { timeout: wait } = makeRunner()
+        export const renamedOwner = () => wait({ task: Promise.resolve(), ms: 1, reason: 'new' })
+      `
+    ]
+  ])('fails closed for an operation runner %s import', async (_label, filePath, source) => {
+    await writeFixture(filePath, source)
+
+    const result = runArchitectureGuard()
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('[operation-runner-namespace-import]')
+    expect(result.stderr).toContain(path.basename(filePath))
+  })
+
+  it('tracks named factory and property aliases to a renamed owner', async () => {
+    await writeFixture(
+      OPERATION_RUNNER_FIXTURE_PATH,
+      `
+        import { createNodeOperationRunner as importedFactory } from './operationRunner'
+
+        export function renamedOwner() {
+          const factoryAlias = importedFactory
+          const runnerAlias = factoryAlias()
+          const timeoutAlias = runnerAlias.timeout
+          return timeoutAlias({ task: Promise.resolve(), ms: 1, reason: 'new' })
+        }
+      `
+    )
+
+    const result = runArchitectureGuard()
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('[operation-runner-legacy-call]')
+    expect(result.stderr).toContain(
+      '__architecture_guard_operation_runner_fixture__.ts#renamedOwner#timeout'
+    )
+  })
+
+  it('tracks a named import through a local type alias', async () => {
+    await writeFixture(
+      OPERATION_RUNNER_FIXTURE_PATH,
+      `
+        import type { OperationRunner as ImportedRunner } from './operationRunner'
+        type LocalRunner = ImportedRunner
+
+        export class Fixture {
+          constructor(private readonly runner: LocalRunner) {}
+
+          async renamedOwner() {
+            return await this.runner.timeout({ task: Promise.resolve(), ms: 1, reason: 'new' })
+          }
+        }
+      `
+    )
+
+    const result = runArchitectureGuard()
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('[operation-runner-legacy-call]')
+    expect(result.stderr).toContain(
+      '__architecture_guard_operation_runner_fixture__.ts#renamedOwner#timeout'
+    )
+  })
+
   it('fails when a renamed route field makes a direct legacy operation runner call', async () => {
     await writeFixture(
       OPERATION_RUNNER_FIXTURE_PATH,

--- a/test/main/scripts/architectureGuard.test.ts
+++ b/test/main/scripts/architectureGuard.test.ts
@@ -41,6 +41,8 @@ const TRACKED_GROWTH_BASELINE_PATH = path.join(
   ROOT,
   'docs/architecture/baselines/architecture-growth.json'
 )
+const ARCHITECTURE_GUARD_PATH = path.join(ROOT, 'scripts/architecture-guard.mjs')
+const OPERATION_RUNNER_PATH = path.join(ROOT, 'src/main/routes/operationRunner.ts')
 const FIXTURE_PATHS = [
   FIXTURE_PATH,
   MEMORY_CORE_FIXTURE_PATH,
@@ -122,6 +124,32 @@ describe.sequential('architecture guard', () => {
 
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('Architecture guard passed.')
+  })
+
+  it('pins the final two legacy calls and the removed retry surface', async () => {
+    const [guardSource, runnerSource] = await Promise.all([
+      readFile(ARCHITECTURE_GUARD_PATH, 'utf8'),
+      readFile(OPERATION_RUNNER_PATH, 'utf8')
+    ])
+    const allowlistBody = guardSource.match(
+      /const LEGACY_OPERATION_RUNNER_ALLOWLIST = new Map\(\[([\s\S]*?)\]\)/
+    )?.[1]
+    const allowlistedCalls = [
+      ...(allowlistBody ?? '').matchAll(/\['([^']+)',\s*(\d+)\]/g)
+    ].map((match) => [match[1], Number(match[2])])
+    const runnerInterface = runnerSource.match(
+      /export interface OperationRunner \{([\s\S]*?)^\}/m
+    )?.[1]
+
+    expect(allowlistedCalls).toEqual([
+      ['src/main/routes/sessions/sessionService.ts#createSession#timeout', 1],
+      ['src/main/routes/providers/providerService.ts#testConnection#timeout', 1]
+    ])
+    expect(allowlistBody).not.toContain('#retry')
+    expect(runnerInterface).not.toMatch(/^\s*retry(?:<|\s*\()/m)
+
+    const result = runArchitectureGuard()
+    expect(result.status).toBe(0)
   })
 
   it('fails when a renamed route field makes a direct legacy operation runner call', async () => {


### PR DESCRIPTION
## Summary

- migrate only capability-proven Session, Chat, and provider-catalog consumers from legacy route timeout/retry wrappers
- preserve Session transient retry as settled-only `2 attempts / 25ms` under one 5s observation deadline
- remove false cancellation deadlines from non-cancellable Chat owner mutations
- keep provider connection probing on the existing legacy 5s route observation until provider owners gain real cancellation
- reduce the production legacy inventory from `19 timeout + 2 retry` calls to exactly two timeout calls

## Session behavior

- restore and getActive retry only typed `transient_error`; missing, unavailable, validation, deadline, and other failures do not retry
- attempts never overlap; deadline/backoff/late settlement do not start another attempt
- binding remains owned throughout transient/deadline handling; only the SES authoritative missing path may unbind
- list/page reads use idempotent observation without per-row retry
- activate/deactivate call the existing synchronous owner exactly once without a timer wrapper

## Provider truth

- model catalog getters execute synchronously and directly; the old `Promise.resolve` + timeout wrappers could not bound work that had already run
- `providers.testConnection` remains the exact legacy exception and is never automatically retried
- model-specific checks still race completion against a 60s observation with no owner teardown
- no-model checks still use provider-native `check()` with no uniform presenter deadline

This PR does not claim those probes are physically cancelled. `PRV-CAN-001` owns that work.

## Chat behavior

- send session/agent and steer session preflights use bounded idempotent observation
- stop fences all concurrent steer preflights for the session; late reads cannot enter the owner mutation
- stale steer cleanup cannot remove a post-stop fence, and steer does not occupy the send lock
- send/steer/respond owner mutations are awaited directly, so an owner `TimeoutError` is no longer reinterpreted as a route timeout
- once an owner mutation has started, stop only requests permission cleanup and generation cancellation; it does not claim physical settlement
- both stop cleanup requests are attempted even when one fails

## Guard boundary

The remaining production legacy calls are exactly:

- `SessionService.createSession#timeout`
- `ProviderService.testConnection#timeout`

Legacy retry input/interface/adapter and production callers are removed. The architecture guard rejects new direct, renamed, aliased, destructured, routes-external, local-type-alias, and namespace-import paths. No `runCancellable`, dependency, or SCH-003 code is introduced.

## Automated validation

- independent final review: PASS
- final focused: 9 files / 438 passed
- blocker-specific Chat + architecture adversarial tests: 46 passed
- Session/AgentRuntime focused during development: 276 passed
- single-worker full before the final local blocker patch: 4,726 passed / 5 known baseline failures / 140 skipped
- unchanged base reproduces the same five failures
- typecheck, format check, i18n, lint, architecture/process guards, and diff check: passed

The final patch only adds steer preflight fencing, fail-closed guard handling, documentation, and focused tests. A combined full suite will be run on the merge commit.

## Impact and remaining limits

Benefits are correctness and clearer ownership, not a blanket performance claim. Removed wrappers save small timer/listener overhead, but the important change is eliminating false failures while mutations continue.

Remaining limits:

- `sessions.create` still has unknown-outcome risk and remains for the atomic SCH-003 cutover
- provider probe cancellation remains for PRV-CAN-001
- an owner operation that never settles can now remain pending instead of being mislabeled as failed
- no packaged/UI manual smoke is relevant to this main-process route slice; real provider cancellation and SCH-003 carry their own manual matrices

## Migration and rollback

No stored-data or IPC schema migration. Existing public route outputs remain unchanged. Rollback is a normal revert of the consumer migration and guard baseline.
