### PR TITLE
fix(provider): settle connection cancellation

### DIFF
--- a/docs/architecture/scheduler-operation-contract/plan.md
+++ b/docs/architecture/scheduler-operation-contract/plan.md
@@ -277,6 +277,34 @@ route 无法单方面取消 provider SDK request。只有 provider owner 能决�
 5. 所有 adapter 完成后才删除 route 5 秒 legacy wrapper；仍不 automatic retry，因为 probe 可能消耗 quota。
 6. 如果此时出现真实 `runCancellable` consumer，再在这个 slice 提出最窄 API；settlement tests 与 consumer 同 PR。
 
+### 已核验的 production capability inventory
+
+`DEFAULT_PROVIDERS` 共有 60 项。按 `ProviderInstanceManager.createProviderInstance()` 与
+`resolveAiSdkProviderDefinition()` 的真实分派结果分类如下：
+
+| Family | 数量 | no-model probe | model probe | PRV-CAN-001 处置 |
+| --- | ---: | --- | --- | --- |
+| AiSdk `fetch-models` | 30 | local catalog、HTTP model list 或 AWS SDK | AI SDK chat | HTTP/AWS 贯穿 owner signal；connection probe 禁止 error fallback；media model typed unsupported |
+| AiSdk `generate-text` | 17 | AI SDK small text request | AI SDK chat | 组合 model timeout 与 owner signal；OpenAI Codex auth refresh 同步接收 owner signal |
+| AiSdk `key-status` | 8 | raw fetch 或 provider HTTP helper | AI SDK chat | raw fetch/helper 贯穿 owner signal |
+| Ollama | 1 | `/api/tags` HTTP | AI SDK OpenAI-compatible chat | 两条均贯穿 owner signal |
+| GitHub Copilot | 1 | device/API token fetch | token fetch + completion fetch | signal 贯穿 device flow；abort 后禁止 API-key fallback |
+| Voice.ai | 1 | voice-list HTTP | 真实 TTS，有成本/副作用 | 只支持 no-model；model 在任何 fetch 前 typed unsupported |
+| ACP | 1 | local config/agent inventory | process/session prompt，无 probe-owned settle | 只支持 no-model；model 在 process/session effect 前 typed unsupported |
+| Fireworks | 1 | 没有 runtime resolver | 没有 runtime resolver | 不猜 OpenAI-compatible mapping；instance 创建前 typed unsupported |
+
+AiSdk registry 本身有 50 个 direct ID（24 `fetch-models`、17 `generate-text`、9 `key-status`）；
+DEFAULT provider 经过 id/apiType fallback 后才得到上表的有效 `30/17/8`，两组数字不能混用。AWS SDK 的
+`client.send(command, { abortSignal })` 是真实能力，不归类为 unsupported。OpenAI-derived model-list 的旧
+fallback 只保留给普通 refresh；connection probe 遇到普通错误直接失败，owner abort 更不能启动 fallback。
+
+typed result 保留历史 `isOk/errorMsg`，并增加可选稳定 `code`：`unsupported`、`cancelled`、
+`deadline_exceeded`。这样旧 renderer 继续显示 `errorMsg`，Electron boundary 又不依赖 custom Error field。
+
+本 slice 出现了第一个可证明的 cancellable consumer，因此增加唯一的 `runCancellable()`：runner 创建 signal，
+deadline/外部 cancel 时 abort owner，随后继续等待同一 task physical settle；settle 前 caller 保持 pending，
+没有 replacement 或 retry。它不接受 already-started Promise，也没有第二个 `Promise.race`。
+
 ### 收益与 gate
 
 - UI timeout 后不再有 provider request 在后台继续；

--- a/docs/architecture/scheduler-operation-contract/spec.md
+++ b/docs/architecture/scheduler-operation-contract/spec.md
@@ -296,10 +296,10 @@ interface OperationRunner {
 这是 contract 方向，不要求实现照抄属性排列。必须保留的语义是 task factory、overall deadline、
 sequential attempt 和 explicit `shouldRetry`。
 
-当前生产 consumer 中，没有一处同时满足“真实 owner 接收 signal”和“abort 后可观察 physical settlement”。
-因此 `SCH-002A` 不实现 `runCancellable()`，也不把 unused method 放进 port。未来只有真实 consumer 与 owner
-一起证明 cancellation/settlement 后，才建立 owner-specific slice；下面 D4 是该 slice 的验收规则，不是
-本轮待实现接口。
+`SCH-002A` 实施时没有一处 production consumer 同时满足“真实 owner 接收 signal”和“abort 后可观察
+physical settlement”，所以当时没有建立 unused `runCancellable()`。`PRV-CAN-001` 已逐 provider 补齐
+HTTP/SDK/auth signal propagation，并让 unsupported path 在副作用前 settle；provider probe 因此成为首个符合
+D4 的真实 consumer，最窄 `runCancellable()` surface 与 consumer、settlement tests 同 slice 引入。
 
 ### D3. `observeIdempotent` 明确只是 observation deadline
 
@@ -321,13 +321,14 @@ contract：
 1. task 必须是 `(signal) => Promise<T>`，不能传 already-started Promise；
 2. deadline 或外部 abort 会 abort runner 创建/组合的 signal；
 3. runner 在 task Promise settle 前不启动任何 replacement/retry；
-4. deadline 导致的 abort 只有在 attempt settle 后才映射为 `TimeoutError`；
+4. deadline 导致的 abort 只有在 attempt settle 后才映射为 `CancellableDeadlineError`；
 5. 外部 abort 只有在 attempt settle 后才映射为 `AbortError`；
 6. task 若忽略 signal 并永不 settle，runner 也不会伪造“已取消”。这是 owner contract violation，不能用
    第二个 race 掩盖；此类 operation 应重新分类为 non-cancellable。
 
-`TimeoutError` 在新 contract 中因此具有更强含义：cancellation request 已发出，且本 attempt 已 settle。
-它仍不自动授权 retry；retry 还要单独证明 idempotency 或 no-effect failure。
+`CancellableDeadlineError` 在新 contract 中因此具有更强含义：cancellation request 已发出，且本 attempt
+已 settle。provider route 把它转换为 Electron-safe `code: 'deadline_exceeded'`，不会把 custom Error field
+当作 IPC contract。它仍不自动授权 retry；provider probe 本 slice 明确不 retry。
 
 该决策现在只冻结语义。`SCH-002A` 不实现、导出或测试 `runCancellable()`；首次真实 consumer 必须在
 owner-specific follow-up slice 中同时补 signal propagation、settlement proof 和 focused tests，不能只在

--- a/docs/architecture/scheduler-operation-contract/tasks.md
+++ b/docs/architecture/scheduler-operation-contract/tasks.md
@@ -76,7 +76,7 @@ SCH-002B development 验证记录：
 - [x] 不 automatic retry provider probe。
 - [x] 若出现首个真实 cancellable consumer，同 PR 设计最窄 runner API 与 settlement tests。
 - [x] 删除 provider route 5s legacy wrapper 后更新 allowlist。
-- [ ] 独立 provider owner verifier 逐 adapter 检查 signal propagation/settlement。
+- [x] 独立 provider owner verifier 逐 adapter 检查 signal propagation/settlement。
 
 PRV-CAN-001 development 验证记录：
 
@@ -90,7 +90,16 @@ PRV-CAN-001 development 验证记录：
   `markstreamTailwindSource` failure 是 worktree 本地 `node_modules/markstream-vue` 未 materialize；补齐同一已安装
   dependency 的 worktree link 后 isolated rerun 通过。其余 `5` 项与合入前 baseline 精确一致：long-steer
   rebudget 1 项、debug mock plan block 1 项、Spotlight Pinia setup 3 项；本 slice 新增失败数为 `0`。
-- independent verifier 尚未执行；本记录不替代 final verify gate。
+- independent final verify：changed focused `18` files、`325 passed`；补充 Anthropic/Kimi/Mistral
+  focused `15 passed`；额外 `runCancellable` adversarial fixture 通过。
+- verifier 在依赖完整的工作树重跑 single-worker full：`473` files，
+  `4773 passed / 5 failed / 140 skipped`；`markstreamTailwindSource` 实际通过，剩余 `5` 项在
+  `07d40527` baseline 上独立重跑完全一致，本 slice 新增失败数为 `0`。
+- verifier 复核 `format:check`、`i18n`、`lint`、`typecheck`、`git diff --check` 全部通过；确认
+  production `runCancellable` consumer 只有 ProviderService，legacy timeout consumer 只剩 SessionService，
+  无 retry、新依赖或 SCH-003 越界。
+- 剩余 manual gap：未使用真实 provider 账户/quota 做网络 smoke，未墙钟等待真实 60 秒 deadline，
+  未在真实设置 UI 手动检查 typed unsupported 文案。
 
 ## SCH-003A：Session create backend development slice（不可独立 merge）
 

--- a/docs/architecture/scheduler-operation-contract/tasks.md
+++ b/docs/architecture/scheduler-operation-contract/tasks.md
@@ -69,14 +69,28 @@ SCH-002B development 验证记录：
 
 ## PRV-CAN-001：Provider owner cancellation（dependent slice）
 
-- [ ] 逐 provider inventory `check()`：local/network/SDK/model、signal/timeout 能力。
-- [ ] `ProviderExecutionPort.testConnection` 与 presenter check 接收 owner cancellation input。
-- [ ] model 60s race 改为发送 cancel 并等待 physical settlement。
-- [ ] no-model provider check 全部获得 finite owner deadline/cancellation，或 typed unsupported。
-- [ ] 不 automatic retry provider probe。
-- [ ] 若出现首个真实 cancellable consumer，同 PR 设计最窄 runner API 与 settlement tests。
-- [ ] 删除 provider route 5s legacy wrapper 后更新 allowlist。
+- [x] 逐 provider inventory `check()`：local/network/SDK/model、signal/timeout 能力。
+- [x] `ProviderExecutionPort.testConnection` 与 presenter check 接收 owner cancellation input。
+- [x] model 60s race 改为发送 cancel 并等待 physical settlement。
+- [x] no-model provider check 全部获得 finite owner deadline/cancellation，或 typed unsupported。
+- [x] 不 automatic retry provider probe。
+- [x] 若出现首个真实 cancellable consumer，同 PR 设计最窄 runner API 与 settlement tests。
+- [x] 删除 provider route 5s legacy wrapper 后更新 allowlist。
 - [ ] 独立 provider owner verifier 逐 adapter 检查 signal propagation/settlement。
+
+PRV-CAN-001 development 验证记录：
+
+- production inventory fixture：`DEFAULT_PROVIDERS = 60`，其中有效 AiSdk 为
+  `30 fetch-models / 17 generate-text / 8 key-status`；其余为 Ollama、ACP、Voice.ai、
+  GitHub Copilot 与无 resolver 的 Fireworks。
+- combined provider/route/runner focused：`19` files，`306 passed`；补充 abort-registration race 后
+  OpenAI Codex auth、runner、key-status focused：`74 passed`。
+- `typecheck`、`format:check`、`i18n`、`lint` 全部通过。
+- single-worker full：`473` files，`4772 passed / 6 failed / 140 skipped`。其中新增的
+  `markstreamTailwindSource` failure 是 worktree 本地 `node_modules/markstream-vue` 未 materialize；补齐同一已安装
+  dependency 的 worktree link 后 isolated rerun 通过。其余 `5` 项与合入前 baseline 精确一致：long-steer
+  rebudget 1 项、debug mock plan block 1 项、Spotlight Pinia setup 3 项；本 slice 新增失败数为 `0`。
+- independent verifier 尚未执行；本记录不替代 final verify gate。
 
 ## SCH-003A：Session create backend development slice（不可独立 merge）
 

--- a/scripts/architecture-guard.mjs
+++ b/scripts/architecture-guard.mjs
@@ -151,11 +151,15 @@ const OPERATION_RUNNER_ALLOWED_METHODS = new Set([
   'sleep',
   'observeIdempotent',
   'retryIdempotent',
+  'runCancellable',
   'timeout'
 ])
 const LEGACY_OPERATION_RUNNER_ALLOWLIST = new Map([
-  ['src/main/routes/sessions/sessionService.ts#createSession#timeout', 1],
-  ['src/main/routes/providers/providerService.ts#testConnection#timeout', 1]
+  ['src/main/routes/sessions/sessionService.ts#createSession#timeout', 1]
+])
+const CANCELLABLE_OPERATION_RUNNER_FILES = new Set([
+  'src/main/routes/operationRunner.ts',
+  'src/main/routes/providers/providerService.ts'
 ])
 
 function toPosix(value) {
@@ -496,7 +500,10 @@ async function checkOperationRunnerContract(fileSet, violations) {
   for (const filePath of fileSet) {
     if (!isUnder(filePath, MAIN_SOURCE_ROOT)) continue
     const source = await fs.readFile(filePath, 'utf8')
-    if (/\brunCancellable\b/.test(source)) {
+    if (
+      /\brunCancellable\b/.test(source) &&
+      !CANCELLABLE_OPERATION_RUNNER_FILES.has(relativePath(filePath))
+    ) {
       violations.push(`[operation-runner-unused-cancellable] ${relativePath(filePath)}`)
     }
   }

--- a/src/main/presenter/githubCopilotDeviceFlow.ts
+++ b/src/main/presenter/githubCopilotDeviceFlow.ts
@@ -78,7 +78,7 @@ export class GitHubCopilotDeviceFlow {
    * 获取 Copilot API token
    * 使用OAuth token交换Copilot API token
    */
-  public async getCopilotToken(): Promise<string> {
+  public async getCopilotToken(signal?: AbortSignal): Promise<string> {
     if (!this.oauthToken) {
       throw new Error('No OAuth token available')
     }
@@ -89,6 +89,7 @@ export class GitHubCopilotDeviceFlow {
     try {
       const response = await fetch(tokenUrl, {
         method: 'GET',
+        signal,
         headers: {
           Authorization: `Bearer ${this.oauthToken}`,
           Accept: 'application/json',

--- a/src/main/presenter/llmProviderPresenter/aiSdk/runtime.ts
+++ b/src/main/presenter/llmProviderPresenter/aiSdk/runtime.ts
@@ -1225,7 +1225,8 @@ export async function runAiSdkGenerateText(
   modelId: string,
   modelConfig: ModelConfig,
   temperature?: number,
-  maxTokens?: number
+  maxTokens?: number,
+  signal?: AbortSignal
 ): Promise<LLMResponse> {
   const normalizedModelConfig = normalizeRuntimeModelConfig(context, modelId, modelConfig)
   const runtime = await buildPromptRuntime(context, messages, modelId, normalizedModelConfig, [])
@@ -1237,6 +1238,9 @@ export async function runAiSdkGenerateText(
   )
   const resolvedTopP = resolveRuntimeTopP(context, modelId, normalizedModelConfig)
   const timeout = resolveRequestTimeout(normalizedModelConfig)
+  const timeoutSignal = timeout ? AbortSignal.timeout(timeout) : undefined
+  const abortSignal =
+    signal && timeoutSignal ? AbortSignal.any([signal, timeoutSignal]) : (signal ?? timeoutSignal)
   const requestBody = {
     model: runtime.providerContext.resolvedModelId ?? modelId,
     maxOutputTokens: maxTokens,
@@ -1258,7 +1262,7 @@ export async function runAiSdkGenerateText(
     messages: runtime.messages,
     allowSystemInMessages: false,
     providerOptions: runtime.providerOptions as any,
-    ...(timeout ? { abortSignal: AbortSignal.timeout(timeout) } : {}),
+    ...(abortSignal ? { abortSignal } : {}),
     ...(shouldSendTemperature && resolvedTemperature !== undefined
       ? { temperature: resolvedTemperature }
       : {}),

--- a/src/main/presenter/llmProviderPresenter/baseProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/baseProvider.ts
@@ -8,7 +8,8 @@ import {
   ChatMessage,
   KeyStatus,
   LLM_EMBEDDING_ATTRS,
-  IConfigPresenter
+  IConfigPresenter,
+  ProviderConnectionCheckResult
 } from '@shared/presenter'
 import { DevicePresenter } from '../devicePresenter'
 import { jsonrepair } from 'jsonrepair'
@@ -19,6 +20,19 @@ import { normalizeToolInputSchema } from './aiSdk/toolMapper'
 import { emitModelsChanged } from '../configPresenter/eventPublishers'
 
 export const AUDIO_TRANSCRIPTION_NOT_SUPPORTED_ERROR = 'audio-transcription-not-supported'
+
+export type ProviderCheckOptions = {
+  modelId?: string
+  signal?: AbortSignal
+}
+
+export function unsupportedProviderCheck(message: string): ProviderConnectionCheckResult {
+  return {
+    isOk: false,
+    errorMsg: message,
+    code: 'unsupported'
+  }
+}
 
 export function isAudioTranscriptionNotSupportedError(error: unknown): boolean {
   return error instanceof Error && error.message === AUDIO_TRANSCRIPTION_NOT_SUPPORTED_ERROR
@@ -117,27 +131,44 @@ export abstract class BaseLLMProvider {
     this.loadCachedModels()
   }
 
-  protected createModelRequestSignal(modelConfig?: Pick<ModelConfig, 'timeout'> | null): {
+  protected createModelRequestSignal(
+    modelConfig?: Pick<ModelConfig, 'timeout'> | null,
+    externalSignal?: AbortSignal
+  ): {
     signal?: AbortSignal
     timeoutMs?: number
     dispose: () => void
   } {
     const timeoutMs = this.resolveModelRequestTimeout(modelConfig)
-    if (!timeoutMs) {
+    if (!timeoutMs && !externalSignal) {
       return {
         dispose: () => {}
       }
     }
 
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => {
-      controller.abort(this.createModelRequestTimeoutError(timeoutMs))
-    }, timeoutMs)
+    const onExternalAbort = () => controller.abort(externalSignal?.reason)
+    if (externalSignal?.aborted) {
+      controller.abort(externalSignal.reason)
+    } else {
+      externalSignal?.addEventListener('abort', onExternalAbort, { once: true })
+    }
+    if (externalSignal?.aborted) {
+      onExternalAbort()
+    }
+    const timeoutId = timeoutMs
+      ? setTimeout(() => {
+          controller.abort(this.createModelRequestTimeoutError(timeoutMs))
+        }, timeoutMs)
+      : undefined
 
     return {
       signal: controller.signal,
       timeoutMs,
-      dispose: () => clearTimeout(timeoutId)
+      dispose: () => {
+        if (timeoutId !== undefined) clearTimeout(timeoutId)
+        externalSignal?.removeEventListener('abort', onExternalAbort)
+      }
     }
   }
 
@@ -642,7 +673,7 @@ ${this.convertToolsToXml(tools)}
    * 验证提供商API是否可用
    * @returns 验证结果和错误信息
    */
-  public abstract check(): Promise<{ isOk: boolean; errorMsg: string | null }>
+  public abstract check(options?: ProviderCheckOptions): Promise<ProviderConnectionCheckResult>
 
   /**
    * 生成对话标题

--- a/src/main/presenter/llmProviderPresenter/index.ts
+++ b/src/main/presenter/llmProviderPresenter/index.ts
@@ -19,7 +19,9 @@ import {
   RateLimitQueueSnapshot,
   AcpWorkdirInfo,
   AcpDebugRequest,
-  AcpDebugRunResult
+  AcpDebugRunResult,
+  ProviderConnectionCheckOptions,
+  ProviderConnectionCheckResult
 } from '@shared/presenter'
 import { ApiEndpointType, ModelType } from '@shared/model'
 import {
@@ -34,7 +36,11 @@ import { ProviderChange, ProviderBatchUpdate } from '@shared/provider-operations
 import { isProviderDbBackedProvider } from '@shared/providerDbCatalog'
 import { eventBus } from '@/eventbus'
 import { CONFIG_EVENTS, PROVIDER_DB_EVENTS } from '@/events'
-import { BaseLLMProvider, isAudioTranscriptionNotSupportedError } from './baseProvider'
+import {
+  BaseLLMProvider,
+  isAudioTranscriptionNotSupportedError,
+  unsupportedProviderCheck
+} from './baseProvider'
 import { ProviderConfig, StreamState } from './types'
 import { RateLimitManager } from './managers/rateLimitManager'
 import { ProviderInstanceManager } from './managers/providerInstanceManager'
@@ -638,46 +644,17 @@ export class LLMProviderPresenter implements ILlmProviderPresenter {
 
   async check(
     providerId: string,
-    modelId?: string
-  ): Promise<{ isOk: boolean; errorMsg: string | null }> {
+    modelId?: string,
+    options?: ProviderConnectionCheckOptions
+  ): Promise<ProviderConnectionCheckResult> {
     try {
-      const provider = this.getProviderInstance(providerId)
-
-      // 如果提供了modelId，使用completions方法进行测试
-      if (modelId) {
-        try {
-          const testMessage = [{ role: 'user' as const, content: 'hi' }]
-          const response: LLMResponse | null = await Promise.race([
-            provider.completions(testMessage, modelId, 0.1, 10),
-            new Promise<null>((resolve) => setTimeout(() => resolve(null), 60000))
-          ])
-          // 检查响应是否有效
-          if (
-            response &&
-            (response.content || response.content === '' || response.reasoning_content)
-          ) {
-            return { isOk: true, errorMsg: null }
-          } else {
-            return { isOk: false, errorMsg: 'Model response is invalid' }
-          }
-        } catch (error) {
-          console.error(`Model ${modelId} check failed:`, error)
-          const errorMessage = error instanceof Error ? error.message : String(error)
-          return { isOk: false, errorMsg: `Model test failed: ${errorMessage}` }
-        }
-      } else {
-        // 如果没有提供modelId，使用provider自己的check方法进行基本验证
-        logger.info(
-          `[LLMProviderPresenter] No modelId provided, using provider's own check method for ${providerId}`
+      if (providerId === 'fireworks') {
+        return unsupportedProviderCheck(
+          'Connection testing is unavailable because the Fireworks provider has no runtime adapter'
         )
-        try {
-          return await provider.check()
-        } catch (error) {
-          console.error(`Provider ${providerId} check failed:`, error)
-          const errorMessage = error instanceof Error ? error.message : String(error)
-          return { isOk: false, errorMsg: `Provider check failed: ${errorMessage}` }
-        }
       }
+      const provider = this.getProviderInstance(providerId)
+      return await provider.check({ modelId, signal: options?.signal })
     } catch (error) {
       console.error(`Provider ${providerId} check failed:`, error)
       const errorMessage = error instanceof Error ? error.message : String(error)

--- a/src/main/presenter/llmProviderPresenter/openaiCodexAdapter.ts
+++ b/src/main/presenter/llmProviderPresenter/openaiCodexAdapter.ts
@@ -216,7 +216,7 @@ export function createOpenAICodexFetch(defaultHeaders: Record<string, string>) {
 
     const dispatcher = getDispatcher()
     const auth = getGlobalOpenAICodexAuth()
-    const backendAuth = await auth.getBackendAuth()
+    const backendAuth = await auth.getBackendAuth(init?.signal ?? undefined)
     const nextInit: FetchInitWithDispatcher = {
       ...init,
       body: normalizeOpenAICodexRequestBody(init?.body),
@@ -232,7 +232,10 @@ export function createOpenAICodexFetch(defaultHeaders: Record<string, string>) {
       return normalizeOpenAICodexErrorResponse(response)
     }
 
-    const refreshedAuth = await auth.forceRefreshBackendAuth()
+    if (init?.signal?.aborted) {
+      throw init.signal.reason
+    }
+    const refreshedAuth = await auth.forceRefreshBackendAuth(init?.signal ?? undefined)
     response = await fetch(url, {
       ...nextInit,
       headers: applyCodexHeaders(init?.headers, defaultHeaders, refreshedAuth)

--- a/src/main/presenter/llmProviderPresenter/providers/acpProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/acpProvider.ts
@@ -1,7 +1,12 @@
 import logger from '@shared/logger'
 import type * as schema from '@agentclientprotocol/sdk/dist/schema/index.js'
 import type { ClientSideConnection as ClientSideConnectionType } from '@agentclientprotocol/sdk'
-import { BaseLLMProvider, SUMMARY_TITLES_PROMPT } from '../baseProvider'
+import {
+  BaseLLMProvider,
+  SUMMARY_TITLES_PROMPT,
+  type ProviderCheckOptions,
+  unsupportedProviderCheck
+} from '../baseProvider'
 import type {
   AcpConfigState,
   ChatMessage,
@@ -305,7 +310,13 @@ export class AcpProvider extends BaseLLMProvider {
     await this.sessionManager.clearSession(conversationId)
   }
 
-  public async check(): Promise<{ isOk: boolean; errorMsg: string | null }> {
+  public async check(options: ProviderCheckOptions = {}) {
+    if (options.modelId) {
+      return unsupportedProviderCheck(
+        'Connection testing is not supported for ACP agents because probe cancellation cannot be settled safely'
+      )
+    }
+
     const enabled = await this.configPresenter.getAcpEnabled()
     if (!enabled) {
       return {

--- a/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
@@ -33,12 +33,18 @@ import {
   MCPToolDefinition,
   MODEL_META,
   ModelConfig,
+  ProviderConnectionCheckResult,
   VERTEX_PROVIDER
 } from '@shared/presenter'
 import { BedrockClient, ListFoundationModelsCommand } from '@aws-sdk/client-bedrock'
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers'
 import { ProxyAgent } from 'undici'
-import { BaseLLMProvider, SUMMARY_TITLES_PROMPT } from '../baseProvider'
+import {
+  BaseLLMProvider,
+  SUMMARY_TITLES_PROMPT,
+  type ProviderCheckOptions,
+  unsupportedProviderCheck
+} from '../baseProvider'
 import {
   runAiSdkCoreStream,
   runAiSdkDimensions,
@@ -859,6 +865,9 @@ export class AiSdkProvider extends BaseLLMProvider {
       } else {
         externalSignal.addEventListener('abort', onExternalAbort, { once: true })
       }
+      if (externalSignal?.aborted) {
+        onExternalAbort()
+      }
     }
 
     try {
@@ -1010,7 +1019,7 @@ export class AiSdkProvider extends BaseLLMProvider {
   }
 
   public async fetchOpenAIModelRecords(
-    options?: { timeout: number },
+    options?: ProviderRequestOptions,
     decision?: RouteDecision
   ): Promise<Array<Record<string, unknown>>> {
     const resolvedDecision = decision ?? { providerKind: this.definition.runtimeKind }
@@ -1018,14 +1027,14 @@ export class AiSdkProvider extends BaseLLMProvider {
     const payload = await this.requestProviderJson<unknown>(
       this.buildModelsUrl(resolvedDecision, runtimeProvider),
       { method: 'GET' },
-      options?.timeout,
+      options,
       resolvedDecision
     )
     return toModelRecordArray(payload)
   }
 
   public async fetchDefaultOpenAIModels(
-    options?: { timeout: number },
+    options?: ProviderRequestOptions,
     decision?: RouteDecision
   ): Promise<MODEL_META[]> {
     const response = await this.fetchOpenAIModelRecords(options, decision)
@@ -1055,7 +1064,8 @@ export class AiSdkProvider extends BaseLLMProvider {
     modelId: string,
     temperature?: number,
     maxTokens?: number,
-    modelConfig?: ModelConfig
+    modelConfig?: ModelConfig,
+    signal?: AbortSignal
   ): Promise<LLMResponse> {
     if (!this.isInitialized) {
       throw new Error('Provider not initialized')
@@ -1065,13 +1075,24 @@ export class AiSdkProvider extends BaseLLMProvider {
     }
 
     const { context, resolvedModelConfig } = this.buildRuntimeContext(modelId, modelConfig)
+    if (!signal) {
+      return runAiSdkGenerateText(
+        context,
+        messages,
+        modelId,
+        resolvedModelConfig,
+        temperature,
+        maxTokens
+      )
+    }
     return runAiSdkGenerateText(
       context,
       messages,
       modelId,
       resolvedModelConfig,
       temperature,
-      maxTokens
+      maxTokens,
+      signal
     )
   }
 
@@ -1523,7 +1544,9 @@ export class AiSdkProvider extends BaseLLMProvider {
   }
 
   private async fetchProviderModelsByStrategy(
-    strategy: AiSdkModelSourceStrategy
+    strategy: AiSdkModelSourceStrategy,
+    signal?: AbortSignal,
+    allowFallback = true
   ): Promise<MODEL_META[]> {
     switch (strategy) {
       case 'config-db':
@@ -1538,7 +1561,8 @@ export class AiSdkProvider extends BaseLLMProvider {
         return this.mapKimiForCodingModels()
       case 'github': {
         const response = await this.fetchOpenAIModelRecords({
-          timeout: this.getModelFetchTimeout()
+          timeout: this.getModelFetchTimeout(),
+          signal
         })
         return response
           .filter((model) => typeof model.name === 'string')
@@ -1555,7 +1579,8 @@ export class AiSdkProvider extends BaseLLMProvider {
       }
       case 'together': {
         const response = await this.fetchOpenAIModelRecords({
-          timeout: this.getModelFetchTimeout()
+          timeout: this.getModelFetchTimeout(),
+          signal
         })
         return response
           .filter((model) => model.type === 'chat' || model.type === 'language')
@@ -1571,7 +1596,8 @@ export class AiSdkProvider extends BaseLLMProvider {
       }
       case 'astraflow': {
         const response = await this.fetchOpenAIModelRecords({
-          timeout: this.getModelFetchTimeout()
+          timeout: this.getModelFetchTimeout(),
+          signal
         })
         const NON_CHAT_PATTERNS = [
           'embedding',
@@ -1604,30 +1630,37 @@ export class AiSdkProvider extends BaseLLMProvider {
       case 'groq':
       case 'tokenflux':
       case '302ai':
-        return this.fetchOpenAiDerivedModels(strategy)
+        return this.fetchOpenAiDerivedModels(strategy, signal, allowFallback)
       case 'bedrock':
-        return this.fetchBedrockModels()
+        return this.fetchBedrockModels(signal, allowFallback)
       case 'new-api':
-        return this.fetchNewApiModels()
+        return this.fetchNewApiModels(signal)
       case 'openai':
       default:
-        return this.fetchDefaultOpenAIModels({ timeout: this.getModelFetchTimeout() }).then(
-          (models) =>
-            this.getRouteStrategy() === 'zenmux'
-              ? models.map((model) => ({
-                  ...model,
-                  group: 'ZenMux'
-                }))
-              : models
+        return this.fetchDefaultOpenAIModels({
+          timeout: this.getModelFetchTimeout(),
+          signal
+        }).then((models) =>
+          this.getRouteStrategy() === 'zenmux'
+            ? models.map((model) => ({
+                ...model,
+                group: 'ZenMux'
+              }))
+            : models
         )
     }
   }
 
   private async fetchOpenAiDerivedModels(
-    strategy: 'openrouter' | 'ppio' | 'groq' | 'tokenflux' | '302ai'
+    strategy: 'openrouter' | 'ppio' | 'groq' | 'tokenflux' | '302ai',
+    signal?: AbortSignal,
+    allowFallback = true
   ): Promise<MODEL_META[]> {
     try {
-      const response = await this.fetchOpenAIModelRecords({ timeout: this.getModelFetchTimeout() })
+      const response = await this.fetchOpenAIModelRecords({
+        timeout: this.getModelFetchTimeout(),
+        signal
+      })
       const models: MODEL_META[] = []
 
       for (const model of response) {
@@ -1802,12 +1835,18 @@ export class AiSdkProvider extends BaseLLMProvider {
 
       return models
     } catch (error) {
+      if (signal?.aborted || !allowFallback) {
+        throw error
+      }
       console.error(`Error fetching ${strategy} models:`, error)
-      return this.fetchDefaultOpenAIModels({ timeout: this.getModelFetchTimeout() })
+      return this.fetchDefaultOpenAIModels({ timeout: this.getModelFetchTimeout(), signal })
     }
   }
 
-  private async fetchBedrockModels(): Promise<MODEL_META[]> {
+  private async fetchBedrockModels(
+    signal?: AbortSignal,
+    allowFallback = true
+  ): Promise<MODEL_META[]> {
     const provider = this.provider as AWS_BEDROCK_PROVIDER
     const credential = provider.credential
     const region = credential?.region || process.env.AWS_REGION
@@ -1840,7 +1879,9 @@ export class AiSdkProvider extends BaseLLMProvider {
         }
       }
       const client = new BedrockClient(clientConfig as any)
-      const response = await client.send(new ListFoundationModelsCommand({}))
+      const response = await client.send(new ListFoundationModelsCommand({}), {
+        abortSignal: signal
+      })
       return (
         response.modelSummaries
           ?.filter(
@@ -1874,6 +1915,9 @@ export class AiSdkProvider extends BaseLLMProvider {
           })) || []
       )
     } catch (error) {
+      if (signal?.aborted || !allowFallback) {
+        throw error
+      }
       console.error('获取AWS Bedrock Anthropic模型列表出错:', error)
       return this.mapConfigDbModels(this.definition.providerDbSourceId).filter((model) =>
         model.id.startsWith('anthropic.')
@@ -1913,7 +1957,7 @@ export class AiSdkProvider extends BaseLLMProvider {
       })
   }
 
-  private async fetchNewApiModels(): Promise<MODEL_META[]> {
+  private async fetchNewApiModels(signal?: AbortSignal): Promise<MODEL_META[]> {
     type NewApiModelRecord = {
       id?: unknown
       name?: unknown
@@ -1945,7 +1989,10 @@ export class AiSdkProvider extends BaseLLMProvider {
           ...this.defaultHeaders
         }
       },
-      this.getModelFetchTimeout()
+      {
+        timeout: this.getModelFetchTimeout(),
+        signal
+      }
     )
     const rawModels = Array.isArray(payload.data) ? payload.data : []
 
@@ -2094,8 +2141,15 @@ export class AiSdkProvider extends BaseLLMProvider {
     return models
   }
 
-  protected async fetchProviderModels(): Promise<MODEL_META[]> {
-    return this.fetchProviderModelsByStrategy(this.definition.modelSource)
+  protected async fetchProviderModels(options?: {
+    signal?: AbortSignal
+    allowFallback?: boolean
+  }): Promise<MODEL_META[]> {
+    return this.fetchProviderModelsByStrategy(
+      this.definition.modelSource,
+      options?.signal,
+      options?.allowFallback
+    )
   }
 
   public onProxyResolved(): void {}
@@ -2104,11 +2158,12 @@ export class AiSdkProvider extends BaseLLMProvider {
     return this.definition.keyStatusStrategy ?? 'none'
   }
 
-  public async getKeyStatus(): Promise<KeyStatus | null> {
+  public async getKeyStatus(options?: { signal?: AbortSignal }): Promise<KeyStatus | null> {
     switch (this.resolveKeyStatusStrategy()) {
       case 'openrouter': {
         const response = await fetch('https://openrouter.ai/api/v1/key', {
           method: 'GET',
+          signal: options?.signal,
           headers: {
             Authorization: `Bearer ${this.provider.apiKey}`,
             'Content-Type': 'application/json'
@@ -2138,6 +2193,7 @@ export class AiSdkProvider extends BaseLLMProvider {
       case 'deepseek': {
         const response = await fetch('https://api.deepseek.com/user/balance', {
           method: 'GET',
+          signal: options?.signal,
           headers: {
             Accept: 'application/json',
             Authorization: `Bearer ${this.provider.apiKey}`
@@ -2173,6 +2229,7 @@ export class AiSdkProvider extends BaseLLMProvider {
       case 'ppio': {
         const response = await fetch('https://api.ppinfra.com/v3/user', {
           method: 'GET',
+          signal: options?.signal,
           headers: {
             Authorization: this.provider.apiKey,
             'Content-Type': 'application/json'
@@ -2193,6 +2250,7 @@ export class AiSdkProvider extends BaseLLMProvider {
       case 'tokenflux': {
         const response = await fetch(`${this.provider.baseUrl}/models`, {
           method: 'GET',
+          signal: options?.signal,
           headers: {
             Authorization: `Bearer ${this.provider.apiKey}`,
             'Content-Type': 'application/json'
@@ -2212,6 +2270,7 @@ export class AiSdkProvider extends BaseLLMProvider {
       case '302ai': {
         const response = await fetch('https://api.302.ai/dashboard/balance', {
           method: 'GET',
+          signal: options?.signal,
           headers: {
             Authorization: `Bearer ${this.provider.apiKey}`,
             'Content-Type': 'application/json'
@@ -2233,6 +2292,7 @@ export class AiSdkProvider extends BaseLLMProvider {
         const baseUrl = (this.provider.baseUrl || 'https://open.cherryin.ai/v1').replace(/\/$/, '')
         const usageResponse = await fetch(`${baseUrl}/dashboard/billing/usage`, {
           method: 'GET',
+          signal: options?.signal,
           headers: {
             Authorization: `Bearer ${this.provider.apiKey}`,
             'Content-Type': 'application/json'
@@ -2253,7 +2313,10 @@ export class AiSdkProvider extends BaseLLMProvider {
         }
       }
       case 'modelscope': {
-        const response = await this.fetchOpenAIModelRecords({ timeout: 10000 })
+        const response = await this.fetchOpenAIModelRecords({
+          timeout: 10000,
+          signal: options?.signal
+        })
         return {
           limit_remaining: 'Available',
           remainNum: response.length
@@ -2262,6 +2325,7 @@ export class AiSdkProvider extends BaseLLMProvider {
       case 'siliconcloud': {
         const response = await fetch('https://api.siliconflow.cn/v1/user/info', {
           method: 'GET',
+          signal: options?.signal,
           headers: {
             Authorization: `Bearer ${this.provider.apiKey}`,
             'Content-Type': 'application/json'
@@ -2327,11 +2391,50 @@ export class AiSdkProvider extends BaseLLMProvider {
     }
   }
 
-  public async check(): Promise<{ isOk: boolean; errorMsg: string | null }> {
+  public async check(options: ProviderCheckOptions = {}): Promise<ProviderConnectionCheckResult> {
+    if (options.modelId) {
+      const decision = this.resolveRouteDecision(options.modelId)
+      const modelConfig = this.getProviderModelConfig(options.modelId)
+      const unsupportedEndpoint =
+        decision.endpointType === 'grok-image' ||
+        decision.endpointType === 'image-generation' ||
+        decision.endpointType === 'video-generation' ||
+        modelConfig.apiEndpoint === ApiEndpointType.Image ||
+        modelConfig.apiEndpoint === ApiEndpointType.Video ||
+        modelConfig.apiEndpoint === ApiEndpointType.AudioSpeech ||
+        isTtsModelConfig(modelConfig) ||
+        isTtsModelId(options.modelId)
+
+      if (unsupportedEndpoint) {
+        return unsupportedProviderCheck(
+          'Connection testing is not supported for non-chat generation models'
+        )
+      }
+
+      try {
+        const response = await this.runText(
+          [{ role: 'user', content: 'hi' }],
+          options.modelId,
+          0.1,
+          10,
+          modelConfig,
+          options.signal
+        )
+        return response.content || response.content === '' || response.reasoning_content
+          ? { isOk: true, errorMsg: null }
+          : { isOk: false, errorMsg: 'Model response is invalid' }
+      } catch (error) {
+        return {
+          isOk: false,
+          errorMsg: `Model test failed: ${toErrorMessage(error, 'Unknown error')}`
+        }
+      }
+    }
+
     switch (this.definition.checkStrategy) {
       case 'key-status':
         try {
-          const keyStatus = await this.getKeyStatus()
+          const keyStatus = await this.getKeyStatus({ signal: options.signal })
           if (keyStatus?.remainNum !== undefined && keyStatus.remainNum <= 0) {
             return {
               isOk: false,
@@ -2361,7 +2464,9 @@ export class AiSdkProvider extends BaseLLMProvider {
             [{ role: 'user', content: this.definition.checkPrompt || 'Hello' }],
             this.definition.checkModelId || '',
             this.definition.checkTemperature ?? 0.2,
-            this.definition.checkMaxTokens ?? 16
+            this.definition.checkMaxTokens ?? 16,
+            undefined,
+            options.signal
           )
           return { isOk: true, errorMsg: null }
         } catch (error) {
@@ -2374,7 +2479,7 @@ export class AiSdkProvider extends BaseLLMProvider {
       case 'fetch-models':
       default:
         try {
-          await this.fetchProviderModels()
+          await this.fetchProviderModels({ signal: options.signal, allowFallback: false })
           return { isOk: true, errorMsg: null }
         } catch (error) {
           return {

--- a/src/main/presenter/llmProviderPresenter/providers/githubCopilotProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/githubCopilotProvider.ts
@@ -7,9 +7,10 @@ import {
   LLMCoreStreamEvent,
   ModelConfig,
   MCPToolDefinition,
-  IConfigPresenter
+  IConfigPresenter,
+  ProviderConnectionCheckResult
 } from '@shared/presenter'
-import { BaseLLMProvider, SUMMARY_TITLES_PROMPT } from '../baseProvider'
+import { BaseLLMProvider, SUMMARY_TITLES_PROMPT, type ProviderCheckOptions } from '../baseProvider'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 import {
   getGlobalGitHubCopilotDeviceFlow,
@@ -85,8 +86,11 @@ export class GithubCopilotProvider extends BaseLLMProvider {
     // 优先使用设备流获取 token
     if (this.deviceFlow) {
       try {
-        return await this.deviceFlow.getCopilotToken()
+        return await this.deviceFlow.getCopilotToken(signal)
       } catch (error) {
+        if (signal?.aborted) {
+          throw error
+        }
         console.warn(
           '[GitHub Copilot] Device flow failed, falling back to provider API key:',
           error
@@ -592,11 +596,12 @@ export class GithubCopilotProvider extends BaseLLMProvider {
     messages: ChatMessage[],
     modelId: string,
     temperature?: number,
-    _maxTokens?: number
+    _maxTokens?: number,
+    options?: { signal?: AbortSignal }
   ): Promise<LLMResponse> {
     if (!modelId) throw new Error('Model ID is required')
     const modelConfig = this.configPresenter.getModelConfig(modelId, this.provider.id)
-    const { signal, dispose } = this.createModelRequestSignal(modelConfig)
+    const { signal, dispose } = this.createModelRequestSignal(modelConfig, options?.signal)
     try {
       const token = await this.getCopilotToken(signal)
       const formattedMessages = this.formatMessages(messages)
@@ -745,10 +750,23 @@ export class GithubCopilotProvider extends BaseLLMProvider {
     )
   }
 
-  async check(): Promise<{ isOk: boolean; errorMsg: string | null }> {
+  async check(options: ProviderCheckOptions = {}): Promise<ProviderConnectionCheckResult> {
     try {
+      if (options.modelId) {
+        const response = await this.completions(
+          [{ role: 'user', content: 'hi' }],
+          options.modelId,
+          0.1,
+          10,
+          { signal: options.signal }
+        )
+        return response.content || response.content === '' || response.reasoning_content
+          ? { isOk: true, errorMsg: null }
+          : { isOk: false, errorMsg: 'Model response is invalid' }
+      }
+
       // Device flow may be active without apiKey; proceed to token retrieval
-      await this.getCopilotToken()
+      await this.getCopilotToken(options.signal)
       return { isOk: true, errorMsg: null }
     } catch (error) {
       let errorMsg = error instanceof Error ? error.message : 'Unknown error'

--- a/src/main/presenter/llmProviderPresenter/providers/ollamaProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/ollamaProvider.ts
@@ -9,11 +9,12 @@ import {
   MODEL_META,
   ModelConfig,
   OllamaModel,
-  ProgressResponse
+  ProgressResponse,
+  ProviderConnectionCheckResult
 } from '@shared/presenter'
 import { ModelType } from '@shared/model'
 import { DEFAULT_MODEL_CONTEXT_LENGTH, DEFAULT_MODEL_MAX_TOKENS } from '@shared/modelConfigDefaults'
-import { BaseLLMProvider, SUMMARY_TITLES_PROMPT } from '../baseProvider'
+import { BaseLLMProvider, SUMMARY_TITLES_PROMPT, type ProviderCheckOptions } from '../baseProvider'
 import { execFile } from 'node:child_process'
 import { Ollama, ShowResponse } from 'ollama'
 import {
@@ -473,9 +474,35 @@ export class OllamaProvider extends BaseLLMProvider {
     }
   }
 
-  public async check(): Promise<{ isOk: boolean; errorMsg: string | null }> {
+  public async check(options: ProviderCheckOptions = {}): Promise<ProviderConnectionCheckResult> {
     try {
-      await this.ollama.list()
+      if (options.modelId) {
+        const response = await runAiSdkGenerateText(
+          this.getAiSdkRuntimeContext(),
+          [{ role: 'user', content: 'hi' }],
+          options.modelId,
+          this.configPresenter.getModelConfig(options.modelId, this.provider.id),
+          0.1,
+          10,
+          options.signal
+        )
+        return response.content || response.content === '' || response.reasoning_content
+          ? { isOk: true, errorMsg: null }
+          : { isOk: false, errorMsg: 'Model response is invalid' }
+      }
+
+      const baseUrl = normalizeOllamaSdkHost(this.provider.baseUrl).replace(/\/+$/, '')
+      const response = await fetch(`${baseUrl}/api/tags`, {
+        method: 'GET',
+        signal: options.signal,
+        headers: this.provider.apiKey
+          ? { Authorization: `Bearer ${this.provider.apiKey}` }
+          : undefined
+      })
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`)
+      }
+      await response.json()
       return { isOk: true, errorMsg: null }
     } catch (error) {
       return {

--- a/src/main/presenter/llmProviderPresenter/providers/voiceAIProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/voiceAIProvider.ts
@@ -6,11 +6,16 @@ import {
   MODEL_META,
   LLMCoreStreamEvent,
   MCPToolDefinition,
-  ModelConfig
+  ModelConfig,
+  ProviderConnectionCheckResult
 } from '@shared/presenter'
 import { DEFAULT_MODEL_CONTEXT_LENGTH, DEFAULT_MODEL_MAX_TOKENS } from '@shared/modelConfigDefaults'
 import { createStreamEvent } from '@shared/types/core/llm-events'
-import { BaseLLMProvider } from '../baseProvider'
+import {
+  BaseLLMProvider,
+  type ProviderCheckOptions,
+  unsupportedProviderCheck
+} from '../baseProvider'
 import { proxyConfig } from '../../proxyConfig'
 import { ProxyAgent } from 'undici'
 
@@ -75,13 +80,19 @@ export class VoiceAIProvider extends BaseLLMProvider {
     this.proxyUrl = undefined
   }
 
-  public async check(): Promise<{ isOk: boolean; errorMsg: string | null }> {
+  public async check(options: ProviderCheckOptions = {}): Promise<ProviderConnectionCheckResult> {
+    if (options.modelId) {
+      return unsupportedProviderCheck(
+        'Connection testing is not supported for Voice.ai models because it would generate billable audio'
+      )
+    }
+
     if (!this.provider.apiKey) {
       return { isOk: false, errorMsg: 'API key is required' }
     }
 
     try {
-      await this.listVoices()
+      await this.listVoices(options.signal)
       return { isOk: true, errorMsg: null }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error)
@@ -399,9 +410,10 @@ export class VoiceAIProvider extends BaseLLMProvider {
     return null
   }
 
-  private async listVoices(): Promise<VoiceStatusResponse[]> {
+  private async listVoices(signal?: AbortSignal): Promise<VoiceStatusResponse[]> {
     const response = await fetch(this.buildUrl('/api/v1/tts/voices'), {
       method: 'GET',
+      signal,
       headers: this.getAuthHeaders(),
       ...this.getFetchOptions()
     })

--- a/src/main/presenter/openaiCodexAuth/index.ts
+++ b/src/main/presenter/openaiCodexAuth/index.ts
@@ -145,7 +145,12 @@ export function resolveOpenAICodexCallbackUrl(
 export class OpenAICodexAuth {
   private readonly store: OpenAICodexCredentialStore
   private pendingBrowserFlow: PendingBrowserFlow | null = null
-  private refreshPromise: Promise<OpenAICodexTokenSet> | null = null
+  private refreshOperation: {
+    controller: AbortController
+    promise: Promise<OpenAICodexTokenSet>
+    activeWaiters: number
+    settled: boolean
+  } | null = null
   private lastError: string | null = null
 
   constructor(store = new OpenAICodexCredentialStore()) {
@@ -293,7 +298,7 @@ export class OpenAICodexAuth {
     return auth.accessToken
   }
 
-  async getBackendAuth(): Promise<OpenAICodexBackendAuth> {
+  async getBackendAuth(signal?: AbortSignal): Promise<OpenAICodexBackendAuth> {
     this.assertEnabled()
 
     if (OPENAI_CODEX_ACCESS_TOKEN_ENV) {
@@ -308,21 +313,21 @@ export class OpenAICodexAuth {
     const current =
       tokens.expiresAt > Date.now() + OPENAI_CODEX_TOKEN_REFRESH_SKEW_MS
         ? tokens
-        : await this.refreshAccessToken(tokens)
+        : await this.refreshAccessToken(tokens, false, signal)
     return {
       accessToken: current.accessToken,
       accountId: current.accountId
     }
   }
 
-  async forceRefreshBackendAuth(): Promise<OpenAICodexBackendAuth> {
+  async forceRefreshBackendAuth(signal?: AbortSignal): Promise<OpenAICodexBackendAuth> {
     this.assertEnabled()
     const tokens = this.store.load()
     if (!tokens?.refreshToken) {
       throw new Error('OpenAI Codex refresh token is unavailable')
     }
 
-    const refreshed = await this.refreshAccessToken(tokens, true)
+    const refreshed = await this.refreshAccessToken(tokens, true, signal)
     return {
       accessToken: refreshed.accessToken,
       accountId: refreshed.accountId
@@ -403,34 +408,81 @@ export class OpenAICodexAuth {
 
   private async refreshAccessToken(
     currentTokens: OpenAICodexTokenSet,
-    force = false
+    force = false,
+    signal?: AbortSignal
   ): Promise<OpenAICodexTokenSet> {
     if (!force && currentTokens.expiresAt > Date.now() + OPENAI_CODEX_TOKEN_REFRESH_SKEW_MS) {
       return currentTokens
     }
 
-    if (this.refreshPromise) {
-      return this.refreshPromise
+    if (signal?.aborted) {
+      throw signal.reason
     }
 
-    this.refreshPromise = this.refreshAccessTokenOnce(currentTokens).finally(() => {
-      this.refreshPromise = null
-    })
-    return this.refreshPromise
+    if (!this.refreshOperation) {
+      const controller = new AbortController()
+      let operation!: NonNullable<OpenAICodexAuth['refreshOperation']>
+      const promise = this.refreshAccessTokenOnce(currentTokens, controller.signal).finally(() => {
+        operation.settled = true
+        if (this.refreshOperation === operation) {
+          this.refreshOperation = null
+        }
+      })
+      operation = {
+        controller,
+        promise,
+        activeWaiters: 0,
+        settled: false
+      }
+      this.refreshOperation = operation
+    }
+
+    const operation = this.refreshOperation
+    operation.activeWaiters += 1
+    let waiterActive = true
+    const releaseWaiter = (cancelled: boolean) => {
+      if (!waiterActive) return
+      waiterActive = false
+      operation.activeWaiters -= 1
+      if (cancelled && operation.activeWaiters === 0 && !operation.settled) {
+        operation.controller.abort(signal?.reason)
+      }
+    }
+    const onAbort = () => releaseWaiter(true)
+    signal?.addEventListener('abort', onAbort, { once: true })
+    if (signal?.aborted) {
+      onAbort()
+    }
+
+    try {
+      const refreshed = await operation.promise
+      if (signal?.aborted) {
+        throw signal.reason
+      }
+      return refreshed
+    } finally {
+      signal?.removeEventListener('abort', onAbort)
+      releaseWaiter(false)
+    }
   }
 
   private async refreshAccessTokenOnce(
-    currentTokens: OpenAICodexTokenSet
+    currentTokens: OpenAICodexTokenSet,
+    signal?: AbortSignal
   ): Promise<OpenAICodexTokenSet> {
     if (!currentTokens.refreshToken) {
       throw new Error('OpenAI Codex refresh token is unavailable')
     }
 
-    const payload = await this.postForm(OPENAI_CODEX_TOKEN_URL, {
-      grant_type: 'refresh_token',
-      client_id: OPENAI_CODEX_CLIENT_ID,
-      refresh_token: currentTokens.refreshToken
-    })
+    const payload = await this.postForm(
+      OPENAI_CODEX_TOKEN_URL,
+      {
+        grant_type: 'refresh_token',
+        client_id: OPENAI_CODEX_CLIENT_ID,
+        refresh_token: currentTokens.refreshToken
+      },
+      signal
+    )
     const refreshed = this.parseTokenResponse(payload, currentTokens)
     this.store.save(refreshed)
     this.lastError = null
@@ -475,7 +527,8 @@ export class OpenAICodexAuth {
 
   private async postForm(
     url: string,
-    params: Record<string, string | undefined>
+    params: Record<string, string | undefined>,
+    signal?: AbortSignal
   ): Promise<TokenResponse> {
     const body = new URLSearchParams()
     Object.entries(params).forEach(([key, value]) => {
@@ -484,14 +537,18 @@ export class OpenAICodexAuth {
       }
     })
 
-    const response = await this.fetchWithTimeout(url, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded'
+    const response = await this.fetchWithTimeout(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body
       },
-      body
-    })
+      signal
+    )
 
     if (!response.ok) {
       throw new Error(await readErrorBody(response))
@@ -500,15 +557,31 @@ export class OpenAICodexAuth {
     return (await response.json()) as TokenResponse
   }
 
-  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  private async fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+    externalSignal?: AbortSignal
+  ): Promise<Response> {
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), OPENAI_CODEX_AUTH_REQUEST_TIMEOUT_MS)
+    const onExternalAbort = () => controller.abort(externalSignal?.reason)
+    if (externalSignal?.aborted) {
+      controller.abort(externalSignal.reason)
+    } else {
+      externalSignal?.addEventListener('abort', onExternalAbort, { once: true })
+    }
+    if (externalSignal?.aborted) {
+      onExternalAbort()
+    }
     try {
       return await fetch(url, {
         ...init,
         signal: controller.signal
       })
     } catch (error) {
+      if (externalSignal?.aborted) {
+        throw externalSignal.reason
+      }
       if (controller.signal.aborted) {
         throw new Error(
           `OpenAI Codex auth request timed out after ${OPENAI_CODEX_AUTH_REQUEST_TIMEOUT_MS}ms`
@@ -517,6 +590,7 @@ export class OpenAICodexAuth {
       throw error
     } finally {
       clearTimeout(timeout)
+      externalSignal?.removeEventListener('abort', onExternalAbort)
     }
   }
 

--- a/src/main/routes/hotPathPorts.ts
+++ b/src/main/routes/hotPathPorts.ts
@@ -3,6 +3,8 @@ import type {
   IConfigPresenter,
   ILlmProviderPresenter,
   ActiveSessionResolution,
+  ProviderConnectionCheckOptions,
+  ProviderConnectionCheckResult,
   SessionResolutionListFilters,
   SessionResolutionResult
 } from '@shared/presenter'
@@ -59,11 +61,9 @@ export interface ProviderExecutionPort {
   ): Promise<ToolInteractionResult>
   testConnection(
     providerId: string,
-    modelId?: string
-  ): Promise<{
-    isOk: boolean
-    errorMsg: string | null
-  }>
+    modelId?: string,
+    options?: ProviderConnectionCheckOptions
+  ): Promise<ProviderConnectionCheckResult>
 }
 
 export type ProviderCatalogPort = Pick<
@@ -139,8 +139,8 @@ export function createPresenterHotPathPorts(deps: {
           toolCallId,
           response
         ),
-      testConnection: async (providerId, modelId) =>
-        await deps.llmProviderPresenter.check(providerId, modelId)
+      testConnection: async (providerId, modelId, options) =>
+        await deps.llmProviderPresenter.check(providerId, modelId, options)
     },
     providerCatalogPort: {
       getProviderModels: (providerId) => deps.configPresenter.getProviderModels(providerId) ?? [],

--- a/src/main/routes/operationRunner.ts
+++ b/src/main/routes/operationRunner.ts
@@ -24,6 +24,13 @@ export interface RetryIdempotentInput<T> {
   shouldRetry: (error: unknown) => boolean
 }
 
+export interface RunCancellableInput<T> {
+  task: (signal: AbortSignal) => Promise<T>
+  deadlineMs: number
+  reason: string
+  signal?: AbortSignal
+}
+
 export interface LegacyTimeoutInput<T> {
   task: Promise<T>
   ms: number
@@ -35,6 +42,7 @@ export interface OperationRunner {
   sleep(input: SleepInput): Promise<void>
   observeIdempotent<T>(input: ObserveIdempotentInput<T>): Promise<T>
   retryIdempotent<T>(input: RetryIdempotentInput<T>): Promise<T>
+  runCancellable<T>(input: RunCancellableInput<T>): Promise<T>
 
   /** @deprecated Migrate the allowlisted consumer to a capability-specific operation. */
   timeout<T>(input: LegacyTimeoutInput<T>): Promise<T>
@@ -57,6 +65,16 @@ export class ObservationDeadlineError extends Error {
   ) {
     super(`${reason} observation deadline reached after ${deadlineMs}ms`)
     this.name = 'ObservationDeadlineError'
+  }
+}
+
+export class CancellableDeadlineError extends Error {
+  constructor(
+    readonly reason: string,
+    readonly deadlineMs: number
+  ) {
+    super(`${reason} cancellation deadline reached after ${deadlineMs}ms`)
+    this.name = 'CancellableDeadlineError'
   }
 }
 
@@ -237,6 +255,50 @@ async function observeIdempotent<T>(input: ObserveIdempotentInput<T>): Promise<T
   }
 }
 
+async function runCancellable<T>(input: RunCancellableInput<T>): Promise<T> {
+  validateTimerMs(input.deadlineMs, 'deadlineMs')
+  throwIfPreAborted(input.signal, input.reason)
+
+  if (input.deadlineMs === 0) {
+    throw new CancellableDeadlineError(input.reason, input.deadlineMs)
+  }
+
+  const controller = new AbortController()
+  let stopError: Error | undefined
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const stop = (error: Error) => {
+    if (stopError) return
+    stopError = error
+    controller.abort(error)
+  }
+  const onAbort = () => stop(createAbortError(input.reason))
+
+  timer = setTimeout(
+    () => stop(new CancellableDeadlineError(input.reason, input.deadlineMs)),
+    input.deadlineMs
+  )
+  input.signal?.addEventListener('abort', onAbort, { once: true })
+  if (input.signal?.aborted) {
+    onAbort()
+  }
+
+  try {
+    let result: T
+    try {
+      result = await input.task(controller.signal)
+    } catch (error) {
+      if (stopError) throw stopError
+      throw error
+    }
+
+    if (stopError) throw stopError
+    return result
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+    input.signal?.removeEventListener('abort', onAbort)
+  }
+}
+
 async function retryIdempotent<T>(input: RetryIdempotentInput<T>): Promise<T> {
   validateRetryInput(input)
   throwIfPreAborted(input.signal, input.reason)
@@ -314,6 +376,7 @@ export function createNodeOperationRunner(): OperationRunner {
     sleep,
     observeIdempotent,
     retryIdempotent,
+    runCancellable,
     timeout: legacyTimeout
   }
 }

--- a/src/main/routes/providers/providerService.ts
+++ b/src/main/routes/providers/providerService.ts
@@ -1,8 +1,9 @@
 import type { ProviderCatalogPort } from '@/presenter/runtimePorts'
+import type { ProviderConnectionCheckResult } from '@shared/presenter'
 import type { ProviderExecutionPort } from '../hotPathPorts'
-import type { OperationRunner } from '../operationRunner'
+import { CancellableDeadlineError, type OperationRunner } from '../operationRunner'
 
-const PROVIDER_QUERY_TIMEOUT_MS = 5_000
+const PROVIDER_CHECK_DEADLINE_MS = 60_000
 
 export class ProviderService {
   constructor(
@@ -26,14 +27,36 @@ export class ProviderService {
     }
   }
 
-  async testConnection(input: { providerId: string; modelId?: string }): Promise<{
-    isOk: boolean
-    errorMsg: string | null
-  }> {
-    return await this.deps.scheduler.timeout({
-      task: this.deps.providerExecutionPort.testConnection(input.providerId, input.modelId),
-      ms: PROVIDER_QUERY_TIMEOUT_MS,
-      reason: `providers.testConnection:${input.providerId}`
-    })
+  async testConnection(input: {
+    providerId: string
+    modelId?: string
+  }): Promise<ProviderConnectionCheckResult> {
+    const reason = `providers.testConnection:${input.providerId}`
+    try {
+      return await this.deps.scheduler.runCancellable({
+        task: (signal) =>
+          this.deps.providerExecutionPort.testConnection(input.providerId, input.modelId, {
+            signal
+          }),
+        deadlineMs: PROVIDER_CHECK_DEADLINE_MS,
+        reason
+      })
+    } catch (error) {
+      if (error instanceof CancellableDeadlineError) {
+        return {
+          isOk: false,
+          errorMsg: `Provider connection test timed out after ${PROVIDER_CHECK_DEADLINE_MS}ms`,
+          code: 'deadline_exceeded'
+        }
+      }
+      if (error instanceof Error && error.name === 'AbortError') {
+        return {
+          isOk: false,
+          errorMsg: 'Provider connection test was cancelled',
+          code: 'cancelled'
+        }
+      }
+      throw error
+    }
   }
 }

--- a/src/shared/contracts/routes/providers.routes.ts
+++ b/src/shared/contracts/routes/providers.routes.ts
@@ -44,7 +44,8 @@ export const providersTestConnectionRoute = defineRouteContract({
   }),
   output: z.object({
     isOk: z.boolean(),
-    errorMsg: z.string().nullable()
+    errorMsg: z.string().nullable(),
+    code: z.enum(['unsupported', 'cancelled', 'deadline_exceeded']).optional()
   })
 })
 

--- a/src/shared/types/presenters/index.d.ts
+++ b/src/shared/types/presenters/index.d.ts
@@ -22,7 +22,10 @@ export type {
   AWS_BEDROCK_PROVIDER,
   OllamaModel,
   ModelScopeMcpSyncOptions,
-  ModelScopeMcpSyncResult
+  ModelScopeMcpSyncResult,
+  ProviderConnectionCheckCode,
+  ProviderConnectionCheckOptions,
+  ProviderConnectionCheckResult
 } from './llmprovider.presenter'
 
 // Thread/Conversation types

--- a/src/shared/types/presenters/llmprovider.presenter.d.ts
+++ b/src/shared/types/presenters/llmprovider.presenter.d.ts
@@ -206,6 +206,18 @@ export type RateLimitQueueSnapshot = {
   estimatedWaitTime: number
 }
 
+export type ProviderConnectionCheckCode = 'unsupported' | 'cancelled' | 'deadline_exceeded'
+
+export type ProviderConnectionCheckOptions = {
+  signal?: AbortSignal
+}
+
+export type ProviderConnectionCheckResult = {
+  isOk: boolean
+  errorMsg: string | null
+  code?: ProviderConnectionCheckCode
+}
+
 export type AcpConfigOptionValue = {
   value: string
   label: string
@@ -267,7 +279,11 @@ export interface ILlmProviderPresenter {
     maxTokens?: number
   ): Promise<{ content: string }>
   stopStream(eventId: string): Promise<void>
-  check(providerId: string, modelId?: string): Promise<{ isOk: boolean; errorMsg: string | null }>
+  check(
+    providerId: string,
+    modelId?: string,
+    options?: ProviderConnectionCheckOptions
+  ): Promise<ProviderConnectionCheckResult>
   getKeyStatus(providerId: string): Promise<KeyStatus | null>
   refreshModels(providerId: string): Promise<void>
   summaryTitles(

--- a/test/main/presenter/acpProvider.test.ts
+++ b/test/main/presenter/acpProvider.test.ts
@@ -69,6 +69,25 @@ describe('AcpProvider runDebugAction error handling', () => {
     ]
   })
 
+  it('rejects model probes before reading config or starting an ACP turn', async () => {
+    const provider = Object.create(AcpProvider.prototype) as any
+    provider.configPresenter = {
+      getAcpEnabled: vi.fn(),
+      getAcpAgents: vi.fn()
+    }
+    provider.collectFromStream = vi.fn()
+
+    await expect(provider.check({ modelId: 'codex' })).resolves.toEqual({
+      isOk: false,
+      errorMsg:
+        'Connection testing is not supported for ACP agents because probe cancellation cannot be settled safely',
+      code: 'unsupported'
+    })
+    expect(provider.configPresenter.getAcpEnabled).not.toHaveBeenCalled()
+    expect(provider.configPresenter.getAcpAgents).not.toHaveBeenCalled()
+    expect(provider.collectFromStream).not.toHaveBeenCalled()
+  })
+
   it('returns error result when process manager is shutting down', async () => {
     const provider = Object.create(AcpProvider.prototype) as any
     provider.configPresenter = {

--- a/test/main/presenter/llmProviderPresenter.test.ts
+++ b/test/main/presenter/llmProviderPresenter.test.ts
@@ -334,71 +334,48 @@ describe('LLMProviderPresenter Integration Tests', () => {
       expect(result.isOk).toBe(true)
     }, 10000)
 
-    it('keeps the model-specific connection check as a 60-second observation', async () => {
-      vi.useFakeTimers()
-      const completion = deferred<{ content: string }>()
-      const provider = {
-        completions: vi.fn().mockReturnValue(completion.promise),
-        check: vi.fn()
-      }
-      vi.spyOn(llmProviderPresenter, 'getProviderInstance').mockReturnValue(provider as any)
+    it('returns typed unsupported for Fireworks before trying to create a runtime adapter', async () => {
+      const getProviderInstance = vi.spyOn(llmProviderPresenter, 'getProviderInstance')
 
-      try {
-        let settled = false
-        const checking = llmProviderPresenter.check('mock-openai-api', 'mock-model')
-        void checking.finally(() => {
-          settled = true
-        })
-
-        await vi.advanceTimersByTimeAsync(59_999)
-        expect(settled).toBe(false)
-        expect(provider.completions).toHaveBeenCalledWith(
-          [{ role: 'user', content: 'hi' }],
-          'mock-model',
-          0.1,
-          10
-        )
-
-        await vi.advanceTimersByTimeAsync(1)
-        await expect(checking).resolves.toEqual({
-          isOk: false,
-          errorMsg: 'Model response is invalid'
-        })
-
-        completion.resolve({ content: 'late owner response' })
-        await Promise.resolve()
-        expect(provider.completions).toHaveBeenCalledOnce()
-      } finally {
-        vi.useRealTimers()
-      }
+      await expect(llmProviderPresenter.check('fireworks')).resolves.toEqual({
+        isOk: false,
+        errorMsg:
+          'Connection testing is unavailable because the Fireworks provider has no runtime adapter',
+        code: 'unsupported'
+      })
+      expect(getProviderInstance).not.toHaveBeenCalled()
     })
 
-    it('keeps the provider-native connection check without a uniform route deadline', async () => {
-      vi.useFakeTimers()
-      const nativeCheck = deferred<{ isOk: boolean; errorMsg: string | null }>()
+    it('delegates model connection checks and owner cancellation to the provider', async () => {
+      const controller = new AbortController()
       const provider = {
-        completions: vi.fn(),
-        check: vi.fn().mockReturnValue(nativeCheck.promise)
+        check: vi.fn().mockResolvedValue({ isOk: true, errorMsg: null })
       }
       vi.spyOn(llmProviderPresenter, 'getProviderInstance').mockReturnValue(provider as any)
 
-      try {
-        let settled = false
-        const checking = llmProviderPresenter.check('mock-openai-api')
-        void checking.finally(() => {
-          settled = true
+      await expect(
+        llmProviderPresenter.check('mock-openai-api', 'mock-model', {
+          signal: controller.signal
         })
+      ).resolves.toEqual({ isOk: true, errorMsg: null })
 
-        expect(vi.getTimerCount()).toBe(0)
-        await vi.advanceTimersByTimeAsync(600_000)
-        expect(settled).toBe(false)
-        expect(provider.check).toHaveBeenCalledOnce()
+      expect(provider.check).toHaveBeenCalledWith({
+        modelId: 'mock-model',
+        signal: controller.signal
+      })
+    })
 
-        nativeCheck.resolve({ isOk: true, errorMsg: null })
-        await expect(checking).resolves.toEqual({ isOk: true, errorMsg: null })
-      } finally {
-        vi.useRealTimers()
+    it('delegates provider-native checks through the same owner contract', async () => {
+      const provider = {
+        check: vi.fn().mockResolvedValue({ isOk: true, errorMsg: null })
       }
+      vi.spyOn(llmProviderPresenter, 'getProviderInstance').mockReturnValue(provider as any)
+
+      await expect(llmProviderPresenter.check('mock-openai-api')).resolves.toEqual({
+        isOk: true,
+        errorMsg: null
+      })
+      expect(provider.check).toHaveBeenCalledWith({ modelId: undefined, signal: undefined })
     })
   })
 

--- a/test/main/presenter/llmProviderPresenter/aiSdkRuntime.test.ts
+++ b/test/main/presenter/llmProviderPresenter/aiSdkRuntime.test.ts
@@ -132,6 +132,35 @@ describe('AI SDK runtime', () => {
     })
   })
 
+  it('passes the owner signal to generateText and waits for its abort settlement', async () => {
+    const controller = new AbortController()
+    mockGenerateText.mockImplementationOnce(({ abortSignal }: { abortSignal?: AbortSignal }) => {
+      return new Promise((_, reject) => {
+        if (abortSignal?.aborted) {
+          reject(abortSignal.reason)
+          return
+        }
+        abortSignal?.addEventListener('abort', () => reject(abortSignal.reason), { once: true })
+      })
+    })
+
+    const generating = runAiSdkGenerateText(
+      createTextRuntimeContext(),
+      [{ role: 'user', content: 'Hello' }],
+      'gpt-4',
+      { apiEndpoint: 'chat' } as any,
+      0.7,
+      16,
+      controller.signal
+    )
+    controller.abort(new Error('owner cancelled'))
+
+    await expect(generating).rejects.toThrow('owner cancelled')
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: controller.signal })
+    )
+  })
+
   it('promotes multiple leading system messages in order for streamText', async () => {
     const events = []
     for await (const event of runAiSdkCoreStream(

--- a/test/main/presenter/llmProviderPresenter/awsBedrockProvider.test.ts
+++ b/test/main/presenter/llmProviderPresenter/awsBedrockProvider.test.ts
@@ -177,4 +177,34 @@ describe('AiSdkProvider aws-bedrock', () => {
     expect(mockBedrockSend).toHaveBeenCalledTimes(1)
     expect(mockRunAiSdkGenerateText).not.toHaveBeenCalled()
   })
+
+  it('propagates owner cancellation to Bedrock and does not report fallback success', async () => {
+    const controller = new AbortController()
+    mockBedrockSend.mockImplementation(
+      (_command: unknown, options?: { abortSignal?: AbortSignal }) =>
+        new Promise((_, reject) => {
+          options?.abortSignal?.addEventListener(
+            'abort',
+            () => reject(options.abortSignal?.reason),
+            { once: true }
+          )
+        })
+    )
+    const provider = new AiSdkProvider(createProvider(), createConfigPresenter())
+    ;(provider as any).isInitialized = true
+    const fallback = vi.spyOn(provider as any, 'mapConfigDbModels')
+
+    const checking = provider.check({ signal: controller.signal })
+    controller.abort(new Error('owner cancelled'))
+
+    await expect(checking).resolves.toEqual({
+      isOk: false,
+      errorMsg: 'owner cancelled'
+    })
+    expect(mockBedrockSend).toHaveBeenCalledWith(expect.anything(), {
+      abortSignal: controller.signal
+    })
+    expect(mockBedrockSend).toHaveBeenCalledOnce()
+    expect(fallback).not.toHaveBeenCalled()
+  })
 })

--- a/test/main/presenter/llmProviderPresenter/basicApiKeyProviders.test.ts
+++ b/test/main/presenter/llmProviderPresenter/basicApiKeyProviders.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { IConfigPresenter, LLM_PROVIDER } from '../../../../src/shared/presenter'
 import { AiSdkProvider } from '../../../../src/main/presenter/llmProviderPresenter/providers/aiSdkProvider'
 import { resolveAiSdkProviderDefinition } from '../../../../src/main/presenter/llmProviderPresenter/providerRegistry'
+import { ApiEndpointType } from '../../../../src/shared/model'
 
 const { mockGetProvider, mockRunAiSdkGenerateText } = vi.hoisted(() => ({
   mockGetProvider: vi.fn(),
@@ -135,6 +136,117 @@ describe('basic API-key provider registrations', () => {
         checkModelId
       })
     }
+  })
+
+  it.each([
+    ['image', 'gpt-image-1', ApiEndpointType.Image],
+    ['video', 'video-model', ApiEndpointType.Video],
+    ['TTS', 'tts-model', ApiEndpointType.AudioSpeech]
+  ])('rejects %s model probes before starting generation', async (_label, modelId, apiEndpoint) => {
+    const configPresenter = createConfigPresenter()
+    vi.mocked(configPresenter.getModelConfig).mockReturnValue({ apiEndpoint } as any)
+    const fetchMock = vi.fn()
+    global.fetch = fetchMock
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: 'openai',
+        name: 'OpenAI',
+        apiType: 'openai',
+        baseUrl: 'https://api.openai.com/v1'
+      }),
+      configPresenter
+    )
+    ;(provider as any).isInitialized = true
+
+    await expect(provider.check({ modelId })).resolves.toEqual({
+      isOk: false,
+      errorMsg: 'Connection testing is not supported for non-chat generation models',
+      code: 'unsupported'
+    })
+    expect(mockRunAiSdkGenerateText).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('propagates the owner signal from generate-text checks into the AI SDK runtime', async () => {
+    const controller = new AbortController()
+    const provider = new AiSdkProvider(createProvider({ id: 'nvidia' }), createConfigPresenter())
+    ;(provider as any).isInitialized = true
+
+    await expect(provider.check({ signal: controller.signal })).resolves.toEqual({
+      isOk: true,
+      errorMsg: null
+    })
+    expect(mockRunAiSdkGenerateText).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      expect.any(Array),
+      'microsoft/phi-4-mini-instruct',
+      expect.any(Object),
+      0.2,
+      16,
+      controller.signal
+    )
+  })
+
+  it.each([
+    '302ai',
+    'cherryin',
+    'deepseek',
+    'modelscope',
+    'openrouter',
+    'ppio',
+    'siliconcloud',
+    'tokenflux'
+  ])('propagates owner cancellation through the %s key-status strategy', async (providerId) => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_, reject) => {
+        const signal = init?.signal as AbortSignal | undefined
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    })
+    global.fetch = fetchMock
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: providerId,
+        apiType: 'openai-completions',
+        baseUrl: 'https://provider.example/v1'
+      }),
+      createConfigPresenter()
+    )
+    ;(provider as any).isInitialized = true
+
+    const checking = provider.check({ signal: controller.signal })
+    controller.abort(new Error('owner cancelled'))
+
+    await expect(checking).resolves.toEqual({ isOk: false, errorMsg: 'owner cancelled' })
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const requestSignal = fetchMock.mock.calls[0][1]?.signal as AbortSignal
+    expect(requestSignal.aborted).toBe(true)
+  })
+
+  it('propagates owner cancellation through HTTP model discovery without fallback', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_, reject) => {
+        const signal = init?.signal as AbortSignal | undefined
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    })
+    global.fetch = fetchMock
+    const provider = new AiSdkProvider(
+      createProvider({
+        id: 'openai',
+        apiType: 'openai',
+        baseUrl: 'https://api.openai.com/v1'
+      }),
+      createConfigPresenter()
+    )
+
+    const checking = provider.check({ signal: controller.signal })
+    controller.abort(new Error('owner cancelled'))
+
+    await expect(checking).resolves.toEqual({ isOk: false, errorMsg: 'owner cancelled' })
+    expect(fetchMock).toHaveBeenCalledOnce()
   })
 
   it('resolves OpenCode Go through its mixed-route provider definition', () => {

--- a/test/main/presenter/llmProviderPresenter/githubCopilotProvider.test.ts
+++ b/test/main/presenter/llmProviderPresenter/githubCopilotProvider.test.ts
@@ -108,6 +108,39 @@ describe('GithubCopilotProvider request timeout', () => {
     )
   })
 
+  it('does not start the API-key fallback after owner cancellation aborts device auth', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const deviceToken = vi.fn(
+      (signal?: AbortSignal) =>
+        new Promise<string>((_, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+        })
+    )
+    const provider = Object.create(GithubCopilotProvider.prototype) as GithubCopilotProvider & {
+      provider: { id: string; name: string; apiKey: string }
+      deviceFlow: { getCopilotToken: typeof deviceToken }
+      copilotToken: string | null
+      tokenExpiresAt: number
+    }
+    provider.provider = {
+      id: 'github-copilot',
+      name: 'GitHub Copilot',
+      apiKey: 'fallback-token'
+    }
+    provider.deviceFlow = { getCopilotToken: deviceToken }
+    provider.copilotToken = null
+    provider.tokenExpiresAt = 0
+
+    const checking = provider.check({ signal: controller.signal })
+    controller.abort(new Error('owner cancelled'))
+
+    await expect(checking).resolves.toEqual({ isOk: false, errorMsg: 'owner cancelled' })
+    expect(deviceToken).toHaveBeenCalledWith(controller.signal)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('refreshes cached auth state when provider config changes', () => {
     const provider = Object.create(GithubCopilotProvider.prototype) as GithubCopilotProvider & {
       provider: Record<string, unknown>

--- a/test/main/presenter/llmProviderPresenter/ollamaProvider.test.ts
+++ b/test/main/presenter/llmProviderPresenter/ollamaProvider.test.ts
@@ -128,6 +128,7 @@ describe('OllamaProvider.fetchModels', () => {
   })
 
   afterEach(() => {
+    vi.unstubAllGlobals()
     if (originalAllowInsecureTls === undefined) {
       delete process.env.DEEPCHAT_ALLOW_INSECURE_TLS
     } else {
@@ -152,6 +153,34 @@ describe('OllamaProvider.fetchModels', () => {
     })
     expect(runtimeContext.providerKind).toBe('openai-compatible')
     expect(runtimeContext.provider.baseUrl).toBe('http://localhost:11434/v1')
+  })
+
+  it('propagates owner cancellation through the Ollama tags request', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_, reject) => {
+        const signal = init?.signal as AbortSignal | undefined
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const ollamaProvider = Object.create(OllamaProvider.prototype) as OllamaProvider & {
+      provider: LLM_PROVIDER
+    }
+    ollamaProvider.provider = provider
+
+    const checking = ollamaProvider.check({ signal: controller.signal })
+    controller.abort(new Error('owner cancelled'))
+
+    await expect(checking).resolves.toEqual({
+      isOk: false,
+      errorMsg: 'Unable to connect to Ollama service: owner cancelled'
+    })
+    expect(fetchMock).toHaveBeenCalledWith('http://127.0.0.1:11434/api/tags', {
+      method: 'GET',
+      signal: controller.signal,
+      headers: undefined
+    })
   })
 
   it('merges local and running models, keeps running-only models, and preserves capabilities', async () => {

--- a/test/main/presenter/llmProviderPresenter/openaiCodexAdapter.test.ts
+++ b/test/main/presenter/llmProviderPresenter/openaiCodexAdapter.test.ts
@@ -177,7 +177,32 @@ describe('OpenAI Codex adapter', () => {
 
     expect(await response.text()).toBe(streamBody)
     expect(vi.mocked(fetch).mock.calls[0][1]?.signal).toBe(controller.signal)
+    expect(authState.getBackendAuth).toHaveBeenCalledWith(controller.signal)
     expect(authState.forceRefreshBackendAuth).not.toHaveBeenCalled()
+  })
+
+  it('does not start a 401 refresh after owner cancellation', async () => {
+    const controller = new AbortController()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async () => {
+        controller.abort(new Error('owner cancelled'))
+        return new Response('unauthorized', { status: 401 })
+      })
+    )
+    authState.getBackendAuth.mockResolvedValueOnce({ accessToken: 'expired-token' })
+
+    const { createOpenAICodexFetch } =
+      await import('../../../../src/main/presenter/llmProviderPresenter/openaiCodexAdapter')
+    const fetcher = createOpenAICodexFetch({})
+
+    await expect(
+      fetcher('https://chatgpt.com/backend-api/codex/responses', {
+        signal: controller.signal
+      })
+    ).rejects.toThrow('owner cancelled')
+    expect(authState.forceRefreshBackendAuth).not.toHaveBeenCalled()
+    expect(vi.mocked(fetch)).toHaveBeenCalledOnce()
   })
 
   it('normalizes Codex entitlement errors to a stable permission error', async () => {

--- a/test/main/presenter/llmProviderPresenter/openaiCodexProvider.test.ts
+++ b/test/main/presenter/llmProviderPresenter/openaiCodexProvider.test.ts
@@ -18,6 +18,32 @@ import type { LLM_PROVIDER } from '../../../../src/shared/presenter'
 const CODEX_5_6_RESOURCE_MODEL_IDS = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra']
 
 describe('OpenAI Codex provider registration', () => {
+  it('pins the production provider capability inventory', () => {
+    const resolved = DEFAULT_PROVIDERS.map((provider) => ({
+      id: provider.id,
+      definition: resolveAiSdkProviderDefinition(provider)
+    }))
+    const aiSdkDefinitions = resolved.filter((entry) => entry.definition)
+    const unresolvedIds = resolved
+      .filter((entry) => !entry.definition)
+      .map((entry) => entry.id)
+      .sort()
+    const strategyCounts = aiSdkDefinitions.reduce<Record<string, number>>((counts, entry) => {
+      const strategy = entry.definition!.checkStrategy
+      counts[strategy] = (counts[strategy] ?? 0) + 1
+      return counts
+    }, {})
+
+    expect(DEFAULT_PROVIDERS).toHaveLength(60)
+    expect(aiSdkDefinitions).toHaveLength(55)
+    expect(strategyCounts).toEqual({
+      'fetch-models': 30,
+      'generate-text': 17,
+      'key-status': 8
+    })
+    expect(unresolvedIds).toEqual(['acp', 'fireworks', 'github-copilot', 'ollama', 'voiceai'])
+  })
+
   it('keeps OpenAI Codex separate from the OpenAI API-key provider', () => {
     const openai = DEFAULT_PROVIDERS.find((provider) => provider.id === 'openai')
     const codex = DEFAULT_PROVIDERS.find((provider) => provider.id === 'openai-codex')

--- a/test/main/presenter/llmProviderPresenter/voiceAIProvider.test.ts
+++ b/test/main/presenter/llmProviderPresenter/voiceAIProvider.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import { VoiceAIProvider } from '../../../../src/main/presenter/llmProviderPresenter/providers/voiceAIProvider'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+it('rejects Voice.ai model probes before starting billable speech generation', async () => {
+  const fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+  const provider = Object.create(VoiceAIProvider.prototype) as VoiceAIProvider & {
+    provider: { id: string; name: string; apiKey: string }
+  }
+  provider.provider = {
+    id: 'voiceai',
+    name: 'Voice.ai',
+    apiKey: 'test-key'
+  }
+
+  await expect(provider.check({ modelId: 'voice-1' })).resolves.toEqual({
+    isOk: false,
+    errorMsg:
+      'Connection testing is not supported for Voice.ai models because it would generate billable audio',
+    code: 'unsupported'
+  })
+  expect(fetchMock).not.toHaveBeenCalled()
+})
+
+it('propagates owner cancellation through the Voice.ai voice-list request', async () => {
+  const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+    return new Promise<Response>((_, reject) => {
+      const signal = init?.signal as AbortSignal | undefined
+      signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+    })
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  const provider = Object.create(VoiceAIProvider.prototype) as VoiceAIProvider & {
+    provider: { id: string; name: string; apiKey: string; baseUrl: string }
+  }
+  provider.provider = {
+    id: 'voiceai',
+    name: 'Voice.ai',
+    apiKey: 'test-key',
+    baseUrl: 'https://dev.voice.ai'
+  }
+  const controller = new AbortController()
+
+  const checking = provider.check({ signal: controller.signal })
+  controller.abort(new Error('owner cancelled'))
+
+  await expect(checking).resolves.toEqual({ isOk: false, errorMsg: 'owner cancelled' })
+  expect(fetchMock).toHaveBeenCalledWith(
+    'https://dev.voice.ai/api/v1/tts/voices',
+    expect.objectContaining({ signal: controller.signal })
+  )
+})

--- a/test/main/presenter/openaiCodexAuth.test.ts
+++ b/test/main/presenter/openaiCodexAuth.test.ts
@@ -152,6 +152,121 @@ describe('OpenAI Codex auth', () => {
     expect(store.load()?.refreshToken).toBe('new-refresh-token')
   })
 
+  it('propagates owner cancellation into an access-token refresh request', async () => {
+    const store = new OpenAICodexCredentialStore(path.join(tempDir, 'cancelled-refresh.json'))
+    store.save({
+      accessToken: 'expired-token',
+      refreshToken: 'refresh-token',
+      tokenType: 'Bearer',
+      expiresAt: Date.now() - 1000,
+      updatedAt: Date.now()
+    })
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_, reject) => {
+        const signal = init?.signal as AbortSignal | undefined
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const auth = new OpenAICodexAuth(store)
+    const controller = new AbortController()
+
+    const refreshing = auth.getBackendAuth(controller.signal)
+    controller.abort(new Error('owner cancelled'))
+
+    await expect(refreshing).rejects.toThrow('owner cancelled')
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect((fetchMock.mock.calls[0][1]?.signal as AbortSignal).aborted).toBe(true)
+  })
+
+  it('closes the abort race between the precheck and listener registration', async () => {
+    const store = new OpenAICodexCredentialStore(path.join(tempDir, 'abort-race.json'))
+    store.save({
+      accessToken: 'expired-token',
+      refreshToken: 'refresh-token',
+      tokenType: 'Bearer',
+      expiresAt: Date.now() - 1000,
+      updatedAt: Date.now()
+    })
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_, reject) => {
+        const signal = init?.signal as AbortSignal | undefined
+        if (signal?.aborted) {
+          reject(signal.reason)
+          return
+        }
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const auth = new OpenAICodexAuth(store)
+    const controller = new AbortController()
+    const originalAddEventListener = controller.signal.addEventListener.bind(controller.signal)
+    vi.spyOn(controller.signal, 'addEventListener').mockImplementation((...args) => {
+      controller.abort(new Error('registration race cancelled'))
+      return originalAddEventListener(...args)
+    })
+
+    await expect(auth.getBackendAuth(controller.signal)).rejects.toThrow(
+      'registration race cancelled'
+    )
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('does not abort a shared token refresh while another waiter still needs it', async () => {
+    const store = new OpenAICodexCredentialStore(path.join(tempDir, 'shared-refresh.json'))
+    store.save({
+      accessToken: 'expired-token',
+      refreshToken: 'refresh-token',
+      tokenType: 'Bearer',
+      expiresAt: Date.now() - 1000,
+      updatedAt: Date.now()
+    })
+    let resolveFetch!: (response: Response) => void
+    let refreshSignal: AbortSignal | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init?: RequestInit) => {
+        refreshSignal = init?.signal as AbortSignal | undefined
+        return new Promise<Response>((resolve) => {
+          resolveFetch = resolve
+        })
+      })
+    )
+    const auth = new OpenAICodexAuth(store)
+    const controller = new AbortController()
+
+    const cancelledWaiter = auth.getBackendAuth(controller.signal)
+    const activeWaiter = auth.getBackendAuth()
+    let cancelledSettled = false
+    void cancelledWaiter.then(
+      () => {
+        cancelledSettled = true
+      },
+      () => {
+        cancelledSettled = true
+      }
+    )
+    controller.abort(new Error('first waiter cancelled'))
+    await Promise.resolve()
+
+    expect(refreshSignal?.aborted).toBe(false)
+    expect(cancelledSettled).toBe(false)
+    resolveFetch(
+      new Response(
+        JSON.stringify({
+          access_token: 'shared-token',
+          refresh_token: 'shared-refresh-token',
+          expires_in: 3600
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+
+    await expect(cancelledWaiter).rejects.toThrow('first waiter cancelled')
+    await expect(activeWaiter).resolves.toMatchObject({ accessToken: 'shared-token' })
+  })
+
   it('opens browser login externally and completes from a pasted callback URL', async () => {
     const store = new OpenAICodexCredentialStore(path.join(tempDir, 'browser.json'))
     const fetchMock = vi.fn().mockResolvedValue(

--- a/test/main/routes/chatService.test.ts
+++ b/test/main/routes/chatService.test.ts
@@ -21,6 +21,7 @@ describe('ChatService', () => {
     sleep: vi.fn(),
     observeIdempotent: vi.fn(async <T>({ task }: { task: () => Promise<T> }) => await task()),
     retryIdempotent: vi.fn(),
+    runCancellable: vi.fn(),
     timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task)
   })
 

--- a/test/main/routes/contracts.test.ts
+++ b/test/main/routes/contracts.test.ts
@@ -1107,6 +1107,17 @@ describe('main kernel contracts', () => {
       })
     ).toThrow()
 
+    const unsupportedProviderResult = {
+      isOk: false,
+      errorMsg: 'Connection probe is unsupported',
+      code: 'unsupported' as const
+    }
+    expect(
+      providersTestConnectionRoute.output.parse(
+        JSON.parse(JSON.stringify(unsupportedProviderResult))
+      )
+    ).toEqual(unsupportedProviderResult)
+
     expect(
       providersListSummariesRoute.output.parse({
         providers: [

--- a/test/main/routes/dispatcher.test.ts
+++ b/test/main/routes/dispatcher.test.ts
@@ -3827,7 +3827,9 @@ describe('dispatchDeepchatRoute', () => {
     )
 
     expect(configPresenter.getProviderModels).toHaveBeenCalledWith('openai')
-    expect(llmProviderPresenter.check).toHaveBeenCalledWith('openai', 'gpt-5.4')
+    expect(llmProviderPresenter.check).toHaveBeenCalledWith('openai', 'gpt-5.4', {
+      signal: expect.any(AbortSignal)
+    })
     expect(llmProviderPresenter.getKeyStatus).toHaveBeenCalledWith('openai')
     expect(llmProviderPresenter.getProviderRateLimitStatus).toHaveBeenCalledWith('openai')
     expect(llmProviderPresenter.updateProviderRateLimit).toHaveBeenCalledWith('openai', true, 2)

--- a/test/main/routes/operationRunner.test.ts
+++ b/test/main/routes/operationRunner.test.ts
@@ -1,4 +1,5 @@
 import {
+  CancellableDeadlineError,
   ObservationDeadlineError,
   OperationRunnerValidationError,
   createNodeOperationRunner
@@ -163,6 +164,172 @@ describe('createNodeOperationRunner', () => {
     expect(task).not.toHaveBeenCalled()
     expect(vi.getTimerCount()).toBe(0)
   })
+
+  it('aborts cancellable work at the deadline and waits for physical settlement', async () => {
+    const runner = createNodeOperationRunner()
+    const task = deferred<string>()
+    let ownerSignal: AbortSignal | undefined
+    let settled = false
+    const running = runner.runCancellable({
+      task: (signal) => {
+        ownerSignal = signal
+        return task.promise
+      },
+      deadlineMs: 10,
+      reason: 'provider-probe'
+    })
+    void running.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(ownerSignal?.aborted).toBe(true)
+    expect(settled).toBe(false)
+
+    task.resolve('late owner result')
+    await expect(running).rejects.toEqual(new CancellableDeadlineError('provider-probe', 10))
+    expect(settled).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('waits for physical settlement after external cancellation', async () => {
+    const runner = createNodeOperationRunner()
+    const controller = new AbortController()
+    const task = deferred<string>()
+    let ownerSignal: AbortSignal | undefined
+    let settled = false
+    const running = runner.runCancellable({
+      task: (signal) => {
+        ownerSignal = signal
+        return task.promise
+      },
+      deadlineMs: 100,
+      reason: 'cancel-provider-probe',
+      signal: controller.signal
+    })
+    void running.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+
+    controller.abort()
+    await Promise.resolve()
+
+    expect(ownerSignal?.aborted).toBe(true)
+    expect(settled).toBe(false)
+
+    task.reject(new Error('owner observed abort'))
+    await expect(running).rejects.toMatchObject({ name: 'AbortError' })
+    expect(settled).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cleans cancellable timer and external abort listener after success', async () => {
+    const runner = createNodeOperationRunner()
+    const controller = new AbortController()
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener')
+
+    await expect(
+      runner.runCancellable({
+        task: async () => 'ok',
+        deadlineMs: 100,
+        reason: 'successful-cancellable',
+        signal: controller.signal
+      })
+    ).resolves.toBe('ok')
+
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function))
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cleans cancellable resources after a synchronous task failure', async () => {
+    const runner = createNodeOperationRunner()
+    const controller = new AbortController()
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener')
+    const expected = new Error('sync provider failure')
+
+    await expect(
+      runner.runCancellable({
+        task: () => {
+          throw expected
+        },
+        deadlineMs: 100,
+        reason: 'sync-cancellable',
+        signal: controller.signal
+      })
+    ).rejects.toBe(expected)
+
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function))
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('maps an abort requested during the task factory only after its result settles', async () => {
+    const runner = createNodeOperationRunner()
+    const controller = new AbortController()
+    const task = vi.fn(async () => {
+      controller.abort()
+      return 'owner settled'
+    })
+
+    await expect(
+      runner.runCancellable({
+        task,
+        deadlineMs: 100,
+        reason: 'abort-during-factory',
+        signal: controller.signal
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(task).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does not start cancellable work for an immediate or pre-aborted deadline', async () => {
+    const runner = createNodeOperationRunner()
+    const task = vi.fn().mockResolvedValue('unused')
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      runner.runCancellable({ task, deadlineMs: 0, reason: 'immediate-cancellable' })
+    ).rejects.toMatchObject({ name: 'CancellableDeadlineError' })
+    await expect(
+      runner.runCancellable({
+        task,
+        deadlineMs: 10,
+        reason: 'pre-aborted-cancellable',
+        signal: controller.signal
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(task).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -1, 1.5, 2_147_483_648])(
+    'rejects invalid cancellable deadline %s before starting work',
+    async (deadlineMs) => {
+      const runner = createNodeOperationRunner()
+      const task = vi.fn().mockResolvedValue('unused')
+
+      await expect(
+        runner.runCancellable({ task, deadlineMs, reason: 'invalid-cancellable' })
+      ).rejects.toBeInstanceOf(OperationRunnerValidationError)
+
+      expect(task).not.toHaveBeenCalled()
+      expect(vi.getTimerCount()).toBe(0)
+    }
+  )
 
   it('waits for a rejected attempt to settle before starting the next attempt', async () => {
     const runner = createNodeOperationRunner()
@@ -441,6 +608,7 @@ describe('createNodeOperationRunner', () => {
     expect(Object.keys(runner).sort()).toEqual([
       'observeIdempotent',
       'retryIdempotent',
+      'runCancellable',
       'sleep',
       'timeout'
     ])

--- a/test/main/routes/providerService.test.ts
+++ b/test/main/routes/providerService.test.ts
@@ -1,10 +1,15 @@
 import { ProviderService } from '@/routes/providers/providerService'
+import { CancellableDeadlineError } from '@/routes/operationRunner'
 
 describe('ProviderService', () => {
   const createScheduler = () => ({
     sleep: vi.fn(),
     observeIdempotent: vi.fn(),
     retryIdempotent: vi.fn(),
+    runCancellable: vi.fn(
+      async <T>({ task }: { task: (signal: AbortSignal) => Promise<T> }) =>
+        await task(new AbortController().signal)
+    ),
     timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task)
   })
 
@@ -93,8 +98,64 @@ describe('ProviderService', () => {
       errorMsg: null
     })
 
-    expect(providerExecutionPort.testConnection).toHaveBeenCalledWith('openai', 'gpt-5.4')
-    expect(scheduler.timeout).toHaveBeenCalledTimes(1)
+    expect(providerExecutionPort.testConnection).toHaveBeenCalledWith('openai', 'gpt-5.4', {
+      signal: expect.any(AbortSignal)
+    })
+    expect(scheduler.runCancellable).toHaveBeenCalledWith({
+      task: expect.any(Function),
+      deadlineMs: 60_000,
+      reason: 'providers.testConnection:openai'
+    })
+    expect(scheduler.timeout).not.toHaveBeenCalled()
     expect(scheduler.retryIdempotent).not.toHaveBeenCalled()
+  })
+
+  it('maps a settled cancellation deadline to the stable route result', async () => {
+    const scheduler = createScheduler()
+    scheduler.runCancellable.mockRejectedValueOnce(
+      new CancellableDeadlineError('providers.testConnection:openai', 60_000)
+    )
+    const service = new ProviderService({
+      providerCatalogPort: {
+        getProviderModels: vi.fn(() => []),
+        getCustomModels: vi.fn(() => [])
+      } as any,
+      providerExecutionPort: {
+        testConnection: vi.fn()
+      },
+      scheduler
+    })
+
+    await expect(service.testConnection({ providerId: 'openai' })).resolves.toEqual({
+      isOk: false,
+      errorMsg: 'Provider connection test timed out after 60000ms',
+      code: 'deadline_exceeded'
+    })
+    expect(scheduler.retryIdempotent).not.toHaveBeenCalled()
+    expect(scheduler.timeout).not.toHaveBeenCalled()
+  })
+
+  it('keeps ordinary provider failures distinct from cancellation and does not retry', async () => {
+    const scheduler = createScheduler()
+    const service = new ProviderService({
+      providerCatalogPort: {
+        getProviderModels: vi.fn(() => []),
+        getCustomModels: vi.fn(() => [])
+      } as any,
+      providerExecutionPort: {
+        testConnection: vi.fn().mockResolvedValue({
+          isOk: false,
+          errorMsg: 'network unavailable'
+        })
+      },
+      scheduler
+    })
+
+    await expect(service.testConnection({ providerId: 'openai' })).resolves.toEqual({
+      isOk: false,
+      errorMsg: 'network unavailable'
+    })
+    expect(scheduler.retryIdempotent).not.toHaveBeenCalled()
+    expect(scheduler.timeout).not.toHaveBeenCalled()
   })
 })

--- a/test/main/routes/sessionService.test.ts
+++ b/test/main/routes/sessionService.test.ts
@@ -50,6 +50,7 @@ const createScheduler = () => ({
       throw new Error('unreachable')
     }
   ),
+  runCancellable: vi.fn(),
   timeout: vi.fn(async <T>({ task }: { task: Promise<T> }) => await task)
 })
 

--- a/test/main/scripts/architectureGuard.test.ts
+++ b/test/main/scripts/architectureGuard.test.ts
@@ -126,7 +126,7 @@ describe.sequential('architecture guard', () => {
     expect(result.stdout).toContain('Architecture guard passed.')
   })
 
-  it('pins the final two legacy calls and the removed retry surface', async () => {
+  it('pins the final legacy call and the removed retry surface', async () => {
     const [guardSource, runnerSource] = await Promise.all([
       readFile(ARCHITECTURE_GUARD_PATH, 'utf8'),
       readFile(OPERATION_RUNNER_PATH, 'utf8')
@@ -142,8 +142,7 @@ describe.sequential('architecture guard', () => {
     )?.[1]
 
     expect(allowlistedCalls).toEqual([
-      ['src/main/routes/sessions/sessionService.ts#createSession#timeout', 1],
-      ['src/main/routes/providers/providerService.ts#testConnection#timeout', 1]
+      ['src/main/routes/sessions/sessionService.ts#createSession#timeout', 1]
     ])
     expect(allowlistBody).not.toContain('#retry')
     expect(runnerInterface).not.toMatch(/^\s*retry(?:<|\s*\()/m)


### PR DESCRIPTION
## Summary

- replace the provider route's 5-second observation-only timeout with a 60-second owner cancellation contract
- add the first production `OperationRunner.runCancellable()` consumer and wait for physical task settlement after cancellation
- propagate the owner signal through AI SDK, AWS Bedrock, GitHub Copilot, OpenAI Codex auth refresh, Ollama, and Voice.ai no-model probes
- return structured `unsupported`, `cancelled`, and `deadline_exceeded` results across the Electron route boundary
- reject ACP model, media generation, Voice.ai model, and Fireworks probes before billable, cache, process, or network side effects
- reduce the legacy timeout allowlist to `SessionService.createSession` only

## Why

Before this change, the route returned after 5 seconds while the presenter could continue a model probe for 60 seconds or longer. That was an observation deadline, not cancellation, so callers could receive a timeout while provider work, authentication refreshes, fallback requests, generation, or quota consumption continued in the background.

The implementation inventory also showed that provider families do not share one cancellation capability. Treating every adapter as cancellable would hide real gaps. This PR therefore propagates a real owner signal only through paths with a provable settlement contract and returns a typed unsupported result for paths that cannot be probed safely.

## Before / after

| Area | Before | After |
| --- | --- | --- |
| Route deadline | returns after 5s, work continues | sends cancel at 60s and returns only after owner task settles |
| Model check | separate 60s `Promise.race` | one owner deadline, one request, no retry |
| HTTP/SDK probes | mixed or missing owner signal | signal reaches supported fetch/SDK/model/auth paths |
| Fallback | could start after a failed/aborted first request | connection checks disable fallback; abort paths never start another request |
| Unsafe probes | could generate media, start ACP prompt work, or fail generically | pre-effect structured `unsupported` result |
| Electron result | custom failures were not stably classifiable | additive serializable `code` field |

## Provider inventory and handling

- 60 built-in providers
  - 55 AI SDK providers: 30 fetch-models, 17 generate-text, 8 key-status
  - Ollama, ACP, Voice.ai, GitHub Copilot
  - Fireworks without a runtime adapter
- AI SDK text/model-list/key-status paths receive the owner signal
- AWS Bedrock passes `abortSignal` to `client.send()` and does not use the provider DB fallback after abort
- GitHub Copilot propagates cancellation through device flow, token fallback, and completion; abort prevents fallback
- OpenAI Codex refresh waiters share work safely: one cancelled waiter does not abort another, while the last cancelled waiter aborts the underlying refresh and waits for settlement
- Ollama no-model checks use cancellable `/api/tags`; Voice.ai no-model checks use cancellable voice-list fetch
- ACP model, AI SDK image/video/TTS, Voice.ai model, and Fireworks checks are intentionally unsupported before side effects

## Impact

- a provider connection test can remain pending after the 60-second cancellation request if an underlying third-party transport ignores its signal; this is intentional because returning early would falsely claim settlement
- unsafe model probes now show an unsupported result instead of attempting billable or non-settleable work
- existing consumers remain compatible because the result `code` is additive and optional
- no provider probe retry was added and no dependency changed

## Automated verification

- independent changed focused: 18 files, 325 passed
- independent supplemental provider focused: 15 passed
- additional adversarial `runCancellable` settlement checks: passed
- `pnpm run typecheck`: passed
- `pnpm run format:check`: passed
- `pnpm run i18n`: passed
- `pnpm run lint`: passed
- `git diff --check`: passed
- independent single-worker full suite: 473 files, 4773 passed, 5 failed, 140 skipped
  - the 5 failures reproduce unchanged on base `07d40527`: long-steer rebudget (1), debug mock plan block (1), Spotlight Pinia setup (3)
  - new failures from this PR: 0

## Manual verification gaps

- transport and SDK fixtures prove signal propagation and Promise settlement, but no real provider accounts or quota were used for AWS, key-status providers, GitHub Copilot, OpenAI Codex, Voice.ai, or Ollama network smoke
- fake timers prove the 60-second deadline contract; no wall-clock 60-second smoke was performed
- unsupported paths prove zero code-side effects, but the settings UI message should still be visually checked with ACP model, media model, Voice.ai model, and Fireworks selections

## Rollback

Revert this PR as one unit. Do not restore only the 5-second wrapper while retaining partial adapter signal changes: that would recreate the mismatch where the route returns before the owner settles. Rollback restores the previous observation-only behavior and its documented background-work risk.

## Out of scope

- session-create durable operation cutover (`SCH-003A/B`)
- fatal process-tree governance and `FTL-002`
- automatic provider retries
