### PR TITLE
fix(agent): accept priority in agent plan item (#1950)

### DIFF
--- a/src/renderer/src/composables/useAgentPlanStatus.ts
+++ b/src/renderer/src/composables/useAgentPlanStatus.ts
@@ -1,7 +1,4 @@
-import {
-  type AgentPlanItem,
-  type AgentPlanStepStatus
-} from '@shared/types/agent-plan'
+import { type AgentPlanItem, type AgentPlanStepStatus } from '@shared/types/agent-plan'
 
 type Translate = (key: string, params?: Record<string, unknown>) => string
 

--- a/src/renderer/src/composables/useAgentPlanStatus.ts
+++ b/src/renderer/src/composables/useAgentPlanStatus.ts
@@ -1,9 +1,6 @@
 import {
-  type AgentPlanDisplayItem,
   type AgentPlanItem,
-  type AgentPlanStepStatus,
-  normalizeAgentPlanEntry as normalizeSharedAgentPlanEntry,
-  normalizeAgentPlanStatus
+  type AgentPlanStepStatus
 } from '@shared/types/agent-plan'
 
 type Translate = (key: string, params?: Record<string, unknown>) => string
@@ -13,23 +10,6 @@ export type AgentPlanStepPresentation = {
   iconClass: string
   badgeClass: string
   textClass: string
-}
-
-export type NormalizedAgentPlanEntry = AgentPlanItem & {
-  priority?: string | null
-}
-
-export function normalizePlanEntry(value: unknown): NormalizedAgentPlanEntry | null {
-  const entry = normalizeSharedAgentPlanEntry(value) as AgentPlanDisplayItem | null
-  if (!entry?.step) {
-    return null
-  }
-
-  return {
-    step: entry.step,
-    status: normalizeAgentPlanStatus(entry.status),
-    ...(entry.priority ? { priority: entry.priority } : {})
-  }
 }
 
 export function resolveStepPresentation(

--- a/src/shared/types/agent-plan.ts
+++ b/src/shared/types/agent-plan.ts
@@ -9,7 +9,8 @@ export const agentPlanItemSchema = z.strictObject({
     .string()
     .transform((value) => value.trim())
     .refine((value) => value.length > 0, 'step must be a non-empty string'),
-  status: agentPlanStepStatusSchema
+  status: agentPlanStepStatusSchema,
+  priority: z.string().nullish()
 })
 
 export type AgentPlanStepStatus = z.infer<typeof agentPlanStepStatusSchema>

--- a/test/main/contracts/zodV4Migration.test.ts
+++ b/test/main/contracts/zodV4Migration.test.ts
@@ -130,6 +130,28 @@ describe('Zod 4 migration contracts', () => {
     expect(parsed.success).toBe(false)
   })
 
+  it('accepts an optional nullable priority field on agent plan items', () => {
+    const withPriority = agentPlanItemSchema.safeParse({
+      step: 'Analyze requirements',
+      status: 'in_progress',
+      priority: 'high'
+    })
+    expect(withPriority.success).toBe(true)
+
+    const withNullPriority = agentPlanItemSchema.safeParse({
+      step: 'Analyze requirements',
+      status: 'in_progress',
+      priority: null
+    })
+    expect(withNullPriority.success).toBe(true)
+
+    const withoutPriority = agentPlanItemSchema.safeParse({
+      step: 'Analyze requirements',
+      status: 'in_progress'
+    })
+    expect(withoutPriority.success).toBe(true)
+  })
+
   it('falls back to content when normalizing blank agent plan steps', () => {
     expect(
       normalizeAgentPlanEntry({


### PR DESCRIPTION
Fix #1950

Since `priority` has already been an valid field in `AgentPlanDisplayItem`, add an optional `priority` in `agentPlanItemSchema`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent plan items now support an optional **priority** value, including cases where it’s set (e.g., “high”) or left unassigned.

* **Bug Fixes**
  * Updated agent plan item validation and type behavior to properly handle the new optional priority field.

* **Tests**
  * Added Zod contract tests confirming priority is accepted as a string, explicitly `null`, or omitted entirely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->