### PR TITLE
fix(acp): support manual health checks

### DIFF
--- a/src/renderer/settings/components/AcpDebugDialog.vue
+++ b/src/renderer/settings/components/AcpDebugDialog.vue
@@ -192,7 +192,6 @@ import { Badge } from '@shadcn/components/ui/badge'
 import { Icon } from '@iconify/vue'
 import type { AcpDebugEventEntry, AcpDebugRequest } from '@shared/presenter'
 import { getRuntimeWebContentsId } from '@api/runtime'
-import { createConfigClient } from '@api/ConfigClient'
 import { createDeviceClient } from '@api/DeviceClient'
 import { createProviderClient } from '@api/ProviderClient'
 import { useToast } from '@/components/use-toast'
@@ -212,7 +211,6 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { toast } = useToast()
-const configClient = createConfigClient()
 const deviceClient = createDeviceClient()
 const providerClient = createProviderClient()
 const uiSettingsStore = useUiSettingsStore()
@@ -600,8 +598,6 @@ const runHealthCheck = async () => {
   debugSessionId.value = ''
   loading.value = true
   try {
-    await configClient.ensureAcpAgentInstalled(props.agentId)
-
     const initializeResult = await providerClient.runAcpDebugAction({
       agentId: props.agentId,
       action: 'initialize',

--- a/test/renderer/components/AcpDebugDialog.test.ts
+++ b/test/renderer/components/AcpDebugDialog.test.ts
@@ -130,6 +130,7 @@ async function setup() {
   return {
     wrapper,
     providerClient,
+    configClient,
     stopDebugEvents,
     emitDebugEvent: (payload: DebugEventPayload) => debugEventListener?.(payload)
   }
@@ -175,5 +176,23 @@ describe('AcpDebugDialog', () => {
 
     wrapper.unmount()
     expect(stopDebugEvents).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs health checks for manual ACP agents without registry installation', async () => {
+    const { wrapper, providerClient, configClient } = await setup()
+    await wrapper.setProps({ agentId: 'manual-acp', agentName: 'Manual ACP' })
+
+    await (wrapper.vm as any).runHealthCheck()
+
+    expect(configClient.ensureAcpAgentInstalled).not.toHaveBeenCalled()
+    expect(providerClient.runAcpDebugAction).toHaveBeenCalledTimes(3)
+    expect(providerClient.runAcpDebugAction).toHaveBeenNthCalledWith(1, {
+      agentId: 'manual-acp',
+      action: 'initialize',
+      payload: {},
+      workdir: undefined
+    })
+
+    wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary

- Remove the registry-only installation precheck from ACP inspector health checks.
- Add regression coverage for manual ACP agents.

## Root cause

The inspector called `config.ensureAcpAgentInstalled` for every ACP agent. That route only accepts registry agent IDs, while the ACP debug runtime already resolves both manual and registry launch specifications.

## Behavior

```text
BEFORE
[Health Check] -> [Registry install] -> [Manual ACP rejected]

AFTER
[Health Check] -> [ACP debug runtime] -> [Manual / Registry ACP]
```

## Validation

- `pnpm exec vitest run test/renderer/components/AcpDebugDialog.test.ts`
- `pnpm run typecheck:web`
- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`

Closes #1949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ACP debug health checks now run successfully for manually configured agents without requiring an installation step.
  * Preserved the existing initialization, session creation, cancellation, state updates, and error handling behavior.
  * Added coverage to verify the updated manual-agent workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->