### PR TITLE
feat(grok): add oauth device login

### DIFF
--- a/docs/features/grok-oauth/plan.md
+++ b/docs/features/grok-oauth/plan.md
@@ -1,0 +1,56 @@
+# Grok OAuth Plan
+
+## Approach
+
+Mirror OpenAI Codex credential isolation and GitHub Copilot device-code UX:
+
+1. Main-process `xaiGrokAuth` module:
+   - OIDC discovery against `https://auth.x.ai`
+   - Device-code request + poll + refresh
+   - Encrypted credential store under userData
+2. Typed routes / events / `OAuthPresenter` methods.
+3. Renderer `GrokOAuth.vue` + `OAuthClient` methods; show on Grok provider settings
+   alongside the existing API-key form.
+4. Runtime auth resolution for `provider.id === 'grok'`:
+   - Prefer refreshed OAuth access token
+   - Fall back to `provider.apiKey`
+   - Inject OAuth credentials only when the resolved API endpoint is a trusted `x.ai` HTTPS URL
+
+## Auth Constants
+
+| Item | Value |
+| --- | --- |
+| Issuer | `https://auth.x.ai` |
+| Discovery | `/.well-known/openid-configuration` |
+| Client ID | public Grok CLI client `b1a00492-073a-47ea-816f-4c329264a828` |
+| Scope | `openid profile email offline_access grok-cli:access api:access` |
+| API base | `https://api.x.ai/v1` |
+
+## Data Flow
+
+```
+Settings UI
+  → oauth.xaiGrok.startDeviceLogin
+  → request device code
+  → open verification URL + show user code
+  → poll token endpoint
+  → credential store (safeStorage/file)
+  → statusChanged event
+
+Chat / models
+  → ensureAccessToken()
+  → Authorization: Bearer <access>
+  → api.x.ai
+```
+
+## Compatibility
+
+- Existing Grok API-key users unchanged.
+- OAuth sign-in does not wipe API key fields.
+- When both exist, OAuth wins until sign-out.
+
+## Test Strategy
+
+- Unit tests for discovery trust checks, device-code poll, refresh, store envelope.
+- Route/presenter wiring covered indirectly via auth module tests.
+- Manual: sign-in with eligible SuperGrok account, list models, chat once, sign-out.

--- a/docs/features/grok-oauth/spec.md
+++ b/docs/features/grok-oauth/spec.md
@@ -1,0 +1,44 @@
+# Grok OAuth (xAI SuperGrok / Premium+)
+
+## User Need
+
+Grok already exists as an API-key provider (`id: grok`). SuperGrok and X Premium+
+users want to sign in with xAI OAuth instead of creating a console API key, and
+use subscription-backed models without storing keys in provider records.
+
+## Goal
+
+Add first-class xAI device-code OAuth to the existing Grok provider while keeping
+the API-key path available as a fallback.
+
+## Acceptance Criteria
+
+- Settings → Grok shows an OAuth login panel for SuperGrok / X Premium+.
+- Login uses OAuth 2.0 device-code against `https://auth.x.ai` (no localhost callback).
+- Tokens are stored outside provider API-key fields (OS safeStorage when available).
+- Access tokens refresh before expiry; concurrent refreshes are coordinated.
+- Chat, model list, image routes, and connection checks use the OAuth bearer when signed in.
+- OAuth bearer tokens are sent only to trusted HTTPS endpoints under `x.ai`.
+- API-key path continues to work when OAuth is signed out or unavailable.
+- Sign-out clears local credentials.
+- Focused unit tests cover device-code exchange, refresh, and credential storage.
+- User-facing strings are i18n keys.
+
+## Constraints
+
+- Reuse DeepChat Presenter + typed route + renderer client patterns (mirror Codex OAuth).
+- Do not store OAuth refresh tokens in `provider.apiKey`.
+- Do not invent a dynamic provider runtime.
+- Public client id/scope follow the shared xAI Grok CLI OAuth client used by open-source clients.
+- xAI may gate OAuth inference by subscription tier; surface errors without leaking tokens.
+
+## Non-Goals
+
+- Separate `xai-oauth` provider id (keep one Grok entry).
+- PKCE loopback browser flow (device-code is the supported remote-friendly path).
+- Billing / subscription management UI.
+- Changing Grok chat transport away from existing OpenAI-compatible routes.
+
+## Open Questions
+
+None remaining for v1.

--- a/docs/features/grok-oauth/tasks.md
+++ b/docs/features/grok-oauth/tasks.md
@@ -1,0 +1,9 @@
+# Grok OAuth Tasks
+
+- [x] Write feature SDD (spec/plan/tasks)
+- [x] Add `xaiGrokAuth` constants, credential store, device-code auth module
+- [x] Shared types, routes, events, OAuthPresenter, route handlers, OAuthClient
+- [x] Inject OAuth bearer into Grok runtime (AI SDK + provider requests)
+- [x] Settings UI (`GrokOAuth.vue`) + i18n keys
+- [x] Unit tests for auth module
+- [x] Run format / i18n / lint / focused tests

--- a/src/main/presenter/llmProviderPresenter/aiSdk/providerFactory.ts
+++ b/src/main/presenter/llmProviderPresenter/aiSdk/providerFactory.ts
@@ -21,6 +21,7 @@ import {
   createOpenAICodexFetch,
   normalizeOpenAICodexBaseUrl
 } from '../openaiCodexAdapter'
+import { createXaiGrokFetch, shouldUseXaiGrokOAuthFetch } from '../xaiGrokAuthAdapter'
 
 export type AiSdkProviderKind =
   | 'openai-compatible'
@@ -586,12 +587,17 @@ export function createAiSdkProviderContext(
       const openAICompatibleBaseUrl = isOllamaProvider(params.provider)
         ? normalizeOllamaOpenAIBaseUrl(baseUrl)
         : baseUrl
+      const useGrokOAuthFetch = shouldUseXaiGrokOAuthFetch(params.provider)
+      const resolvedFetch = useGrokOAuthFetch
+        ? createXaiGrokFetch(params.provider, params.defaultHeaders, fetch)
+        : fetch
+      const resolvedApiKey = params.provider.apiKey || (useGrokOAuthFetch ? 'xai-grok-oauth' : '')
       const provider = createOpenAICompatible({
         name: params.provider.id,
         baseURL: openAICompatibleBaseUrl,
-        apiKey: params.provider.apiKey,
+        apiKey: resolvedApiKey,
         headers: params.defaultHeaders,
-        fetch,
+        fetch: resolvedFetch,
         includeUsage: true
       })
 

--- a/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
+++ b/src/main/presenter/llmProviderPresenter/providers/aiSdkProvider.ts
@@ -48,6 +48,9 @@ import {
 } from '../aiSdk'
 import type { AiSdkProviderKind } from '../aiSdk/providerFactory'
 import { normalizeAzureBaseUrl, normalizeGeminiBaseUrl } from '../aiSdk/providerFactory'
+import { shouldUseXaiGrokOAuthFetch } from '../xaiGrokAuthAdapter'
+import { getGlobalXaiGrokAuth } from '../../xaiGrokAuth'
+import { isTrustedXaiApiEndpoint } from '../../xaiGrokAuth/constants'
 import { proxyConfig } from '../../proxyConfig'
 import type { ProviderMcpRuntimePort } from '../runtimePorts'
 import {
@@ -585,10 +588,22 @@ export class AiSdkProvider extends BaseLLMProvider {
   }
 
   private getRuntimeProvider(decision: RouteDecision): LLM_PROVIDER {
-    return {
+    const base: LLM_PROVIDER = {
       ...this.provider,
       ...decision.providerPatch
     }
+
+    if (shouldUseXaiGrokOAuthFetch(base)) {
+      const oauthToken = getGlobalXaiGrokAuth().peekAccessToken()
+      if (oauthToken) {
+        return {
+          ...base,
+          oauthToken
+        }
+      }
+    }
+
+    return base
   }
 
   private getResolvedModelConfig(modelId: string, modelConfig?: ModelConfig): ModelConfig {
@@ -834,7 +849,6 @@ export class AiSdkProvider extends BaseLLMProvider {
     decision?: RouteDecision
   ): Promise<T> {
     const resolvedDecision = decision ?? { providerKind: this.definition.runtimeKind }
-    const runtimeProvider = this.getRuntimeProvider(resolvedDecision)
     const defaultHeaders = {
       ...this.defaultHeaders,
       ...this.definition.defaultHeadersPatch
@@ -862,13 +876,26 @@ export class AiSdkProvider extends BaseLLMProvider {
     }
 
     try {
+      // Refresh Grok OAuth tokens before model/list requests that use sync headers.
+      const runtimeProvider = this.getRuntimeProvider(resolvedDecision)
+      const useGrokOAuth =
+        shouldUseXaiGrokOAuthFetch(runtimeProvider) && isTrustedXaiApiEndpoint(url)
+      if (useGrokOAuth) {
+        await getGlobalXaiGrokAuth()
+          .ensureAccessToken()
+          .catch(() => null)
+      }
+      const refreshedRuntimeProvider = this.getRuntimeProvider(resolvedDecision)
+      const requestRuntimeProvider = useGrokOAuth
+        ? refreshedRuntimeProvider
+        : { ...refreshedRuntimeProvider, oauthToken: undefined }
       const dispatcher = this.getFetchDispatcher()
       const response = await fetch(url, {
         ...init,
         headers: {
           ...this.getRequestHeaders(
             resolvedDecision,
-            runtimeProvider,
+            requestRuntimeProvider,
             defaultHeaders,
             init.body && !(init.body instanceof FormData) ? 'application/json' : undefined
           ),
@@ -2297,6 +2324,12 @@ export class AiSdkProvider extends BaseLLMProvider {
   private validateCredentials(strategy: AiSdkCredentialStrategy): string | null {
     switch (strategy) {
       case 'api-key':
+        if (shouldUseXaiGrokOAuthFetch(this.provider)) {
+          if (this.provider.apiKey || getGlobalXaiGrokAuth().isAuthenticated()) {
+            return null
+          }
+          return 'Missing API key or xAI Grok OAuth sign-in'
+        }
         return this.provider.apiKey ? null : 'Missing API key'
       case 'anthropic':
         return this.provider.apiKey || process.env.ANTHROPIC_API_KEY ? null : 'Missing API key'

--- a/src/main/presenter/llmProviderPresenter/xaiGrokAuthAdapter.ts
+++ b/src/main/presenter/llmProviderPresenter/xaiGrokAuthAdapter.ts
@@ -1,0 +1,110 @@
+import { ProxyAgent } from 'undici'
+import { proxyConfig } from '../proxyConfig'
+import { getGlobalXaiGrokAuth } from '../xaiGrokAuth'
+import {
+  XAI_GROK_API_BASE_URL,
+  XAI_GROK_PROVIDER_ID,
+  isTrustedXaiApiEndpoint
+} from '../xaiGrokAuth/constants'
+import type { LLM_PROVIDER } from '@shared/presenter'
+
+type FetchInitWithDispatcher = RequestInit & { dispatcher?: ProxyAgent }
+
+function applyBearerHeaders(
+  headersInit: HeadersInit | undefined,
+  defaultHeaders: Record<string, string>,
+  accessToken: string
+): Headers {
+  const headers = new Headers(headersInit ?? {})
+  Object.entries(defaultHeaders).forEach(([key, value]) => headers.set(key, value))
+  headers.set('Authorization', `Bearer ${accessToken}`)
+  return headers
+}
+
+/**
+ * Custom fetch for the Grok provider that prefers refreshed OAuth access tokens
+ * and falls back to the configured API key.
+ */
+export function createXaiGrokFetch(
+  provider: LLM_PROVIDER,
+  defaultHeaders: Record<string, string>,
+  baseFetch?: (url: string | URL | Request, init?: RequestInit) => Promise<Response>
+) {
+  let currentProxyUrl: string | null = null
+  let proxyAgent: ProxyAgent | undefined
+  const underlyingFetch = baseFetch ?? fetch
+
+  const closeProxyAgent = () => {
+    if (proxyAgent) {
+      void proxyAgent.close().catch(() => undefined)
+    }
+    proxyAgent = undefined
+    currentProxyUrl = null
+  }
+
+  const getDispatcher = () => {
+    const proxyUrl = proxyConfig.getProxyUrl()
+    if (!proxyUrl) {
+      closeProxyAgent()
+      return undefined
+    }
+
+    if (currentProxyUrl !== proxyUrl || !proxyAgent) {
+      closeProxyAgent()
+      proxyAgent = new ProxyAgent(proxyUrl)
+      currentProxyUrl = proxyUrl
+    }
+
+    return proxyAgent
+  }
+
+  return async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const requestUrl = url instanceof Request ? url.url : url.toString()
+    if (!isTrustedXaiApiEndpoint(requestUrl)) {
+      throw new Error('Refusing to send xAI credentials to an untrusted API endpoint')
+    }
+
+    const auth = getGlobalXaiGrokAuth()
+    const oauthToken = await auth.ensureAccessToken().catch(() => null)
+    const accessToken = oauthToken || provider.apiKey?.trim() || ''
+    if (!accessToken) {
+      throw new Error('Grok requires xAI OAuth sign-in or an API key')
+    }
+
+    const dispatcher = getDispatcher()
+    const nextInit: FetchInitWithDispatcher = {
+      ...init,
+      headers: applyBearerHeaders(init?.headers, defaultHeaders, accessToken)
+    }
+
+    if (dispatcher) {
+      nextInit.dispatcher = dispatcher
+    }
+
+    let response = await underlyingFetch(url, nextInit)
+    if (response.status !== 401 || !oauthToken) {
+      return response
+    }
+
+    // OAuth token may have been revoked mid-session; force refresh once.
+    try {
+      const refreshed = await auth.forceRefreshAccessToken()
+      if (!refreshed || refreshed === accessToken) {
+        return response
+      }
+      return underlyingFetch(url, {
+        ...nextInit,
+        headers: applyBearerHeaders(init?.headers, defaultHeaders, refreshed)
+      })
+    } catch {
+      return response
+    }
+  }
+}
+
+export function shouldUseXaiGrokOAuthFetch(provider: LLM_PROVIDER): boolean {
+  return (
+    provider.id === XAI_GROK_PROVIDER_ID &&
+    isTrustedXaiApiEndpoint(provider.baseUrl || XAI_GROK_API_BASE_URL)
+  )
+}

--- a/src/main/presenter/oauthPresenter.ts
+++ b/src/main/presenter/oauthPresenter.ts
@@ -6,8 +6,10 @@ import { URL } from 'url'
 import { createGitHubCopilotOAuth } from './githubCopilotOAuth'
 import { getGlobalGitHubCopilotDeviceFlow } from './githubCopilotDeviceFlow'
 import { getGlobalOpenAICodexAuth } from './openaiCodexAuth'
+import { getGlobalXaiGrokAuth } from './xaiGrokAuth'
 import { eventBus } from '@/eventbus'
 import type { OpenAICodexAuthStatus } from '@shared/types/openai-codex'
+import type { XaiGrokAuthStatus } from '@shared/types/xai-grok'
 
 export interface OAuthConfig {
   authUrl: string
@@ -107,6 +109,22 @@ export class OAuthPresenter {
 
   async logoutOpenAICodex(): Promise<OpenAICodexAuthStatus> {
     return getGlobalOpenAICodexAuth().logout()
+  }
+
+  async getXaiGrokStatus(): Promise<XaiGrokAuthStatus> {
+    return getGlobalXaiGrokAuth().getStatus()
+  }
+
+  async startXaiGrokDeviceLogin(): Promise<XaiGrokAuthStatus> {
+    return getGlobalXaiGrokAuth().startDeviceLogin()
+  }
+
+  async cancelXaiGrokLogin(): Promise<XaiGrokAuthStatus> {
+    return getGlobalXaiGrokAuth().cancelLogin()
+  }
+
+  async logoutXaiGrok(): Promise<XaiGrokAuthStatus> {
+    return getGlobalXaiGrokAuth().logout()
   }
 
   /**

--- a/src/main/presenter/xaiGrokAuth/constants.ts
+++ b/src/main/presenter/xaiGrokAuth/constants.ts
@@ -1,0 +1,93 @@
+export const XAI_GROK_PROVIDER_ID = 'grok'
+
+const DEFAULT_ISSUER = 'https://auth.x.ai'
+const DEFAULT_API_BASE_URL = 'https://api.x.ai/v1'
+
+function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, '')
+}
+
+function getBooleanEnv(name: string): boolean {
+  const value = process.env[name]?.trim().toLowerCase()
+  return value === '1' || value === 'true' || value === 'yes'
+}
+
+function getNumberEnv(name: string, fallback: number): number {
+  const value = Number(process.env[name])
+  return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+export const XAI_GROK_OAUTH_CLIENT_ID =
+  process.env.XAI_GROK_OAUTH_CLIENT_ID?.trim() || 'b1a00492-073a-47ea-816f-4c329264a828'
+
+export const XAI_GROK_OAUTH_ISSUER = normalizeBaseUrl(
+  process.env.XAI_GROK_OAUTH_ISSUER || DEFAULT_ISSUER
+)
+
+export const XAI_GROK_OAUTH_DISCOVERY_URL =
+  process.env.XAI_GROK_OAUTH_DISCOVERY_URL?.trim() ||
+  `${XAI_GROK_OAUTH_ISSUER}/.well-known/openid-configuration`
+
+export const XAI_GROK_OAUTH_SCOPE =
+  process.env.XAI_GROK_OAUTH_SCOPE?.trim() ||
+  'openid profile email offline_access grok-cli:access api:access'
+
+export const XAI_GROK_API_BASE_URL = normalizeBaseUrl(
+  process.env.XAI_GROK_API_BASE_URL || DEFAULT_API_BASE_URL
+)
+
+export const XAI_GROK_DEVICE_CODE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
+
+export const XAI_GROK_OAUTH_USER_AGENT =
+  process.env.XAI_GROK_OAUTH_USER_AGENT?.trim() || 'DeepChat/xai-grok-oauth'
+
+// Access tokens are short-lived (~6h). Refresh up to one hour early so chat/cron
+// workloads that touch Grok infrequently stay warm.
+export const XAI_GROK_TOKEN_REFRESH_SKEW_MS = getNumberEnv(
+  'XAI_GROK_TOKEN_REFRESH_SKEW_MS',
+  60 * 60 * 1000
+)
+
+export const XAI_GROK_AUTH_REQUEST_TIMEOUT_MS = getNumberEnv(
+  'XAI_GROK_AUTH_REQUEST_TIMEOUT_MS',
+  30 * 1000
+)
+
+export const XAI_GROK_DEVICE_CODE_DEFAULT_INTERVAL_MS = getNumberEnv(
+  'XAI_GROK_DEVICE_CODE_DEFAULT_INTERVAL_MS',
+  5 * 1000
+)
+
+export const XAI_GROK_DEVICE_CODE_MIN_INTERVAL_MS = 1000
+export const XAI_GROK_DEVICE_CODE_SLOW_DOWN_INCREMENT_MS = 5 * 1000
+
+export const XAI_GROK_ACCESS_TOKEN_ENV =
+  process.env.XAI_GROK_ACCESS_TOKEN?.trim() || process.env.XAI_ACCESS_TOKEN?.trim() || ''
+
+export function isXaiGrokOAuthDisabled(): boolean {
+  return (
+    getBooleanEnv('DEEPCHAT_XAI_GROK_OAUTH_DISABLED') ||
+    getBooleanEnv('XAI_GROK_OAUTH_DISABLED') ||
+    getBooleanEnv('DEEPCHAT_GROK_OAUTH_DISABLED')
+  )
+}
+
+export function isTrustedXaiOAuthEndpoint(endpoint: string): boolean {
+  return isTrustedXaiEndpoint(endpoint)
+}
+
+export function isTrustedXaiApiEndpoint(endpoint: string): boolean {
+  return isTrustedXaiEndpoint(endpoint)
+}
+
+function isTrustedXaiEndpoint(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint)
+    if (url.protocol !== 'https:') {
+      return false
+    }
+    return url.hostname === 'x.ai' || url.hostname.endsWith('.x.ai')
+  } catch {
+    return false
+  }
+}

--- a/src/main/presenter/xaiGrokAuth/credentialStore.ts
+++ b/src/main/presenter/xaiGrokAuth/credentialStore.ts
@@ -1,0 +1,128 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { app, safeStorage } from 'electron'
+
+export type XaiGrokCredentialStorage = 'safeStorage' | 'file' | 'none'
+
+export interface XaiGrokTokenSet {
+  accessToken: string
+  refreshToken?: string
+  idToken?: string
+  tokenType: string
+  expiresAt: number
+  accountId?: string
+  accountLabel?: string
+  tokenEndpoint?: string
+  deviceAuthorizationEndpoint?: string
+  updatedAt: number
+}
+
+type StoredCredentialEnvelope =
+  | {
+      version: 1
+      storage: 'safeStorage'
+      wrapped: string
+      updatedAt: number
+    }
+  | {
+      version: 1
+      storage: 'file'
+      tokens: XaiGrokTokenSet
+      updatedAt: number
+    }
+
+export class XaiGrokCredentialStore {
+  private readonly filePath: string
+
+  constructor(filePath?: string) {
+    this.filePath =
+      filePath || path.join(app.getPath('userData'), 'xai-grok-auth', 'credentials.json')
+  }
+
+  getStorageState(): XaiGrokCredentialStorage {
+    try {
+      return safeStorage.isEncryptionAvailable() ? 'safeStorage' : 'file'
+    } catch {
+      return 'file'
+    }
+  }
+
+  load(): XaiGrokTokenSet | null {
+    try {
+      if (!fs.existsSync(this.filePath)) {
+        return null
+      }
+
+      const envelope = JSON.parse(fs.readFileSync(this.filePath, 'utf-8')) as
+        | StoredCredentialEnvelope
+        | undefined
+
+      if (!envelope || envelope.version !== 1) {
+        return null
+      }
+
+      if (envelope.storage === 'file') {
+        return this.normalizeTokens(envelope.tokens)
+      }
+
+      const raw = safeStorage.decryptString(Buffer.from(envelope.wrapped, 'base64'))
+      return this.normalizeTokens(JSON.parse(raw) as XaiGrokTokenSet)
+    } catch {
+      return null
+    }
+  }
+
+  save(tokens: XaiGrokTokenSet): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true, mode: 0o700 })
+    const normalized = this.normalizeTokens(tokens)
+    if (!normalized) {
+      throw new Error('Invalid xAI Grok token payload')
+    }
+
+    const now = Date.now()
+    const envelope: StoredCredentialEnvelope =
+      this.getStorageState() === 'safeStorage'
+        ? {
+            version: 1,
+            storage: 'safeStorage',
+            wrapped: safeStorage.encryptString(JSON.stringify(normalized)).toString('base64'),
+            updatedAt: now
+          }
+        : {
+            version: 1,
+            storage: 'file',
+            tokens: normalized,
+            updatedAt: now
+          }
+
+    fs.writeFileSync(this.filePath, JSON.stringify(envelope, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600
+    })
+  }
+
+  clear(): void {
+    try {
+      fs.rmSync(this.filePath, { force: true })
+    } catch {}
+  }
+
+  private normalizeTokens(tokens: XaiGrokTokenSet | undefined): XaiGrokTokenSet | null {
+    if (!tokens?.accessToken || typeof tokens.accessToken !== 'string') {
+      return null
+    }
+
+    return {
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      idToken: tokens.idToken,
+      tokenType: tokens.tokenType || 'Bearer',
+      expiresAt: Number.isFinite(tokens.expiresAt) ? tokens.expiresAt : 0,
+      accountId: tokens.accountId,
+      accountLabel: tokens.accountLabel,
+      tokenEndpoint: tokens.tokenEndpoint,
+      deviceAuthorizationEndpoint: tokens.deviceAuthorizationEndpoint,
+      updatedAt: Number.isFinite(tokens.updatedAt) ? tokens.updatedAt : Date.now()
+    }
+  }
+}

--- a/src/main/presenter/xaiGrokAuth/index.ts
+++ b/src/main/presenter/xaiGrokAuth/index.ts
@@ -1,0 +1,744 @@
+import logger from '@shared/logger'
+import { shell } from 'electron'
+import { publishDeepchatEvent } from '@/routes/publishDeepchatEvent'
+import type { XaiGrokAuthStatus } from '@shared/types/xai-grok'
+import {
+  XAI_GROK_ACCESS_TOKEN_ENV,
+  XAI_GROK_AUTH_REQUEST_TIMEOUT_MS,
+  XAI_GROK_DEVICE_CODE_DEFAULT_INTERVAL_MS,
+  XAI_GROK_DEVICE_CODE_GRANT_TYPE,
+  XAI_GROK_DEVICE_CODE_MIN_INTERVAL_MS,
+  XAI_GROK_DEVICE_CODE_SLOW_DOWN_INCREMENT_MS,
+  XAI_GROK_OAUTH_CLIENT_ID,
+  XAI_GROK_OAUTH_DISCOVERY_URL,
+  XAI_GROK_OAUTH_SCOPE,
+  XAI_GROK_OAUTH_USER_AGENT,
+  XAI_GROK_TOKEN_REFRESH_SKEW_MS,
+  isTrustedXaiOAuthEndpoint,
+  isXaiGrokOAuthDisabled
+} from './constants'
+import { XaiGrokCredentialStore, type XaiGrokTokenSet } from './credentialStore'
+
+type TokenResponse = Record<string, unknown>
+
+type DiscoveryEndpoints = {
+  deviceAuthorizationEndpoint: string
+  tokenEndpoint: string
+  revocationEndpoint?: string
+}
+
+type DeviceCodeResponse = {
+  deviceCode: string
+  userCode: string
+  verificationUri: string
+  verificationUriComplete?: string
+  expiresInMs: number
+  intervalMs: number
+}
+
+type PendingDeviceFlow = {
+  cancelled: boolean
+  abortController: AbortController
+  userCode: string
+  verificationUri: string
+  verificationUriComplete?: string
+  flowPromise?: Promise<void>
+}
+
+let globalXaiGrokAuth: XaiGrokAuth | null = null
+
+function toStringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function toNumberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function sanitizeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  return message
+    .replace(/access_token["\s:=]+[^"'\s,}]+/gi, 'access_token:[redacted]')
+    .replace(/refresh_token["\s:=]+[^"'\s,}]+/gi, 'refresh_token:[redacted]')
+    .replace(/Bearer\s+[A-Za-z0-9._~+/-]+/g, 'Bearer [redacted]')
+}
+
+function decodeJwtPayload(token: string | undefined): Record<string, unknown> {
+  if (!token) {
+    return {}
+  }
+
+  const parts = token.split('.')
+  if (parts.length < 2) {
+    return {}
+  }
+
+  try {
+    const normalized = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=')
+    return JSON.parse(Buffer.from(padded, 'base64').toString('utf-8')) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+function maskAccountId(accountId: string | undefined): string | undefined {
+  if (!accountId) {
+    return undefined
+  }
+
+  if (accountId.length <= 8) {
+    return accountId
+  }
+
+  return `${accountId.slice(0, 4)}...${accountId.slice(-4)}`
+}
+
+function requireTrustedEndpoint(endpoint: string, label: string): string {
+  if (!isTrustedXaiOAuthEndpoint(endpoint)) {
+    throw new Error(`xAI OAuth discovery returned untrusted ${label}`)
+  }
+  return endpoint
+}
+
+function secondsToMs(value: unknown, fallbackMs: number): number {
+  const seconds = toNumberValue(value)
+  if (!seconds || seconds <= 0) {
+    return fallbackMs
+  }
+  return Math.min(seconds * 1000, Number.MAX_SAFE_INTEGER)
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    const text = await response.text()
+    if (!text.trim()) {
+      return `${response.status} ${response.statusText}`
+    }
+    return text.slice(0, 1000)
+  } catch {
+    return `${response.status} ${response.statusText}`
+  }
+}
+
+function toFormBody(params: Record<string, string | undefined>): URLSearchParams {
+  const body = new URLSearchParams()
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) {
+      body.set(key, value)
+    }
+  })
+  return body
+}
+
+export class XaiGrokAuth {
+  private readonly store: XaiGrokCredentialStore
+  private pendingDeviceFlow: PendingDeviceFlow | null = null
+  private refreshPromise: Promise<XaiGrokTokenSet> | null = null
+  private lastError: string | null = null
+  private cachedDiscovery: DiscoveryEndpoints | null = null
+
+  constructor(store = new XaiGrokCredentialStore()) {
+    this.store = store
+  }
+
+  getStatus(): XaiGrokAuthStatus {
+    if (isXaiGrokOAuthDisabled()) {
+      return this.withStorage({
+        state: 'disabled',
+        authenticated: false
+      })
+    }
+
+    if (this.pendingDeviceFlow && !this.pendingDeviceFlow.cancelled) {
+      return this.withStorage({
+        state: 'pending-device',
+        authenticated: false,
+        userCode: this.pendingDeviceFlow.userCode,
+        verificationUri: this.pendingDeviceFlow.verificationUri,
+        verificationUriComplete: this.pendingDeviceFlow.verificationUriComplete,
+        ...(this.lastError ? { error: this.lastError } : {})
+      })
+    }
+
+    const tokens = this.store.load()
+    if (tokens) {
+      return this.statusFromTokens(tokens)
+    }
+
+    return this.withStorage({
+      state: this.lastError ? 'error' : 'signed-out',
+      authenticated: false,
+      ...(this.lastError ? { error: this.lastError } : {})
+    })
+  }
+
+  isAuthenticated(): boolean {
+    return this.getStatus().authenticated
+  }
+
+  /**
+   * Returns a non-expired cached access token without network I/O.
+   * Prefer ensureAccessToken() when a network refresh is acceptable.
+   */
+  peekAccessToken(): string | null {
+    if (XAI_GROK_ACCESS_TOKEN_ENV) {
+      return XAI_GROK_ACCESS_TOKEN_ENV
+    }
+
+    const tokens = this.store.load()
+    if (!tokens) {
+      return null
+    }
+
+    if (tokens.expiresAt > Date.now() + XAI_GROK_TOKEN_REFRESH_SKEW_MS) {
+      return tokens.accessToken
+    }
+
+    // Still return near-expiry tokens for sync header paths; ensureAccessToken
+    // will refresh on the next async entry point. Never return an expired token,
+    // so API-key fallback remains available if refresh fails.
+    return tokens.expiresAt > Date.now() ? tokens.accessToken : null
+  }
+
+  async startDeviceLogin(): Promise<XaiGrokAuthStatus> {
+    this.assertEnabled()
+    this.cancelLogin()
+    this.lastError = null
+
+    const abortController = new AbortController()
+
+    try {
+      const discovery = await this.fetchDiscovery(abortController.signal)
+      const deviceCode = await this.requestDeviceCode(
+        discovery.deviceAuthorizationEndpoint,
+        abortController.signal
+      )
+
+      const flow: PendingDeviceFlow = {
+        cancelled: false,
+        abortController,
+        userCode: deviceCode.userCode,
+        verificationUri: deviceCode.verificationUri,
+        verificationUriComplete: deviceCode.verificationUriComplete
+      }
+      this.pendingDeviceFlow = flow
+
+      const browserUrl = deviceCode.verificationUriComplete || deviceCode.verificationUri
+      try {
+        await shell.openExternal(browserUrl)
+      } catch (error) {
+        logger.warn('[xAI Grok OAuth] Failed to open browser:', sanitizeError(error))
+      }
+
+      flow.flowPromise = this.completeDeviceLogin(flow, discovery, deviceCode)
+      this.publishStatusChanged()
+      return this.getStatus()
+    } catch (error) {
+      this.lastError = sanitizeError(error)
+      this.pendingDeviceFlow = null
+      this.publishStatusChanged()
+      return this.getStatus()
+    }
+  }
+
+  cancelLogin(): XaiGrokAuthStatus {
+    if (this.pendingDeviceFlow) {
+      this.pendingDeviceFlow.cancelled = true
+      this.pendingDeviceFlow.abortController.abort()
+      this.pendingDeviceFlow = null
+    }
+    this.publishStatusChanged()
+    return this.getStatus()
+  }
+
+  async logout(): Promise<XaiGrokAuthStatus> {
+    const tokens = this.store.load()
+    this.cancelLogin()
+    this.store.clear()
+    this.lastError = null
+
+    if (tokens?.refreshToken || tokens?.accessToken) {
+      try {
+        const discovery = await this.fetchDiscovery()
+        if (discovery.revocationEndpoint) {
+          await this.postForm(
+            discovery.revocationEndpoint,
+            {
+              token: tokens.refreshToken || tokens.accessToken,
+              client_id: XAI_GROK_OAUTH_CLIENT_ID
+            },
+            false
+          )
+        }
+      } catch (error) {
+        logger.warn('[xAI Grok OAuth] Token revoke failed:', sanitizeError(error))
+      }
+    }
+
+    this.publishStatusChanged()
+    return this.getStatus()
+  }
+
+  async ensureAccessToken(): Promise<string | null> {
+    if (isXaiGrokOAuthDisabled()) {
+      return null
+    }
+
+    if (XAI_GROK_ACCESS_TOKEN_ENV) {
+      return XAI_GROK_ACCESS_TOKEN_ENV
+    }
+
+    const tokens = this.store.load()
+    if (!tokens) {
+      return null
+    }
+
+    try {
+      const current =
+        tokens.expiresAt > Date.now() + XAI_GROK_TOKEN_REFRESH_SKEW_MS
+          ? tokens
+          : await this.refreshAccessToken(tokens)
+      return current.accessToken
+    } catch (error) {
+      this.lastError = sanitizeError(error)
+      this.publishStatusChanged()
+      throw error
+    }
+  }
+
+  async getAccessToken(): Promise<string> {
+    const token = await this.ensureAccessToken()
+    if (!token) {
+      throw new Error('xAI Grok OAuth sign-in is required')
+    }
+    return token
+  }
+
+  async forceRefreshAccessToken(): Promise<string> {
+    this.assertEnabled()
+    const tokens = this.store.load()
+    if (!tokens?.refreshToken) {
+      throw new Error('xAI Grok OAuth refresh token is unavailable')
+    }
+    const refreshed = await this.refreshAccessToken(tokens, true)
+    return refreshed.accessToken
+  }
+
+  private withStorage(status: Omit<XaiGrokAuthStatus, 'storage'>): XaiGrokAuthStatus {
+    return {
+      ...status,
+      storage: this.store.getStorageState()
+    }
+  }
+
+  private statusFromTokens(tokens: XaiGrokTokenSet): XaiGrokAuthStatus {
+    return this.withStorage({
+      state: 'authenticated',
+      authenticated: true,
+      accountId: maskAccountId(tokens.accountId),
+      accountLabel: tokens.accountLabel,
+      expiresAt: tokens.expiresAt
+    })
+  }
+
+  private assertEnabled(): void {
+    if (isXaiGrokOAuthDisabled()) {
+      throw new Error('xAI Grok OAuth is disabled by environment')
+    }
+  }
+
+  private async completeDeviceLogin(
+    flow: PendingDeviceFlow,
+    discovery: DiscoveryEndpoints,
+    deviceCode: DeviceCodeResponse
+  ): Promise<void> {
+    try {
+      const tokens = await this.pollDeviceCodeToken(
+        discovery.tokenEndpoint,
+        deviceCode,
+        flow.abortController.signal
+      )
+      if (flow.cancelled || this.pendingDeviceFlow !== flow) {
+        return
+      }
+
+      const tokenSet = this.parseTokenResponse(tokens, undefined, {
+        tokenEndpoint: discovery.tokenEndpoint,
+        deviceAuthorizationEndpoint: discovery.deviceAuthorizationEndpoint
+      })
+      this.store.save(tokenSet)
+      this.lastError = null
+      this.pendingDeviceFlow = null
+      this.publishStatusChanged()
+    } catch (error) {
+      if (flow.cancelled || this.pendingDeviceFlow !== flow) {
+        return
+      }
+
+      this.lastError = sanitizeError(error)
+      this.pendingDeviceFlow = null
+      this.publishStatusChanged()
+    }
+  }
+
+  private async fetchDiscovery(signal?: AbortSignal): Promise<DiscoveryEndpoints> {
+    if (this.cachedDiscovery) {
+      return this.cachedDiscovery
+    }
+
+    const response = await this.fetchWithTimeout(
+      XAI_GROK_OAUTH_DISCOVERY_URL,
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': XAI_GROK_OAUTH_USER_AGENT
+        }
+      },
+      signal
+    )
+
+    if (!response.ok) {
+      throw new Error(`xAI OAuth discovery failed: ${await readErrorBody(response)}`)
+    }
+
+    const payload = (await response.json()) as TokenResponse
+    const deviceAuthorizationEndpoint = toStringValue(payload.device_authorization_endpoint)
+    const tokenEndpoint = toStringValue(payload.token_endpoint)
+    if (!deviceAuthorizationEndpoint || !tokenEndpoint) {
+      throw new Error('xAI OAuth discovery response is missing device code endpoints')
+    }
+
+    const discovery: DiscoveryEndpoints = {
+      deviceAuthorizationEndpoint: requireTrustedEndpoint(
+        deviceAuthorizationEndpoint,
+        'device authorization endpoint'
+      ),
+      tokenEndpoint: requireTrustedEndpoint(tokenEndpoint, 'token endpoint'),
+      ...(toStringValue(payload.revocation_endpoint)
+        ? {
+            revocationEndpoint: requireTrustedEndpoint(
+              toStringValue(payload.revocation_endpoint)!,
+              'revocation endpoint'
+            )
+          }
+        : {})
+    }
+    this.cachedDiscovery = discovery
+    return discovery
+  }
+
+  private async requestDeviceCode(
+    deviceAuthorizationEndpoint: string,
+    signal?: AbortSignal
+  ): Promise<DeviceCodeResponse> {
+    const response = await this.fetchWithTimeout(
+      requireTrustedEndpoint(deviceAuthorizationEndpoint, 'device authorization endpoint'),
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'User-Agent': XAI_GROK_OAUTH_USER_AGENT
+        },
+        body: toFormBody({
+          client_id: XAI_GROK_OAUTH_CLIENT_ID,
+          scope: XAI_GROK_OAUTH_SCOPE
+        })
+      },
+      signal
+    )
+
+    if (!response.ok) {
+      throw new Error(`xAI device code request failed: ${await readErrorBody(response)}`)
+    }
+
+    const payload = (await response.json()) as TokenResponse
+    const deviceCode = toStringValue(payload.device_code)
+    const userCode = toStringValue(payload.user_code)
+    const verificationUri = toStringValue(payload.verification_uri)
+    if (!deviceCode || !userCode || !verificationUri) {
+      throw new Error(
+        'xAI device code response is missing device_code, user_code, or verification_uri'
+      )
+    }
+
+    const verificationUriComplete = toStringValue(payload.verification_uri_complete)
+
+    return {
+      deviceCode,
+      userCode,
+      verificationUri: requireTrustedEndpoint(verificationUri, 'device verification URI'),
+      ...(verificationUriComplete
+        ? {
+            verificationUriComplete: requireTrustedEndpoint(
+              verificationUriComplete,
+              'complete device verification URI'
+            )
+          }
+        : {}),
+      expiresInMs: secondsToMs(payload.expires_in, 10 * 60 * 1000),
+      intervalMs: secondsToMs(payload.interval, XAI_GROK_DEVICE_CODE_DEFAULT_INTERVAL_MS)
+    }
+  }
+
+  private async pollDeviceCodeToken(
+    tokenEndpoint: string,
+    deviceCode: DeviceCodeResponse,
+    signal?: AbortSignal
+  ): Promise<TokenResponse> {
+    const deadlineMs = Date.now() + deviceCode.expiresInMs
+    let intervalMs = deviceCode.intervalMs
+
+    while (Date.now() < deadlineMs) {
+      if (signal?.aborted) {
+        throw new Error('xAI Grok OAuth login cancelled')
+      }
+
+      const response = await this.fetchWithTimeout(
+        requireTrustedEndpoint(tokenEndpoint, 'token endpoint'),
+        {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'User-Agent': XAI_GROK_OAUTH_USER_AGENT
+          },
+          body: toFormBody({
+            grant_type: XAI_GROK_DEVICE_CODE_GRANT_TYPE,
+            client_id: XAI_GROK_OAUTH_CLIENT_ID,
+            device_code: deviceCode.deviceCode
+          })
+        },
+        signal
+      )
+
+      let payload: TokenResponse = {}
+      try {
+        payload = (await response.json()) as TokenResponse
+      } catch {
+        payload = {}
+      }
+
+      if (response.ok) {
+        return payload
+      }
+
+      const error = toStringValue(payload.error)
+      if (error === 'authorization_pending') {
+        await this.sleep(Math.max(intervalMs, XAI_GROK_DEVICE_CODE_MIN_INTERVAL_MS), signal)
+        continue
+      }
+      if (error === 'slow_down') {
+        intervalMs += XAI_GROK_DEVICE_CODE_SLOW_DOWN_INCREMENT_MS
+        await this.sleep(Math.max(intervalMs, XAI_GROK_DEVICE_CODE_MIN_INTERVAL_MS), signal)
+        continue
+      }
+      if (error === 'access_denied' || error === 'authorization_denied') {
+        throw new Error('xAI device authorization was denied')
+      }
+      if (error === 'expired_token') {
+        throw new Error('xAI device code expired. Re-run the login.')
+      }
+
+      const description = toStringValue(payload.error_description)
+      throw new Error(
+        description
+          ? `xAI device token exchange failed (${response.status}): ${error || 'error'} (${description})`
+          : `xAI device token exchange failed (${response.status}): ${error || (await readErrorBody(response))}`
+      )
+    }
+
+    throw new Error('xAI device authorization timed out')
+  }
+
+  private async refreshAccessToken(
+    currentTokens: XaiGrokTokenSet,
+    force = false
+  ): Promise<XaiGrokTokenSet> {
+    if (!force && currentTokens.expiresAt > Date.now() + XAI_GROK_TOKEN_REFRESH_SKEW_MS) {
+      return currentTokens
+    }
+
+    if (this.refreshPromise) {
+      return this.refreshPromise
+    }
+
+    this.refreshPromise = this.refreshAccessTokenOnce(currentTokens).finally(() => {
+      this.refreshPromise = null
+    })
+    return this.refreshPromise
+  }
+
+  private async refreshAccessTokenOnce(currentTokens: XaiGrokTokenSet): Promise<XaiGrokTokenSet> {
+    if (!currentTokens.refreshToken) {
+      throw new Error('xAI Grok OAuth refresh token is unavailable')
+    }
+
+    let tokenEndpoint = currentTokens.tokenEndpoint
+    if (!tokenEndpoint || !isTrustedXaiOAuthEndpoint(tokenEndpoint)) {
+      tokenEndpoint = (await this.fetchDiscovery()).tokenEndpoint
+    }
+
+    const payload = await this.postForm(tokenEndpoint, {
+      grant_type: 'refresh_token',
+      client_id: XAI_GROK_OAUTH_CLIENT_ID,
+      refresh_token: currentTokens.refreshToken
+    })
+
+    const refreshed = this.parseTokenResponse(payload, currentTokens, {
+      tokenEndpoint,
+      deviceAuthorizationEndpoint: currentTokens.deviceAuthorizationEndpoint
+    })
+    this.store.save(refreshed)
+    this.lastError = null
+    this.publishStatusChanged()
+    return refreshed
+  }
+
+  private parseTokenResponse(
+    payload: TokenResponse,
+    previous?: XaiGrokTokenSet,
+    endpoints?: {
+      tokenEndpoint?: string
+      deviceAuthorizationEndpoint?: string
+    }
+  ): XaiGrokTokenSet {
+    const accessToken = toStringValue(payload.access_token) || previous?.accessToken
+    if (!accessToken) {
+      throw new Error('xAI OAuth token response did not include an access token')
+    }
+
+    const refreshToken = toStringValue(payload.refresh_token) || previous?.refreshToken
+    const idToken = toStringValue(payload.id_token) || previous?.idToken
+    const tokenType = toStringValue(payload.token_type) || previous?.tokenType || 'Bearer'
+    const expiresIn = toNumberValue(payload.expires_in) || 3600
+    const jwtPayload = decodeJwtPayload(idToken || accessToken)
+    const accountId =
+      toStringValue(jwtPayload.sub) || toStringValue(jwtPayload.account_id) || previous?.accountId
+    const email = toStringValue(jwtPayload.email)
+    const name = toStringValue(jwtPayload.name)
+
+    return {
+      accessToken,
+      refreshToken,
+      idToken,
+      tokenType,
+      expiresAt: Date.now() + expiresIn * 1000,
+      accountId,
+      accountLabel: email || name || maskAccountId(accountId) || previous?.accountLabel,
+      tokenEndpoint: endpoints?.tokenEndpoint || previous?.tokenEndpoint,
+      deviceAuthorizationEndpoint:
+        endpoints?.deviceAuthorizationEndpoint || previous?.deviceAuthorizationEndpoint,
+      updatedAt: Date.now()
+    }
+  }
+
+  private async postForm(
+    url: string,
+    params: Record<string, string | undefined>,
+    requireOk = true
+  ): Promise<TokenResponse> {
+    const response = await this.fetchWithTimeout(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': XAI_GROK_OAUTH_USER_AGENT
+      },
+      body: toFormBody(params)
+    })
+
+    if (!response.ok) {
+      if (!requireOk) {
+        return {}
+      }
+      throw new Error(await readErrorBody(response))
+    }
+
+    return (await response.json()) as TokenResponse
+  }
+
+  private async fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+    externalSignal?: AbortSignal
+  ): Promise<Response> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), XAI_GROK_AUTH_REQUEST_TIMEOUT_MS)
+    const onExternalAbort = () => controller.abort(externalSignal?.reason)
+
+    if (externalSignal) {
+      if (externalSignal.aborted) {
+        controller.abort(externalSignal.reason)
+      } else {
+        externalSignal.addEventListener('abort', onExternalAbort, { once: true })
+      }
+    }
+
+    try {
+      return await fetch(url, {
+        ...init,
+        signal: controller.signal
+      })
+    } catch (error) {
+      if (controller.signal.aborted) {
+        if (externalSignal?.aborted) {
+          throw new Error('xAI Grok OAuth login cancelled')
+        }
+        throw new Error(
+          `xAI Grok OAuth request timed out after ${XAI_GROK_AUTH_REQUEST_TIMEOUT_MS}ms`
+        )
+      }
+      throw error
+    } finally {
+      clearTimeout(timeout)
+      externalSignal?.removeEventListener('abort', onExternalAbort)
+    }
+  }
+
+  private async sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    if (!signal) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, ms)
+      })
+      return
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        clearTimeout(timeout)
+        reject(new Error('xAI Grok OAuth login cancelled'))
+      }
+      const timeout = setTimeout(() => {
+        signal.removeEventListener('abort', onAbort)
+        resolve()
+      }, ms)
+      signal.addEventListener('abort', onAbort, { once: true })
+      if (signal.aborted) {
+        onAbort()
+      }
+    })
+  }
+
+  private publishStatusChanged(): void {
+    publishDeepchatEvent('oauth.xaiGrok.statusChanged', {
+      status: this.getStatus(),
+      version: Date.now()
+    })
+  }
+}
+
+export function getGlobalXaiGrokAuth(): XaiGrokAuth {
+  if (!globalXaiGrokAuth) {
+    globalXaiGrokAuth = new XaiGrokAuth()
+  }
+  return globalXaiGrokAuth
+}
+
+export function resetGlobalXaiGrokAuthForTests(): void {
+  globalXaiGrokAuth = null
+}
+
+export { XAI_GROK_PROVIDER_ID, XAI_GROK_OAUTH_ISSUER, isTrustedXaiOAuthEndpoint } from './constants'

--- a/src/main/routes/index.ts
+++ b/src/main/routes/index.ts
@@ -196,6 +196,10 @@ import {
   oauthOpenAICodexGetStatusRoute,
   oauthOpenAICodexLogoutRoute,
   oauthOpenAICodexStartBrowserLoginRoute,
+  oauthXaiGrokCancelLoginRoute,
+  oauthXaiGrokGetStatusRoute,
+  oauthXaiGrokLogoutRoute,
+  oauthXaiGrokStartDeviceLoginRoute,
   remoteControlCancelFeishuAuthRoute,
   remoteControlCancelFeishuInstallRoute,
   remoteControlClearChannelPairCodeRoute,
@@ -2659,6 +2663,34 @@ export async function dispatchDeepchatRoute(
       oauthOpenAICodexLogoutRoute.input.parse(rawInput)
       return oauthOpenAICodexLogoutRoute.output.parse({
         status: await runtime.oauthPresenter.logoutOpenAICodex()
+      })
+    }
+
+    case oauthXaiGrokGetStatusRoute.name: {
+      oauthXaiGrokGetStatusRoute.input.parse(rawInput)
+      return oauthXaiGrokGetStatusRoute.output.parse({
+        status: await runtime.oauthPresenter.getXaiGrokStatus()
+      })
+    }
+
+    case oauthXaiGrokStartDeviceLoginRoute.name: {
+      oauthXaiGrokStartDeviceLoginRoute.input.parse(rawInput)
+      return oauthXaiGrokStartDeviceLoginRoute.output.parse({
+        status: await runtime.oauthPresenter.startXaiGrokDeviceLogin()
+      })
+    }
+
+    case oauthXaiGrokCancelLoginRoute.name: {
+      oauthXaiGrokCancelLoginRoute.input.parse(rawInput)
+      return oauthXaiGrokCancelLoginRoute.output.parse({
+        status: await runtime.oauthPresenter.cancelXaiGrokLogin()
+      })
+    }
+
+    case oauthXaiGrokLogoutRoute.name: {
+      oauthXaiGrokLogoutRoute.input.parse(rawInput)
+      return oauthXaiGrokLogoutRoute.output.parse({
+        status: await runtime.oauthPresenter.logoutXaiGrok()
       })
     }
 

--- a/src/renderer/api/OAuthClient.ts
+++ b/src/renderer/api/OAuthClient.ts
@@ -1,5 +1,8 @@
 import type { DeepchatBridge } from '@shared/contracts/bridge'
-import { oauthOpenAICodexStatusChangedEvent } from '@shared/contracts/events'
+import {
+  oauthOpenAICodexStatusChangedEvent,
+  oauthXaiGrokStatusChangedEvent
+} from '@shared/contracts/events'
 import {
   oauthOpenAICodexCancelLoginRoute,
   oauthOpenAICodexCompleteBrowserLoginFromUrlRoute,
@@ -8,7 +11,12 @@ import {
   oauthOpenAICodexStartBrowserLoginRoute,
   oauthGithubCopilotStartDeviceFlowLoginRoute,
   oauthGithubCopilotStartLoginRoute,
-  type OpenAICodexAuthStatus
+  oauthXaiGrokCancelLoginRoute,
+  oauthXaiGrokGetStatusRoute,
+  oauthXaiGrokLogoutRoute,
+  oauthXaiGrokStartDeviceLoginRoute,
+  type OpenAICodexAuthStatus,
+  type XaiGrokAuthStatus
 } from '@shared/contracts/routes'
 import { getDeepchatBridge } from './core'
 
@@ -62,6 +70,32 @@ export function createOAuthClient(bridge: DeepchatBridge = getDeepchatBridge()) 
     })
   }
 
+  async function getXaiGrokStatus(): Promise<XaiGrokAuthStatus> {
+    const result = await bridge.invoke(oauthXaiGrokGetStatusRoute.name, {})
+    return result.status
+  }
+
+  async function startXaiGrokDeviceLogin(): Promise<XaiGrokAuthStatus> {
+    const result = await bridge.invoke(oauthXaiGrokStartDeviceLoginRoute.name, {})
+    return result.status
+  }
+
+  async function cancelXaiGrokLogin(): Promise<XaiGrokAuthStatus> {
+    const result = await bridge.invoke(oauthXaiGrokCancelLoginRoute.name, {})
+    return result.status
+  }
+
+  async function logoutXaiGrok(): Promise<XaiGrokAuthStatus> {
+    const result = await bridge.invoke(oauthXaiGrokLogoutRoute.name, {})
+    return result.status
+  }
+
+  function onXaiGrokStatusChanged(listener: (status: XaiGrokAuthStatus) => void): () => void {
+    return bridge.on(oauthXaiGrokStatusChangedEvent.name, (payload) => {
+      listener(payload.status)
+    })
+  }
+
   return {
     startGitHubCopilotLogin,
     startGitHubCopilotDeviceFlowLogin,
@@ -70,7 +104,12 @@ export function createOAuthClient(bridge: DeepchatBridge = getDeepchatBridge()) 
     completeOpenAICodexBrowserLoginFromUrl,
     cancelOpenAICodexLogin,
     logoutOpenAICodex,
-    onOpenAICodexStatusChanged
+    onOpenAICodexStatusChanged,
+    getXaiGrokStatus,
+    startXaiGrokDeviceLogin,
+    cancelXaiGrokLogin,
+    logoutXaiGrok,
+    onXaiGrokStatusChanged
   }
 }
 

--- a/src/renderer/settings/components/GrokOAuth.vue
+++ b/src/renderer/settings/components/GrokOAuth.vue
@@ -1,0 +1,294 @@
+<template>
+  <div class="flex flex-col items-start gap-3">
+    <Label class="flex-1">
+      {{ t('settings.provider.xaiGrokAuth') }}
+    </Label>
+
+    <div :class="['w-full rounded-md border px-3 py-2', statusClass]">
+      <div class="flex items-start gap-2">
+        <Icon :icon="statusIcon" class="mt-0.5 h-4 w-4 shrink-0" />
+        <div class="min-w-0 flex-1">
+          <div class="text-sm font-medium leading-5">
+            {{ statusText }}
+          </div>
+          <div
+            v-if="status.accountLabel || status.accountId"
+            class="mt-1 space-y-0.5 text-xs opacity-80"
+          >
+            <div v-if="status.accountLabel">
+              {{ status.accountLabel }}
+            </div>
+            <div v-if="status.accountId">
+              {{ t('settings.provider.xaiGrokAccount') }}: {{ status.accountId }}
+            </div>
+          </div>
+          <div v-if="isPending && status.userCode" class="mt-2 space-y-1 text-xs">
+            <div class="font-mono text-sm font-semibold tracking-wider">
+              {{ status.userCode }}
+            </div>
+            <a
+              v-if="verificationLink"
+              :href="verificationLink"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="break-all text-primary underline"
+              @click.prevent="openVerificationUrl"
+            >
+              {{ verificationLink }}
+            </a>
+          </div>
+          <div v-if="status.error" class="mt-1 text-xs opacity-90">
+            {{ status.error }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex flex-wrap gap-2">
+      <Button
+        v-if="status.authenticated"
+        data-testid="grok-test-connection-button"
+        variant="outline"
+        size="sm"
+        class="text-xs text-normal rounded-lg"
+        :disabled="!provider.enable"
+        @click="openModelCheckDialog"
+      >
+        <Icon icon="lucide:check-check" class="h-4 w-4 text-muted-foreground" />
+        {{ t('settings.provider.verifyKey') }}
+      </Button>
+
+      <Button
+        data-testid="grok-device-login-button"
+        variant="default"
+        size="sm"
+        class="text-xs"
+        :disabled="isBusy || status.state === 'disabled'"
+        @click="startDeviceLogin"
+      >
+        <Icon
+          :icon="isDeviceBusy ? 'lucide:loader-2' : 'lucide:smartphone'"
+          :class="['h-4 w-4', { 'animate-spin': isDeviceBusy }]"
+        />
+        {{ deviceButtonText }}
+      </Button>
+
+      <Button
+        v-if="isPending && verificationLink"
+        data-testid="grok-open-verification-button"
+        variant="outline"
+        size="sm"
+        class="text-xs"
+        @click="openVerificationUrl"
+      >
+        <Icon icon="lucide:external-link" class="h-4 w-4" />
+        {{ t('settings.provider.xaiGrokOpenVerification') }}
+      </Button>
+
+      <Button
+        v-if="isPending"
+        data-testid="grok-cancel-login-button"
+        variant="outline"
+        size="sm"
+        class="text-xs"
+        @click="cancelLogin"
+      >
+        <Icon icon="lucide:x" class="h-4 w-4" />
+        {{ t('settings.provider.xaiGrokCancel') }}
+      </Button>
+
+      <Button
+        v-if="status.authenticated"
+        data-testid="grok-logout-button"
+        variant="outline"
+        size="sm"
+        class="text-xs text-destructive"
+        @click="logout"
+      >
+        <Icon icon="lucide:unlink" class="h-4 w-4 text-destructive" />
+        {{ t('settings.provider.xaiGrokSignOut') }}
+      </Button>
+    </div>
+
+    <div class="text-xs leading-5 text-muted-foreground">
+      {{ t('settings.provider.xaiGrokLoginTip') }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Label } from '@shadcn/components/ui/label'
+import { Button } from '@shadcn/components/ui/button'
+import { Icon } from '@iconify/vue'
+import { createOAuthClient } from '@api/OAuthClient'
+import { createBrowserClient } from '@api/BrowserClient'
+import { useModelCheckStore } from '@/stores/modelCheck'
+import type { LLM_PROVIDER } from '@shared/presenter'
+import type { XaiGrokAuthStatus } from '@shared/contracts/routes'
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  provider: LLM_PROVIDER
+}>()
+
+const emit = defineEmits<{
+  'auth-success': []
+  'auth-error': [error: string]
+}>()
+
+const signedOutStatus: XaiGrokAuthStatus = {
+  state: 'signed-out',
+  authenticated: false,
+  storage: 'none'
+}
+
+const oauthClient = createOAuthClient()
+const browserClient = createBrowserClient()
+const modelCheckStore = useModelCheckStore()
+const status = ref<XaiGrokAuthStatus>(signedOutStatus)
+const busyAction = ref<'device' | 'cancel' | 'logout' | null>(null)
+let pollTimer: number | null = null
+let unsubscribeStatus: (() => void) | null = null
+
+const isPending = computed(() => status.value.state === 'pending-device')
+const isBusy = computed(() => busyAction.value !== null)
+const isDeviceBusy = computed(
+  () => busyAction.value === 'device' || status.value.state === 'pending-device'
+)
+const verificationLink = computed(
+  () => status.value.verificationUriComplete || status.value.verificationUri || ''
+)
+const statusClass = computed(() => {
+  if (status.value.authenticated) {
+    return 'border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-200'
+  }
+  if (status.value.state === 'error' || status.value.state === 'disabled') {
+    return 'border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200'
+  }
+  if (status.value.state === 'pending-device') {
+    return 'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200'
+  }
+  return 'border-border bg-muted/40 text-foreground'
+})
+const statusIcon = computed(() => {
+  if (status.value.authenticated) return 'lucide:check-circle'
+  if (status.value.state === 'pending-device') return 'lucide:loader-2'
+  if (status.value.state === 'error' || status.value.state === 'disabled') return 'lucide:x-circle'
+  return 'lucide:info'
+})
+const statusText = computed(() => {
+  if (status.value.state === 'disabled') return t('settings.provider.xaiGrokDisabled')
+  if (status.value.authenticated) return t('settings.provider.xaiGrokConnected')
+  if (status.value.state === 'pending-device') return t('settings.provider.xaiGrokPendingDevice')
+  if (status.value.state === 'error') return t('settings.provider.xaiGrokError')
+  return t('settings.provider.xaiGrokNotConnected')
+})
+const deviceButtonText = computed(() => {
+  if (status.value.authenticated) return t('settings.provider.xaiGrokReconnect')
+  if (status.value.state === 'pending-device') return t('settings.provider.loggingIn')
+  return t('settings.provider.xaiGrokSignInDevice')
+})
+
+const applyStatus = (nextStatus: XaiGrokAuthStatus, options?: { emitEvents?: boolean }) => {
+  const previousStatus = status.value
+  status.value = nextStatus
+  if (!options?.emitEvents) {
+    return
+  }
+  if (nextStatus.authenticated && !previousStatus.authenticated) {
+    emit('auth-success')
+  } else if (
+    nextStatus.error &&
+    nextStatus.state === 'error' &&
+    (previousStatus.state !== 'error' || previousStatus.error !== nextStatus.error)
+  ) {
+    emit('auth-error', nextStatus.error)
+  }
+}
+
+const applyError = (error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+  applyStatus(
+    {
+      ...status.value,
+      state: 'error',
+      authenticated: false,
+      error: message
+    },
+    { emitEvents: true }
+  )
+}
+
+const refreshStatus = async () => applyStatus(await oauthClient.getXaiGrokStatus())
+
+const runAuthAction = async (
+  action: 'device' | 'cancel' | 'logout',
+  runner: () => Promise<XaiGrokAuthStatus>
+) => {
+  busyAction.value = action
+  try {
+    applyStatus(await runner(), { emitEvents: true })
+  } catch (error) {
+    applyError(error)
+  } finally {
+    busyAction.value = null
+  }
+}
+
+const startDeviceLogin = () => runAuthAction('device', () => oauthClient.startXaiGrokDeviceLogin())
+
+const cancelLogin = () => runAuthAction('cancel', () => oauthClient.cancelXaiGrokLogin())
+
+const logout = () => runAuthAction('logout', () => oauthClient.logoutXaiGrok())
+
+const openVerificationUrl = () => {
+  if (verificationLink.value) {
+    void browserClient.openExternal(verificationLink.value)
+  }
+}
+
+const openModelCheckDialog = () => {
+  modelCheckStore.openDialog(props.provider.id)
+}
+
+const stopPolling = () => {
+  if (pollTimer !== null) {
+    window.clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+const startPolling = () => {
+  stopPolling()
+  pollTimer = window.setInterval(() => {
+    void refreshStatus().catch(applyError)
+  }, 1500)
+}
+
+watch(
+  () => status.value.state,
+  (state) => {
+    if (state === 'pending-device') {
+      startPolling()
+    } else {
+      stopPolling()
+    }
+  }
+)
+
+onMounted(() => {
+  unsubscribeStatus = oauthClient.onXaiGrokStatusChanged((next) => {
+    applyStatus(next, { emitEvents: true })
+  })
+  void refreshStatus().catch(applyError)
+})
+
+onUnmounted(() => {
+  stopPolling()
+  unsubscribeStatus?.()
+  unsubscribeStatus = null
+})
+</script>

--- a/src/renderer/settings/components/ProviderApiConfig.vue
+++ b/src/renderer/settings/components/ProviderApiConfig.vue
@@ -98,6 +98,20 @@
     />
 
     <div v-else class="flex flex-col items-start gap-4">
+      <GrokOAuth
+        v-if="isGrokOAuthAvailable"
+        :provider="provider"
+        @auth-success="handleOAuthSuccess"
+        @auth-error="handleOAuthError"
+      />
+
+      <div
+        v-if="isGrokOAuthAvailable"
+        class="w-full border-t border-border pt-3 text-xs text-muted-foreground"
+      >
+        {{ t('settings.provider.xaiGrokApiKeyAlternative') }}
+      </div>
+
       <div class="flex flex-col gap-2 w-full">
         <Label :for="`${provider.id}-apikey`" class="w-full">API Key</Label>
         <div class="relative w-full">
@@ -202,6 +216,7 @@ import {
 import { Icon } from '@iconify/vue'
 import GitHubCopilotOAuth from './GitHubCopilotOAuth.vue'
 import OpenAICodexOAuth from './OpenAICodexOAuth.vue'
+import GrokOAuth from './GrokOAuth.vue'
 import { createProviderClient } from '@api/ProviderClient'
 import { useToast } from '@/components/use-toast'
 import { useModelCheckStore } from '@/stores/modelCheck'
@@ -262,6 +277,18 @@ const showLockedBaseUrl = computed(
   () => !isBaseUrlEditableByDefault.value && !baseUrlUnlocked.value
 )
 const shouldRefreshProviderDbFirst = computed(() => isProviderDbBackedProvider(props.provider.id))
+const isGrokOAuthAvailable = computed(() => {
+  if (props.provider.id !== 'grok') {
+    return false
+  }
+
+  try {
+    const url = new URL(apiHost.value.trim())
+    return url.protocol === 'https:' && (url.hostname === 'x.ai' || url.hostname.endsWith('.x.ai'))
+  } catch {
+    return false
+  }
+})
 const providerApiKeyUrl = computed(() => {
   if (props.provider.id !== 'new-api') {
     return props.providerWebsites?.apiKey || ''

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -1068,7 +1068,21 @@
     "openaiCodexCallbackTitle": "Fuldfør godkendelse",
     "openaiCodexCallbackDescription": "Når browseren er færdig, skal du vende tilbage til DeepChat. Hvis DeepChat ikke opdateres, skal du indsætte den fulde callback-URL her.",
     "openaiCodexCallbackPlaceholder": "Indsæt den fulde callback-URL",
-    "openaiCodexCompleteAuthentication": "Fuldfør godkendelse"
+    "openaiCodexCompleteAuthentication": "Fuldfør godkendelse",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok er tilsluttet",
+    "xaiGrokNotConnected": "xAI Grok er ikke tilsluttet",
+    "xaiGrokPendingDevice": "Venter på enhedsgodkendelse",
+    "xaiGrokDisabled": "xAI Grok OAuth er deaktiveret",
+    "xaiGrokError": "Godkendelse af xAI Grok mislykkedes",
+    "xaiGrokAccount": "Konto",
+    "xaiGrokSignInDevice": "Log ind med SuperGrok / Premium+",
+    "xaiGrokReconnect": "Opret forbindelse igen",
+    "xaiGrokSignOut": "Log ud",
+    "xaiGrokCancel": "Annuller",
+    "xaiGrokOpenVerification": "Åbn bekræftelsessiden",
+    "xaiGrokLoginTip": "Bruger xAI-enhedskode-OAuth til SuperGrok eller X Premium+. Tokens gemmes separat fra API-nøgler. API-nøgler fra Console understøttes stadig nedenfor.",
+    "xaiGrokApiKeyAlternative": "Eller brug en xAI Console-API-nøgle:"
   },
   "knowledgeBase": {
     "title": "Indstillinger for vidensbase",

--- a/src/renderer/src/i18n/de-DE/settings.json
+++ b/src/renderer/src/i18n/de-DE/settings.json
@@ -1395,7 +1395,21 @@
     "openaiCodexCallbackTitle": "Authentifizierung abschließen",
     "openaiCodexCallbackDescription": "Kehre nach Abschluss im Browser zu DeepChat zurück. Wenn DeepChat nicht aktualisiert wird, füge hier die vollständige Callback-URL ein.",
     "openaiCodexCallbackPlaceholder": "Vollständige Callback-URL einfügen",
-    "openaiCodexCompleteAuthentication": "Authentifizierung abschließen"
+    "openaiCodexCompleteAuthentication": "Authentifizierung abschließen",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok ist verbunden",
+    "xaiGrokNotConnected": "xAI Grok ist nicht verbunden",
+    "xaiGrokPendingDevice": "Warten auf Geräteautorisierung",
+    "xaiGrokDisabled": "xAI Grok OAuth ist deaktiviert",
+    "xaiGrokError": "xAI Grok-Autorisierung fehlgeschlagen",
+    "xaiGrokAccount": "Konto",
+    "xaiGrokSignInDevice": "Mit SuperGrok / Premium+ anmelden",
+    "xaiGrokReconnect": "Erneut verbinden",
+    "xaiGrokSignOut": "Abmelden",
+    "xaiGrokCancel": "Abbrechen",
+    "xaiGrokOpenVerification": "Bestätigungsseite öffnen",
+    "xaiGrokLoginTip": "Verwendet xAI-Gerätecode-OAuth für SuperGrok oder X Premium+. Tokens werden getrennt von API-Schlüsseln gespeichert. Console-API-Schlüssel werden unten weiterhin unterstützt.",
+    "xaiGrokApiKeyAlternative": "Oder einen xAI Console-API-Schlüssel verwenden:"
   },
   "knowledgeBase": {
     "title": "Wissensdatenbank-Einstellungen",

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -1396,7 +1396,21 @@
     "openaiCodexCallbackTitle": "Complete authentication",
     "openaiCodexCallbackDescription": "After the browser finishes, return to DeepChat. If DeepChat does not update, paste the full callback URL here.",
     "openaiCodexCallbackPlaceholder": "Paste the full callback URL",
-    "openaiCodexCompleteAuthentication": "Complete authentication"
+    "openaiCodexCompleteAuthentication": "Complete authentication",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok Connected",
+    "xaiGrokNotConnected": "xAI Grok Not Connected",
+    "xaiGrokPendingDevice": "Waiting for device authorization",
+    "xaiGrokDisabled": "xAI Grok OAuth is disabled",
+    "xaiGrokError": "xAI Grok authorization failed",
+    "xaiGrokAccount": "Account",
+    "xaiGrokSignInDevice": "Sign in with SuperGrok / Premium+",
+    "xaiGrokReconnect": "Reconnect",
+    "xaiGrokSignOut": "Sign out",
+    "xaiGrokCancel": "Cancel",
+    "xaiGrokOpenVerification": "Open verification page",
+    "xaiGrokLoginTip": "Uses xAI device-code OAuth for SuperGrok or X Premium+. Tokens are stored separately from API keys. Console API keys remain supported below.",
+    "xaiGrokApiKeyAlternative": "Or use an xAI Console API key:"
   },
   "knowledgeBase": {
     "title": "Knowledge Base Settings",

--- a/src/renderer/src/i18n/es-ES/settings.json
+++ b/src/renderer/src/i18n/es-ES/settings.json
@@ -1395,7 +1395,21 @@
     "openaiCodexCallbackTitle": "Completar autenticación",
     "openaiCodexCallbackDescription": "Cuando termine el navegador, vuelve a DeepChat. Si DeepChat no se actualiza, pega aquí la URL completa de callback.",
     "openaiCodexCallbackPlaceholder": "Pega la URL completa de callback",
-    "openaiCodexCompleteAuthentication": "Completar autenticación"
+    "openaiCodexCompleteAuthentication": "Completar autenticación",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok conectado",
+    "xaiGrokNotConnected": "xAI Grok no conectado",
+    "xaiGrokPendingDevice": "Esperando la autorización del dispositivo",
+    "xaiGrokDisabled": "xAI Grok OAuth está desactivado",
+    "xaiGrokError": "Error al autorizar xAI Grok",
+    "xaiGrokAccount": "Cuenta",
+    "xaiGrokSignInDevice": "Iniciar sesión con SuperGrok / Premium+",
+    "xaiGrokReconnect": "Volver a conectar",
+    "xaiGrokSignOut": "Cerrar sesión",
+    "xaiGrokCancel": "Cancelar",
+    "xaiGrokOpenVerification": "Abrir la página de verificación",
+    "xaiGrokLoginTip": "Usa el OAuth con código de dispositivo de xAI para SuperGrok o X Premium+. Los tokens se almacenan por separado de las claves API. Las claves API de Console siguen siendo compatibles a continuación.",
+    "xaiGrokApiKeyAlternative": "O usa una clave API de xAI Console:"
   },
   "knowledgeBase": {
     "title": "Configuración de la base de conocimientos",

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -1135,7 +1135,21 @@
     "openaiCodexCallbackTitle": "تکمیل احراز هویت",
     "openaiCodexCallbackDescription": "پس از پایان کار مرورگر، به DeepChat برگردید. اگر DeepChat به‌روزرسانی نشد، URL کامل بازگشت را اینجا بچسبانید.",
     "openaiCodexCallbackPlaceholder": "URL کامل بازگشت را بچسبانید",
-    "openaiCodexCompleteAuthentication": "تکمیل احراز هویت"
+    "openaiCodexCompleteAuthentication": "تکمیل احراز هویت",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok متصل است",
+    "xaiGrokNotConnected": "xAI Grok متصل نیست",
+    "xaiGrokPendingDevice": "در انتظار مجوز دستگاه",
+    "xaiGrokDisabled": "OAuth ‏xAI Grok غیرفعال است",
+    "xaiGrokError": "مجوزدهی xAI Grok ناموفق بود",
+    "xaiGrokAccount": "حساب",
+    "xaiGrokSignInDevice": "ورود با SuperGrok / Premium+",
+    "xaiGrokReconnect": "اتصال مجدد",
+    "xaiGrokSignOut": "خروج از حساب",
+    "xaiGrokCancel": "لغو",
+    "xaiGrokOpenVerification": "باز کردن صفحه تأیید",
+    "xaiGrokLoginTip": "برای SuperGrok یا X Premium+ از OAuth کد دستگاه xAI استفاده می‌کند. توکن‌ها جدا از کلیدهای API ذخیره می‌شوند. کلیدهای API کنسول نیز در پایین پشتیبانی می‌شوند.",
+    "xaiGrokApiKeyAlternative": "یا از کلید API کنسول xAI استفاده کنید:"
   },
   "knowledgeBase": {
     "title": "تنظیمات پایگاه دانش",

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -1135,7 +1135,21 @@
     "openaiCodexCallbackTitle": "Terminer l'authentification",
     "openaiCodexCallbackDescription": "Lorsque le navigateur a terminé, revenez à DeepChat. Si DeepChat ne se met pas à jour, collez ici l'URL de rappel complète.",
     "openaiCodexCallbackPlaceholder": "Coller l'URL de rappel complète",
-    "openaiCodexCompleteAuthentication": "Terminer l'authentification"
+    "openaiCodexCompleteAuthentication": "Terminer l'authentification",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok connecté",
+    "xaiGrokNotConnected": "xAI Grok non connecté",
+    "xaiGrokPendingDevice": "En attente de l’autorisation de l’appareil",
+    "xaiGrokDisabled": "OAuth xAI Grok est désactivé",
+    "xaiGrokError": "Échec de l’autorisation xAI Grok",
+    "xaiGrokAccount": "Compte",
+    "xaiGrokSignInDevice": "Se connecter avec SuperGrok / Premium+",
+    "xaiGrokReconnect": "Reconnecter",
+    "xaiGrokSignOut": "Se déconnecter",
+    "xaiGrokCancel": "Annuler",
+    "xaiGrokOpenVerification": "Ouvrir la page de vérification",
+    "xaiGrokLoginTip": "Utilise le flux OAuth par code d’appareil de xAI pour SuperGrok ou X Premium+. Les jetons sont stockés séparément des clés API. Les clés API de Console restent prises en charge ci-dessous.",
+    "xaiGrokApiKeyAlternative": "Ou utiliser une clé API xAI Console :"
   },
   "knowledgeBase": {
     "title": "Paramètres de la base de connaissances",

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -1135,7 +1135,21 @@
     "openaiCodexCallbackTitle": "השלמת האימות",
     "openaiCodexCallbackDescription": "לאחר שהדפדפן מסיים, חזור אל DeepChat. אם DeepChat לא מתעדכן, הדבק כאן את כתובת ה-URL המלאה לחזרה.",
     "openaiCodexCallbackPlaceholder": "הדבק את כתובת ה-URL המלאה לחזרה",
-    "openaiCodexCompleteAuthentication": "השלמת האימות"
+    "openaiCodexCompleteAuthentication": "השלמת האימות",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok מחובר",
+    "xaiGrokNotConnected": "xAI Grok אינו מחובר",
+    "xaiGrokPendingDevice": "ממתין לאישור המכשיר",
+    "xaiGrokDisabled": "OAuth של xAI Grok מושבת",
+    "xaiGrokError": "האישור של xAI Grok נכשל",
+    "xaiGrokAccount": "חשבון",
+    "xaiGrokSignInDevice": "כניסה באמצעות SuperGrok / Premium+",
+    "xaiGrokReconnect": "התחברות מחדש",
+    "xaiGrokSignOut": "יציאה",
+    "xaiGrokCancel": "ביטול",
+    "xaiGrokOpenVerification": "פתיחת דף האימות",
+    "xaiGrokLoginTip": "משתמש ב-OAuth עם קוד מכשיר של xAI עבור SuperGrok או X Premium+. האסימונים נשמרים בנפרד ממפתחות API. מפתחות API של Console עדיין נתמכים למטה.",
+    "xaiGrokApiKeyAlternative": "או להשתמש במפתח API של xAI Console:"
   },
   "knowledgeBase": {
     "title": "הגדרות בסיס ידע",

--- a/src/renderer/src/i18n/id-ID/settings.json
+++ b/src/renderer/src/i18n/id-ID/settings.json
@@ -1395,7 +1395,21 @@
     "openaiCodexCallbackTitle": "Selesaikan autentikasi",
     "openaiCodexCallbackDescription": "Setelah browser selesai, kembali ke DeepChat. Jika DeepChat tidak diperbarui, tempel URL callback lengkap di sini.",
     "openaiCodexCallbackPlaceholder": "Tempel URL callback lengkap",
-    "openaiCodexCompleteAuthentication": "Selesaikan autentikasi"
+    "openaiCodexCompleteAuthentication": "Selesaikan autentikasi",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok terhubung",
+    "xaiGrokNotConnected": "xAI Grok tidak terhubung",
+    "xaiGrokPendingDevice": "Menunggu otorisasi perangkat",
+    "xaiGrokDisabled": "OAuth xAI Grok dinonaktifkan",
+    "xaiGrokError": "Otorisasi xAI Grok gagal",
+    "xaiGrokAccount": "Akun",
+    "xaiGrokSignInDevice": "Masuk dengan SuperGrok / Premium+",
+    "xaiGrokReconnect": "Hubungkan kembali",
+    "xaiGrokSignOut": "Keluar",
+    "xaiGrokCancel": "Batal",
+    "xaiGrokOpenVerification": "Buka halaman verifikasi",
+    "xaiGrokLoginTip": "Menggunakan OAuth kode perangkat xAI untuk SuperGrok atau X Premium+. Token disimpan terpisah dari kunci API. Kunci API Console tetap didukung di bawah ini.",
+    "xaiGrokApiKeyAlternative": "Atau gunakan kunci API xAI Console:"
   },
   "knowledgeBase": {
     "title": "Pengaturan basis pengetahuan",

--- a/src/renderer/src/i18n/it-IT/settings.json
+++ b/src/renderer/src/i18n/it-IT/settings.json
@@ -1395,7 +1395,21 @@
     "openaiCodexCallbackTitle": "Completa autenticazione",
     "openaiCodexCallbackDescription": "Dopo il completamento nel browser, torna a DeepChat. Se DeepChat non si aggiorna, incolla qui l'URL di callback completo.",
     "openaiCodexCallbackPlaceholder": "Incolla l'URL di callback completo",
-    "openaiCodexCompleteAuthentication": "Completa autenticazione"
+    "openaiCodexCompleteAuthentication": "Completa autenticazione",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok connesso",
+    "xaiGrokNotConnected": "xAI Grok non connesso",
+    "xaiGrokPendingDevice": "In attesa dell’autorizzazione del dispositivo",
+    "xaiGrokDisabled": "OAuth xAI Grok è disabilitato",
+    "xaiGrokError": "Autorizzazione xAI Grok non riuscita",
+    "xaiGrokAccount": "Account",
+    "xaiGrokSignInDevice": "Accedi con SuperGrok / Premium+",
+    "xaiGrokReconnect": "Riconnetti",
+    "xaiGrokSignOut": "Esci",
+    "xaiGrokCancel": "Annulla",
+    "xaiGrokOpenVerification": "Apri la pagina di verifica",
+    "xaiGrokLoginTip": "Usa OAuth con codice dispositivo di xAI per SuperGrok o X Premium+. I token vengono archiviati separatamente dalle chiavi API. Le chiavi API di Console restano supportate qui sotto.",
+    "xaiGrokApiKeyAlternative": "Oppure usa una chiave API xAI Console:"
   },
   "knowledgeBase": {
     "title": "Impostazioni base di conoscenza",

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -1135,7 +1135,21 @@
     "openaiCodexCallbackTitle": "認証を完了",
     "openaiCodexCallbackDescription": "ブラウザーで完了したら DeepChat に戻ってください。DeepChat が更新されない場合は、完全なコールバックURLをここに貼り付けてください。",
     "openaiCodexCallbackPlaceholder": "完全なコールバックURLを貼り付け",
-    "openaiCodexCompleteAuthentication": "認証を完了"
+    "openaiCodexCompleteAuthentication": "認証を完了",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok 接続済み",
+    "xaiGrokNotConnected": "xAI Grok 未接続",
+    "xaiGrokPendingDevice": "デバイス認証を待機中",
+    "xaiGrokDisabled": "xAI Grok OAuth は無効です",
+    "xaiGrokError": "xAI Grok 認可に失敗しました",
+    "xaiGrokAccount": "アカウント",
+    "xaiGrokSignInDevice": "SuperGrok / Premium+ でサインイン",
+    "xaiGrokReconnect": "再接続",
+    "xaiGrokSignOut": "サインアウト",
+    "xaiGrokCancel": "キャンセル",
+    "xaiGrokOpenVerification": "認証ページを開く",
+    "xaiGrokLoginTip": "SuperGrok または X Premium+ 向けの xAI デバイスコード OAuth を使用します。トークンは API キーとは別に保存されます。下記の Console API キーも引き続き使用できます。",
+    "xaiGrokApiKeyAlternative": "または xAI Console API キーを使用："
   },
   "knowledgeBase": {
     "title": "ナレッジベース設定",

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -1135,7 +1135,21 @@
     "openaiCodexCallbackTitle": "인증 완료",
     "openaiCodexCallbackDescription": "브라우저에서 완료되면 DeepChat으로 돌아오세요. DeepChat이 업데이트되지 않으면 전체 콜백 URL을 여기에 붙여넣으세요.",
     "openaiCodexCallbackPlaceholder": "전체 콜백 URL 붙여넣기",
-    "openaiCodexCompleteAuthentication": "인증 완료"
+    "openaiCodexCompleteAuthentication": "인증 완료",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok 연결됨",
+    "xaiGrokNotConnected": "xAI Grok 연결 안 됨",
+    "xaiGrokPendingDevice": "기기 인증 대기 중",
+    "xaiGrokDisabled": "xAI Grok OAuth가 비활성화되어 있습니다",
+    "xaiGrokError": "xAI Grok 인증에 실패했습니다",
+    "xaiGrokAccount": "계정",
+    "xaiGrokSignInDevice": "SuperGrok / Premium+로 로그인",
+    "xaiGrokReconnect": "다시 연결",
+    "xaiGrokSignOut": "로그아웃",
+    "xaiGrokCancel": "취소",
+    "xaiGrokOpenVerification": "인증 페이지 열기",
+    "xaiGrokLoginTip": "SuperGrok 또는 X Premium+에 xAI 기기 코드 OAuth를 사용합니다. 토큰은 API 키와 별도로 저장됩니다. 아래에서 Console API 키도 계속 사용할 수 있습니다.",
+    "xaiGrokApiKeyAlternative": "또는 xAI Console API 키 사용:"
   },
   "knowledgeBase": {
     "title": "지식 베이스 설정",

--- a/src/renderer/src/i18n/ms-MY/settings.json
+++ b/src/renderer/src/i18n/ms-MY/settings.json
@@ -1395,7 +1395,21 @@
     "openaiCodexCallbackTitle": "Lengkapkan pengesahan",
     "openaiCodexCallbackDescription": "Selepas pelayar selesai, kembali ke DeepChat. Jika DeepChat tidak dikemas kini, tampal URL panggil balik penuh di sini.",
     "openaiCodexCallbackPlaceholder": "Tampal URL panggil balik penuh",
-    "openaiCodexCompleteAuthentication": "Lengkapkan pengesahan"
+    "openaiCodexCompleteAuthentication": "Lengkapkan pengesahan",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok disambungkan",
+    "xaiGrokNotConnected": "xAI Grok tidak disambungkan",
+    "xaiGrokPendingDevice": "Menunggu kebenaran peranti",
+    "xaiGrokDisabled": "OAuth xAI Grok dinyahdayakan",
+    "xaiGrokError": "Kebenaran xAI Grok gagal",
+    "xaiGrokAccount": "Akaun",
+    "xaiGrokSignInDevice": "Log masuk dengan SuperGrok / Premium+",
+    "xaiGrokReconnect": "Sambung semula",
+    "xaiGrokSignOut": "Log keluar",
+    "xaiGrokCancel": "Batal",
+    "xaiGrokOpenVerification": "Buka halaman pengesahan",
+    "xaiGrokLoginTip": "Menggunakan OAuth kod peranti xAI untuk SuperGrok atau X Premium+. Token disimpan berasingan daripada kunci API. Kunci API Console masih disokong di bawah.",
+    "xaiGrokApiKeyAlternative": "Atau gunakan kunci API xAI Console:"
   },
   "knowledgeBase": {
     "title": "Tetapan asas pengetahuan",

--- a/src/renderer/src/i18n/pl-PL/settings.json
+++ b/src/renderer/src/i18n/pl-PL/settings.json
@@ -1395,7 +1395,21 @@
     "openaiCodexCallbackTitle": "Zakończ uwierzytelnianie",
     "openaiCodexCallbackDescription": "Po zakończeniu w przeglądarce wróć do DeepChat. Jeśli DeepChat się nie zaktualizuje, wklej tutaj pełny adres URL wywołania zwrotnego.",
     "openaiCodexCallbackPlaceholder": "Wklej pełny adres URL wywołania zwrotnego",
-    "openaiCodexCompleteAuthentication": "Zakończ uwierzytelnianie"
+    "openaiCodexCompleteAuthentication": "Zakończ uwierzytelnianie",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok połączony",
+    "xaiGrokNotConnected": "xAI Grok niepołączony",
+    "xaiGrokPendingDevice": "Oczekiwanie na autoryzację urządzenia",
+    "xaiGrokDisabled": "OAuth xAI Grok jest wyłączony",
+    "xaiGrokError": "Autoryzacja xAI Grok nie powiodła się",
+    "xaiGrokAccount": "Konto",
+    "xaiGrokSignInDevice": "Zaloguj się przez SuperGrok / Premium+",
+    "xaiGrokReconnect": "Połącz ponownie",
+    "xaiGrokSignOut": "Wyloguj się",
+    "xaiGrokCancel": "Anuluj",
+    "xaiGrokOpenVerification": "Otwórz stronę weryfikacji",
+    "xaiGrokLoginTip": "Używa OAuth z kodem urządzenia xAI dla SuperGrok lub X Premium+. Tokeny są przechowywane oddzielnie od kluczy API. Klucze API Console są nadal obsługiwane poniżej.",
+    "xaiGrokApiKeyAlternative": "Lub użyj klucza API xAI Console:"
   },
   "knowledgeBase": {
     "title": "Ustawienia bazy wiedzy",

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -1135,7 +1135,21 @@
     "openaiCodexCallbackTitle": "Concluir autenticação",
     "openaiCodexCallbackDescription": "Depois que o navegador terminar, volte ao DeepChat. Se o DeepChat não atualizar, cole aqui a URL de callback completa.",
     "openaiCodexCallbackPlaceholder": "Cole a URL de callback completa",
-    "openaiCodexCompleteAuthentication": "Concluir autenticação"
+    "openaiCodexCompleteAuthentication": "Concluir autenticação",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok conectado",
+    "xaiGrokNotConnected": "xAI Grok não conectado",
+    "xaiGrokPendingDevice": "Aguardando autorização do dispositivo",
+    "xaiGrokDisabled": "O OAuth do xAI Grok está desativado",
+    "xaiGrokError": "Falha na autorização do xAI Grok",
+    "xaiGrokAccount": "Conta",
+    "xaiGrokSignInDevice": "Entrar com SuperGrok / Premium+",
+    "xaiGrokReconnect": "Reconectar",
+    "xaiGrokSignOut": "Sair",
+    "xaiGrokCancel": "Cancelar",
+    "xaiGrokOpenVerification": "Abrir página de verificação",
+    "xaiGrokLoginTip": "Usa o OAuth com código de dispositivo da xAI para SuperGrok ou X Premium+. Os tokens são armazenados separadamente das chaves de API. As chaves de API do Console continuam disponíveis abaixo.",
+    "xaiGrokApiKeyAlternative": "Ou use uma chave de API do xAI Console:"
   },
   "knowledgeBase": {
     "title": "Configurações da Base de Conhecimento",

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -1135,7 +1135,21 @@
     "openaiCodexCallbackTitle": "Завершить аутентификацию",
     "openaiCodexCallbackDescription": "Когда браузер завершит процесс, вернитесь в DeepChat. Если DeepChat не обновится, вставьте здесь полный URL обратного вызова.",
     "openaiCodexCallbackPlaceholder": "Вставьте полный URL обратного вызова",
-    "openaiCodexCompleteAuthentication": "Завершить аутентификацию"
+    "openaiCodexCompleteAuthentication": "Завершить аутентификацию",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok подключён",
+    "xaiGrokNotConnected": "xAI Grok не подключён",
+    "xaiGrokPendingDevice": "Ожидание авторизации устройства",
+    "xaiGrokDisabled": "OAuth xAI Grok отключён",
+    "xaiGrokError": "Не удалось авторизовать xAI Grok",
+    "xaiGrokAccount": "Учётная запись",
+    "xaiGrokSignInDevice": "Войти через SuperGrok / Premium+",
+    "xaiGrokReconnect": "Подключить снова",
+    "xaiGrokSignOut": "Выйти",
+    "xaiGrokCancel": "Отмена",
+    "xaiGrokOpenVerification": "Открыть страницу подтверждения",
+    "xaiGrokLoginTip": "Используется OAuth xAI с кодом устройства для SuperGrok или X Premium+. Токены хранятся отдельно от ключей API. Ниже по-прежнему можно использовать ключи API Console.",
+    "xaiGrokApiKeyAlternative": "Или используйте ключ API xAI Console:"
   },
   "knowledgeBase": {
     "title": "Настройки базы знаний",

--- a/src/renderer/src/i18n/tr-TR/settings.json
+++ b/src/renderer/src/i18n/tr-TR/settings.json
@@ -1395,7 +1395,21 @@
     "openaiCodexCallbackTitle": "Kimlik doğrulamayı tamamla",
     "openaiCodexCallbackDescription": "Tarayıcı işlemi tamamladıktan sonra DeepChat'e dönün. DeepChat güncellenmezse tam geri çağırma URL'sini buraya yapıştırın.",
     "openaiCodexCallbackPlaceholder": "Tam geri çağırma URL'sini yapıştır",
-    "openaiCodexCompleteAuthentication": "Kimlik doğrulamayı tamamla"
+    "openaiCodexCompleteAuthentication": "Kimlik doğrulamayı tamamla",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok bağlı",
+    "xaiGrokNotConnected": "xAI Grok bağlı değil",
+    "xaiGrokPendingDevice": "Cihaz yetkilendirmesi bekleniyor",
+    "xaiGrokDisabled": "xAI Grok OAuth devre dışı",
+    "xaiGrokError": "xAI Grok yetkilendirmesi başarısız oldu",
+    "xaiGrokAccount": "Hesap",
+    "xaiGrokSignInDevice": "SuperGrok / Premium+ ile oturum aç",
+    "xaiGrokReconnect": "Yeniden bağlan",
+    "xaiGrokSignOut": "Oturumu kapat",
+    "xaiGrokCancel": "İptal",
+    "xaiGrokOpenVerification": "Doğrulama sayfasını aç",
+    "xaiGrokLoginTip": "SuperGrok veya X Premium+ için xAI cihaz kodu OAuth kullanır. Token'lar API anahtarlarından ayrı saklanır. Console API anahtarları aşağıda desteklenmeye devam eder.",
+    "xaiGrokApiKeyAlternative": "Veya bir xAI Console API anahtarı kullanın:"
   },
   "knowledgeBase": {
     "title": "Bilgi Bankası Ayarları",

--- a/src/renderer/src/i18n/vi-VN/settings.json
+++ b/src/renderer/src/i18n/vi-VN/settings.json
@@ -1395,7 +1395,21 @@
     "openaiCodexCallbackTitle": "Hoàn tất xác thực",
     "openaiCodexCallbackDescription": "Sau khi trình duyệt hoàn tất, hãy quay lại DeepChat. Nếu DeepChat không cập nhật, hãy dán URL callback đầy đủ vào đây.",
     "openaiCodexCallbackPlaceholder": "Dán URL callback đầy đủ",
-    "openaiCodexCompleteAuthentication": "Hoàn tất xác thực"
+    "openaiCodexCompleteAuthentication": "Hoàn tất xác thực",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok đã kết nối",
+    "xaiGrokNotConnected": "xAI Grok chưa kết nối",
+    "xaiGrokPendingDevice": "Đang chờ cấp quyền thiết bị",
+    "xaiGrokDisabled": "OAuth xAI Grok đã bị tắt",
+    "xaiGrokError": "Cấp quyền xAI Grok thất bại",
+    "xaiGrokAccount": "Tài khoản",
+    "xaiGrokSignInDevice": "Đăng nhập bằng SuperGrok / Premium+",
+    "xaiGrokReconnect": "Kết nối lại",
+    "xaiGrokSignOut": "Đăng xuất",
+    "xaiGrokCancel": "Hủy",
+    "xaiGrokOpenVerification": "Mở trang xác minh",
+    "xaiGrokLoginTip": "Sử dụng OAuth mã thiết bị của xAI cho SuperGrok hoặc X Premium+. Token được lưu riêng với khóa API. Khóa API Console vẫn được hỗ trợ bên dưới.",
+    "xaiGrokApiKeyAlternative": "Hoặc sử dụng khóa API xAI Console:"
   },
   "knowledgeBase": {
     "title": "Cài đặt cơ sở kiến thức",

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -1395,7 +1395,21 @@
     "openaiCodexCallbackTitle": "完成认证",
     "openaiCodexCallbackDescription": "浏览器完成后回到 DeepChat。如果 DeepChat 没有更新，请把完整回调 URL 粘贴到这里。",
     "openaiCodexCallbackPlaceholder": "粘贴完整回调 URL",
-    "openaiCodexCompleteAuthentication": "完成认证"
+    "openaiCodexCompleteAuthentication": "完成认证",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok 已连接",
+    "xaiGrokNotConnected": "xAI Grok 未连接",
+    "xaiGrokPendingDevice": "等待设备授权",
+    "xaiGrokDisabled": "xAI Grok OAuth 已禁用",
+    "xaiGrokError": "xAI Grok 授权失败",
+    "xaiGrokAccount": "账号",
+    "xaiGrokSignInDevice": "使用 SuperGrok / Premium+ 登录",
+    "xaiGrokReconnect": "重新连接",
+    "xaiGrokSignOut": "退出登录",
+    "xaiGrokCancel": "取消",
+    "xaiGrokOpenVerification": "打开验证页面",
+    "xaiGrokLoginTip": "通过 xAI 设备码 OAuth 使用 SuperGrok 或 X Premium+ 订阅。Token 单独存储，不会写入 API Key。下方仍支持控制台 API Key。",
+    "xaiGrokApiKeyAlternative": "或者使用 xAI 控制台 API Key："
   },
   "knowledgeBase": {
     "title": "知识库设置",

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -1135,7 +1135,21 @@
     "openaiCodexCallbackTitle": "完成認證",
     "openaiCodexCallbackDescription": "瀏覽器完成後返回 DeepChat。如果 DeepChat 沒有更新，請在此貼上完整回調 URL。",
     "openaiCodexCallbackPlaceholder": "貼上完整回調 URL",
-    "openaiCodexCompleteAuthentication": "完成認證"
+    "openaiCodexCompleteAuthentication": "完成認證",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok 已連線",
+    "xaiGrokNotConnected": "xAI Grok 未連線",
+    "xaiGrokPendingDevice": "正在等待裝置授權",
+    "xaiGrokDisabled": "xAI Grok OAuth 已停用",
+    "xaiGrokError": "xAI Grok 授權失敗",
+    "xaiGrokAccount": "帳戶",
+    "xaiGrokSignInDevice": "使用 SuperGrok / Premium+ 登入",
+    "xaiGrokReconnect": "重新連線",
+    "xaiGrokSignOut": "登出",
+    "xaiGrokCancel": "取消",
+    "xaiGrokOpenVerification": "開啟驗證頁面",
+    "xaiGrokLoginTip": "透過 xAI 裝置代碼 OAuth 使用 SuperGrok 或 X Premium+。Token 會與 API Key 分開儲存，下方仍支援 Console API Key。",
+    "xaiGrokApiKeyAlternative": "或使用 xAI Console API Key："
   },
   "knowledgeBase": {
     "fastgptTitle": "FastGPT知識庫",

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -1135,7 +1135,21 @@
     "openaiCodexCallbackTitle": "完成驗證",
     "openaiCodexCallbackDescription": "瀏覽器完成後返回 DeepChat。如果 DeepChat 沒有更新，請在此貼上完整回呼 URL。",
     "openaiCodexCallbackPlaceholder": "貼上完整回呼 URL",
-    "openaiCodexCompleteAuthentication": "完成驗證"
+    "openaiCodexCompleteAuthentication": "完成驗證",
+    "xaiGrokAuth": "xAI Grok OAuth",
+    "xaiGrokConnected": "xAI Grok 已連線",
+    "xaiGrokNotConnected": "xAI Grok 未連線",
+    "xaiGrokPendingDevice": "正在等待裝置授權",
+    "xaiGrokDisabled": "xAI Grok OAuth 已停用",
+    "xaiGrokError": "xAI Grok 授權失敗",
+    "xaiGrokAccount": "帳號",
+    "xaiGrokSignInDevice": "使用 SuperGrok / Premium+ 登入",
+    "xaiGrokReconnect": "重新連線",
+    "xaiGrokSignOut": "登出",
+    "xaiGrokCancel": "取消",
+    "xaiGrokOpenVerification": "開啟驗證頁面",
+    "xaiGrokLoginTip": "透過 xAI 裝置代碼 OAuth 使用 SuperGrok 或 X Premium+。Token 會與 API Key 分開儲存，下方仍支援 Console API Key。",
+    "xaiGrokApiKeyAlternative": "或使用 xAI Console API Key："
   },
   "knowledgeBase": {
     "title": "知識庫設置",

--- a/src/shared/contracts/events.ts
+++ b/src/shared/contracts/events.ts
@@ -65,7 +65,10 @@ import {
   modelBatchStatusChangedEvent
 } from './events/models.events'
 import { databaseRepairSuggestedEvent, notificationErrorEvent } from './events/notification.events'
-import { oauthOpenAICodexStatusChangedEvent } from './events/oauth.events'
+import {
+  oauthOpenAICodexStatusChangedEvent,
+  oauthXaiGrokStatusChangedEvent
+} from './events/oauth.events'
 import { providersOllamaPullProgressEvent } from './events/misc.providers.events'
 import { projectEnvironmentsChangedEvent } from './events/project.events'
 import {
@@ -197,6 +200,7 @@ export const DEEPCHAT_EVENT_CATALOG = {
   [configCustomPromptsChangedEvent.name]: configCustomPromptsChangedEvent,
   [providersChangedEvent.name]: providersChangedEvent,
   [oauthOpenAICodexStatusChangedEvent.name]: oauthOpenAICodexStatusChangedEvent,
+  [oauthXaiGrokStatusChangedEvent.name]: oauthXaiGrokStatusChangedEvent,
   [projectEnvironmentsChangedEvent.name]: projectEnvironmentsChangedEvent,
   [providersRateLimitConfigUpdatedEvent.name]: providersRateLimitConfigUpdatedEvent,
   [providersRateLimitRequestQueuedEvent.name]: providersRateLimitRequestQueuedEvent,

--- a/src/shared/contracts/events/oauth.events.ts
+++ b/src/shared/contracts/events/oauth.events.ts
@@ -1,11 +1,19 @@
 import { z } from 'zod'
 import { TimestampMsSchema, defineEventContract } from '../common'
-import { OpenAICodexAuthStatusSchema } from '../routes/oauth.routes'
+import { OpenAICodexAuthStatusSchema, XaiGrokAuthStatusSchema } from '../routes/oauth.routes'
 
 export const oauthOpenAICodexStatusChangedEvent = defineEventContract({
   name: 'oauth.openaiCodex.statusChanged',
   payload: z.object({
     status: OpenAICodexAuthStatusSchema,
+    version: TimestampMsSchema
+  })
+})
+
+export const oauthXaiGrokStatusChangedEvent = defineEventContract({
+  name: 'oauth.xaiGrok.statusChanged',
+  payload: z.object({
+    status: XaiGrokAuthStatusSchema,
     version: TimestampMsSchema
   })
 })

--- a/src/shared/contracts/routes.ts
+++ b/src/shared/contracts/routes.ts
@@ -239,7 +239,11 @@ import {
   oauthOpenAICodexCompleteBrowserLoginFromUrlRoute,
   oauthOpenAICodexGetStatusRoute,
   oauthOpenAICodexLogoutRoute,
-  oauthOpenAICodexStartBrowserLoginRoute
+  oauthOpenAICodexStartBrowserLoginRoute,
+  oauthXaiGrokCancelLoginRoute,
+  oauthXaiGrokGetStatusRoute,
+  oauthXaiGrokLogoutRoute,
+  oauthXaiGrokStartDeviceLoginRoute
 } from './routes/oauth.routes'
 import {
   remoteControlCancelFeishuAuthRoute,
@@ -590,6 +594,10 @@ const DEEPCHAT_ROUTE_CATALOG_PART_1 = {
     oauthOpenAICodexCompleteBrowserLoginFromUrlRoute,
   [oauthOpenAICodexCancelLoginRoute.name]: oauthOpenAICodexCancelLoginRoute,
   [oauthOpenAICodexLogoutRoute.name]: oauthOpenAICodexLogoutRoute,
+  [oauthXaiGrokGetStatusRoute.name]: oauthXaiGrokGetStatusRoute,
+  [oauthXaiGrokStartDeviceLoginRoute.name]: oauthXaiGrokStartDeviceLoginRoute,
+  [oauthXaiGrokCancelLoginRoute.name]: oauthXaiGrokCancelLoginRoute,
+  [oauthXaiGrokLogoutRoute.name]: oauthXaiGrokLogoutRoute,
   [remoteControlListChannelsRoute.name]: remoteControlListChannelsRoute,
   [remoteControlGetChannelSettingsRoute.name]: remoteControlGetChannelSettingsRoute,
   [remoteControlSaveChannelSettingsRoute.name]: remoteControlSaveChannelSettingsRoute,

--- a/src/shared/contracts/routes/oauth.routes.ts
+++ b/src/shared/contracts/routes/oauth.routes.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod'
 import { EntityIdSchema, defineRouteContract } from '../common'
 import type { OpenAICodexAuthStatus } from '../../types/openai-codex'
+import type { XaiGrokAuthStatus } from '../../types/xai-grok'
 
 export type { OpenAICodexAuthStatus } from '../../types/openai-codex'
+export type { XaiGrokAuthStatus } from '../../types/xai-grok'
 
 const OAuthProviderIdSchema = EntityIdSchema
 
@@ -23,6 +25,23 @@ export const OpenAICodexAuthStatusSchema: z.ZodType<OpenAICodexAuthStatus> = z.o
 
 const OpenAICodexStatusResultSchema = z.object({
   status: OpenAICodexAuthStatusSchema
+})
+
+export const XaiGrokAuthStatusSchema: z.ZodType<XaiGrokAuthStatus> = z.object({
+  state: z.enum(['disabled', 'signed-out', 'pending-device', 'authenticated', 'error']),
+  authenticated: z.boolean(),
+  accountId: z.string().optional(),
+  accountLabel: z.string().optional(),
+  expiresAt: z.number().optional(),
+  userCode: z.string().optional(),
+  verificationUri: z.string().optional(),
+  verificationUriComplete: z.string().optional(),
+  storage: z.enum(['safeStorage', 'file', 'none']),
+  error: z.string().optional()
+})
+
+const XaiGrokStatusResultSchema = z.object({
+  status: XaiGrokAuthStatusSchema
 })
 
 export const oauthGithubCopilotStartLoginRoute = defineRouteContract({
@@ -71,4 +90,28 @@ export const oauthOpenAICodexLogoutRoute = defineRouteContract({
   name: 'oauth.openaiCodex.logout',
   input: z.object({}),
   output: OpenAICodexStatusResultSchema
+})
+
+export const oauthXaiGrokGetStatusRoute = defineRouteContract({
+  name: 'oauth.xaiGrok.getStatus',
+  input: z.object({}),
+  output: XaiGrokStatusResultSchema
+})
+
+export const oauthXaiGrokStartDeviceLoginRoute = defineRouteContract({
+  name: 'oauth.xaiGrok.startDeviceLogin',
+  input: z.object({}),
+  output: XaiGrokStatusResultSchema
+})
+
+export const oauthXaiGrokCancelLoginRoute = defineRouteContract({
+  name: 'oauth.xaiGrok.cancelLogin',
+  input: z.object({}),
+  output: XaiGrokStatusResultSchema
+})
+
+export const oauthXaiGrokLogoutRoute = defineRouteContract({
+  name: 'oauth.xaiGrok.logout',
+  input: z.object({}),
+  output: XaiGrokStatusResultSchema
 })

--- a/src/shared/types/presenters/core.presenter.d.ts
+++ b/src/shared/types/presenters/core.presenter.d.ts
@@ -25,6 +25,7 @@ import type { IProjectPresenter } from './project.presenter'
 import type { BrowserPageInfo, DownloadInfo, ScreenshotOptions, YoBrowserStatus } from '../browser'
 import type { IWindowPresenter, TabData } from './window.presenter'
 import type { OpenAICodexAuthStatus } from '../openai-codex'
+import type { XaiGrokAuthStatus } from '../xai-grok'
 import type {
   Agent,
   AgentType,
@@ -412,6 +413,10 @@ export interface IOAuthPresenter {
   completeOpenAICodexBrowserLoginFromUrl(callbackUrl: string): Promise<OpenAICodexAuthStatus>
   cancelOpenAICodexLogin(): Promise<OpenAICodexAuthStatus>
   logoutOpenAICodex(): Promise<OpenAICodexAuthStatus>
+  getXaiGrokStatus(): Promise<XaiGrokAuthStatus>
+  startXaiGrokDeviceLogin(): Promise<XaiGrokAuthStatus>
+  cancelXaiGrokLogin(): Promise<XaiGrokAuthStatus>
+  logoutXaiGrok(): Promise<XaiGrokAuthStatus>
 }
 
 export interface OAuthConfig {

--- a/src/shared/types/xai-grok.ts
+++ b/src/shared/types/xai-grok.ts
@@ -1,0 +1,19 @@
+export type XaiGrokAuthState =
+  | 'disabled'
+  | 'signed-out'
+  | 'pending-device'
+  | 'authenticated'
+  | 'error'
+
+export type XaiGrokAuthStatus = {
+  state: XaiGrokAuthState
+  authenticated: boolean
+  accountId?: string
+  accountLabel?: string
+  expiresAt?: number
+  userCode?: string
+  verificationUri?: string
+  verificationUriComplete?: string
+  storage: 'safeStorage' | 'file' | 'none'
+  error?: string
+}

--- a/test/main/presenter/xaiGrokAuth.test.ts
+++ b/test/main/presenter/xaiGrokAuth.test.ts
@@ -1,0 +1,283 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { shell } from 'electron'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  XaiGrokAuth,
+  resetGlobalXaiGrokAuthForTests
+} from '../../../src/main/presenter/xaiGrokAuth'
+import { XaiGrokCredentialStore } from '../../../src/main/presenter/xaiGrokAuth/credentialStore'
+import {
+  XAI_GROK_OAUTH_CLIENT_ID,
+  isTrustedXaiApiEndpoint,
+  isTrustedXaiOAuthEndpoint
+} from '../../../src/main/presenter/xaiGrokAuth/constants'
+import {
+  createXaiGrokFetch,
+  shouldUseXaiGrokOAuthFetch
+} from '../../../src/main/presenter/llmProviderPresenter/xaiGrokAuthAdapter'
+
+vi.mock('@/routes/publishDeepchatEvent', () => ({
+  publishDeepchatEvent: vi.fn()
+}))
+
+function jsonResponse(value: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init
+  })
+}
+
+describe('xAI Grok OAuth', () => {
+  let tempDir: string
+  let files: Map<string, string>
+
+  beforeEach(() => {
+    files = new Map()
+    tempDir = `/tmp/deepchat-xai-grok-auth-${Date.now()}`
+    vi.mocked(fs.existsSync).mockImplementation((file) => files.has(String(file)))
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined)
+    vi.mocked(fs.writeFileSync).mockImplementation((file, data) => {
+      files.set(String(file), String(data))
+    })
+    vi.mocked(fs.readFileSync).mockImplementation((file) => files.get(String(file)) || '')
+    vi.mocked(fs.rmSync).mockImplementation((file) => {
+      files.delete(String(file))
+    })
+    vi.mocked(shell.openExternal).mockClear()
+    delete process.env.DEEPCHAT_XAI_GROK_OAUTH_DISABLED
+    delete process.env.XAI_GROK_ACCESS_TOKEN
+    resetGlobalXaiGrokAuthForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    delete process.env.DEEPCHAT_XAI_GROK_OAUTH_DISABLED
+    delete process.env.XAI_GROK_ACCESS_TOKEN
+    resetGlobalXaiGrokAuthForTests()
+  })
+
+  it('accepts only trusted xAI OAuth endpoints', () => {
+    expect(isTrustedXaiOAuthEndpoint('https://auth.x.ai/oauth2/token')).toBe(true)
+    expect(isTrustedXaiOAuthEndpoint('https://accounts.x.ai/oauth2/token')).toBe(true)
+    expect(isTrustedXaiOAuthEndpoint('http://auth.x.ai/oauth2/token')).toBe(false)
+    expect(isTrustedXaiOAuthEndpoint('https://x.ai.evil.test/oauth2/token')).toBe(false)
+    expect(isTrustedXaiOAuthEndpoint('not a url')).toBe(false)
+    expect(isTrustedXaiApiEndpoint('https://api.x.ai/v1/chat/completions')).toBe(true)
+    expect(isTrustedXaiApiEndpoint('https://api.x.ai.evil.test/v1')).toBe(false)
+  })
+
+  it('enables OAuth injection only for the built-in Grok provider on xAI endpoints', () => {
+    const provider = {
+      id: 'grok',
+      name: 'Grok',
+      apiType: 'grok',
+      apiKey: '',
+      baseUrl: 'https://api.x.ai/v1',
+      enable: true
+    }
+
+    expect(shouldUseXaiGrokOAuthFetch(provider)).toBe(true)
+    expect(
+      shouldUseXaiGrokOAuthFetch({
+        ...provider,
+        baseUrl: 'https://grok-compatible.example.com/v1'
+      })
+    ).toBe(false)
+    expect(
+      shouldUseXaiGrokOAuthFetch({
+        ...provider,
+        id: 'custom-grok'
+      })
+    ).toBe(false)
+  })
+
+  it('refuses to send credentials when a wrapped request targets an untrusted endpoint', async () => {
+    const underlyingFetch = vi.fn<typeof fetch>()
+    const fetcher = createXaiGrokFetch(
+      {
+        id: 'grok',
+        name: 'Grok',
+        apiType: 'grok',
+        apiKey: 'console-key',
+        baseUrl: 'https://api.x.ai/v1',
+        enable: true
+      },
+      {},
+      underlyingFetch
+    )
+
+    await expect(fetcher('https://attacker.example.com/v1/models')).rejects.toThrow(
+      'untrusted API endpoint'
+    )
+    expect(underlyingFetch).not.toHaveBeenCalled()
+  })
+
+  it('stores Grok OAuth credentials outside provider records', () => {
+    const credentialPath = path.join(tempDir, 'credentials.json')
+    const store = new XaiGrokCredentialStore(credentialPath)
+    store.save({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      tokenType: 'Bearer',
+      expiresAt: Date.now() + 3600_000,
+      accountId: 'account-id',
+      accountLabel: 'user@example.com',
+      tokenEndpoint: 'https://auth.x.ai/oauth2/token',
+      updatedAt: Date.now()
+    })
+
+    expect(fs.mkdirSync).toHaveBeenCalledWith(path.dirname(credentialPath), {
+      recursive: true,
+      mode: 0o700
+    })
+    expect(fs.writeFileSync).toHaveBeenCalledWith(credentialPath, expect.any(String), {
+      encoding: 'utf-8',
+      mode: 0o600
+    })
+
+    const loaded = store.load()
+    expect(loaded?.accessToken).toBe('access-token')
+    expect(loaded?.refreshToken).toBe('refresh-token')
+    expect(loaded?.accountLabel).toBe('user@example.com')
+  })
+
+  it('completes device-code login and exposes authenticated status', async () => {
+    const credentialPath = path.join(tempDir, 'credentials.json')
+    const store = new XaiGrokCredentialStore(credentialPath)
+    const auth = new XaiGrokAuth(store)
+
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input)
+      if (url.includes('.well-known/openid-configuration')) {
+        return jsonResponse({
+          device_authorization_endpoint: 'https://auth.x.ai/oauth2/device/code',
+          token_endpoint: 'https://auth.x.ai/oauth2/token',
+          revocation_endpoint: 'https://auth.x.ai/oauth2/revoke'
+        })
+      }
+      if (url.includes('/oauth2/device/code')) {
+        expect(init?.method).toBe('POST')
+        expect(String(init?.body)).toContain(`client_id=${XAI_GROK_OAUTH_CLIENT_ID}`)
+        return jsonResponse({
+          device_code: 'device-1',
+          user_code: 'ABCD-EFGH',
+          verification_uri: 'https://auth.x.ai/device',
+          verification_uri_complete: 'https://auth.x.ai/device?user_code=ABCD-EFGH',
+          expires_in: 600,
+          interval: 1
+        })
+      }
+      if (url.includes('/oauth2/token')) {
+        return jsonResponse({
+          access_token: 'access-1',
+          refresh_token: 'refresh-1',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          id_token: [
+            Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url'),
+            Buffer.from(JSON.stringify({ sub: 'user-1', email: 'grok@example.com' })).toString(
+              'base64url'
+            ),
+            'sig'
+          ].join('.')
+        })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchImpl)
+
+    const pending = await auth.startDeviceLogin()
+    expect(pending.state).toBe('pending-device')
+    expect(pending.userCode).toBe('ABCD-EFGH')
+    expect(shell.openExternal).toHaveBeenCalled()
+
+    // Wait for background poll to finish
+    await vi.waitFor(() => {
+      expect(auth.getStatus().authenticated).toBe(true)
+    })
+
+    const status = auth.getStatus()
+    expect(status.state).toBe('authenticated')
+    expect(status.accountLabel).toBe('grok@example.com')
+    expect(await auth.ensureAccessToken()).toBe('access-1')
+  })
+
+  it('refreshes near-expiry access tokens', async () => {
+    const credentialPath = path.join(tempDir, 'credentials.json')
+    const store = new XaiGrokCredentialStore(credentialPath)
+    store.save({
+      accessToken: 'access-old',
+      refreshToken: 'refresh-1',
+      tokenType: 'Bearer',
+      expiresAt: Date.now() + 1000,
+      tokenEndpoint: 'https://auth.x.ai/oauth2/token',
+      updatedAt: Date.now()
+    })
+    const auth = new XaiGrokAuth(store)
+
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input)
+      expect(url).toBe('https://auth.x.ai/oauth2/token')
+      expect(String(init?.body)).toContain('grant_type=refresh_token')
+      expect(String(init?.body)).toContain('refresh_token=refresh-1')
+      return jsonResponse({
+        access_token: 'access-new',
+        expires_in: 3600
+      })
+    })
+    vi.stubGlobal('fetch', fetchImpl)
+
+    const token = await auth.ensureAccessToken()
+    expect(token).toBe('access-new')
+    expect(store.load()?.accessToken).toBe('access-new')
+  })
+
+  it('coordinates concurrent forced token refreshes', async () => {
+    const credentialPath = path.join(tempDir, 'credentials.json')
+    const store = new XaiGrokCredentialStore(credentialPath)
+    store.save({
+      accessToken: 'access-old',
+      refreshToken: 'refresh-1',
+      tokenType: 'Bearer',
+      expiresAt: Date.now() + 3600_000,
+      tokenEndpoint: 'https://auth.x.ai/oauth2/token',
+      updatedAt: Date.now()
+    })
+    const auth = new XaiGrokAuth(store)
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      jsonResponse({ access_token: 'access-new', expires_in: 3600 })
+    )
+    vi.stubGlobal('fetch', fetchImpl)
+
+    await expect(
+      Promise.all([auth.forceRefreshAccessToken(), auth.forceRefreshAccessToken()])
+    ).resolves.toEqual(['access-new', 'access-new'])
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not expose an expired access token to synchronous request paths', () => {
+    const store = new XaiGrokCredentialStore(path.join(tempDir, 'credentials.json'))
+    store.save({
+      accessToken: 'access-expired',
+      refreshToken: 'refresh-1',
+      tokenType: 'Bearer',
+      expiresAt: Date.now() - 1000,
+      tokenEndpoint: 'https://auth.x.ai/oauth2/token',
+      updatedAt: Date.now()
+    })
+
+    expect(new XaiGrokAuth(store).peekAccessToken()).toBeNull()
+  })
+
+  it('reports disabled state when kill switch is set', () => {
+    process.env.DEEPCHAT_XAI_GROK_OAUTH_DISABLED = '1'
+    const auth = new XaiGrokAuth(new XaiGrokCredentialStore(path.join(tempDir, 'c.json')))
+    expect(auth.getStatus()).toMatchObject({
+      state: 'disabled',
+      authenticated: false
+    })
+  })
+})

--- a/test/renderer/components/GrokOAuth.test.ts
+++ b/test/renderer/components/GrokOAuth.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import type { LLM_PROVIDER } from '../../../src/shared/presenter'
+import type { XaiGrokAuthStatus } from '../../../src/shared/contracts/routes'
+
+const buttonStub = defineComponent({
+  name: 'Button',
+  inheritAttrs: false,
+  emits: ['click'],
+  template: '<button v-bind="$attrs" type="button" @click="$emit(\'click\')"><slot /></button>'
+})
+
+const labelStub = defineComponent({
+  name: 'Label',
+  inheritAttrs: false,
+  template: '<label v-bind="$attrs"><slot /></label>'
+})
+
+const iconStub = defineComponent({
+  name: 'Icon',
+  template: '<i />'
+})
+
+const signedOutStatus: XaiGrokAuthStatus = {
+  state: 'signed-out',
+  authenticated: false,
+  storage: 'safeStorage'
+}
+
+const authenticatedStatus: XaiGrokAuthStatus = {
+  state: 'authenticated',
+  authenticated: true,
+  storage: 'safeStorage',
+  accountId: 'acct...1234',
+  accountLabel: 'grok@example.com'
+}
+
+const pendingDeviceStatus: XaiGrokAuthStatus = {
+  state: 'pending-device',
+  authenticated: false,
+  storage: 'safeStorage',
+  userCode: 'ABCD-EFGH',
+  verificationUri: 'https://auth.x.ai/device'
+}
+
+const provider: LLM_PROVIDER = {
+  id: 'grok',
+  name: 'Grok',
+  apiType: 'grok',
+  apiKey: '',
+  baseUrl: 'https://api.x.ai/v1',
+  enable: true,
+  custom: false
+}
+
+describe('GrokOAuth', () => {
+  async function setup(initialStatus: XaiGrokAuthStatus = signedOutStatus) {
+    vi.resetModules()
+
+    const oauthClient = {
+      getXaiGrokStatus: vi.fn().mockResolvedValue(initialStatus),
+      startXaiGrokDeviceLogin: vi.fn().mockResolvedValue(authenticatedStatus),
+      cancelXaiGrokLogin: vi.fn().mockResolvedValue(signedOutStatus),
+      logoutXaiGrok: vi.fn().mockResolvedValue(signedOutStatus),
+      onXaiGrokStatusChanged: vi.fn(() => vi.fn())
+    }
+    const browserClient = {
+      openExternal: vi.fn().mockResolvedValue(undefined)
+    }
+    const modelCheckStore = {
+      openDialog: vi.fn()
+    }
+
+    vi.doMock('@api/OAuthClient', () => ({
+      createOAuthClient: () => oauthClient
+    }))
+    vi.doMock('@api/BrowserClient', () => ({
+      createBrowserClient: () => browserClient
+    }))
+    vi.doMock('@/stores/modelCheck', () => ({
+      useModelCheckStore: () => modelCheckStore
+    }))
+    vi.doMock('vue-i18n', () => ({
+      useI18n: () => ({
+        t: (key: string) => key
+      })
+    }))
+    vi.doMock('@shadcn/components/ui/button', () => ({
+      Button: buttonStub
+    }))
+    vi.doMock('@shadcn/components/ui/label', () => ({
+      Label: labelStub
+    }))
+    vi.doMock('@iconify/vue', () => ({
+      Icon: iconStub
+    }))
+
+    const GrokOAuth = (await import('../../../src/renderer/settings/components/GrokOAuth.vue'))
+      .default
+    const wrapper = mount(GrokOAuth, {
+      props: { provider }
+    })
+    await flushPromises()
+
+    return { wrapper, oauthClient, browserClient, modelCheckStore }
+  }
+
+  it('starts device login and emits auth success', async () => {
+    const { wrapper, oauthClient } = await setup()
+
+    await wrapper.get('[data-testid="grok-device-login-button"]').trigger('click')
+    await flushPromises()
+
+    expect(oauthClient.startXaiGrokDeviceLogin).toHaveBeenCalledTimes(1)
+    expect(wrapper.emitted('auth-success')).toHaveLength(1)
+    expect(wrapper.text()).toContain('grok@example.com')
+  })
+
+  it('shows the device code and reopens the trusted verification page', async () => {
+    const { wrapper, browserClient } = await setup(pendingDeviceStatus)
+
+    expect(wrapper.text()).toContain('ABCD-EFGH')
+    await wrapper.get('[data-testid="grok-open-verification-button"]').trigger('click')
+
+    expect(browserClient.openExternal).toHaveBeenCalledWith('https://auth.x.ai/device')
+    expect(wrapper.find('[data-testid="grok-cancel-login-button"]').exists()).toBe(true)
+  })
+
+  it('opens model checks only for an enabled authenticated provider', async () => {
+    const { wrapper, modelCheckStore } = await setup(authenticatedStatus)
+
+    await wrapper.get('[data-testid="grok-test-connection-button"]').trigger('click')
+
+    expect(modelCheckStore.openDialog).toHaveBeenCalledWith('grok')
+  })
+})

--- a/test/renderer/components/ProviderApiConfig.test.ts
+++ b/test/renderer/components/ProviderApiConfig.test.ts
@@ -150,7 +150,8 @@ async function setup(options?: {
     global: {
       stubs: {
         GitHubCopilotOAuth: true,
-        OpenAICodexOAuth: true
+        OpenAICodexOAuth: true,
+        GrokOAuth: true
       }
     }
   })
@@ -245,6 +246,38 @@ describe('ProviderApiConfig', () => {
 
     expect(wrapper.findComponent({ name: 'OpenAICodexOAuth' }).exists()).toBe(true)
     expect(wrapper.find('[data-testid="provider-api-key-input"]').exists()).toBe(false)
+  })
+
+  it('shows Grok OAuth alongside the API key fallback', async () => {
+    const { wrapper } = await setup({
+      provider: createProvider({
+        id: 'grok',
+        name: 'Grok',
+        apiType: 'grok',
+        apiKey: '',
+        baseUrl: 'https://api.x.ai/v1'
+      })
+    })
+
+    expect(wrapper.findComponent({ name: 'GrokOAuth' }).exists()).toBe(true)
+    expect(wrapper.find('[data-testid="provider-api-key-input"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('settings.provider.xaiGrokApiKeyAlternative')
+  })
+
+  it('hides Grok OAuth when the API URL is not an xAI endpoint', async () => {
+    const { wrapper } = await setup({
+      provider: createProvider({
+        id: 'grok',
+        name: 'Grok',
+        apiType: 'grok',
+        apiKey: '',
+        baseUrl: 'https://grok-compatible.example.com/v1'
+      })
+    })
+
+    expect(wrapper.findComponent({ name: 'GrokOAuth' }).exists()).toBe(false)
+    expect(wrapper.find('[data-testid="provider-api-key-input"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('settings.provider.xaiGrokApiKeyAlternative')
   })
 
   it('keeps custom providers editable by default', async () => {


### PR DESCRIPTION
## Summary

- add xAI device-code OAuth for SuperGrok and X Premium+ accounts
- store credentials outside provider records and coordinate token refreshes
- retain API-key fallback while restricting OAuth bearer use to trusted x.ai endpoints
- add localized UI copy for all supported locales and main/renderer regression tests

## UI

BEFORE

    Grok provider settings
    ├── API URL
    ├── API Key
    └── Verify / Refresh models

AFTER

    Grok provider settings
    ├── API URL
    ├── xAI Grok OAuth
    │   ├── connection status / account
    │   ├── device code + verification link
    │   └── sign in / reconnect / sign out
    ├── API Key fallback
    └── Verify / Refresh models

## Validation

- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck
- pnpm exec vitest run test/main/presenter/xaiGrokAuth.test.ts test/renderer/components/GrokOAuth.test.ts test/renderer/components/ProviderApiConfig.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-class xAI Grok OAuth sign-in using device authorization.
  * Added Grok connection status, verification, cancellation, reconnection, and sign-out controls in provider settings.
  * OAuth credentials are securely stored and refreshed automatically.
  * Existing Grok API-key authentication remains available as a fallback.
  * Added localized settings text across supported languages.
* **Security**
  * Restricted OAuth credential injection to trusted xAI HTTPS endpoints.
* **Tests**
  * Added coverage for authentication, token refresh, secure storage, endpoint validation, and settings UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->