### PR TITLE
fix(chat): preserve sidebar workspace intent

### DIFF
--- a/docs/issues/sidebar-new-chat-workspace-intent/spec.md
+++ b/docs/issues/sidebar-new-chat-workspace-intent/spec.md
@@ -1,0 +1,163 @@
+# Sidebar new chat workspace intent
+
+Status: diagnosed; implementation pending
+
+Related contracts:
+
+- `docs/features/sidebar-chat-section-actions/spec.md`
+- `docs/features/default-workspace/spec.md`
+
+## Issue
+
+Starting a new conversation from another sidebar workspace while a conversation is active can open
+the new-thread page with the active conversation's directory instead of the workspace whose `+`
+button was clicked.
+
+This affects both the `Chats` header action and project-folder header actions. The same action usually
+works when no conversation is active.
+
+## Reproduction
+
+1. Configure a DeepChat agent with a default directory, then activate one of its conversations.
+2. In project grouping, click `+` on `Chats` or on a different project folder.
+3. Submit the new conversation.
+4. Inspect the created session's `projectDir`.
+
+Actual behavior: the selected directory can be replaced by the active agent's default directory,
+which commonly matches the active conversation's directory.
+
+Expected behavior: the workspace selected by the sidebar action is the directory used by the new
+conversation. An explicit `Chats` selection must also preserve its existing nullable/default-chat
+workspace semantics.
+
+## Behavior shape
+
+Before:
+
+```text
+Active session: Project A
+        |
+        +-- click Project B [+]
+                  |
+                  +-- select Project B
+                  +-- close active session
+                  +-- mount NewThreadPage
+                  +-- apply agent default (Project A)
+                  `-- create session in Project A
+```
+
+After:
+
+```text
+Active session: Project A
+        |
+        +-- click Project B [+]
+                  |
+                  +-- carry explicit Project B intent through navigation
+                  +-- close active session
+                  +-- mount NewThreadPage
+                  +-- resolve defaults without replacing the explicit intent
+                  `-- create session in Project B
+```
+
+## Impact
+
+- The sidebar action communicates a specific target workspace but creates the conversation in a
+  different directory.
+- Agent tools, file references, workspace panels, and ACP workdir validation can operate against the
+  wrong directory.
+- The defect is conditional on the active-session transition, so the same button appears reliable
+  from an already-open new-thread page and unreliable from an active chat.
+
+## Root cause
+
+The defect is in renderer navigation and draft initialization, before session creation reaches the
+main process.
+
+1. `WindowSideBar.vue::handleNewChatForProject` writes the clicked path to the general
+   `projectStore` selection and then calls `sessionStore.startNewConversation()`.
+2. With an active conversation, `startNewConversation()` calls `closeSession()`. This changes the
+   internal page route from `ChatPage` to a newly mounted `NewThreadPage`.
+3. `NewThreadPage` immediately runs `applyDraftDefaultsForSelectedAgent()` from its selected-agent
+   watcher.
+4. For DeepChat agents, that initializer resolves directories as
+   `agentDefaultProjectPath ?? currentProjectPath ?? globalDefaultProjectPath` and calls
+   `projectStore.selectProject(agentDefaultProjectPath, ...)` whenever an agent default exists.
+5. The active conversation keeps its agent selected during the transition, so the new page applies
+   that agent's default and overwrites the workspace selected by the sidebar action.
+
+There is no direct copy from `activeSession.projectDir` in this path. The apparent inheritance is an
+indirect result of losing the explicit sidebar intent and reapplying the active agent's default.
+
+The main-process assignment policy is not the source of the bug:
+`SessionAgentAssignmentPolicy.resolveProjectDir()` already gives a provided `input.projectDir`
+precedence over agent and global defaults. The wrong value has already been selected in the renderer
+before submission.
+
+## Regression origin and coverage gap
+
+Commit `810fe691c` added the `Chats` and project-folder new-conversation actions. Its sidebar tests
+mock `startNewConversation()` and assert only that selection and navigation methods were called. They
+do not exercise active-session teardown followed by `NewThreadPage` initialization.
+
+Separately, `NewThreadPage` has a test that intentionally verifies an agent default wins over the
+ordinary current selection. Both unit contracts pass while their composition drops the stronger,
+one-shot workspace intent.
+
+## Correct ownership
+
+- `WindowSideBar` owns the clicked target workspace.
+- `sessionStore` / `pageRouter` own the active-session-to-new-thread transition.
+- `NewThreadPage` owns agent/default draft initialization.
+- The explicit workspace target must be represented across those owners; a pre-navigation mutation
+  of generic project selection is insufficient.
+
+## Fix plan
+
+1. Extend the unified new-conversation navigation with an optional one-shot workspace intent. The
+   representation must distinguish an omitted intent from an explicit `null` used by `Chats`.
+2. Pass the `Chats` or project-folder target through that navigation intent instead of relying only
+   on `projectStore.selectProject()` before active-session teardown.
+3. Resolve the intent inside `NewThreadPage`'s draft-default initialization with this precedence:
+   explicit navigation intent (including `null`) > existing agent/default resolution.
+4. Consume the intent after initial application. Keep it renderer-local and non-persisted.
+5. Preserve current behavior for generic New Chat actions with no workspace intent: agent defaults,
+   current selection, and global defaults keep their existing precedence.
+6. Do not change `SessionAgentAssignmentPolicy`; it already honors explicit session input.
+
+Avoid timing-based fixes such as delayed reselection or extra `nextTick()` calls. They would leave the
+result dependent on async agent-config resolution and component mount timing.
+
+## Task checklist
+
+- [x] Trace the sidebar action through active-session teardown and new-thread initialization.
+- [x] Confirm the main-process project-directory precedence is correct.
+- [x] Record the regression and existing test gap.
+- [ ] Add a one-shot workspace intent to the unified new-conversation path.
+- [ ] Apply and consume the intent during new-thread draft initialization.
+- [ ] Update sidebar and session-store tests for the intent payload.
+- [ ] Add a regression test where an active agent default differs from the clicked workspace.
+- [ ] Add coverage for both a project-folder target and an explicit `Chats` target.
+- [ ] After implementation, rerun formatter, i18n validation, lint, and focused renderer tests.
+
+## Validation
+
+- Active Project A + Project B header `+` creates the next session with Project B as `projectDir`.
+- Active Project A + `Chats` header `+` preserves the configured default-chat workspace or explicit
+  nullable project selection used by the existing `Chats` contract.
+- The same actions behave identically whether a session is active or the new-thread page is already
+  open.
+- Generic New Chat without a workspace target still applies the selected agent's default directory.
+- Explicit `projectDir` continues to outrank agent and global defaults in the main-process assignment
+  policy.
+
+## Non-goals
+
+- Changing sidebar layout or labels.
+- Changing agent default-directory settings.
+- Persisting a new workspace preference.
+- Changing session database schemas or main-process assignment policy.
+
+## Linked GitHub issue
+
+Not synced; GitHub issue creation requires explicit developer approval.

--- a/docs/issues/sidebar-new-chat-workspace-intent/spec.md
+++ b/docs/issues/sidebar-new-chat-workspace-intent/spec.md
@@ -1,6 +1,6 @@
 # Sidebar new chat workspace intent
 
-Status: diagnosed; implementation pending
+Status: implemented and validated
 
 Related contracts:
 
@@ -133,12 +133,12 @@ result dependent on async agent-config resolution and component mount timing.
 - [x] Trace the sidebar action through active-session teardown and new-thread initialization.
 - [x] Confirm the main-process project-directory precedence is correct.
 - [x] Record the regression and existing test gap.
-- [ ] Add a one-shot workspace intent to the unified new-conversation path.
-- [ ] Apply and consume the intent during new-thread draft initialization.
-- [ ] Update sidebar and session-store tests for the intent payload.
-- [ ] Add a regression test where an active agent default differs from the clicked workspace.
-- [ ] Add coverage for both a project-folder target and an explicit `Chats` target.
-- [ ] After implementation, rerun formatter, i18n validation, lint, and focused renderer tests.
+- [x] Add a one-shot workspace intent to the unified new-conversation path.
+- [x] Apply and consume the intent during new-thread draft initialization.
+- [x] Update sidebar and session-store tests for the intent payload.
+- [x] Add a regression test where an active agent default differs from the clicked workspace.
+- [x] Add coverage for both a project-folder target and an explicit `Chats` target.
+- [x] After implementation, rerun formatter, i18n validation, lint, and focused renderer tests.
 
 ## Validation
 

--- a/src/renderer/src/components/WindowSideBar.vue
+++ b/src/renderer/src/components/WindowSideBar.vue
@@ -545,7 +545,12 @@ import { createRemoteControlClient } from '@api/RemoteControlClient'
 import { createDeviceClient } from '@api/DeviceClient'
 import { useAgentStore } from '@/stores/ui/agent'
 import { useProjectStore } from '@/stores/ui/project'
-import { useSessionStore, type SessionGroup, type UISession } from '@/stores/ui/session'
+import {
+  useSessionStore,
+  type SessionGroup,
+  type StartNewConversationOptions,
+  type UISession
+} from '@/stores/ui/session'
 import { useSpotlightStore } from '@/stores/ui/spotlight'
 import { usePluginCatalogStore } from '@/stores/pluginCatalog'
 import type { RemoteChannel, RemoteRuntimeState } from '@shared/presenter'
@@ -1250,19 +1255,23 @@ const navigateToChat = async () => {
   }
 }
 
-const handleNewChat = async () => {
+const startNewChat = async (options: StartNewConversationOptions) => {
   try {
     await navigateToChat()
   } catch (error) {
     console.warn('[WindowSideBar] Failed to switch to chat route:', error)
   } finally {
-    await sessionStore.startNewConversation({ refresh: true })
+    await sessionStore.startNewConversation(options)
   }
+}
+
+const handleNewChat = async () => {
+  await startNewChat({ refresh: true })
 }
 
 const handleNewChatForProject = async (projectPath: string | null) => {
   await projectStore.selectProject(projectPath, 'manual')
-  await handleNewChat()
+  await startNewChat({ refresh: true, projectDir: projectPath })
 }
 
 const handleAgentSelect = async (id: string | null) => {

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -245,6 +245,7 @@ const lastAcpDraftKey = ref<string | null>(null)
 const acpDraftRequestSeq = ref(0)
 const isCompletingSwitchAgentGuide = ref(false)
 let currentDraftDefaultsTask: Promise<void> | null = null
+let draftDefaultsRequestSeq = 0
 let cancelEnsureDraftTask: (() => void) | null = null
 let voiceInputConfigToken = 0
 let attachmentFilterToken = 0
@@ -925,10 +926,18 @@ const resolveDeepChatAgentConfig = async (agentId: string): Promise<DeepChatAgen
   })
 }
 
-const applyDraftDefaultsForSelectedAgent = async (): Promise<void> => {
+const applyDraftDefaultsForSelectedAgent = async (requestSeq: number): Promise<void> => {
   const agentId = selectedAgent.value.id
   const globalDefaultProjectPath = normalizeProjectPath(projectStore.defaultProjectPath)
   const currentProjectPath = normalizeProjectPath(projectStore.selectedProject?.path)
+  const pendingProjectDirIntent = sessionStore.newConversationProjectDirIntent
+  const projectDirIntent =
+    pendingProjectDirIntent && !pendingProjectDirIntent.consumed
+      ? {
+          id: pendingProjectDirIntent.id,
+          projectDir: normalizeProjectPath(pendingProjectDirIntent.projectDir)
+        }
+      : null
   draftStore.agentId = agentId
   draftStore.providerId = undefined
   draftStore.modelId = undefined
@@ -950,8 +959,12 @@ const applyDraftDefaultsForSelectedAgent = async (): Promise<void> => {
   draftStore.videoGeneration = undefined
 
   if (selectedAgent.value.type === 'acp') {
-    const resolvedProjectPath = currentProjectPath ?? globalDefaultProjectPath
-    if (!currentProjectPath && globalDefaultProjectPath) {
+    const resolvedProjectPath = projectDirIntent
+      ? projectDirIntent.projectDir
+      : (currentProjectPath ?? globalDefaultProjectPath)
+    if (projectDirIntent) {
+      projectStore.selectProject(projectDirIntent.projectDir, 'manual')
+    } else if (!currentProjectPath && globalDefaultProjectPath) {
       projectStore.selectProject(globalDefaultProjectPath, 'default')
     }
     draftStore.projectDir = resolvedProjectPath ?? undefined
@@ -960,14 +973,23 @@ const applyDraftDefaultsForSelectedAgent = async (): Promise<void> => {
     draftStore.permissionMode = 'full_access'
     draftStore.disabledAgentTools = []
     draftStore.subagentEnabled = false
+    if (projectDirIntent) {
+      sessionStore.consumeNewConversationProjectDirIntent(projectDirIntent.id)
+    }
     return
   }
 
   const config = await resolveDeepChatAgentConfig(agentId)
+  if (requestSeq !== draftDefaultsRequestSeq) {
+    return
+  }
   const agentDefaultProjectPath = normalizeProjectPath(config.defaultProjectPath)
-  const resolvedProjectPath =
-    agentDefaultProjectPath ?? currentProjectPath ?? globalDefaultProjectPath
-  if (agentDefaultProjectPath) {
+  const resolvedProjectPath = projectDirIntent
+    ? projectDirIntent.projectDir
+    : (agentDefaultProjectPath ?? currentProjectPath ?? globalDefaultProjectPath)
+  if (projectDirIntent) {
+    projectStore.selectProject(projectDirIntent.projectDir, 'manual')
+  } else if (agentDefaultProjectPath) {
     projectStore.selectProject(
       agentDefaultProjectPath,
       agentDefaultProjectPath === globalDefaultProjectPath ? 'default' : 'manual'
@@ -982,6 +1004,9 @@ const applyDraftDefaultsForSelectedAgent = async (): Promise<void> => {
   draftStore.disabledAgentTools = [...(config.disabledAgentTools ?? DEFAULT_DISABLED_AGENT_TOOLS)]
   draftStore.subagentEnabled = config.subagentEnabled === true
   Object.assign(draftStore, buildDraftGenerationSettings(config))
+  if (projectDirIntent) {
+    sessionStore.consumeNewConversationProjectDirIntent(projectDirIntent.id)
+  }
 }
 
 function onAttach() {
@@ -1171,9 +1196,14 @@ watch(
 )
 
 watch(
-  () => [selectedAgent.value.id, selectedAgent.value.type] as const,
+  [
+    () => selectedAgent.value.id,
+    () => selectedAgent.value.type,
+    () => sessionStore.newConversationProjectDirIntent?.id ?? 0
+  ],
   () => {
-    const task = applyDraftDefaultsForSelectedAgent().finally(() => {
+    const requestSeq = ++draftDefaultsRequestSeq
+    const task = applyDraftDefaultsForSelectedAgent(requestSeq).finally(() => {
       if (currentDraftDefaultsTask === task) {
         currentDraftDefaultsTask = null
       }

--- a/src/renderer/src/stores/ui/session.ts
+++ b/src/renderer/src/stores/ui/session.ts
@@ -60,8 +60,14 @@ export interface SessionGroup {
 }
 
 export type GroupMode = 'time' | 'project'
+export interface NewConversationProjectDirIntent {
+  id: number
+  projectDir: string | null
+  consumed: boolean
+}
 export type StartNewConversationOptions = {
   refresh?: boolean
+  projectDir?: string | null
 }
 export type CloseSessionOptions = {
   refresh?: boolean
@@ -280,12 +286,14 @@ export const useSessionStore = defineStore('session', () => {
   let initialPageRequestId = 0
   let nextPageRequestId = 0
   let activationNavigationRequestId = 0
+  let newConversationProjectDirIntentId = 0
   let sessionFetchPromise: Promise<void> | null = null
 
   const sessions = ref<UISession[]>([])
   const bootstrapActiveSession = ref<UISession | null>(null)
   const activeSessionSummary = ref<UIActiveSessionSummary | null>(null)
   const activeSessionId = ref<string | null>(null)
+  const newConversationProjectDirIntent = ref<NewConversationProjectDirIntent | null>(null)
   const groupMode = ref<GroupMode>(DEFAULT_GROUP_MODE)
   const loading = ref(false)
   const loadingMore = ref(false)
@@ -737,6 +745,17 @@ export const useSessionStore = defineStore('session', () => {
       return
     }
 
+    newConversationProjectDirIntent.value = Object.prototype.hasOwnProperty.call(
+      options,
+      'projectDir'
+    )
+      ? {
+          id: ++newConversationProjectDirIntentId,
+          projectDir: options.projectDir?.trim() || null,
+          consumed: false
+        }
+      : null
+
     if (agentStore.selectedAgentId !== targetAgentId) {
       agentStore.setSelectedAgent(targetAgentId)
     }
@@ -748,6 +767,15 @@ export const useSessionStore = defineStore('session', () => {
 
     pageRouter.goToNewThread({ refresh: options.refresh ?? true })
     createActivationNavigationRequest()
+  }
+
+  function consumeNewConversationProjectDirIntent(intentId: number): void {
+    const intent = newConversationProjectDirIntent.value
+    if (!intent || intent.id !== intentId || intent.consumed) {
+      return
+    }
+
+    newConversationProjectDirIntent.value = { ...intent, consumed: true }
   }
 
   async function completeOnboardingStep(stepId: GuidedOnboardingStepId): Promise<void> {
@@ -1056,6 +1084,7 @@ export const useSessionStore = defineStore('session', () => {
   return {
     sessions,
     activeSessionId,
+    newConversationProjectDirIntent,
     groupMode,
     loading,
     loadingMore,
@@ -1077,6 +1106,7 @@ export const useSessionStore = defineStore('session', () => {
     selectSession,
     closeSession,
     startNewConversation,
+    consumeNewConversationProjectDirIntent,
     renameSession,
     toggleSessionPinned,
     clearSessionMessages,

--- a/test/renderer/components/NewThreadPage.test.ts
+++ b/test/renderer/components/NewThreadPage.test.ts
@@ -66,6 +66,14 @@ const setup = async (options?: {
   defaultModel?: { providerId: string; modelId: string }
   preferredModel?: { providerId: string; modelId: string }
   resolvedAgentConfig?: Record<string, unknown>
+  resolveDeepChatAgentConfig?: (agentId: string) => Promise<Record<string, unknown>>
+  selectedAgentId?: string
+  selectedAgentType?: 'deepchat' | 'acp'
+  newConversationProjectDirIntent?: {
+    id: number
+    projectDir: string | null
+    consumed?: boolean
+  } | null
   deferStartupTasks?: boolean
   modelStoreInitialized?: boolean
   initializeModels?: () => Promise<void>
@@ -107,15 +115,36 @@ const setup = async (options?: {
     openFolderPicker: vi.fn()
   })
 
-  const sessionStore = {
+  const initialProjectDirIntent = options?.newConversationProjectDirIntent
+    ? {
+        ...options.newConversationProjectDirIntent,
+        consumed: options.newConversationProjectDirIntent.consumed ?? false
+      }
+    : null
+  const sessionStore = reactive({
     createSession: vi.fn().mockResolvedValue(undefined),
     selectSession: vi.fn().mockResolvedValue(undefined),
-    sendMessage: vi.fn().mockResolvedValue(undefined)
-  }
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    newConversationProjectDirIntent: initialProjectDirIntent,
+    consumeNewConversationProjectDirIntent: vi.fn((intentId: number) => {
+      const intent = sessionStore.newConversationProjectDirIntent
+      if (!intent || intent.id !== intentId || intent.consumed) {
+        return
+      }
+      sessionStore.newConversationProjectDirIntent = { ...intent, consumed: true }
+    })
+  })
 
+  const selectedAgentId = options?.selectedAgentId ?? 'acp-agent'
+  const selectedAgentType = options?.selectedAgentType ?? 'acp'
   const agentStore = reactive({
-    selectedAgentId: 'acp-agent',
-    selectedAgent: { id: 'acp-agent', name: 'ACP Agent', type: 'acp' as const, enabled: true }
+    selectedAgentId,
+    selectedAgent: {
+      id: selectedAgentId,
+      name: selectedAgentId,
+      type: selectedAgentType,
+      enabled: true
+    }
   })
 
   const getChatSelectableModelGroups = () => modelStore.enabledModels
@@ -180,11 +209,15 @@ const setup = async (options?: {
       }
       return Promise.resolve(undefined)
     }),
-    resolveDeepChatAgentConfig: vi.fn().mockResolvedValue(
-      options?.resolvedAgentConfig ?? {
-        disabledAgentTools: [],
-        permissionMode: 'full_access'
-      }
+    resolveDeepChatAgentConfig: vi.fn(
+      options?.resolveDeepChatAgentConfig ??
+        (() =>
+          Promise.resolve(
+            options?.resolvedAgentConfig ?? {
+              disabledAgentTools: [],
+              permissionMode: 'full_access'
+            }
+          ))
     )
   }
 
@@ -719,6 +752,96 @@ describe('NewThreadPage ACP draft session bootstrap', () => {
       name: 'agent-writer'
     })
     expect(draftStore.projectDir).toBe('/workspaces/agent-writer')
+  })
+
+  it('prefers a new-conversation workspace intent over the agent default directory', async () => {
+    const { projectStore, draftStore, sessionStore } = await setup({
+      selectedAgentId: 'deepchat',
+      selectedAgentType: 'deepchat',
+      defaultProjectPath: '/workspaces/global',
+      resolvedAgentConfig: {
+        defaultProjectPath: '/workspaces/agent-writer',
+        disabledAgentTools: [],
+        permissionMode: 'full_access'
+      },
+      newConversationProjectDirIntent: {
+        id: 1,
+        projectDir: '/workspaces/design'
+      }
+    })
+
+    expect(projectStore.selectProject).toHaveBeenCalledWith('/workspaces/design', 'manual')
+    expect(projectStore.selectedProject).toEqual({
+      path: '/workspaces/design',
+      name: 'design'
+    })
+    expect(draftStore.projectDir).toBe('/workspaces/design')
+    expect(sessionStore.consumeNewConversationProjectDirIntent).toHaveBeenCalledWith(1)
+  })
+
+  it('preserves an explicit null Chats intent over the agent default directory', async () => {
+    const { projectStore, draftStore, sessionStore } = await setup({
+      selectedAgentId: 'deepchat',
+      selectedAgentType: 'deepchat',
+      resolvedAgentConfig: {
+        defaultProjectPath: '/workspaces/agent-writer',
+        disabledAgentTools: [],
+        permissionMode: 'full_access'
+      },
+      newConversationProjectDirIntent: {
+        id: 1,
+        projectDir: null
+      }
+    })
+
+    expect(projectStore.selectProject).toHaveBeenCalledWith(null, 'manual')
+    expect(projectStore.selectedProject).toBeNull()
+    expect(projectStore.selectionSource).toBe('manual')
+    expect(draftStore.projectDir).toBeUndefined()
+    expect(sessionStore.consumeNewConversationProjectDirIntent).toHaveBeenCalledWith(1)
+  })
+
+  it('fences stale agent defaults after a workspace intent arrives', async () => {
+    const configResolvers: Array<(config: Record<string, unknown>) => void> = []
+    const { projectStore, draftStore, sessionStore } = await setup({
+      selectedAgentId: 'deepchat',
+      selectedAgentType: 'deepchat',
+      resolveDeepChatAgentConfig: () =>
+        new Promise((resolve) => {
+          configResolvers.push(resolve)
+        })
+    })
+
+    expect(configResolvers).toHaveLength(1)
+
+    sessionStore.newConversationProjectDirIntent = {
+      id: 1,
+      projectDir: '/workspaces/design',
+      consumed: false
+    }
+    await Promise.resolve()
+    expect(configResolvers).toHaveLength(2)
+
+    configResolvers[1]({
+      defaultProjectPath: '/workspaces/agent-writer',
+      disabledAgentTools: [],
+      permissionMode: 'full_access'
+    })
+    await flushPromises()
+
+    configResolvers[0]({
+      defaultProjectPath: '/workspaces/agent-writer',
+      disabledAgentTools: [],
+      permissionMode: 'full_access'
+    })
+    await flushPromises()
+
+    expect(projectStore.selectedProject).toEqual({
+      path: '/workspaces/design',
+      name: 'design'
+    })
+    expect(draftStore.projectDir).toBe('/workspaces/design')
+    expect(sessionStore.consumeNewConversationProjectDirIntent).toHaveBeenCalledTimes(1)
   })
 
   it('prefers preferredModel over defaultModel when creating a deepchat session', async () => {

--- a/test/renderer/components/WindowSideBar.test.ts
+++ b/test/renderer/components/WindowSideBar.test.ts
@@ -718,7 +718,10 @@ describe('WindowSideBar agent switch', () => {
         'manual'
       )
       expect(router.push).toHaveBeenCalledWith({ name: 'chat' })
-      expect(sessionStore.startNewConversation).toHaveBeenCalledWith({ refresh: true })
+      expect(sessionStore.startNewConversation).toHaveBeenCalledWith({
+        refresh: true,
+        projectDir: '/Users/test/Documents/DeepChat'
+      })
       expect(wrapper.get('[data-group-id="__chat__"]').attributes('aria-expanded')).toBe('true')
 
       await wrapper.find('[data-group-id="__chat__"]').trigger('click')
@@ -770,7 +773,10 @@ describe('WindowSideBar agent switch', () => {
 
       expect(projectStore.selectProject).toHaveBeenCalledWith('/work/design', 'manual')
       expect(router.push).toHaveBeenCalledWith({ name: 'chat' })
-      expect(sessionStore.startNewConversation).toHaveBeenCalledWith({ refresh: true })
+      expect(sessionStore.startNewConversation).toHaveBeenCalledWith({
+        refresh: true,
+        projectDir: '/work/design'
+      })
 
       const { wrapper: timeWrapper } = await setup({
         groupMode: 'time',

--- a/test/renderer/stores/sessionStore.test.ts
+++ b/test/renderer/stores/sessionStore.test.ts
@@ -722,7 +722,7 @@ describe('sessionStore.startNewConversation', () => {
     expect(pageRouter.goToNewThread).toHaveBeenCalledWith({ refresh: true })
   })
 
-  it('keeps the active session agent when all agents is selected during a chat', async () => {
+  it('keeps the active session agent and workspace intent during a chat', async () => {
     const { store, agentStore, pageRouter, sessionClient } = await setupStore({
       selectedAgentId: null,
       enabledAgents: []
@@ -731,12 +731,36 @@ describe('sessionStore.startNewConversation', () => {
     store.sessions.value = [createSession({ id: 'session-active', agentId: 'acp-a' })]
     store.activeSessionId.value = 'session-active'
 
-    await store.startNewConversation({ refresh: true })
+    await store.startNewConversation({ refresh: true, projectDir: '/work/design' })
 
     expect(agentStore.setSelectedAgent).toHaveBeenCalledWith('acp-a')
     expect(sessionClient.deactivate).toHaveBeenCalledTimes(1)
     expect(store.activeSessionId.value).toBeNull()
     expect(pageRouter.goToNewThread).toHaveBeenCalledWith({ refresh: true })
+    expect(store.newConversationProjectDirIntent.value).toEqual({
+      id: 1,
+      projectDir: '/work/design',
+      consumed: false
+    })
+
+    store.consumeNewConversationProjectDirIntent(1)
+
+    expect(store.newConversationProjectDirIntent.value?.consumed).toBe(true)
+  })
+
+  it('preserves an explicit null workspace intent for Chats', async () => {
+    const { store } = await setupStore({
+      selectedAgentId: 'deepchat',
+      enabledAgents: [{ id: 'deepchat' }]
+    })
+
+    await store.startNewConversation({ refresh: true, projectDir: null })
+
+    expect(store.newConversationProjectDirIntent.value).toEqual({
+      id: 1,
+      projectDir: null,
+      consumed: false
+    })
   })
 
   it('preserves the selected agent when one is already chosen', async () => {


### PR DESCRIPTION
## Summary

- carry the sidebar workspace target through active-session teardown as a one-shot renderer intent
- preserve explicit `Chats` null semantics and keep generic New Chat defaults unchanged
- fence stale asynchronous agent configuration from overwriting the requested workspace
- document the regression, ownership boundary, and validation contract

## Root cause

The sidebar updated the general project selection before starting a new conversation. When an active session was closed, `NewThreadPage` mounted and reapplied the selected agent's default directory, overwriting the stronger workspace target from the clicked sidebar action.

## Impact

Creating a conversation from another workspace now consistently uses the clicked project or `Chats` target, regardless of whether a session is already active.

## Validation

- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec vitest --config vitest.config.renderer.ts run test/renderer/components/NewThreadPage.test.ts test/renderer/components/WindowSideBar.test.ts test/renderer/stores/sessionStore.test.ts` (107 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed new conversations started from the sidebar opening in the wrong workspace when an agent chat is active.
  * New conversations now open in the selected workspace, including the Chats workspace.
  * Improved navigation reliability when starting a new conversation.

* **Tests**
  * Added coverage for workspace selection, Chats workspace intent, and protection against stale agent defaults.

* **Documentation**
  * Documented the issue, expected behavior, validation steps, and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->