### PR TITLE
fix: restore MCP delivery and settings tooltips

### DIFF
--- a/docs/issues/mcp-tools-filtered-by-legacy-allowlist/spec.md
+++ b/docs/issues/mcp-tools-filtered-by-legacy-allowlist/spec.md
@@ -1,0 +1,78 @@
+# MCP Tools Filtered by Legacy Agent Allowlist
+
+## Issue
+
+DeepChat sessions can omit every normal MCP tool from provider requests even when MCP is globally
+enabled and an MCP server is running. The affected built-in `deepchat` Agent has a persisted legacy
+`enabledMcpServerIds: []` value.
+
+## Impact
+
+- Provider requests contain built-in Agent tools but no normal MCP tool definitions.
+- The global MCP settings page can show a server as enabled while the current Agent still receives
+  no tools, making the failure look like an MCP connection or provider-injection problem.
+- Manual DeepChat Agents that inherit the built-in Agent policy are affected as well.
+
+## Root Cause
+
+Agent-scoped MCP policy intentionally defines `[]` as "disable every MCP server" and
+`null`/missing as "inherit compatible global behavior." Before Agent-scoped MCP shipped, historical
+config could already contain an empty allowlist. The earlier runtime workaround stopped applying
+that legacy value, but the later Agent-scoped policy restored strict empty-list filtering without a
+one-time data migration.
+
+The current path is:
+
+1. `DeepChatToolResolver` reads `enabledMcpServerIds: []` from the resolved Agent config.
+2. `ToolService` forwards it as `enabledServerIds` to MCP tool discovery.
+3. `ToolManager` rejects every normal MCP server because none can match the empty allowlist.
+4. The provider receives only built-in Agent tool definitions.
+
+## Fix Plan
+
+Add a versioned startup compatibility migration that runs before the first application window is
+created:
+
+- Inspect only the built-in `deepchat` Agent's stored config.
+- On the first migration run, convert a legacy empty `enabledMcpServerIds` array to `null`.
+- Preserve missing, `null`, and non-empty values.
+- Record completion even when no update is needed.
+- After completion, never reinterpret a future explicit `[]`; it remains the supported
+  Agent-scoped "disable all" policy.
+- Keep runtime filtering unchanged.
+
+The first-run conversion necessarily treats any pre-migration built-in empty list as legacy because
+the old stored value has no provenance marker. This is the narrow compatibility tradeoff required
+to restore existing users while preserving explicit empty-list semantics after migration.
+
+## Constraints
+
+- Do not disable or bypass Agent-scoped MCP filtering.
+- Do not modify manual Agent configs.
+- Do not modify MCP server definitions, credentials, authentication, or global enablement.
+- Do not add renderer state, IPC routes, or user-facing strings.
+- The migration must be idempotent and retry after failure.
+
+## Task Checklist
+
+- [x] Confirm the persisted empty allowlist and provider trace symptom.
+- [x] Document the compatibility boundary and migration semantics.
+- [x] Add the versioned startup migration.
+- [x] Run it before the first window can accept a chat request.
+- [x] Add focused tests for migration, preservation, idempotency, and failure retry.
+- [x] Run format, i18n, lint, typecheck, and focused tests.
+
+## Validation
+
+- A pre-migration built-in config with `enabledMcpServerIds: []` is updated to `null` exactly once.
+- Missing, `null`, and non-empty allowlists are not changed.
+- Once the migration is complete, a later explicit `[]` is not changed.
+- A failed migration records failure and succeeds on the next run.
+- Existing MCP filtering tests continue to prove that explicit Agent allowlists are enforced.
+
+Validated with `pnpm run format`, `pnpm run i18n`, `pnpm run lint`, `pnpm run typecheck`, and 87
+focused main-process tests (with two environment-gated SQLite tests skipped).
+
+## GitHub Issue
+
+Not synced; local SDD only.

--- a/src/main/app/composition.ts
+++ b/src/main/app/composition.ts
@@ -177,6 +177,7 @@ import { killTerminal } from '@/agent/acp/launch/acpInitHelper'
 import { rtkRuntimeService } from '@/agent/shared/process/rtkRuntimeService'
 import { backgroundExecSessionManager } from '@/agent/shared/process/backgroundExecSessionManager'
 import {
+  runBuiltinMcpAllowlistCompatibilityMigration,
   runDisabledAgentToolCapabilityCleanupMigration,
   runMainlineNormalizationMigration
 } from './startupMigrations/sessionDataMigrations'
@@ -2177,6 +2178,10 @@ export async function createMainProcessControl(dependencies: {
   deeplinkService.init()
   setupApplicationListeners()
   await runAcpRegistryMigration()
+  await runBuiltinMcpAllowlistCompatibilityMigration({
+    sqlitePresenter: sessionDataMigrationSQLite,
+    agentSettings
+  })
 
   if (windowPresenter.getAllWindows().length === 0) {
     const windowId = await windowPresenter.createAppWindow({ initialRoute: 'chat' })

--- a/src/main/app/startupMigrations/sessionDataMigrations.ts
+++ b/src/main/app/startupMigrations/sessionDataMigrations.ts
@@ -10,9 +10,11 @@ import type { SessionDatabase } from '@/session/data/database'
 import type { DeepChatMessageRow } from '@/session/data/tables/deepchatMessages'
 import type { StartupWorkloadTaskContext } from '@/app/startupWorkloadCoordinator'
 import type { AgentSettingsPort } from '@/agent/settings'
+import { BUILTIN_DEEPCHAT_AGENT_ID } from '@/agent/repository'
 import { normalizeDisabledAgentTools } from '@/agent/shared/agentSessionNormalization'
 
 export const SQLITE_MAINLINE_NORMALIZATION_KEY = 'sqlite-mainline-normalization-v1'
+export const BUILTIN_MCP_ALLOWLIST_COMPATIBILITY_KEY = 'builtin-mcp-allowlist-compatibility-v1'
 export const DISABLED_SEARCH_TOOL_CLEANUP_V1_KEY = 'agent-disabled-search-tool-cleanup-v1'
 export const DISABLED_AGENT_TOOL_CAPABILITY_CLEANUP_KEY =
   'agent-disabled-tool-capability-cleanup-v2'
@@ -33,6 +35,11 @@ export type SessionDataMigrationSQLitePort = Pick<SettingsDatabase, 'appSettings
 
 type SessionDataMigrationDependencies = {
   sqlitePresenter: SessionDataMigrationSQLitePort
+}
+
+type BuiltinMcpAllowlistMigrationDependencies = {
+  sqlitePresenter: Pick<SettingsDatabase, 'appSettingsTable'>
+  agentSettings: Pick<AgentSettingsPort, 'getDeepChatAgentConfig' | 'updateDeepChatAgent'>
 }
 
 type DisabledToolCleanupDependencies = SessionDataMigrationDependencies & {
@@ -324,6 +331,56 @@ export async function runMainlineNormalizationMigration(
 
 const areStringArraysEqual = (left: string[], right: string[]): boolean =>
   left.length === right.length && left.every((item, index) => item === right[index])
+
+export async function runBuiltinMcpAllowlistCompatibilityMigration({
+  sqlitePresenter,
+  agentSettings
+}: BuiltinMcpAllowlistMigrationDependencies): Promise<void> {
+  const current =
+    sqlitePresenter.appSettingsTable.getAppSetting<{
+      status?: 'running' | 'completed' | 'failed'
+    }>(BUILTIN_MCP_ALLOWLIST_COMPATIBILITY_KEY) ?? null
+  if (current?.status === 'completed') return
+
+  const startedAt = Date.now()
+  sqlitePresenter.appSettingsTable.setAppSetting(BUILTIN_MCP_ALLOWLIST_COMPATIBILITY_KEY, {
+    status: 'running',
+    startedAt,
+    finishedAt: null,
+    migrated: false
+  })
+
+  try {
+    const config = await agentSettings.getDeepChatAgentConfig(BUILTIN_DEEPCHAT_AGENT_ID)
+    const shouldMigrate = config?.enabledMcpServerIds?.length === 0
+    if (shouldMigrate) {
+      const updated = await agentSettings.updateDeepChatAgent(BUILTIN_DEEPCHAT_AGENT_ID, {
+        config: { enabledMcpServerIds: null }
+      })
+      if (!updated) throw new Error('Built-in DeepChat Agent not found')
+    }
+
+    const finishedAt = Date.now()
+    sqlitePresenter.appSettingsTable.setAppSetting(BUILTIN_MCP_ALLOWLIST_COMPATIBILITY_KEY, {
+      status: 'completed',
+      startedAt,
+      finishedAt,
+      migrated: shouldMigrate,
+      durationMs: finishedAt - startedAt
+    })
+  } catch (error) {
+    const finishedAt = Date.now()
+    sqlitePresenter.appSettingsTable.setAppSetting(BUILTIN_MCP_ALLOWLIST_COMPATIBILITY_KEY, {
+      status: 'failed',
+      startedAt,
+      finishedAt,
+      migrated: false,
+      error: error instanceof Error ? error.message : String(error),
+      durationMs: finishedAt - startedAt
+    })
+    throw error
+  }
+}
 
 export async function runDisabledAgentToolCapabilityCleanupMigration(
   { sqlitePresenter, agentSettings }: DisabledToolCleanupDependencies,

--- a/src/main/provider/aiSdk/toolProtocol.ts
+++ b/src/main/provider/aiSdk/toolProtocol.ts
@@ -225,17 +225,16 @@ export function toToolResultOutput(value: unknown): any {
   }
 
   if (typeof value === 'string') {
-    const parsed = tryParseJson(value)
-    if (parsed !== undefined) {
+    try {
       return {
         type: 'json',
-        value: parsed
+        value: JSON.parse(value)
       }
-    }
-
-    return {
-      type: 'text',
-      value
+    } catch {
+      return {
+        type: 'text',
+        value
+      }
     }
   }
 

--- a/src/renderer/settings/App.vue
+++ b/src/renderer/settings/App.vue
@@ -1,89 +1,91 @@
 <template>
-  <div
-    data-testid="settings-page"
-    class="w-full h-screen flex flex-col"
-    :class="isWinMacOS ? '' : 'bg-background'"
-  >
+  <TooltipProvider :delay-duration="200">
     <div
-      class="w-full h-9 window-drag-region shrink-0 justify-end flex flex-row relative border border-b-0 border-window-inner-border box-border rounded-t-[10px]"
-      :class="[
-        isMacOS ? '' : 'rounded-t-none',
-        isMacOS ? 'bg-window-background' : 'bg-window-background/10'
-      ]"
+      data-testid="settings-page"
+      class="w-full h-screen flex flex-col"
+      :class="isWinMacOS ? '' : 'bg-background'"
     >
-      <div class="absolute bottom-0 left-0 w-full h-[1px] bg-border z-10"></div>
-      <Button
-        v-if="!isMacOS"
-        class="window-no-drag-region shrink-0 w-12 bg-transparent shadow-none rounded-none hover:bg-red-700/80 hover:text-white text-xs font-medium text-foreground flex items-center justify-center transition-all duration-200 group"
-        :title="t('common.close')"
-        :aria-label="t('common.close')"
-        @click="closeWindow"
-      >
-        <CloseIcon class="h-3! w-3!" />
-      </Button>
-    </div>
-    <div class="w-full h-0 flex-1 flex flex-row bg-background relative">
       <div
-        class="border-x border-b border-window-inner-border rounded-b-[10px] absolute z-10 top-0 left-0 bottom-0 right-0 pointer-events-none"
-      ></div>
-      <div
-        data-testid="settings-navigation"
-        class="w-60 h-full border-r border-border shrink-0 overflow-y-auto bg-muted/10"
+        class="w-full h-9 window-drag-region shrink-0 justify-end flex flex-row relative border border-b-0 border-window-inner-border box-border rounded-t-[10px]"
+        :class="[
+          isMacOS ? '' : 'rounded-t-none',
+          isMacOS ? 'bg-window-background' : 'bg-window-background/10'
+        ]"
       >
-        <div class="flex flex-col gap-4 p-3">
-          <div v-for="group in settingGroups" :key="group.key" class="flex flex-col gap-1">
-            <div class="px-2 text-xs font-medium text-muted-foreground">
-              {{ t(group.titleKey) }}
-            </div>
-            <div class="flex flex-col gap-1">
-              <button
-                v-for="setting in group.items"
-                :key="setting.name"
-                type="button"
-                :data-testid="getSettingsTabTestId(setting.name)"
-                :class="[
-                  'flex w-full min-w-0 flex-row items-center gap-2 rounded-md px-2 py-2 text-start transition-colors hover:bg-accent',
-                  route.name === setting.name ? 'bg-accent text-accent-foreground' : '',
-                  pendingRouteName === setting.name ? 'cursor-wait' : ''
-                ]"
-                :aria-busy="pendingRouteName === setting.name"
-                @pointerenter="prefetchSetting(setting.name)"
-                @focus="prefetchSetting(setting.name)"
-                @click="handleClick(setting)"
-              >
-                <Spinner
-                  v-if="pendingRouteName === setting.name"
-                  class="size-4 shrink-0 text-muted-foreground"
-                />
-                <Icon v-else :icon="setting.icon" class="size-4 shrink-0 text-muted-foreground" />
-                <span class="min-w-0 truncate text-sm font-medium">{{ t(setting.title) }}</span>
-              </button>
+        <div class="absolute bottom-0 left-0 w-full h-[1px] bg-border z-10"></div>
+        <Button
+          v-if="!isMacOS"
+          class="window-no-drag-region shrink-0 w-12 bg-transparent shadow-none rounded-none hover:bg-red-700/80 hover:text-white text-xs font-medium text-foreground flex items-center justify-center transition-all duration-200 group"
+          :title="t('common.close')"
+          :aria-label="t('common.close')"
+          @click="closeWindow"
+        >
+          <CloseIcon class="h-3! w-3!" />
+        </Button>
+      </div>
+      <div class="w-full h-0 flex-1 flex flex-row bg-background relative">
+        <div
+          class="border-x border-b border-window-inner-border rounded-b-[10px] absolute z-10 top-0 left-0 bottom-0 right-0 pointer-events-none"
+        ></div>
+        <div
+          data-testid="settings-navigation"
+          class="w-60 h-full border-r border-border shrink-0 overflow-y-auto bg-muted/10"
+        >
+          <div class="flex flex-col gap-4 p-3">
+            <div v-for="group in settingGroups" :key="group.key" class="flex flex-col gap-1">
+              <div class="px-2 text-xs font-medium text-muted-foreground">
+                {{ t(group.titleKey) }}
+              </div>
+              <div class="flex flex-col gap-1">
+                <button
+                  v-for="setting in group.items"
+                  :key="setting.name"
+                  type="button"
+                  :data-testid="getSettingsTabTestId(setting.name)"
+                  :class="[
+                    'flex w-full min-w-0 flex-row items-center gap-2 rounded-md px-2 py-2 text-start transition-colors hover:bg-accent',
+                    route.name === setting.name ? 'bg-accent text-accent-foreground' : '',
+                    pendingRouteName === setting.name ? 'cursor-wait' : ''
+                  ]"
+                  :aria-busy="pendingRouteName === setting.name"
+                  @pointerenter="prefetchSetting(setting.name)"
+                  @focus="prefetchSetting(setting.name)"
+                  @click="handleClick(setting)"
+                >
+                  <Spinner
+                    v-if="pendingRouteName === setting.name"
+                    class="size-4 shrink-0 text-muted-foreground"
+                  />
+                  <Icon v-else :icon="setting.icon" class="size-4 shrink-0 text-muted-foreground" />
+                  <span class="min-w-0 truncate text-sm font-medium">{{ t(setting.title) }}</span>
+                </button>
+              </div>
             </div>
           </div>
         </div>
+        <RouterView />
       </div>
-      <RouterView />
+      <ModelCheckDialog
+        :open="modelCheckStore.isDialogOpen"
+        :provider-id="modelCheckStore.currentProviderId"
+        @update:open="
+          (open) => {
+            if (!open) modelCheckStore.closeDialog()
+          }
+        "
+      />
+      <ProviderDeeplinkImportDialog
+        :key="pendingProviderImportToken"
+        :open="Boolean(pendingProviderImportPreview)"
+        :preview="pendingProviderImportPreview"
+        :confirm-disabled="providerImportConfirmDisabled"
+        :submitting="isImportingProvider"
+        @update:open="handleProviderImportDialogOpenChange"
+        @confirm="confirmProviderImport"
+      />
+      <Toaster :theme="toasterTheme" />
     </div>
-    <ModelCheckDialog
-      :open="modelCheckStore.isDialogOpen"
-      :provider-id="modelCheckStore.currentProviderId"
-      @update:open="
-        (open) => {
-          if (!open) modelCheckStore.closeDialog()
-        }
-      "
-    />
-    <ProviderDeeplinkImportDialog
-      :key="pendingProviderImportToken"
-      :open="Boolean(pendingProviderImportPreview)"
-      :preview="pendingProviderImportPreview"
-      :confirm-disabled="providerImportConfirmDisabled"
-      :submitting="isImportingProvider"
-      @update:open="handleProviderImportDialogOpenChange"
-      @confirm="confirmProviderImport"
-    />
-    <Toaster :theme="toasterTheme" />
-  </div>
+  </TooltipProvider>
 </template>
 
 <script setup lang="ts">
@@ -105,6 +107,7 @@ import ModelCheckDialog from '@/components/settings/ModelCheckDialog.vue'
 import { useDeviceVersion } from '../src/composables/useDeviceVersion'
 import { Toaster } from '@shadcn/components/ui/sonner'
 import { Spinner } from '@shadcn/components/ui/spinner'
+import { TooltipProvider } from '@shadcn/components/ui/tooltip'
 import 'vue-sonner/style.css'
 import { useToast } from '@/components/use-toast'
 import { useThemeStore } from '@/stores/theme'

--- a/test/main/app/compositionBoundaries.test.ts
+++ b/test/main/app/compositionBoundaries.test.ts
@@ -232,6 +232,9 @@ describe('session boundary composition', () => {
     expect(startupSource.indexOf('await runAcpRegistryMigration()')).toBeLessThan(
       startupSource.indexOf('init(dependencies.startupRunId)')
     )
+    expect(
+      startupSource.indexOf('await runBuiltinMcpAllowlistCompatibilityMigration(')
+    ).toBeLessThan(startupSource.indexOf("createAppWindow({ initialRoute: 'chat' })"))
     expect(startupSource.indexOf("createAppWindow({ initialRoute: 'chat' })")).toBeLessThan(
       startupSource.indexOf('init(dependencies.startupRunId)')
     )

--- a/test/main/app/startupMigrations/sessionDataMigrations.test.ts
+++ b/test/main/app/startupMigrations/sessionDataMigrations.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  BUILTIN_MCP_ALLOWLIST_COMPATIBILITY_KEY,
   DISABLED_AGENT_TOOL_CAPABILITY_CLEANUP_KEY,
   DISABLED_SEARCH_TOOL_CLEANUP_V1_KEY,
   SQLITE_MAINLINE_NORMALIZATION_KEY,
+  runBuiltinMcpAllowlistCompatibilityMigration,
   runDisabledAgentToolCapabilityCleanupMigration,
   runMainlineNormalizationMigration,
   type SessionDataMigrationSQLitePort
@@ -69,7 +71,7 @@ function createFixture() {
   const providerSettings = {
     listAgents: vi.fn(async () => []),
     getDeepChatAgentConfig: vi.fn(),
-    updateDeepChatAgent: vi.fn()
+    updateDeepChatAgent: vi.fn(async () => ({ id: 'deepchat' }))
   }
   const taskContext = {
     reportProgress: vi.fn(),
@@ -138,6 +140,64 @@ describe('session data migrations', () => {
     expect(fixture.settings.get(SQLITE_MAINLINE_NORMALIZATION_KEY)).toMatchObject({
       status: 'failed',
       error: 'database unavailable'
+    })
+  })
+
+  it('migrates the legacy built-in empty MCP allowlist exactly once', async () => {
+    const fixture = createFixture()
+    fixture.agentSettings.getDeepChatAgentConfig.mockResolvedValue({ enabledMcpServerIds: [] })
+
+    await runBuiltinMcpAllowlistCompatibilityMigration(fixture as never)
+
+    expect(fixture.agentSettings.getDeepChatAgentConfig).toHaveBeenCalledWith('deepchat')
+    expect(fixture.agentSettings.updateDeepChatAgent).toHaveBeenCalledWith('deepchat', {
+      config: { enabledMcpServerIds: null }
+    })
+    expect(fixture.settings.get(BUILTIN_MCP_ALLOWLIST_COMPATIBILITY_KEY)).toMatchObject({
+      status: 'completed',
+      migrated: true
+    })
+
+    fixture.agentSettings.updateDeepChatAgent.mockClear()
+    await runBuiltinMcpAllowlistCompatibilityMigration(fixture as never)
+    expect(fixture.agentSettings.updateDeepChatAgent).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['missing', {}],
+    ['inherited', { enabledMcpServerIds: null }],
+    ['non-empty', { enabledMcpServerIds: ['server-a'] }]
+  ])('preserves %s built-in MCP policy', async (_label, config) => {
+    const fixture = createFixture()
+    fixture.agentSettings.getDeepChatAgentConfig.mockResolvedValue(config)
+
+    await runBuiltinMcpAllowlistCompatibilityMigration(fixture as never)
+
+    expect(fixture.agentSettings.updateDeepChatAgent).not.toHaveBeenCalled()
+    expect(fixture.settings.get(BUILTIN_MCP_ALLOWLIST_COMPATIBILITY_KEY)).toMatchObject({
+      status: 'completed',
+      migrated: false
+    })
+  })
+
+  it('retries a failed built-in MCP allowlist migration', async () => {
+    const fixture = createFixture()
+    fixture.agentSettings.getDeepChatAgentConfig.mockResolvedValue({ enabledMcpServerIds: [] })
+    fixture.agentSettings.updateDeepChatAgent.mockRejectedValueOnce(new Error('write failed'))
+
+    await expect(runBuiltinMcpAllowlistCompatibilityMigration(fixture as never)).rejects.toThrow(
+      'write failed'
+    )
+    expect(fixture.settings.get(BUILTIN_MCP_ALLOWLIST_COMPATIBILITY_KEY)).toMatchObject({
+      status: 'failed',
+      error: 'write failed'
+    })
+
+    await runBuiltinMcpAllowlistCompatibilityMigration(fixture as never)
+    expect(fixture.agentSettings.updateDeepChatAgent).toHaveBeenCalledTimes(2)
+    expect(fixture.settings.get(BUILTIN_MCP_ALLOWLIST_COMPATIBILITY_KEY)).toMatchObject({
+      status: 'completed',
+      migrated: true
     })
   })
 

--- a/test/main/provider/aiSdkMessageMapper.test.ts
+++ b/test/main/provider/aiSdkMessageMapper.test.ts
@@ -336,6 +336,39 @@ describe('AI SDK message mapper', () => {
     ])
   })
 
+  it('preserves plain-text tool results containing URLs', () => {
+    const response = 'Success. Image URL(s): https://example.com/image.jpeg?Expires=1&Signature=abc'
+    const result = mapMessagesToModelMessages(
+      [
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'tc1',
+              type: 'function',
+              function: { name: 'text_to_image', arguments: '{}' }
+            }
+          ]
+        },
+        {
+          role: 'tool',
+          tool_call_id: 'tc1',
+          content: response
+        }
+      ],
+      {
+        tools: [],
+        supportsNativeTools: true
+      }
+    )
+
+    expect((result[1] as any).content[0].output).toEqual({
+      type: 'text',
+      value: response
+    })
+  })
+
   it('drops invalid provider options before returning AI SDK messages', () => {
     const result = mapMessagesToModelMessages(
       [


### PR DESCRIPTION
## Summary

- provide the shared tooltip context at the settings application root
- migrate the built-in DeepChat Agent's legacy empty MCP allowlist before the first window opens
- preserve plain-text MCP tool results when strict JSON parsing fails

## Root cause

The built-in Agent could retain a historical `enabledMcpServerIds: []` value, so Agent-scoped filtering removed every normal MCP tool even while MCP was globally enabled. Separately, tool-result conversion ran `jsonrepair` on arbitrary text; signed URLs containing `https://` were interpreted as comments and truncated to `https:`.

## Impact

Existing users recover globally enabled MCP tools on startup without disabling Agent-scoped filtering. MCP text responses, including signed image URLs, reach the provider unchanged. Settings controls also receive the required tooltip provider context.

## Validation

- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- 87 focused main-process tests passed; 2 environment-gated SQLite tests skipped
- 10 AI SDK message-mapper tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored access to MCP tools in sessions affected by legacy built-in Agent settings.
  - Preserved intentional configurations that disable all MCP servers.
  - Fixed tool results containing URLs or other plain text so they display correctly instead of being misinterpreted as JSON.

- **User Experience**
  - Improved tooltip behavior across the Settings page for more consistent help text and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->