### PR TITLE
feat(provider): add Routerra as a built-in OpenAI-compatible provider preset

### DIFF
--- a/src/main/provider/defaults.ts
+++ b/src/main/provider/defaults.ts
@@ -370,6 +370,21 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
     }
   },
   {
+    id: 'routerra',
+    name: 'Routerra',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://routerra.ai/v1',
+    enable: false,
+    websites: {
+      official: 'https://routerra.ai/',
+      apiKey: 'https://routerra.ai/',
+      docs: '',
+      models: 'https://routerra.ai/v1/models',
+      defaultBaseUrl: 'https://routerra.ai/v1'
+    }
+  },
+  {
     id: 'poe',
     name: 'Poe',
     apiType: 'poe',

--- a/src/renderer/src/assets/llm-icons/routerra.svg
+++ b/src/renderer/src/assets/llm-icons/routerra.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="7" fill="#0B0E14"/><path d="M9 23V9h8.5a4.5 4.5 0 0 1 1.7 8.67L23 23h-4.1l-3.2-4.8H12.6V23H9zm3.6-8h4.6a1.9 1.9 0 0 0 0-3.8h-4.6V15z" fill="#4FD1C5"/></svg>

--- a/src/renderer/src/components/icons/modelIconRegistry.ts
+++ b/src/renderer/src/components/icons/modelIconRegistry.ts
@@ -49,6 +49,7 @@ import daoxeColorIcon from '@/assets/llm-icons/daoxe.png?url'
 import kimiColorIcon from '@/assets/llm-icons/kimi-color.svg?url'
 import moonshotColorIcon from '@/assets/llm-icons/moonshot.svg?url'
 import openrouterColorIcon from '@/assets/llm-icons/openrouter.svg?url'
+import routerraColorIcon from '@/assets/llm-icons/routerra.svg?url'
 import poeColorIcon from '@/assets/llm-icons/poe-color.svg?url'
 import geminiColorIcon from '@/assets/llm-icons/gemini-color.svg?url'
 import githubColorIcon from '@/assets/llm-icons/github.svg?url'
@@ -156,6 +157,7 @@ export const modelIcons = {
   qwen: qwenColorIcon,
   moonshot: moonshotColorIcon,
   openrouter: openrouterColorIcon,
+  routerra: routerraColorIcon,
   poe: poeColorIcon,
   gemini: geminiColorIcon,
   github: githubColorIcon,


### PR DESCRIPTION
Implements #1911.

### What
Adds Routerra as a built-in provider preset, following the proposal and @zerob13's guidance in the issue.

### Scope (item-by-item to the maintainer's guidance)
1. **Default preset** — added `routerra` to `DEFAULT_PROVIDERS` in `src/main/provider/defaults.ts`, mirroring the existing OpenAI-compatible aggregator entries (`openrouter`, `opencode-go`). `apiType: 'openai-completions'`, `enable: false` by default.
2. **Icon** — added Routerra's brand logo at `src/renderer/src/assets/llm-icons/routerra.svg` and registered it in `modelIconRegistry.ts`. The asset is Routerra's own mark (a cyan "R" on a dark rounded square), declared as the site logo in the provider's public `/api/status` config (`system_name: "Routerra"`, `logo: ".../site/favicon.svg"`) — deliberately **not** the default New API gateway image that `routerra.ai/logo.png` serves. It is a colored logo, so it is intentionally not added to the monochrome-tint set.
3. **Deeplink** — no provider-specific code. **Covered by the generic `provider/install` flow**: `handleProviderInstall` → `parseProviderInstallParams` validates a builtin id via `providerInstall.hasProvider(id)`; adding `routerra` to `DEFAULT_PROVIDERS` makes that resolve, and `iconModelId: id` picks up the icon above.

   A working install deeplink (payload = `{"id":"routerra","baseUrl":"https://routerra.ai/v1","apiKey":"<ROUTERRA_API_KEY>"}`):
   ```
   deepchat://provider/install?v=1&data=eyJpZCI6InJvdXRlcnJhIiwiYmFzZVVybCI6Imh0dHBzOi8vcm91dGVycmEuYWkvdjEiLCJhcGlLZXkiOiI8Uk9VVEVSUkFfQVBJX0tFWT4ifQ%3D%3D
   ```
   (Minor heads-up: the example deeplink in the issue base64-encodes `api.routerra.ai/v1`, which doesn't resolve from our network — see the base-URL note below.)
4. **i18n** — **no provider-specific locale key exists or is needed**. The provider's display name comes from the `name` field in `defaults.ts` ("Routerra"), rendered directly in the provider list — not from i18n. The only i18n-driven provider labels are the WelcomePage's hardcoded featured grid (`WelcomePage.vue`, 6 curated headline providers); Routerra is not one of those, so no `welcome.page.providers.*` key applies. Adding one would be a dead key across all locales.

### Note on the base URL (please confirm)
The issue body proposes `https://routerra.ai/v1`; a later example in the thread uses `https://api.routerra.ai/v1`. Observed from our network they differ:
- `https://api.routerra.ai/v1/models` → TLS connection fails, no HTTP response (`http_code=000`, `SSL_ERROR_SYSCALL`).
- `https://routerra.ai/v1/models` → returns an OpenAI/New-API-compatible `401 {"error":{"type":"new_api_error", ...}}`.

So this PR uses `https://routerra.ai/v1` (the issue body's value). Maintainers: please confirm the canonical base URL — happy to switch to `api.routerra.ai` if that's the intended host and it's reachable on your side.

### Testing (node 24.14.1 via the repo's `mise.toml`)
- `typecheck` (node + web), `oxlint`, `oxfmt --check`: pass
- `test:main` (incl. `providerDeeplink.test.ts`): pass
- provider/icon renderer tests (`iconWhitelist`, `ModelIcon`, `ModelProviderSettings`, `ProviderApiConfig`, `providerDeeplinkImportStore`, `SettingsApp.providerDeeplink`): pass
- Manual (`pnpm run dev`): Routerra appears in the provider list, is selectable, the brand icon renders, and the config panel shows the base URL / API-key fields correctly; the install deeplink above opens the Import Provider dialog with the icon, URL, and masked key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Routerra as an available provider option.
  * Added Routerra model branding and icon support.
  * Routerra is disabled by default and can be enabled when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->