### PR TITLE
feat(provider): add Straico as a built-in OpenAI-compatible provider

### DIFF
--- a/src/main/provider/defaults.ts
+++ b/src/main/provider/defaults.ts
@@ -385,6 +385,21 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
     }
   },
   {
+    id: 'straico',
+    name: 'Straico',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://api.straico.com/v2',
+    enable: false,
+    websites: {
+      official: 'https://www.straico.com/',
+      apiKey: 'https://platform.straico.com/settings-api',
+      docs: 'https://documenter.getpostman.com/view/5900072/2s9YyzddrR',
+      models: 'https://api.straico.com/v2/models',
+      defaultBaseUrl: 'https://api.straico.com/v2'
+    }
+  },
+  {
     id: 'poe',
     name: 'Poe',
     apiType: 'poe',

--- a/src/renderer/src/assets/llm-icons/straico.svg
+++ b/src/renderer/src/assets/llm-icons/straico.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="7" fill="#111827"/><path d="M8 22.5V9.5h6.2c3.1 0 5.1 1.7 5.1 4.2 0 1.7-.9 3.1-2.5 3.8L20.5 22.5h-3.6l-3.1-4.5H11.2v4.5H8zm3.2-7.4h2.9c1.4 0 2.2-.7 2.2-1.8s-.8-1.8-2.2-1.8h-2.9v3.6z" fill="#8B5CF6"/><circle cx="23.2" cy="11.2" r="2.1" fill="#A78BFA"/></svg>

--- a/src/renderer/src/components/icons/modelIconRegistry.ts
+++ b/src/renderer/src/components/icons/modelIconRegistry.ts
@@ -50,6 +50,7 @@ import kimiColorIcon from '@/assets/llm-icons/kimi-color.svg?url'
 import moonshotColorIcon from '@/assets/llm-icons/moonshot.svg?url'
 import openrouterColorIcon from '@/assets/llm-icons/openrouter.svg?url'
 import routerraColorIcon from '@/assets/llm-icons/routerra.svg?url'
+import straicoColorIcon from '@/assets/llm-icons/straico.svg?url'
 import poeColorIcon from '@/assets/llm-icons/poe-color.svg?url'
 import geminiColorIcon from '@/assets/llm-icons/gemini-color.svg?url'
 import githubColorIcon from '@/assets/llm-icons/github.svg?url'
@@ -158,6 +159,7 @@ export const modelIcons = {
   moonshot: moonshotColorIcon,
   openrouter: openrouterColorIcon,
   routerra: routerraColorIcon,
+  straico: straicoColorIcon,
   poe: poeColorIcon,
   gemini: geminiColorIcon,
   github: githubColorIcon,


### PR DESCRIPTION
## Summary
Adds **Straico** as a built-in provider preset (issue #959).

Straico exposes an OpenAI-compatible surface on `https://api.straico.com/v2`, so this follows the same path as OpenRouter / Routerra / OpenCode Go:

1. `DEFAULT_PROVIDERS` entry in `src/main/provider/defaults.ts` (`apiType: 'openai-completions'`, `enable: false`)
2. Brand icon at `src/renderer/src/assets/llm-icons/straico.svg`
3. Registry wiring in `modelIconRegistry.ts`

## Scope
Intentionally **preset-only** for the first landing (chat/completions + models via the existing OpenAI-compatible stack). Native Straico-only surfaces (RAG / Agents / video / TTS) can be separate follow-ups.

## Test plan
- [ ] App loads with Straico listed among providers (disabled by default)
- [ ] Enabling + API key + model list against `https://api.straico.com/v2` works for chat completions

Closes #959.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Straico as a supported default AI provider.
  * Added Straico provider details, documentation links, and model access configuration.
  * Added a dedicated Straico icon for clearer provider and model identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->