### PR TITLE
feat(build): support Linux ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,14 +116,20 @@ jobs:
             !dist/win-arm64-unpacked
 
   build-linux:
+    name: build-linux(${{ matrix.arch }})
     if: github.event.inputs.platform == 'all' || contains(github.event.inputs.platform, 'linux')
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        arch: [x64]
         include:
           - arch: x64
             platform: linux-x64
+            runner: ubuntu-22.04
+            unpacked: linux-unpacked
+          - arch: arm64
+            platform: linux-arm64
+            runner: ubuntu-22.04-arm
+            unpacked: linux-arm64-unpacked
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -153,40 +159,49 @@ jobs:
       - name: Verify OpenDAL native package for Linux
         run: pnpm run smoke:opendal:native -- --platform linux --arch ${{ matrix.arch }}
 
-      # - name: Install Node Runtime
-        # run: pnpm run installRuntime:linux:${{ matrix.arch }}
+      - name: Install Linux runtimes
+        run: pnpm run installRuntime:linux:${{ matrix.arch }}
+        env:
+          GITHUB_TOKEN: ${{ env.RTK_INSTALL_GITHUB_TOKEN }}
 
       - name: Install and verify DuckDB VSS for Linux
         run: |
           pnpm run installRuntime:duckdb:vss -- --platform linux --arch ${{ matrix.arch }}
           pnpm run smoke:duckdb:vss -- --platform linux --arch ${{ matrix.arch }}
 
-      - name: Build Linux
-        run: |
-          pnpm run build
-          pnpm run plugin:bundle -- --name cua --platform linux --arch ${{ matrix.arch }}
-          pnpm run plugin:bundle -- --name feishu --platform linux --arch ${{ matrix.arch }}
-          pnpm exec electron-builder --linux --${{ matrix.arch }} --publish=never
+      - name: Build Linux application
+        run: pnpm run build
         env:
           VITE_GITHUB_CLIENT_ID: ${{ secrets.DC_GITHUB_CLIENT_ID }}
           VITE_GITHUB_CLIENT_SECRET: ${{ secrets.DC_GITHUB_CLIENT_SECRET }}
           VITE_GITHUB_REDIRECT_URI: ${{ secrets.DC_GITHUB_REDIRECT_URI }}
 
+      - name: Bundle CUA plugin
+        if: matrix.arch == 'x64'
+        run: pnpm run plugin:bundle -- --name cua --platform linux --arch ${{ matrix.arch }}
+
+      - name: Bundle Feishu plugin
+        run: pnpm run plugin:bundle -- --name feishu --platform linux --arch ${{ matrix.arch }}
+
+      - name: Package Linux
+        run: pnpm exec electron-builder --linux --${{ matrix.arch }} --publish=never
+
       - name: Verify packaged DuckDB VSS for Linux
         shell: bash
         run: |
-          EXTENSION_PATH="dist/linux-unpacked/resources/app.asar.unpacked/runtime/duckdb/extensions/vss.duckdb_extension"
+          EXTENSION_PATH="dist/${{ matrix.unpacked }}/resources/app.asar.unpacked/runtime/duckdb/extensions/vss.duckdb_extension"
           test -f "$EXTENSION_PATH"
           pnpm run smoke:duckdb:vss -- --platform linux --arch ${{ matrix.arch }} --extension-path "$EXTENSION_PATH"
 
       - name: Verify packaged OpenDAL native package for Linux
-        run: pnpm run smoke:opendal:native -- --platform linux --arch ${{ matrix.arch }} --resources-path dist/linux-unpacked/resources
+        run: pnpm run smoke:opendal:native -- --platform linux --arch ${{ matrix.arch }} --resources-path dist/${{ matrix.unpacked }}/resources
 
-      - name: Verify bundled plugins
-        shell: bash
-        run: |
-          pnpm run plugin:verify -- --name cua --platform linux --arch ${{ matrix.arch }} --plugin-root dist/linux-unpacked/resources/app.asar.unpacked/plugins
-          pnpm run plugin:verify -- --name feishu --platform linux --arch ${{ matrix.arch }} --plugin-root dist/linux-unpacked/resources/app.asar.unpacked/plugins
+      - name: Verify bundled CUA plugin
+        if: matrix.arch == 'x64'
+        run: pnpm run plugin:verify -- --name cua --platform linux --arch ${{ matrix.arch }} --plugin-root dist/${{ matrix.unpacked }}/resources/app.asar.unpacked/plugins
+
+      - name: Verify bundled Feishu plugin
+        run: pnpm run plugin:verify -- --name feishu --platform linux --arch ${{ matrix.arch }} --plugin-root dist/${{ matrix.unpacked }}/resources/app.asar.unpacked/plugins
 
       - name: Upload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -195,6 +210,7 @@ jobs:
           path: |
             dist/*
             !dist/linux-unpacked
+            !dist/linux-arm64-unpacked
 
   build-mac:
     if: github.event.inputs.platform == 'all' || contains(github.event.inputs.platform, 'mac')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,14 +210,20 @@ jobs:
             !dist/win-arm64-unpacked
 
   build-linux:
+    name: build-linux(${{ matrix.arch }})
     needs: [resolve-tag, validate-main-ancestor]
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        arch: [x64]
         include:
           - arch: x64
             platform: linux-x64
+            runner: ubuntu-22.04
+            unpacked: linux-unpacked
+          - arch: arm64
+            platform: linux-arm64
+            runner: ubuntu-22.04-arm
+            unpacked: linux-arm64-unpacked
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -249,38 +255,51 @@ jobs:
       - name: Verify OpenDAL native package for Linux
         run: pnpm run smoke:opendal:native -- --platform linux --arch ${{ matrix.arch }}
 
+      - name: Install Linux runtimes
+        run: pnpm run installRuntime:linux:${{ matrix.arch }}
+        env:
+          GITHUB_TOKEN: ${{ env.RTK_INSTALL_GITHUB_TOKEN }}
+
       - name: Install and verify DuckDB VSS for Linux
         run: |
           pnpm run installRuntime:duckdb:vss -- --platform linux --arch ${{ matrix.arch }}
           pnpm run smoke:duckdb:vss -- --platform linux --arch ${{ matrix.arch }}
 
-      - name: Build Linux
-        run: |
-          pnpm run build
-          pnpm run plugin:bundle -- --name cua --platform linux --arch ${{ matrix.arch }}
-          pnpm run plugin:bundle -- --name feishu --platform linux --arch ${{ matrix.arch }}
-          pnpm exec electron-builder --linux --${{ matrix.arch }} --publish=never
+      - name: Build Linux application
+        run: pnpm run build
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_GITHUB_CLIENT_ID: ${{ secrets.DC_GITHUB_CLIENT_ID }}
           VITE_GITHUB_CLIENT_SECRET: ${{ secrets.DC_GITHUB_CLIENT_SECRET }}
           VITE_GITHUB_REDIRECT_URI: ${{ secrets.DC_GITHUB_REDIRECT_URI }}
 
+      - name: Bundle CUA plugin
+        if: matrix.arch == 'x64'
+        run: pnpm run plugin:bundle -- --name cua --platform linux --arch ${{ matrix.arch }}
+
+      - name: Bundle Feishu plugin
+        run: pnpm run plugin:bundle -- --name feishu --platform linux --arch ${{ matrix.arch }}
+
+      - name: Package Linux
+        run: pnpm exec electron-builder --linux --${{ matrix.arch }} --publish=never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Verify packaged DuckDB VSS for Linux
         shell: bash
         run: |
-          EXTENSION_PATH="dist/linux-unpacked/resources/app.asar.unpacked/runtime/duckdb/extensions/vss.duckdb_extension"
+          EXTENSION_PATH="dist/${{ matrix.unpacked }}/resources/app.asar.unpacked/runtime/duckdb/extensions/vss.duckdb_extension"
           test -f "$EXTENSION_PATH"
           pnpm run smoke:duckdb:vss -- --platform linux --arch ${{ matrix.arch }} --extension-path "$EXTENSION_PATH"
 
       - name: Verify packaged OpenDAL native package for Linux
-        run: pnpm run smoke:opendal:native -- --platform linux --arch ${{ matrix.arch }} --resources-path dist/linux-unpacked/resources
+        run: pnpm run smoke:opendal:native -- --platform linux --arch ${{ matrix.arch }} --resources-path dist/${{ matrix.unpacked }}/resources
 
-      - name: Verify bundled plugins
-        shell: bash
-        run: |
-          pnpm run plugin:verify -- --name cua --platform linux --arch ${{ matrix.arch }} --plugin-root dist/linux-unpacked/resources/app.asar.unpacked/plugins
-          pnpm run plugin:verify -- --name feishu --platform linux --arch ${{ matrix.arch }} --plugin-root dist/linux-unpacked/resources/app.asar.unpacked/plugins
+      - name: Verify bundled CUA plugin
+        if: matrix.arch == 'x64'
+        run: pnpm run plugin:verify -- --name cua --platform linux --arch ${{ matrix.arch }} --plugin-root dist/${{ matrix.unpacked }}/resources/app.asar.unpacked/plugins
+
+      - name: Verify bundled Feishu plugin
+        run: pnpm run plugin:verify -- --name feishu --platform linux --arch ${{ matrix.arch }} --plugin-root dist/${{ matrix.unpacked }}/resources/app.asar.unpacked/plugins
 
       - name: Upload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -289,6 +308,7 @@ jobs:
           path: |
             dist/*
             !dist/linux-unpacked
+            !dist/linux-arm64-unpacked
 
   build-mac:
     needs: [resolve-tag, validate-main-ancestor]
@@ -519,6 +539,16 @@ jobs:
             cp artifacts/deepchat-linux-x64/*.tar.gz release_assets/ 2>/dev/null || true
             cp artifacts/deepchat-linux-x64/*.yml release_assets/ 2>/dev/null || true
             cp artifacts/deepchat-linux-x64/*.blockmap release_assets/ 2>/dev/null || true
+          fi
+
+          # Process Linux arm64 artifacts
+          if [ -d "artifacts/deepchat-linux-arm64" ]; then
+            cp artifacts/deepchat-linux-arm64/*.AppImage release_assets/ 2>/dev/null || true
+            cp artifacts/deepchat-linux-arm64/*.deb release_assets/ 2>/dev/null || true
+            cp artifacts/deepchat-linux-arm64/*.rpm release_assets/ 2>/dev/null || true
+            cp artifacts/deepchat-linux-arm64/*.tar.gz release_assets/ 2>/dev/null || true
+            cp artifacts/deepchat-linux-arm64/*.yml release_assets/ 2>/dev/null || true
+            cp artifacts/deepchat-linux-arm64/*.blockmap release_assets/ 2>/dev/null || true
           fi
 
           # Process Mac x64 artifacts

--- a/docs/features/linux-arm64-support/plan.md
+++ b/docs/features/linux-arm64-support/plan.md
@@ -1,0 +1,42 @@
+# Linux ARM64 Support Plan
+
+## Approach
+
+Reuse the repository's existing Linux ARM64 scripts and target-aware plugin contract. Limit source
+changes to CI orchestration, release artifact collection, and regression coverage.
+
+## Workflow Changes
+
+1. Convert each Linux matrix from an x64-only entry to explicit x64 and ARM64 entries.
+2. Keep x64 on `ubuntu-22.04` and run ARM64 natively on `ubuntu-22.04-arm`.
+3. Add the unpacked directory name to matrix metadata and use it for smoke checks and plugin
+   verification.
+4. Run `installRuntime:linux:<arch>` before packaging.
+5. Split CUA bundling and verification into x64-only steps.
+6. Keep Feishu bundling and verification common to both architectures.
+7. Upload artifacts under architecture-specific names.
+
+## Release Assembly
+
+Downloaded Linux ARM64 artifacts remain separate from Linux x64 artifacts. Copy ARM64 packages,
+blockmaps, and `latest-linux-arm64.yml` into the release directory without merging update metadata
+across architectures.
+
+## CUA Contract
+
+No new business-logic branch is required. The existing `engines.targets` gate is the authoritative
+visibility rule, and the existing packaging validation rejects `linux/arm64`. Regression tests will
+cover those contracts together with the workflow-level skip so CI cannot accidentally package CUA.
+
+## Verification
+
+Run focused workflow/plugin packaging tests, then the required repository checks:
+
+```bash
+pnpm run format
+pnpm run i18n
+pnpm run lint
+```
+
+After local validation, commit and push the branch, manually dispatch the build workflow for Linux,
+and require the Linux ARM64 job to complete successfully before opening a Draft PR.

--- a/docs/features/linux-arm64-support/spec.md
+++ b/docs/features/linux-arm64-support/spec.md
@@ -1,0 +1,59 @@
+# Linux ARM64 Support Spec
+
+## Status
+
+In progress.
+
+## Background
+
+DeepChat already contains most Linux ARM64 packaging primitives, including an Electron Builder
+script, ARM64 native dependency mappings, and runtime installers. The build and release workflows
+still schedule only Linux x64, use x64-specific unpacked paths, and always bundle the CUA plugin.
+
+CUA is intentionally unsupported on Linux ARM64 because the pinned upstream driver release has no
+matching runtime asset. DeepChat already gates official plugin visibility by platform and
+architecture and rejects direct CUA packaging for `linux/arm64`. Linux ARM64 application support
+must preserve that contract rather than exposing a non-functional plugin.
+
+## Goal
+
+Produce Linux ARM64 application artifacts in both build and release CI while keeping CUA hidden,
+unbundled, and unverified for that target.
+
+## Scope
+
+- Add native Linux ARM64 jobs to `.github/workflows/build.yml` and
+  `.github/workflows/release.yml`.
+- Install the existing target-specific runtimes before packaging each Linux architecture.
+- Parameterize unpacked output paths for Linux x64 and ARM64.
+- Bundle and verify CUA only for Linux x64.
+- Bundle and verify Feishu for both Linux architectures.
+- Collect Linux ARM64 artifacts and architecture-specific update metadata in the release job.
+- Preserve the existing manifest-based CUA visibility gate and unsupported-target packaging error.
+
+## Non-Goals
+
+- Do not add a Linux ARM64 CUA runtime or claim Linux ARM64 CUA support.
+- Do not change CUA behavior on any supported target.
+- Do not redesign the plugin discovery or packaging systems.
+- Do not run the release workflow as part of this change.
+
+## Target Matrix
+
+| Target | Runner | Application package | CUA | Feishu |
+| --- | --- | --- | --- | --- |
+| `linux/x64` | `ubuntu-22.04` | Required | Bundle and verify | Bundle and verify |
+| `linux/arm64` | `ubuntu-22.04-arm` | Required | Skip | Bundle and verify |
+
+## Acceptance Criteria
+
+- Build CI emits Linux x64 and Linux ARM64 artifacts from native GitHub-hosted runners.
+- Release CI emits both Linux architectures and preserves `latest-linux-arm64.yml` separately
+  from x64 update metadata.
+- Linux jobs use the correct `linux-unpacked` or `linux-arm64-unpacked` output directory.
+- Linux ARM64 jobs never invoke CUA bundling or verification.
+- A packaged Linux ARM64 app does not contain a CUA `.dcplugin` artifact.
+- CUA remains unavailable in business logic on a Linux ARM64 runtime.
+- Direct CUA packaging for `linux/arm64` continues to fail with an unsupported-target error.
+- Focused tests and the repository formatting, i18n, and lint checks pass.
+- A manually dispatched build workflow succeeds for the branch's Linux ARM64 matrix job.

--- a/docs/features/linux-arm64-support/spec.md
+++ b/docs/features/linux-arm64-support/spec.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-In progress.
+Implemented and validated in
+[Build Application run 29933595490](https://github.com/ThinkInAIXYZ/deepchat/actions/runs/29933595490).
 
 ## Background
 

--- a/docs/features/linux-arm64-support/tasks.md
+++ b/docs/features/linux-arm64-support/tasks.md
@@ -1,0 +1,33 @@
+# Linux ARM64 Support Tasks
+
+## Task List
+
+- [x] T01 - Add Linux ARM64 to build CI
+  - Add a native ARM64 runner matrix entry.
+  - Install target runtimes and parameterize unpacked paths.
+  - Skip CUA bundling and verification on ARM64.
+
+- [x] T02 - Add Linux ARM64 to release CI
+  - Mirror the build matrix and CUA skip.
+  - Upload architecture-specific build artifacts.
+  - Collect ARM64 packages and update metadata for the release.
+
+- [x] T03 - Add regression coverage
+  - Validate both workflow matrices and output directories.
+  - Validate the workflow-level CUA skip.
+  - Preserve business visibility and direct packaging rejection coverage.
+
+- [x] T04 - Run local validation
+  - Run focused tests.
+  - Run formatting, i18n, and lint checks.
+
+- [ ] T05 - Validate CI and publish for review
+  - Commit and push the feature branch.
+  - Dispatch Linux build CI and confirm the ARM64 job packages successfully.
+  - Open a Draft PR against `dev`.
+
+## Done Definition
+
+- Build and release workflows define working Linux x64 and ARM64 jobs.
+- Linux ARM64 application artifacts exclude CUA by contract and by CI execution.
+- The branch is pushed, Linux ARM64 build CI succeeds, and a Draft PR is open.

--- a/docs/features/linux-arm64-support/tasks.md
+++ b/docs/features/linux-arm64-support/tasks.md
@@ -21,10 +21,17 @@
   - Run focused tests.
   - Run formatting, i18n, and lint checks.
 
-- [ ] T05 - Validate CI and publish for review
+- [x] T05 - Validate CI and publish for review
   - Commit and push the feature branch.
   - Dispatch Linux build CI and confirm the ARM64 job packages successfully.
   - Open a Draft PR against `dev`.
+
+## Validation Evidence
+
+- Linux ARM64 packaging, native dependency checks, plugin verification, and artifact upload passed
+  in [Build Application run 29933595490](https://github.com/ThinkInAIXYZ/deepchat/actions/runs/29933595490).
+- CUA bundling and verification were skipped in the Linux ARM64 job as intended.
+- Draft PR: [#2006](https://github.com/ThinkInAIXYZ/deepchat/pull/2006).
 
 ## Done Definition
 

--- a/test/main/build/electronBuilderConfig.test.ts
+++ b/test/main/build/electronBuilderConfig.test.ts
@@ -10,6 +10,37 @@ interface ElectronBuilderConfig {
 interface PackageJson {
   dependencies?: Record<string, string>
   optionalDependencies?: Record<string, string>
+  scripts?: Record<string, string>
+}
+
+interface WorkflowMatrixEntry {
+  arch: string
+  platform: string
+  runner: string
+  unpacked: string
+}
+
+interface WorkflowStep {
+  name?: string
+  if?: string
+  run?: string
+  with?: {
+    path?: string
+  }
+}
+
+interface WorkflowJob {
+  'runs-on'?: string
+  strategy?: {
+    matrix?: {
+      include?: WorkflowMatrixEntry[]
+    }
+  }
+  steps?: WorkflowStep[]
+}
+
+interface GitHubWorkflow {
+  jobs?: Record<string, WorkflowJob>
 }
 
 const OPENDAL_VERSION = '0.49.2'
@@ -32,6 +63,11 @@ const readElectronBuilderConfig = async () => {
 const readPackageJson = async () => {
   const packageJsonPath = path.join(process.cwd(), 'package.json')
   return JSON.parse(await readFile(packageJsonPath, 'utf8')) as PackageJson
+}
+
+const readWorkflow = async (name: string) => {
+  const workflowPath = path.join(process.cwd(), '.github', 'workflows', name)
+  return parse(await readFile(workflowPath, 'utf8')) as GitHubWorkflow
 }
 
 describe('electron-builder config', () => {
@@ -61,5 +97,67 @@ describe('electron-builder config', () => {
     for (const packageName of OPENDAL_NATIVE_PACKAGES) {
       expect(packageJson.optionalDependencies?.[packageName]).toBe(OPENDAL_VERSION)
     }
+  })
+})
+
+describe('Linux ARM64 packaging', () => {
+  it.each(['build.yml', 'release.yml'])('%s builds both Linux architectures without ARM64 CUA', async (name) => {
+    const workflow = await readWorkflow(name)
+    const linuxJob = workflow.jobs?.['build-linux']
+    const steps = linuxJob?.steps ?? []
+
+    expect(linuxJob?.['runs-on']).toBe('${{ matrix.runner }}')
+    expect(linuxJob?.strategy?.matrix?.include).toEqual([
+      {
+        arch: 'x64',
+        platform: 'linux-x64',
+        runner: 'ubuntu-22.04',
+        unpacked: 'linux-unpacked'
+      },
+      {
+        arch: 'arm64',
+        platform: 'linux-arm64',
+        runner: 'ubuntu-22.04-arm',
+        unpacked: 'linux-arm64-unpacked'
+      }
+    ])
+
+    const cuaSteps = steps.filter((step) => step.run?.includes('--name cua --platform linux'))
+    expect(cuaSteps).toHaveLength(2)
+    expect(cuaSteps.every((step) => step.if === "matrix.arch == 'x64'")).toBe(true)
+
+    expect(steps.find((step) => step.name === 'Install Linux runtimes')?.run).toBe(
+      'pnpm run installRuntime:linux:${{ matrix.arch }}'
+    )
+    expect(steps.find((step) => step.name === 'Bundle Feishu plugin')?.if).toBeUndefined()
+
+    const commands = steps.map((step) => step.run ?? '').join('\n')
+    expect(commands).toContain('dist/${{ matrix.unpacked }}/resources')
+    expect(commands).not.toContain('dist/linux-unpacked/resources')
+
+    const uploadPaths = steps.find((step) => step.name === 'Upload artifacts')?.with?.path
+    expect(uploadPaths).toContain('!dist/linux-unpacked')
+    expect(uploadPaths).toContain('!dist/linux-arm64-unpacked')
+  })
+
+  it('keeps local Linux ARM64 packaging free of CUA', async () => {
+    const packageJson = await readPackageJson()
+    const buildScript = packageJson.scripts?.['build:linux:arm64']
+
+    expect(buildScript).toContain('plugin:bundle -- --name feishu --platform linux --arch arm64')
+    expect(buildScript).toContain('electron-builder --linux --arm64')
+    expect(buildScript).not.toContain('plugin:bundle -- --name cua')
+  })
+
+  it('collects Linux ARM64 packages and update metadata for releases', async () => {
+    const workflow = await readWorkflow('release.yml')
+    const prepareAssets = workflow.jobs?.release?.steps?.find(
+      (step) => step.name === 'Prepare release assets'
+    )?.run
+
+    expect(prepareAssets).toContain('artifacts/deepchat-linux-arm64/*.AppImage')
+    expect(prepareAssets).toContain('artifacts/deepchat-linux-arm64/*.tar.gz')
+    expect(prepareAssets).toContain('artifacts/deepchat-linux-arm64/*.yml')
+    expect(prepareAssets).toContain('artifacts/deepchat-linux-arm64/*.blockmap')
   })
 })

--- a/test/main/plugin/pluginService.test.ts
+++ b/test/main/plugin/pluginService.test.ts
@@ -1423,7 +1423,7 @@ describe('PluginService', () => {
     expect(buildWorkflow).toContain(
       'dist/${{ matrix.unpacked }}/resources/app.asar.unpacked/runtime/duckdb/extensions/vss.duckdb_extension'
     )
-    expect(buildWorkflow).toContain(
+    expect(buildWorkflow).not.toContain(
       'dist/linux-unpacked/resources/app.asar.unpacked/runtime/duckdb/extensions/vss.duckdb_extension'
     )
     expect(buildWorkflow).toContain(
@@ -1478,7 +1478,7 @@ describe('PluginService', () => {
     expect(releaseWorkflow).toContain(
       'dist/${{ matrix.unpacked }}/resources/app.asar.unpacked/runtime/duckdb/extensions/vss.duckdb_extension'
     )
-    expect(releaseWorkflow).toContain(
+    expect(releaseWorkflow).not.toContain(
       'dist/linux-unpacked/resources/app.asar.unpacked/runtime/duckdb/extensions/vss.duckdb_extension'
     )
     expect(releaseWorkflow).toContain(


### PR DESCRIPTION
## Summary

- add native Linux ARM64 jobs to build and release CI
- install target runtimes and use architecture-specific unpacked paths
- keep CUA hidden and excluded from Linux ARM64 bundling and verification
- collect Linux ARM64 packages and update metadata for releases
- add feature SDD and workflow regression coverage

## Validation

- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec vitest run test/main/build/electronBuilderConfig.test.ts test/main/plugin/pluginService.test.ts test/main/scripts/packagePlugin.test.ts test/main/shared/settingsNavigation.test.ts` — 55 tests passed
- [Build Application run 29933595490](https://github.com/ThinkInAIXYZ/deepchat/actions/runs/29933595490): Linux ARM64 packaging, native dependency checks, plugin verification, and artifact upload passed; CUA bundle and verification steps were skipped as intended

## Handoff

The release workflow and full cross-platform packaging matrix were not dispatched. Those checks are intentionally left for maintainer validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux ARM64 build and release support alongside x64.
  * ARM64 packages and update metadata are now generated and published separately.
  * Linux build and release verification now adapts to each architecture.
  * CUA remains available only for supported x64 Linux builds.

* **Documentation**
  * Added planning, specification, task, and validation documentation for Linux ARM64 support.

* **Tests**
  * Added coverage for architecture-specific workflows, packaging, artifacts, and plugin behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->