### PR TITLE
fix(agent): address skill review feedback

### DIFF
--- a/scripts/generate-icon-collections.mjs
+++ b/scripts/generate-icon-collections.mjs
@@ -109,11 +109,13 @@ function createSubsetCollection(collection, iconNames) {
     addIcon(iconName)
   }
 
-  return {
+  const subset = {
     ...collection,
     icons,
     aliases
   }
+  delete subset.lastModified
+  return subset
 }
 
 function assertKnownIcons(collection, prefix, iconNames) {

--- a/src/main/agent/deepchat/runtime/deepChatRuntimeCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/deepChatRuntimeCoordinator.ts
@@ -1,5 +1,6 @@
 import type { ProviderModelResolutionPort } from '@/provider/settings'
 import logger from '@shared/logger'
+import { redactRuntimeErrorForLog } from './runtimeErrorLogging'
 import type {
   AssistantMessageBlock,
   DeepChatSessionState,
@@ -2009,9 +2010,9 @@ export class DeepChatRuntimeCoordinator {
     reason: 'enqueue' | 'completed'
   ): void {
     void this.drainPendingQueueIfPossible(sessionId, reason).catch((error) => {
-      console.error(
-        `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=${reason}:`,
-        error
+      logger.error(
+        `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=${reason}`,
+        redactRuntimeErrorForLog(error)
       )
     })
   }
@@ -2047,7 +2048,10 @@ export class DeepChatRuntimeCoordinator {
     try {
       projectDir = this.resolveProjectDir(sessionId)
     } catch (error) {
-      console.error('[DeepChatAgent] drainPendingQueueIfPossible error:', error)
+      logger.error(
+        `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=${reason} stage=resolve-project-dir`,
+        redactRuntimeErrorForLog(error)
+      )
       return false
     }
 
@@ -2065,7 +2069,10 @@ export class DeepChatRuntimeCoordinator {
       // row is already claimed; release is idempotent for a row that never left the pending state.
       this.tryReleaseClaimedPendingInput(sessionId, nextPendingInput.id, pendingInputSource)
       instance.markPendingQueueDrainFinished()
-      console.error('[DeepChatAgent] drainPendingQueueIfPossible error:', error)
+      logger.error(
+        `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=${reason} stage=claim-input`,
+        redactRuntimeErrorForLog(error)
+      )
       return false
     }
 
@@ -2076,7 +2083,10 @@ export class DeepChatRuntimeCoordinator {
     } catch (error) {
       this.tryReleaseClaimedPendingInput(sessionId, claimedInput.id, pendingInputSource)
       instance.markPendingQueueDrainFinished()
-      console.error('[DeepChatAgent] drainPendingQueueIfPossible error:', error)
+      logger.error(
+        `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=${reason} stage=clear-steer`,
+        redactRuntimeErrorForLog(error)
+      )
       return false
     }
 
@@ -2086,7 +2096,10 @@ export class DeepChatRuntimeCoordinator {
       pendingQueueItemSource: pendingInputSource
     })
       .catch((error) => {
-        console.error('[DeepChatAgent] drainPendingQueueIfPossible error:', error)
+        logger.error(
+          `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=${reason} stage=process-message`,
+          redactRuntimeErrorForLog(error)
+        )
       })
       .finally(async () => {
         instance.markPendingQueueDrainFinished()
@@ -2103,11 +2116,17 @@ export class DeepChatRuntimeCoordinator {
             this.schedulePendingQueueDrain(sessionId, 'completed')
           }
         } catch (error) {
-          console.error('[DeepChatAgent] drainPendingQueueIfPossible cleanup error:', error)
+          logger.error(
+            `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=${reason} stage=cleanup`,
+            redactRuntimeErrorForLog(error)
+          )
         }
       })
       .catch((error) => {
-        console.error('[DeepChatAgent] drainPendingQueueIfPossible finalization error:', error)
+        logger.error(
+          `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=${reason} stage=finalization`,
+          redactRuntimeErrorForLog(error)
+        )
       })
 
     return true

--- a/src/main/agent/deepchat/runtime/interactionCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/interactionCoordinator.ts
@@ -32,6 +32,7 @@ import {
   updateSkillDraftToolCallResponse,
   updateToolCallResponse
 } from './interactionProjection'
+import { redactRuntimeErrorForLog } from './runtimeErrorLogging'
 import type { SessionTranscript } from '@/session/data/transcript'
 import type { ProviderPermissionCoordinator } from './providerPermissionCoordinator'
 import { MAX_TOOL_CALLS_SKIPPED_ERROR } from './process'
@@ -520,7 +521,10 @@ export class InteractionCoordinator {
           JSON.stringify(stampTerminalMetadata(accounting, 'aborted', 'user_stop'))
         )
         void this.ports.drainPendingQueueIfPossible(sessionId, 'completed').catch((drainError) => {
-          logger.error('[DeepChatAgent] drainPendingQueueIfPossible error:', drainError)
+          logger.error(
+            `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=completed`,
+            redactRuntimeErrorForLog(drainError)
+          )
         })
         return { resumed: false }
       }

--- a/src/main/agent/deepchat/runtime/runtimeErrorLogging.ts
+++ b/src/main/agent/deepchat/runtime/runtimeErrorLogging.ts
@@ -1,0 +1,7 @@
+export interface RedactedRuntimeError {
+  name: string
+}
+
+export function redactRuntimeErrorForLog(error: unknown): RedactedRuntimeError {
+  return { name: error instanceof Error ? 'Error' : 'UnknownError' }
+}

--- a/src/main/agent/deepchat/runtime/turnCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/turnCoordinator.ts
@@ -1,5 +1,6 @@
 import type { ProviderModelResolutionPort } from '@/provider/settings'
 import logger from '@shared/logger'
+import { redactRuntimeErrorForLog } from './runtimeErrorLogging'
 import type {
   AttachmentPreparationSummary,
   AssistantMessageBlock,
@@ -1396,9 +1397,9 @@ export class TurnCoordinator {
     reason: 'enqueue' | 'completed'
   ): void {
     void this.ports.drainPendingQueueIfPossible(sessionId, reason).catch((error) => {
-      console.error(
-        `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=${reason}:`,
-        error
+      logger.error(
+        `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=${reason}`,
+        redactRuntimeErrorForLog(error)
       )
     })
   }

--- a/src/main/session/lifecycle.ts
+++ b/src/main/session/lifecycle.ts
@@ -24,7 +24,9 @@ import type {
   SessionLifecycleStorePort,
   SessionLifecyclePermissionPort,
   SessionLifecycleSubagentInput,
-  SessionLifecycleTranscriptPort
+  SessionLifecycleTranscriptPort,
+  ResolvedSessionAssignment,
+  ResolvedSubagentAssignment
 } from './contracts'
 import type { AgentLifecycleGatePort } from '@/agent/lifecycleGate'
 
@@ -57,17 +59,6 @@ export class SessionLifecycle implements SessionLifecyclePort {
     webContentsId: number,
     options?: { signal?: AbortSignal }
   ): Promise<SessionWithState & { initialTurn?: MessageStartResult }> {
-    const agentId = input.agentId?.trim() || 'deepchat'
-    return await this.dependencies.agentLifecycle.runWithAgentOperation(agentId, async () => {
-      return await this.createSessionUnderLifecycleGate(input, webContentsId, options)
-    })
-  }
-
-  private async createSessionUnderLifecycleGate(
-    input: CreateSessionInput,
-    webContentsId: number,
-    options?: { signal?: AbortSignal }
-  ): Promise<SessionWithState & { initialTurn?: MessageStartResult }> {
     const assignment = await this.dependencies.assignmentPolicy.resolveCreateAssignment({
       agentId: input.agentId || 'deepchat',
       providerId: input.providerId,
@@ -79,6 +70,19 @@ export class SessionLifecycle implements SessionLifecyclePort {
       preserveExplicitNullProjectDir: true
     })
     options?.signal?.throwIfAborted()
+    return await this.dependencies.agentLifecycle.runWithAgentOperation(
+      assignment.agentId,
+      async () =>
+        await this.createSessionUnderLifecycleGate(input, webContentsId, options, assignment)
+    )
+  }
+
+  private async createSessionUnderLifecycleGate(
+    input: CreateSessionInput,
+    webContentsId: number,
+    options: { signal?: AbortSignal } | undefined,
+    assignment: ResolvedSessionAssignment
+  ): Promise<SessionWithState & { initialTurn?: MessageStartResult }> {
     const {
       agentId,
       providerId,
@@ -163,15 +167,25 @@ export class SessionLifecycle implements SessionLifecyclePort {
   }
 
   async createDetachedSession(input: CreateDetachedSessionInput): Promise<SessionWithState> {
-    const agentId = input.agentId?.trim() || 'deepchat'
+    const assignment = await this.dependencies.assignmentPolicy.resolveCreateAssignment({
+      agentId: input.agentId?.trim() || 'deepchat',
+      providerId: input.providerId,
+      modelId: input.modelId,
+      projectDir: input.projectDir,
+      permissionMode: input.permissionMode,
+      generationSettings: input.generationSettings,
+      disabledAgentTools: input.disabledAgentTools,
+      preserveExplicitNullProjectDir: false
+    })
     return await this.dependencies.agentLifecycle.runWithAgentOperation(
-      agentId,
-      async () => await this.createDetachedSessionUnderLifecycleGate(input)
+      assignment.agentId,
+      async () => await this.createDetachedSessionUnderLifecycleGate(input, assignment)
     )
   }
 
   private async createDetachedSessionUnderLifecycleGate(
-    input: CreateDetachedSessionInput
+    input: CreateDetachedSessionInput,
+    assignment: ResolvedSessionAssignment
   ): Promise<SessionWithState> {
     const title = input.title?.trim() || 'New Chat'
     const {
@@ -182,16 +196,7 @@ export class SessionLifecycle implements SessionLifecyclePort {
       permissionMode,
       generationSettings,
       disabledAgentTools
-    } = await this.dependencies.assignmentPolicy.resolveCreateAssignment({
-      agentId: input.agentId?.trim() || 'deepchat',
-      providerId: input.providerId,
-      modelId: input.modelId,
-      projectDir: input.projectDir,
-      permissionMode: input.permissionMode,
-      generationSettings: input.generationSettings,
-      disabledAgentTools: input.disabledAgentTools,
-      preserveExplicitNullProjectDir: false
-    })
+    } = assignment
 
     const sessionId = this.dependencies.sessions.create(agentId, title, projectDir, {
       isDraft: false,
@@ -240,25 +245,6 @@ export class SessionLifecycle implements SessionLifecyclePort {
   async createSubagentSession(input: SessionLifecycleSubagentInput): Promise<SessionWithState> {
     const agentId = input.agentId?.trim()
     if (!agentId) throw new Error('Subagent session requires an agentId.')
-    return await this.dependencies.agentLifecycle.runWithAgentOperation(
-      agentId,
-      async () => await this.createSubagentSessionUnderLifecycleGate(input)
-    )
-  }
-
-  private async createSubagentSessionUnderLifecycleGate(
-    input: SessionLifecycleSubagentInput
-  ): Promise<SessionWithState> {
-    const parentSessionId = input.parentSessionId?.trim()
-    if (!parentSessionId) throw new Error('Subagent session requires a parentSessionId.')
-
-    const slotId = input.slotId?.trim()
-    if (!slotId) throw new Error('Subagent session requires a slotId.')
-
-    const displayName = input.displayName?.trim() || 'Subagent'
-    const agentId = input.agentId?.trim()
-    if (!agentId) throw new Error('Subagent session requires an agentId.')
-
     const projectDir = input.projectDir?.trim() || null
     const runtimeConfig = await this.dependencies.assignmentPolicy.resolveSubagentAssignment({
       agentId,
@@ -272,6 +258,24 @@ export class SessionLifecycle implements SessionLifecyclePort {
       disabledAgentTools: input.disabledAgentTools,
       activeSkills: input.activeSkills
     })
+    return await this.dependencies.agentLifecycle.runWithAgentOperation(
+      runtimeConfig.agentId,
+      async () => await this.createSubagentSessionUnderLifecycleGate(input, runtimeConfig)
+    )
+  }
+
+  private async createSubagentSessionUnderLifecycleGate(
+    input: SessionLifecycleSubagentInput,
+    runtimeConfig: ResolvedSubagentAssignment
+  ): Promise<SessionWithState> {
+    const parentSessionId = input.parentSessionId?.trim()
+    if (!parentSessionId) throw new Error('Subagent session requires a parentSessionId.')
+
+    const slotId = input.slotId?.trim()
+    if (!slotId) throw new Error('Subagent session requires a slotId.')
+
+    const displayName = input.displayName?.trim() || 'Subagent'
+    const projectDir = input.projectDir?.trim() || null
     const subagentMeta: DeepChatSubagentMeta = {
       slotId,
       displayName,

--- a/src/renderer/src/lib/icons/icon-collections.generated.ts
+++ b/src/renderer/src/lib/icons/icon-collections.generated.ts
@@ -301,6 +301,9 @@ export const lucideIconCollection = {
     'folder-plus': {
       body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m-3-3h6m5 7a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/>'
     },
+    'folder-search': {
+      body: '<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M10.7 20H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H20a2 2 0 0 1 2 2v4.1M21 21l-1.9-1.9"/><circle cx="17" cy="17" r="3"/></g>'
+    },
     'folder-tree': {
       body: '<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M20 10a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2.5a1 1 0 0 1-.8-.4l-.9-1.2A1 1 0 0 0 15 3h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1Zm0 11a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1h-2.9a1 1 0 0 1-.88-.55l-.42-.85a1 1 0 0 0-.92-.6H13a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1ZM3 5a2 2 0 0 0 2 2h3"/><path d="M3 3v13a2 2 0 0 0 2 2h3"/></g>'
     },
@@ -755,7 +758,7 @@ export const lucideIconCollection = {
       parent: 'circle-x'
     }
   },
-  lastModified: 1779346445,
+  lastModified: 1783920389,
   width: 24,
   height: 24
 } as const
@@ -816,7 +819,7 @@ export const vscodeIconCollection = {
     }
   },
   aliases: {},
-  lastModified: 1779168064,
+  lastModified: 1783920591,
   width: 32,
   height: 32
 } as const

--- a/src/renderer/src/lib/icons/icon-collections.generated.ts
+++ b/src/renderer/src/lib/icons/icon-collections.generated.ts
@@ -758,7 +758,6 @@ export const lucideIconCollection = {
       parent: 'circle-x'
     }
   },
-  lastModified: 1783920389,
   width: 24,
   height: 24
 } as const
@@ -819,14 +818,12 @@ export const vscodeIconCollection = {
     }
   },
   aliases: {},
-  lastModified: 1783920591,
   width: 32,
   height: 32
 } as const
 
 export const lineMdIconCollection = {
   prefix: 'line-md',
-  lastModified: 1767255360,
   aliases: {},
   width: 24,
   height: 24,

--- a/src/renderer/src/lib/icons/icon-whitelist.generated.ts
+++ b/src/renderer/src/lib/icons/icon-whitelist.generated.ts
@@ -106,6 +106,7 @@ export const GENERATED_ICON_WHITELIST: Record<GeneratedIconCollectionKey, readon
     'folder-open',
     'folder-open-dot',
     'folder-plus',
+    'folder-search',
     'folder-tree',
     'folder-x',
     'folders',

--- a/test/main/agent/deepchat/runtime/deepChatRuntimeCoordinator.test.ts
+++ b/test/main/agent/deepchat/runtime/deepChatRuntimeCoordinator.test.ts
@@ -9500,8 +9500,8 @@ describe('DeepChatRuntimeCoordinator', () => {
       await expect(interaction).resolves.toEqual({ resumed: false })
       await vi.waitFor(() =>
         expect(logger.error).toHaveBeenCalledWith(
-          '[DeepChatAgent] drainPendingQueueIfPossible error:',
-          drainError
+          '[DeepChatAgent] drainPendingQueueIfPossible error session=s1 reason=completed',
+          { name: 'Error' }
         )
       )
       expect(drainPendingQueue).toHaveBeenCalledWith('s1', 'completed')

--- a/test/main/session/assignment.test.ts
+++ b/test/main/session/assignment.test.ts
@@ -527,7 +527,7 @@ describe('SessionAssignment', () => {
     {
       name: 'retry',
       invoke: (turn: SessionTurn) => turn.retryMessage('s1', 'message-1'),
-      expectedResult: undefined
+      expectedResult: { requestId: 'request-1', messageId: 'message-1' }
     }
   ])(
     'holds a concurrent $name until transfer runtime and persisted Agent state agree',

--- a/test/main/session/lifecycle.test.ts
+++ b/test/main/session/lifecycle.test.ts
@@ -267,6 +267,76 @@ function createHarness(initialSessions: SessionRecord[] = []) {
 }
 
 describe('SessionLifecycle', () => {
+  it('gates session creation with the resolved canonical agent id', async () => {
+    const harness = createHarness()
+    harness.assignmentPolicy.resolveCreateAssignment.mockResolvedValueOnce({
+      agentId: 'kimi',
+      agentType: 'acp',
+      providerId: 'acp',
+      modelId: 'kimi',
+      projectDir: '/repo',
+      permissionMode: 'full_access',
+      disabledAgentTools: []
+    })
+
+    await harness.coordinator.createSession({ agentId: 'kimi-cli', message: 'Hello' }, 42)
+
+    expect(harness.agentLifecycle.runWithAgentOperation).toHaveBeenCalledWith(
+      'kimi',
+      expect.any(Function)
+    )
+    expect(harness.assignmentPolicy.resolveCreateAssignment).toHaveBeenCalledOnce()
+  })
+
+  it('gates detached session creation with the resolved canonical agent id', async () => {
+    const harness = createHarness()
+    harness.assignmentPolicy.resolveCreateAssignment.mockResolvedValueOnce({
+      agentId: 'kimi',
+      agentType: 'acp',
+      providerId: 'acp',
+      modelId: 'kimi',
+      projectDir: '/repo',
+      permissionMode: 'full_access',
+      disabledAgentTools: []
+    })
+
+    await harness.coordinator.createDetachedSession({ agentId: 'kimi-cli' })
+
+    expect(harness.agentLifecycle.runWithAgentOperation).toHaveBeenCalledWith(
+      'kimi',
+      expect.any(Function)
+    )
+    expect(harness.assignmentPolicy.resolveCreateAssignment).toHaveBeenCalledOnce()
+  })
+
+  it('gates subagent creation with the resolved canonical agent id', async () => {
+    const harness = createHarness()
+    harness.assignmentPolicy.resolveSubagentAssignment.mockResolvedValueOnce({
+      agentId: 'kimi',
+      targetAgentId: 'kimi',
+      providerId: 'acp',
+      modelId: 'kimi',
+      permissionMode: 'full_access',
+      disabledAgentTools: [],
+      activeSkills: []
+    })
+
+    await harness.coordinator.createSubagentSession({
+      parentSessionId: 'parent',
+      agentId: 'kimi-cli',
+      slotId: 'worker',
+      displayName: 'Worker',
+      providerId: 'acp',
+      modelId: 'kimi'
+    })
+
+    expect(harness.agentLifecycle.runWithAgentOperation).toHaveBeenCalledWith(
+      'kimi',
+      expect.any(Function)
+    )
+    expect(harness.assignmentPolicy.resolveSubagentAssignment).toHaveBeenCalledOnce()
+  })
+
   it('initializes before publication and awaits initial-turn preflight', async () => {
     const harness = createHarness()
     harness.initialTurn.startInitialTurn.mockImplementation(async () => {

--- a/test/main/skill/toolNameMapping.test.ts
+++ b/test/main/skill/toolNameMapping.test.ts
@@ -41,7 +41,13 @@ describe('toolNameMapping', () => {
       'deepchat_settings_open'
     ])
 
-    expect(result.tools).toHaveLength(5)
+    expect(result.tools).toEqual([
+      'deepchat_settings_toggle',
+      'deepchat_settings_set_language',
+      'deepchat_settings_set_theme',
+      'deepchat_settings_set_font_size',
+      'deepchat_settings_open'
+    ])
     expect(result.warnings).toEqual([])
   })
 })

--- a/test/main/tool/agentTools/agentToolManagerFffSearch.test.ts
+++ b/test/main/tool/agentTools/agentToolManagerFffSearch.test.ts
@@ -41,6 +41,7 @@ function buildRuntimePort() {
     resolveConversationWorkdir: vi.fn().mockResolvedValue(null),
     resolveConversationSessionInfo: vi.fn().mockResolvedValue(null),
     skillService: {
+      getSkillsDir: vi.fn().mockResolvedValue('/tmp/deepchat-skills'),
       getActiveSkills: vi.fn().mockResolvedValue([]),
       getActiveSkillsAllowedTools: vi.fn().mockResolvedValue([]),
       listSkillScripts: vi.fn().mockResolvedValue([]),

--- a/test/main/tool/agentTools/agentToolManagerRead.test.ts
+++ b/test/main/tool/agentTools/agentToolManagerRead.test.ts
@@ -92,6 +92,7 @@ describe('AgentToolManager read routing', () => {
         resolveConversationWorkdir,
         resolveConversationSessionInfo,
         skillService: {
+          getSkillsDir: vi.fn().mockResolvedValue(path.join(os.tmpdir(), 'deepchat-skills')),
           getActiveSkills: vi.fn().mockResolvedValue([]),
           getActiveSkillsAllowedTools: vi.fn().mockResolvedValue([]),
           listSkillScripts: vi.fn().mockResolvedValue([]),

--- a/test/renderer/stores/skillsStore.test.ts
+++ b/test/renderer/stores/skillsStore.test.ts
@@ -54,6 +54,7 @@ describe('skillsStore catalog events', () => {
     catalogListener?.({ agentIds: ['deepchat'] })
     await Promise.resolve()
     expect(skillClient.getUnifiedSkillCatalog).toHaveBeenCalledTimes(1)
+    expect(skillClient.getUnifiedSkillCatalog).toHaveBeenCalledWith('deepchat')
 
     catalogListener?.({})
     await Promise.resolve()


### PR DESCRIPTION
Addresses follow-up review findings from #2007:

- Gate session lifecycle operations with resolved canonical agent IDs.
- Redact queue-drain error logs across runtime and interaction paths.
- Tighten skill tool/catalog assertions.

Validation: targeted Vitest suite, node/web typechecks, format, i18n, and lint passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session creation now consistently uses the canonical assignment/runtime configuration across session types.
  * Runtime errors are now redacted in logs and reported with clearer stage context during pending queue draining and abort flows.
* **Tests**
  * Expanded and updated coverage for canonical agent handling, built-in settings tool recognition, skills catalog refresh parameters, and refined runtime/error expectations.
* **Chores**
  * Improved icon collection subset generation to remove stale modification metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->