### PR TITLE
build(deps): upgrade OpenDAL to 0.49.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "nanoid": "^5.1.11",
     "node-pty": "1.2.0-beta.14",
     "ollama": "^0.6.3",
-    "opendal": "0.49.2",
+    "opendal": "0.49.5",
     "pdf-parse-new": "^1.4.1",
     "qrcode": "^1.5.4",
     "run-applescript": "^7.1.0",
@@ -235,14 +235,14 @@
     "yaml": "^2.9.0"
   },
   "optionalDependencies": {
-    "@opendal/lib-darwin-arm64": "0.49.2",
-    "@opendal/lib-darwin-x64": "0.49.2",
-    "@opendal/lib-linux-arm64-gnu": "0.49.2",
-    "@opendal/lib-linux-arm64-musl": "0.49.2",
-    "@opendal/lib-linux-x64-gnu": "0.49.2",
-    "@opendal/lib-linux-x64-musl": "0.49.2",
-    "@opendal/lib-win32-arm64-msvc": "0.49.2",
-    "@opendal/lib-win32-x64-msvc": "0.49.2"
+    "@opendal/lib-darwin-arm64": "0.49.5",
+    "@opendal/lib-darwin-x64": "0.49.5",
+    "@opendal/lib-linux-arm64-gnu": "0.49.5",
+    "@opendal/lib-linux-arm64-musl": "0.49.5",
+    "@opendal/lib-linux-x64-gnu": "0.49.5",
+    "@opendal/lib-linux-x64-musl": "0.49.5",
+    "@opendal/lib-win32-arm64-msvc": "0.49.5",
+    "@opendal/lib-win32-x64-msvc": "0.49.5"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^0.6.3
         version: 0.6.3
       opendal:
-        specifier: 0.49.2
-        version: 0.49.2
+        specifier: 0.49.5
+        version: 0.49.5
       pdf-parse-new:
         specifier: ^1.4.1
         version: 1.4.1
@@ -407,29 +407,29 @@ importers:
         version: 2.9.0
     optionalDependencies:
       '@opendal/lib-darwin-arm64':
-        specifier: 0.49.2
-        version: 0.49.2
+        specifier: 0.49.5
+        version: 0.49.5
       '@opendal/lib-darwin-x64':
-        specifier: 0.49.2
-        version: 0.49.2
+        specifier: 0.49.5
+        version: 0.49.5
       '@opendal/lib-linux-arm64-gnu':
-        specifier: 0.49.2
-        version: 0.49.2
+        specifier: 0.49.5
+        version: 0.49.5
       '@opendal/lib-linux-arm64-musl':
-        specifier: 0.49.2
-        version: 0.49.2
+        specifier: 0.49.5
+        version: 0.49.5
       '@opendal/lib-linux-x64-gnu':
-        specifier: 0.49.2
-        version: 0.49.2
+        specifier: 0.49.5
+        version: 0.49.5
       '@opendal/lib-linux-x64-musl':
-        specifier: 0.49.2
-        version: 0.49.2
+        specifier: 0.49.5
+        version: 0.49.5
       '@opendal/lib-win32-arm64-msvc':
-        specifier: 0.49.2
-        version: 0.49.2
+        specifier: 0.49.5
+        version: 0.49.5
       '@opendal/lib-win32-x64-msvc':
-        specifier: 0.49.2
-        version: 0.49.2
+        specifier: 0.49.5
+        version: 0.49.5
 
 packages:
 
@@ -1932,54 +1932,54 @@ packages:
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
-  '@opendal/lib-darwin-arm64@0.49.2':
-    resolution: {integrity: sha512-Yg+d24uWV57/iGkbqf0XAOcJVpoxFbnQa5gjhBHhRiJPK4j3Aer6QenKImeW3BO96GY5TZ2GLv6GOijcUBjSxA==}
+  '@opendal/lib-darwin-arm64@0.49.5':
+    resolution: {integrity: sha512-TYZ0/XEUyz8ylr+AG0gkGsFBrEor9jQkx3aDU9UfkoNY4vIfxp23iaE0pyZEiYczLi0DYQtzjhIS+PvHHnP/PA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@opendal/lib-darwin-x64@0.49.2':
-    resolution: {integrity: sha512-arlAgDMtuaYKw6QS2szDamIbZ6ti3iUWF7piaTg9740uBvtJHi4Mqj6bqxmYAFcW08vWdugsbLrpPntkIaDcVA==}
+  '@opendal/lib-darwin-x64@0.49.5':
+    resolution: {integrity: sha512-p8HwKxFHpv4Kl2ElNJrQ4irYYVjiHUcPK166/+uTptTyJiUCA8CbmRWxmidYxDKBZcc/TizFbFcJ0tf5hEhdYA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@opendal/lib-linux-arm64-gnu@0.49.2':
-    resolution: {integrity: sha512-U8TkDGrKbeccpXw40E3oSv4aboqkOCUq2Hwfz9nt4Nw7FpscV7SIJqE9cAbz/a3lWZ3s6msE8nsAHfBn8jq/Yg==}
+  '@opendal/lib-linux-arm64-gnu@0.49.5':
+    resolution: {integrity: sha512-OC+yeb+BMNn2KBDLENLBsHu/QkQf77i6oHPDlWGtv+x5vcrPLElL9FDSLqs0GIeqnfDFku0iLRtE6vwnhZOmkQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@opendal/lib-linux-arm64-musl@0.49.2':
-    resolution: {integrity: sha512-vvg1LCXBUjARrp0UaL/2lnbK1LajlWbAez4ZHZmTAoMRStYoWSCAzip3euMCHBHjrBrDvrS6eJyLeD0X/R+izw==}
+  '@opendal/lib-linux-arm64-musl@0.49.5':
+    resolution: {integrity: sha512-KGLnKULK9n/FIMKbYclTuI5JqHfI6fFJF4txTsQfCUDVcu6JC/sirT9hfmVNO0477ZqpNqNFrL6sJrqs+TwJKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@opendal/lib-linux-x64-gnu@0.49.2':
-    resolution: {integrity: sha512-mS5Jc7PvRO42xf9ASTyTJr1bEhsbsSPihMnDAZONkWa9njl8ux3F1T6AghLLwdPOkTvst9VH7likDDrj+6gcCA==}
+  '@opendal/lib-linux-x64-gnu@0.49.5':
+    resolution: {integrity: sha512-zb6qZ4ZNJhef2ccHRoKoMSm02scYFNRzyUSDpXicZIO1GUavR0E6oHu9zJnnLDGqBX9L29/f21DKP/7aHMv4eA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@opendal/lib-linux-x64-musl@0.49.2':
-    resolution: {integrity: sha512-4b4r5pjVyZqkCDrgm1c0A9UWZaC8djTSSGpNuVEkvzf3COBuwpKu/7nWNWWefk+7JJtuHsVatR62Fzfl0fSJ4Q==}
+  '@opendal/lib-linux-x64-musl@0.49.5':
+    resolution: {integrity: sha512-L/F1w/0T3WBg+BT9wTKIP5W8PLFDOnq9XVyY4hqeM/+0Aelk0T3HaXwZ6StG0DB2Q6L03ublgBnbB5VZqXHEeQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@opendal/lib-win32-arm64-msvc@0.49.2':
-    resolution: {integrity: sha512-/p/lylG0V+kN4YcmgTWXQlOAOuDt7gLLZBBkAC1BqoCOuguyWTFIAgNOjf5faw6fnMkUZfe8Mj/Sg+xr6LWoMg==}
+  '@opendal/lib-win32-arm64-msvc@0.49.5':
+    resolution: {integrity: sha512-jvxtFxMbARnL6bnd2CR4onTm7fQEtZNFySDW2NCm7N+yHIP5/32+6esTi6DuzpCvwt77aD5pm8ILppG8DRByhw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@opendal/lib-win32-x64-msvc@0.49.2':
-    resolution: {integrity: sha512-b9FLXpz3sygHso9csRGX7eLOlwhnHwDlQmlAQGlgodLuAaRpCZAFtamwxC7ocd5F7DttL30vmdJJDPi9UU7Gxg==}
+  '@opendal/lib-win32-x64-msvc@0.49.5':
+    resolution: {integrity: sha512-CEJbjjhgCpoO8IiRK1UUk5YQv3gQy5BwKwQb0cO4GeSczj9yFAQJ8mvSSVmAu1AFWy7wFMj21VRXNISVEHvcrQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -5970,8 +5970,8 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
-  opendal@0.49.2:
-    resolution: {integrity: sha512-FZxLgJSssYUZSgLD66nQgaieHhfWpK9D/BCaS7lCUWR5pDYsYTJqCm1rbL0/jwwOMmNUhz0g49LMY8OnHOd5Ng==}
+  opendal@0.49.5:
+    resolution: {integrity: sha512-GeClCGR5mGOejFL2EqFXeJf/911BjXxGKNyLDO8dGdtsTlap/MisyIpgO9zBmwYxej9IfilodF6UA4e8Wndoiw==}
     engines: {node: '>= 10'}
 
   option@0.2.4:
@@ -9087,28 +9087,28 @@ snapshots:
 
   '@one-ini/wasm@0.1.1': {}
 
-  '@opendal/lib-darwin-arm64@0.49.2':
+  '@opendal/lib-darwin-arm64@0.49.5':
     optional: true
 
-  '@opendal/lib-darwin-x64@0.49.2':
+  '@opendal/lib-darwin-x64@0.49.5':
     optional: true
 
-  '@opendal/lib-linux-arm64-gnu@0.49.2':
+  '@opendal/lib-linux-arm64-gnu@0.49.5':
     optional: true
 
-  '@opendal/lib-linux-arm64-musl@0.49.2':
+  '@opendal/lib-linux-arm64-musl@0.49.5':
     optional: true
 
-  '@opendal/lib-linux-x64-gnu@0.49.2':
+  '@opendal/lib-linux-x64-gnu@0.49.5':
     optional: true
 
-  '@opendal/lib-linux-x64-musl@0.49.2':
+  '@opendal/lib-linux-x64-musl@0.49.5':
     optional: true
 
-  '@opendal/lib-win32-arm64-msvc@0.49.2':
+  '@opendal/lib-win32-arm64-msvc@0.49.5':
     optional: true
 
-  '@opendal/lib-win32-x64-msvc@0.49.2':
+  '@opendal/lib-win32-x64-msvc@0.49.5':
     optional: true
 
   '@oxc-parser/binding-android-arm-eabi@0.129.0':
@@ -13092,16 +13092,16 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  opendal@0.49.2:
+  opendal@0.49.5:
     optionalDependencies:
-      '@opendal/lib-darwin-arm64': 0.49.2
-      '@opendal/lib-darwin-x64': 0.49.2
-      '@opendal/lib-linux-arm64-gnu': 0.49.2
-      '@opendal/lib-linux-arm64-musl': 0.49.2
-      '@opendal/lib-linux-x64-gnu': 0.49.2
-      '@opendal/lib-linux-x64-musl': 0.49.2
-      '@opendal/lib-win32-arm64-msvc': 0.49.2
-      '@opendal/lib-win32-x64-msvc': 0.49.2
+      '@opendal/lib-darwin-arm64': 0.49.5
+      '@opendal/lib-darwin-x64': 0.49.5
+      '@opendal/lib-linux-arm64-gnu': 0.49.5
+      '@opendal/lib-linux-arm64-musl': 0.49.5
+      '@opendal/lib-linux-x64-gnu': 0.49.5
+      '@opendal/lib-linux-x64-musl': 0.49.5
+      '@opendal/lib-win32-arm64-msvc': 0.49.5
+      '@opendal/lib-win32-x64-msvc': 0.49.5
 
   option@0.2.4: {}
 

--- a/resources/acp-registry/registry.json
+++ b/resources/acp-registry/registry.json
@@ -692,7 +692,7 @@
     {
       "id": "harn",
       "name": "Harn",
-      "version": "0.10.34",
+      "version": "0.10.35",
       "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
       "repository": "https://github.com/burin-labs/harn",
       "website": "https://harnlang.com",
@@ -703,49 +703,49 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-aarch64-apple-darwin.tar.gz",
+            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-aarch64-apple-darwin.tar.gz",
             "cmd": "./harn",
             "args": [
               "serve",
               "acp"
             ],
-            "sha256": "45a0667753c35b584675be4721d09cdea99e2de25a4f301a79eb75262b2ed1c3"
+            "sha256": "89d6b1b6af73caf7ab252e682ba69944985457086345d628fe6e30da0c18c297"
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-apple-darwin.tar.gz",
+            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-x86_64-apple-darwin.tar.gz",
             "cmd": "./harn",
             "args": [
               "serve",
               "acp"
             ],
-            "sha256": "38778e67ab1f692c7d573f1807642577000175c79a24e868e210149a0309e2d3"
+            "sha256": "c3737a9ec5ffca06fc11273f9933251abd1d381af6d512e2d15df1f92ebc3574"
           },
           "linux-aarch64": {
-            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-aarch64-unknown-linux-gnu.tar.gz",
+            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-aarch64-unknown-linux-gnu.tar.gz",
             "cmd": "./harn",
             "args": [
               "serve",
               "acp"
             ],
-            "sha256": "fdfa669b2c09e2b5f5c146a87fd88f53f29a389ed0e76236e589fbc3b6484556"
+            "sha256": "95f412f75f2ed5da5d9d942e1c111a79e9c26d3b76fbbb42617e84d563c03d7f"
           },
           "linux-x86_64": {
-            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-unknown-linux-gnu.tar.gz",
+            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-x86_64-unknown-linux-gnu.tar.gz",
             "cmd": "./harn",
             "args": [
               "serve",
               "acp"
             ],
-            "sha256": "2d7c77b65043a2de3f170e10e9c05e3472f0a52d64a0a2b56e7cccc98300298f"
+            "sha256": "28dc77f7aa48acb80efc293b8f52262e3b47e137f353a4d163c88e6340163474"
           },
           "windows-x86_64": {
-            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-pc-windows-msvc.zip",
+            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-x86_64-pc-windows-msvc.zip",
             "cmd": "harn.exe",
             "args": [
               "serve",
               "acp"
             ],
-            "sha256": "951128859b4bf49647ceccf0b2bb063c892f65523bbd95b5c7fe1548fa96dcc8"
+            "sha256": "bc837e5dee093e25f29af54c49a7cab58c713a1d4ce7c9a962fa820a5ddefa2f"
           }
         }
       },

--- a/resources/model-db/providers.json
+++ b/resources/model-db/providers.json
@@ -264209,7 +264209,7 @@
             ]
           },
           "limit": {
-            "context": 204800,
+            "context": 196608,
             "output": 131072
           },
           "temperature": true,
@@ -271286,34 +271286,6 @@
           "type": "chat"
         },
         {
-          "id": "grok-4-fast-reasoning",
-          "name": "grok-4-fast-reasoning",
-          "display_name": "grok-4-fast-reasoning",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 2000000,
-            "output": 2000000
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true
-            }
-          },
-          "type": "chat"
-        },
-        {
           "id": "deepseek/deepseek-v4-flash",
           "name": "Deepseek V4 Flash",
           "display_name": "Deepseek V4 Flash",
@@ -272636,29 +272608,6 @@
           "type": "chat"
         },
         {
-          "id": "gpt-5.3-chat-latest",
-          "name": "gpt-5.3-chat-latest",
-          "display_name": "gpt-5.3-chat-latest",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 16000
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-5.2-pro",
           "name": "gpt-5.2-pro",
           "display_name": "gpt-5.2-pro",
@@ -272744,29 +272693,6 @@
               ],
               "visibility": "hidden"
             }
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-5.2-chat-latest",
-          "name": "gpt-5.2-chat-latest",
-          "display_name": "gpt-5.2-chat-latest",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 16000
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
           },
           "type": "chat"
         },
@@ -273337,44 +273263,6 @@
           "type": "chat"
         },
         {
-          "id": "o1",
-          "name": "o1",
-          "display_name": "o1",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 200000,
-            "output": 100000
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "mode": "effort",
-              "effort": "medium",
-              "effort_options": [
-                "low",
-                "medium",
-                "high"
-              ],
-              "visibility": "hidden"
-            }
-          },
-          "type": "chat"
-        },
-        {
           "id": "o3",
           "name": "o3",
           "display_name": "o3",
@@ -273390,44 +273278,6 @@
           "limit": {
             "context": 200000,
             "output": 100000
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "mode": "effort",
-              "effort": "medium",
-              "effort_options": [
-                "low",
-                "medium",
-                "high"
-              ],
-              "visibility": "hidden"
-            }
-          },
-          "type": "chat"
-        },
-        {
-          "id": "o1-mini",
-          "name": "o1-mini",
-          "display_name": "o1-mini",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 65536
           },
           "tool_call": true,
           "reasoning": {
@@ -273774,51 +273624,6 @@
           "type": "chat"
         },
         {
-          "id": "gemini-2.5-flash-lite-preview-06-17",
-          "name": "gemini-2.5-flash-lite-preview-06-17",
-          "display_name": "gemini-2.5-flash-lite-preview-06-17",
-          "modalities": {
-            "input": [
-              "text",
-              "video",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 1048576,
-            "output": 65535
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": false
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": false,
-              "mode": "budget",
-              "budget": {
-                "default": -1,
-                "min": 512,
-                "max": 24576,
-                "auto": -1,
-                "unit": "tokens"
-              },
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": [
-                "thought_signatures"
-              ]
-            }
-          },
-          "type": "chat"
-        },
-        {
           "id": "gemini-2.5-flash-lite-preview-09-2025",
           "name": "gemini-2.5-flash-lite-preview-09-2025",
           "display_name": "gemini-2.5-flash-lite-preview-09-2025",
@@ -273905,31 +273710,6 @@
                 "thought_signatures"
               ]
             }
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gemini-2.0-flash-20250609",
-          "name": "gemini-2.0-flash-20250609",
-          "display_name": "gemini-2.0-flash-20250609",
-          "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 1048576,
-            "output": 200000
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
           },
           "type": "chat"
         },
@@ -274127,76 +273907,6 @@
           "tool_call": true,
           "reasoning": {
             "supported": false
-          },
-          "type": "chat"
-        },
-        {
-          "id": "grok-4-fast-non-reasoning",
-          "name": "grok-4-fast-non-reasoning",
-          "display_name": "grok-4-fast-non-reasoning",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 2000000,
-            "output": 2000000
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "type": "chat"
-        },
-        {
-          "id": "grok-3",
-          "name": "grok-3",
-          "display_name": "grok-3",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 131072,
-            "output": 32000
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "type": "chat"
-        },
-        {
-          "id": "grok-3-mini",
-          "name": "grok-3-mini",
-          "display_name": "grok-3-mini",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 131072,
-            "output": 131072
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
           },
           "type": "chat"
         },

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -243,9 +243,17 @@ async function copyOpendalNativePackages(context) {
   }
 
   const projectDir = packager?.projectDir ?? process.cwd()
+  const opendalPackageJson = await readJson(path.join(opendalDir, 'package.json'))
+  if (opendalPackageJson.name !== 'opendal' || typeof opendalPackageJson.version !== 'string') {
+    throw new Error(`Invalid unpacked opendal package identity at ${opendalDir}`)
+  }
 
   for (const packageName of packageNames) {
-    const sourceDir = await resolveInstalledPackageDir(projectDir, packageName)
+    const sourceDir = await resolveInstalledPackageDir(
+      projectDir,
+      packageName,
+      opendalPackageJson.version
+    )
     const destinationDir = path.join(nodeModulesDir, ...packageName.split('/'))
 
     await fs.mkdir(path.dirname(destinationDir), { recursive: true })

--- a/scripts/smoke-opendal-native.js
+++ b/scripts/smoke-opendal-native.js
@@ -2,8 +2,10 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { createRequire } from 'node:module'
 import { pathToFileURL } from 'node:url'
+
+const SMOKE_CONTENT = Buffer.from('deepchat-opendal-smoke')
+const REQUIRED_CONSTRUCTORS = ['Operator', 'RetryLayer', 'TimeoutLayer']
 
 export function parseArgs(argv) {
   const options = {}
@@ -80,14 +82,23 @@ function packagePathParts(packageName) {
   return packageName.split('/')
 }
 
-function resolvePackageDirFromNodeModules(nodeModulesDir, packageName) {
+function packageMatches(packageDir, packageName, expectedVersion) {
+  const packageJsonPath = path.join(packageDir, 'package.json')
+  if (!fs.existsSync(packageJsonPath)) return false
+  if (!expectedVersion) return true
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+  return packageJson.name === packageName && packageJson.version === expectedVersion
+}
+
+function resolvePackageDirFromNodeModules(nodeModulesDir, packageName, expectedVersion) {
   const directDir = path.join(nodeModulesDir, ...packagePathParts(packageName))
-  if (fs.existsSync(path.join(directDir, 'package.json'))) {
+  if (packageMatches(directDir, packageName, expectedVersion)) {
     return fs.realpathSync(directDir)
   }
 
   const pnpmNodeModulesDir = path.join(nodeModulesDir, '.pnpm', 'node_modules', ...packagePathParts(packageName))
-  if (fs.existsSync(path.join(pnpmNodeModulesDir, 'package.json'))) {
+  if (packageMatches(pnpmNodeModulesDir, packageName, expectedVersion)) {
     return fs.realpathSync(pnpmNodeModulesDir)
   }
 
@@ -101,13 +112,14 @@ function resolvePackageDirFromNodeModules(nodeModulesDir, packageName) {
         'node_modules',
         ...packagePathParts(packageName)
       )
-      if (fs.existsSync(path.join(candidate, 'package.json'))) {
+      if (packageMatches(candidate, packageName, expectedVersion)) {
         return fs.realpathSync(candidate)
       }
     }
   }
 
-  throw new Error(`OpenDAL package ${packageName} not found under ${nodeModulesDir}`)
+  const versionSuffix = expectedVersion ? `@${expectedVersion}` : ''
+  throw new Error(`OpenDAL package ${packageName}${versionSuffix} not found under ${nodeModulesDir}`)
 }
 
 function assertPackageMainExists(packageDir, label) {
@@ -128,7 +140,7 @@ function assertPackageMainExists(packageDir, label) {
   return mainPath
 }
 
-function maybeLoadOpendal(opendalDir, platform, arch, label) {
+async function maybeLoadOpendal(opendalDir, platform, arch, label) {
   if (platform !== process.platform || arch !== process.arch) {
     console.log(
       `[OpenDAL Smoke] ${label}: target ${platform}/${arch} differs from host ${process.platform}/${process.arch}; verified file presence only.`
@@ -136,31 +148,77 @@ function maybeLoadOpendal(opendalDir, platform, arch, label) {
     return
   }
 
-  const opendalEntry = path.join(opendalDir, 'index.cjs')
-  const requireFromOpendal = createRequire(opendalEntry)
-  requireFromOpendal(opendalEntry)
-  console.log(`[OpenDAL Smoke] ${label}: loaded opendal from ${opendalEntry}`)
+  const opendalEntry = path.join(opendalDir, 'index.mjs')
+  if (!fs.existsSync(opendalEntry)) {
+    throw new Error(`${label} OpenDAL ESM entry not found at ${opendalEntry}`)
+  }
+
+  const opendal = await import(pathToFileURL(opendalEntry).href)
+  for (const exportName of REQUIRED_CONSTRUCTORS) {
+    if (typeof opendal[exportName] !== 'function') {
+      throw new Error(`${label} OpenDAL export ${exportName} is not a constructor`)
+    }
+  }
+
+  const memory = new opendal.Operator('memory')
+  const timeout = new opendal.TimeoutLayer()
+  timeout.timeout = 5_000
+  timeout.ioTimeout = 5_000
+  memory.layer(timeout.build())
+
+  const retry = new opendal.RetryLayer()
+  retry.maxTimes = 1
+  retry.jitter = true
+  memory.layer(retry.build())
+
+  await memory.write('smoke.txt', SMOKE_CONTENT)
+  const content = Buffer.from(await memory.read('smoke.txt'))
+  if (!content.equals(SMOKE_CONTENT)) {
+    throw new Error(`${label} OpenDAL memory round trip returned unexpected content`)
+  }
+
+  new opendal.Operator('s3', {
+    root: '/',
+    endpoint: 'https://example.invalid',
+    bucket: 'deepchat-smoke',
+    region: 'auto',
+    access_key_id: 'smoke',
+    secret_access_key: 'smoke',
+    enable_exact_buf_write: 'true'
+  })
+
+  console.log(`[OpenDAL Smoke] ${label}: exercised ESM runtime from ${opendalEntry}`)
 }
 
-function smokeNodeModules({ nodeModulesDir, platform, arch, label }) {
+async function smokeNodeModules({ nodeModulesDir, platform, arch, label }) {
   const nativePackageName = getOpendalNativePackage(platform, arch)
   const opendalDir = resolvePackageDirFromNodeModules(nodeModulesDir, 'opendal')
-  const nativePackageDir = resolvePackageDirFromNodeModules(nodeModulesDir, nativePackageName)
+  const opendalPackageJson = JSON.parse(
+    fs.readFileSync(path.join(opendalDir, 'package.json'), 'utf8')
+  )
+  if (opendalPackageJson.name !== 'opendal' || typeof opendalPackageJson.version !== 'string') {
+    throw new Error(`Invalid ${label} OpenDAL package identity at ${opendalDir}`)
+  }
+  const nativePackageDir = resolvePackageDirFromNodeModules(
+    nodeModulesDir,
+    nativePackageName,
+    opendalPackageJson.version
+  )
   const nativeEntry = assertPackageMainExists(nativePackageDir, `${label} ${nativePackageName}`)
 
   console.log(`[OpenDAL Smoke] ${label}: found ${nativePackageName} at ${nativePackageDir}`)
   console.log(`[OpenDAL Smoke] ${label}: native entry ${nativeEntry}`)
-  maybeLoadOpendal(opendalDir, platform, arch, label)
+  await maybeLoadOpendal(opendalDir, platform, arch, label)
 }
 
-function main() {
+async function main() {
   const args = parseArgs(process.argv.slice(2))
   const platform = args.platform ? normalizePlatform(args.platform) : process.platform
   const arch = args.arch ? normalizeArch(args.arch) : process.arch
   const projectDir = path.resolve(args.projectDir ?? args['project-dir'] ?? process.cwd())
   const resourcesPath = args.resourcesPath ?? args['resources-path']
 
-  smokeNodeModules({
+  await smokeNodeModules({
     nodeModulesDir: path.join(projectDir, 'node_modules'),
     platform,
     arch,
@@ -168,7 +226,7 @@ function main() {
   })
 
   if (resourcesPath) {
-    smokeNodeModules({
+    await smokeNodeModules({
       nodeModulesDir: path.join(path.resolve(resourcesPath), 'app.asar.unpacked', 'node_modules'),
       platform,
       arch,
@@ -178,10 +236,8 @@ function main() {
 }
 
 if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
-  try {
-    main()
-  } catch (error) {
+  main().catch((error) => {
     console.error('[OpenDAL Smoke] failed:', error)
     process.exit(1)
-  }
+  })
 }

--- a/test/main/build/electronBuilderConfig.test.ts
+++ b/test/main/build/electronBuilderConfig.test.ts
@@ -38,7 +38,7 @@ interface GitHubWorkflow {
   jobs?: Record<string, WorkflowJob>
 }
 
-const OPENDAL_VERSION = '0.49.2'
+const OPENDAL_VERSION = '0.49.5'
 const OPENDAL_NATIVE_PACKAGES = [
   '@opendal/lib-darwin-arm64',
   '@opendal/lib-darwin-x64',
@@ -81,7 +81,7 @@ describe('electron-builder config', () => {
     )
   })
 
-  it('pins OpenDAL native packages to the Ubuntu 22.04 compatible ABI version', async () => {
+  it('pins the OpenDAL facade and native packages to the same release', async () => {
     const packageJson = await readPackageJson()
 
     expect(packageJson.dependencies?.opendal).toBe(OPENDAL_VERSION)

--- a/test/main/scripts/afterPack.test.ts
+++ b/test/main/scripts/afterPack.test.ts
@@ -37,17 +37,20 @@ const loadPackageLightOcrAssets = async () => {
   }) => Promise<void>
 }
 
+const OPENDAL_TEST_VERSION = '0.49.5'
+
 const packageDir = (nodeModulesDir: string, packageName: string) =>
   path.join(nodeModulesDir, ...packageName.split('/'))
 
 const writePackage = async (
   nodeModulesDir: string,
   packageName: string,
-  files: Record<string, string> = {}
+  files: Record<string, string> = {},
+  version?: string
 ) => {
   const dir = packageDir(nodeModulesDir, packageName)
   await mkdir(dir, { recursive: true })
-  await writeFile(path.join(dir, 'package.json'), `{"name":"${packageName}"}`)
+  await writeFile(path.join(dir, 'package.json'), JSON.stringify({ name: packageName, version }))
   for (const [relativePath, body] of Object.entries(files)) {
     const filePath = path.join(dir, relativePath)
     await mkdir(path.dirname(filePath), { recursive: true })
@@ -58,17 +61,39 @@ const writePackage = async (
 const writeVirtualPackage = async (
   projectDir: string,
   packageName: string,
+  files: Record<string, string> = {},
+  version?: string
+) => {
+  await writePackage(
+    path.join(projectDir, 'node_modules', '.pnpm', 'node_modules'),
+    packageName,
+    files,
+    version
+  )
+}
+
+const writeVersionedVirtualStorePackage = async (
+  projectDir: string,
+  packageName: string,
+  version: string,
   files: Record<string, string> = {}
 ) => {
-  await writePackage(path.join(projectDir, 'node_modules', '.pnpm', 'node_modules'), packageName, files)
+  const virtualStoreName = `${packageName.replace('/', '+')}@${version}`
+  await writePackage(
+    path.join(projectDir, 'node_modules', '.pnpm', virtualStoreName, 'node_modules'),
+    packageName,
+    files,
+    version
+  )
 }
 
 const writeUnpackedPackage = async (
   nodeModulesDir: string,
   packageName: string,
-  files: Record<string, string> = {}
+  files: Record<string, string> = {},
+  version?: string
 ) => {
-  await writePackage(nodeModulesDir, packageName, files)
+  await writePackage(nodeModulesDir, packageName, files, version)
 }
 
 const sha256 = (value: string) => createHash('sha256').update(value).digest('hex')
@@ -225,12 +250,12 @@ const seedDarwinNativePrerequisites = async (
   })
   await writeVirtualPackage(projectDir, `@opendal/${opendalPackageDir}`, {
     [`opendal.darwin-${archName}.node`]: 'opendal-native'
-  })
+  }, OPENDAL_TEST_VERSION)
   await writeUnpackedPackage(nodeModulesDir, '@ff-labs/fff-node')
   await writeUnpackedPackage(nodeModulesDir, '@parcel/watcher')
   await writeUnpackedPackage(nodeModulesDir, 'opendal', {
     'index.cjs': 'module.exports = {}'
-  })
+  }, OPENDAL_TEST_VERSION)
   await seedLightOcrPrerequisites(projectDir, nodeModulesDir, 'darwin', archName)
 
   return { fffPackageDir, parcelPackageDir, opendalPackageDir }
@@ -247,7 +272,7 @@ const seedLinuxNativePrerequisites = async (projectDir: string, nodeModulesDir: 
   await writeUnpackedPackage(nodeModulesDir, '@parcel/watcher')
   await writeUnpackedPackage(nodeModulesDir, 'opendal', {
     'index.cjs': 'module.exports = {}'
-  })
+  }, OPENDAL_TEST_VERSION)
   await seedLightOcrPrerequisites(projectDir, nodeModulesDir, 'linux', 'x64')
 }
 
@@ -475,9 +500,18 @@ describe('afterPack', () => {
     const nodeModulesDir = path.join(tmpDir, 'resources', 'app.asar.unpacked', 'node_modules')
 
     await seedLinuxNativePrerequisites(projectDir, nodeModulesDir)
-    await writeVirtualPackage(projectDir, '@opendal/lib-linux-x64-gnu', {
-      'opendal.linux-x64-gnu.node': 'opendal-native'
-    })
+    await writeVirtualPackage(
+      projectDir,
+      '@opendal/lib-linux-x64-gnu',
+      { 'opendal.linux-x64-gnu.node': 'stale-opendal-native' },
+      '0.49.2'
+    )
+    await writeVersionedVirtualStorePackage(
+      projectDir,
+      '@opendal/lib-linux-x64-gnu',
+      OPENDAL_TEST_VERSION,
+      { 'opendal.linux-x64-gnu.node': 'opendal-native' }
+    )
 
     await afterPack({
       targets: [],
@@ -527,7 +561,9 @@ describe('afterPack', () => {
           projectDir
         }
       })
-    ).rejects.toThrow('Unable to find installed package: @opendal/lib-linux-x64-gnu')
+    ).rejects.toThrow(
+      `Unable to find installed package: @opendal/lib-linux-x64-gnu@${OPENDAL_TEST_VERSION}`
+    )
   })
 
   it('fails fast when FFF node output is missing for supported packages', async () => {


### PR DESCRIPTION
## Summary

- Upgrade `opendal` and all platform-specific native packages from `0.49.2` to `0.49.5`.
- Require packaged OpenDAL native modules to exactly match the facade version, preventing stale pnpm virtual-store packages from causing ABI mismatches.
- Expand the native smoke check to cover the production ESM entry, memory read/write, S3 operator construction, and retry/timeout layers.
- Refresh the generated provider database and ACP registry through the standard prebuild workflow.

## Compatibility

- OpenDAL `0.49.5` Linux x64 requires `GLIBC_2.38`.
- This matches DeepChat's current Ubuntu 24.04 Linux build and runtime baseline; Ubuntu 22.04 is not supported by this native package.
- Native package sizes increased, most notably Linux x64 from approximately 43.2 MB to 80.9 MB. Package-size CI gates will validate final installer growth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the bundled agent registry to the latest Harn release.
  * Improved OpenDAL native package compatibility across supported platforms and package managers.
  * Added stronger runtime validation for OpenDAL’s ESM exports and memory/S3 operations.

* **Bug Fixes**
  * Corrected OpenDAL native package version matching during packaging.
  * Updated supported model listings and adjusted a provider context limit.

* **Tests**
  * Expanded packaging and smoke tests to verify version-aware native package resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->