### PR TITLE
refactor(agent): type tool execution contract

### DIFF
--- a/docs/architecture/deepchat-agent-harness-boundaries/plan.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/plan.md
@@ -30,6 +30,7 @@ Add an explicit contract at every production definition boundary:
 
 Use a tool's maximum capability when its effect depends on arguments. Keep these classifications
 close to definition construction rather than introducing a second name-to-policy registry.
+Prompt-only fallback descriptors remain base definitions and do not fabricate execution metadata.
 
 ## Runtime Policy
 
@@ -48,8 +49,9 @@ mechanics.
 
 Keep provider mapping explicit: AI SDK and legacy prompt paths consume function metadata only.
 Change the DeepChat token estimator to measure the historical definition projection without
-`effect` and `executionMode`. Add regression coverage proving execution metadata neither reaches
-the AI SDK tool schema nor changes the existing reserve calculation.
+`effect` and `executionMode`. Use the same projection for Tape ViewManifest tool-definition hashes
+so execution policy does not redefine provider-view identity. Add regression coverage proving
+execution metadata neither reaches the AI SDK tool schema nor changes the existing reserve or hash.
 
 ## Tests
 
@@ -77,7 +79,8 @@ pnpm exec vitest run --config vitest.config.ts \
   test/main/agent/deepchat/runtime/contextBuilder.test.ts \
   test/main/provider/aiSdkToolMapper.test.ts \
   test/main/mcp/toolManager.test.ts \
-  test/main/tool/toolService.test.ts
+  test/main/tool/toolService.test.ts \
+  test/main/session/data/tapeViewManifest.test.ts
 pnpm run typecheck
 pnpm run format
 pnpm run i18n

--- a/docs/architecture/deepchat-agent-harness-boundaries/plan.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/plan.md
@@ -10,9 +10,10 @@ catalog-owned capability metadata.
 
 1. Add `ToolEffect`, `ToolExecutionMode`, and the discriminated `ToolExecutionContract` union to the
    canonical core MCP types.
-2. Convert `MCPToolDefinition` into the intersection of its existing structural definition and the
-   execution contract.
-3. Export readonly constants for parallel read, sequential read, and sequential write contracts.
+2. Add one required `execution` object to `MCPToolDefinition` so capability metadata remains atomic
+   and namespaced from model-visible definition fields.
+3. Export one deeply frozen `TOOL_EXECUTION` preset catalog for parallel read, sequential read, and
+   sequential write contracts so shared preset references cannot be mutated at runtime.
 4. Replace the duplicate `MCPToolDefinition` declaration in the broad shared MCP module with a type
    alias and re-exports from the canonical module.
 
@@ -49,7 +50,7 @@ mechanics.
 
 Keep provider mapping explicit: AI SDK and legacy prompt paths consume function metadata only.
 Change the DeepChat token estimator to measure the historical definition projection without
-`effect` and `executionMode`. Use the same projection for Tape ViewManifest tool-definition hashes
+the complete `execution` object. Use the same projection for Tape ViewManifest tool-definition hashes
 so execution policy does not redefine provider-view identity. Add regression coverage proving
 execution metadata neither reaches the AI SDK tool schema nor changes the existing reserve or hash.
 

--- a/docs/architecture/deepchat-agent-harness-boundaries/plan.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/plan.md
@@ -1,0 +1,106 @@
+# DeepChat Agent Harness Boundaries Plan
+
+## Current Slice
+
+Implement the typed tool execution contract as an independently reviewable refactor. Keep the
+observable scheduler behavior unchanged while replacing the runtime tool-name allowlist with
+catalog-owned capability metadata.
+
+## Type Model
+
+1. Add `ToolEffect`, `ToolExecutionMode`, and the discriminated `ToolExecutionContract` union to the
+   canonical core MCP types.
+2. Convert `MCPToolDefinition` into the intersection of its existing structural definition and the
+   execution contract.
+3. Export readonly constants for parallel read, sequential read, and sequential write contracts.
+4. Replace the duplicate `MCPToolDefinition` declaration in the broad shared MCP module with a type
+   alias and re-exports from the canonical module.
+
+This keeps one source of truth while preserving both existing import paths.
+
+## Catalog Classification
+
+Add an explicit contract at every production definition boundary:
+
+- filesystem `read`: parallel read;
+- filesystem `glob` and `grep`, Tape query tools, `skill_list`, and browser status: sequential read;
+- every other built-in Agent tool: sequential write;
+- MCP and plugin definitions: sequential write at the MCP discovery boundary, independent of MCP
+  annotations.
+
+Use a tool's maximum capability when its effect depends on arguments. Keep these classifications
+close to definition construction rather than introducing a second name-to-policy registry.
+
+## Runtime Policy
+
+Create a small pure module in the DeepChat runtime that selects a batch execution mode from:
+
+- Session permission mode;
+- ordered completed tool calls;
+- current tool definitions.
+
+Build a definition-name index once per decision. Treat duplicate names as ambiguous and fail closed.
+Return `parallel` only for a multi-call, `full_access`, all-parallel-read batch. Integrate this
+selector at the existing parallel branch in `dispatch.ts` without changing execution or commit
+mechanics.
+
+## Provider And Context Boundaries
+
+Keep provider mapping explicit: AI SDK and legacy prompt paths consume function metadata only.
+Change the DeepChat token estimator to measure the historical definition projection without
+`effect` and `executionMode`. Add regression coverage proving execution metadata neither reaches
+the AI SDK tool schema nor changes the existing reserve calculation.
+
+## Tests
+
+Add a focused pure-policy suite for:
+
+- homogeneous parallel reads;
+- sequential reads and mixed effects;
+- non-`full_access` modes;
+- missing, malformed, and duplicate definitions;
+- single-call batches.
+
+Extend dispatch coverage to prove the policy drives real concurrency and serialization without
+changing result order or failure isolation. Extend MCP catalog coverage to prove `readOnlyHint`
+does not grant concurrency. Update production and test definition fixtures to satisfy the canonical
+type.
+
+## Validation
+
+Run in increasing scope:
+
+```bash
+pnpm exec vitest run --config vitest.config.ts \
+  test/main/agent/deepchat/runtime/toolExecutionPolicy.test.ts \
+  test/main/agent/deepchat/runtime/dispatch.test.ts \
+  test/main/agent/deepchat/runtime/contextBuilder.test.ts \
+  test/main/provider/aiSdkToolMapper.test.ts \
+  test/main/mcp/toolManager.test.ts \
+  test/main/tool/toolService.test.ts
+pnpm run typecheck
+pnpm run format
+pnpm run i18n
+pnpm run lint
+pnpm run test:main
+```
+
+If the full main suite has unrelated environment-gated failures, reproduce them on `dev` and report
+the distinction rather than weakening coverage.
+
+## Commit And Review Strategy
+
+Use two local commits:
+
+1. `docs(agent): specify tool execution contract`
+2. `refactor(agent): type tool execution policy`
+
+Before each commit, inspect both staged and unstaged changes for hidden side effects, compatibility,
+edge cases, performance, security, misleading names, missing tests, and future maintenance cost.
+Fix all findings and repeat the relevant validation before committing. Do not push either commit.
+
+## Later Slices
+
+After this contract lands in `dev`, later branches may extend this architecture record for
+coordinator boundaries, a thin Harness facade, and typed hook reduction. Those changes must not be
+implemented or coupled to the current branch. Same-run steering remains a separate feature design.

--- a/docs/architecture/deepchat-agent-harness-boundaries/spec.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/spec.md
@@ -49,8 +49,12 @@ type ToolExecutionMode = 'sequential' | 'parallel'
 type ToolEffect = 'read' | 'write'
 
 type ToolExecutionContract =
-  | { effect: 'read'; executionMode: ToolExecutionMode }
-  | { effect: 'write'; executionMode: 'sequential' }
+  | { effect: 'read'; mode: ToolExecutionMode }
+  | { effect: 'write'; mode: 'sequential' }
+
+type MCPToolDefinition = MCPToolDefinitionBase & {
+  execution: ToolExecutionContract
+}
 ```
 
 `effect` describes the maximum observable capability of the tool, not the behavior of one selected
@@ -61,14 +65,18 @@ argument branch:
 - `write` includes any tool that can mutate state, incur an externally visible action, pause for an
   interaction, or select a mutating operation based on arguments.
 
-`executionMode` is a positive scheduling grant. A `read` tool may remain sequential because of
+`execution.mode` is a positive scheduling grant. A `read` tool may remain sequential because of
 resource limits, internal mutable caches, ordering requirements, or because concurrency has not yet
 been validated. Only an explicit `read + parallel` contract authorizes parallel execution.
 
-Shared readonly constants represent the three valid contracts so definition sites make a concise,
-reviewable choice. `MCPToolDefinition` has one canonical declaration under `src/shared/types/core`;
-the broader shared MCP module aliases that declaration instead of maintaining a second structural
-copy.
+A single deeply frozen `TOOL_EXECUTION` preset catalog represents the three valid contracts.
+Definition sites assign one atomic `execution` value, for example `TOOL_EXECUTION.write` or
+`TOOL_EXECUTION.read.parallel`, instead of spreading independent fields into the definition. Runtime
+freezing prevents one definition from mutating the shared preset used by every other definition.
+This keeps execution-only metadata namespaced, makes the classification concise and reviewable, and
+lets provider-facing projections remove the complete contract when it evolves. `MCPToolDefinition`
+has one canonical declaration under `src/shared/types/core`; the broader shared MCP module aliases
+that declaration instead of maintaining a second structural copy.
 
 ## Trust And Classification
 
@@ -103,15 +111,16 @@ execution continues to settle independently and commit results in provider call 
 
 ## Compatibility
 
-- The runtime tool-definition shape gains two additive internal fields, so structural readers and
-  IPC consumers remain compatible. The fields are intentionally required in TypeScript, which is
-  a source-level contract tightening for definition constructors; all in-repository constructors
-  are updated atomically. No persisted format or database migration changes.
+- The runtime tool-definition shape gains one additive internal `execution` object, so structural
+  readers and IPC consumers remain compatible. The contract is intentionally required in
+  TypeScript, which is a source-level contract tightening for definition constructors; all
+  in-repository constructors are updated atomically. No persisted format or database migration
+  changes.
 - Provider adapters continue projecting only model-visible function metadata. Legacy XML prompt
   generation also continues reading only function metadata.
-- Context reserve estimation excludes the two execution fields so this internal contract does not
+- Context reserve estimation excludes the execution object so this internal contract does not
   reduce user-visible context capacity.
-- Tape ViewManifest tool-definition hashes exclude the execution fields, preserving their existing
+- Tape ViewManifest tool-definition hashes exclude the execution object, preserving their existing
   provider-view identity. Future execution-policy replay must use a separate versioned identity.
 - Existing external MCP tools remain sequential. Existing built-in behavior remains unchanged:
   only Agent filesystem `read` batches gain the parallel path they already had.

--- a/docs/architecture/deepchat-agent-harness-boundaries/spec.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/spec.md
@@ -37,7 +37,8 @@ parallel decision from a name allowlist to an explicit catalog-owned contract.
   read tools may run concurrently, and only in `full_access` mode.
 - Preserve tool-call result ordering, failure isolation, abort behavior, permission recovery,
   interaction pauses, output fitting, and durable execution-state updates.
-- Keep execution-only metadata out of provider payloads and context-window token estimates.
+- Keep execution-only metadata out of provider payloads, context-window token estimates, and
+  provider-view tool-definition hashes.
 
 ## Execution Contract
 
@@ -110,6 +111,8 @@ execution continues to settle independently and commit results in provider call 
   generation also continues reading only function metadata.
 - Context reserve estimation excludes the two execution fields so this internal contract does not
   reduce user-visible context capacity.
+- Tape ViewManifest tool-definition hashes exclude the execution fields, preserving their existing
+  provider-view identity. Future execution-policy replay must use a separate versioned identity.
 - Existing external MCP tools remain sequential. Existing built-in behavior remains unchanged:
   only Agent filesystem `read` batches gain the parallel path they already had.
 - Permission preflight, auto-grant, post-call permission handling, and interaction semantics remain
@@ -138,5 +141,5 @@ execution continues to settle independently and commit results in provider call 
 5. Parallel failures remain isolated per call; abort and already-returned-result settlement retain
    current behavior.
 6. Execution metadata is absent from provider tool schemas and does not change the historical tool
-   token reserve.
+   token reserve or ViewManifest tool-definition hash.
 7. Focused tests, type checks, formatting, i18n validation, and lint pass before handoff.

--- a/docs/architecture/deepchat-agent-harness-boundaries/spec.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/spec.md
@@ -1,0 +1,142 @@
+# DeepChat Agent Harness Boundaries
+
+## Context
+
+DeepChat's tool runtime already has a conservative parallel fast path, but the scheduling policy is
+encoded in `dispatch.ts` as an Agent tool-name allowlist. That makes execution safety depend on a
+string convention instead of the tool catalog that owns tool capabilities. A rename, replacement,
+or new read-only tool therefore requires runtime knowledge that does not belong in dispatch.
+
+This architecture goal will establish stable contracts around the DeepChat Agent harness over
+multiple short-lived pull requests. The current slice covers only the typed tool execution
+contract. Coordinator decomposition, a Harness facade, typed hooks, and same-run steering remain
+separate changes.
+
+## Comparative Evidence
+
+Pi places an optional `executionMode` on each Agent tool. Its loop executes a batch in parallel by
+default unless global configuration or any tool requests sequential execution. This correctly puts
+the capability on the tool, but its default-open policy is too permissive for DeepChat's mixed
+built-in/MCP catalog, permission pauses, durable queue, and persisted tool settlement.
+
+Bub's asynchronous executor applies `asyncio.gather` to every tool-call batch. It preserves input
+result order and isolates declared tool errors, but it has no side-effect or scheduling contract.
+That model cannot safely represent DeepChat tools that mutate files, settings, memory, Tape-visible
+state, browser state, processes, or user interactions.
+
+DeepChat will keep its existing fail-closed, all-or-nothing batch behavior while moving the
+parallel decision from a name allowlist to an explicit catalog-owned contract.
+
+## Goals
+
+- Define one canonical, typed execution contract for every `MCPToolDefinition`.
+- Make a tool's maximum side effect and concurrency permission explicit at its definition site.
+- Make `write + parallel` unrepresentable in TypeScript.
+- Admit external MCP tools with a conservative contract without trusting server-supplied hints.
+- Keep current runtime behavior: only a multi-call batch composed entirely of explicitly parallel
+  read tools may run concurrently, and only in `full_access` mode.
+- Preserve tool-call result ordering, failure isolation, abort behavior, permission recovery,
+  interaction pauses, output fitting, and durable execution-state updates.
+- Keep execution-only metadata out of provider payloads and context-window token estimates.
+
+## Execution Contract
+
+The canonical definition uses a closed discriminated union:
+
+```ts
+type ToolExecutionMode = 'sequential' | 'parallel'
+type ToolEffect = 'read' | 'write'
+
+type ToolExecutionContract =
+  | { effect: 'read'; executionMode: ToolExecutionMode }
+  | { effect: 'write'; executionMode: 'sequential' }
+```
+
+`effect` describes the maximum observable capability of the tool, not the behavior of one selected
+argument branch:
+
+- `read` means the tool has no durable, external, user-interaction, or non-idempotent mutation that
+  can conflict with another call.
+- `write` includes any tool that can mutate state, incur an externally visible action, pause for an
+  interaction, or select a mutating operation based on arguments.
+
+`executionMode` is a positive scheduling grant. A `read` tool may remain sequential because of
+resource limits, internal mutable caches, ordering requirements, or because concurrency has not yet
+been validated. Only an explicit `read + parallel` contract authorizes parallel execution.
+
+Shared readonly constants represent the three valid contracts so definition sites make a concise,
+reviewable choice. `MCPToolDefinition` has one canonical declaration under `src/shared/types/core`;
+the broader shared MCP module aliases that declaration instead of maintaining a second structural
+copy.
+
+## Trust And Classification
+
+Built-in Agent definitions declare their contract at the owning definition site. For compatibility
+with current behavior, only the filesystem `read` tool is initially `read + parallel`.
+
+- Filesystem `glob` and `grep`, Tape queries, `skill_list`, and `get_browser_status` are
+  `read + sequential` until their concurrency behavior is deliberately validated.
+- File mutation, commands, processes, questions, plans, settings, image generation, cron jobs,
+  subagents, skill activation/management/execution, and browser navigation/CDP are
+  `write + sequential`.
+- All memory tools are `write + sequential`; recall updates access metadata and is not a pure read.
+- Parameter-dependent tools use their maximum capability. A tool that can either inspect or mutate
+  is classified as `write`.
+
+External MCP and plugin tools enter the catalog as `write + sequential`. MCP annotations such as
+`readOnlyHint` are descriptive hints from an untrusted server and never grant local concurrency.
+Supporting trusted per-server overrides would require a separate authenticated policy design.
+
+## Batch Scheduling
+
+A pure runtime policy selects `parallel` only when every condition holds:
+
+1. the Session permission mode is `full_access`;
+2. the batch contains at least two calls;
+3. every call resolves to exactly one definition;
+4. every resolved definition is `read + parallel`.
+
+Missing, malformed, or duplicate definitions fail closed to `sequential`. Mixed batches remain
+fully sequential; this change does not introduce segmented scheduling around write calls. Parallel
+execution continues to settle independently and commit results in provider call order.
+
+## Compatibility
+
+- The runtime tool-definition shape gains two additive internal fields, so structural readers and
+  IPC consumers remain compatible. The fields are intentionally required in TypeScript, which is
+  a source-level contract tightening for definition constructors; all in-repository constructors
+  are updated atomically. No persisted format or database migration changes.
+- Provider adapters continue projecting only model-visible function metadata. Legacy XML prompt
+  generation also continues reading only function metadata.
+- Context reserve estimation excludes the two execution fields so this internal contract does not
+  reduce user-visible context capacity.
+- Existing external MCP tools remain sequential. Existing built-in behavior remains unchanged:
+  only Agent filesystem `read` batches gain the parallel path they already had.
+- Permission preflight, auto-grant, post-call permission handling, and interaction semantics remain
+  owned by dispatch.
+
+## Non-Goals
+
+- Do not parallelize additional built-in or MCP tools in this slice.
+- Do not infer execution policy from MCP annotations, names, schemas, permission results, or call
+  arguments.
+- Do not add per-call dynamic effect classification or a segmented dependency scheduler.
+- Do not rewrite tool dispatch or change durable queue and Tape semantics.
+- Do not extract the coordinator or Harness facade and do not add typed hooks.
+- Do not add same-run steering.
+- Do not create or synchronize a GitHub issue for this architecture work.
+
+## Acceptance Criteria
+
+1. The canonical type rejects `write + parallel`, and all production definition ingress paths
+   produce an explicit valid contract.
+2. Two or more `read + parallel` calls run concurrently only in `full_access`, while result commits
+   preserve call order.
+3. A sequential read, write, missing definition, malformed contract, duplicate definition, or
+   non-`full_access` permission mode makes the complete batch sequential.
+4. External MCP definitions remain `write + sequential` even when `readOnlyHint` is true.
+5. Parallel failures remain isolated per call; abort and already-returned-result settlement retain
+   current behavior.
+6. Execution metadata is absent from provider tool schemas and does not change the historical tool
+   token reserve.
+7. Focused tests, type checks, formatting, i18n validation, and lint pass before handoff.

--- a/docs/architecture/deepchat-agent-harness-boundaries/tasks.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/tasks.md
@@ -6,7 +6,7 @@
 - [x] Record the 156-test dispatch, context-builder, and ToolService baseline.
 - [x] Define the trust boundary, capability model, scheduling invariants, and non-goals.
 - [x] Review and commit the SDD slice.
-- [x] Add the canonical discriminated execution contract and shared constants.
+- [x] Add the canonical nested execution contract and shared preset catalog.
 - [x] Classify every built-in definition and default external MCP definitions conservatively.
 - [x] Extract and integrate the fail-closed batch execution policy.
 - [x] Preserve provider projection and historical context-reserve behavior.

--- a/docs/architecture/deepchat-agent-harness-boundaries/tasks.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/tasks.md
@@ -5,16 +5,16 @@
 - [x] Compare Pi and Bub execution semantics with DeepChat's current runtime.
 - [x] Record the 156-test dispatch, context-builder, and ToolService baseline.
 - [x] Define the trust boundary, capability model, scheduling invariants, and non-goals.
-- [ ] Review and commit the SDD slice.
-- [ ] Add the canonical discriminated execution contract and shared constants.
-- [ ] Classify every built-in definition and default external MCP definitions conservatively.
-- [ ] Extract and integrate the fail-closed batch execution policy.
-- [ ] Preserve provider projection and historical context-reserve behavior.
-- [ ] Add policy, dispatch, MCP ingress, provider-boundary, and token-boundary coverage.
-- [ ] Run focused tests and full type checking.
-- [ ] Run formatting, i18n validation, lint, and the full main-process suite.
-- [ ] Review the complete implementation diff and fix every finding.
-- [ ] Commit the implementation without pushing.
+- [x] Review and commit the SDD slice.
+- [x] Add the canonical discriminated execution contract and shared constants.
+- [x] Classify every built-in definition and default external MCP definitions conservatively.
+- [x] Extract and integrate the fail-closed batch execution policy.
+- [x] Preserve provider projection and historical context-reserve behavior.
+- [x] Add policy, dispatch, MCP ingress, provider-boundary, and token-boundary coverage.
+- [x] Run focused tests and full type checking.
+- [x] Run formatting, i18n validation, lint, and the full main-process suite.
+- [x] Review the complete implementation diff and fix every finding.
+- [x] Commit the implementation without pushing.
 
 ## Future Pull Requests
 

--- a/docs/architecture/deepchat-agent-harness-boundaries/tasks.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/tasks.md
@@ -1,0 +1,24 @@
+# DeepChat Agent Harness Boundaries Tasks
+
+## Typed Tool Execution Contract
+
+- [x] Compare Pi and Bub execution semantics with DeepChat's current runtime.
+- [x] Record the 156-test dispatch, context-builder, and ToolService baseline.
+- [x] Define the trust boundary, capability model, scheduling invariants, and non-goals.
+- [ ] Review and commit the SDD slice.
+- [ ] Add the canonical discriminated execution contract and shared constants.
+- [ ] Classify every built-in definition and default external MCP definitions conservatively.
+- [ ] Extract and integrate the fail-closed batch execution policy.
+- [ ] Preserve provider projection and historical context-reserve behavior.
+- [ ] Add policy, dispatch, MCP ingress, provider-boundary, and token-boundary coverage.
+- [ ] Run focused tests and full type checking.
+- [ ] Run formatting, i18n validation, lint, and the full main-process suite.
+- [ ] Review the complete implementation diff and fix every finding.
+- [ ] Commit the implementation without pushing.
+
+## Future Pull Requests
+
+- [ ] Define and implement coordinator ownership boundaries without behavior changes.
+- [ ] Add a thin Harness facade over the stabilized internal services.
+- [ ] Add typed deterministic hook/event reduction over the facade event model.
+- [ ] Design same-run steering separately if the product semantics are approved.

--- a/src/main/agent/deepchat/runtime/contextBuilder.ts
+++ b/src/main/agent/deepchat/runtime/contextBuilder.ts
@@ -2,7 +2,10 @@ import fs from 'fs'
 import path from 'path'
 import { approximateTokenSize } from 'tokenx'
 import type { ChatMessage, ChatMessageProviderOptions } from '@shared/types/core/chat-message'
-import type { MCPToolDefinition } from '@shared/types/core/mcp'
+import {
+  stripToolExecutionContract,
+  type MCPToolDefinition
+} from '@shared/types/core/mcp'
 import type {
   ChatMessageRecord,
   AssistantMessageBlock,
@@ -650,7 +653,8 @@ function hasPromptMessageContent(message: ChatMessage): boolean {
 
 export function estimateToolDefinitionTokens(toolDefinitions: MCPToolDefinition[]): number {
   return toolDefinitions.reduce(
-    (total, tool) => total + approximateTokenSize(JSON.stringify(tool)),
+    (total, tool) =>
+      total + approximateTokenSize(JSON.stringify(stripToolExecutionContract(tool))),
     0
   )
 }

--- a/src/main/agent/deepchat/runtime/dispatch.ts
+++ b/src/main/agent/deepchat/runtime/dispatch.ts
@@ -52,6 +52,7 @@ import {
   extractWaitingInteraction
 } from './sessionUpdates'
 import { extractToolCallImagePreviews } from '@/lib/toolCallImagePreviews'
+import { selectToolBatchExecutionMode } from './toolExecutionPolicy'
 
 type PermissionType = 'read' | 'write' | 'all' | 'command'
 
@@ -142,7 +143,6 @@ type MutableToolBatchState = {
   committedResultCallIds: Set<string>
 }
 
-const PARALLEL_READ_ONLY_AGENT_TOOLS = new Set(['read'])
 const USER_CANCELED_GENERATION_ERROR = 'common.error.userCanceledGeneration'
 export const TRUNCATED_TOOL_CALL_ERROR =
   'Tool call was not executed because the model response reached the output token limit, so its arguments may be incomplete. Retry the tool call with complete arguments.'
@@ -686,18 +686,6 @@ function extractActivatedSkillAfterCall(toolName: string, rawData: MCPToolRespon
   const activatedSkill =
     typeof toolResult.activatedSkill === 'string' ? toolResult.activatedSkill.trim() : ''
   return activatedSkill || null
-}
-
-function isParallelReadOnlyToolCall(
-  toolCall: StreamState['completedToolCalls'][number],
-  tools: MCPToolDefinition[]
-): boolean {
-  if (!PARALLEL_READ_ONLY_AGENT_TOOLS.has(toolCall.name)) {
-    return false
-  }
-
-  const toolDef = tools.find((tool) => tool.function.name === toolCall.name)
-  return toolDef?.source === 'agent'
 }
 
 function buildToolExecutionContext(
@@ -1819,12 +1807,13 @@ export async function settleToolBatch(
 
   const toolPermissionMode = getToolCapabilityPermissionMode(permissionMode)
 
-  const canRunReadOnlyBatchInParallel =
-    permissionMode === 'full_access' &&
-    toolCalls.length > 1 &&
-    toolCalls.every((tc) => isParallelReadOnlyToolCall(tc, tools))
+  const batchExecutionMode = selectToolBatchExecutionMode({
+    permissionMode,
+    toolCalls,
+    toolDefinitions: tools
+  })
 
-  if (canRunReadOnlyBatchInParallel) {
+  if (batchExecutionMode === 'parallel') {
     const executions = toolCalls.map((tc) =>
       buildToolExecutionContext(tc, tools, io.sessionId, providerId)
     )

--- a/src/main/agent/deepchat/runtime/toolExecutionPolicy.ts
+++ b/src/main/agent/deepchat/runtime/toolExecutionPolicy.ts
@@ -39,7 +39,7 @@ export function selectToolBatchExecutionMode({
       return false
     }
     const definition = definitionsByName.get(name)
-    return definition?.effect === 'read' && definition.executionMode === 'parallel'
+    return definition?.execution?.effect === 'read' && definition.execution.mode === 'parallel'
   })
 
   return canRunInParallel ? 'parallel' : 'sequential'

--- a/src/main/agent/deepchat/runtime/toolExecutionPolicy.ts
+++ b/src/main/agent/deepchat/runtime/toolExecutionPolicy.ts
@@ -1,0 +1,46 @@
+import type { PermissionMode } from '@shared/types/agent-interface'
+import type {
+  MCPToolDefinition,
+  ToolExecutionMode
+} from '@shared/types/core/mcp'
+
+type ToolCallTarget = {
+  name: string
+}
+
+type ToolBatchExecutionPolicyInput = {
+  permissionMode: PermissionMode
+  toolCalls: readonly ToolCallTarget[]
+  toolDefinitions: readonly MCPToolDefinition[]
+}
+
+export function selectToolBatchExecutionMode({
+  permissionMode,
+  toolCalls,
+  toolDefinitions
+}: ToolBatchExecutionPolicyInput): ToolExecutionMode {
+  if (permissionMode !== 'full_access' || toolCalls.length < 2) {
+    return 'sequential'
+  }
+
+  const definitionsByName = new Map<string, MCPToolDefinition | null>()
+  for (const definition of toolDefinitions) {
+    const name = definition?.function?.name
+    if (typeof name !== 'string' || name.length === 0) {
+      continue
+    }
+
+    definitionsByName.set(name, definitionsByName.has(name) ? null : definition)
+  }
+
+  const canRunInParallel = toolCalls.every((toolCall) => {
+    const name = toolCall?.name
+    if (typeof name !== 'string' || name.length === 0) {
+      return false
+    }
+    const definition = definitionsByName.get(name)
+    return definition?.effect === 'read' && definition.executionMode === 'parallel'
+  })
+
+  return canRunInParallel ? 'parallel' : 'sequential'
+}

--- a/src/main/mcp/index.ts
+++ b/src/main/mcp/index.ts
@@ -2,19 +2,20 @@ import type { ProviderSettingsPort } from '@/provider/settings'
 import logger from '@shared/logger'
 import { performance } from 'node:perf_hooks'
 import type { Prompt } from '@shared/types/prompt'
-import type {
-  McpServicePort,
-  MCPServerConfig,
-  MCPToolDefinition,
-  MCPToolCall,
-  McpClient,
-  MCPToolResponse,
-  ResourceListEntry,
-  Resource,
-  PromptListEntry,
-  McpSamplingRequestPayload,
-  McpSamplingDecision,
-  McpServerAuthStatus
+import {
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  type McpClient,
+  type McpSamplingDecision,
+  type McpSamplingRequestPayload,
+  type MCPServerConfig,
+  type McpServerAuthStatus,
+  type McpServicePort,
+  type MCPToolCall,
+  type MCPToolDefinition,
+  type MCPToolResponse,
+  type PromptListEntry,
+  type Resource,
+  type ResourceListEntry
 } from '@shared/types/mcp'
 import type { ProviderRuntimePort } from '@shared/types/provider'
 import { ServerManager } from './serverManager'
@@ -515,6 +516,7 @@ export class McpService implements McpServicePort {
           }
         }
         results.push({
+          ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
           type: 'function',
           function: {
             name: tool.name,

--- a/src/main/mcp/index.ts
+++ b/src/main/mcp/index.ts
@@ -3,7 +3,7 @@ import logger from '@shared/logger'
 import { performance } from 'node:perf_hooks'
 import type { Prompt } from '@shared/types/prompt'
 import {
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  TOOL_EXECUTION,
   type McpClient,
   type McpSamplingDecision,
   type McpSamplingRequestPayload,
@@ -516,7 +516,7 @@ export class McpService implements McpServicePort {
           }
         }
         results.push({
-          ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+          execution: TOOL_EXECUTION.write,
           type: 'function',
           function: {
             name: tool.name,

--- a/src/main/mcp/toolManager.ts
+++ b/src/main/mcp/toolManager.ts
@@ -1,12 +1,13 @@
 import logger from '@shared/logger'
-import type {
-  MCPToolCall,
-  MCPToolDefinition,
-  MCPToolResponse,
-  MCPContentItem,
-  MCPTextContent,
-  MCPServerConfig,
-  Resource
+import {
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  type MCPContentItem,
+  type MCPServerConfig,
+  type MCPTextContent,
+  type MCPToolCall,
+  type MCPToolDefinition,
+  type MCPToolResponse,
+  type Resource
 } from '@shared/types/mcp'
 import type { AgentSettingsPort } from '@/agent/settings'
 import { ServerManager } from './serverManager'
@@ -263,6 +264,7 @@ export class ToolManager {
             }
 
             results.push({
+              ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
               type: 'function',
               function: {
                 name: finalName,

--- a/src/main/mcp/toolManager.ts
+++ b/src/main/mcp/toolManager.ts
@@ -1,6 +1,6 @@
 import logger from '@shared/logger'
 import {
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  TOOL_EXECUTION,
   type MCPContentItem,
   type MCPServerConfig,
   type MCPTextContent,
@@ -264,7 +264,7 @@ export class ToolManager {
             }
 
             results.push({
-              ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+              execution: TOOL_EXECUTION.write,
               type: 'function',
               function: {
                 name: finalName,

--- a/src/main/tape/domain/viewManifest.ts
+++ b/src/main/tape/domain/viewManifest.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto'
 import type { ChatMessage } from '@shared/types/core/chat-message'
-import type { MCPToolDefinition } from '@shared/types/core/mcp'
+import { stripToolExecutionContract, type MCPToolDefinition } from '@shared/types/core/mcp'
 import type { ChatMessageRecord } from '@shared/types/agent-interface'
 import type {
   DeepChatTapeViewEntryRef,
@@ -224,7 +224,7 @@ export function createTapeViewManifest(
     },
     hashes: {
       promptHash: hashJson(input.messages),
-      toolDefinitionsHash: hashJson(input.tools),
+      toolDefinitionsHash: hashJson(input.tools.map(stripToolExecutionContract)),
       manifestHash: ''
     },
     meta: {

--- a/src/main/tool/agentTools/agentImageGenerationTool.ts
+++ b/src/main/tool/agentTools/agentImageGenerationTool.ts
@@ -1,7 +1,7 @@
 import type { ProviderSettingsPort } from '@/provider/settings'
 import { z } from 'zod'
 import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import type { ToolCallImagePreview } from '@shared/types/core/mcp'
 import type { ImageGenerationOptions } from '@shared/imageGenerationSettings'
 import {
@@ -96,6 +96,7 @@ export class AgentImageGenerationTool {
 
   getToolDefinition(): MCPToolDefinition {
     return {
+      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
       type: 'function',
       function: {
         name: IMAGE_GENERATE_TOOL_NAME,

--- a/src/main/tool/agentTools/agentImageGenerationTool.ts
+++ b/src/main/tool/agentTools/agentImageGenerationTool.ts
@@ -1,7 +1,7 @@
 import type { ProviderSettingsPort } from '@/provider/settings'
 import { z } from 'zod'
 import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
-import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import type { ToolCallImagePreview } from '@shared/types/core/mcp'
 import type { ImageGenerationOptions } from '@shared/imageGenerationSettings'
 import {
@@ -96,7 +96,7 @@ export class AgentImageGenerationTool {
 
   getToolDefinition(): MCPToolDefinition {
     return {
-      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+      execution: TOOL_EXECUTION.write,
       type: 'function',
       function: {
         name: IMAGE_GENERATE_TOOL_NAME,

--- a/src/main/tool/agentTools/agentMemoryTools.ts
+++ b/src/main/tool/agentTools/agentMemoryTools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
-import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import { createAgentToolSuccessResult } from '@shared/lib/agentToolResultEnvelope'
 import { unicodeCodePointLength } from '@shared/lib/unicodeText'
 import {
@@ -67,7 +67,7 @@ function buildToolDefinition(
   schema: z.ZodTypeAny
 ): MCPToolDefinition {
   return {
-    ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+    execution: TOOL_EXECUTION.write,
     type: 'function',
     function: {
       name,

--- a/src/main/tool/agentTools/agentMemoryTools.ts
+++ b/src/main/tool/agentTools/agentMemoryTools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import { createAgentToolSuccessResult } from '@shared/lib/agentToolResultEnvelope'
 import { unicodeCodePointLength } from '@shared/lib/unicodeText'
 import {
@@ -67,6 +67,7 @@ function buildToolDefinition(
   schema: z.ZodTypeAny
 ): MCPToolDefinition {
   return {
+    ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
     type: 'function',
     function: {
       name,

--- a/src/main/tool/agentTools/agentPlanTool.ts
+++ b/src/main/tool/agentTools/agentPlanTool.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import type { AgentToolProgressUpdate } from '@shared/types/tool'
 import {
   UPDATE_PLAN_TOOL_NAME,
@@ -51,6 +51,7 @@ export class AgentPlanTool {
 
   getToolDefinition(): MCPToolDefinition {
     return {
+      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
       type: 'function',
       function: {
         name: UPDATE_PLAN_TOOL_NAME,

--- a/src/main/tool/agentTools/agentPlanTool.ts
+++ b/src/main/tool/agentTools/agentPlanTool.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
-import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import type { AgentToolProgressUpdate } from '@shared/types/tool'
 import {
   UPDATE_PLAN_TOOL_NAME,
@@ -51,7 +51,7 @@ export class AgentPlanTool {
 
   getToolDefinition(): MCPToolDefinition {
     return {
-      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+      execution: TOOL_EXECUTION.write,
       type: 'function',
       function: {
         name: UPDATE_PLAN_TOOL_NAME,

--- a/src/main/tool/agentTools/agentTapeTools.ts
+++ b/src/main/tool/agentTools/agentTapeTools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import { SEQUENTIAL_READ_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import { createAgentToolSuccessResult } from '@shared/lib/agentToolResultEnvelope'
 import type { AgentTapeToolPort, AgentToolSessionPort } from '../runtimePorts'
 import { TAPE_TOOL_NAMES, getAgentToolExposure, isTapeToolName } from '@shared/agentTools'
@@ -123,6 +123,7 @@ function buildToolDefinition(
   schema: z.ZodTypeAny
 ): MCPToolDefinition {
   return {
+    ...SEQUENTIAL_READ_TOOL_EXECUTION,
     type: 'function',
     function: {
       name,

--- a/src/main/tool/agentTools/agentTapeTools.ts
+++ b/src/main/tool/agentTools/agentTapeTools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
-import { SEQUENTIAL_READ_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import { createAgentToolSuccessResult } from '@shared/lib/agentToolResultEnvelope'
 import type { AgentTapeToolPort, AgentToolSessionPort } from '../runtimePorts'
 import { TAPE_TOOL_NAMES, getAgentToolExposure, isTapeToolName } from '@shared/agentTools'
@@ -123,7 +123,7 @@ function buildToolDefinition(
   schema: z.ZodTypeAny
 ): MCPToolDefinition {
   return {
-    ...SEQUENTIAL_READ_TOOL_EXECUTION,
+    execution: TOOL_EXECUTION.read.sequential,
     type: 'function',
     function: {
       name,

--- a/src/main/tool/agentTools/agentToolManager.ts
+++ b/src/main/tool/agentTools/agentToolManager.ts
@@ -1,5 +1,10 @@
 import type { ProviderSettingsPort } from '@/provider/settings'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import {
+  PARALLEL_READ_TOOL_EXECUTION,
+  SEQUENTIAL_READ_TOOL_EXECUTION,
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  type MCPToolDefinition
+} from '@shared/types/mcp'
 import type { AgentSettingsPort } from '@/agent/settings'
 import type { SettingsStore } from '@/config/settingsStore'
 import type { AgentToolProgressUpdate } from '@shared/types/tool'
@@ -692,6 +697,7 @@ export class AgentToolManager {
     const schemas = this.fileSystemSchemas
     const defs: MCPToolDefinition[] = [
       {
+        ...PARALLEL_READ_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'read',
@@ -710,6 +716,7 @@ export class AgentToolManager {
         }
       },
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'write',
@@ -728,6 +735,7 @@ export class AgentToolManager {
         }
       },
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'edit',
@@ -746,6 +754,7 @@ export class AgentToolManager {
         }
       },
       {
+        ...SEQUENTIAL_READ_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: GLOB_TOOL_NAME,
@@ -764,6 +773,7 @@ export class AgentToolManager {
         }
       },
       {
+        ...SEQUENTIAL_READ_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: GREP_TOOL_NAME,
@@ -782,6 +792,7 @@ export class AgentToolManager {
         }
       },
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'exec',
@@ -800,6 +811,7 @@ export class AgentToolManager {
         }
       },
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'process',
@@ -824,6 +836,7 @@ export class AgentToolManager {
   private getQuestionToolDefinitions(): MCPToolDefinition[] {
     return [
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: QUESTION_TOOL_NAME,
@@ -1958,6 +1971,7 @@ export class AgentToolManager {
     const schemas = this.skillSchemas
     return [
       {
+        ...SEQUENTIAL_READ_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'skill_list',
@@ -1976,6 +1990,7 @@ export class AgentToolManager {
         }
       },
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'skill_view',
@@ -1994,6 +2009,7 @@ export class AgentToolManager {
         }
       },
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'skill_manage',
@@ -2016,6 +2032,7 @@ export class AgentToolManager {
 
   private getSkillRunToolDefinition(): MCPToolDefinition {
     return {
+      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
       type: 'function',
       function: {
         name: 'skill_run',

--- a/src/main/tool/agentTools/agentToolManager.ts
+++ b/src/main/tool/agentTools/agentToolManager.ts
@@ -1,10 +1,5 @@
 import type { ProviderSettingsPort } from '@/provider/settings'
-import {
-  PARALLEL_READ_TOOL_EXECUTION,
-  SEQUENTIAL_READ_TOOL_EXECUTION,
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
-  type MCPToolDefinition
-} from '@shared/types/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import type { AgentSettingsPort } from '@/agent/settings'
 import type { SettingsStore } from '@/config/settingsStore'
 import type { AgentToolProgressUpdate } from '@shared/types/tool'
@@ -697,7 +692,7 @@ export class AgentToolManager {
     const schemas = this.fileSystemSchemas
     const defs: MCPToolDefinition[] = [
       {
-        ...PARALLEL_READ_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.read.parallel,
         type: 'function',
         function: {
           name: 'read',
@@ -716,7 +711,7 @@ export class AgentToolManager {
         }
       },
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: 'write',
@@ -735,7 +730,7 @@ export class AgentToolManager {
         }
       },
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: 'edit',
@@ -754,7 +749,7 @@ export class AgentToolManager {
         }
       },
       {
-        ...SEQUENTIAL_READ_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.read.sequential,
         type: 'function',
         function: {
           name: GLOB_TOOL_NAME,
@@ -773,7 +768,7 @@ export class AgentToolManager {
         }
       },
       {
-        ...SEQUENTIAL_READ_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.read.sequential,
         type: 'function',
         function: {
           name: GREP_TOOL_NAME,
@@ -792,7 +787,7 @@ export class AgentToolManager {
         }
       },
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: 'exec',
@@ -811,7 +806,7 @@ export class AgentToolManager {
         }
       },
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: 'process',
@@ -836,7 +831,7 @@ export class AgentToolManager {
   private getQuestionToolDefinitions(): MCPToolDefinition[] {
     return [
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: QUESTION_TOOL_NAME,
@@ -1971,7 +1966,7 @@ export class AgentToolManager {
     const schemas = this.skillSchemas
     return [
       {
-        ...SEQUENTIAL_READ_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.read.sequential,
         type: 'function',
         function: {
           name: 'skill_list',
@@ -1990,7 +1985,7 @@ export class AgentToolManager {
         }
       },
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: 'skill_view',
@@ -2009,7 +2004,7 @@ export class AgentToolManager {
         }
       },
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: 'skill_manage',
@@ -2032,7 +2027,7 @@ export class AgentToolManager {
 
   private getSkillRunToolDefinition(): MCPToolDefinition {
     return {
-      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+      execution: TOOL_EXECUTION.write,
       type: 'function',
       function: {
         name: 'skill_run',

--- a/src/main/tool/agentTools/chatSettingsTools.ts
+++ b/src/main/tool/agentTools/chatSettingsTools.ts
@@ -8,7 +8,7 @@ import type {
   OpenChatSettingsSection
 } from '@shared/types/chatSettings'
 import type { SkillServicePort } from '@shared/types/skill'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import type { AgentDesktopToolPort, AgentDisplaySettingsPort } from '../runtimePorts'
 import type { SkillSettingsPort } from '@/skill/settings'
 
@@ -428,6 +428,7 @@ export const buildChatSettingsToolDefinitions = (allowedTools: string[]): MCPToo
 
   if (allowToggle) {
     definitions.push({
+      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
       type: 'function',
       function: {
         name: CHAT_SETTINGS_TOOL_NAMES.toggle,
@@ -448,6 +449,7 @@ export const buildChatSettingsToolDefinitions = (allowedTools: string[]): MCPToo
 
   if (allowLanguage) {
     definitions.push({
+      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
       type: 'function',
       function: {
         name: CHAT_SETTINGS_TOOL_NAMES.setLanguage,
@@ -468,6 +470,7 @@ export const buildChatSettingsToolDefinitions = (allowedTools: string[]): MCPToo
 
   if (allowTheme) {
     definitions.push({
+      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
       type: 'function',
       function: {
         name: CHAT_SETTINGS_TOOL_NAMES.setTheme,
@@ -488,6 +491,7 @@ export const buildChatSettingsToolDefinitions = (allowedTools: string[]): MCPToo
 
   if (allowFontSize) {
     definitions.push({
+      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
       type: 'function',
       function: {
         name: CHAT_SETTINGS_TOOL_NAMES.setFontSize,
@@ -508,6 +512,7 @@ export const buildChatSettingsToolDefinitions = (allowedTools: string[]): MCPToo
 
   if (allowOpen) {
     definitions.push({
+      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
       type: 'function',
       function: {
         name: CHAT_SETTINGS_TOOL_NAMES.open,

--- a/src/main/tool/agentTools/chatSettingsTools.ts
+++ b/src/main/tool/agentTools/chatSettingsTools.ts
@@ -8,7 +8,7 @@ import type {
   OpenChatSettingsSection
 } from '@shared/types/chatSettings'
 import type { SkillServicePort } from '@shared/types/skill'
-import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import type { AgentDesktopToolPort, AgentDisplaySettingsPort } from '../runtimePorts'
 import type { SkillSettingsPort } from '@/skill/settings'
 
@@ -428,7 +428,7 @@ export const buildChatSettingsToolDefinitions = (allowedTools: string[]): MCPToo
 
   if (allowToggle) {
     definitions.push({
-      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+      execution: TOOL_EXECUTION.write,
       type: 'function',
       function: {
         name: CHAT_SETTINGS_TOOL_NAMES.toggle,
@@ -449,7 +449,7 @@ export const buildChatSettingsToolDefinitions = (allowedTools: string[]): MCPToo
 
   if (allowLanguage) {
     definitions.push({
-      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+      execution: TOOL_EXECUTION.write,
       type: 'function',
       function: {
         name: CHAT_SETTINGS_TOOL_NAMES.setLanguage,
@@ -470,7 +470,7 @@ export const buildChatSettingsToolDefinitions = (allowedTools: string[]): MCPToo
 
   if (allowTheme) {
     definitions.push({
-      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+      execution: TOOL_EXECUTION.write,
       type: 'function',
       function: {
         name: CHAT_SETTINGS_TOOL_NAMES.setTheme,
@@ -491,7 +491,7 @@ export const buildChatSettingsToolDefinitions = (allowedTools: string[]): MCPToo
 
   if (allowFontSize) {
     definitions.push({
-      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+      execution: TOOL_EXECUTION.write,
       type: 'function',
       function: {
         name: CHAT_SETTINGS_TOOL_NAMES.setFontSize,
@@ -512,7 +512,7 @@ export const buildChatSettingsToolDefinitions = (allowedTools: string[]): MCPToo
 
   if (allowOpen) {
     definitions.push({
-      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+      execution: TOOL_EXECUTION.write,
       type: 'function',
       function: {
         name: CHAT_SETTINGS_TOOL_NAMES.open,

--- a/src/main/tool/agentTools/cronJobTool.ts
+++ b/src/main/tool/agentTools/cronJobTool.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
-import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import { CRON_JOB_AGENT_TOOL_NAME } from '@shared/agentTools'
 import {
   CRON_JOBS_DEFAULT_CRON_EXPR,
@@ -233,7 +233,7 @@ export class CronJobToolHandler {
 
   getToolDefinition(): MCPToolDefinition {
     return {
-      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+      execution: TOOL_EXECUTION.write,
       type: 'function',
       function: {
         name: CRON_JOB_AGENT_TOOL_NAME,

--- a/src/main/tool/agentTools/cronJobTool.ts
+++ b/src/main/tool/agentTools/cronJobTool.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import { CRON_JOB_AGENT_TOOL_NAME } from '@shared/agentTools'
 import {
   CRON_JOBS_DEFAULT_CRON_EXPR,
@@ -233,6 +233,7 @@ export class CronJobToolHandler {
 
   getToolDefinition(): MCPToolDefinition {
     return {
+      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
       type: 'function',
       function: {
         name: CRON_JOB_AGENT_TOOL_NAME,

--- a/src/main/tool/agentTools/subagentOrchestratorTool.ts
+++ b/src/main/tool/agentTools/subagentOrchestratorTool.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid'
 import { z } from 'zod'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import type { DeepChatSubagentSlot, SubagentTapeLinkOutcome } from '@shared/types/agent-interface'
 import type { AgentToolProgressUpdate } from '@shared/types/tool'
 import type { AgentToolCallResult } from './agentToolManager'
@@ -808,6 +808,7 @@ export class SubagentOrchestratorTool {
     const slotIdParameter = this.buildSlotIdParameter(capability.slots)
 
     return {
+      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
       type: 'function',
       function: {
         name: SUBAGENT_ORCHESTRATOR_TOOL_NAME,

--- a/src/main/tool/agentTools/subagentOrchestratorTool.ts
+++ b/src/main/tool/agentTools/subagentOrchestratorTool.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid'
 import { z } from 'zod'
-import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import type { DeepChatSubagentSlot, SubagentTapeLinkOutcome } from '@shared/types/agent-interface'
 import type { AgentToolProgressUpdate } from '@shared/types/tool'
 import type { AgentToolCallResult } from './agentToolManager'
@@ -808,7 +808,7 @@ export class SubagentOrchestratorTool {
     const slotIdParameter = this.buildSlotIdParameter(capability.slots)
 
     return {
-      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+      execution: TOOL_EXECUTION.write,
       type: 'function',
       function: {
         name: SUBAGENT_ORCHESTRATOR_TOOL_NAME,

--- a/src/main/tool/browser/definitions.ts
+++ b/src/main/tool/browser/definitions.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import {
+  SEQUENTIAL_READ_TOOL_EXECUTION,
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  type MCPToolDefinition,
+  type ToolExecutionContract
+} from '@shared/types/mcp'
 import { toDeepChatJsonSchema } from '@shared/lib/zodJsonSchema'
 
 const yoBrowserSchemas = {
@@ -39,8 +44,14 @@ function asParameters(schema: z.ZodTypeAny) {
   }
 }
 
-function toDefinition(name: string, description: string, schema: z.ZodTypeAny): MCPToolDefinition {
+function toDefinition(
+  name: string,
+  description: string,
+  schema: z.ZodTypeAny,
+  execution: ToolExecutionContract
+): MCPToolDefinition {
   return {
+    ...execution,
     type: 'function',
     function: {
       name,
@@ -60,17 +71,20 @@ export function getYoBrowserToolDefinitions(): MCPToolDefinition[] {
     toDefinition(
       'get_browser_status',
       'Get the current session browser status',
-      yoBrowserSchemas.get_browser_status
+      yoBrowserSchemas.get_browser_status,
+      SEQUENTIAL_READ_TOOL_EXECUTION
     ),
     toDefinition(
       'load_url',
       'Create the session browser on demand and load a URL into it',
-      yoBrowserSchemas.load_url
+      yoBrowserSchemas.load_url,
+      SEQUENTIAL_WRITE_TOOL_EXECUTION
     ),
     toDefinition(
       'cdp_send',
       'Send a Chrome DevTools Protocol (CDP) command to the current session browser page',
-      yoBrowserSchemas.cdp_send
+      yoBrowserSchemas.cdp_send,
+      SEQUENTIAL_WRITE_TOOL_EXECUTION
     )
   ]
 }

--- a/src/main/tool/browser/definitions.ts
+++ b/src/main/tool/browser/definitions.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 import {
-  SEQUENTIAL_READ_TOOL_EXECUTION,
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  TOOL_EXECUTION,
   type MCPToolDefinition,
   type ToolExecutionContract
 } from '@shared/types/mcp'
@@ -51,7 +50,7 @@ function toDefinition(
   execution: ToolExecutionContract
 ): MCPToolDefinition {
   return {
-    ...execution,
+    execution,
     type: 'function',
     function: {
       name,
@@ -72,19 +71,19 @@ export function getYoBrowserToolDefinitions(): MCPToolDefinition[] {
       'get_browser_status',
       'Get the current session browser status',
       yoBrowserSchemas.get_browser_status,
-      SEQUENTIAL_READ_TOOL_EXECUTION
+      TOOL_EXECUTION.read.sequential
     ),
     toDefinition(
       'load_url',
       'Create the session browser on demand and load a URL into it',
       yoBrowserSchemas.load_url,
-      SEQUENTIAL_WRITE_TOOL_EXECUTION
+      TOOL_EXECUTION.write
     ),
     toDefinition(
       'cdp_send',
       'Send a Chrome DevTools Protocol (CDP) command to the current session browser page',
       yoBrowserSchemas.cdp_send,
-      SEQUENTIAL_WRITE_TOOL_EXECUTION
+      TOOL_EXECUTION.write
     )
   ]
 }

--- a/src/main/tool/index.ts
+++ b/src/main/tool/index.ts
@@ -1,10 +1,11 @@
 import type { ProviderSettingsPort } from '@/provider/settings'
 import { awaitWithAbort } from '@/lib/awaitWithAbort'
-import type {
-  McpServicePort,
-  MCPToolDefinition,
-  MCPToolCall,
-  MCPToolResponse
+import {
+  type McpServicePort,
+  type MCPToolCall,
+  type MCPToolDefinition,
+  type MCPToolDefinitionBase,
+  type MCPToolResponse
 } from '@shared/types/mcp'
 import type {
   ToolCallOptions,
@@ -491,10 +492,11 @@ export class ToolService implements ToolServicePort {
     const offloadPath =
       resolveToolOffloadTemplatePath(conversationId) ??
       '~/.deepchat/sessions/<conversationId>/tool_<toolCallId>.offload'
-    const toolDefinitions =
-      context.toolDefinitions?.filter((tool) => tool.source === 'agent') ?? this.getFallbackTools()
+    const toolDefinitions: MCPToolDefinitionBase[] =
+      context.toolDefinitions?.filter((tool) => tool.source === 'agent') ??
+      this.getFallbackPromptToolDefinitions()
     const toolNames = new Set(toolDefinitions.map((tool) => tool.function.name))
-    const groupedTools = new Map<string, MCPToolDefinition[]>()
+    const groupedTools = new Map<string, MCPToolDefinitionBase[]>()
 
     for (const tool of toolDefinitions) {
       const existing = groupedTools.get(tool.server.name) ?? []
@@ -517,7 +519,7 @@ export class ToolService implements ToolServicePort {
     return sections.filter(Boolean).join('\n\n')
   }
 
-  private getFallbackTools(): MCPToolDefinition[] {
+  private getFallbackPromptToolDefinitions(): MCPToolDefinitionBase[] {
     return FILESYSTEM_TOOL_ORDER.map((name) => ({
       type: 'function' as const,
       source: 'agent' as const,
@@ -704,7 +706,7 @@ export class ToolService implements ToolServicePort {
     ].join('\n')
   }
 
-  private buildTapePrompt(tools: MCPToolDefinition[]): string {
+  private buildTapePrompt(tools: MCPToolDefinitionBase[]): string {
     const modelTools = tools.filter(
       (tool) => getAgentToolExposure(tool.function.name) === 'system-model'
     )
@@ -729,7 +731,7 @@ export class ToolService implements ToolServicePort {
     return lines.join('\n')
   }
 
-  private buildCronJobPrompt(tools: MCPToolDefinition[]): string {
+  private buildCronJobPrompt(tools: MCPToolDefinitionBase[]): string {
     if (tools.length === 0) {
       return ''
     }
@@ -741,7 +743,7 @@ export class ToolService implements ToolServicePort {
     ].join('\n')
   }
 
-  private buildSettingsPrompt(tools: MCPToolDefinition[]): string {
+  private buildSettingsPrompt(tools: MCPToolDefinitionBase[]): string {
     if (tools.length === 0) {
       return ''
     }
@@ -754,7 +756,7 @@ export class ToolService implements ToolServicePort {
     ].join('\n')
   }
 
-  private buildYoBrowserPrompt(tools: MCPToolDefinition[]): string {
+  private buildYoBrowserPrompt(tools: MCPToolDefinitionBase[]): string {
     if (tools.length === 0) {
       return ''
     }

--- a/src/renderer/src/components/mcp-config/components/McpToolPanel.vue
+++ b/src/renderer/src/components/mcp-config/components/McpToolPanel.vue
@@ -165,7 +165,7 @@ const toolParametersDescription = computed(() => {
     const property = asSchemaRecord(value)
     const propertyType = typeof property.type === 'string' ? property.type : 'unknown'
     const enumValues = asDisplayEnum(property.enum)
-    const rawItems = asSchemaRecord(property.items)
+    const rawItems = propertyType === 'array' ? asSchemaRecord(property.items) : {}
     const itemEnumValues = asDisplayEnum(rawItems.enum)
     const items =
       Object.keys(rawItems).length > 0
@@ -375,14 +375,7 @@ const selectTool = (tool: MCPToolDefinition) => {
                           </div>
                         </div>
                         <!-- 显示数组元素类型的枚举值 -->
-                        <div
-                          v-if="
-                            param.type === 'array' &&
-                            param.items?.enum &&
-                            param.items.enum.length > 0
-                          "
-                          class="mt-1"
-                        >
+                        <div v-if="param.items?.enum && param.items.enum.length > 0" class="mt-1">
                           <p class="text-xs font-medium text-foreground mb-1">
                             {{ t('mcp.tools.arrayItemValues') }}:
                           </p>

--- a/src/renderer/src/components/mcp-config/components/McpToolPanel.vue
+++ b/src/renderer/src/components/mcp-config/components/McpToolPanel.vue
@@ -132,27 +132,63 @@ const formatToolInput = (toolName: string) => {
   }
 }
 
+const asSchemaRecord = (value: unknown): Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+
+const formatSchemaValue = (value: unknown): string => {
+  if (typeof value === 'string') return value
+
+  try {
+    return JSON.stringify(value) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+const asDisplayEnum = (value: unknown): string[] | null =>
+  Array.isArray(value) ? value.map(formatSchemaValue) : null
+
 // 计算属性：获取工具参数描述
 const toolParametersDescription = computed(() => {
   if (!selectedTool.value?.function.parameters?.properties) return []
 
   const properties = selectedTool.value.function.parameters.properties
-  const required = selectedTool.value.function.parameters.required || []
+  const required = Array.isArray(selectedTool.value.function.parameters.required)
+    ? selectedTool.value.function.parameters.required.filter(
+        (value): value is string => typeof value === 'string'
+      )
+    : []
 
-  return Object.entries(properties).map(([key, prop]) => ({
-    name: key,
-    description: prop.description || '',
-    type: prop.enum
-      ? 'enum'
-      : prop.type === 'array' && prop.items?.enum
-        ? 'array[enum]'
-        : prop.type || 'unknown',
-    originalType: prop.type || 'unknown',
-    required: required.includes(key),
-    annotations: prop.annotations,
-    enum: prop.enum || null,
-    items: prop.items || null
-  }))
+  return Object.entries(properties).map(([key, value]) => {
+    const property = asSchemaRecord(value)
+    const propertyType = typeof property.type === 'string' ? property.type : 'unknown'
+    const enumValues = asDisplayEnum(property.enum)
+    const rawItems = asSchemaRecord(property.items)
+    const itemEnumValues = asDisplayEnum(rawItems.enum)
+    const items =
+      Object.keys(rawItems).length > 0
+        ? {
+            type: typeof rawItems.type === 'string' ? rawItems.type : 'unknown',
+            enum: itemEnumValues
+          }
+        : null
+
+    return {
+      name: key,
+      description: typeof property.description === 'string' ? property.description : '',
+      type: enumValues
+        ? 'enum'
+        : propertyType === 'array' && itemEnumValues
+          ? 'array[enum]'
+          : propertyType,
+      originalType: propertyType,
+      required: required.includes(key),
+      enum: enumValues,
+      items
+    }
+  })
 })
 
 // 选择工具的处理函数
@@ -329,8 +365,8 @@ const selectTool = (tool: MCPToolDefinition) => {
                           </p>
                           <div class="flex flex-wrap gap-1">
                             <Badge
-                              v-for="enumValue in param.enum"
-                              :key="enumValue"
+                              v-for="(enumValue, enumIndex) in param.enum"
+                              :key="`${param.name}-enum-${enumIndex}`"
                               variant="secondary"
                               class="text-xs px-1.5 py-0.5 font-mono"
                             >
@@ -352,8 +388,8 @@ const selectTool = (tool: MCPToolDefinition) => {
                           </p>
                           <div class="flex flex-wrap gap-1">
                             <Badge
-                              v-for="enumValue in param.items.enum"
-                              :key="enumValue"
+                              v-for="(enumValue, enumIndex) in param.items.enum"
+                              :key="`${param.name}-item-enum-${enumIndex}`"
                               variant="secondary"
                               class="text-xs px-1.5 py-0.5 font-mono"
                             >

--- a/src/shared/types/core/mcp.ts
+++ b/src/shared/types/core/mcp.ts
@@ -25,7 +25,30 @@ export interface McpServerStatusChangedPayload {
   version: number
 }
 
-export interface MCPToolDefinition {
+export type ToolExecutionMode = 'sequential' | 'parallel'
+
+export type ToolEffect = 'read' | 'write'
+
+export type ToolExecutionContract =
+  | { readonly effect: 'read'; readonly executionMode: ToolExecutionMode }
+  | { readonly effect: 'write'; readonly executionMode: 'sequential' }
+
+export const PARALLEL_READ_TOOL_EXECUTION = {
+  effect: 'read',
+  executionMode: 'parallel'
+} as const satisfies ToolExecutionContract
+
+export const SEQUENTIAL_READ_TOOL_EXECUTION = {
+  effect: 'read',
+  executionMode: 'sequential'
+} as const satisfies ToolExecutionContract
+
+export const SEQUENTIAL_WRITE_TOOL_EXECUTION = {
+  effect: 'write',
+  executionMode: 'sequential'
+} as const satisfies ToolExecutionContract
+
+export interface MCPToolDefinitionBase {
   type: string
   source?: 'mcp' | 'agent'
   function: {
@@ -42,6 +65,16 @@ export interface MCPToolDefinition {
     icons: string
     description: string
   }
+}
+
+export type MCPToolDefinition = MCPToolDefinitionBase & ToolExecutionContract
+
+export function stripToolExecutionContract({
+  effect: _effect,
+  executionMode: _executionMode,
+  ...baseDefinition
+}: MCPToolDefinition): MCPToolDefinitionBase {
+  return baseDefinition
 }
 
 export interface MCPToolCall {

--- a/src/shared/types/core/mcp.ts
+++ b/src/shared/types/core/mcp.ts
@@ -30,23 +30,26 @@ export type ToolExecutionMode = 'sequential' | 'parallel'
 export type ToolEffect = 'read' | 'write'
 
 export type ToolExecutionContract =
-  | { readonly effect: 'read'; readonly executionMode: ToolExecutionMode }
-  | { readonly effect: 'write'; readonly executionMode: 'sequential' }
+  | { readonly effect: 'read'; readonly mode: ToolExecutionMode }
+  | { readonly effect: 'write'; readonly mode: 'sequential' }
 
-export const PARALLEL_READ_TOOL_EXECUTION = {
-  effect: 'read',
-  executionMode: 'parallel'
-} as const satisfies ToolExecutionContract
+type ToolExecutionPresetCatalog = {
+  readonly read: {
+    readonly [Mode in ToolExecutionMode]: {
+      readonly effect: 'read'
+      readonly mode: Mode
+    }
+  }
+  readonly write: Extract<ToolExecutionContract, { effect: 'write' }>
+}
 
-export const SEQUENTIAL_READ_TOOL_EXECUTION = {
-  effect: 'read',
-  executionMode: 'sequential'
-} as const satisfies ToolExecutionContract
-
-export const SEQUENTIAL_WRITE_TOOL_EXECUTION = {
-  effect: 'write',
-  executionMode: 'sequential'
-} as const satisfies ToolExecutionContract
+export const TOOL_EXECUTION = Object.freeze({
+  read: Object.freeze({
+    sequential: Object.freeze({ effect: 'read', mode: 'sequential' }),
+    parallel: Object.freeze({ effect: 'read', mode: 'parallel' })
+  }),
+  write: Object.freeze({ effect: 'write', mode: 'sequential' })
+}) satisfies ToolExecutionPresetCatalog
 
 export interface MCPToolDefinitionBase {
   type: string
@@ -67,11 +70,12 @@ export interface MCPToolDefinitionBase {
   }
 }
 
-export type MCPToolDefinition = MCPToolDefinitionBase & ToolExecutionContract
+export type MCPToolDefinition = MCPToolDefinitionBase & {
+  readonly execution: ToolExecutionContract
+}
 
 export function stripToolExecutionContract({
-  effect: _effect,
-  executionMode: _executionMode,
+  execution: _execution,
   ...baseDefinition
 }: MCPToolDefinition): MCPToolDefinitionBase {
   return baseDefinition

--- a/src/shared/types/mcp.ts
+++ b/src/shared/types/mcp.ts
@@ -1,5 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { FileItem } from './file'
+import type { MCPToolDefinition as CoreMCPToolDefinition } from './core/mcp'
+
+export {
+  PARALLEL_READ_TOOL_EXECUTION,
+  SEQUENTIAL_READ_TOOL_EXECUTION,
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  stripToolExecutionContract
+} from './core/mcp'
+export type {
+  MCPToolDefinitionBase,
+  ToolEffect,
+  ToolExecutionContract,
+  ToolExecutionMode
+} from './core/mcp'
 
 export interface McpClient {
   name: string
@@ -103,24 +117,7 @@ export interface McpServerAuthStatus {
   storage?: 'safeStorage' | 'file' | 'none'
 }
 
-export interface MCPToolDefinition {
-  type: string
-  source?: 'mcp' | 'agent'
-  function: {
-    name: string
-    description: string
-    parameters: {
-      type: string
-      properties: Record<string, any>
-      required?: string[]
-    }
-  }
-  server: {
-    name: string
-    icons: string
-    description: string
-  }
-}
+export type MCPToolDefinition = CoreMCPToolDefinition
 
 export interface MCPToolCall {
   id: string

--- a/src/shared/types/mcp.ts
+++ b/src/shared/types/mcp.ts
@@ -2,12 +2,7 @@
 import type { FileItem } from './file'
 import type { MCPToolDefinition as CoreMCPToolDefinition } from './core/mcp'
 
-export {
-  PARALLEL_READ_TOOL_EXECUTION,
-  SEQUENTIAL_READ_TOOL_EXECUTION,
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
-  stripToolExecutionContract
-} from './core/mcp'
+export { TOOL_EXECUTION, stripToolExecutionContract } from './core/mcp'
 export type {
   MCPToolDefinitionBase,
   ToolEffect,

--- a/test/main/agent/acp/runtime/acpCompatibilityPromptBuilder.test.ts
+++ b/test/main/agent/acp/runtime/acpCompatibilityPromptBuilder.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { AcpCompatibilityPromptBuilder } from '@/agent/acp/runtime/acpCompatibilityPromptBuilder'
 import type { AcpCompatibilityPromptSections } from '@/agent/acp/instance'
-import type { MCPToolDefinition } from '@shared/types/core/mcp'
+import {
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  type MCPToolDefinition
+} from '@shared/types/core/mcp'
 
 const sections: AcpCompatibilityPromptSections = {
   configured: 'configured',
@@ -15,6 +18,7 @@ const sections: AcpCompatibilityPromptSections = {
 }
 
 const localTool = {
+  ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
   type: 'function',
   function: { name: 'read', description: 'Read', parameters: {} },
   server: { name: 'agent', description: 'Agent tools' },

--- a/test/main/agent/acp/runtime/acpCompatibilityPromptBuilder.test.ts
+++ b/test/main/agent/acp/runtime/acpCompatibilityPromptBuilder.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { AcpCompatibilityPromptBuilder } from '@/agent/acp/runtime/acpCompatibilityPromptBuilder'
 import type { AcpCompatibilityPromptSections } from '@/agent/acp/instance'
 import {
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  TOOL_EXECUTION,
   type MCPToolDefinition
 } from '@shared/types/core/mcp'
 
@@ -18,7 +18,7 @@ const sections: AcpCompatibilityPromptSections = {
 }
 
 const localTool = {
-  ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  execution: TOOL_EXECUTION.write,
   type: 'function',
   function: { name: 'read', description: 'Read', parameters: {} },
   server: { name: 'agent', description: 'Agent tools' },

--- a/test/main/agent/deepchat/instance/deepChatAgentRuntime.test.ts
+++ b/test/main/agent/deepchat/instance/deepChatAgentRuntime.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import { DeepChatAgentRuntime } from '@/agent/deepchat/instance/deepChatAgentRuntime'
 import { toAppSessionId } from '@/agent/shared/agentSessionIds'
-import type { MCPToolDefinition } from '@shared/types/core/mcp'
+import { PARALLEL_READ_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/core/mcp'
 import { createLoopRun } from '@/agent/deepchat/loop/loopRun'
 
 const TOOL_DEFINITION: MCPToolDefinition = {
+  ...PARALLEL_READ_TOOL_EXECUTION,
   type: 'function',
   source: 'agent',
   function: {

--- a/test/main/agent/deepchat/instance/deepChatAgentRuntime.test.ts
+++ b/test/main/agent/deepchat/instance/deepChatAgentRuntime.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import { DeepChatAgentRuntime } from '@/agent/deepchat/instance/deepChatAgentRuntime'
 import { toAppSessionId } from '@/agent/shared/agentSessionIds'
-import { PARALLEL_READ_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/core/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/core/mcp'
 import { createLoopRun } from '@/agent/deepchat/loop/loopRun'
 
 const TOOL_DEFINITION: MCPToolDefinition = {
-  ...PARALLEL_READ_TOOL_EXECUTION,
+  execution: TOOL_EXECUTION.read.parallel,
   type: 'function',
   source: 'agent',
   function: {

--- a/test/main/agent/deepchat/runtime/contextBuilder.test.ts
+++ b/test/main/agent/deepchat/runtime/contextBuilder.test.ts
@@ -6,6 +6,7 @@ import {
   buildContextWithMetadata,
   buildResumeContext,
   buildResumeContextWithMetadata,
+  estimateToolDefinitionTokens,
   estimateMessagesTokens,
   fitCacheAwareMessagesToContextWindow,
   fitMessagesToContextWindow,
@@ -13,6 +14,11 @@ import {
 } from '@/agent/deepchat/runtime/contextBuilder'
 import { buildContextCheckpoint } from '@/agent/deepchat/runtime/contextContributions'
 import { TRUNCATED_TOOL_CALL_ERROR } from '@/agent/deepchat/runtime/dispatch'
+import { approximateTokenSize } from 'tokenx'
+import {
+  PARALLEL_READ_TOOL_EXECUTION,
+  type MCPToolDefinitionBase
+} from '@shared/types/core/mcp'
 
 vi.mock('tokenx', () => ({
   approximateTokenSize: vi.fn((text: string) => {
@@ -26,6 +32,29 @@ function createMockMessageStore(messages: any[] = []) {
     getMessages: vi.fn().mockReturnValue(messages)
   } as any
 }
+
+describe('estimateToolDefinitionTokens', () => {
+  it('preserves the historical reserve when execution metadata is present', () => {
+    const legacyDefinition: MCPToolDefinitionBase = {
+      type: 'function',
+      source: 'agent',
+      function: {
+        name: 'inspect',
+        description: 'Inspect a resource',
+        parameters: { type: 'object', properties: {} }
+      },
+      server: { name: 'test-server', icons: '', description: 'Test server' }
+    }
+
+    const tokens = estimateToolDefinitionTokens([
+      { ...legacyDefinition, ...PARALLEL_READ_TOOL_EXECUTION }
+    ])
+
+    const serializedLegacyDefinition = JSON.stringify(legacyDefinition)
+    expect(tokens).toBe(Math.ceil(serializedLegacyDefinition.length / 4))
+    expect(approximateTokenSize).toHaveBeenLastCalledWith(serializedLegacyDefinition)
+  })
+})
 
 function makeUserRecord(
   orderSeq: number,

--- a/test/main/agent/deepchat/runtime/contextBuilder.test.ts
+++ b/test/main/agent/deepchat/runtime/contextBuilder.test.ts
@@ -16,7 +16,7 @@ import { buildContextCheckpoint } from '@/agent/deepchat/runtime/contextContribu
 import { TRUNCATED_TOOL_CALL_ERROR } from '@/agent/deepchat/runtime/dispatch'
 import { approximateTokenSize } from 'tokenx'
 import {
-  PARALLEL_READ_TOOL_EXECUTION,
+  TOOL_EXECUTION,
   type MCPToolDefinitionBase
 } from '@shared/types/core/mcp'
 
@@ -47,7 +47,7 @@ describe('estimateToolDefinitionTokens', () => {
     }
 
     const tokens = estimateToolDefinitionTokens([
-      { ...legacyDefinition, ...PARALLEL_READ_TOOL_EXECUTION }
+      { ...legacyDefinition, execution: TOOL_EXECUTION.read.parallel }
     ])
 
     const serializedLegacyDefinition = JSON.stringify(legacyDefinition)

--- a/test/main/agent/deepchat/runtime/dispatch.test.ts
+++ b/test/main/agent/deepchat/runtime/dispatch.test.ts
@@ -15,8 +15,7 @@ import {
   estimateToolDefinitionTokens
 } from '@/agent/deepchat/runtime/contextBuilder'
 import {
-  PARALLEL_READ_TOOL_EXECUTION,
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  TOOL_EXECUTION,
   type MCPToolDefinition,
   type ToolExecutionContract
 } from '@shared/types/mcp'
@@ -86,10 +85,10 @@ function createIo(overrides?: Partial<IoParams>): IoParams {
 
 function makeTool(
   name: string,
-  execution: ToolExecutionContract = SEQUENTIAL_WRITE_TOOL_EXECUTION
+  execution: ToolExecutionContract = TOOL_EXECUTION.write
 ): MCPToolDefinition {
   return {
-    ...execution,
+    execution,
     type: 'function',
     function: {
       name,
@@ -102,8 +101,7 @@ function makeTool(
 
 function makeAgentTool(
   name: string,
-  execution: ToolExecutionContract =
-    name === 'read' ? PARALLEL_READ_TOOL_EXECUTION : SEQUENTIAL_WRITE_TOOL_EXECUTION
+  execution: ToolExecutionContract = TOOL_EXECUTION.write
 ): MCPToolDefinition {
   return {
     ...makeTool(name, execution),
@@ -802,7 +800,7 @@ describe('dispatch', () => {
     })
 
     it('ignores agent plan progress from parallel read-only tool batches', async () => {
-      const tools = [makeAgentTool('read')]
+      const tools = [makeAgentTool('read', TOOL_EXECUTION.read.parallel)]
       const toolService = {
         ...createMockToolService(),
         callTool: vi.fn(async (request, options) => {
@@ -873,7 +871,7 @@ describe('dispatch', () => {
     })
 
     it('runs explicitly parallel read batches without a tool-name allowlist', async () => {
-      const tools = [makeAgentTool('catalog_read', PARALLEL_READ_TOOL_EXECUTION)]
+      const tools = [makeAgentTool('catalog_read', TOOL_EXECUTION.read.parallel)]
       const started: string[] = []
       let releaseFirstRead: (() => void) | null = null
       let firstReadStarted: (() => void) | null = null
@@ -969,7 +967,7 @@ describe('dispatch', () => {
     })
 
     it('isolates parallel pre-check failures to the affected tool call', async () => {
-      const tools = [makeAgentTool('read')]
+      const tools = [makeAgentTool('read', TOOL_EXECUTION.read.parallel)]
       const toolService = {
         ...createMockToolService(),
         preCheckToolPermission: vi.fn(async (request) => {
@@ -1034,7 +1032,10 @@ describe('dispatch', () => {
     })
 
     it('keeps mixed read/write Agent tool batches serialized', async () => {
-      const tools = [makeAgentTool('write'), makeAgentTool('read')]
+      const tools = [
+        makeAgentTool('write'),
+        makeAgentTool('read', TOOL_EXECUTION.read.parallel)
+      ]
       const started: string[] = []
       let releaseWrite: (() => void) | null = null
       let writeStarted: (() => void) | null = null
@@ -2684,7 +2685,7 @@ describe('dispatch', () => {
     it('commits a returned parallel result before stopping on abort', async () => {
       const abortController = new AbortController()
       const abortIo = createIo({ abortSignal: abortController.signal })
-      const tools = [makeAgentTool('read')]
+      const tools = [makeAgentTool('read', TOOL_EXECUTION.read.parallel)]
       const toolService = createMockToolService()
 
       // Abort after first tool call
@@ -2745,7 +2746,7 @@ describe('dispatch', () => {
     })
 
     it('stages CanceledError from a parallel read batch when the run remains active', async () => {
-      const tools = [makeAgentTool('read')]
+      const tools = [makeAgentTool('read', TOOL_EXECUTION.read.parallel)]
       const toolService = createMockToolService()
       const canceledError = new Error('Canceled')
       canceledError.name = 'CanceledError'

--- a/test/main/agent/deepchat/runtime/dispatch.test.ts
+++ b/test/main/agent/deepchat/runtime/dispatch.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
-import { approximateTokenSize } from 'tokenx'
 import type {
   InterleavedReasoningConfig,
   IoParams,
@@ -11,8 +10,16 @@ import type {
   StreamState
 } from '@/agent/deepchat/runtime/types'
 import { createState } from '@/agent/deepchat/runtime/types'
-import { estimateMessagesTokens } from '@/agent/deepchat/runtime/contextBuilder'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import {
+  estimateMessagesTokens,
+  estimateToolDefinitionTokens
+} from '@/agent/deepchat/runtime/contextBuilder'
+import {
+  PARALLEL_READ_TOOL_EXECUTION,
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  type MCPToolDefinition,
+  type ToolExecutionContract
+} from '@shared/types/mcp'
 import type { ToolServicePort } from '@shared/types/tool'
 import type { AssistantMessageBlock, PermissionMode } from '@shared/types/agent-interface'
 import { ToolOutputGuard } from '@/agent/deepchat/runtime/toolOutputGuard'
@@ -77,8 +84,12 @@ function createIo(overrides?: Partial<IoParams>): IoParams {
   }
 }
 
-function makeTool(name: string): MCPToolDefinition {
+function makeTool(
+  name: string,
+  execution: ToolExecutionContract = SEQUENTIAL_WRITE_TOOL_EXECUTION
+): MCPToolDefinition {
   return {
+    ...execution,
     type: 'function',
     function: {
       name,
@@ -89,9 +100,13 @@ function makeTool(name: string): MCPToolDefinition {
   }
 }
 
-function makeAgentTool(name: string): MCPToolDefinition {
+function makeAgentTool(
+  name: string,
+  execution: ToolExecutionContract =
+    name === 'read' ? PARALLEL_READ_TOOL_EXECUTION : SEQUENTIAL_WRITE_TOOL_EXECUTION
+): MCPToolDefinition {
   return {
-    ...makeTool(name),
+    ...makeTool(name, execution),
     source: 'agent'
   }
 }
@@ -857,8 +872,8 @@ describe('dispatch', () => {
       ).toBe(false)
     })
 
-    it('runs all-read-only Agent tool batches in parallel and preserves result order', async () => {
-      const tools = [makeAgentTool('read')]
+    it('runs explicitly parallel read batches without a tool-name allowlist', async () => {
+      const tools = [makeAgentTool('catalog_read', PARALLEL_READ_TOOL_EXECUTION)]
       const started: string[] = []
       let releaseFirstRead: (() => void) | null = null
       let firstReadStarted: (() => void) | null = null
@@ -902,18 +917,28 @@ describe('dispatch', () => {
         content: '',
         status: 'pending',
         timestamp: Date.now(),
-        tool_call: { id: 'tc-read-a', name: 'read', params: '{"path":"a.txt"}', response: '' }
+        tool_call: {
+          id: 'tc-read-a',
+          name: 'catalog_read',
+          params: '{"path":"a.txt"}',
+          response: ''
+        }
       })
       state.blocks.push({
         type: 'tool_call',
         content: '',
         status: 'pending',
         timestamp: Date.now(),
-        tool_call: { id: 'tc-read-b', name: 'read', params: '{"path":"b.txt"}', response: '' }
+        tool_call: {
+          id: 'tc-read-b',
+          name: 'catalog_read',
+          params: '{"path":"b.txt"}',
+          response: ''
+        }
       })
       state.completedToolCalls = [
-        { id: 'tc-read-a', name: 'read', arguments: '{"path":"a.txt"}' },
-        { id: 'tc-read-b', name: 'read', arguments: '{"path":"b.txt"}' }
+        { id: 'tc-read-a', name: 'catalog_read', arguments: '{"path":"a.txt"}' },
+        { id: 'tc-read-b', name: 'catalog_read', arguments: '{"path":"b.txt"}' }
       ]
 
       const execution = settleToolBatch(
@@ -3477,10 +3502,7 @@ describe('dispatch', () => {
         { role: 'tool' as const, tool_call_id: 'tc1', content: 'a'.repeat(40) },
         { role: 'tool' as const, tool_call_id: 'tc2', content: 'b'.repeat(40) }
       ]
-      const toolDefinitionTokens = tools.reduce(
-        (total, tool) => total + approximateTokenSize(JSON.stringify(tool)),
-        0
-      )
+      const toolDefinitionTokens = estimateToolDefinitionTokens(tools)
       const contextLength = estimateMessagesTokens(fittingPrefixMessages) + toolDefinitionTokens + 1
 
       const executed = await settleToolBatch(

--- a/test/main/agent/deepchat/runtime/process.test.ts
+++ b/test/main/agent/deepchat/runtime/process.test.ts
@@ -4,8 +4,7 @@ import os from 'os'
 import path from 'path'
 import type { LLMCoreStreamEvent } from '@shared/types/core/llm-events'
 import {
-  PARALLEL_READ_TOOL_EXECUTION,
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  TOOL_EXECUTION,
   type MCPToolDefinition
 } from '@shared/types/mcp'
 import type { ChatMessage } from '@shared/types/core/chat-message'
@@ -110,7 +109,7 @@ function createMockMessageStore() {
 
 function makeTool(name: string): MCPToolDefinition {
   return {
-    ...(name === 'read' ? PARALLEL_READ_TOOL_EXECUTION : SEQUENTIAL_WRITE_TOOL_EXECUTION),
+    execution: TOOL_EXECUTION.write,
     type: 'function',
     function: {
       name,

--- a/test/main/agent/deepchat/runtime/process.test.ts
+++ b/test/main/agent/deepchat/runtime/process.test.ts
@@ -3,7 +3,11 @@ import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
 import type { LLMCoreStreamEvent } from '@shared/types/core/llm-events'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import {
+  PARALLEL_READ_TOOL_EXECUTION,
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  type MCPToolDefinition
+} from '@shared/types/mcp'
 import type { ChatMessage } from '@shared/types/core/chat-message'
 import type { ToolServicePort } from '@shared/types/tool'
 import type { ProcessParams } from '@/agent/deepchat/runtime/types'
@@ -106,6 +110,7 @@ function createMockMessageStore() {
 
 function makeTool(name: string): MCPToolDefinition {
   return {
+    ...(name === 'read' ? PARALLEL_READ_TOOL_EXECUTION : SEQUENTIAL_WRITE_TOOL_EXECUTION),
     type: 'function',
     function: {
       name,

--- a/test/main/agent/deepchat/runtime/toolAdapters.test.ts
+++ b/test/main/agent/deepchat/runtime/toolAdapters.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { PermissionMode } from '@shared/types/agent-interface'
-import type { MCPToolCall, MCPToolDefinition } from '@shared/types/core/mcp'
+import {
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  type MCPToolCall,
+  type MCPToolDefinition
+} from '@shared/types/core/mcp'
 import type { ToolServicePort } from '@shared/types/tool'
 import type { ToolResultPort } from '@/agent/deepchat/loop/ports'
 import {
@@ -13,6 +17,7 @@ import {
 
 function makeTool(name: string): MCPToolDefinition {
   return {
+    ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
     type: 'function',
     function: {
       name,

--- a/test/main/agent/deepchat/runtime/toolAdapters.test.ts
+++ b/test/main/agent/deepchat/runtime/toolAdapters.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { PermissionMode } from '@shared/types/agent-interface'
 import {
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  TOOL_EXECUTION,
   type MCPToolCall,
   type MCPToolDefinition
 } from '@shared/types/core/mcp'
@@ -17,7 +17,7 @@ import {
 
 function makeTool(name: string): MCPToolDefinition {
   return {
-    ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+    execution: TOOL_EXECUTION.write,
     type: 'function',
     function: {
       name,

--- a/test/main/agent/deepchat/runtime/toolExecutionPolicy.test.ts
+++ b/test/main/agent/deepchat/runtime/toolExecutionPolicy.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { selectToolBatchExecutionMode } from '@/agent/deepchat/runtime/toolExecutionPolicy'
 import {
-  PARALLEL_READ_TOOL_EXECUTION,
-  SEQUENTIAL_READ_TOOL_EXECUTION,
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  TOOL_EXECUTION,
   type MCPToolDefinition,
   type ToolExecutionContract
 } from '@shared/types/core/mcp'
@@ -14,7 +12,7 @@ function makeDefinition(
   execution: ToolExecutionContract
 ): MCPToolDefinition {
   return {
-    ...execution,
+    execution,
     type: 'function',
     function: {
       name,
@@ -38,14 +36,22 @@ function selectMode(
 }
 
 describe('selectToolBatchExecutionMode', () => {
+  it('keeps shared execution presets immutable at runtime', () => {
+    expect(Object.isFrozen(TOOL_EXECUTION)).toBe(true)
+    expect(Object.isFrozen(TOOL_EXECUTION.read)).toBe(true)
+    expect(Object.isFrozen(TOOL_EXECUTION.read.parallel)).toBe(true)
+    expect(Object.isFrozen(TOOL_EXECUTION.read.sequential)).toBe(true)
+    expect(Object.isFrozen(TOOL_EXECUTION.write)).toBe(true)
+  })
+
   it('restricts write tools to sequential execution at the type boundary', () => {
     type WriteExecution = Extract<ToolExecutionContract, { effect: 'write' }>
 
-    expectTypeOf<WriteExecution['executionMode']>().toEqualTypeOf<'sequential'>()
+    expectTypeOf<WriteExecution['mode']>().toEqualTypeOf<'sequential'>()
   })
 
   it('selects parallel for a multi-call batch of explicitly parallel reads', () => {
-    const definitions = [makeDefinition('inspect', PARALLEL_READ_TOOL_EXECUTION)]
+    const definitions = [makeDefinition('inspect', TOOL_EXECUTION.read.parallel)]
 
     expect(selectMode(['inspect', 'inspect'], definitions)).toBe('parallel')
   })
@@ -53,23 +59,23 @@ describe('selectToolBatchExecutionMode', () => {
   it.each<PermissionMode>(['default', 'auto_approve'])(
     'keeps parallel reads sequential in %s permission mode',
     (permissionMode) => {
-      const definitions = [makeDefinition('inspect', PARALLEL_READ_TOOL_EXECUTION)]
+      const definitions = [makeDefinition('inspect', TOOL_EXECUTION.read.parallel)]
 
       expect(selectMode(['inspect', 'inspect'], definitions, permissionMode)).toBe('sequential')
     }
   )
 
   it('keeps single calls sequential', () => {
-    const definitions = [makeDefinition('inspect', PARALLEL_READ_TOOL_EXECUTION)]
+    const definitions = [makeDefinition('inspect', TOOL_EXECUTION.read.parallel)]
 
     expect(selectMode(['inspect'], definitions)).toBe('sequential')
   })
 
   it('keeps batches containing a sequential read or write sequential', () => {
     const definitions = [
-      makeDefinition('parallel-read', PARALLEL_READ_TOOL_EXECUTION),
-      makeDefinition('sequential-read', SEQUENTIAL_READ_TOOL_EXECUTION),
-      makeDefinition('write', SEQUENTIAL_WRITE_TOOL_EXECUTION)
+      makeDefinition('parallel-read', TOOL_EXECUTION.read.parallel),
+      makeDefinition('sequential-read', TOOL_EXECUTION.read.sequential),
+      makeDefinition('write', TOOL_EXECUTION.write)
     ]
 
     expect(selectMode(['parallel-read', 'sequential-read'], definitions)).toBe('sequential')
@@ -77,11 +83,10 @@ describe('selectToolBatchExecutionMode', () => {
   })
 
   it('fails closed for missing, malformed, or duplicate definitions', () => {
-    const parallelRead = makeDefinition('inspect', PARALLEL_READ_TOOL_EXECUTION)
+    const parallelRead = makeDefinition('inspect', TOOL_EXECUTION.read.parallel)
     const malformed = {
-      ...makeDefinition('malformed', SEQUENTIAL_WRITE_TOOL_EXECUTION),
-      effect: 'write',
-      executionMode: 'parallel'
+      ...makeDefinition('malformed', TOOL_EXECUTION.write),
+      execution: { effect: 'write', mode: 'parallel' }
     } as unknown as MCPToolDefinition
 
     expect(selectMode(['inspect', 'missing'], [parallelRead])).toBe('sequential')

--- a/test/main/agent/deepchat/runtime/toolExecutionPolicy.test.ts
+++ b/test/main/agent/deepchat/runtime/toolExecutionPolicy.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { selectToolBatchExecutionMode } from '@/agent/deepchat/runtime/toolExecutionPolicy'
+import {
+  PARALLEL_READ_TOOL_EXECUTION,
+  SEQUENTIAL_READ_TOOL_EXECUTION,
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  type MCPToolDefinition,
+  type ToolExecutionContract
+} from '@shared/types/core/mcp'
+import type { PermissionMode } from '@shared/types/agent-interface'
+
+function makeDefinition(
+  name: string,
+  execution: ToolExecutionContract
+): MCPToolDefinition {
+  return {
+    ...execution,
+    type: 'function',
+    function: {
+      name,
+      description: `${name} tool`,
+      parameters: { type: 'object', properties: {} }
+    },
+    server: { name: 'test-server', icons: '', description: 'Test server' }
+  }
+}
+
+function selectMode(
+  names: string[],
+  toolDefinitions: MCPToolDefinition[],
+  permissionMode: PermissionMode = 'full_access'
+) {
+  return selectToolBatchExecutionMode({
+    permissionMode,
+    toolCalls: names.map((name) => ({ name })),
+    toolDefinitions
+  })
+}
+
+describe('selectToolBatchExecutionMode', () => {
+  it('restricts write tools to sequential execution at the type boundary', () => {
+    type WriteExecution = Extract<ToolExecutionContract, { effect: 'write' }>
+
+    expectTypeOf<WriteExecution['executionMode']>().toEqualTypeOf<'sequential'>()
+  })
+
+  it('selects parallel for a multi-call batch of explicitly parallel reads', () => {
+    const definitions = [makeDefinition('inspect', PARALLEL_READ_TOOL_EXECUTION)]
+
+    expect(selectMode(['inspect', 'inspect'], definitions)).toBe('parallel')
+  })
+
+  it.each<PermissionMode>(['default', 'auto_approve'])(
+    'keeps parallel reads sequential in %s permission mode',
+    (permissionMode) => {
+      const definitions = [makeDefinition('inspect', PARALLEL_READ_TOOL_EXECUTION)]
+
+      expect(selectMode(['inspect', 'inspect'], definitions, permissionMode)).toBe('sequential')
+    }
+  )
+
+  it('keeps single calls sequential', () => {
+    const definitions = [makeDefinition('inspect', PARALLEL_READ_TOOL_EXECUTION)]
+
+    expect(selectMode(['inspect'], definitions)).toBe('sequential')
+  })
+
+  it('keeps batches containing a sequential read or write sequential', () => {
+    const definitions = [
+      makeDefinition('parallel-read', PARALLEL_READ_TOOL_EXECUTION),
+      makeDefinition('sequential-read', SEQUENTIAL_READ_TOOL_EXECUTION),
+      makeDefinition('write', SEQUENTIAL_WRITE_TOOL_EXECUTION)
+    ]
+
+    expect(selectMode(['parallel-read', 'sequential-read'], definitions)).toBe('sequential')
+    expect(selectMode(['parallel-read', 'write'], definitions)).toBe('sequential')
+  })
+
+  it('fails closed for missing, malformed, or duplicate definitions', () => {
+    const parallelRead = makeDefinition('inspect', PARALLEL_READ_TOOL_EXECUTION)
+    const malformed = {
+      ...makeDefinition('malformed', SEQUENTIAL_WRITE_TOOL_EXECUTION),
+      effect: 'write',
+      executionMode: 'parallel'
+    } as unknown as MCPToolDefinition
+
+    expect(selectMode(['inspect', 'missing'], [parallelRead])).toBe('sequential')
+    expect(selectMode(['malformed', 'malformed'], [malformed])).toBe('sequential')
+    expect(selectMode(['inspect', 'inspect'], [parallelRead, { ...parallelRead }])).toBe(
+      'sequential'
+    )
+  })
+})

--- a/test/main/agent/deepchat/runtime/toolOutputGuard.test.ts
+++ b/test/main/agent/deepchat/runtime/toolOutputGuard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
-  SEQUENTIAL_READ_TOOL_EXECUTION,
+  TOOL_EXECUTION,
   type MCPToolDefinition
 } from '@shared/types/core/mcp'
 import { getUsableContextLength } from '@/agent/deepchat/runtime/contextBudget'
@@ -16,7 +16,7 @@ describe('ToolOutputGuard', () => {
     const guard = new ToolOutputGuard()
     const toolDefinitions: MCPToolDefinition[] = [
       {
-        ...SEQUENTIAL_READ_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.read.sequential,
         type: 'function',
         function: {
           name: 'lookup',

--- a/test/main/agent/deepchat/runtime/toolOutputGuard.test.ts
+++ b/test/main/agent/deepchat/runtime/toolOutputGuard.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { MCPToolDefinition } from '@shared/types/core/mcp'
+import {
+  SEQUENTIAL_READ_TOOL_EXECUTION,
+  type MCPToolDefinition
+} from '@shared/types/core/mcp'
 import { getUsableContextLength } from '@/agent/deepchat/runtime/contextBudget'
+import { estimateToolDefinitionTokens } from '@/agent/deepchat/runtime/contextBuilder'
 import { ToolOutputGuard } from '@/agent/deepchat/runtime/toolOutputGuard'
 
 vi.mock('tokenx', () => ({
@@ -12,6 +16,7 @@ describe('ToolOutputGuard', () => {
     const guard = new ToolOutputGuard()
     const toolDefinitions: MCPToolDefinition[] = [
       {
+        ...SEQUENTIAL_READ_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'lookup',
@@ -31,7 +36,7 @@ describe('ToolOutputGuard', () => {
         }
       }
     ]
-    const toolDefinitionTokens = JSON.stringify(toolDefinitions[0]).length
+    const toolDefinitionTokens = estimateToolDefinitionTokens(toolDefinitions)
     const maxMessageTokens = getUsableContextLength(5000) - 1000 - toolDefinitionTokens
 
     expect(

--- a/test/main/evals/nativeAgent/harness.ts
+++ b/test/main/evals/nativeAgent/harness.ts
@@ -3,12 +3,7 @@ import { ModelType } from '@shared/model'
 import type { AssistantMessageBlock } from '@shared/types/agent-interface'
 import type { ChatMessage } from '@shared/types/core/chat-message'
 import type { LLMCoreStreamEvent } from '@shared/types/core/llm-events'
-import {
-  PARALLEL_READ_TOOL_EXECUTION,
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
-  type MCPToolCall,
-  type MCPToolDefinition
-} from '@shared/types/core/mcp'
+import { TOOL_EXECUTION, type MCPToolCall, type MCPToolDefinition } from '@shared/types/core/mcp'
 import type { ToolServicePort } from '@shared/types/tool'
 import type { SessionTranscript } from '@/session/data/transcript'
 import { processStream } from '@/agent/deepchat/runtime/process'
@@ -224,7 +219,7 @@ function createMessageStore(): {
 
 function makeToolDefinition(name: string): MCPToolDefinition {
   return {
-    ...(name === 'read' ? PARALLEL_READ_TOOL_EXECUTION : SEQUENTIAL_WRITE_TOOL_EXECUTION),
+    execution: TOOL_EXECUTION.write,
     type: 'function',
     source: 'agent',
     function: {

--- a/test/main/evals/nativeAgent/harness.ts
+++ b/test/main/evals/nativeAgent/harness.ts
@@ -3,7 +3,12 @@ import { ModelType } from '@shared/model'
 import type { AssistantMessageBlock } from '@shared/types/agent-interface'
 import type { ChatMessage } from '@shared/types/core/chat-message'
 import type { LLMCoreStreamEvent } from '@shared/types/core/llm-events'
-import type { MCPToolCall, MCPToolDefinition } from '@shared/types/core/mcp'
+import {
+  PARALLEL_READ_TOOL_EXECUTION,
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  type MCPToolCall,
+  type MCPToolDefinition
+} from '@shared/types/core/mcp'
 import type { ToolServicePort } from '@shared/types/tool'
 import type { SessionTranscript } from '@/session/data/transcript'
 import { processStream } from '@/agent/deepchat/runtime/process'
@@ -219,6 +224,7 @@ function createMessageStore(): {
 
 function makeToolDefinition(name: string): MCPToolDefinition {
   return {
+    ...(name === 'read' ? PARALLEL_READ_TOOL_EXECUTION : SEQUENTIAL_WRITE_TOOL_EXECUTION),
     type: 'function',
     source: 'agent',
     function: {

--- a/test/main/mcp/toolManager.test.ts
+++ b/test/main/mcp/toolManager.test.ts
@@ -185,8 +185,7 @@ describe('ToolManager', () => {
 
     expect(definitions).toHaveLength(1)
     expect(definitions[0]).toMatchObject({
-      effect: 'write',
-      executionMode: 'sequential'
+      execution: { effect: 'write', mode: 'sequential' }
     })
   })
 

--- a/test/main/mcp/toolManager.test.ts
+++ b/test/main/mcp/toolManager.test.ts
@@ -166,6 +166,30 @@ describe('ToolManager', () => {
     ).toBe('Regular launch app description')
   })
 
+  it('keeps MCP tools sequential even when the server declares readOnlyHint', async () => {
+    const client = createClient('untrusted-server', [
+      {
+        name: 'inspect',
+        description: 'Inspect remote state',
+        inputSchema: { properties: {}, required: [] },
+        annotations: { readOnlyHint: true }
+      }
+    ])
+    const providerSettings = createProviderSettings('untrusted-server')
+    const manager = createToolManager(
+      providerSettings as never,
+      createServerManager([client]) as never
+    )
+
+    const definitions = await manager.getAllToolDefinitions()
+
+    expect(definitions).toHaveLength(1)
+    expect(definitions[0]).toMatchObject({
+      effect: 'write',
+      executionMode: 'sequential'
+    })
+  })
+
   it('uses explicit ACP agent context instead of global chat mode', async () => {
     const client = createClient('blocked-server')
     const providerSettings = createProviderSettings('blocked-server')

--- a/test/main/provider/aiSdkToolMapper.test.ts
+++ b/test/main/provider/aiSdkToolMapper.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { mcpToolsToAISDKTools, normalizeToolInputSchema } from '@/provider/aiSdk/toolMapper'
-import { SEQUENTIAL_WRITE_TOOL_EXECUTION } from '@shared/types/core/mcp'
+import { TOOL_EXECUTION } from '@shared/types/core/mcp'
 
 describe('AI SDK tool schema normalization', () => {
   it('normalizes discriminated union schemas to a top-level object schema', () => {
@@ -200,7 +200,7 @@ describe('AI SDK tool schema normalization', () => {
   it('uses a safe dictionary and skips unsafe tool names', () => {
     const tools = mcpToolsToAISDKTools([
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: '__proto__',
@@ -217,7 +217,7 @@ describe('AI SDK tool schema normalization', () => {
         }
       },
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: 'safe_tool',
@@ -238,7 +238,6 @@ describe('AI SDK tool schema normalization', () => {
     expect(Object.getPrototypeOf(tools)).toBeNull()
     expect(tools).not.toHaveProperty('__proto__')
     expect(tools).toHaveProperty('safe_tool')
-    expect(tools.safe_tool).not.toHaveProperty('effect')
-    expect(tools.safe_tool).not.toHaveProperty('executionMode')
+    expect(tools.safe_tool).not.toHaveProperty('execution')
   })
 })

--- a/test/main/provider/aiSdkToolMapper.test.ts
+++ b/test/main/provider/aiSdkToolMapper.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { mcpToolsToAISDKTools, normalizeToolInputSchema } from '@/provider/aiSdk/toolMapper'
+import { SEQUENTIAL_WRITE_TOOL_EXECUTION } from '@shared/types/core/mcp'
 
 describe('AI SDK tool schema normalization', () => {
   it('normalizes discriminated union schemas to a top-level object schema', () => {
@@ -199,6 +200,7 @@ describe('AI SDK tool schema normalization', () => {
   it('uses a safe dictionary and skips unsafe tool names', () => {
     const tools = mcpToolsToAISDKTools([
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: '__proto__',
@@ -215,6 +217,7 @@ describe('AI SDK tool schema normalization', () => {
         }
       },
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'safe_tool',
@@ -235,5 +238,7 @@ describe('AI SDK tool schema normalization', () => {
     expect(Object.getPrototypeOf(tools)).toBeNull()
     expect(tools).not.toHaveProperty('__proto__')
     expect(tools).toHaveProperty('safe_tool')
+    expect(tools.safe_tool).not.toHaveProperty('effect')
+    expect(tools.safe_tool).not.toHaveProperty('executionMode')
   })
 })

--- a/test/main/provider/baseProvider.test.ts
+++ b/test/main/provider/baseProvider.test.ts
@@ -1,7 +1,7 @@
 import type { ProviderSettingsPort } from '@/provider/settings'
 import { describe, expect, it, vi } from 'vitest'
 import type { LLM_PROVIDER, MODEL_META, ModelConfig } from '@shared/types/provider'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import type { ChatMessage } from '@shared/types/core/chat-message'
 import type { LLMResponse } from '@shared/types/provider'
 import { BaseLLMProvider } from '../../../src/main/provider/baseProvider'
@@ -105,6 +105,7 @@ describe('BaseLLMProvider tool XML conversion', () => {
     const provider = new TestProvider(providerSettings)
     const tools: MCPToolDefinition[] = [
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'skill_manage',
@@ -157,6 +158,7 @@ describe('BaseLLMProvider tool XML conversion', () => {
     const provider = new TestProvider(providerSettings)
     const xml = provider.renderToolsXml([
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'noop',
@@ -181,6 +183,7 @@ describe('BaseLLMProvider tool XML conversion', () => {
     const provider = new TestProvider(providerSettings)
     const xml = provider.renderToolsXml([
       {
+        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
         type: 'function',
         function: {
           name: 'escape_test',

--- a/test/main/provider/baseProvider.test.ts
+++ b/test/main/provider/baseProvider.test.ts
@@ -1,7 +1,7 @@
 import type { ProviderSettingsPort } from '@/provider/settings'
 import { describe, expect, it, vi } from 'vitest'
 import type { LLM_PROVIDER, MODEL_META, ModelConfig } from '@shared/types/provider'
-import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import type { ChatMessage } from '@shared/types/core/chat-message'
 import type { LLMResponse } from '@shared/types/provider'
 import { BaseLLMProvider } from '../../../src/main/provider/baseProvider'
@@ -105,7 +105,7 @@ describe('BaseLLMProvider tool XML conversion', () => {
     const provider = new TestProvider(providerSettings)
     const tools: MCPToolDefinition[] = [
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: 'skill_manage',
@@ -158,7 +158,7 @@ describe('BaseLLMProvider tool XML conversion', () => {
     const provider = new TestProvider(providerSettings)
     const xml = provider.renderToolsXml([
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: 'noop',
@@ -183,7 +183,7 @@ describe('BaseLLMProvider tool XML conversion', () => {
     const provider = new TestProvider(providerSettings)
     const xml = provider.renderToolsXml([
       {
-        ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+        execution: TOOL_EXECUTION.write,
         type: 'function',
         function: {
           name: 'escape_test',

--- a/test/main/session/data/tapeViewManifest.test.ts
+++ b/test/main/session/data/tapeViewManifest.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { ChatMessageRecord } from '@shared/types/agent-interface'
 import {
+  PARALLEL_READ_TOOL_EXECUTION,
+  SEQUENTIAL_READ_TOOL_EXECUTION,
+  type MCPToolDefinitionBase
+} from '@shared/types/core/mcp'
+import {
   buildIncludedRefs,
   buildRequestRefs,
   createTapeViewManifest,
@@ -109,6 +114,59 @@ describe('tapeViewManifest', () => {
     expect(first.hashes.manifestHash).toHaveLength(64)
     expect(first.tokenBudget.estimatedPromptTokens).toBeGreaterThan(0)
     expect(JSON.stringify(first)).not.toContain('secret prompt content')
+  })
+
+  it('keeps execution metadata out of provider-view tool hashes', () => {
+    const baseTool: MCPToolDefinitionBase = {
+      type: 'function',
+      source: 'agent',
+      function: {
+        name: 'inspect',
+        description: 'Inspect a resource',
+        parameters: { type: 'object', properties: {} }
+      },
+      server: { name: 'test-server', icons: '', description: 'Test server' }
+    }
+    const baseInput = {
+      sessionId: 's1',
+      messageId: 'a1',
+      requestSeq: 1,
+      taskType: 'chat' as const,
+      policy: 'legacy_context_v1' as const,
+      policyVersion: 1,
+      messages: [{ role: 'user' as const, content: 'hello' }],
+      latestEntryId: 1,
+      anchorEntryIds: [],
+      included: [],
+      excluded: [],
+      tokenBudget: {
+        contextLength: 1000,
+        requestedMaxTokens: 100,
+        effectiveMaxTokens: 100,
+        reserveTokens: 100,
+        toolReserveTokens: 0
+      },
+      providerId: 'openai',
+      modelId: 'gpt-4o',
+      summaryCursorOrderSeq: 0,
+      supportsVision: false,
+      supportsAudioInput: false,
+      traceDebugEnabled: false,
+      assembledAt: 123
+    }
+
+    const parallel = createTapeViewManifest({
+      ...baseInput,
+      tools: [{ ...baseTool, ...PARALLEL_READ_TOOL_EXECUTION }]
+    })
+    const sequential = createTapeViewManifest({
+      ...baseInput,
+      tools: [{ ...baseTool, ...SEQUENTIAL_READ_TOOL_EXECUTION }]
+    })
+
+    expect(parallel.hashes.toolDefinitionsHash).toBe(hashJson([baseTool]))
+    expect(sequential.hashes.toolDefinitionsHash).toBe(parallel.hashes.toolDefinitionsHash)
+    expect(sequential.hashes.manifestHash).toBe(parallel.hashes.manifestHash)
   })
 
   it('excludes wall-clock assembledAt from the manifest hash and viewId', () => {

--- a/test/main/session/data/tapeViewManifest.test.ts
+++ b/test/main/session/data/tapeViewManifest.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { ChatMessageRecord } from '@shared/types/agent-interface'
-import {
-  PARALLEL_READ_TOOL_EXECUTION,
-  SEQUENTIAL_READ_TOOL_EXECUTION,
-  type MCPToolDefinitionBase
-} from '@shared/types/core/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinitionBase } from '@shared/types/core/mcp'
 import {
   buildIncludedRefs,
   buildRequestRefs,
@@ -157,11 +153,11 @@ describe('tapeViewManifest', () => {
 
     const parallel = createTapeViewManifest({
       ...baseInput,
-      tools: [{ ...baseTool, ...PARALLEL_READ_TOOL_EXECUTION }]
+      tools: [{ ...baseTool, execution: TOOL_EXECUTION.read.parallel }]
     })
     const sequential = createTapeViewManifest({
       ...baseInput,
-      tools: [{ ...baseTool, ...SEQUENTIAL_READ_TOOL_EXECUTION }]
+      tools: [{ ...baseTool, execution: TOOL_EXECUTION.read.sequential }]
     })
 
     expect(parallel.hashes.toolDefinitionsHash).toBe(hashJson([baseTool]))

--- a/test/main/tool/agentTools/agentToolManagerRead.test.ts
+++ b/test/main/tool/agentTools/agentToolManagerRead.test.ts
@@ -117,6 +117,30 @@ describe('AgentToolManager read routing', () => {
     })
   })
 
+  it('declares filesystem execution contracts at the definition owner', async () => {
+    const definitions = await manager.getAllToolDefinitions({
+      chatMode: 'agent',
+      supportsVision: false,
+      agentWorkspacePath: workspaceDir,
+      conversationId: 'conv1'
+    })
+    const filesystemContracts = Object.fromEntries(
+      definitions
+        .filter((definition) => definition.server.name === 'agent-filesystem')
+        .map(({ function: { name }, effect, executionMode }) => [name, { effect, executionMode }])
+    )
+
+    expect(filesystemContracts).toEqual({
+      read: { effect: 'read', executionMode: 'parallel' },
+      write: { effect: 'write', executionMode: 'sequential' },
+      edit: { effect: 'write', executionMode: 'sequential' },
+      glob: { effect: 'read', executionMode: 'sequential' },
+      grep: { effect: 'read', executionMode: 'sequential' },
+      exec: { effect: 'write', executionMode: 'sequential' },
+      process: { effect: 'write', executionMode: 'sequential' }
+    })
+  })
+
   it('uses raw read for text/code files', async () => {
     const filePath = path.join(workspaceDir, 'note.txt')
     await fs.writeFile(filePath, 'hello text', 'utf-8')

--- a/test/main/tool/agentTools/agentToolManagerRead.test.ts
+++ b/test/main/tool/agentTools/agentToolManagerRead.test.ts
@@ -127,17 +127,17 @@ describe('AgentToolManager read routing', () => {
     const filesystemContracts = Object.fromEntries(
       definitions
         .filter((definition) => definition.server.name === 'agent-filesystem')
-        .map(({ function: { name }, effect, executionMode }) => [name, { effect, executionMode }])
+        .map(({ function: { name }, execution }) => [name, execution])
     )
 
     expect(filesystemContracts).toEqual({
-      read: { effect: 'read', executionMode: 'parallel' },
-      write: { effect: 'write', executionMode: 'sequential' },
-      edit: { effect: 'write', executionMode: 'sequential' },
-      glob: { effect: 'read', executionMode: 'sequential' },
-      grep: { effect: 'read', executionMode: 'sequential' },
-      exec: { effect: 'write', executionMode: 'sequential' },
-      process: { effect: 'write', executionMode: 'sequential' }
+      read: { effect: 'read', mode: 'parallel' },
+      write: { effect: 'write', mode: 'sequential' },
+      edit: { effect: 'write', mode: 'sequential' },
+      glob: { effect: 'read', mode: 'sequential' },
+      grep: { effect: 'read', mode: 'sequential' },
+      exec: { effect: 'write', mode: 'sequential' },
+      process: { effect: 'write', mode: 'sequential' }
     })
   })
 

--- a/test/main/tool/toolService.test.ts
+++ b/test/main/tool/toolService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import { ToolService } from '@/tool'
 import { createToolCatalogPort } from '@/agent/deepchat/runtime/toolAdapters'
 import { CronJobToolHandler, TAPE_TOOL_NAMES, UPDATE_PLAN_TOOL_NAME } from '@/tool/agentTools'
@@ -22,7 +22,7 @@ vi.mock('electron', () => ({
 }))
 
 const buildToolDefinition = (name: string, serverName: string): MCPToolDefinition => ({
-  ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  execution: TOOL_EXECUTION.write,
   type: 'function',
   function: {
     name,

--- a/test/main/tool/toolService.test.ts
+++ b/test/main/tool/toolService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { MCPToolDefinition } from '@shared/types/mcp'
+import { SEQUENTIAL_WRITE_TOOL_EXECUTION, type MCPToolDefinition } from '@shared/types/mcp'
 import { ToolService } from '@/tool'
 import { createToolCatalogPort } from '@/agent/deepchat/runtime/toolAdapters'
 import { CronJobToolHandler, TAPE_TOOL_NAMES, UPDATE_PLAN_TOOL_NAME } from '@/tool/agentTools'
@@ -22,6 +22,7 @@ vi.mock('electron', () => ({
 }))
 
 const buildToolDefinition = (name: string, serverName: string): MCPToolDefinition => ({
+  ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
   type: 'function',
   function: {
     name,

--- a/test/renderer/components/McpToolPanel.test.ts
+++ b/test/renderer/components/McpToolPanel.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick, reactive, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { TOOL_EXECUTION } from '@shared/types/mcp'
+
+const passthrough = (name: string) =>
+  defineComponent({
+    name,
+    template: '<div><slot /></div>'
+  })
+
+const buttonStub = defineComponent({
+  name: 'Button',
+  emits: ['click'],
+  template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>'
+})
+
+const selectStub = defineComponent({
+  name: 'Select',
+  emits: ['update:modelValue'],
+  template:
+    '<button data-testid="tool-select" @click="$emit(\'update:modelValue\', \'inspect\')"><slot /></button>'
+})
+
+describe('McpToolPanel', () => {
+  it('renders enum values declared by array items', async () => {
+    vi.resetModules()
+    const mcpStore = reactive({
+      tools: [
+        {
+          execution: TOOL_EXECUTION.write,
+          type: 'function',
+          source: 'mcp' as const,
+          function: {
+            name: 'inspect',
+            description: 'Inspect values',
+            parameters: {
+              type: 'object',
+              properties: {
+                formats: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                    enum: ['json', { format: 'xml' }]
+                  }
+                }
+              }
+            }
+          },
+          server: {
+            name: 'test-server',
+            icons: '',
+            description: 'Test server'
+          }
+        }
+      ],
+      toolInputs: {} as Record<string, unknown>,
+      toolLoadingStates: {} as Record<string, boolean>,
+      callTool: vi.fn()
+    })
+
+    vi.doMock('@/stores/mcp', () => ({ useMcpStore: () => mcpStore }))
+    vi.doMock('@vueuse/core', () => ({ useMediaQuery: () => ref(false) }))
+    vi.doMock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+
+    const McpToolPanel = (await import('@/components/mcp-config/components/McpToolPanel.vue'))
+      .default
+    const wrapper = mount(McpToolPanel, {
+      props: {
+        open: true,
+        serverName: 'test-server'
+      },
+      global: {
+        stubs: {
+          Button: buttonStub,
+          Badge: passthrough('Badge'),
+          ScrollArea: passthrough('ScrollArea'),
+          Sheet: passthrough('Sheet'),
+          SheetContent: passthrough('SheetContent'),
+          SheetHeader: passthrough('SheetHeader'),
+          SheetTitle: passthrough('SheetTitle'),
+          SheetDescription: passthrough('SheetDescription'),
+          Select: selectStub,
+          SelectContent: passthrough('SelectContent'),
+          SelectItem: passthrough('SelectItem'),
+          SelectTrigger: passthrough('SelectTrigger'),
+          SelectValue: passthrough('SelectValue'),
+          Spinner: true,
+          Icon: true,
+          McpJsonViewer: true
+        }
+      }
+    })
+
+    await wrapper.get('[data-testid="tool-select"]').trigger('click')
+    await nextTick()
+    const parametersToggle = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('mcp.tools.parameters'))
+
+    expect(parametersToggle).toBeDefined()
+    await parametersToggle!.trigger('click')
+
+    expect(wrapper.text()).toContain('array[enum(string)]')
+    expect(wrapper.text()).toContain('mcp.tools.arrayItemValues')
+    expect(wrapper.text()).toContain('json')
+    expect(wrapper.text()).toContain('{"format":"xml"}')
+  })
+})

--- a/test/renderer/composables/useChatInputMentions.test.ts
+++ b/test/renderer/composables/useChatInputMentions.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import type { MCPToolDefinition, PromptListEntry } from '@shared/types/mcp'
+import {
+  SEQUENTIAL_WRITE_TOOL_EXECUTION,
+  type MCPToolDefinition,
+  type PromptListEntry
+} from '@shared/types/mcp'
 import {
   filterSlashSuggestionItems,
   flattenPromptResultToText,
@@ -90,6 +94,7 @@ describe('resolveSlashSelectionAction', () => {
 
   it('inserts @toolName for tool selection', () => {
     const tool: MCPToolDefinition = {
+      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
       type: 'function',
       server: {
         name: 'deepchat-tools',

--- a/test/renderer/composables/useChatInputMentions.test.ts
+++ b/test/renderer/composables/useChatInputMentions.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  SEQUENTIAL_WRITE_TOOL_EXECUTION,
-  type MCPToolDefinition,
-  type PromptListEntry
-} from '@shared/types/mcp'
+import { TOOL_EXECUTION, type MCPToolDefinition, type PromptListEntry } from '@shared/types/mcp'
 import {
   filterSlashSuggestionItems,
   flattenPromptResultToText,
@@ -94,7 +90,7 @@ describe('resolveSlashSelectionAction', () => {
 
   it('inserts @toolName for tool selection', () => {
     const tool: MCPToolDefinition = {
-      ...SEQUENTIAL_WRITE_TOOL_EXECUTION,
+      execution: TOOL_EXECUTION.write,
       type: 'function',
       server: {
         name: 'deepchat-tools',


### PR DESCRIPTION
## Summary

- Introduce a required, typed execution contract for tool definitions.
- Centralize tool batch scheduling in a fail-closed execution policy.
- Preserve existing execution behavior while replacing name-based dispatch checks.
- Add architecture documentation and focused regression coverage.

## Design

Each executable tool now declares:

- `effect`: `read` or `write`
- `executionMode`: `sequential` or `parallel`

The type contract makes `write + parallel` unrepresentable.

A batch runs in parallel only when:

- permission mode is `full_access`;
- the batch contains at least two calls;
- every tool definition is present and unambiguous;
- every tool is explicitly declared as `read + parallel`.

Missing, malformed, duplicate, mixed, or write-capable definitions fall back to whole-batch sequential execution.

External MCP and plugin tools remain `write + sequential`. Their advisory metadata is not trusted as an execution-safety boundary. Currently, only the filesystem `read` tool opts into parallel execution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit execution contracts for tools, defining read/write effects and allowed parallel vs sequential execution.
  * Enabled parallel execution for eligible read tool batches in full-access sessions; otherwise falls back to sequential.
* **Bug Fixes**
  * Prevented execution metadata from affecting provider tool schemas, token estimation, or manifest hash verification.
  * Improved MCP tool parameter rendering for enums and required fields.
* **Documentation**
  * Added architecture docs and task tracking for agent harness execution-safety boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->