### PR TITLE
refactor(hook): add typed notification pipeline

### DIFF
--- a/docs/architecture/baselines/agent-system-layered-runtime-baseline.json
+++ b/docs/architecture/baselines/agent-system-layered-runtime-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "goal": "agent-system-layered-runtime",
-  "headCommit": "da311751a416a15ff035a2e678a184563e4cf1fd",
+  "headCommit": "83ed779287c1101a8054da0eeab7754f0cd42445",
   "relevantWorkingTree": {
     "dirty": false,
     "files": []

--- a/docs/architecture/baselines/agent-system-layered-runtime-baseline.json
+++ b/docs/architecture/baselines/agent-system-layered-runtime-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "goal": "agent-system-layered-runtime",
-  "headCommit": "fb9d8f440812b5b4a667a46130771bc799bd2676",
+  "headCommit": "da311751a416a15ff035a2e678a184563e4cf1fd",
   "relevantWorkingTree": {
     "dirty": false,
     "files": []
@@ -487,7 +487,7 @@
       "src/main/app/mainProcess.ts",
       "src/main/appMain.ts"
     ],
-    "sha256": "9aa65740bd036615370628cb61bb7cb6aacdabcab1f0fd95f0c0b74040eb3418"
+    "sha256": "506b8f26ee2565752f44677d6b9aabc92a3446d780302146133f2597301e836f"
   },
   "dependencyMetrics": {
     "loopFiles": [

--- a/docs/architecture/baselines/dependency-report.md
+++ b/docs/architecture/baselines/dependency-report.md
@@ -1,12 +1,12 @@
 # Dependency Baseline
 
-Generated on 2026-07-25.
+Generated on 2026-07-26.
 
 ## main
 
-- Total files: 683
-- Internal dependency edges: 2182
-- Cycles detected: 10
+- Total files: 684
+- Internal dependency edges: 2183
+- Cycles detected: 9
 
 ### Top outgoing dependencies
 
@@ -19,7 +19,7 @@ Generated on 2026-07-25.
 - `agent/deepchat/harness/runtimeServices.ts`: 26
 - `session/data/database.ts`: 23
 - `agent/deepchat/runtime/compactionRuntimeCoordinator.ts`: 21
-- `agent/deepchat/runtime/interactionCoordinator.ts`: 21
+- `agent/deepchat/runtime/interactionCoordinator.ts`: 20
 - `memory/index.ts`: 20
 - `app/mainProcess.ts`: 18
 - `mcp/inMemoryServers/builder.ts`: 18
@@ -49,7 +49,6 @@ Generated on 2026-07-25.
 - `memory/injection.ts -> memory/core/injectionPort.ts -> memory/types.ts -> memory/injection.ts`
 - `agent/acp/runtime/index.ts -> agent/acp/runtime/acpCompatibilityPromptBuilder.ts -> agent/acp/instance/ports.ts -> agent/acp/runtime/index.ts`
 - `agent/acp/client/acpRuntimeOwner.ts -> agent/acp/client/index.ts -> agent/acp/client/acpRuntimeOwner.ts`
-- `hook/observer.ts -> hook/index.ts -> hook/observer.ts`
 - `desktop/browser/YoBrowserPresenter.ts -> desktop/browser/YoBrowserToolHandler.ts -> desktop/browser/YoBrowserPresenter.ts`
 - `tool/agentTools/agentToolManager.ts -> tool/agentTools/subagentOrchestratorTool.ts -> tool/agentTools/agentToolManager.ts`
 - `tool/agentTools/agentToolManager.ts -> tool/agentTools/agentTapeTools.ts -> tool/agentTools/agentToolManager.ts`

--- a/docs/architecture/baselines/main-kernel-boundary-baseline.md
+++ b/docs/architecture/baselines/main-kernel-boundary-baseline.md
@@ -1,6 +1,6 @@
 # Main Kernel Boundary Baseline
 
-Generated on 2026-07-25.
+Generated on 2026-07-26.
 Current phase: P5.
 
 ## Metric Snapshot

--- a/docs/architecture/baselines/main-kernel-migration-scoreboard.json
+++ b/docs/architecture/baselines/main-kernel-migration-scoreboard.json
@@ -1,6 +1,6 @@
 {
   "program": "main-kernel-refactor",
-  "generatedOn": "2026-07-25",
+  "generatedOn": "2026-07-26",
   "currentPhase": "P5",
   "metrics": {
     "renderer.usePresenter.count": 0,

--- a/docs/architecture/baselines/main-kernel-migration-scoreboard.md
+++ b/docs/architecture/baselines/main-kernel-migration-scoreboard.md
@@ -1,6 +1,6 @@
 # Main Kernel Migration Scoreboard
 
-Generated on 2026-07-25.
+Generated on 2026-07-26.
 Current phase: P5.
 
 Phase 0 establishes the comparison baseline. Later phases should update this report and compare against this checkpoint.

--- a/docs/architecture/baselines/zero-inbound-candidates.md
+++ b/docs/architecture/baselines/zero-inbound-candidates.md
@@ -1,6 +1,6 @@
 # Zero Inbound Candidates
 
-Generated on 2026-07-25.
+Generated on 2026-07-26.
 
 These files have no in-repo importers inside their scope and need manual classification before deletion.
 

--- a/docs/architecture/deepchat-agent-harness-boundaries/plan.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/plan.md
@@ -2,9 +2,61 @@
 
 ## Current Slice
 
-Replace the orchestration root with a thin Harness facade over a one-directional service graph.
-This slice changes no runtime behavior. The typed tool execution contract and the coordinator
-ownership slice below are complete and remain retained records.
+Replace the untyped hook fan-out with a typed deterministic notification pipeline. The typed tool
+execution contract, the coordinator ownership slice, and the Harness facade below are complete and
+remain retained records.
+
+## Typed Hook Notification Pipeline Plan
+
+### Target Layout
+
+```text
+src/main/hook/
+├── events.ts     # canonical HookEvent union with coverage and rejection guards
+├── observer.ts   # isObserved plus typed notify
+├── index.ts      # subscription index, synchronous projection, per-session delivery
+└── routes.ts     # configuration reads and writes through the service
+
+src/main/agent/deepchat/runtime/
+└── runtimeHookSink.ts  # scope factory plus the single terminal projection
+```
+
+### Stage 1: Contract
+
+Add the `HookEvent` union and the two compile-time guards, then replace the observer interface. The
+shared settings module, the renderer surface, and the version 1 payload stay untouched.
+
+### Stage 2: Delivery
+
+Give `HookService` ownership of its configuration and derived subscription index, refreshed
+atomically on every write path. Project and truncate synchronously, clone only the permission
+record, and serialize delivery per session.
+
+### Stage 3: Producers
+
+Turn `RuntimeHookSink` into a scope factory, unify the terminal projection, and migrate the loop,
+turn, interaction, and ACP compatibility producers. Drop the ports each producer no longer needs.
+
+### Validation
+
+```bash
+pnpm exec vitest run --config vitest.config.ts \
+  test/main/hook \
+  test/main/agent/deepchat/runtime/runtimeHookSink.test.ts \
+  test/main/agent/deepchat/runtime/process.test.ts \
+  test/main/agent/deepchat/runtime/dispatch.test.ts \
+  test/main/session/runtimeIntegration.test.ts \
+  test/main/routes/dispatcher.test.ts \
+  test/main/app/compositionBoundaries.test.ts
+pnpm run typecheck
+pnpm run format
+pnpm run i18n
+pnpm run lint
+pnpm test
+```
+
+Verify both compile-time guards by temporarily removing an event variant and by weakening a
+required fact, confirming each fails `typecheck:node` before restoring the contract.
 
 ## Harness Facade Plan
 
@@ -348,7 +400,8 @@ silently reverted.
 
 ## Later Slices
 
-After the harness facade lands in `dev`, a later branch may extend this architecture record for
-typed hook reduction over the stabilized owner graph. That slice designs its own restricted hook
-context facades; it must not expose the composed service graph as a container, and it must not be
-implemented or coupled to the current branch. Same-run steering remains a separate feature design.
+Hook decision semantics remain unscheduled. Letting a hook block, replace, cancel, or rewrite a
+provider request or tool arguments needs a versioned stdout protocol, a conflict and timeout policy,
+argument revalidation, a permission recheck after rewriting, and a trust surface in settings. That
+is a product feature with its own security model and must not be folded into a delivery contract.
+Same-run steering remains a separate feature design.

--- a/docs/architecture/deepchat-agent-harness-boundaries/spec.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/spec.md
@@ -392,22 +392,31 @@ That weak contract produced measurable defects:
 
 ### Event Contract
 
-`HookEvent` is a discriminated union of one session envelope and one event body. Each body carries
-exactly the facts its event defines, so tool facts cannot ride on `Stop` and `PreToolUse` cannot omit
-them. Two compile-time guards keep it honest: one fails when the union and `HOOK_EVENT_NAMES` drift
-apart in either direction, and one pins the combinations the union must refuse. Surplus fields on an
-event literal are refused by excess property checking at the emit site, which no type-level assertion
-can express.
+`HookEvent` is a discriminated union of one session envelope and one event body. Each variant is
+closed against every fact it does not declare, so tool facts cannot ride on `Stop` and `PreToolUse`
+cannot omit them. Closing the variants matters because excess property checking alone only refuses
+surplus fields on a fresh literal: a variable carrying both `stop` and `tool` would otherwise
+satisfy the union. Two compile-time guards keep it honest: one fails when the union and
+`HOOK_EVENT_NAMES` drift apart in either direction, and one pins the combinations the union must
+refuse, for both missing and foreign facts.
 
 `HookEventName`, the settings shape, and the `payloadVersion: 1` wire payload are unchanged, because
 they are the renderer contract and the user script contract respectively.
 
 ### Runtime Scope
 
-`RuntimeHookSink` becomes a factory for `RuntimeHookScope`, which binds the immutable session facts
-of one turn: session and message identity, provider, model, agent, and working directory. The scope
-holds no service graph, persists nothing, and duplicates no runtime state. Producers emit event
-bodies against it, so no call site assembles an envelope.
+`RuntimeHookSink` becomes a factory for `RuntimeHookScope`, a bound emitter that resolves one session
+envelope once for the producer that created it: session and message identity, provider, model,
+agent, and working directory. The scope holds no service graph, persists nothing, and duplicates no
+runtime state. Producers emit event bodies against it, so no emit site assembles an envelope
+field by field.
+
+The scope is per producer, not per turn. A normal turn creates three: `TurnCoordinator` for the
+submitted prompt, `DeepChatLoopRunner` for the run and its tool facts, and
+`RuntimeHookSink.observeTerminal` for settlement, which reaches the sink from
+`RunLifecycleCoordinator` without the turn's scope. Threading one scope through the run lifecycle
+would add a new state carrier to that owner and is out of this slice, so a setting changed mid-turn
+can still be observed by later events of the same turn.
 
 The scope resolves the working directory lazily and once. An unobserved event resolves nothing, and
 a resolution failure leaves the directory unanswered rather than dropping the notification, so
@@ -441,6 +450,18 @@ and unrelated sessions never wait for each other. The guarantee is event accepta
 order; completion order of external processes is not ordered, no hook is awaited, and Agent tool
 execution never blocks on one.
 
+Configuration is owned at acceptance, not at delivery. An accepted event carries the identity and
+command of every hook eligible at that moment, and delivery runs a hook only when it is still
+eligible under the same command. A hook enabled or edited after an event happened therefore never
+receives it, and one disabled while the event was queued stops receiving it. Because enrichment is
+asynchronous, that revalidation is settled immediately before spawning rather than when the delivery
+was dequeued.
+
+A hook command that outlives its timeout settles its own result. A killed shell can keep a process
+tree alive and never emit `close`, so waiting for exit could leave the settings test call pending
+forever. Captured stdout and stderr are bounded by the diagnostic limit they are truncated to, so a
+command that streams for its whole timeout window cannot grow main-process memory without bound.
+
 Fault isolation stays layered rather than collapsed. The loop guards its notification boundary, the
 scope guards the runtime boundary so no hook failure reaches settlement, the service guards each
 queued delivery, and each hook command is isolated from its siblings and from the next event.
@@ -449,7 +470,7 @@ queued delivery, and each hook command is isolated from its siblings and from th
 
 | Correction | Previous behavior | Required behavior and rationale |
 | --- | --- | --- |
-| Terminal drift | Four independent `Stop` plus `SessionEnd` implementations computed their own reason, and the ACP path omitted `usage`. | One projection owns the pair, so `usage` and `error` no longer depend on the entry point. |
+| Terminal drift | Four independent `Stop` plus `SessionEnd` implementations computed their own reason and fallbacks, and each could drift again. | One projection owns the pair and normalizes a missing `usage` or `error` to an explicit null. ACP still reports `usage: null` because `AcpObserverPort.terminal` carries no token accounting; giving ACP real usage needs protocol design and is not part of this slice. |
 | Assistant text as prompt preview | An event carrying a message id but no preview read that message and reported its text as `user.promptPreview`. Every producer passes an assistant message id, so the fallback was wrong at every call site and cost a row read per event. | Prompt previews come from the producer that owns the prompt. The message lookup and its query port are removed; `user.messageId` is unchanged. |
 | Answered null project directory | Enrichment triggered whenever `workdir` was falsy, so an explicit null cost a session read that returned null. | Only an unanswered field triggers a lookup. |
 | Unguarded envelope resolution | `observeTerminal` resolved the project directory outside the sink's guard, so a stale-instance assertion could propagate into run settlement. | Envelope resolution happens inside the guarded region and degrades to an unanswered field. |
@@ -465,6 +486,8 @@ captured when the event occurs rather than when its payload is assembled.
 | --- | --- | --- |
 | Hydrating project-directory read | `resolveProjectDir` reaches `getOrHydrateScope`, so resolving a hook envelope can recreate a runtime instance for an evicted session. | Pre-existing. The subscription gate removes the call entirely for unconfigured installations; making the read non-hydrating changes `SessionSettingsCoordinator` and belongs to its own change. |
 | Hook command environment inheritance | Hook commands spawn with the full parent environment, so any secret in the Agent process environment is visible to them. | Pre-existing and out of scope for a delivery contract. Closing it requires an allowlist design and a settings surface. |
+| Orphaned process trees | A timed-out command is killed with `SIGKILL` on the shell only, so grandchildren can survive and keep the child registered until the process exits. | The result no longer depends on that exit. Killing the whole tree and bounding concurrent hook processes is separate reliability work. |
+| Per-turn envelope resolution | Three producers each resolve their own envelope, so a setting changed mid-turn can be observed by later events of the same turn. | Accepted. Threading one scope through the run lifecycle adds a state carrier to `RunLifecycleCoordinator` and belongs to its own change. |
 
 ## Typed Hook Notification Pipeline Goals
 
@@ -676,19 +699,23 @@ execution continues to settle independently and commit results in provider call 
 
 ## Typed Hook Notification Pipeline Acceptance Criteria
 
-1. `HookEvent` correlates every event name with its payload, and the coverage and rejection guards
-   fail compilation when a name loses its body variant or a required fact becomes optional.
-2. No producer assembles a session envelope, and `Stop` plus `SessionEnd` has one implementation
-   that all four previous entry points reach.
+1. `HookEvent` correlates every event name with its payload, refuses a foreign fact through a
+   variable as well as a literal, and the coverage and rejection guards fail compilation when a name
+   loses its body variant or a required fact becomes optional.
+2. No emit site assembles a session envelope field by field, and `Stop` plus `SessionEnd` has one
+   implementation that all four previous entry points reach.
 3. An event with no enabled subscriber performs one subscription lookup and nothing else: no
    envelope resolution, projection, clone, settings read, session read, or spawn.
 4. A configuration write through the service refreshes the subscription index atomically, and a
    write that bypasses the service is picked up by the next explicit refresh or service restart.
+   A hook enabled or edited after an event was accepted never receives that event, and a hook
+   disabled while the event was queued does not run it.
 5. Tool previews are truncated before any clone, and the permission record receives the only clone.
 6. Events of one session start their commands in emission order under delayed enrichment, and a
    stalled session does not delay another.
 7. A hook command that fails to spawn, times out, or throws does not stall its siblings or the next
-   event, and no hook failure reaches run settlement.
+   event, and no hook failure reaches run settlement. A timed-out command settles its own result
+   without waiting for an exit that may never arrive, and captured diagnostics stay bounded.
 8. `payloadVersion`, the stdin payload shape, environment variables, command placeholders, the
    command timeout, and the settings contract are unchanged; `user.promptPreview` reports only a
    prompt the producer supplied.

--- a/docs/architecture/deepchat-agent-harness-boundaries/spec.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/spec.md
@@ -8,10 +8,10 @@ string convention instead of the tool catalog that owns tool capabilities. A ren
 or new read-only tool therefore requires runtime knowledge that does not belong in dispatch.
 
 This architecture goal establishes stable contracts around the DeepChat Agent harness over
-multiple short-lived pull requests. The typed tool execution contract and the coordinator ownership
-slice are complete. The current slice replaces the orchestration root with a thin Harness facade
-over a one-directional service graph, and is a strict zero-behavior-change refactor. Typed hooks
-and same-run steering remain separate changes.
+multiple short-lived pull requests. The typed tool execution contract, the coordinator ownership
+slice, and the Harness facade are complete. The current slice replaces the untyped hook fan-out with
+a typed deterministic notification pipeline. Same-run steering remains a separate change, and hook
+decision semantics remain an unscheduled product feature rather than part of this goal.
 
 ## Comparative Evidence
 
@@ -360,6 +360,120 @@ not be smuggled into a graph rewrite.
 - Leave a stable service layer for a later typed hook reducer without exposing that layer as a
   service locator.
 
+## Typed Hook Notification Pipeline Slice
+
+### Problem
+
+Hooks are user-configured shell commands that observe the Agent lifecycle. The contract that reaches
+them is a single flat `HookContext` whose fields are all optional, so the event name and its payload
+are uncorrelated. `dispatch('Stop', { tool })` compiles, `dispatch('PreToolUse', { sessionId })`
+compiles, and adding a name to `HOOK_EVENT_NAMES` fails no build.
+
+That weak contract produced measurable defects:
+
+- Every dispatch site hand-assembles the session envelope, and the `Stop` plus `SessionEnd` pair has
+  four independent implementations in `runtimeHookSink`, `turnCoordinator`, `interactionCoordinator`,
+  and the ACP compatibility path. The ACP copy already dropped `usage`.
+- `HookService` re-read `hooksNotifications` on every event. That key is a sensitive app setting, so
+  each read is a database read plus a JSON deep clone, a Zod normalization, and two `JSON.stringify`
+  calls, performed twice per tool call even when no hook is configured.
+- A tool event was `structuredClone`d three times before truncation, so multi-megabyte tool
+  arguments and responses were copied for a payload that keeps 1200 characters of each.
+- Payload enrichment read the session row whenever `workdir` was falsy, so a session with no project
+  directory paid a database read per event.
+- The `messageId` to `promptPreview` fallback read a message row and described the assistant's own
+  output as the user's prompt, because every producer passes an assistant message id.
+- Events were dispatched through independent microtasks with per-event asynchronous enrichment, so
+  the order in which hook commands started did not match the order in which events happened.
+- Three nested layers repeated the same defensive catch with two different loggers, while
+  `dispatchEvent` remained a public untyped bypass of the runtime sink.
+- `observeTerminal` resolved the project directory as an argument expression outside the sink's
+  guard, so an envelope failure could propagate into run settlement.
+
+### Event Contract
+
+`HookEvent` is a discriminated union of one session envelope and one event body. Each body carries
+exactly the facts its event defines, so tool facts cannot ride on `Stop` and `PreToolUse` cannot omit
+them. Two compile-time guards keep it honest: one fails when the union and `HOOK_EVENT_NAMES` drift
+apart in either direction, and one pins the combinations the union must refuse. Surplus fields on an
+event literal are refused by excess property checking at the emit site, which no type-level assertion
+can express.
+
+`HookEventName`, the settings shape, and the `payloadVersion: 1` wire payload are unchanged, because
+they are the renderer contract and the user script contract respectively.
+
+### Runtime Scope
+
+`RuntimeHookSink` becomes a factory for `RuntimeHookScope`, which binds the immutable session facts
+of one turn: session and message identity, provider, model, agent, and working directory. The scope
+holds no service graph, persists nothing, and duplicates no runtime state. Producers emit event
+bodies against it, so no call site assembles an envelope.
+
+The scope resolves the working directory lazily and once. An unobserved event resolves nothing, and
+a resolution failure leaves the directory unanswered rather than dropping the notification, so
+delivery can still resolve it from the session row.
+
+`RuntimeHookScope.terminal` is the single terminal projection. Every settled turn, whatever its entry
+point, reports `Stop` then `SessionEnd` through it.
+
+The loop keeps its own tool-fact vocabulary. `DeepChatLoopNotification` describes what a tool batch
+did, not what a hook consumes, and the scope's tool observer is the one adapter between them. Making
+the loop import the hook contract to remove a structural duplicate would trade a real layer boundary
+for cosmetic reuse.
+
+### Delivery Semantics
+
+`HookService` owns its configuration as state instead of re-reading a store per event. The
+configuration and the derived subscription index are rebuilt as one unit, so a subscription probe
+can never disagree with the hooks the delivery path will run. Every write path refreshes it
+atomically: the routes write through the service, and `start()` covers the maintenance window that
+already brackets configuration import.
+
+`isObserved` is a synchronous set lookup exposed to producers. An unsubscribed event costs one
+lookup: no envelope resolution, no projection, no clone, no database read, and no spawn.
+
+An observed event is projected synchronously into detached wire facts, with previews truncated
+first, so no oversized string reaches a clone. The permission record is the only field of unbounded
+shape and receives the single bounded clone.
+
+Delivery is serialized per session. Events of one session reach their commands in emission order,
+and unrelated sessions never wait for each other. The guarantee is event acceptance and command start
+order; completion order of external processes is not ordered, no hook is awaited, and Agent tool
+execution never blocks on one.
+
+Fault isolation stays layered rather than collapsed. The loop guards its notification boundary, the
+scope guards the runtime boundary so no hook failure reaches settlement, the service guards each
+queued delivery, and each hook command is isolated from its siblings and from the next event.
+
+### Included Corrections
+
+| Correction | Previous behavior | Required behavior and rationale |
+| --- | --- | --- |
+| Terminal drift | Four independent `Stop` plus `SessionEnd` implementations computed their own reason, and the ACP path omitted `usage`. | One projection owns the pair, so `usage` and `error` no longer depend on the entry point. |
+| Assistant text as prompt preview | An event carrying a message id but no preview read that message and reported its text as `user.promptPreview`. Every producer passes an assistant message id, so the fallback was wrong at every call site and cost a row read per event. | Prompt previews come from the producer that owns the prompt. The message lookup and its query port are removed; `user.messageId` is unchanged. |
+| Answered null project directory | Enrichment triggered whenever `workdir` was falsy, so an explicit null cost a session read that returned null. | Only an unanswered field triggers a lookup. |
+| Unguarded envelope resolution | `observeTerminal` resolved the project directory outside the sink's guard, so a stale-instance assertion could propagate into run settlement. | Envelope resolution happens inside the guarded region and degrades to an unanswered field. |
+
+`user.promptPreview` therefore becomes empty for tool events and for a resumed `SessionStart`, where
+it previously contained assistant output. The payload shape, `payloadVersion`, environment variables,
+command placeholders, command timeout, redaction, and settings contract are unchanged. `time` is now
+captured when the event occurs rather than when its payload is assembled.
+
+### Deferred Findings
+
+| Finding | Observation | Current handling |
+| --- | --- | --- |
+| Hydrating project-directory read | `resolveProjectDir` reaches `getOrHydrateScope`, so resolving a hook envelope can recreate a runtime instance for an evicted session. | Pre-existing. The subscription gate removes the call entirely for unconfigured installations; making the read non-hydrating changes `SessionSettingsCoordinator` and belongs to its own change. |
+| Hook command environment inheritance | Hook commands spawn with the full parent environment, so any secret in the Agent process environment is visible to them. | Pre-existing and out of scope for a delivery contract. Closing it requires an allowlist design and a settings surface. |
+
+## Typed Hook Notification Pipeline Goals
+
+- Make the event name and its payload one value that cannot describe an impossible event.
+- Give the terminal projection, and every session envelope, exactly one implementation.
+- Make an unconfigured installation pay one map lookup per event.
+- Make delivery order within a session deterministic without coupling sessions or blocking the Agent.
+- Keep the user-facing hook contract, including the version 1 payload, byte-compatible.
+
 ## Typed Tool Execution Contract Goals (Completed)
 
 - Define one canonical, typed execution contract for every `MCPToolDefinition`.
@@ -473,8 +587,13 @@ execution continues to settle independently and commit results in provider call 
   above while extracting runtime owners.
 - Do not add a Pi-style `run`/`steer`/`followUp`/`subscribe` vocabulary or any third event channel;
   the facade implements the existing manager and session contracts only.
-- Do not pass the composed service graph to hooks as a container. A later typed hook slice designs
-  its own restricted context facades.
+- Do not pass the composed service graph to hooks as a container. `RuntimeHookScope` carries
+  immutable session facts only.
+- Do not give hooks a decision channel. Blocking, replacing, cancelling, or rewriting provider
+  requests and tool arguments would require a versioned stdout protocol, a conflict and timeout
+  policy, argument revalidation, permission recheck after rewriting, and a trust surface. It is a
+  product feature with its own security model, not part of a delivery contract, and DeepChat has no
+  in-process participant that could use it today.
 - Do not fix defects discovered while moving code beyond the narrow final-review corrections listed
   above; record them and open a separate branch.
 - Do not move durable pending inputs into `DeepChatAgentInstance` or add another source of truth.
@@ -554,3 +673,24 @@ execution continues to settle independently and commit results in provider call 
     harness module pair import each other, including type-only imports.
 12. Focused owner suites, the full main-process suite, type checks, formatting, i18n validation,
     lint, the agent cleanup guard, and a regenerated layered-runtime baseline pass before handoff.
+
+## Typed Hook Notification Pipeline Acceptance Criteria
+
+1. `HookEvent` correlates every event name with its payload, and the coverage and rejection guards
+   fail compilation when a name loses its body variant or a required fact becomes optional.
+2. No producer assembles a session envelope, and `Stop` plus `SessionEnd` has one implementation
+   that all four previous entry points reach.
+3. An event with no enabled subscriber performs one subscription lookup and nothing else: no
+   envelope resolution, projection, clone, settings read, session read, or spawn.
+4. A configuration write through the service refreshes the subscription index atomically, and a
+   write that bypasses the service is picked up by the next explicit refresh or service restart.
+5. Tool previews are truncated before any clone, and the permission record receives the only clone.
+6. Events of one session start their commands in emission order under delayed enrichment, and a
+   stalled session does not delay another.
+7. A hook command that fails to spawn, times out, or throws does not stall its siblings or the next
+   event, and no hook failure reaches run settlement.
+8. `payloadVersion`, the stdin payload shape, environment variables, command placeholders, the
+   command timeout, and the settings contract are unchanged; `user.promptPreview` reports only a
+   prompt the producer supplied.
+9. Focused suites, the full main-process suite, type checks, formatting, i18n validation, lint, and
+   the agent cleanup guard pass, and executed test count does not drop.

--- a/docs/architecture/deepchat-agent-harness-boundaries/tasks.md
+++ b/docs/architecture/deepchat-agent-harness-boundaries/tasks.md
@@ -84,8 +84,23 @@
 - [x] Run focused and full validation, review the complete diff, and disposition every finding.
 - [x] Commit every reviewed stage without pushing.
 
+## Typed Hook Notification Pipeline
+
+- [x] Record the 16-test hook baseline and enumerate the contract, ordering, and cost defects.
+- [x] Specify the event contract, runtime scope, delivery semantics, corrections, and non-goals.
+- [x] Add the canonical `HookEvent` union with coverage and rejection guards.
+- [x] Replace the untyped observer contract with `isObserved` plus a typed `notify`.
+- [x] Make `HookService` own its configuration and derived subscription index with atomic refresh.
+- [x] Project and truncate synchronously, then clone only the permission record.
+- [x] Serialize delivery per session without coupling sessions or awaiting hook commands.
+- [x] Turn `RuntimeHookSink` into a scope factory and unify the terminal projection.
+- [x] Migrate the loop, turn, interaction, and ACP compatibility producers onto the scope.
+- [x] Route hook configuration writes through the service and drop the unused message query port.
+- [x] Add subscription, ordering, projection, terminal parity, and resilience coverage.
+- [x] Run focused and full validation, review the complete diff, and disposition every finding.
+- [x] Commit every reviewed stage without pushing.
+
 ## Future Pull Requests
 
-- [ ] Add typed deterministic hook/event reduction with restricted hook context facades over the
-      stabilized owner graph.
+- [ ] Design hook decision semantics separately if the product and security model are approved.
 - [ ] Design same-run steering separately if the product semantics are approved.

--- a/resources/acp-registry/registry.json
+++ b/resources/acp-registry/registry.json
@@ -487,7 +487,7 @@
     {
       "id": "dirac",
       "name": "Dirac",
-      "version": "0.4.24",
+      "version": "0.4.25",
       "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
       "repository": "https://github.com/dirac-run/dirac",
       "website": "https://dirac.run",
@@ -498,7 +498,7 @@
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/dirac.svg",
       "distribution": {
         "npx": {
-          "package": "dirac-cli@0.4.24",
+          "package": "dirac-cli@0.4.25",
           "args": [
             "--acp"
           ]

--- a/resources/model-db/providers.json
+++ b/resources/model-db/providers.json
@@ -5684,6 +5684,47 @@
           "type": "chat"
         },
         {
+          "id": "anthropic/claude-opus-5",
+          "name": "Claude Opus 5",
+          "display_name": "Claude Opus 5",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "temperature": false,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true
+            }
+          },
+          "attachment": true,
+          "open_weights": false,
+          "knowledge": "2026-05",
+          "release_date": "2026-07-24",
+          "last_updated": "2026-07-24",
+          "cost": {
+            "input": 5,
+            "output": 25,
+            "cache_read": 0.5,
+            "cache_write": 6.25
+          },
+          "type": "chat"
+        },
+        {
           "id": "z-ai/glm-5",
           "name": "GLM-5",
           "display_name": "GLM-5",
@@ -78802,8 +78843,8 @@
           "release_date": "2026-06-12",
           "last_updated": "2026-06-12",
           "cost": {
-            "input": 0.82,
-            "output": 3.75,
+            "input": 0.78,
+            "output": 3.5,
             "cache_read": 0.15,
             "cache_write": 0
           },
@@ -99827,151 +99868,6 @@
           "type": "embedding"
         },
         {
-          "id": "llama-3.2-11b-vision-instruct",
-          "name": "Llama-3.2-11B-Vision-Instruct",
-          "display_name": "Llama-3.2-11B-Vision-Instruct",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 8192
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": true,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-09-25",
-          "last_updated": "2024-09-25",
-          "cost": {
-            "input": 0.37,
-            "output": 0.37
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-4",
-          "name": "GPT-4",
-          "display_name": "GPT-4",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 8192,
-            "output": 8192
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2023-11",
-          "release_date": "2023-03-14",
-          "last_updated": "2023-03-14",
-          "cost": {
-            "input": 60,
-            "output": 120
-          },
-          "type": "chat"
-        },
-        {
-          "id": "phi-3-medium-128k-instruct",
-          "name": "Phi-3-medium-instruct (128k)",
-          "display_name": "Phi-3-medium-instruct (128k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.17,
-            "output": 0.68
-          },
-          "type": "chat"
-        },
-        {
-          "id": "o1-mini",
-          "name": "o1-mini",
-          "display_name": "o1-mini",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 65536
-          },
-          "temperature": false,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "mode": "effort",
-              "effort": "medium",
-              "effort_options": [
-                "low",
-                "medium",
-                "high"
-              ],
-              "visibility": "hidden"
-            }
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2023-09",
-          "release_date": "2024-09-12",
-          "last_updated": "2024-09-12",
-          "cost": {
-            "input": 1.1,
-            "output": 4.4,
-            "cache_read": 0.55
-          },
-          "type": "chat"
-        },
-        {
           "id": "cohere-command-a",
           "name": "Command A",
           "display_name": "Command A",
@@ -100050,70 +99946,6 @@
             "input": 1.1,
             "output": 4.4,
             "cache_read": 0.275
-          },
-          "type": "chat"
-        },
-        {
-          "id": "meta-llama-3.1-70b-instruct",
-          "name": "Meta-Llama-3.1-70B-Instruct",
-          "display_name": "Meta-Llama-3.1-70B-Instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 32768
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-07-23",
-          "last_updated": "2024-07-23",
-          "cost": {
-            "input": 2.68,
-            "output": 3.54
-          },
-          "type": "chat"
-        },
-        {
-          "id": "meta-llama-3.1-405b-instruct",
-          "name": "Meta-Llama-3.1-405B-Instruct",
-          "display_name": "Meta-Llama-3.1-405B-Instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 32768
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-07-23",
-          "last_updated": "2024-07-23",
-          "cost": {
-            "input": 5.33,
-            "output": 16
           },
           "type": "chat"
         },
@@ -100328,38 +100160,6 @@
           "type": "chat"
         },
         {
-          "id": "meta-llama-3-8b-instruct",
-          "name": "Meta-Llama-3-8B-Instruct",
-          "display_name": "Meta-Llama-3-8B-Instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 8192,
-            "output": 2048
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-04-18",
-          "last_updated": "2024-04-18",
-          "cost": {
-            "input": 0.3,
-            "output": 0.61
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-5-nano",
           "name": "GPT-5 Nano",
           "display_name": "GPT-5 Nano",
@@ -100412,38 +100212,6 @@
             "input": 0.05,
             "output": 0.4,
             "cache_read": 0.01
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-3.5-turbo-0301",
-          "name": "GPT-3.5 Turbo 0301",
-          "display_name": "GPT-3.5 Turbo 0301",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 4096,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2021-08",
-          "release_date": "2023-03-01",
-          "last_updated": "2023-03-01",
-          "cost": {
-            "input": 1.5,
-            "output": 2
           },
           "type": "chat"
         },
@@ -100503,83 +100271,6 @@
             "input": 1.25,
             "output": 10,
             "cache_read": 0.125
-          },
-          "type": "chat"
-        },
-        {
-          "id": "kimi-k2-thinking",
-          "name": "Kimi K2 Thinking",
-          "display_name": "Kimi K2 Thinking",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 262144,
-            "output": 262144
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "interleaved": true,
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": [
-                "thinking_blocks"
-              ]
-            }
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-08",
-          "release_date": "2025-11-06",
-          "last_updated": "2025-12-02",
-          "cost": {
-            "input": 0.6,
-            "output": 2.5,
-            "cache_read": 0.15
-          },
-          "type": "chat"
-        },
-        {
-          "id": "cohere-command-r-plus-08-2024",
-          "name": "Command R+",
-          "display_name": "Command R+",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4000
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-06-01",
-          "release_date": "2024-08-30",
-          "last_updated": "2024-08-30",
-          "cost": {
-            "input": 2.5,
-            "output": 10
           },
           "type": "chat"
         },
@@ -100704,71 +100395,6 @@
             "input": 1.25,
             "output": 10,
             "cache_read": 0.125
-          },
-          "type": "chat"
-        },
-        {
-          "id": "meta-llama-3.1-8b-instruct",
-          "name": "Meta-Llama-3.1-8B-Instruct",
-          "display_name": "Meta-Llama-3.1-8B-Instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 32768
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-07-23",
-          "last_updated": "2024-07-23",
-          "cost": {
-            "input": 0.3,
-            "output": 0.61
-          },
-          "type": "chat"
-        },
-        {
-          "id": "llama-3.2-90b-vision-instruct",
-          "name": "Llama-3.2-90B-Vision-Instruct",
-          "display_name": "Llama-3.2-90B-Vision-Instruct",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 8192
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": true,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-09-25",
-          "last_updated": "2024-09-25",
-          "cost": {
-            "input": 2.04,
-            "output": 2.04
           },
           "type": "chat"
         },
@@ -100918,38 +100544,6 @@
           "type": "chat"
         },
         {
-          "id": "phi-3-small-8k-instruct",
-          "name": "Phi-3-small-instruct (8k)",
-          "display_name": "Phi-3-small-instruct (8k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 8192,
-            "output": 2048
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.15,
-            "output": 0.6
-          },
-          "type": "chat"
-        },
-        {
           "id": "deepseek-r1",
           "name": "DeepSeek-R1",
           "display_name": "DeepSeek-R1",
@@ -100990,38 +100584,6 @@
           "cost": {
             "input": 1.35,
             "output": 5.4
-          },
-          "type": "chat"
-        },
-        {
-          "id": "phi-3-small-128k-instruct",
-          "name": "Phi-3-small-instruct (128k)",
-          "display_name": "Phi-3-small-instruct (128k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.15,
-            "output": 0.6
           },
           "type": "chat"
         },
@@ -101132,38 +100694,6 @@
           "type": "chat"
         },
         {
-          "id": "phi-3-mini-128k-instruct",
-          "name": "Phi-3-mini-instruct (128k)",
-          "display_name": "Phi-3-mini-instruct (128k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.13,
-            "output": 0.52
-          },
-          "type": "chat"
-        },
-        {
           "id": "mistral-small-2503",
           "name": "Mistral Small 3.1",
           "display_name": "Mistral Small 3.1",
@@ -101193,70 +100723,6 @@
           "cost": {
             "input": 0.1,
             "output": 0.3
-          },
-          "type": "chat"
-        },
-        {
-          "id": "meta-llama-3-70b-instruct",
-          "name": "Meta-Llama-3-70B-Instruct",
-          "display_name": "Meta-Llama-3-70B-Instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 8192,
-            "output": 2048
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-04-18",
-          "last_updated": "2024-04-18",
-          "cost": {
-            "input": 2.68,
-            "output": 3.54
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-4-32k",
-          "name": "GPT-4 32K",
-          "display_name": "GPT-4 32K",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 32768,
-            "output": 32768
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2023-11",
-          "release_date": "2023-03-14",
-          "last_updated": "2023-03-14",
-          "cost": {
-            "input": 60,
-            "output": 120
           },
           "type": "chat"
         },
@@ -101380,70 +100846,6 @@
           "type": "chat"
         },
         {
-          "id": "mistral-nemo",
-          "name": "Mistral Nemo",
-          "display_name": "Mistral Nemo",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 128000
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-07",
-          "release_date": "2024-07-18",
-          "last_updated": "2024-07-18",
-          "cost": {
-            "input": 0.15,
-            "output": 0.15
-          },
-          "type": "chat"
-        },
-        {
-          "id": "deepseek-v3-0324",
-          "name": "DeepSeek-V3-0324",
-          "display_name": "DeepSeek-V3-0324",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 131072,
-            "output": 131072
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-07",
-          "release_date": "2025-03-24",
-          "last_updated": "2025-03-24",
-          "cost": {
-            "input": 1.14,
-            "output": 4.56
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-5.2-codex",
           "name": "GPT-5.2 Codex",
           "display_name": "GPT-5.2 Codex",
@@ -101492,41 +100894,6 @@
           "knowledge": "2025-08-31",
           "release_date": "2026-01-14",
           "last_updated": "2026-01-14",
-          "cost": {
-            "input": 1.75,
-            "output": 14,
-            "cache_read": 0.175
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-5.2-chat",
-          "name": "GPT-5.2 Chat",
-          "display_name": "GPT-5.2 Chat",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 16384
-          },
-          "temperature": false,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "attachment": true,
-          "open_weights": false,
-          "knowledge": "2025-08-31",
-          "release_date": "2025-12-11",
-          "last_updated": "2025-12-11",
           "cost": {
             "input": 1.75,
             "output": 14,
@@ -101597,82 +100964,6 @@
           "cost": {
             "input": 10,
             "output": 30
-          },
-          "type": "chat"
-        },
-        {
-          "id": "deepseek-r1-0528",
-          "name": "DeepSeek-R1-0528",
-          "display_name": "DeepSeek-R1-0528",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 163840,
-            "output": 163840
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "interleaved": true,
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": [
-                "thinking_blocks"
-              ]
-            }
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-07",
-          "release_date": "2025-05-28",
-          "last_updated": "2025-05-28",
-          "cost": {
-            "input": 1.35,
-            "output": 5.4
-          },
-          "type": "chat"
-        },
-        {
-          "id": "phi-3-mini-4k-instruct",
-          "name": "Phi-3-mini-instruct (4k)",
-          "display_name": "Phi-3-mini-instruct (4k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 4096,
-            "output": 1024
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.13,
-            "output": 0.52
           },
           "type": "chat"
         },
@@ -101761,76 +101052,6 @@
             "input": 1.25,
             "output": 10,
             "cache_read": 0.13
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-5.1-chat",
-          "name": "GPT-5.1 Chat",
-          "display_name": "GPT-5.1 Chat",
-          "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "image",
-              "audio"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 16384
-          },
-          "temperature": false,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "attachment": true,
-          "open_weights": false,
-          "knowledge": "2024-09-30",
-          "release_date": "2025-11-14",
-          "last_updated": "2025-11-14",
-          "cost": {
-            "input": 1.25,
-            "output": 10,
-            "cache_read": 0.125
-          },
-          "type": "chat"
-        },
-        {
-          "id": "phi-3.5-moe-instruct",
-          "name": "Phi-3.5-MoE-instruct",
-          "display_name": "Phi-3.5-MoE-instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-08-20",
-          "last_updated": "2024-08-20",
-          "cost": {
-            "input": 0.16,
-            "output": 0.64
           },
           "type": "chat"
         },
@@ -102024,38 +101245,6 @@
           "type": "chat"
         },
         {
-          "id": "gpt-3.5-turbo-0613",
-          "name": "GPT-3.5 Turbo 0613",
-          "display_name": "GPT-3.5 Turbo 0613",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 16384,
-            "output": 16384
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2021-08",
-          "release_date": "2023-06-13",
-          "last_updated": "2023-06-13",
-          "cost": {
-            "input": 3,
-            "output": 4
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-5.5",
           "name": "GPT-5.5",
           "display_name": "GPT-5.5",
@@ -102125,38 +101314,6 @@
               "output": 45,
               "cache_read": 1
             }
-          },
-          "type": "chat"
-        },
-        {
-          "id": "mistral-large-2411",
-          "name": "Mistral Large 24.11",
-          "display_name": "Mistral Large 24.11",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 32768
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2024-09",
-          "release_date": "2024-11-01",
-          "last_updated": "2024-11-01",
-          "cost": {
-            "input": 2,
-            "output": 6
           },
           "type": "chat"
         },
@@ -102237,38 +101394,6 @@
             "input": 1.1,
             "output": 4.4,
             "cache_read": 0.55
-          },
-          "type": "chat"
-        },
-        {
-          "id": "cohere-command-r-08-2024",
-          "name": "Command R",
-          "display_name": "Command R",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4000
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-06-01",
-          "release_date": "2024-08-30",
-          "last_updated": "2024-08-30",
-          "cost": {
-            "input": 0.15,
-            "output": 0.6
           },
           "type": "chat"
         },
@@ -102401,70 +101526,6 @@
           "type": "chat"
         },
         {
-          "id": "phi-3-medium-4k-instruct",
-          "name": "Phi-3-medium-instruct (4k)",
-          "display_name": "Phi-3-medium-instruct (4k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 4096,
-            "output": 1024
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.17,
-            "output": 0.68
-          },
-          "type": "chat"
-        },
-        {
-          "id": "phi-3.5-mini-instruct",
-          "name": "Phi-3.5-mini-instruct",
-          "display_name": "Phi-3.5-mini-instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-08-20",
-          "last_updated": "2024-08-20",
-          "cost": {
-            "input": 0.13,
-            "output": 0.52
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-4.1-nano",
           "name": "GPT-4.1 nano",
           "display_name": "GPT-4.1 nano",
@@ -102529,46 +101590,6 @@
           "type": "embedding"
         },
         {
-          "id": "grok-4-fast-reasoning",
-          "name": "Grok 4 Fast (Reasoning)",
-          "display_name": "Grok 4 Fast (Reasoning)",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 2000000,
-            "output": 30000
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true
-            }
-          },
-          "attachment": true,
-          "open_weights": false,
-          "knowledge": "2025-07",
-          "release_date": "2025-09-19",
-          "last_updated": "2025-09-19",
-          "cost": {
-            "input": 0.2,
-            "output": 0.5,
-            "cache_read": 0.05
-          },
-          "type": "chat"
-        },
-        {
           "id": "phi-4-multimodal",
           "name": "Phi-4-multimodal",
           "display_name": "Phi-4-multimodal",
@@ -102600,41 +101621,6 @@
             "input": 0.08,
             "output": 0.32,
             "input_audio": 4
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-5-chat",
-          "name": "GPT-5 Chat",
-          "display_name": "GPT-5 Chat",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 16384
-          },
-          "temperature": false,
-          "tool_call": false,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "attachment": true,
-          "open_weights": false,
-          "knowledge": "2024-10-24",
-          "release_date": "2025-08-07",
-          "last_updated": "2025-08-07",
-          "cost": {
-            "input": 1.25,
-            "output": 10,
-            "cache_read": 0.13
           },
           "type": "chat"
         },
@@ -102737,39 +101723,6 @@
             "input": 0.4,
             "output": 1.6,
             "cache_read": 0.1
-          },
-          "type": "chat"
-        },
-        {
-          "id": "deepseek-v3.1",
-          "name": "DeepSeek-V3.1",
-          "display_name": "DeepSeek-V3.1",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 131072,
-            "output": 131072
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-07",
-          "release_date": "2025-08-21",
-          "last_updated": "2025-08-21",
-          "cost": {
-            "input": 0.56,
-            "output": 1.68
           },
           "type": "chat"
         },
@@ -116381,39 +115334,6 @@
           "type": "chat"
         },
         {
-          "id": "deepseek-v3.1",
-          "name": "DeepSeek-V3.1",
-          "display_name": "DeepSeek-V3.1",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 131072,
-            "output": 131072
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-07",
-          "release_date": "2025-08-21",
-          "last_updated": "2025-08-21",
-          "cost": {
-            "input": 0.56,
-            "output": 1.68
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-4.1-mini",
           "name": "GPT-4.1 mini",
           "display_name": "GPT-4.1 mini",
@@ -116512,41 +115432,6 @@
             "input": 1.5,
             "output": 6,
             "cache_read": 0.375
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-5-chat",
-          "name": "GPT-5 Chat",
-          "display_name": "GPT-5 Chat",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 16384
-          },
-          "temperature": false,
-          "tool_call": false,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "attachment": true,
-          "open_weights": false,
-          "knowledge": "2024-10-24",
-          "release_date": "2025-08-07",
-          "last_updated": "2025-08-07",
-          "cost": {
-            "input": 1.25,
-            "output": 10,
-            "cache_read": 0.13
           },
           "type": "chat"
         },
@@ -116708,46 +115593,6 @@
               "input": 60,
               "output": 270
             }
-          },
-          "type": "chat"
-        },
-        {
-          "id": "grok-4-fast-reasoning",
-          "name": "Grok 4 Fast (Reasoning)",
-          "display_name": "Grok 4 Fast (Reasoning)",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 2000000,
-            "output": 30000
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true
-            }
-          },
-          "attachment": true,
-          "open_weights": false,
-          "knowledge": "2025-07",
-          "release_date": "2025-09-19",
-          "last_updated": "2025-09-19",
-          "cost": {
-            "input": 0.2,
-            "output": 0.5,
-            "cache_read": 0.05
           },
           "type": "chat"
         },
@@ -117207,70 +116052,6 @@
           "type": "chat"
         },
         {
-          "id": "phi-3.5-mini-instruct",
-          "name": "Phi-3.5-mini-instruct",
-          "display_name": "Phi-3.5-mini-instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-08-20",
-          "last_updated": "2024-08-20",
-          "cost": {
-            "input": 0.13,
-            "output": 0.52
-          },
-          "type": "chat"
-        },
-        {
-          "id": "phi-3-medium-4k-instruct",
-          "name": "Phi-3-medium-instruct (4k)",
-          "display_name": "Phi-3-medium-instruct (4k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 4096,
-            "output": 1024
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.17,
-            "output": 0.68
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-3.5-turbo-1106",
           "name": "GPT-3.5 Turbo 1106",
           "display_name": "GPT-3.5 Turbo 1106",
@@ -117399,38 +116180,6 @@
           "type": "chat"
         },
         {
-          "id": "cohere-command-r-08-2024",
-          "name": "Command R",
-          "display_name": "Command R",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4000
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-06-01",
-          "release_date": "2024-08-30",
-          "last_updated": "2024-08-30",
-          "cost": {
-            "input": 0.15,
-            "output": 0.6
-          },
-          "type": "chat"
-        },
-        {
           "id": "o3-mini",
           "name": "o3-mini",
           "display_name": "o3-mini",
@@ -117551,38 +116300,6 @@
           "type": "chat"
         },
         {
-          "id": "mistral-large-2411",
-          "name": "Mistral Large 24.11",
-          "display_name": "Mistral Large 24.11",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 32768
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2024-09",
-          "release_date": "2024-11-01",
-          "last_updated": "2024-11-01",
-          "cost": {
-            "input": 2,
-            "output": 6
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-5.5",
           "name": "GPT-5.5",
           "display_name": "GPT-5.5",
@@ -117652,38 +116369,6 @@
               "output": 45,
               "cache_read": 1
             }
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-3.5-turbo-0613",
-          "name": "GPT-3.5 Turbo 0613",
-          "display_name": "GPT-3.5 Turbo 0613",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 16384,
-            "output": 16384
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2021-08",
-          "release_date": "2023-06-13",
-          "last_updated": "2023-06-13",
-          "cost": {
-            "input": 3,
-            "output": 4
           },
           "type": "chat"
         },
@@ -117935,76 +116620,6 @@
           "type": "chat"
         },
         {
-          "id": "phi-3.5-moe-instruct",
-          "name": "Phi-3.5-MoE-instruct",
-          "display_name": "Phi-3.5-MoE-instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-08-20",
-          "last_updated": "2024-08-20",
-          "cost": {
-            "input": 0.16,
-            "output": 0.64
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-5.1-chat",
-          "name": "GPT-5.1 Chat",
-          "display_name": "GPT-5.1 Chat",
-          "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "image",
-              "audio"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 16384
-          },
-          "temperature": false,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "attachment": true,
-          "open_weights": false,
-          "knowledge": "2024-09-30",
-          "release_date": "2025-11-14",
-          "last_updated": "2025-11-14",
-          "cost": {
-            "input": 1.25,
-            "output": 10,
-            "cache_read": 0.125
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-5-codex",
           "name": "GPT-5-Codex",
           "display_name": "GPT-5-Codex",
@@ -118089,38 +116704,6 @@
           "cost": {
             "input": 0.71,
             "output": 0.71
-          },
-          "type": "chat"
-        },
-        {
-          "id": "phi-3-mini-4k-instruct",
-          "name": "Phi-3-mini-instruct (4k)",
-          "display_name": "Phi-3-mini-instruct (4k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 4096,
-            "output": 1024
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.13,
-            "output": 0.52
           },
           "type": "chat"
         },
@@ -118223,50 +116806,6 @@
           "cost": {
             "input": 1.74,
             "output": 3.48
-          },
-          "type": "chat"
-        },
-        {
-          "id": "deepseek-r1-0528",
-          "name": "DeepSeek-R1-0528",
-          "display_name": "DeepSeek-R1-0528",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 163840,
-            "output": 163840
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "interleaved": true,
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": [
-                "thinking_blocks"
-              ]
-            }
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-07",
-          "release_date": "2025-05-28",
-          "last_updated": "2025-05-28",
-          "cost": {
-            "input": 1.35,
-            "output": 5.4
           },
           "type": "chat"
         },
@@ -118450,41 +116989,6 @@
           "type": "chat"
         },
         {
-          "id": "gpt-5.2-chat",
-          "name": "GPT-5.2 Chat",
-          "display_name": "GPT-5.2 Chat",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 16384
-          },
-          "temperature": false,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "attachment": true,
-          "open_weights": false,
-          "knowledge": "2025-08-31",
-          "release_date": "2025-12-11",
-          "last_updated": "2025-12-11",
-          "cost": {
-            "input": 1.75,
-            "output": 14,
-            "cache_read": 0.175
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-image-1.5",
           "name": "GPT-Image-1.5",
           "display_name": "GPT-Image-1.5",
@@ -118571,70 +117075,6 @@
             "input": 1.75,
             "output": 14,
             "cache_read": 0.175
-          },
-          "type": "chat"
-        },
-        {
-          "id": "deepseek-v3-0324",
-          "name": "DeepSeek-V3-0324",
-          "display_name": "DeepSeek-V3-0324",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 131072,
-            "output": 131072
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-07",
-          "release_date": "2025-03-24",
-          "last_updated": "2025-03-24",
-          "cost": {
-            "input": 1.14,
-            "output": 4.56
-          },
-          "type": "chat"
-        },
-        {
-          "id": "mistral-nemo",
-          "name": "Mistral Nemo",
-          "display_name": "Mistral Nemo",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 128000
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-07",
-          "release_date": "2024-07-18",
-          "last_updated": "2024-07-18",
-          "cost": {
-            "input": 0.15,
-            "output": 0.15
           },
           "type": "chat"
         },
@@ -118816,38 +117256,6 @@
           "type": "chat"
         },
         {
-          "id": "gpt-4-32k",
-          "name": "GPT-4 32K",
-          "display_name": "GPT-4 32K",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 32768,
-            "output": 32768
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2023-11",
-          "release_date": "2023-03-14",
-          "last_updated": "2023-03-14",
-          "cost": {
-            "input": 60,
-            "output": 120
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-5.4-mini",
           "name": "GPT-5.4 Mini",
           "display_name": "GPT-5.4 Mini",
@@ -118906,38 +117314,6 @@
           "type": "chat"
         },
         {
-          "id": "meta-llama-3-70b-instruct",
-          "name": "Meta-Llama-3-70B-Instruct",
-          "display_name": "Meta-Llama-3-70B-Instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 8192,
-            "output": 2048
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-04-18",
-          "last_updated": "2024-04-18",
-          "cost": {
-            "input": 2.68,
-            "output": 3.54
-          },
-          "type": "chat"
-        },
-        {
           "id": "mistral-small-2503",
           "name": "Mistral Small 3.1",
           "display_name": "Mistral Small 3.1",
@@ -118967,38 +117343,6 @@
           "cost": {
             "input": 0.1,
             "output": 0.3
-          },
-          "type": "chat"
-        },
-        {
-          "id": "phi-3-mini-128k-instruct",
-          "name": "Phi-3-mini-instruct (128k)",
-          "display_name": "Phi-3-mini-instruct (128k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.13,
-            "output": 0.52
           },
           "type": "chat"
         },
@@ -119184,38 +117528,6 @@
           "type": "chat"
         },
         {
-          "id": "phi-3-small-128k-instruct",
-          "name": "Phi-3-small-instruct (128k)",
-          "display_name": "Phi-3-small-instruct (128k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.15,
-            "output": 0.6
-          },
-          "type": "chat"
-        },
-        {
           "id": "deepseek-r1",
           "name": "DeepSeek-R1",
           "display_name": "DeepSeek-R1",
@@ -119256,38 +117568,6 @@
           "cost": {
             "input": 1.35,
             "output": 5.4
-          },
-          "type": "chat"
-        },
-        {
-          "id": "phi-3-small-8k-instruct",
-          "name": "Phi-3-small-instruct (8k)",
-          "display_name": "Phi-3-small-instruct (8k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 8192,
-            "output": 2048
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.15,
-            "output": 0.6
           },
           "type": "chat"
         },
@@ -119437,106 +117717,6 @@
           "type": "chat"
         },
         {
-          "id": "llama-3.2-90b-vision-instruct",
-          "name": "Llama-3.2-90B-Vision-Instruct",
-          "display_name": "Llama-3.2-90B-Vision-Instruct",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 8192
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": true,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-09-25",
-          "last_updated": "2024-09-25",
-          "cost": {
-            "input": 2.04,
-            "output": 2.04
-          },
-          "type": "chat"
-        },
-        {
-          "id": "meta-llama-3.1-8b-instruct",
-          "name": "Meta-Llama-3.1-8B-Instruct",
-          "display_name": "Meta-Llama-3.1-8B-Instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 32768
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-07-23",
-          "last_updated": "2024-07-23",
-          "cost": {
-            "input": 0.3,
-            "output": 0.61
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-5.3-chat",
-          "name": "GPT-5.3 Chat",
-          "display_name": "GPT-5.3 Chat",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 16384
-          },
-          "temperature": false,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "attachment": true,
-          "open_weights": false,
-          "knowledge": "2025-08-31",
-          "release_date": "2026-03-03",
-          "last_updated": "2026-03-03",
-          "cost": {
-            "input": 1.75,
-            "output": 14,
-            "cache_read": 0.175
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-5.1",
           "name": "GPT-5.1",
           "display_name": "GPT-5.1",
@@ -119661,83 +117841,6 @@
           "type": "chat"
         },
         {
-          "id": "cohere-command-r-plus-08-2024",
-          "name": "Command R+",
-          "display_name": "Command R+",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4000
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-06-01",
-          "release_date": "2024-08-30",
-          "last_updated": "2024-08-30",
-          "cost": {
-            "input": 2.5,
-            "output": 10
-          },
-          "type": "chat"
-        },
-        {
-          "id": "kimi-k2-thinking",
-          "name": "Kimi K2 Thinking",
-          "display_name": "Kimi K2 Thinking",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 262144,
-            "output": 262144
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "interleaved": true,
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": [
-                "thinking_blocks"
-              ]
-            }
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2024-08",
-          "release_date": "2025-11-06",
-          "last_updated": "2025-12-02",
-          "cost": {
-            "input": 0.6,
-            "output": 2.5,
-            "cache_read": 0.15
-          },
-          "type": "chat"
-        },
-        {
           "id": "grok-4-1-fast-non-reasoning",
           "name": "Grok 4.1 Fast (Non-Reasoning)",
           "display_name": "Grok 4.1 Fast (Non-Reasoning)",
@@ -119830,38 +117933,6 @@
           "type": "chat"
         },
         {
-          "id": "gpt-3.5-turbo-0301",
-          "name": "GPT-3.5 Turbo 0301",
-          "display_name": "GPT-3.5 Turbo 0301",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 4096,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2021-08",
-          "release_date": "2023-03-01",
-          "last_updated": "2023-03-01",
-          "cost": {
-            "input": 1.5,
-            "output": 2
-          },
-          "type": "chat"
-        },
-        {
           "id": "gpt-5-nano",
           "name": "GPT-5 Nano",
           "display_name": "GPT-5 Nano",
@@ -119914,38 +117985,6 @@
             "input": 0.05,
             "output": 0.4,
             "cache_read": 0.01
-          },
-          "type": "chat"
-        },
-        {
-          "id": "meta-llama-3-8b-instruct",
-          "name": "Meta-Llama-3-8B-Instruct",
-          "display_name": "Meta-Llama-3-8B-Instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 8192,
-            "output": 2048
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-04-18",
-          "last_updated": "2024-04-18",
-          "cost": {
-            "input": 0.3,
-            "output": 0.61
           },
           "type": "chat"
         },
@@ -120374,70 +118413,6 @@
           "type": "chat"
         },
         {
-          "id": "meta-llama-3.1-405b-instruct",
-          "name": "Meta-Llama-3.1-405B-Instruct",
-          "display_name": "Meta-Llama-3.1-405B-Instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 32768
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-07-23",
-          "last_updated": "2024-07-23",
-          "cost": {
-            "input": 5.33,
-            "output": 16
-          },
-          "type": "chat"
-        },
-        {
-          "id": "meta-llama-3.1-70b-instruct",
-          "name": "Meta-Llama-3.1-70B-Instruct",
-          "display_name": "Meta-Llama-3.1-70B-Instruct",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 32768
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-07-23",
-          "last_updated": "2024-07-23",
-          "cost": {
-            "input": 2.68,
-            "output": 3.54
-          },
-          "type": "chat"
-        },
-        {
           "id": "o4-mini",
           "name": "o4-mini",
           "display_name": "o4-mini",
@@ -120558,86 +118533,6 @@
           "type": "chat"
         },
         {
-          "id": "o1-mini",
-          "name": "o1-mini",
-          "display_name": "o1-mini",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 65536
-          },
-          "temperature": false,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "mode": "effort",
-              "effort": "medium",
-              "effort_options": [
-                "low",
-                "medium",
-                "high"
-              ],
-              "visibility": "hidden"
-            }
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2023-09",
-          "release_date": "2024-09-12",
-          "last_updated": "2024-09-12",
-          "cost": {
-            "input": 1.1,
-            "output": 4.4,
-            "cache_read": 0.55
-          },
-          "type": "chat"
-        },
-        {
-          "id": "phi-3-medium-128k-instruct",
-          "name": "Phi-3-medium-instruct (128k)",
-          "display_name": "Phi-3-medium-instruct (128k)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 4096
-          },
-          "temperature": true,
-          "tool_call": false,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": true,
-          "knowledge": "2023-10",
-          "release_date": "2024-04-23",
-          "last_updated": "2024-04-23",
-          "cost": {
-            "input": 0.17,
-            "output": 0.68
-          },
-          "type": "chat"
-        },
-        {
           "id": "claude-opus-5",
           "name": "Claude Opus 5",
           "display_name": "Claude Opus 5",
@@ -120732,71 +118627,6 @@
             "input": 1.25,
             "output": 10,
             "cache_read": 0.125
-          },
-          "type": "chat"
-        },
-        {
-          "id": "gpt-4",
-          "name": "GPT-4",
-          "display_name": "GPT-4",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 8192,
-            "output": 8192
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": false,
-          "open_weights": false,
-          "knowledge": "2023-11",
-          "release_date": "2023-03-14",
-          "last_updated": "2023-03-14",
-          "cost": {
-            "input": 60,
-            "output": 120
-          },
-          "type": "chat"
-        },
-        {
-          "id": "llama-3.2-11b-vision-instruct",
-          "name": "Llama-3.2-11B-Vision-Instruct",
-          "display_name": "Llama-3.2-11B-Vision-Instruct",
-          "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 128000,
-            "output": 8192
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": false
-          },
-          "attachment": true,
-          "open_weights": true,
-          "knowledge": "2023-12",
-          "release_date": "2024-09-25",
-          "last_updated": "2024-09-25",
-          "cost": {
-            "input": 0.37,
-            "output": 0.37
           },
           "type": "chat"
         },
@@ -263374,8 +261204,8 @@
             ]
           },
           "limit": {
-            "context": 1048575,
-            "output": 1048575
+            "context": 1048576,
+            "output": 393216
           },
           "tool_call": true,
           "reasoning": {
@@ -270325,8 +268155,8 @@
             ]
           },
           "limit": {
-            "context": 131072,
-            "output": 131072
+            "context": 262144,
+            "output": 65536
           },
           "tool_call": true,
           "reasoning": {
@@ -277420,8 +275250,7 @@
           "modalities": {
             "input": [
               "text",
-              "image",
-              "pdf"
+              "image"
             ],
             "output": [
               "text"
@@ -277431,7 +275260,7 @@
             "context": 1000000,
             "output": 128000
           },
-          "temperature": true,
+          "temperature": false,
           "tool_call": true,
           "reasoning": {
             "supported": true,

--- a/src/main/agent/acp/compatibility/dependencies.ts
+++ b/src/main/agent/acp/compatibility/dependencies.ts
@@ -2,8 +2,7 @@ import type { ProviderModelResolutionPort } from '@/provider/settings'
 import type { ProviderExecutionPort, RateLimitQueueSnapshot } from '@shared/types/provider'
 import type { DeepChatSessionState } from '@shared/types/agent-interface'
 import type { MCPToolDefinition } from '@shared/types/core/mcp'
-import type { HookEventName } from '@shared/hooksNotifications'
-import type { HookContext } from '@/hook/observer'
+import type { RuntimeHookSink } from '@/agent/deepchat/runtime/runtimeHookSink'
 import type { AcpAgentInstanceDependencyFactory } from '@/agent/acp/instance'
 import { AcpCompatibilityPromptBuilder } from '@/agent/acp/runtime'
 import type { AcpViewManifestInput } from '@/agent/acp/instance/ports'
@@ -58,7 +57,7 @@ export interface AcpCompatibilityDependencyBuilderDependencies {
     snapshot: RateLimitQueueSnapshot
   ): void
   clearRateLimitWaitingMessage(sessionId: string, messageId: string, requestId: string): void
-  dispatchHook(event: HookEventName, context: HookContext): void
+  hookSink: Pick<RuntimeHookSink, 'scope'>
 }
 
 function throwIfAbortRequested(signal?: AbortSignal): void {
@@ -229,41 +228,29 @@ export function createAcpCompatibilityDependencies(
     },
     observer: {
       userPromptSubmitted: (input) => {
-        dependencies.dispatchHook('UserPromptSubmit', {
+        const hooks = dependencies.hookSink.scope({
           sessionId: input.sessionId,
           messageId: input.messageId,
-          promptPreview: input.promptPreview,
           providerId: 'acp',
           modelId: input.agentId,
           projectDir: input.workdir
         })
-        dependencies.dispatchHook('SessionStart', {
-          sessionId: input.sessionId,
-          messageId: input.messageId,
-          promptPreview: input.promptPreview,
-          providerId: 'acp',
-          modelId: input.agentId,
-          projectDir: input.workdir
-        })
+        hooks.emit({ event: 'UserPromptSubmit', promptPreview: input.promptPreview })
+        hooks.emit({ event: 'SessionStart', promptPreview: input.promptPreview })
       },
       terminal: (input) => {
-        dependencies.dispatchHook('Stop', {
-          sessionId: input.sessionId,
-          providerId: 'acp',
-          modelId: input.agentId,
-          projectDir: input.workdir,
-          stop: {
+        dependencies.hookSink
+          .scope({
+            sessionId: input.sessionId,
+            providerId: 'acp',
+            modelId: input.agentId,
+            projectDir: input.workdir
+          })
+          .terminal({
             reason: input.stopReason,
-            userStop: input.status === 'aborted'
-          }
-        })
-        dependencies.dispatchHook('SessionEnd', {
-          sessionId: input.sessionId,
-          providerId: 'acp',
-          modelId: input.agentId,
-          projectDir: input.workdir,
-          error: input.errorMessage ? { message: input.errorMessage } : null
-        })
+            userStop: input.status === 'aborted',
+            error: input.errorMessage ? { message: input.errorMessage } : null
+          })
       }
     }
   }

--- a/src/main/agent/deepchat/harness/createDeepChatAgentHarness.ts
+++ b/src/main/agent/deepchat/harness/createDeepChatAgentHarness.ts
@@ -303,7 +303,6 @@ function createDeepChatRuntimeServices(deps: DeepChatHarnessDependencies): DeepC
     skillService,
     runLifecycle,
     registry: runtime,
-    sessionSettings,
     sessionPermissionPort,
     deferredToolExecutor,
     messageProjection,
@@ -363,7 +362,7 @@ function createDeepChatRuntimeServices(deps: DeepChatHarnessDependencies): DeepC
           loopRunner.emitRateLimitWaitingMessage(sessionId, messageId, requestId, snapshot),
         clearRateLimitWaitingMessage: (sessionId, messageId, requestId) =>
           loopRunner.clearRateLimitWaitingMessage(sessionId, messageId, requestId),
-        dispatchHook: (event, context) => hookSink.dispatch(event, context)
+        hookSink
       },
       input
     )

--- a/src/main/agent/deepchat/loop/notificationObserver.ts
+++ b/src/main/agent/deepchat/loop/notificationObserver.ts
@@ -9,12 +9,10 @@ export function emitDeepChatLoopNotification(
   }
 
   try {
-    const pending = observer.notify(structuredClone(notification))
-    if (pending) {
-      void Promise.resolve(pending).catch((error) => {
-        console.warn('[DeepChatLoop] Notification observer failed:', error)
-      })
+    if (!observer.isObserved(notification.event)) {
+      return
     }
+    observer.notify(notification)
   } catch (error) {
     console.warn('[DeepChatLoop] Notification observer failed:', error)
   }

--- a/src/main/agent/deepchat/loop/ports.ts
+++ b/src/main/agent/deepchat/loop/ports.ts
@@ -64,7 +64,8 @@ export type DeepChatLoopNotification =
     }
 
 export interface DeepChatLoopNotificationObserver {
-  notify(notification: DeepChatLoopNotification): void | PromiseLike<void>
+  isObserved(event: DeepChatLoopNotification['event']): boolean
+  notify(notification: DeepChatLoopNotification): void
 }
 
 export type PendingToolInteractionOrigin =

--- a/src/main/agent/deepchat/runtime/deepChatLoopRunner.ts
+++ b/src/main/agent/deepchat/runtime/deepChatLoopRunner.ts
@@ -197,7 +197,7 @@ export interface DeepChatLoopRunnerPorts {
   identity: Pick<SessionIdentityService, 'getAgentId'>
   sessionPermissionPort: SessionPermissionPort
   reviewToolPermission: ToolPermissionReviewer
-  hookSink: Pick<RuntimeHookSink, 'dispatch'>
+  hookSink: Pick<RuntimeHookSink, 'scope'>
   compaction: Pick<CompactionRuntimeCoordinator, 'apply'>
 }
 
@@ -426,15 +426,16 @@ export class DeepChatLoopRunner {
     const emitRateLimitWaitingMessage = this.emitRateLimitWaitingMessage.bind(this)
     const clearRateLimitWaitingMessage = this.clearRateLimitWaitingMessage.bind(this)
 
+    const hooks = this.ports.hookSink.scope({
+      sessionId,
+      messageId,
+      providerId: state.providerId,
+      modelId: state.modelId,
+      projectDir
+    })
+
     try {
-      this.ports.hookSink.dispatch('SessionStart', {
-        sessionId,
-        messageId,
-        promptPreview,
-        providerId: state.providerId,
-        modelId: state.modelId,
-        projectDir
-      })
+      hooks.emit({ event: 'SessionStart', promptPreview })
 
       let reviewConversationMessages = messages
       const result = await processStream({
@@ -672,20 +673,7 @@ export class DeepChatLoopRunner {
         },
         shouldYieldForPendingInput: () =>
           Boolean(this.ports.pendingInputCoordinator.getNextSteerInput(sessionId)),
-        notificationObserver: {
-          notify: (notification) => {
-            this.ports.hookSink.dispatch(notification.event, {
-              sessionId,
-              messageId,
-              providerId: state.providerId,
-              modelId: state.modelId,
-              projectDir,
-              tool: { ...notification.tool },
-              permission:
-                notification.event === 'PermissionRequest' ? { ...notification.permission } : null
-            })
-          }
-        },
+        notificationObserver: hooks.toolObserver(),
         controls: {
           getActiveSkillNames: () => getEffectiveRuntimeSkillNames(),
           getEnabledMcpServerIds: () =>

--- a/src/main/agent/deepchat/runtime/interactionCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/interactionCoordinator.ts
@@ -41,14 +41,13 @@ import type { DeferredToolExecutionResult, DeferredToolExecutor } from './deferr
 import type { SessionScopeRegistry } from '@/agent/deepchat/instance/deepChatAgentRuntime'
 import { toAppSessionId } from '@/agent/shared/agentSessionIds'
 import type { MessageProjectionService } from './messageProjectionService'
-import type { SessionSettingsCoordinator } from './sessionSettingsCoordinator'
 import type { ResumeBudgetToolCall, TurnResumePort } from './turnResumeContract'
 import type { DeepChatEventPublisher, PendingToolInteraction } from './types'
 import { parseMessageMetadata } from '@/session/usageStats'
 import { MAX_TOOL_CALLS } from '@/agent/deepchat/loop/deepChatLoopEngine'
 import { isAbortError, throwIfAbortRequested } from './abortErrors'
 import type { RunLifecycleCoordinator } from './runLifecycleCoordinator'
-import type { RuntimeHookSink } from './runtimeHookSink'
+import type { RuntimeHookScope, RuntimeHookSink } from './runtimeHookSink'
 
 type InteractionRunLifecyclePort = Pick<
   RunLifecycleCoordinator,
@@ -74,11 +73,10 @@ export interface InteractionCoordinatorPorts {
   skillService: SkillDraftPresenter
   runLifecycle: InteractionRunLifecyclePort
   registry: SessionScopeRegistry
-  sessionSettings: Pick<SessionSettingsCoordinator, 'resolveProjectDir'>
   sessionPermissionPort: SessionPermissionPort
   deferredToolExecutor: Pick<DeferredToolExecutor, 'execute'>
   messageProjection: Pick<MessageProjectionService, 'refresh'>
-  hookSink: Pick<RuntimeHookSink, 'dispatch'>
+  hookSink: Pick<RuntimeHookSink, 'scope'>
   turnCoordinator: TurnResumePort
   publishEvent: DeepChatEventPublisher
 }
@@ -225,7 +223,12 @@ export class InteractionCoordinator {
           return { resumed: false }
         }
         const state = this.ports.registry.getHydratedScope(toAppSessionId(sessionId))?.state()
-        const projectDir = this.ports.sessionSettings.resolveProjectDir(sessionId)
+        const hooks = this.ports.hookSink.scope({
+          sessionId,
+          messageId,
+          providerId: state?.providerId,
+          modelId: state?.modelId
+        })
         let shouldDispatchResolvedToolHook = false
 
         if (response.granted) {
@@ -254,17 +257,9 @@ export class InteractionCoordinator {
               isError: true
             }
           } else {
-            this.ports.hookSink.dispatch('PreToolUse', {
-              sessionId,
-              messageId,
-              providerId: state?.providerId,
-              modelId: state?.modelId,
-              projectDir,
-              tool: {
-                callId: toolCall.id,
-                name: toolCall.name,
-                params: toolCall.params
-              }
+            hooks.emit({
+              event: 'PreToolUse',
+              tool: { callId: toolCall.id, name: toolCall.name, params: toolCall.params }
             })
             execution = await this.ports.deferredToolExecutor.execute(
               sessionId,
@@ -293,12 +288,8 @@ export class InteractionCoordinator {
           if (execution.terminalError) {
             const terminalMetadata = stampTerminalMetadata(resumeAccounting, 'error', 'tool_error')
             instance.advancePendingToolBatch({ committedResultCallId: toolCall.id })
-            this.ports.hookSink.dispatch('PostToolUseFailure', {
-              sessionId,
-              messageId,
-              providerId: state?.providerId,
-              modelId: state?.modelId,
-              projectDir,
+            hooks.emit({
+              event: 'PostToolUseFailure',
               tool: {
                 callId: toolCall.id,
                 name: toolCall.name,
@@ -320,20 +311,9 @@ export class InteractionCoordinator {
               failedAt: Date.now(),
               error: execution.terminalError
             })
-            this.ports.hookSink.dispatch('Stop', {
-              sessionId,
-              messageId,
-              providerId: state?.providerId,
-              modelId: state?.modelId,
-              projectDir,
-              stop: { reason: 'tool_error', userStop: false }
-            })
-            this.ports.hookSink.dispatch('SessionEnd', {
-              sessionId,
-              messageId,
-              providerId: state?.providerId,
-              modelId: state?.modelId,
-              projectDir,
+            hooks.terminal({
+              reason: 'tool_error',
+              userStop: false,
               usage: buildUsageFromMetadata(terminalMetadata) ?? null,
               error: { message: execution.terminalError }
             })
@@ -375,18 +355,10 @@ export class InteractionCoordinator {
               toolCall.id,
               'post-call-permission'
             )
-            this.ports.hookSink.dispatch('PermissionRequest', {
-              sessionId,
-              messageId,
-              providerId: state?.providerId,
-              modelId: state?.modelId,
-              projectDir,
+            hooks.emit({
+              event: 'PermissionRequest',
               permission: execution.permissionRequest,
-              tool: {
-                callId: toolCall.id,
-                name: toolCall.name,
-                params: toolCall.params
-              }
+              tool: { callId: toolCall.id, name: toolCall.name, params: toolCall.params }
             })
             actionBlock.status = 'pending'
             actionBlock.content = execution.permissionRequest.description
@@ -409,15 +381,7 @@ export class InteractionCoordinator {
 
         emitResolvedToolHook = shouldDispatchResolvedToolHook
           ? () => {
-              this.dispatchResolvedToolHook({
-                sessionId,
-                messageId,
-                providerId: state?.providerId,
-                modelId: state?.modelId,
-                projectDir,
-                blocks,
-                toolCall
-              })
+              this.emitResolvedToolFacts(hooks, blocks, toolCall)
             }
           : null
       } else {
@@ -626,41 +590,23 @@ export class InteractionCoordinator {
     return { keepPending: false, waitingForUserMessage: false }
   }
 
-  private dispatchResolvedToolHook(params: {
-    sessionId: string
-    messageId: string
-    providerId?: string
-    modelId?: string
-    projectDir?: string | null
-    blocks: AssistantMessageBlock[]
+  private emitResolvedToolFacts(
+    hooks: RuntimeHookScope,
+    blocks: AssistantMessageBlock[],
     toolCall: NonNullable<AssistantMessageBlock['tool_call']>
-  }): void {
-    const resolvedBlock = params.blocks.find(
-      (block) => block.type === 'tool_call' && block.tool_call?.id === params.toolCall.id
+  ): void {
+    const resolvedBlock = blocks.find(
+      (block) => block.type === 'tool_call' && block.tool_call?.id === toolCall.id
     )
     const responseText = resolvedBlock?.tool_call?.response ?? ''
     const isError = resolvedBlock?.status === 'error'
+    const tool = { callId: toolCall.id, name: toolCall.name, params: toolCall.params }
 
-    this.ports.hookSink.dispatch(isError ? 'PostToolUseFailure' : 'PostToolUse', {
-      sessionId: params.sessionId,
-      messageId: params.messageId,
-      providerId: params.providerId,
-      modelId: params.modelId,
-      projectDir: params.projectDir,
-      tool: isError
-        ? {
-            callId: params.toolCall.id,
-            name: params.toolCall.name,
-            params: params.toolCall.params,
-            error: responseText
-          }
-        : {
-            callId: params.toolCall.id,
-            name: params.toolCall.name,
-            params: params.toolCall.params,
-            response: responseText
-          }
-    })
+    hooks.emit(
+      isError
+        ? { event: 'PostToolUseFailure', tool: { ...tool, error: responseText } }
+        : { event: 'PostToolUse', tool: { ...tool, response: responseText } }
+    )
   }
 
   private async grantPermissionForPayload(

--- a/src/main/agent/deepchat/runtime/runtimeHookSink.ts
+++ b/src/main/agent/deepchat/runtime/runtimeHookSink.ts
@@ -1,11 +1,18 @@
 import type { DeepChatSessionState } from '@shared/types/agent-interface'
-import type { HookEventName } from '@shared/hooksNotifications'
-import type { HookContext, HookObserver } from '@/hook/observer'
+import type {
+  HookErrorFacts,
+  HookEventBody,
+  HookSessionFacts,
+  HookUsageFacts
+} from '@/hook/events'
+import type { HookObserver } from '@/hook/observer'
+import type {
+  DeepChatLoopNotification,
+  DeepChatLoopNotificationObserver
+} from '@/agent/deepchat/loop/ports'
 import type { ProcessResult } from './types'
 import type { SessionIdentityService } from './sessionIdentityService'
 import type { SessionSettingsCoordinator } from './sessionSettingsCoordinator'
-
-export type RuntimeHookContext = Omit<HookContext, 'agentId'>
 
 export interface RuntimeHookSinkDependencies {
   observer: HookObserver
@@ -13,21 +20,93 @@ export interface RuntimeHookSinkDependencies {
   sessionSettings: Pick<SessionSettingsCoordinator, 'resolveProjectDir'>
 }
 
+export interface RuntimeHookScopeInput {
+  readonly sessionId: string
+  readonly messageId?: string
+  readonly providerId?: string
+  readonly modelId?: string
+  /** Omit to resolve from session settings; pass null to state that the session has none. */
+  readonly projectDir?: string | null
+}
+
+export interface RuntimeTerminalFacts {
+  readonly reason?: string
+  readonly userStop: boolean
+  readonly usage?: HookUsageFacts | null
+  readonly error?: HookErrorFacts | null
+}
+
+export class RuntimeHookScope {
+  private facts: HookSessionFacts | undefined
+
+  constructor(
+    private readonly deps: RuntimeHookSinkDependencies,
+    private readonly input: RuntimeHookScopeInput
+  ) {}
+
+  emit(body: HookEventBody): void {
+    try {
+      if (!this.deps.observer.isObserved(body.event)) {
+        return
+      }
+      this.deps.observer.notify({ ...body, session: this.sessionFacts() })
+    } catch (error) {
+      console.warn(`[DeepChatAgent] Failed to dispatch ${body.event} hook:`, error)
+    }
+  }
+
+  /** The single terminal projection: every settled turn reports Stop then SessionEnd. */
+  terminal(facts: RuntimeTerminalFacts): void {
+    this.emit({ event: 'Stop', stop: { reason: facts.reason, userStop: facts.userStop } })
+    this.emit({ event: 'SessionEnd', usage: facts.usage ?? null, error: facts.error ?? null })
+  }
+
+  toolObserver(): DeepChatLoopNotificationObserver {
+    return {
+      isObserved: (event) => this.deps.observer.isObserved(event),
+      notify: (notification: DeepChatLoopNotification) => {
+        this.emit(
+          notification.event === 'PermissionRequest'
+            ? {
+                event: 'PermissionRequest',
+                tool: notification.tool,
+                permission: notification.permission
+              }
+            : { event: notification.event, tool: notification.tool }
+        )
+      }
+    }
+  }
+
+  private sessionFacts(): HookSessionFacts {
+    this.facts ??= {
+      sessionId: this.input.sessionId,
+      messageId: this.input.messageId,
+      providerId: this.input.providerId,
+      modelId: this.input.modelId,
+      projectDir:
+        this.input.projectDir !== undefined ? this.input.projectDir : this.resolveProjectDir(),
+      agentId: this.deps.identity.getAgentId(this.input.sessionId) ?? 'deepchat'
+    }
+    return this.facts
+  }
+
+  /** Leaves the directory unanswered on failure so delivery can still resolve it from the session. */
+  private resolveProjectDir(): string | null | undefined {
+    try {
+      return this.deps.sessionSettings.resolveProjectDir(this.input.sessionId)
+    } catch (error) {
+      console.warn('[DeepChatAgent] Failed to resolve hook project directory:', error)
+      return undefined
+    }
+  }
+}
+
 export class RuntimeHookSink {
   constructor(private readonly deps: RuntimeHookSinkDependencies) {}
 
-  dispatch(event: HookEventName, context: RuntimeHookContext): void {
-    try {
-      this.deps.observer.notify({
-        event,
-        context: {
-          ...context,
-          agentId: this.deps.identity.getAgentId(context.sessionId) ?? 'deepchat'
-        }
-      })
-    } catch (error) {
-      console.warn(`[DeepChatAgent] Failed to dispatch ${event} hook:`, error)
-    }
+  scope(input: RuntimeHookScopeInput): RuntimeHookScope {
+    return new RuntimeHookScope(this.deps, input)
   }
 
   observeTerminal(
@@ -39,33 +118,19 @@ export class RuntimeHookSink {
       return
     }
 
-    this.dispatch('Stop', {
-      sessionId,
-      providerId: state.providerId,
-      modelId: state.modelId,
-      projectDir: this.deps.sessionSettings.resolveProjectDir(sessionId),
-      stop: {
-        reason:
-          result.stopReason ??
-          (result.status === 'completed'
-            ? 'complete'
-            : result.status === 'aborted'
-              ? 'user_stop'
-              : 'error'),
-        userStop: result.status === 'aborted'
-      }
-    })
-    this.dispatch('SessionEnd', {
-      sessionId,
-      providerId: state.providerId,
-      modelId: state.modelId,
-      projectDir: this.deps.sessionSettings.resolveProjectDir(sessionId),
+    this.scope({ sessionId, providerId: state.providerId, modelId: state.modelId }).terminal({
+      reason:
+        result.stopReason ??
+        (result.status === 'completed'
+          ? 'complete'
+          : result.status === 'aborted'
+            ? 'user_stop'
+            : 'error'),
+      userStop: result.status === 'aborted',
       usage: result.usage ?? null,
       error:
         result.errorMessage || result.terminalError
-          ? {
-              message: result.errorMessage ?? result.terminalError
-            }
+          ? { message: result.errorMessage ?? result.terminalError }
           : null
     })
   }

--- a/src/main/agent/deepchat/runtime/turnCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/turnCoordinator.ts
@@ -140,7 +140,7 @@ export interface TurnCoordinatorPorts {
   promptAssembly: Pick<PromptAssemblyService, 'createBasePromptAssembler'>
   loopRunner: Pick<DeepChatLoopRunner, 'run'>
   messageProjection: Pick<MessageProjectionService, 'refresh'>
-  hookSink: Pick<RuntimeHookSink, 'dispatch'>
+  hookSink: Pick<RuntimeHookSink, 'scope'>
 }
 
 export class TurnCoordinator {
@@ -553,14 +553,15 @@ export class TurnCoordinator {
       throwIfAbortRequested(preStreamAbortSignal)
       this.ports.messageProjection.refresh(sessionId, userMessageId)
 
-      this.ports.hookSink.dispatch('UserPromptSubmit', {
-        sessionId,
-        messageId: userMessageId,
-        promptPreview: content.text,
-        providerId: state.providerId,
-        modelId: state.modelId,
-        projectDir
-      })
+      this.ports.hookSink
+        .scope({
+          sessionId,
+          messageId: userMessageId,
+          providerId: state.providerId,
+          modelId: state.modelId,
+          projectDir
+        })
+        .emit({ event: 'UserPromptSubmit', promptPreview: content.text })
 
       const preparedContext = await this.ports.contextCoordinator.assemble({
         assembleContributions: async () => {
@@ -863,21 +864,14 @@ export class TurnCoordinator {
           error: errorMessage
         })
       }
-      this.ports.hookSink.dispatch('Stop', {
-        sessionId,
-        providerId: state.providerId,
-        modelId: state.modelId,
-        projectDir,
-        stop: { reason: stopReason, userStop: false }
-      })
-      this.ports.hookSink.dispatch('SessionEnd', {
-        sessionId,
-        providerId: state.providerId,
-        modelId: state.modelId,
-        projectDir,
-        usage: buildUsageFromMetadata(terminalMetadata) ?? null,
-        error: { message: errorMessage }
-      })
+      this.ports.hookSink
+        .scope({ sessionId, providerId: state.providerId, modelId: state.modelId, projectDir })
+        .terminal({
+          reason: stopReason,
+          userStop: false,
+          usage: buildUsageFromMetadata(terminalMetadata) ?? null,
+          error: { message: errorMessage }
+        })
       this.ports.runLifecycle.transitionCurrentStatus(sessionId, 'error')
       return complete({
         requestId: assistantMessageId,

--- a/src/main/app/composition.ts
+++ b/src/main/app/composition.ts
@@ -895,8 +895,7 @@ export async function createMainProcessControl(dependencies: {
   skillSyncService = new SkillSyncService(skillService, skillSettings, publishDeepchatEvent)
 
   hookService = new HookService(hookSettings, {
-    getSession: (sessionId) => sessionQuery.getSession(sessionId),
-    getMessage: (messageId) => sessionQuery.getMessage(messageId)
+    getSession: (sessionId) => sessionQuery.getSession(sessionId)
   })
   const providerCatalogPort: ProviderCatalogPort = {
     getProviderModels: (providerId) => providerSettings.getProviderModels(providerId),
@@ -1848,10 +1847,7 @@ export async function createMainProcessControl(dependencies: {
         if (proxyConfig.getProxyMode() === ProxyMode.CUSTOM) void proxyConfig.resolveProxy()
       }
     })
-    const hookRoutes = createHookRoutes({
-      settings: hookSettings,
-      testCommand: (hookId) => hookService.testHookCommand(hookId)
-    })
+    const hookRoutes = createHookRoutes({ service: hookService })
     const appSettingsRoutes = createAppSettingsRoutes({
       settings: dependencies.settingsStore,
       agentDefaults,

--- a/src/main/hook/events.ts
+++ b/src/main/hook/events.ts
@@ -31,23 +31,34 @@ export type HookUsageFacts = Readonly<Record<string, number>>
 
 export type HookPermissionFacts = Readonly<Record<string, unknown>>
 
+type HookFactKey = 'promptPreview' | 'tool' | 'permission' | 'stop' | 'error' | 'usage'
+
+/**
+ * Closes a variant against every fact it does not declare. Excess property checking alone only
+ * refuses surplus fields on a fresh literal, so a variable carrying both `stop` and `tool` would
+ * otherwise satisfy the union.
+ */
+type Exclusive<TBody> = TBody & {
+  readonly [TKey in Exclude<HookFactKey, keyof TBody>]?: never
+}
+
 export type HookEventBody =
-  | { readonly event: 'SessionStart'; readonly promptPreview?: string }
-  | { readonly event: 'UserPromptSubmit'; readonly promptPreview: string }
-  | { readonly event: 'PreToolUse'; readonly tool: HookToolFacts }
-  | { readonly event: 'PostToolUse'; readonly tool: HookToolFacts }
-  | { readonly event: 'PostToolUseFailure'; readonly tool: HookToolFacts }
-  | {
+  | Exclusive<{ readonly event: 'SessionStart'; readonly promptPreview?: string }>
+  | Exclusive<{ readonly event: 'UserPromptSubmit'; readonly promptPreview: string }>
+  | Exclusive<{ readonly event: 'PreToolUse'; readonly tool: HookToolFacts }>
+  | Exclusive<{ readonly event: 'PostToolUse'; readonly tool: HookToolFacts }>
+  | Exclusive<{ readonly event: 'PostToolUseFailure'; readonly tool: HookToolFacts }>
+  | Exclusive<{
       readonly event: 'PermissionRequest'
       readonly tool: HookToolFacts
       readonly permission: HookPermissionFacts
-    }
-  | { readonly event: 'Stop'; readonly stop: HookStopFacts }
-  | {
+    }>
+  | Exclusive<{ readonly event: 'Stop'; readonly stop: HookStopFacts }>
+  | Exclusive<{
       readonly event: 'SessionEnd'
       readonly usage?: HookUsageFacts | null
       readonly error?: HookErrorFacts | null
-    }
+    }>
 
 export type HookEvent = HookEventBody & { readonly session: HookSessionFacts }
 
@@ -61,13 +72,13 @@ export type HookEventCoverage = [
   AssertNever<Exclude<HookEventBody['event'], HookEventName>>
 ]
 
-/**
- * Pins the combinations the union must refuse. Surplus fields on an event literal are refused by
- * excess property checking at the emit site, which no type-level assertion can express.
- */
+/** Pins the combinations the union must refuse, for both missing and foreign facts. */
 export type HookEventBodyRejections = [
   AssertTrue<Rejects<{ event: 'PreToolUse' }>>,
+  AssertTrue<Rejects<{ event: 'UserPromptSubmit' }>>,
   AssertTrue<Rejects<{ event: 'PermissionRequest'; tool: HookToolFacts }>>,
-  AssertTrue<Rejects<{ event: 'Stop'; tool: HookToolFacts }>>,
-  AssertTrue<Rejects<{ event: 'UserPromptSubmit' }>>
+  AssertTrue<Rejects<{ event: 'Stop'; stop: HookStopFacts; tool: HookToolFacts }>>,
+  AssertTrue<Rejects<{ event: 'PostToolUse'; tool: HookToolFacts; stop: HookStopFacts }>>,
+  AssertTrue<Rejects<{ event: 'SessionEnd'; stop: HookStopFacts }>>,
+  AssertTrue<Rejects<{ event: 'SessionStart'; promptPreview: string; usage: HookUsageFacts }>>
 ]

--- a/src/main/hook/events.ts
+++ b/src/main/hook/events.ts
@@ -1,0 +1,73 @@
+import type { HookEventName } from '@shared/hooksNotifications'
+
+export interface HookSessionFacts {
+  readonly sessionId: string
+  readonly agentId?: string | null
+  readonly projectDir?: string | null
+  readonly providerId?: string
+  readonly modelId?: string
+  readonly messageId?: string
+}
+
+export interface HookToolFacts {
+  readonly callId?: string
+  readonly name?: string
+  readonly params?: string
+  readonly response?: string
+  readonly error?: string
+}
+
+export interface HookStopFacts {
+  readonly reason?: string
+  readonly userStop?: boolean
+}
+
+export interface HookErrorFacts {
+  readonly message?: string
+  readonly stack?: string
+}
+
+export type HookUsageFacts = Readonly<Record<string, number>>
+
+export type HookPermissionFacts = Readonly<Record<string, unknown>>
+
+export type HookEventBody =
+  | { readonly event: 'SessionStart'; readonly promptPreview?: string }
+  | { readonly event: 'UserPromptSubmit'; readonly promptPreview: string }
+  | { readonly event: 'PreToolUse'; readonly tool: HookToolFacts }
+  | { readonly event: 'PostToolUse'; readonly tool: HookToolFacts }
+  | { readonly event: 'PostToolUseFailure'; readonly tool: HookToolFacts }
+  | {
+      readonly event: 'PermissionRequest'
+      readonly tool: HookToolFacts
+      readonly permission: HookPermissionFacts
+    }
+  | { readonly event: 'Stop'; readonly stop: HookStopFacts }
+  | {
+      readonly event: 'SessionEnd'
+      readonly usage?: HookUsageFacts | null
+      readonly error?: HookErrorFacts | null
+    }
+
+export type HookEvent = HookEventBody & { readonly session: HookSessionFacts }
+
+type AssertNever<T extends never> = T
+type AssertTrue<T extends true> = T
+type Rejects<TCandidate> = TCandidate extends HookEventBody ? false : true
+
+/** Fails compilation when HookEventBody and HOOK_EVENT_NAMES drift apart in either direction. */
+export type HookEventCoverage = [
+  AssertNever<Exclude<HookEventName, HookEventBody['event']>>,
+  AssertNever<Exclude<HookEventBody['event'], HookEventName>>
+]
+
+/**
+ * Pins the combinations the union must refuse. Surplus fields on an event literal are refused by
+ * excess property checking at the emit site, which no type-level assertion can express.
+ */
+export type HookEventBodyRejections = [
+  AssertTrue<Rejects<{ event: 'PreToolUse' }>>,
+  AssertTrue<Rejects<{ event: 'PermissionRequest'; tool: HookToolFacts }>>,
+  AssertTrue<Rejects<{ event: 'Stop'; tool: HookToolFacts }>>,
+  AssertTrue<Rejects<{ event: 'UserPromptSubmit' }>>
+]

--- a/src/main/hook/index.ts
+++ b/src/main/hook/index.ts
@@ -500,6 +500,13 @@ export class HookService implements HookObserver {
         resolve(result)
       }
 
+      // Every settlement path reports diagnostics through here, so redaction cannot be forgotten
+      // on one of them.
+      const diagnostics = () => ({
+        stdout: redactSensitiveText(truncateText(stdout, DIAGNOSTIC_TEXT_LIMIT), secrets),
+        stderr: redactSensitiveText(truncateText(stderr, DIAGNOSTIC_TEXT_LIMIT), secrets)
+      })
+
       const timeout = setTimeout(() => {
         timedOut = true
         try {
@@ -513,8 +520,7 @@ export class HookService implements HookObserver {
           success: false,
           durationMs: Date.now() - start,
           exitCode: null,
-          stdout: redactSensitiveText(truncateText(stdout, DIAGNOSTIC_TEXT_LIMIT), secrets),
-          stderr: redactSensitiveText(truncateText(stderr, DIAGNOSTIC_TEXT_LIMIT), secrets),
+          ...diagnostics(),
           error: 'Command timed out'
         })
       }, COMMAND_TIMEOUT_MS)
@@ -526,8 +532,7 @@ export class HookService implements HookObserver {
           success: false,
           durationMs: Date.now() - start,
           exitCode: null,
-          stdout: truncateText(stdout, DIAGNOSTIC_TEXT_LIMIT),
-          stderr: truncateText(stderr, DIAGNOSTIC_TEXT_LIMIT),
+          ...diagnostics(),
           error: error instanceof Error ? error.message : String(error)
         })
       })
@@ -546,8 +551,7 @@ export class HookService implements HookObserver {
           success: !timedOut && code === 0,
           durationMs: Date.now() - start,
           exitCode: code ?? null,
-          stdout: redactSensitiveText(truncateText(stdout, DIAGNOSTIC_TEXT_LIMIT), secrets),
-          stderr: redactSensitiveText(truncateText(stderr, DIAGNOSTIC_TEXT_LIMIT), secrets),
+          ...diagnostics(),
           error: timedOut ? 'Command timed out' : code === 0 ? undefined : 'Command failed'
         })
       })
@@ -571,8 +575,7 @@ export class HookService implements HookObserver {
           success: false,
           durationMs: Date.now() - start,
           exitCode: null,
-          stdout: truncateText(stdout, DIAGNOSTIC_TEXT_LIMIT),
-          stderr: truncateText(stderr, DIAGNOSTIC_TEXT_LIMIT),
+          ...diagnostics(),
           error: error instanceof Error ? error.message : String(error)
         })
       }

--- a/src/main/hook/index.ts
+++ b/src/main/hook/index.ts
@@ -53,6 +53,18 @@ type HookConfigSnapshot = {
   readonly subscribedEvents: ReadonlySet<HookEventName>
 }
 
+/** Identity of a hook as it stood when the event was accepted. */
+type AcceptedHook = {
+  readonly id: string
+  readonly command: string
+}
+
+/** An accepted event together with the subscribers that were eligible at that moment. */
+type HookDelivery = {
+  readonly projection: HookEventProjection
+  readonly accepted: readonly AcceptedHook[]
+}
+
 /** One event reduced to detached, already-truncated wire facts. */
 type HookEventProjection = {
   readonly event: HookEventName
@@ -236,7 +248,14 @@ export class HookService implements HookObserver {
       if (!this.isObserved(event.event)) {
         return
       }
-      this.enqueue(projectHookEvent(event, new Date().toISOString()))
+      const accepted = this.acceptSubscribers(event.event)
+      if (accepted.length === 0) {
+        return
+      }
+      this.enqueue({
+        projection: projectHookEvent(event, new Date().toISOString()),
+        accepted
+      })
     } catch (error) {
       log.warn('[Hook] Notification observer failed:', error)
     }
@@ -282,12 +301,18 @@ export class HookService implements HookObserver {
     return this.snapshot
   }
 
-  private enqueue(projection: HookEventProjection): void {
-    const sessionId = projection.session.sessionId
+  private acceptSubscribers(event: HookEventName): readonly AcceptedHook[] {
+    return this.readSnapshot()
+      .config.hooks.filter((hook) => shouldDispatchHook(hook, event))
+      .map((hook) => ({ id: hook.id, command: hook.command }))
+  }
+
+  private enqueue(delivery: HookDelivery): void {
+    const sessionId = delivery.projection.session.sessionId
     const previous = this.sessionChains.get(sessionId) ?? Promise.resolve()
     const next = previous.then(async () => {
       try {
-        await this.deliver(projection)
+        await this.deliver(delivery)
       } catch (error) {
         log.warn('[Hook] Dispatch failed:', error)
       }
@@ -301,27 +326,45 @@ export class HookService implements HookObserver {
     })
   }
 
-  private async deliver(projection: HookEventProjection): Promise<void> {
+  private async deliver({ projection, accepted }: HookDelivery): Promise<void> {
     if (!this.accepting) {
       return
     }
 
-    const { config } = this.readSnapshot()
+    // Skip enrichment entirely when nothing can run any more.
+    if (this.runnableHooks(projection.event, accepted).length === 0) {
+      return
+    }
+
     const payload = await this.buildPayload(projection)
     if (!this.accepting) {
       return
     }
 
-    for (const hook of config.hooks) {
-      if (!shouldDispatchHook(hook, projection.event)) {
-        continue
-      }
-
+    // Authoritative revalidation: enrichment is asynchronous, so eligibility is settled here
+    // rather than before it.
+    for (const hook of this.runnableHooks(projection.event, accepted)) {
       // Per-command isolation: one failing hook must not affect its siblings or the next event.
       void this.runHookCommand(hook, payload).catch((error) => {
         log.warn(`[HooksNotifications] Hook "${hook.name}" failed:`, error)
       })
     }
+  }
+
+  /**
+   * A hook runs only if it was eligible when the event happened and is still eligible now under
+   * the same command, so a hook enabled or edited afterwards never receives an earlier event and
+   * one disabled meanwhile stops receiving queued ones.
+   */
+  private runnableHooks(
+    event: HookEventName,
+    accepted: readonly AcceptedHook[]
+  ): readonly HookCommandItem[] {
+    return this.readSnapshot().config.hooks.filter(
+      (hook) =>
+        shouldDispatchHook(hook, event) &&
+        accepted.some((item) => item.id === hook.id && item.command === hook.command)
+    )
   }
 
   private async buildPayload(projection: HookEventProjection): Promise<HookEventPayload> {

--- a/src/main/hook/index.ts
+++ b/src/main/hook/index.ts
@@ -10,7 +10,8 @@ import type {
   HookTestResult,
   HooksNotificationsSettings
 } from '@shared/hooksNotifications'
-import type { HookNotification, HookObserver } from './observer'
+import type { HookEvent, HookSessionFacts } from './events'
+import type { HookObserver } from './observer'
 
 const HOOK_PAYLOAD_VERSION = 1 as const
 const COMMAND_TIMEOUT_MS = 30_000
@@ -31,51 +32,38 @@ const HOOK_COMMAND_PLACEHOLDER_ENV_MAP = {
   toolCallId: 'DEEPCHAT_TOOL_CALL_ID'
 } as const
 
-export type HookDispatchContext = {
-  conversationId?: string
-  messageId?: string
-  promptPreview?: string
-  providerId?: string
-  modelId?: string
-  agentId?: string | null
-  workdir?: string | null
-  tool?: {
-    callId?: string
-    name?: string
-    params?: string
-    response?: string
-    error?: string
-  }
-  permission?: Record<string, unknown> | null
-  stop?: {
-    reason?: string
-    userStop?: boolean
-  } | null
-  usage?: Record<string, number> | null
-  error?: {
-    message?: string
-    stack?: string
-  } | null
-  isTest?: boolean
-}
-
 type HookSessionLookup = {
   providerId?: string
   modelId?: string
   projectDir?: string | null
 }
 
-type HookMessageLookup = {
-  content: unknown
-}
-
 export interface HookSettingsPort {
   getHooksNotificationsConfig(): HooksNotificationsSettings
+  setHooksNotificationsConfig(config: HooksNotificationsSettings): HooksNotificationsSettings
 }
 
 export interface HookQueryPort {
   getSession(sessionId: string): Promise<HookSessionLookup | null>
-  getMessage(messageId: string): Promise<HookMessageLookup | null>
+}
+
+/** Configuration and its derived subscription index, rebuilt as one unit so they cannot disagree. */
+type HookConfigSnapshot = {
+  readonly config: HooksNotificationsSettings
+  readonly subscribedEvents: ReadonlySet<HookEventName>
+}
+
+/** One event reduced to detached, already-truncated wire facts. */
+type HookEventProjection = {
+  readonly event: HookEventName
+  readonly time: string
+  readonly session: HookSessionFacts
+  readonly user: HookEventPayload['user']
+  readonly tool: HookEventPayload['tool']
+  readonly permission: HookEventPayload['permission']
+  readonly stop: HookEventPayload['stop']
+  readonly usage: HookEventPayload['usage']
+  readonly error: HookEventPayload['error']
 }
 
 export const truncateText = (value: string, limit: number): string => {
@@ -104,37 +92,6 @@ export const expandHookCommandPlaceholders = (
     return platform === 'win32' ? `"%${envName}%"` : `"\${${envName}}"`
   })
 
-const extractPromptPreview = (content: unknown): string => {
-  if (typeof content === 'string') {
-    try {
-      return extractPromptPreview(JSON.parse(content) as unknown)
-    } catch {
-      return content
-    }
-  }
-
-  if (!content || typeof content !== 'object') {
-    return ''
-  }
-
-  const userCandidate = content as { text?: string }
-  if (typeof userCandidate.text === 'string') {
-    return userCandidate.text
-  }
-
-  if (Array.isArray(content)) {
-    return content
-      .filter((block) => typeof block === 'object' && block && 'type' in block)
-      .map((block) => {
-        const contentBlock = block as { type?: string; content?: string }
-        return contentBlock.type === 'content' ? contentBlock.content || '' : ''
-      })
-      .join('')
-  }
-
-  return ''
-}
-
 const redactSensitiveText = (text: string, secrets: string[]): string => {
   if (!text) {
     return ''
@@ -157,10 +114,77 @@ const redactSensitiveText = (text: string, secrets: string[]): string => {
   return output
 }
 
+const projectUser = (
+  messageId: string | undefined,
+  promptPreview: string | undefined
+): HookEventPayload['user'] =>
+  promptPreview || messageId
+    ? { messageId, promptPreview: truncateText(promptPreview || '', PREVIEW_TEXT_LIMIT) }
+    : null
+
+const projectTool = (tool: {
+  callId?: string
+  name?: string
+  params?: string
+  response?: string
+  error?: string
+}): HookEventPayload['tool'] => ({
+  callId: tool.callId,
+  name: tool.name,
+  paramsPreview: tool.params ? truncateText(tool.params, PREVIEW_TEXT_LIMIT) : undefined,
+  responsePreview: tool.response ? truncateText(tool.response, PREVIEW_TEXT_LIMIT) : undefined,
+  error: tool.error ? truncateText(tool.error, PREVIEW_TEXT_LIMIT) : undefined
+})
+
+/** Truncates before the only clone, so a multi-megabyte tool argument never reaches structuredClone. */
+const projectHookEvent = (event: HookEvent, time: string): HookEventProjection => {
+  const base = {
+    event: event.event,
+    time,
+    session: { ...event.session },
+    user: projectUser(event.session.messageId, undefined),
+    tool: null,
+    permission: null,
+    stop: null,
+    usage: null,
+    error: null
+  } satisfies HookEventProjection
+
+  switch (event.event) {
+    case 'SessionStart':
+    case 'UserPromptSubmit':
+      return { ...base, user: projectUser(event.session.messageId, event.promptPreview) }
+    case 'PreToolUse':
+    case 'PostToolUse':
+    case 'PostToolUseFailure':
+      return { ...base, tool: projectTool(event.tool) }
+    case 'PermissionRequest':
+      return {
+        ...base,
+        tool: projectTool(event.tool),
+        permission: structuredClone(event.permission) as Record<string, unknown>
+      }
+    case 'Stop':
+      return { ...base, stop: { reason: event.stop.reason, userStop: event.stop.userStop } }
+    case 'SessionEnd':
+      return {
+        ...base,
+        usage: event.usage ? { ...event.usage } : null,
+        error: event.error ? { message: event.error.message, stack: event.error.stack } : null
+      }
+    default: {
+      const unreachable: never = event
+      throw new Error(`Unhandled hook event: ${JSON.stringify(unreachable)}`)
+    }
+  }
+}
+
 export class HookService implements HookObserver {
   private accepting = true
   private readonly activeChildren = new Set<ChildProcess>()
-  private readonly pendingDispatches = new Set<Promise<void>>()
+  /** Per-session delivery chain: emission order within a session, no coupling across sessions. */
+  private readonly sessionChains = new Map<string, Promise<void>>()
+  private snapshot: HookConfigSnapshot | null = null
 
   constructor(
     private readonly settings: HookSettingsPort,
@@ -168,11 +192,24 @@ export class HookService implements HookObserver {
   ) {}
 
   getConfigSnapshot(): HooksNotificationsSettings {
-    return this.settings.getHooksNotificationsConfig()
+    return this.readSnapshot().config
+  }
+
+  /** Store write and subscription refresh happen together so the index is never behind the config. */
+  updateConfig(config: HooksNotificationsSettings): HooksNotificationsSettings {
+    const stored = this.settings.setHooksNotificationsConfig(config)
+    this.snapshot = buildConfigSnapshot(stored)
+    return stored
+  }
+
+  /** Drops the cached snapshot for writers that reach the settings store directly. */
+  refreshSubscriptions(): void {
+    this.snapshot = null
   }
 
   start(): void {
     this.accepting = true
+    this.refreshSubscriptions()
   }
 
   async stop(): Promise<void> {
@@ -184,46 +221,25 @@ export class HookService implements HookObserver {
         // Process may already be closing.
       }
     }
-    await Promise.allSettled(this.pendingDispatches)
+    await Promise.allSettled(Array.from(this.sessionChains.values()))
   }
 
-  notify(notification: HookNotification): void {
+  isObserved(event: HookEventName): boolean {
+    if (!this.accepting) {
+      return false
+    }
+    return this.readSnapshot().subscribedEvents.has(event)
+  }
+
+  notify(event: HookEvent): void {
     try {
-      const context = structuredClone(notification.context)
-      this.dispatchEvent(notification.event, {
-        conversationId: context.sessionId,
-        messageId: context.messageId,
-        promptPreview: context.promptPreview,
-        providerId: context.providerId,
-        modelId: context.modelId,
-        agentId: context.agentId ?? null,
-        workdir: context.projectDir ?? null,
-        tool: context.tool,
-        permission: context.permission ?? null,
-        stop: context.stop ?? null,
-        usage: context.usage ?? null,
-        error: context.error ?? null
-      })
+      if (!this.isObserved(event.event)) {
+        return
+      }
+      this.enqueue(projectHookEvent(event, new Date().toISOString()))
     } catch (error) {
       log.warn('[Hook] Notification observer failed:', error)
     }
-  }
-
-  dispatchEvent(event: HookEventName, context: HookDispatchContext): void {
-    if (!this.accepting) {
-      return
-    }
-    const snapshot = structuredClone(context)
-    queueMicrotask(() => {
-      if (!this.accepting) {
-        return
-      }
-      const pending = this.dispatchEventAsync(event, snapshot).catch((error) => {
-        log.warn('[Hook] Dispatch failed:', error)
-      })
-      this.pendingDispatches.add(pending)
-      void pending.finally(() => this.pendingDispatches.delete(pending))
-    })
   }
 
   async testHookCommand(hookId: string): Promise<HookTestResult> {
@@ -245,56 +261,89 @@ export class HookService implements HookObserver {
     }
 
     const event = hook.events[0] ?? 'SessionStart'
-    const payload = await this.buildPayload(event, {
+    return await this.runHookCommand(hook, {
+      payloadVersion: HOOK_PAYLOAD_VERSION,
+      event,
+      time: new Date().toISOString(),
       isTest: true,
-      promptPreview: 'Test message'
+      app: { version: app.getVersion(), platform: process.platform },
+      session: { conversationId: undefined, agentId: null, workdir: null },
+      user: { messageId: undefined, promptPreview: 'Test message' },
+      tool: null,
+      permission: null,
+      stop: null,
+      usage: null,
+      error: null
     })
-
-    return await this.runHookCommand(hook, payload)
   }
 
-  private async dispatchEventAsync(
-    event: HookEventName,
-    context: HookDispatchContext
-  ): Promise<void> {
-    const config = this.getConfigSnapshot()
-    const payload = await this.buildPayload(event, context)
+  private readSnapshot(): HookConfigSnapshot {
+    this.snapshot ??= buildConfigSnapshot(this.settings.getHooksNotificationsConfig())
+    return this.snapshot
+  }
+
+  private enqueue(projection: HookEventProjection): void {
+    const sessionId = projection.session.sessionId
+    const previous = this.sessionChains.get(sessionId) ?? Promise.resolve()
+    const next = previous.then(async () => {
+      try {
+        await this.deliver(projection)
+      } catch (error) {
+        log.warn('[Hook] Dispatch failed:', error)
+      }
+    })
+
+    this.sessionChains.set(sessionId, next)
+    void next.finally(() => {
+      if (this.sessionChains.get(sessionId) === next) {
+        this.sessionChains.delete(sessionId)
+      }
+    })
+  }
+
+  private async deliver(projection: HookEventProjection): Promise<void> {
+    if (!this.accepting) {
+      return
+    }
+
+    const { config } = this.readSnapshot()
+    const payload = await this.buildPayload(projection)
+    if (!this.accepting) {
+      return
+    }
 
     for (const hook of config.hooks) {
-      if (!this.shouldDispatchHook(hook, event)) {
+      if (!shouldDispatchHook(hook, projection.event)) {
         continue
       }
 
+      // Per-command isolation: one failing hook must not affect its siblings or the next event.
       void this.runHookCommand(hook, payload).catch((error) => {
         log.warn(`[HooksNotifications] Hook "${hook.name}" failed:`, error)
       })
     }
   }
 
-  private shouldDispatchHook(hook: HookCommandItem, event: HookEventName): boolean {
-    return Boolean(hook.enabled && hook.command.trim() && hook.events.includes(event))
-  }
+  private async buildPayload(projection: HookEventProjection): Promise<HookEventPayload> {
+    const { sessionId, agentId, providerId, modelId, projectDir } = projection.session
+    let resolvedAgentId = agentId
+    let resolvedProviderId = providerId
+    let resolvedModelId = modelId
+    let resolvedWorkdir = projectDir
 
-  private async buildPayload(
-    event: HookEventName,
-    context: HookDispatchContext
-  ): Promise<HookEventPayload> {
-    const now = new Date().toISOString()
-    let conversationId = context.conversationId
-    let providerId = context.providerId
-    let modelId = context.modelId
-    let agentId = context.agentId
-    let workdir = context.workdir
-
-    if (conversationId && (!providerId || !modelId || !workdir)) {
+    // Only an unanswered field triggers a lookup; an explicit null is already a resolved answer.
+    if (
+      sessionId &&
+      (providerId === undefined || modelId === undefined || projectDir === undefined)
+    ) {
       try {
-        const session = await this.query.getSession(conversationId)
+        const session = await this.query.getSession(sessionId)
         if (session) {
-          providerId = providerId ?? session.providerId
-          modelId = modelId ?? session.modelId
-          workdir = workdir ?? session.projectDir
-          if (!agentId && session.providerId === 'acp') {
-            agentId = session.modelId
+          resolvedProviderId = resolvedProviderId ?? session.providerId
+          resolvedModelId = resolvedModelId ?? session.modelId
+          resolvedWorkdir = resolvedWorkdir ?? session.projectDir
+          if (!resolvedAgentId && session.providerId === 'acp') {
+            resolvedAgentId = session.modelId
           }
         }
       } catch (error) {
@@ -302,60 +351,28 @@ export class HookService implements HookObserver {
       }
     }
 
-    let promptPreview = context.promptPreview
-    if (!promptPreview && context.messageId) {
-      try {
-        const message = await this.query.getMessage(context.messageId)
-        if (message) {
-          promptPreview = extractPromptPreview(message.content)
-        }
-      } catch (error) {
-        log.warn('[HooksNotifications] Failed to read message for preview:', error)
-      }
-    }
-
-    const hasUser = Boolean(promptPreview || context.messageId)
     return {
       payloadVersion: HOOK_PAYLOAD_VERSION,
-      event,
-      time: now,
-      isTest: Boolean(context.isTest),
+      event: projection.event,
+      time: projection.time,
+      isTest: false,
       app: {
         version: app.getVersion(),
         platform: process.platform
       },
       session: {
-        conversationId,
-        agentId: agentId ?? null,
-        workdir: workdir ?? null,
-        providerId,
-        modelId
+        conversationId: sessionId,
+        agentId: resolvedAgentId ?? null,
+        workdir: resolvedWorkdir ?? null,
+        providerId: resolvedProviderId,
+        modelId: resolvedModelId
       },
-      user: hasUser
-        ? {
-            messageId: context.messageId,
-            promptPreview: truncateText(promptPreview || '', PREVIEW_TEXT_LIMIT)
-          }
-        : null,
-      tool: context.tool
-        ? {
-            callId: context.tool.callId,
-            name: context.tool.name,
-            paramsPreview: context.tool.params
-              ? truncateText(context.tool.params, PREVIEW_TEXT_LIMIT)
-              : undefined,
-            responsePreview: context.tool.response
-              ? truncateText(context.tool.response, PREVIEW_TEXT_LIMIT)
-              : undefined,
-            error: context.tool.error
-              ? truncateText(context.tool.error, PREVIEW_TEXT_LIMIT)
-              : undefined
-          }
-        : null,
-      permission: context.permission ?? null,
-      stop: context.stop ?? null,
-      usage: context.usage ?? null,
-      error: context.error ?? null
+      user: projection.user,
+      tool: projection.tool,
+      permission: projection.permission,
+      stop: projection.stop,
+      usage: projection.usage,
+      error: projection.error
     }
   }
 
@@ -500,4 +517,23 @@ export class HookService implements HookObserver {
       }
     })
   }
+}
+
+const shouldDispatchHook = (hook: HookCommandItem, event: HookEventName): boolean =>
+  Boolean(hook.enabled && hook.command.trim() && hook.events.includes(event))
+
+const buildConfigSnapshot = (config: HooksNotificationsSettings): HookConfigSnapshot => {
+  const subscribedEvents = new Set<HookEventName>()
+  for (const hook of config.hooks) {
+    Object.freeze(Object.freeze(hook).events)
+    if (!hook.enabled || !hook.command.trim()) {
+      continue
+    }
+    for (const event of hook.events) {
+      subscribedEvents.add(event)
+    }
+  }
+  // The delivery path and every getConfigSnapshot caller share this object.
+  Object.freeze(Object.freeze(config).hooks)
+  return { config, subscribedEvents }
 }

--- a/src/main/hook/index.ts
+++ b/src/main/hook/index.ts
@@ -211,7 +211,7 @@ export class HookService implements HookObserver {
   ) {}
 
   getConfigSnapshot(): HooksNotificationsSettings {
-    return this.readSnapshot().config
+    return cloneConfig(this.readSnapshot().config)
   }
 
   /** Store write and subscription refresh happen together so the index is never behind the config. */
@@ -586,10 +586,17 @@ const isHookRunnable = (hook: HookCommandItem): boolean =>
 const shouldDispatchHook = (hook: HookCommandItem, event: HookEventName): boolean =>
   isHookRunnable(hook) && hook.events.includes(event)
 
-const buildConfigSnapshot = (config: HooksNotificationsSettings): HookConfigSnapshot => {
+const cloneConfig = (config: HooksNotificationsSettings): HooksNotificationsSettings => ({
+  hooks: config.hooks.map((hook) => ({ ...hook, events: [...hook.events] }))
+})
+
+// Owns a private copy so the settings port never observes the delivery path freezing its result.
+const buildConfigSnapshot = (source: HooksNotificationsSettings): HookConfigSnapshot => {
+  const config = cloneConfig(source)
   const subscribedEvents = new Set<HookEventName>()
   for (const hook of config.hooks) {
-    Object.freeze(Object.freeze(hook).events)
+    Object.freeze(hook.events)
+    Object.freeze(hook)
     if (!isHookRunnable(hook)) {
       continue
     }
@@ -597,7 +604,7 @@ const buildConfigSnapshot = (config: HooksNotificationsSettings): HookConfigSnap
       subscribedEvents.add(event)
     }
   }
-  // The delivery path and every getConfigSnapshot caller share this object.
-  Object.freeze(Object.freeze(config).hooks)
+  Object.freeze(config.hooks)
+  Object.freeze(config)
   return { config, subscribedEvents }
 }

--- a/src/main/hook/index.ts
+++ b/src/main/hook/index.ts
@@ -104,6 +104,13 @@ export const expandHookCommandPlaceholders = (
     return platform === 'win32' ? `"%${envName}%"` : `"\${${envName}}"`
   })
 
+/**
+ * Diagnostics are truncated to DIAGNOSTIC_TEXT_LIMIT anyway, so a command that streams for its
+ * whole timeout window must not be able to hold more than that in the main process.
+ */
+const captureDiagnostic = (current: string, chunk: unknown): string =>
+  current.length >= DIAGNOSTIC_TEXT_LIMIT ? current : current + String(chunk)
+
 const redactSensitiveText = (text: string, secrets: string[]): string => {
   if (!text) {
     return ''
@@ -469,6 +476,8 @@ export class HookService implements HookObserver {
       DEEPCHAT_TOOL_CALL_ID: payload.tool?.callId ?? ''
     }
 
+    const secrets = [payload.session.conversationId ?? '', payload.session.workdir ?? '']
+
     return await new Promise<HookCommandResult>((resolve) => {
       let stdout = ''
       let stderr = ''
@@ -498,6 +507,16 @@ export class HookService implements HookObserver {
         } catch {
           // ignore
         }
+        // A killed shell can keep its process tree alive and never emit `close`, so the timeout
+        // settles the result itself instead of waiting for an exit that may never arrive.
+        finalize({
+          success: false,
+          durationMs: Date.now() - start,
+          exitCode: null,
+          stdout: redactSensitiveText(truncateText(stdout, DIAGNOSTIC_TEXT_LIMIT), secrets),
+          stderr: redactSensitiveText(truncateText(stderr, DIAGNOSTIC_TEXT_LIMIT), secrets),
+          error: 'Command timed out'
+        })
       }, COMMAND_TIMEOUT_MS)
 
       child.on('error', (error) => {
@@ -514,16 +533,15 @@ export class HookService implements HookObserver {
       })
 
       child.stdout?.on('data', (chunk) => {
-        stdout += String(chunk)
+        stdout = captureDiagnostic(stdout, chunk)
       })
       child.stderr?.on('data', (chunk) => {
-        stderr += String(chunk)
+        stderr = captureDiagnostic(stderr, chunk)
       })
 
       child.on('close', (code) => {
         this.activeChildren.delete(child)
         clearTimeout(timeout)
-        const secrets = [payload.session.conversationId ?? '', payload.session.workdir ?? '']
         finalize({
           success: !timedOut && code === 0,
           durationMs: Date.now() - start,

--- a/src/main/hook/index.ts
+++ b/src/main/hook/index.ts
@@ -519,14 +519,17 @@ export class HookService implements HookObserver {
   }
 }
 
+const isHookRunnable = (hook: HookCommandItem): boolean =>
+  Boolean(hook.enabled && hook.command.trim())
+
 const shouldDispatchHook = (hook: HookCommandItem, event: HookEventName): boolean =>
-  Boolean(hook.enabled && hook.command.trim() && hook.events.includes(event))
+  isHookRunnable(hook) && hook.events.includes(event)
 
 const buildConfigSnapshot = (config: HooksNotificationsSettings): HookConfigSnapshot => {
   const subscribedEvents = new Set<HookEventName>()
   for (const hook of config.hooks) {
     Object.freeze(Object.freeze(hook).events)
-    if (!hook.enabled || !hook.command.trim()) {
+    if (!isHookRunnable(hook)) {
       continue
     }
     for (const event of hook.events) {

--- a/src/main/hook/observer.ts
+++ b/src/main/hook/observer.ts
@@ -1,26 +1,10 @@
 import type { HookEventName } from '@shared/hooksNotifications'
-import type { HookDispatchContext } from './index'
-
-export type HookContext = Readonly<{
-  sessionId: string
-  agentId?: string | null
-  projectDir?: string | null
-  messageId?: string
-  promptPreview?: string
-  providerId?: string
-  modelId?: string
-  tool?: Readonly<NonNullable<HookDispatchContext['tool']>>
-  permission?: Readonly<Record<string, unknown>> | null
-  stop?: Readonly<NonNullable<HookDispatchContext['stop']>> | null
-  usage?: Readonly<Record<string, number>> | null
-  error?: Readonly<NonNullable<HookDispatchContext['error']>> | null
-}>
-
-export interface HookNotification {
-  readonly event: HookEventName
-  readonly context: HookContext
-}
+import type { HookEvent } from './events'
 
 export interface HookObserver {
-  notify(notification: HookNotification): void
+  /** Synchronous subscription probe so producers can skip assembling facts nobody consumes. */
+  isObserved(event: HookEventName): boolean
+
+  /** Must not throw, must snapshot synchronously, and must never block the caller. */
+  notify(event: HookEvent): void
 }

--- a/src/main/hook/routes.ts
+++ b/src/main/hook/routes.ts
@@ -4,12 +4,16 @@ import {
   configTestHookCommandRoute,
   type DeepchatRouteName
 } from '@shared/contracts/routes'
-import type { HookTestResult } from '@shared/hooksNotifications'
-import type { HookSettings } from './config'
+import type { HooksNotificationsSettings, HookTestResult } from '@shared/hooksNotifications'
+
+export interface HookRoutesPort {
+  getConfigSnapshot(): HooksNotificationsSettings
+  updateConfig(config: HooksNotificationsSettings): HooksNotificationsSettings
+  testHookCommand(hookId: string): Promise<HookTestResult>
+}
 
 export function createHookRoutes(deps: {
-  settings: HookSettings
-  testCommand(hookId: string): Promise<HookTestResult>
+  service: HookRoutesPort
 }): ReadonlyMap<DeepchatRouteName, (rawInput: unknown) => Promise<unknown>> {
   return new Map<DeepchatRouteName, (rawInput: unknown) => Promise<unknown>>([
     [
@@ -17,7 +21,7 @@ export function createHookRoutes(deps: {
       async (rawInput: unknown) => {
         configGetHooksNotificationsRoute.input.parse(rawInput)
         return configGetHooksNotificationsRoute.output.parse({
-          config: deps.settings.getHooksNotificationsConfig()
+          config: deps.service.getConfigSnapshot()
         })
       }
     ],
@@ -26,7 +30,7 @@ export function createHookRoutes(deps: {
       async (rawInput: unknown) => {
         const input = configSetHooksNotificationsRoute.input.parse(rawInput)
         return configSetHooksNotificationsRoute.output.parse({
-          config: deps.settings.setHooksNotificationsConfig(input.config)
+          config: deps.service.updateConfig(input.config)
         })
       }
     ],
@@ -35,7 +39,7 @@ export function createHookRoutes(deps: {
       async (rawInput: unknown) => {
         const input = configTestHookCommandRoute.input.parse(rawInput)
         return configTestHookCommandRoute.output.parse({
-          result: await deps.testCommand(input.hookId)
+          result: await deps.service.testHookCommand(input.hookId)
         })
       }
     ]

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -23,8 +23,7 @@ import {
   PRE_STREAM_STUCK_WARN_MS
 } from '@/agent/deepchat/runtime/preStreamWatchdog'
 import logger from '@shared/logger'
-import type { HookEvent } from '@/hook/events'
-import type { HookObserver } from '@/hook/observer'
+import { createHookObserver, noopHookObserver } from '../../../hook/hookObserverFixture'
 import { estimateMessagesTokens } from '@/agent/deepchat/runtime/contextBuilder'
 import {
   estimateToolReserveTokens,
@@ -49,28 +48,6 @@ import { AcpPromptController, AcpRuntimeOwner, type AcpClientRuntime } from '@/a
 import { AcpAgentRuntime } from '@/agent/acp/instance'
 import type { AcpAgentDescriptor } from '@/agent/shared/agentDescriptors'
 
-const createHookObserver = (dispatcher: {
-  dispatchEvent: ReturnType<typeof vi.fn>
-}): HookObserver => ({
-  isObserved: () => true,
-  notify(event: HookEvent) {
-    dispatcher.dispatchEvent(event.event, {
-      conversationId: event.session.sessionId,
-      agentId: event.session.agentId,
-      workdir: event.session.projectDir,
-      messageId: event.session.messageId,
-      providerId: event.session.providerId,
-      modelId: event.session.modelId,
-      promptPreview: 'promptPreview' in event ? event.promptPreview : undefined,
-      tool: 'tool' in event ? event.tool : undefined,
-      permission: 'permission' in event ? event.permission : undefined,
-      stop: 'stop' in event ? event.stop : undefined,
-      usage: 'usage' in event ? event.usage : undefined,
-      error: 'error' in event ? event.error : undefined
-    })
-  }
-})
-const noopHookObserver: HookObserver = { isObserved: () => true, notify: vi.fn() }
 import type { AcpAgentConfig } from '@shared/types/acp'
 import type * as schema from '@agentclientprotocol/sdk/dist/schema/index.js'
 import { nanoid } from 'nanoid'

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -23,7 +23,8 @@ import {
   PRE_STREAM_STUCK_WARN_MS
 } from '@/agent/deepchat/runtime/preStreamWatchdog'
 import logger from '@shared/logger'
-import type { HookNotification, HookObserver } from '@/hook/observer'
+import type { HookEvent } from '@/hook/events'
+import type { HookObserver } from '@/hook/observer'
 import { estimateMessagesTokens } from '@/agent/deepchat/runtime/contextBuilder'
 import {
   estimateToolReserveTokens,
@@ -51,24 +52,25 @@ import type { AcpAgentDescriptor } from '@/agent/shared/agentDescriptors'
 const createHookObserver = (dispatcher: {
   dispatchEvent: ReturnType<typeof vi.fn>
 }): HookObserver => ({
-  notify({ event, context }: HookNotification) {
-    dispatcher.dispatchEvent(event, {
-      conversationId: context.sessionId,
-      agentId: context.agentId,
-      workdir: context.projectDir,
-      messageId: context.messageId,
-      promptPreview: context.promptPreview,
-      providerId: context.providerId,
-      modelId: context.modelId,
-      tool: context.tool,
-      permission: context.permission,
-      stop: context.stop,
-      usage: context.usage,
-      error: context.error
+  isObserved: () => true,
+  notify(event: HookEvent) {
+    dispatcher.dispatchEvent(event.event, {
+      conversationId: event.session.sessionId,
+      agentId: event.session.agentId,
+      workdir: event.session.projectDir,
+      messageId: event.session.messageId,
+      providerId: event.session.providerId,
+      modelId: event.session.modelId,
+      promptPreview: 'promptPreview' in event ? event.promptPreview : undefined,
+      tool: 'tool' in event ? event.tool : undefined,
+      permission: 'permission' in event ? event.permission : undefined,
+      stop: 'stop' in event ? event.stop : undefined,
+      usage: 'usage' in event ? event.usage : undefined,
+      error: 'error' in event ? event.error : undefined
     })
   }
 })
-const noopHookObserver: HookObserver = { notify: vi.fn() }
+const noopHookObserver: HookObserver = { isObserved: () => true, notify: vi.fn() }
 import type { AcpAgentConfig } from '@shared/types/acp'
 import type * as schema from '@agentclientprotocol/sdk/dist/schema/index.js'
 import { nanoid } from 'nanoid'

--- a/test/main/agent/deepchat/runtime/dispatch.test.ts
+++ b/test/main/agent/deepchat/runtime/dispatch.test.ts
@@ -246,6 +246,7 @@ async function settleToolBatch(
     collaborators: {
       notificationObserver: hooks
         ? {
+            isObserved: () => true,
             notify: (notification) => {
               if (notification.event === 'PreToolUse') {
                 hooks.onPreToolUse?.(notification.tool)

--- a/test/main/agent/deepchat/runtime/process.test.ts
+++ b/test/main/agent/deepchat/runtime/process.test.ts
@@ -1059,6 +1059,7 @@ describe('processStream', () => {
         permissionMode: 'auto_approve',
         controls,
         notificationObserver: {
+          isObserved: () => true,
           notify: (notification) => notifications.push(structuredClone(notification))
         }
       })
@@ -1981,6 +1982,7 @@ describe('processStream', () => {
       toolExecution: createToolExecutionPort(toolService),
       tools: [makeTool('get_weather')],
       notificationObserver: {
+        isObserved: () => true,
         notify: (notification) => {
           notifications.push(structuredClone(notification))
           ;(notification.tool as { name?: string; response?: string }).name = 'observer-mutated'
@@ -2031,6 +2033,7 @@ describe('processStream', () => {
           toolExecution: createToolExecutionPort(toolService),
           tools: [makeTool('get_weather')],
           notificationObserver: {
+            isObserved: () => true,
             notify: () => {
               throw new Error('observer failed')
             }
@@ -2046,52 +2049,23 @@ describe('processStream', () => {
     }
   })
 
-  it('does not await rejected or never-settling notification observers', async () => {
-    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    let releaseObserver!: () => void
-    const neverSettlingUntilReleased = new Promise<void>((resolve) => {
-      releaseObserver = resolve
-    })
-    const rejectedThenable = {
-      then: (_resolve: unknown, reject?: (reason: unknown) => unknown) => {
-        reject?.(new Error('observer rejected'))
-      }
-    } as unknown as PromiseLike<void>
-    const notify = vi.fn((notification: DeepChatLoopNotification) =>
-      notification.event === 'PreToolUse' ? neverSettlingUntilReleased : rejectedThenable
-    )
+  it('assembles no notification for an unobserved event', async () => {
+    const notify = vi.fn()
+    const isObserved = vi.fn((event: DeepChatLoopNotification['event']) => event !== 'PreToolUse')
     const toolService = createMockToolService({ get_weather: 'Sunny, 72F' })
-    const processPromise = processStream(
+
+    const result = await processStream(
       createParams({
         coreStream: createToolThenCompleteStream('get_weather'),
         toolExecution: createToolExecutionPort(toolService),
         tools: [makeTool('get_weather')],
-        notificationObserver: { notify }
+        notificationObserver: { isObserved, notify }
       })
     )
-    let settled = false
-    void processPromise.then(() => {
-      settled = true
-    })
 
-    try {
-      await vi.runAllTimersAsync()
-      await Promise.resolve()
-
-      expect(notify.mock.calls.map(([notification]) => notification.event)).toEqual([
-        'PreToolUse',
-        'PostToolUse'
-      ])
-      expect(settled).toBe(true)
-    } finally {
-      releaseObserver()
-    }
-
-    const result = await processPromise
-    await Promise.resolve()
     expect(result.status).toBe('completed')
-    expect(warning).toHaveBeenCalledTimes(1)
-    warning.mockRestore()
+    expect(isObserved.mock.calls.map(([event]) => event)).toEqual(['PreToolUse', 'PostToolUse'])
+    expect(notify.mock.calls.map(([notification]) => notification.event)).toEqual(['PostToolUse'])
   })
 
   it('signals first provider round after flushing without blocking tool loop', async () => {

--- a/test/main/agent/deepchat/runtime/runtimeHookSink.test.ts
+++ b/test/main/agent/deepchat/runtime/runtimeHookSink.test.ts
@@ -1,4 +1,5 @@
-import type { HookNotification, HookObserver } from '@/hook/observer'
+import type { HookEvent } from '@/hook/events'
+import type { HookObserver } from '@/hook/observer'
 import { RuntimeHookSink } from '@/agent/deepchat/runtime/runtimeHookSink'
 import type { DeepChatSessionState } from '@shared/types/agent-interface'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -10,64 +11,131 @@ const STATE: DeepChatSessionState = {
   permissionMode: 'full_access'
 }
 
-function createHarness() {
-  const notifications: HookNotification[] = []
+function createHarness(observed = true) {
+  const events: HookEvent[] = []
   const observer: HookObserver = {
-    notify: vi.fn((notification: HookNotification) => notifications.push(notification))
+    isObserved: vi.fn(() => observed),
+    notify: vi.fn((event: HookEvent) => events.push(event))
   }
-  const getSessionAgentId = vi.fn().mockReturnValue('agent-id')
+  const getAgentId = vi.fn().mockReturnValue('agent-id')
   const resolveProjectDir = vi.fn().mockReturnValue('/workspace')
   const sink = new RuntimeHookSink({
     observer,
-    identity: { getAgentId: getSessionAgentId },
+    identity: { getAgentId },
     sessionSettings: { resolveProjectDir }
   })
-  return { getSessionAgentId, notifications, observer, resolveProjectDir, sink }
+  return { events, getAgentId, observer, resolveProjectDir, sink }
 }
 
-describe('RuntimeHookSink', () => {
+describe('RuntimeHookSink scope', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('adds the current agent identity without changing the hook context', () => {
-    const { notifications, sink } = createHarness()
-
-    sink.dispatch('UserPromptSubmit', {
+  it('binds the session envelope once for every event it emits', () => {
+    const { events, resolveProjectDir, sink } = createHarness()
+    const hooks = sink.scope({
       sessionId: 'session',
       messageId: 'message',
-      promptPreview: 'prompt'
+      providerId: 'openai',
+      modelId: 'gpt-5'
     })
 
-    expect(notifications).toEqual([
+    hooks.emit({ event: 'UserPromptSubmit', promptPreview: 'prompt' })
+    hooks.emit({ event: 'PreToolUse', tool: { callId: 'call-1', name: 'read_file' } })
+
+    expect(resolveProjectDir).toHaveBeenCalledTimes(1)
+    expect(events).toEqual([
       {
         event: 'UserPromptSubmit',
-        context: {
+        promptPreview: 'prompt',
+        session: {
           sessionId: 'session',
           messageId: 'message',
-          promptPreview: 'prompt',
+          providerId: 'openai',
+          modelId: 'gpt-5',
+          projectDir: '/workspace',
+          agentId: 'agent-id'
+        }
+      },
+      {
+        event: 'PreToolUse',
+        tool: { callId: 'call-1', name: 'read_file' },
+        session: {
+          sessionId: 'session',
+          messageId: 'message',
+          providerId: 'openai',
+          modelId: 'gpt-5',
+          projectDir: '/workspace',
           agentId: 'agent-id'
         }
       }
     ])
   })
 
-  it('isolates observer failures from runtime settlement', () => {
+  it('keeps an explicit project directory instead of resolving one', () => {
+    const { events, resolveProjectDir, sink } = createHarness()
+
+    sink.scope({ sessionId: 'session', projectDir: null }).emit({ event: 'SessionStart' })
+
+    expect(resolveProjectDir).not.toHaveBeenCalled()
+    expect(events[0].session.projectDir).toBeNull()
+  })
+
+  it('assembles nothing when the event has no subscriber', () => {
+    const { events, getAgentId, resolveProjectDir, sink } = createHarness(false)
+
+    sink.scope({ sessionId: 'session' }).emit({ event: 'SessionStart' })
+
+    expect(events).toEqual([])
+    expect(resolveProjectDir).not.toHaveBeenCalled()
+    expect(getAgentId).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the deepchat agent identity', () => {
+    const { events, getAgentId, sink } = createHarness()
+    getAgentId.mockReturnValue(undefined)
+
+    sink.scope({ sessionId: 'session' }).emit({ event: 'SessionStart' })
+
+    expect(events[0].session.agentId).toBe('deepchat')
+  })
+
+  it('isolates an observer failure from the caller', () => {
     const { observer, sink } = createHarness()
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     vi.mocked(observer.notify).mockImplementationOnce(() => {
       throw new Error('observer failed')
     })
 
-    expect(() => sink.dispatch('SessionStart', { sessionId: 'session' })).not.toThrow()
+    expect(() => sink.scope({ sessionId: 'session' }).emit({ event: 'SessionStart' })).not.toThrow()
     expect(warning).toHaveBeenCalledWith(
       '[DeepChatAgent] Failed to dispatch SessionStart hook:',
       expect.objectContaining({ message: 'observer failed' })
     )
   })
 
-  it('maps a completed terminal result to Stop then SessionEnd', () => {
-    const { notifications, resolveProjectDir, sink } = createHarness()
+  it('still reports a terminal pair when the project directory cannot be resolved', () => {
+    const { events, resolveProjectDir, sink } = createHarness()
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    resolveProjectDir.mockImplementation(() => {
+      throw new Error('stale instance')
+    })
+
+    expect(() => sink.observeTerminal('session', STATE, { status: 'completed' })).not.toThrow()
+    expect(warning).toHaveBeenCalledTimes(1)
+    expect(events.map((event) => event.event)).toEqual(['Stop', 'SessionEnd'])
+    expect(events[0].session.projectDir).toBeUndefined()
+  })
+})
+
+describe('RuntimeHookSink terminal projection', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('maps a completed result to Stop then SessionEnd', () => {
+    const { events, sink } = createHarness()
 
     sink.observeTerminal('session', STATE, {
       status: 'completed',
@@ -75,36 +143,37 @@ describe('RuntimeHookSink', () => {
       usage: { totalTokens: 12 }
     })
 
-    expect(notifications).toEqual([
+    expect(events).toEqual([
       {
         event: 'Stop',
-        context: {
+        stop: { reason: 'tool_calls_complete', userStop: false },
+        session: {
           sessionId: 'session',
+          messageId: undefined,
           providerId: 'openai',
           modelId: 'gpt-5',
           projectDir: '/workspace',
-          stop: { reason: 'tool_calls_complete', userStop: false },
           agentId: 'agent-id'
         }
       },
       {
         event: 'SessionEnd',
-        context: {
+        usage: { totalTokens: 12 },
+        error: null,
+        session: {
           sessionId: 'session',
+          messageId: undefined,
           providerId: 'openai',
           modelId: 'gpt-5',
           projectDir: '/workspace',
-          usage: { totalTokens: 12 },
-          error: null,
           agentId: 'agent-id'
         }
       }
     ])
-    expect(resolveProjectDir).toHaveBeenCalledTimes(2)
   })
 
   it('maps abort and error fallbacks while ignoring paused results', () => {
-    const { notifications, sink } = createHarness()
+    const { events, sink } = createHarness()
 
     sink.observeTerminal('session', STATE, { status: 'paused' })
     sink.observeTerminal('session', STATE, { status: 'aborted' })
@@ -113,27 +182,91 @@ describe('RuntimeHookSink', () => {
       terminalError: 'provider failed'
     })
 
-    expect(notifications.map(({ event, context }) => ({
-      event,
-      stop: context.stop,
-      error: context.error
-    }))).toEqual([
-      {
-        event: 'Stop',
-        stop: { reason: 'user_stop', userStop: true },
-        error: undefined
-      },
+    expect(
+      events.map((event) => ({
+        event: event.event,
+        stop: 'stop' in event ? event.stop : undefined,
+        error: 'error' in event ? event.error : undefined
+      }))
+    ).toEqual([
+      { event: 'Stop', stop: { reason: 'user_stop', userStop: true }, error: undefined },
       { event: 'SessionEnd', stop: undefined, error: null },
+      { event: 'Stop', stop: { reason: 'error', userStop: false }, error: undefined },
+      { event: 'SessionEnd', stop: undefined, error: { message: 'provider failed' } }
+    ])
+  })
+
+  it('skips terminal projection without session state', () => {
+    const { events, sink } = createHarness()
+
+    sink.observeTerminal('session', undefined, { status: 'completed' })
+
+    expect(events).toEqual([])
+  })
+
+  it('reports the same terminal pair for every entry point', () => {
+    const { events, sink } = createHarness()
+
+    sink.scope({ sessionId: 'session', providerId: 'openai', modelId: 'gpt-5' }).terminal({
+      reason: 'tool_error',
+      userStop: false,
+      usage: { totalTokens: 5 },
+      error: { message: 'tool exploded' }
+    })
+
+    expect(events.map((event) => event.event)).toEqual(['Stop', 'SessionEnd'])
+    expect(events[1]).toMatchObject({ usage: { totalTokens: 5 }, error: { message: 'tool exploded' } })
+  })
+
+  it('normalizes a missing usage or error into an explicit null', () => {
+    const { events, sink } = createHarness()
+
+    sink.scope({ sessionId: 'session' }).terminal({ reason: 'complete', userStop: false })
+
+    expect(events[1]).toMatchObject({ usage: null, error: null })
+  })
+})
+
+describe('RuntimeHookSink tool observer', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('completes loop tool notifications with the bound session envelope', () => {
+    const { events, sink } = createHarness()
+    const observer = sink
+      .scope({ sessionId: 'session', messageId: 'message', providerId: 'openai' })
+      .toolObserver()
+
+    observer.notify({
+      event: 'PostToolUseFailure',
+      tool: { callId: 'call-1', name: 'write_file', error: 'denied' }
+    })
+    observer.notify({
+      event: 'PermissionRequest',
+      tool: { callId: 'call-2', name: 'write_file' },
+      permission: { permissionType: 'write' }
+    })
+
+    expect(events).toEqual([
       {
-        event: 'Stop',
-        stop: { reason: 'error', userStop: false },
-        error: undefined
+        event: 'PostToolUseFailure',
+        tool: { callId: 'call-1', name: 'write_file', error: 'denied' },
+        session: expect.objectContaining({ sessionId: 'session', messageId: 'message' })
       },
       {
-        event: 'SessionEnd',
-        stop: undefined,
-        error: { message: 'provider failed' }
+        event: 'PermissionRequest',
+        tool: { callId: 'call-2', name: 'write_file' },
+        permission: { permissionType: 'write' },
+        session: expect.objectContaining({ sessionId: 'session', messageId: 'message' })
       }
     ])
+  })
+
+  it('reports subscription state through to the loop', () => {
+    const { sink } = createHarness(false)
+    const observer = sink.scope({ sessionId: 'session' }).toolObserver()
+
+    expect(observer.isObserved('PreToolUse')).toBe(false)
   })
 })

--- a/test/main/app/compositionBoundaries.test.ts
+++ b/test/main/app/compositionBoundaries.test.ts
@@ -34,7 +34,7 @@ describe('session boundary composition', () => {
     )
   })
 
-  it('keeps hooks notifications on one instance with lazy projection dependencies', async () => {
+  it('keeps hooks notifications on one instance that owns every configuration write', async () => {
     const { readFileSync } = await vi.importActual<typeof import('node:fs')>('node:fs')
     const compositionSource = readFileSync(
       path.resolve(process.cwd(), 'src/main/app/composition.ts'),
@@ -45,9 +45,8 @@ describe('session boundary composition', () => {
     expect(compositionSource).toContain(
       'getSession: (sessionId) => sessionQuery.getSession(sessionId)'
     )
-    expect(compositionSource).toContain(
-      'getMessage: (messageId) => sessionQuery.getMessage(messageId)'
-    )
+    expect(compositionSource).toContain('createHookRoutes({ service: hookService })')
+    expect(compositionSource).not.toContain('settings: hookSettings')
   })
 
   it('constructs Scheduler once after Remote with complete execution dependencies', async () => {

--- a/test/main/evals/nativeAgent/harness.ts
+++ b/test/main/evals/nativeAgent/harness.ts
@@ -490,6 +490,7 @@ export async function runNativeAgentEvalScenario(
     maxProviderRounds: scenario.maxProviderRounds,
     shouldYieldForPendingInput: () => scenario.yieldForPendingInput === true,
     notificationObserver: {
+      isObserved: () => true,
       notify: (notification) => {
         if (notification.event === 'PermissionRequest') {
           permissionRequests += 1

--- a/test/main/hook/hookObserverFixture.ts
+++ b/test/main/hook/hookObserverFixture.ts
@@ -1,0 +1,27 @@
+import { vi } from 'vitest'
+import type { HookEvent } from '@/hook/events'
+import type { HookObserver } from '@/hook/observer'
+
+export const createHookObserver = (dispatcher: {
+  dispatchEvent: ReturnType<typeof vi.fn>
+}): HookObserver => ({
+  isObserved: () => true,
+  notify(event: HookEvent) {
+    dispatcher.dispatchEvent(event.event, {
+      conversationId: event.session.sessionId,
+      agentId: event.session.agentId,
+      workdir: event.session.projectDir,
+      messageId: event.session.messageId,
+      providerId: event.session.providerId,
+      modelId: event.session.modelId,
+      promptPreview: 'promptPreview' in event ? event.promptPreview : undefined,
+      tool: 'tool' in event ? event.tool : undefined,
+      permission: 'permission' in event ? event.permission : undefined,
+      stop: 'stop' in event ? event.stop : undefined,
+      usage: 'usage' in event ? event.usage : undefined,
+      error: 'error' in event ? event.error : undefined
+    })
+  }
+})
+
+export const noopHookObserver: HookObserver = { isObserved: () => true, notify: vi.fn() }

--- a/test/main/hook/hookService.test.ts
+++ b/test/main/hook/hookService.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it, vi } from 'vitest'
-import { expandHookCommandPlaceholders, HookService, truncateText } from '../../../src/main/hook'
-import {
-  createDefaultHookCommand,
-  createDefaultHooksNotificationsConfig,
-  normalizeHooksNotificationsConfig
-} from '../../../src/main/hook/config'
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  HookCommandItem,
+  HookEventName,
+  HookEventPayload,
+  HooksNotificationsSettings
+} from '../../../src/shared/hooksNotifications'
 import { DEFAULT_IMPORTANT_HOOK_EVENTS } from '../../../src/shared/hooksNotifications'
 
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+
+vi.mock('child_process', () => ({ spawn: spawnMock }))
 vi.mock('electron-log', () => ({
   default: {
     warn: vi.fn(),
@@ -14,6 +18,14 @@ vi.mock('electron-log', () => ({
     error: vi.fn()
   }
 }))
+
+import { expandHookCommandPlaceholders, HookService, truncateText } from '../../../src/main/hook'
+import {
+  createDefaultHookCommand,
+  createDefaultHooksNotificationsConfig,
+  normalizeHooksNotificationsConfig
+} from '../../../src/main/hook/config'
+import type { HookEvent } from '../../../src/main/hook/events'
 
 describe('HookService helpers', () => {
   it('truncateText keeps short strings intact', () => {
@@ -168,70 +180,480 @@ describe('HookService helpers', () => {
   })
 })
 
-describe('HookService observer', () => {
-  const createService = () =>
-    new HookService(
-      { getHooksNotificationsConfig: () => ({ hooks: [] }) },
-      {
-        getSession: vi.fn().mockResolvedValue(null),
-        getMessage: vi.fn().mockResolvedValue(null)
-      }
-    )
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
 
-  it('forwards ordered detached snapshots to the notification dispatcher', () => {
-    const service = createService()
-    const dispatchEvent = vi.spyOn(service, 'dispatchEvent').mockImplementation(() => undefined)
-    const context = {
-      sessionId: 'session-1',
-      agentId: 'agent-1',
-      tool: {
-        callId: 'tool-1',
-        name: 'write_file',
-        params: '{"path":"before.txt"}'
-      },
-      permission: {
-        permissionType: 'write',
-        metadata: { path: 'before.txt' }
-      }
+const enabledHook = (id: string, events: HookEventName[]): HookCommandItem => ({
+  id,
+  name: id,
+  enabled: true,
+  command: `run-${id}`,
+  events
+})
+
+class FakeChild extends EventEmitter {
+  readonly stdout = new EventEmitter()
+  readonly stderr = new EventEmitter()
+  readonly stdin = { write: vi.fn(), end: vi.fn() }
+  readonly kill = vi.fn()
+}
+
+const spawnedPayloads = (): HookEventPayload[] =>
+  spawnMock.mock.results.map(
+    (result) =>
+      JSON.parse(
+        (result.value as FakeChild).stdin.write.mock.calls[0][0] as string
+      ) as HookEventPayload
+  )
+
+const createHarness = (hooks: HookCommandItem[] = []) => {
+  let stored: HooksNotificationsSettings = { hooks }
+  const getHooksNotificationsConfig = vi.fn(() => stored)
+  const setHooksNotificationsConfig = vi.fn((next: HooksNotificationsSettings) => {
+    stored = next
+    return next
+  })
+  const getSession = vi.fn().mockResolvedValue(null)
+  const service = new HookService(
+    { getHooksNotificationsConfig, setHooksNotificationsConfig },
+    { getSession }
+  )
+  return {
+    service,
+    getSession,
+    getHooksNotificationsConfig,
+    setHooksNotificationsConfig,
+    writeExternally: (next: HooksNotificationsSettings) => {
+      stored = next
     }
+  }
+}
 
-    service.notify({ event: 'PermissionRequest', context })
-    context.tool.name = 'mutated_tool'
-    context.permission.metadata.path = 'after.txt'
-    service.notify({ event: 'PreToolUse', context })
+const toolEvent = (sessionId: string, callId: string): HookEvent => ({
+  event: 'PostToolUse',
+  session: { sessionId, providerId: 'openai', modelId: 'gpt-5', projectDir: null },
+  tool: { callId, name: 'read_file', params: '{"path":"a.txt"}', response: 'ok' }
+})
 
-    expect(dispatchEvent.mock.calls.map(([event]) => event)).toEqual([
-      'PermissionRequest',
-      'PreToolUse'
+describe('HookService subscription index', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+    spawnMock.mockImplementation(() => {
+      const child = new FakeChild()
+      queueMicrotask(() => child.emit('close', 0))
+      return child
+    })
+  })
+
+  it('does nothing but one index lookup when no hook subscribes', async () => {
+    const { service, getSession, getHooksNotificationsConfig } = createHarness()
+
+    expect(service.isObserved('PostToolUse')).toBe(false)
+    for (let index = 0; index < 25; index += 1) {
+      service.notify(toolEvent('session-1', `call-${index}`))
+    }
+    await flush()
+
+    expect(getSession).not.toHaveBeenCalled()
+    expect(spawnMock).not.toHaveBeenCalled()
+    expect(getHooksNotificationsConfig).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores hooks that are disabled or have no command', async () => {
+    const { service } = createHarness([
+      { id: 'a', name: 'a', enabled: false, command: 'run-a', events: ['PostToolUse'] },
+      { id: 'b', name: 'b', enabled: true, command: '   ', events: ['PostToolUse'] }
     ])
-    expect(dispatchEvent.mock.calls[0][1]).toEqual(
-      expect.objectContaining({
-        conversationId: 'session-1',
-        agentId: 'agent-1',
-        tool: expect.objectContaining({ name: 'write_file' }),
-        permission: expect.objectContaining({
-          metadata: { path: 'before.txt' }
-        })
+
+    expect(service.isObserved('PostToolUse')).toBe(false)
+    service.notify(toolEvent('session-1', 'call-1'))
+    await flush()
+
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('applies a configuration write to the index without re-reading the store', async () => {
+    const { service, getHooksNotificationsConfig, setHooksNotificationsConfig } = createHarness()
+
+    expect(service.isObserved('PostToolUse')).toBe(false)
+    service.updateConfig({ hooks: [enabledHook('a', ['PostToolUse'])] })
+
+    expect(setHooksNotificationsConfig).toHaveBeenCalledTimes(1)
+    expect(service.isObserved('PostToolUse')).toBe(true)
+    expect(getHooksNotificationsConfig).toHaveBeenCalledTimes(1)
+
+    service.notify(toolEvent('session-1', 'call-1'))
+    await flush()
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('hands out an immutable configuration snapshot', () => {
+    const { service } = createHarness([enabledHook('a', ['Stop'])])
+    const snapshot = service.getConfigSnapshot()
+
+    expect(() => snapshot.hooks.push(enabledHook('b', ['PreToolUse']))).toThrow(TypeError)
+    expect(service.isObserved('PreToolUse')).toBe(false)
+  })
+
+  it('picks up a store write that bypassed the service after a refresh', () => {
+    const { service, writeExternally } = createHarness()
+
+    expect(service.isObserved('Stop')).toBe(false)
+    writeExternally({ hooks: [enabledHook('a', ['Stop'])] })
+    expect(service.isObserved('Stop')).toBe(false)
+
+    service.refreshSubscriptions()
+    expect(service.isObserved('Stop')).toBe(true)
+  })
+
+  it('rebuilds the index when the service restarts around a maintenance window', async () => {
+    const { service, writeExternally } = createHarness()
+
+    await service.stop()
+    expect(service.isObserved('Stop')).toBe(false)
+
+    writeExternally({ hooks: [enabledHook('a', ['Stop'])] })
+    service.start()
+
+    expect(service.isObserved('Stop')).toBe(true)
+  })
+})
+
+describe('HookService delivery ordering', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+    spawnMock.mockImplementation(() => {
+      const child = new FakeChild()
+      queueMicrotask(() => child.emit('close', 0))
+      return child
+    })
+  })
+
+  it('keeps one session in emission order even when enrichment is slow', async () => {
+    const { service, getSession } = createHarness([enabledHook('a', ['PostToolUse'])])
+    let releaseSession: (value: null) => void = () => undefined
+    getSession.mockReturnValueOnce(
+      new Promise<null>((resolve) => {
+        releaseSession = resolve
       })
     )
-    expect(dispatchEvent.mock.calls[1][1]).toEqual(
+
+    service.notify({
+      event: 'PostToolUse',
+      session: { sessionId: 'session-1' },
+      tool: { callId: 'slow' }
+    })
+    service.notify(toolEvent('session-1', 'fast'))
+    await flush()
+
+    expect(spawnMock).not.toHaveBeenCalled()
+
+    releaseSession(null)
+    await flush()
+
+    expect(spawnedPayloads().map((payload) => payload.tool?.callId)).toEqual(['slow', 'fast'])
+  })
+
+  it('does not let one session block another', async () => {
+    const { service, getSession } = createHarness([enabledHook('a', ['PostToolUse'])])
+    getSession.mockReturnValueOnce(new Promise<null>(() => undefined))
+
+    service.notify({
+      event: 'PostToolUse',
+      session: { sessionId: 'blocked' },
+      tool: { callId: 'stuck' }
+    })
+    service.notify(toolEvent('other', 'free'))
+    await flush()
+
+    expect(spawnedPayloads().map((payload) => payload.tool?.callId)).toEqual(['free'])
+  })
+
+  it('keeps delivering after a hook command fails to spawn', async () => {
+    const { service } = createHarness([
+      enabledHook('broken', ['PostToolUse']),
+      enabledHook('healthy', ['PostToolUse'])
+    ])
+    spawnMock.mockImplementationOnce(() => {
+      throw new Error('spawn failed')
+    })
+
+    service.notify(toolEvent('session-1', 'first'))
+    await flush()
+    service.notify(toolEvent('session-1', 'second'))
+    await flush()
+
+    expect(spawnMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('stops delivering queued events once the service is stopped', async () => {
+    const { service, getSession } = createHarness([enabledHook('a', ['PostToolUse'])])
+    let releaseSession: (value: null) => void = () => undefined
+    getSession.mockReturnValueOnce(
+      new Promise<null>((resolve) => {
+        releaseSession = resolve
+      })
+    )
+
+    service.notify({
+      event: 'PostToolUse',
+      session: { sessionId: 'session-1' },
+      tool: { callId: 'queued' }
+    })
+    releaseSession(null)
+    const stopped = service.stop()
+    await stopped
+    await flush()
+
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('kills a hook command that outlives the command timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const { service } = createHarness([enabledHook('a', ['SessionStart'])])
+      const child = new FakeChild()
+      spawnMock.mockImplementationOnce(() => child)
+
+      const pending = service.testHookCommand('a')
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+
+      child.emit('close', null)
+      await expect(pending).resolves.toMatchObject({
+        success: false,
+        error: 'Command timed out'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('kills running hook commands on stop', async () => {
+    const { service } = createHarness([enabledHook('a', ['PostToolUse'])])
+    const child = new FakeChild()
+    spawnMock.mockImplementationOnce(() => child)
+
+    service.notify(toolEvent('session-1', 'call-1'))
+    await flush()
+    await service.stop()
+
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+})
+
+describe('HookService payload projection', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+    spawnMock.mockImplementation(() => {
+      const child = new FakeChild()
+      queueMicrotask(() => child.emit('close', 0))
+      return child
+    })
+  })
+
+  it('truncates tool previews before any clone runs', async () => {
+    const { service } = createHarness([enabledHook('a', ['PostToolUse'])])
+    const clone = vi.spyOn(globalThis, 'structuredClone')
+    const huge = 'x'.repeat(2_000_000)
+
+    service.notify({
+      event: 'PostToolUse',
+      session: { sessionId: 'session-1', providerId: 'openai', modelId: 'gpt-5', projectDir: null },
+      tool: { callId: 'call-1', name: 'write_file', params: huge, response: huge }
+    })
+    await flush()
+
+    const [payload] = spawnedPayloads()
+    expect(payload.tool?.paramsPreview).toHaveLength(1200)
+    expect(payload.tool?.responsePreview).toHaveLength(1200)
+    expect(clone).not.toHaveBeenCalled()
+    clone.mockRestore()
+  })
+
+  it('clones only the permission record and detaches it from later mutation', async () => {
+    const { service } = createHarness([enabledHook('a', ['PermissionRequest'])])
+    const clone = vi.spyOn(globalThis, 'structuredClone')
+    const permission = { permissionType: 'write', metadata: { path: 'before.txt' } }
+
+    service.notify({
+      event: 'PermissionRequest',
+      session: { sessionId: 'session-1', providerId: 'openai', modelId: 'gpt-5', projectDir: null },
+      tool: { callId: 'call-1', name: 'write_file' },
+      permission
+    })
+    permission.metadata.path = 'after.txt'
+    await flush()
+
+    expect(clone).toHaveBeenCalledTimes(1)
+    expect(spawnedPayloads()[0].permission).toEqual({
+      permissionType: 'write',
+      metadata: { path: 'before.txt' }
+    })
+    clone.mockRestore()
+  })
+
+  it('emits the version 1 payload shape', async () => {
+    const { service } = createHarness([enabledHook('a', ['SessionEnd'])])
+
+    service.notify({
+      event: 'SessionEnd',
+      session: {
+        sessionId: 'session-1',
+        agentId: 'deepchat',
+        providerId: 'openai',
+        modelId: 'gpt-5',
+        projectDir: '/workspace',
+        messageId: 'message-1'
+      },
+      usage: { totalTokens: 12 },
+      error: { message: 'boom' }
+    })
+    await flush()
+
+    const [payload] = spawnedPayloads()
+    expect(payload.time).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/)
+    expect({ ...payload, time: undefined }).toEqual({
+      payloadVersion: 1,
+      event: 'SessionEnd',
+      time: undefined,
+      isTest: false,
+      app: { version: expect.any(String), platform: process.platform },
+      session: {
+        conversationId: 'session-1',
+        agentId: 'deepchat',
+        workdir: '/workspace',
+        providerId: 'openai',
+        modelId: 'gpt-5'
+      },
+      user: { messageId: 'message-1', promptPreview: '' },
+      tool: null,
+      permission: null,
+      stop: null,
+      usage: { totalTokens: 12 },
+      error: { message: 'boom' }
+    })
+  })
+
+  it('exposes the same core metadata through the command environment', async () => {
+    const { service } = createHarness([enabledHook('a', ['PreToolUse'])])
+
+    service.notify({
+      event: 'PreToolUse',
+      session: {
+        sessionId: 'session-1',
+        agentId: 'deepchat',
+        providerId: 'openai',
+        modelId: 'gpt-5',
+        projectDir: null,
+        messageId: 'message-1'
+      },
+      tool: { callId: 'call-1', name: 'read_file' }
+    })
+    await flush()
+
+    const [, , options] = spawnMock.mock.calls[0]
+    expect(options.env).toEqual(
       expect.objectContaining({
-        tool: expect.objectContaining({ name: 'mutated_tool' }),
-        permission: expect.objectContaining({
-          metadata: { path: 'after.txt' }
-        })
+        DEEPCHAT_HOOK_EVENT: 'PreToolUse',
+        DEEPCHAT_HOOK_IS_TEST: 'false',
+        DEEPCHAT_CONVERSATION_ID: 'session-1',
+        DEEPCHAT_AGENT_ID: 'deepchat',
+        DEEPCHAT_PROVIDER_ID: 'openai',
+        DEEPCHAT_MODEL_ID: 'gpt-5',
+        DEEPCHAT_MESSAGE_ID: 'message-1',
+        DEEPCHAT_TOOL_NAME: 'read_file',
+        DEEPCHAT_TOOL_CALL_ID: 'call-1',
+        DEEPCHAT_WORKDIR: ''
       })
     )
   })
 
-  it('isolates a synchronous observer failure', () => {
-    const service = createService()
-    vi.spyOn(service, 'dispatchEvent').mockImplementation(() => {
-      throw new Error('sync failure')
+  it('treats an explicit null project directory as an answered fact', async () => {
+    const { service, getSession } = createHarness([enabledHook('a', ['Stop'])])
+
+    service.notify({
+      event: 'Stop',
+      session: { sessionId: 'session-1', providerId: 'openai', modelId: 'gpt-5', projectDir: null },
+      stop: { reason: 'complete', userStop: false }
+    })
+    await flush()
+
+    expect(getSession).not.toHaveBeenCalled()
+    expect(spawnedPayloads()[0].session.workdir).toBeNull()
+  })
+
+  it('resolves unanswered session facts from the session store', async () => {
+    const { service, getSession } = createHarness([enabledHook('a', ['Stop'])])
+    getSession.mockResolvedValueOnce({
+      providerId: 'acp',
+      modelId: 'claude-code',
+      projectDir: '/from-db'
     })
 
-    expect(() =>
-      service.notify({ event: 'SessionStart', context: { sessionId: 'session-1' } })
-    ).not.toThrow()
+    service.notify({
+      event: 'Stop',
+      session: { sessionId: 'session-1' },
+      stop: { reason: 'complete', userStop: false }
+    })
+    await flush()
+
+    expect(getSession).toHaveBeenCalledTimes(1)
+    expect(spawnedPayloads()[0].session).toEqual({
+      conversationId: 'session-1',
+      agentId: 'claude-code',
+      workdir: '/from-db',
+      providerId: 'acp',
+      modelId: 'claude-code'
+    })
+  })
+
+  it('never reads a message to describe a prompt it was not given', async () => {
+    const { service } = createHarness([enabledHook('a', ['SessionStart'])])
+
+    service.notify({
+      event: 'SessionStart',
+      session: {
+        sessionId: 'session-1',
+        providerId: 'openai',
+        modelId: 'gpt-5',
+        projectDir: null,
+        messageId: 'assistant-1'
+      }
+    })
+    await flush()
+
+    expect(spawnedPayloads()[0].user).toEqual({
+      messageId: 'assistant-1',
+      promptPreview: ''
+    })
+  })
+})
+
+describe('HookService detachment', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+    spawnMock.mockImplementation(() => {
+      const child = new FakeChild()
+      queueMicrotask(() => child.emit('close', 0))
+      return child
+    })
+  })
+
+  it('detaches session facts mutated after the event was accepted', async () => {
+    const { service, getSession } = createHarness([enabledHook('a', ['Stop'])])
+    let releaseSession: (value: null) => void = () => undefined
+    getSession.mockReturnValueOnce(
+      new Promise<null>((resolve) => {
+        releaseSession = resolve
+      })
+    )
+    const session = { sessionId: 'session-1', modelId: 'gpt-5' }
+
+    service.notify({ event: 'Stop', session, stop: { reason: 'complete', userStop: false } })
+    session.modelId = 'mutated'
+    releaseSession(null)
+    await flush()
+
+    expect(spawnedPayloads()[0].session.modelId).toBe('gpt-5')
   })
 })

--- a/test/main/hook/hookService.test.ts
+++ b/test/main/hook/hookService.test.ts
@@ -485,16 +485,34 @@ describe('HookService delivery ordering', () => {
 
       const pending = service.testHookCommand('a')
       await vi.advanceTimersByTimeAsync(30_000)
-      expect(child.kill).toHaveBeenCalledWith('SIGKILL')
 
-      child.emit('close', null)
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+      // Settles without any close event: a killed shell can keep its process tree alive.
       await expect(pending).resolves.toMatchObject({
         success: false,
+        exitCode: undefined,
         error: 'Command timed out'
       })
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('bounds captured command output while the command streams', async () => {
+    const { service } = createHarness([enabledHook('a', ['SessionStart'])])
+    const child = new FakeChild()
+    spawnMock.mockImplementationOnce(() => child)
+
+    const pending = service.testHookCommand('a')
+    await flush()
+    for (let index = 0; index < 64; index += 1) {
+      child.stdout.emit('data', 'x'.repeat(4096))
+    }
+    child.emit('close', 0)
+
+    const result = await pending
+    expect(result.stdout).toHaveLength(2000)
+    expect(result.stdout?.endsWith(' ...(truncated)')).toBe(true)
   })
 
   it('kills running hook commands on stop', async () => {

--- a/test/main/hook/hookService.test.ts
+++ b/test/main/hook/hookService.test.ts
@@ -294,6 +294,75 @@ describe('HookService subscription index', () => {
     expect(service.isObserved('PreToolUse')).toBe(false)
   })
 
+  it('never backfills an event to a hook enabled in the same tick', async () => {
+    const { service } = createHarness([enabledHook('a', ['PostToolUse'])])
+
+    service.notify(toolEvent('session-1', 'call-1'))
+    service.updateConfig({
+      hooks: [enabledHook('a', ['PostToolUse']), enabledHook('b', ['PostToolUse'])]
+    })
+    await flush()
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    expect(spawnMock.mock.calls[0][0]).toBe('run-a')
+  })
+
+  it('never backfills an event while enrichment is still pending', async () => {
+    const { service, getSession } = createHarness([enabledHook('a', ['PostToolUse'])])
+    let releaseSession: (value: null) => void = () => undefined
+    getSession.mockReturnValueOnce(
+      new Promise<null>((resolve) => {
+        releaseSession = resolve
+      })
+    )
+
+    service.notify({
+      event: 'PostToolUse',
+      session: { sessionId: 'session-1' },
+      tool: { callId: 'call-1' }
+    })
+    await flush()
+    service.updateConfig({
+      hooks: [enabledHook('a', ['PostToolUse']), enabledHook('b', ['PostToolUse'])]
+    })
+    releaseSession(null)
+    await flush()
+
+    expect(spawnMock.mock.calls.map(([command]) => command)).toEqual(['run-a'])
+  })
+
+  it('drops a queued event for a hook disabled or edited before delivery', async () => {
+    const { service, getSession } = createHarness([
+      enabledHook('a', ['PostToolUse']),
+      enabledHook('b', ['PostToolUse']),
+      enabledHook('c', ['PostToolUse'])
+    ])
+    let releaseSession: (value: null) => void = () => undefined
+    getSession.mockReturnValueOnce(
+      new Promise<null>((resolve) => {
+        releaseSession = resolve
+      })
+    )
+
+    service.notify({
+      event: 'PostToolUse',
+      session: { sessionId: 'session-1' },
+      tool: { callId: 'call-1' }
+    })
+    await flush()
+    service.updateConfig({
+      hooks: [
+        { ...enabledHook('a', ['PostToolUse']), enabled: false },
+        { ...enabledHook('b', ['PostToolUse']), command: 'run-b-edited' },
+        enabledHook('c', ['PostToolUse'])
+      ]
+    })
+    releaseSession(null)
+    await flush()
+
+    expect(spawnMock.mock.calls.map(([command]) => command)).toEqual(['run-c'])
+  })
+
   it('picks up a store write that bypassed the service after a refresh', () => {
     const { service, writeExternally } = createHarness()
 

--- a/test/main/hook/hookService.test.ts
+++ b/test/main/hook/hookService.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
   HookCommandItem,
   HookEventName,
@@ -234,16 +234,20 @@ const toolEvent = (sessionId: string, callId: string): HookEvent => ({
   tool: { callId, name: 'read_file', params: '{"path":"a.txt"}', response: 'ok' }
 })
 
-describe('HookService subscription index', () => {
-  beforeEach(() => {
-    spawnMock.mockReset()
-    spawnMock.mockImplementation(() => {
-      const child = new FakeChild()
-      queueMicrotask(() => child.emit('close', 0))
-      return child
-    })
+beforeEach(() => {
+  spawnMock.mockReset()
+  spawnMock.mockImplementation(() => {
+    const child = new FakeChild()
+    queueMicrotask(() => child.emit('close', 0))
+    return child
   })
+})
 
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('HookService subscription index', () => {
   it('does nothing but one index lookup when no hook subscribes', async () => {
     const { service, getSession, getHooksNotificationsConfig } = createHarness()
 
@@ -399,15 +403,6 @@ describe('HookService subscription index', () => {
 })
 
 describe('HookService delivery ordering', () => {
-  beforeEach(() => {
-    spawnMock.mockReset()
-    spawnMock.mockImplementation(() => {
-      const child = new FakeChild()
-      queueMicrotask(() => child.emit('close', 0))
-      return child
-    })
-  })
-
   it('keeps one session in emission order even when enrichment is slow', async () => {
     const { service, getSession } = createHarness([enabledHook('a', ['PostToolUse'])])
     let releaseSession: (value: null) => void = () => undefined
@@ -526,6 +521,21 @@ describe('HookService delivery ordering', () => {
     expect(result.stdout?.endsWith(' ...(truncated)')).toBe(true)
   })
 
+  it('redacts diagnostics on every settlement path', async () => {
+    const { service } = createHarness([enabledHook('a', ['SessionStart'])])
+    const child = new FakeChild()
+    spawnMock.mockImplementationOnce(() => child)
+
+    const pending = service.testHookCommand('a')
+    await flush()
+    child.stderr.emit('data', 'Authorization: Bearer sk-secret-token\n')
+    child.emit('error', new Error('spawn ENOENT'))
+
+    const result = await pending
+    expect(result.error).toBe('spawn ENOENT')
+    expect(result.stderr).toBe('Authorization: ***REDACTED***\n')
+  })
+
   it('kills running hook commands on stop', async () => {
     const { service } = createHarness([enabledHook('a', ['PostToolUse'])])
     const child = new FakeChild()
@@ -540,15 +550,6 @@ describe('HookService delivery ordering', () => {
 })
 
 describe('HookService payload projection', () => {
-  beforeEach(() => {
-    spawnMock.mockReset()
-    spawnMock.mockImplementation(() => {
-      const child = new FakeChild()
-      queueMicrotask(() => child.emit('close', 0))
-      return child
-    })
-  })
-
   it('truncates tool previews before any clone runs', async () => {
     const { service } = createHarness([enabledHook('a', ['PostToolUse'])])
     const clone = vi.spyOn(globalThis, 'structuredClone')
@@ -565,7 +566,6 @@ describe('HookService payload projection', () => {
     expect(payload.tool?.paramsPreview).toHaveLength(1200)
     expect(payload.tool?.responsePreview).toHaveLength(1200)
     expect(clone).not.toHaveBeenCalled()
-    clone.mockRestore()
   })
 
   it('clones only the permission record and detaches it from later mutation', async () => {
@@ -587,7 +587,6 @@ describe('HookService payload projection', () => {
       permissionType: 'write',
       metadata: { path: 'before.txt' }
     })
-    clone.mockRestore()
   })
 
   it('emits the version 1 payload shape', async () => {
@@ -728,15 +727,6 @@ describe('HookService payload projection', () => {
 })
 
 describe('HookService detachment', () => {
-  beforeEach(() => {
-    spawnMock.mockReset()
-    spawnMock.mockImplementation(() => {
-      const child = new FakeChild()
-      queueMicrotask(() => child.emit('close', 0))
-      return child
-    })
-  })
-
   it('detaches session facts mutated after the event was accepted', async () => {
     const { service, getSession } = createHarness([enabledHook('a', ['Stop'])])
     let releaseSession: (value: null) => void = () => undefined

--- a/test/main/hook/hookService.test.ts
+++ b/test/main/hook/hookService.test.ts
@@ -286,12 +286,23 @@ describe('HookService subscription index', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1)
   })
 
-  it('hands out an immutable configuration snapshot', () => {
-    const { service } = createHarness([enabledHook('a', ['Stop'])])
-    const snapshot = service.getConfigSnapshot()
+  it('detaches the configuration snapshot from its own delivery state', () => {
+    const stored: HooksNotificationsSettings = { hooks: [enabledHook('a', ['Stop'])] }
+    const service = new HookService(
+      {
+        getHooksNotificationsConfig: () => stored,
+        setHooksNotificationsConfig: (next) => next
+      },
+      { getSession: vi.fn().mockResolvedValue(null) }
+    )
 
-    expect(() => snapshot.hooks.push(enabledHook('b', ['PreToolUse']))).toThrow(TypeError)
+    const snapshot = service.getConfigSnapshot()
+    snapshot.hooks.push(enabledHook('b', ['PreToolUse']))
+    snapshot.hooks[0].events.push('PreToolUse')
+
     expect(service.isObserved('PreToolUse')).toBe(false)
+    expect(Object.isFrozen(stored)).toBe(false)
+    expect(Object.isFrozen(stored.hooks[0])).toBe(false)
   })
 
   it('never backfills an event to a hook enabled in the same tick', async () => {

--- a/test/main/routes/dispatcher.test.ts
+++ b/test/main/routes/dispatcher.test.ts
@@ -1664,8 +1664,11 @@ function createRuntime() {
     applyCustomProxyUrl
   })
   const hookRoutes = createHookRoutes({
-    settings: hookSettings as never,
-    testCommand: testHookCommand
+    service: {
+      getConfigSnapshot: () => hookSettings.getHooksNotificationsConfig(),
+      updateConfig: (config) => hookSettings.setHooksNotificationsConfig(config as never),
+      testHookCommand
+    } as never
   })
   const appSettingsRoutes = createAppSettingsRoutes({
     settings: {

--- a/test/main/session/runtimeIntegration.test.ts
+++ b/test/main/session/runtimeIntegration.test.ts
@@ -2,7 +2,8 @@ import { AppSessionService } from '@/agent/shared/appSessionService'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createDeepChatAgentHarness, type DeepChatAgentHarness } from '@/agent/deepchat/harness'
 import { estimateMessagesTokens } from '@/agent/deepchat/runtime/contextBuilder'
-import type { HookNotification, HookObserver } from '@/hook/observer'
+import type { HookEvent } from '@/hook/events'
+import type { HookObserver } from '@/hook/observer'
 import type { PermissionMode } from '@shared/types/agent-interface'
 import type { ReasoningEffort, Verbosity } from '@shared/types/model-db'
 import logger from '@shared/logger'
@@ -22,24 +23,25 @@ vi.mock('nanoid', () => {
 const createHookObserver = (dispatcher: {
   dispatchEvent: ReturnType<typeof vi.fn>
 }): HookObserver => ({
-  notify({ event, context }: HookNotification) {
-    dispatcher.dispatchEvent(event, {
-      conversationId: context.sessionId,
-      agentId: context.agentId,
-      workdir: context.projectDir,
-      messageId: context.messageId,
-      promptPreview: context.promptPreview,
-      providerId: context.providerId,
-      modelId: context.modelId,
-      tool: context.tool,
-      permission: context.permission,
-      stop: context.stop,
-      usage: context.usage,
-      error: context.error
+  isObserved: () => true,
+  notify(event: HookEvent) {
+    dispatcher.dispatchEvent(event.event, {
+      conversationId: event.session.sessionId,
+      agentId: event.session.agentId,
+      workdir: event.session.projectDir,
+      messageId: event.session.messageId,
+      providerId: event.session.providerId,
+      modelId: event.session.modelId,
+      promptPreview: 'promptPreview' in event ? event.promptPreview : undefined,
+      tool: 'tool' in event ? event.tool : undefined,
+      permission: 'permission' in event ? event.permission : undefined,
+      stop: 'stop' in event ? event.stop : undefined,
+      usage: 'usage' in event ? event.usage : undefined,
+      error: 'error' in event ? event.error : undefined
     })
   }
 })
-const noopHookObserver: HookObserver = { notify: vi.fn() }
+const noopHookObserver: HookObserver = { isObserved: () => true, notify: vi.fn() }
 
 const publishDeepchatEventMock = vi.hoisted(() => vi.fn())
 

--- a/test/main/session/runtimeIntegration.test.ts
+++ b/test/main/session/runtimeIntegration.test.ts
@@ -2,8 +2,7 @@ import { AppSessionService } from '@/agent/shared/appSessionService'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createDeepChatAgentHarness, type DeepChatAgentHarness } from '@/agent/deepchat/harness'
 import { estimateMessagesTokens } from '@/agent/deepchat/runtime/contextBuilder'
-import type { HookEvent } from '@/hook/events'
-import type { HookObserver } from '@/hook/observer'
+import { createHookObserver, noopHookObserver } from '../hook/hookObserverFixture'
 import type { PermissionMode } from '@shared/types/agent-interface'
 import type { ReasoningEffort, Verbosity } from '@shared/types/model-db'
 import logger from '@shared/logger'
@@ -19,29 +18,6 @@ vi.mock('nanoid', () => {
   let counter = 0
   return { nanoid: vi.fn(() => `id-${++counter}`) }
 })
-
-const createHookObserver = (dispatcher: {
-  dispatchEvent: ReturnType<typeof vi.fn>
-}): HookObserver => ({
-  isObserved: () => true,
-  notify(event: HookEvent) {
-    dispatcher.dispatchEvent(event.event, {
-      conversationId: event.session.sessionId,
-      agentId: event.session.agentId,
-      workdir: event.session.projectDir,
-      messageId: event.session.messageId,
-      providerId: event.session.providerId,
-      modelId: event.session.modelId,
-      promptPreview: 'promptPreview' in event ? event.promptPreview : undefined,
-      tool: 'tool' in event ? event.tool : undefined,
-      permission: 'permission' in event ? event.permission : undefined,
-      stop: 'stop' in event ? event.stop : undefined,
-      usage: 'usage' in event ? event.usage : undefined,
-      error: 'error' in event ? event.error : undefined
-    })
-  }
-})
-const noopHookObserver: HookObserver = { isObserved: () => true, notify: vi.fn() }
 
 const publishDeepchatEventMock = vi.hoisted(() => vi.fn())
 


### PR DESCRIPTION
## Summary

This PR replaces the untyped hook fan-out with a typed, deterministic notification pipeline.

- Add a closed `HookEvent` discriminated union with compile-time coverage and invalid-combination guards.
- Introduce producer-bound `RuntimeHookScope` emitters and a single `Stop` → `SessionEnd` projection.
- Move hook configuration and the derived subscription index into `HookService`.
- Bind events to subscribers eligible at acceptance, then revalidate them immediately before spawning.
- Serialize command starts per session without coupling sessions or awaiting external commands.
- Project and truncate tool payloads before cloning; clone only the permission record.
- Remove the incorrect `messageId` → prompt fallback that exposed assistant output as user input.
- Resolve only unanswered session facts, preserving explicit `null` project directories.
- Make command timeouts settle independently of process `close` and bound captured stdout/stderr.
- Keep configuration snapshots detached without freezing values owned by the settings port.

The design and deferred decisions are recorded in:

`docs/architecture/deepchat-agent-harness-boundaries/`

## Motivation

The previous hook contract used an event name plus an all-optional context, so invalid combinations compiled and adding an event could silently escape exhaustive handling.

The delivery path also had several correctness and reliability problems:

- `Stop` and `SessionEnd` were assembled independently in four runtime paths.
- Independent asynchronous enrichment could reorder command starts within a session.
- Hook configuration was read and normalized for every event, even with no subscribers.
- Large tool parameters and responses were cloned repeatedly before truncation.
- Tool and resumed-session events could report assistant output as `user.promptPreview`.
- Configuration changes could backfill an already accepted event into a newly enabled or edited command.
- A timed-out shell could keep the settings test request pending forever.
- Captured command output could grow without bound until process exit.

## Delivery semantics

- An unsubscribed event performs one subscription lookup and no envelope resolution, clone, database read, or spawn.
- Events within one session start their commands in emission order.
- Different sessions remain independent.
- External command completion order is intentionally not serialized.
- Hooks never block Agent execution.
- A hook enabled or edited after an event occurred does not receive that event.
- A hook disabled before delivery no longer receives queued events.

## Compatibility

The following public behavior remains unchanged:

- `payloadVersion: 1`
- stdin payload shape
- environment variable names
- command placeholders
- 30-second timeout value
- redaction behavior
- settings and IPC contracts

Intentional value corrections:

- `user.promptPreview` is populated only when supplied by the producer; tool events and resumed `SessionStart` events no longer contain assistant output.
- `time` is captured when the event is accepted rather than after asynchronous enrichment.
- ACP continues to report `usage: null` because its terminal port has no canonical token accounting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a typed, session-scoped hook notification pipeline with deterministic per-session ordering and isolated delivery across sessions.
  * Added hook configuration update support and subscription-aware notification delivery.
  * Updated the model catalog by adding **Anthropic Claude Opus 5**.

* **Bug Fixes**
  * Improved hook command timeout handling, output truncation, failure isolation, and consistent terminal event reporting.
  * Notifications now skip processing when observers are not interested in a given event.

* **Documentation**
  * Expanded the hook pipeline architecture/specs, tasks, and acceptance criteria; regenerated architecture baseline metadata.

* **Chores**
  * Updated the Dirac agent registry to **0.4.25**; refreshed model/pricing/availability data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->