### PR TITLE
fix(mac): harden CUA helper distribution integrity

### DIFF
--- a/.github/workflows/_package-macos.yml
+++ b/.github/workflows/_package-macos.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Build and package macOS
         run: |
           pnpm run build
-          pnpm run plugin:bundle -- --name cua --platform darwin --arch "${TARGET_ARCH}"
+          pnpm run plugin:bundle -- --name cua --platform darwin --arch "${TARGET_ARCH}" --purpose "${PACKAGE_PURPOSE}"
           pnpm run plugin:bundle -- --name feishu --platform darwin --arch "${TARGET_ARCH}"
           pnpm exec electron-builder --mac --"${TARGET_ARCH}" --publish=never
         env:

--- a/docs/architecture/ci-release-packaging/spec.md
+++ b/docs/architecture/ci-release-packaging/spec.md
@@ -57,6 +57,11 @@ assembly fails closed against an explicit six-target contract.
   Apple notarization credentials before expensive work starts.
 - Distribution packaging verifies the signed and stapled application bundle and final DMG with
   `codesign`, `stapler`, `spctl`, and DMG integrity checks.
+- The final nested CUA helper preserves its dedicated staging signature. Distribution verification
+  requires its Developer ID authority, expected Team ID, hardened runtime, secure timestamp, exact
+  entitlement allowlist, and allowed Mach-O load paths before accepting the outer application.
+- `syspolicy_check distribution` assesses the final DeepChat application after all electron-builder
+  and notarization transformations.
 - Verification packaging explicitly disables certificate auto-discovery, receives no Apple signing
   secrets, and never uploads a complete unsigned installer.
 - Windows and Linux manifests contain no macOS distribution fields and no generic `signed` claim.
@@ -72,6 +77,8 @@ assembly fails closed against an explicit six-target contract.
 - A distribution manifest is generated only after package smoke and requested size gates pass.
 - macOS distribution status is derived from actual verification commands, not caller-supplied
   booleans.
+- Package manifest schema version 2 records final CUA helper distribution verification separately
+  from the outer application and DMG checks.
 
 ### AC-4 — Fail-Closed Release
 
@@ -83,6 +90,8 @@ assembly fails closed against an explicit six-target contract.
 - Every manifest must use the release source commit, version, and `distribution` purpose.
 - Missing files, duplicate public names, unexpected targets, digest mismatches, incomplete macOS
   distribution evidence, or invalid updater metadata fail the release.
+- Release index schema version 2 requires the CUA helper evidence for both macOS targets; version 1
+  manifests cannot silently cross this strengthened verification boundary.
 - Only the final draft-release job receives `contents: write`.
 
 ### AC-5 — Updater Compatibility
@@ -130,6 +139,8 @@ assembly fails closed against an explicit six-target contract.
 - Shared package configuration, native dependency, runtime, plugin, or package-contract changes run
   all six targets. OS-owned workflows, signing scripts, entitlements, installer scripts, and icons
   run only the corresponding operating system.
+- The CUA Mach-O contract, final-helper verifier, and helper-signing path are macOS-owned package
+  inputs and therefore trigger both macOS architectures.
 - `package.json` is compared semantically: production dependency, Electron toolchain, package
   metadata, lifecycle, build, runtime, plugin, and package-smoke changes are relevant; test-only and
   unrelated development-tool changes are not. A lockfile change remains conservatively shared.
@@ -166,6 +177,9 @@ assembly fails closed against an explicit six-target contract.
 
 - The final metadata intentionally follows electron-builder 26 and electron-updater 6 selection
   semantics. Dependency upgrades must rerun the metadata contract tests before release.
+- Package manifest and release index schema version 2 intentionally reject version 1 producers and
+  consumers. All release jobs execute from one immutable source SHA, so no mixed-version migration
+  path is supported or required.
 - The exact nineteen-asset allowlist intentionally rejects new package formats until the contract,
   tests, and release index are updated together.
 - Verification-mode macOS package sizes can differ slightly from signed distribution sizes. The

--- a/docs/architecture/ci-release-packaging/spec.md
+++ b/docs/architecture/ci-release-packaging/spec.md
@@ -60,8 +60,10 @@ assembly fails closed against an explicit six-target contract.
 - The final nested CUA helper preserves its dedicated staging signature. Distribution verification
   requires its Developer ID authority, expected Team ID, hardened runtime, secure timestamp, exact
   entitlement allowlist, and allowed Mach-O load paths before accepting the outer application.
-- `syspolicy_check distribution` assesses the final DeepChat application after all electron-builder
-  and notarization transformations.
+- The staged updater ZIP is extracted as the real updater consumer payload. Its sole root
+  `DeepChat.app` must pass the same CUA helper and complete application distribution checks.
+- `syspolicy_check distribution` assesses both the staging application and the application
+  extracted from the updater ZIP after all electron-builder and notarization transformations.
 - Verification packaging explicitly disables certificate auto-discovery, receives no Apple signing
   secrets, and never uploads a complete unsigned installer.
 - Windows and Linux manifests contain no macOS distribution fields and no generic `signed` claim.
@@ -77,8 +79,8 @@ assembly fails closed against an explicit six-target contract.
 - A distribution manifest is generated only after package smoke and requested size gates pass.
 - macOS distribution status is derived from actual verification commands, not caller-supplied
   booleans.
-- Package manifest schema version 2 records final CUA helper distribution verification separately
-  from the outer application and DMG checks.
+- Package manifest schema version 2 records final CUA helper and updater ZIP distribution
+  verification separately from the staging application and DMG checks.
 
 ### AC-4 — Fail-Closed Release
 

--- a/docs/issues/cua-macos-distribution-integrity/spec.md
+++ b/docs/issues/cua-macos-distribution-integrity/spec.md
@@ -1,6 +1,6 @@
 # CUA macOS Distribution Integrity
 
-Status: implementation in progress.
+Status: implemented locally; signed distribution and clean-install validation pending.
 
 GitHub issue: not created; this is a local SDD record. PR #1801 introduced the current managed
 helper packaging model, but this fix does not change its runtime/TCC ownership model.
@@ -106,15 +106,15 @@ Distribution verification runs after electron-builder and notarization and must:
 
 ## Task Checklist
 
-- [ ] Add a shared CUA macOS Mach-O contract and sanitize the helper before signing.
-- [ ] Thread an explicit package purpose from the macOS workflow through plugin bundling.
-- [ ] Validate distribution, verification and local-development signing modes at the signer.
-- [ ] Remove `--deep` from helper signing.
-- [ ] Prevent electron-builder from re-signing the staged helper.
-- [ ] Verify the final helper signature, Team ID, runtime, timestamp, entitlements and load paths.
-- [ ] Add `syspolicy_check distribution` to final macOS application verification.
-- [ ] Add focused regression tests for every fail-closed boundary.
-- [ ] Run formatting, i18n, lint and relevant main-process test suites.
+- [x] Add a shared CUA macOS Mach-O contract and sanitize the helper before signing.
+- [x] Thread an explicit package purpose from the macOS workflow through plugin bundling.
+- [x] Validate distribution, verification and local-development signing modes at the signer.
+- [x] Remove `--deep` from helper signing.
+- [x] Prevent electron-builder from re-signing the staged helper.
+- [x] Verify the final helper signature, Team ID, runtime, timestamp, entitlements and load paths.
+- [x] Add `syspolicy_check distribution` to final macOS application verification.
+- [x] Add focused regression tests for every fail-closed boundary.
+- [x] Run formatting, i18n, lint and relevant main-process test suites.
 - [ ] Validate a signed DMG first install on a clean supported macOS machine or VM.
 
 ## Validation
@@ -135,3 +135,21 @@ Manual release validation must start from the notarized DMG on a machine with ne
 the upstream `/Applications/CuaDriver.app` previously installed. It must exercise startup, screen
 capture, Accessibility access, CGEvent input and the permission flow while observing helper exit
 status and macOS code-signing/library-validation logs.
+
+### Local results
+
+Validated on 2026-07-26:
+
+- `pnpm run format`, `pnpm run i18n`, `pnpm run lint`, and `pnpm run typecheck:node` passed.
+- `pnpm exec vitest run test/main/scripts` passed 25 files and 167 tests.
+- `pnpm exec vitest run --config vitest.config.ts test/main --reporter=dot` passed 436 files and
+  5,031 tests, with 19 files and 239 tests skipped.
+- A copy of the generated universal helper was sanitized and ad-hoc signed through the production
+  scripts. Both Xcode RPATHs were removed across the x86_64 and ARM64 slices; final inspection found
+  one Mach-O file, only `/usr/lib/swift` as its RPATH, and exactly the managed Apple Events
+  entitlement.
+
+Local verification cannot prove the Developer ID, notarization, stapling, final
+`syspolicy_check distribution`, or clean-install behavior because the local run has no signed and
+notarized distribution artifact. Those checks remain fail-closed CI requirements, and the
+clean-machine DMG test remains the release acceptance gate.

--- a/docs/issues/cua-macos-distribution-integrity/spec.md
+++ b/docs/issues/cua-macos-distribution-integrity/spec.md
@@ -54,8 +54,9 @@ the later recursive re-sign with unrelated entitlements, not the initial DeepCha
 ### Signing purpose
 
 - Reuse the package purpose contract; do not introduce another environment-only signing mode.
-- Distribution packaging requires purpose `distribution`, `build_for_release=2`, a Developer ID
-  Application identity, hardened runtime and a secure timestamp.
+- Distribution packaging requires purpose `distribution`, a non-empty `build_for_release` release
+  notarization mode, a Developer ID Application identity, hardened runtime and a secure timestamp.
+  CI uses mode `2` for Apple ID credentials; the existing keychain-profile mode remains supported.
 - Verification packaging explicitly permits an ad-hoc helper signature and must not set
   `build_for_release`.
 - Local packaging without a package purpose is treated as development only outside CI.

--- a/docs/issues/cua-macos-distribution-integrity/spec.md
+++ b/docs/issues/cua-macos-distribution-integrity/spec.md
@@ -1,0 +1,137 @@
+# CUA macOS Distribution Integrity
+
+Status: implementation in progress.
+
+GitHub issue: not created; this is a local SDD record. PR #1801 introduced the current managed
+helper packaging model, but this fix does not change its runtime/TCC ownership model.
+
+## Issue
+
+A quarantined DeepChat DMG can fail on a clean macOS installation with Gatekeeper reporting that it
+cannot verify the developer and cannot determine whether the application contains malware. The same
+build can appear healthy when installed as an update because the update path does not reproduce the
+first-install quarantine and distribution assessment.
+
+The affected release artifact passes ordinary `codesign`, stapler and `spctl` checks, while
+`syspolicy_check distribution` reports a fatal error for the nested
+`DeepChat Computer Use.app` helper.
+
+## Impact
+
+- Clean macOS installations can reject an otherwise notarized DeepChat release.
+- Existing installations can hide the defect, so upgrade-only release testing is insufficient.
+- CI currently validates the staged CUA helper before electron-builder performs its final signing
+  pass, not the helper identity and entitlements present in the distributed application.
+
+## Root Cause
+
+The failure requires two conditions:
+
+1. The upstream universal CUA executable contains absolute `LC_RPATH` entries pointing into the
+   Xcode installation used to build the upstream release.
+2. DeepChat signs the rebranded helper with its dedicated entitlement, then electron-builder signs
+   it again with the main application's inherited entitlements. That second entitlement set includes
+   `com.apple.security.cs.disable-library-validation`.
+
+Disabling library validation causes Gatekeeper's distribution policy to inspect a wider Mach-O
+surface and exposes the invalid build-machine RPATHs. The upstream content defect and DeepChat's
+second-signing policy therefore combine into the user-visible failure.
+
+Re-signing the helper once is required: DeepChat renames the application and executable, changes the
+bundle identifier and display metadata, and removes the invalid upstream signature. The defect is
+the later recursive re-sign with unrelated entitlements, not the initial DeepChat signature.
+
+## Required Invariants
+
+### Mach-O sanitation
+
+- Inspect every architecture represented by `otool` output.
+- Remove non-system absolute RPATHs before any DeepChat signature is created.
+- Preserve system Swift lookup paths and relative loader paths.
+- Reject unexpected non-system linked-library paths instead of silently rewriting them.
+- Reinspect the executable after mutation and fail if a disallowed path remains.
+
+### Signing purpose
+
+- Reuse the package purpose contract; do not introduce another environment-only signing mode.
+- Distribution packaging requires purpose `distribution`, `build_for_release=2`, a Developer ID
+  Application identity, hardened runtime and a secure timestamp.
+- Verification packaging explicitly permits an ad-hoc helper signature and must not set
+  `build_for_release`.
+- Local packaging without a package purpose is treated as development only outside CI.
+- A CI invocation without an explicit supported purpose fails closed.
+- The signer validates the purpose/build-mode relationship itself; workflow validation alone is not
+  authoritative.
+
+### Signing ownership
+
+- The CUA staging step is the only phase that signs the nested helper.
+- electron-builder ignores the complete `Contents/Helpers/DeepChat Computer Use.app` subtree while
+  still signing the containing DeepChat application.
+- CUA signing does not use `codesign --deep`; any future nested code must be signed explicitly.
+- The dedicated CUA entitlement remains an exact allowlist containing only
+  `com.apple.security.automation.apple-events`.
+
+### Final artifact verification
+
+Distribution verification runs after electron-builder and notarization and must:
+
+- verify the nested helper's strict code signature;
+- verify Developer ID authority, expected Team ID, hardened runtime and secure timestamp;
+- compare its effective entitlements with the exact CUA allowlist;
+- recursively reject non-system absolute Mach-O load paths and RPATHs;
+- run `syspolicy_check distribution` on the final DeepChat application in addition to existing
+  `codesign`, stapler and `spctl` checks.
+
+## Compatibility and Risk
+
+- Verification packages remain unsigned at the outer application level, while their CUA helper
+  remains ad-hoc signed so it can execute locally.
+- Removing the two observed Xcode RPATHs is low risk because the executable retains
+  `/usr/lib/swift`, but launch, ScreenCaptureKit, Accessibility, CGEvent injection and lazy-loaded
+  paths still require end-to-end testing across supported macOS versions.
+- Library validation stays enabled for the helper. Its visible direct dynamic load target is the
+  Apple-signed SkyLight framework, but private API compatibility is a separate technical risk.
+- `signIgnore` deliberately creates a phase dependency on the staged signature. Explicit purpose
+  validation and final-artifact checks are mandatory parts of the same fix, not optional follow-up.
+
+## Non-goals
+
+- Do not include the updater-metadata follow-up from PR #2025.
+- Do not choose or implement a host-owned versus helper-owned TCC responsibility model.
+- Do not patch hard-coded `CuaDriver.app` strings in the upstream binary.
+- Do not remove the Apple Events entitlement without runtime evidence.
+- Do not replace upstream SkyLight private API usage or sanitize inert Rust source-location strings.
+- Do not create or synchronize a GitHub issue without explicit approval.
+
+## Task Checklist
+
+- [ ] Add a shared CUA macOS Mach-O contract and sanitize the helper before signing.
+- [ ] Thread an explicit package purpose from the macOS workflow through plugin bundling.
+- [ ] Validate distribution, verification and local-development signing modes at the signer.
+- [ ] Remove `--deep` from helper signing.
+- [ ] Prevent electron-builder from re-signing the staged helper.
+- [ ] Verify the final helper signature, Team ID, runtime, timestamp, entitlements and load paths.
+- [ ] Add `syspolicy_check distribution` to final macOS application verification.
+- [ ] Add focused regression tests for every fail-closed boundary.
+- [ ] Run formatting, i18n, lint and relevant main-process test suites.
+- [ ] Validate a signed DMG first install on a clean supported macOS machine or VM.
+
+## Validation
+
+Automated validation must cover:
+
+- universal `otool` output with duplicate per-slice RPATHs;
+- allowed system and relative load paths;
+- removal and post-mutation rejection of disallowed RPATHs;
+- missing and contradictory purpose/build-mode combinations;
+- distribution and verification signing command differences;
+- electron-builder ignore-pattern scope;
+- entitlement additions, removals and value changes;
+- wrong Team ID, ad-hoc identity, missing timestamp and missing hardened runtime;
+- `syspolicy_check distribution` execution against the final app.
+
+Manual release validation must start from the notarized DMG on a machine with neither DeepChat nor
+the upstream `/Applications/CuaDriver.app` previously installed. It must exercise startup, screen
+capture, Accessibility access, CGEvent input and the permission flow while observing helper exit
+status and macOS code-signing/library-validation logs.

--- a/docs/issues/cua-macos-distribution-integrity/spec.md
+++ b/docs/issues/cua-macos-distribution-integrity/spec.md
@@ -149,6 +149,9 @@ Validated on 2026-07-26:
   scripts. Both Xcode RPATHs were removed across the x86_64 and ARM64 slices; final inspection found
   one Mach-O file, only `/usr/lib/swift` as its RPATH, and exactly the managed Apple Events
   entitlement.
+- A synthetic universal Mach-O with different disallowed RPATHs in its x86_64 and ARM64 slices
+  reproduced `install_name_tool`'s whole-file failure. Per-slice sanitation removed both paths,
+  rebuilt both architectures, and preserved executable permissions.
 
 Local verification cannot prove the Developer ID, notarization, stapling, final
 `syspolicy_check distribution`, or clean-install behavior because the local run has no signed and

--- a/docs/issues/cua-macos-distribution-integrity/spec.md
+++ b/docs/issues/cua-macos-distribution-integrity/spec.md
@@ -47,7 +47,9 @@ the later recursive re-sign with unrelated entitlements, not the initial DeepCha
 
 - Inspect every architecture represented by `otool` output.
 - Remove non-system absolute RPATHs before any DeepChat signature is created.
-- Preserve system Swift lookup paths and relative loader paths.
+- Preserve system Swift lookup paths, direct token-relative paths and the canonical
+  `@loader_path/../Frameworks` / `@executable_path/../Frameworks` bundle lookup.
+- Reject all other traversal-bearing relative paths that can escape the helper bundle.
 - Reject unexpected non-system linked-library paths instead of silently rewriting them.
 - Reinspect the executable after mutation and fail if a disallowed path remains.
 
@@ -72,15 +74,18 @@ the later recursive re-sign with unrelated entitlements, not the initial DeepCha
 - CUA signing does not use `codesign --deep`; any future nested code must be signed explicitly.
 - The dedicated CUA entitlement remains an exact allowlist containing only
   `com.apple.security.automation.apple-events`.
+- Verification does not assume `codesign --deep --test-requirement` propagates the external
+  requirement to nested code; each discovered Mach-O is checked as an explicit path.
 
 ### Final artifact verification
 
 Distribution verification runs after electron-builder and notarization and must:
 
 - verify the nested helper's strict code signature;
-- verify Developer ID authority, expected Team ID, hardened runtime and secure timestamp;
+- verify Developer ID authority, hardened runtime and secure timestamp, and apply the expected
+  Team-ID requirement to the helper bundle and every discovered Mach-O;
 - compare its effective entitlements with the exact CUA allowlist;
-- recursively reject non-system absolute Mach-O load paths and RPATHs;
+- recursively reject non-system absolute or unsafe traversal-bearing Mach-O load paths and RPATHs;
 - extract the staged updater ZIP and apply the same helper and application checks to its sole
   `DeepChat.app`;
 - run `syspolicy_check distribution` on the final DeepChat application in addition to existing
@@ -126,7 +131,7 @@ Distribution verification runs after electron-builder and notarization and must:
 Automated validation must cover:
 
 - universal `otool` output with duplicate per-slice RPATHs;
-- allowed system and relative load paths;
+- allowed system and bundle-contained relative load paths, plus rejected relative traversal;
 - removal and post-mutation rejection of disallowed RPATHs;
 - missing and contradictory purpose/build-mode combinations;
 - distribution and verification signing command differences;

--- a/docs/issues/cua-macos-distribution-integrity/spec.md
+++ b/docs/issues/cua-macos-distribution-integrity/spec.md
@@ -81,6 +81,8 @@ Distribution verification runs after electron-builder and notarization and must:
 - verify Developer ID authority, expected Team ID, hardened runtime and secure timestamp;
 - compare its effective entitlements with the exact CUA allowlist;
 - recursively reject non-system absolute Mach-O load paths and RPATHs;
+- extract the staged updater ZIP and apply the same helper and application checks to its sole
+  `DeepChat.app`;
 - run `syspolicy_check distribution` on the final DeepChat application in addition to existing
   `codesign`, stapler and `spctl` checks.
 
@@ -113,6 +115,7 @@ Distribution verification runs after electron-builder and notarization and must:
 - [x] Remove `--deep` from helper signing.
 - [x] Prevent electron-builder from re-signing the staged helper.
 - [x] Verify the final helper signature, Team ID, runtime, timestamp, entitlements and load paths.
+- [x] Verify the extracted updater ZIP application with the same distribution checks.
 - [x] Add `syspolicy_check distribution` to final macOS application verification.
 - [x] Add focused regression tests for every fail-closed boundary.
 - [x] Run formatting, i18n, lint and relevant main-process test suites.
@@ -142,9 +145,9 @@ status and macOS code-signing/library-validation logs.
 Validated on 2026-07-26:
 
 - `pnpm run format`, `pnpm run i18n`, `pnpm run lint`, and `pnpm run typecheck:node` passed.
-- `pnpm exec vitest run test/main/scripts` passed 25 files and 167 tests.
+- `pnpm exec vitest run test/main/scripts` passed 25 files and 178 tests.
 - `pnpm exec vitest run --config vitest.config.ts test/main --reporter=dot` passed 436 files and
-  5,031 tests, with 19 files and 239 tests skipped.
+  5,040 tests, with 19 files and 239 tests skipped.
 - A copy of the generated universal helper was sanitized and ad-hoc signed through the production
   scripts. Both Xcode RPATHs were removed across the x86_64 and ARM64 slices; final inspection found
   one Mach-O file, only `/usr/lib/swift` as its RPATH, and exactly the managed Apple Events
@@ -152,6 +155,9 @@ Validated on 2026-07-26:
 - A synthetic universal Mach-O with different disallowed RPATHs in its x86_64 and ARM64 slices
   reproduced `install_name_tool`'s whole-file failure. Per-slice sanitation removed both paths,
   rebuilt both architectures, and preserved executable permissions.
+- An existing electron-builder macOS updater ZIP passed the new 3,220-entry path contract, `ditto`
+  extraction, sole-root application check, and cleanup path. Its distribution signatures were not
+  used as current-fix evidence; current Developer ID verification still requires a new CI artifact.
 
 Local verification cannot prove the Developer ID, notarization, stapling, final
 `syspolicy_check distribution`, or clean-install behavior because the local run has no signed and

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -93,6 +93,8 @@ afterSign: scripts/notarize.js
 artifactBuildCompleted: scripts/notarize-dmg.js
 afterPack: scripts/afterPack.js
 mac:
+  signIgnore:
+    - '/Contents/Helpers/DeepChat Computer Use[.]app(?:/|$)'
   entitlementsInherit: build/entitlements.mac.plist
   extraFiles:
     - from: ./build/managed-helpers/

--- a/scripts/apple-notarization.js
+++ b/scripts/apple-notarization.js
@@ -1,6 +1,9 @@
 import { notarize } from '@electron/notarize'
+import { isReleaseNotarizationEnabled } from './macos-release-contract.mjs'
 
 const APPLE_TEAM_ID_PATTERN = /^[A-Z0-9]{10}$/
+
+export { isReleaseNotarizationEnabled }
 
 function requireEnvironmentValue(env, name) {
   const value = env[name]
@@ -8,10 +11,6 @@ function requireEnvironmentValue(env, name) {
     throw new Error(`Missing required macOS notarization environment variable: ${name}`)
   }
   return value
-}
-
-export function isReleaseNotarizationEnabled(env = process.env) {
-  return typeof env.build_for_release === 'string' && env.build_for_release.length > 0
 }
 
 export function validateAppleTeamId(teamId) {

--- a/scripts/apple-notarization.js
+++ b/scripts/apple-notarization.js
@@ -13,9 +13,12 @@ function requireEnvironmentValue(env, name) {
   return value
 }
 
-export function validateAppleTeamId(teamId) {
-  if (!APPLE_TEAM_ID_PATTERN.test(teamId)) {
-    throw new Error('DEEPCHAT_APPLE_NOTARY_TEAM_ID must be a 10-character Apple team ID')
+export function validateAppleTeamId(
+  teamId,
+  label = 'DEEPCHAT_APPLE_NOTARY_TEAM_ID'
+) {
+  if (typeof teamId !== 'string' || !APPLE_TEAM_ID_PATTERN.test(teamId)) {
+    throw new Error(`${label} must be a 10-character Apple team ID`)
   }
   return teamId
 }

--- a/scripts/build-cua-plugin-runtime.mjs
+++ b/scripts/build-cua-plugin-runtime.mjs
@@ -6,6 +6,14 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { unzipSync } from 'fflate'
+import {
+  CUA_DARWIN_HELPER_APP_NAME,
+  CUA_DARWIN_HELPER_BUNDLE_IDENTIFIER,
+  CUA_DARWIN_HELPER_EXECUTABLE_NAME,
+  findDisallowedDarwinLoadPaths,
+  parseDarwinLinkedLibraries,
+  parseDarwinRpaths
+} from './cua-macos-contract.mjs'
 import { signMacHelperForRelease } from './sign-cua-helper.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -21,9 +29,9 @@ const vendorRoot = process.env.DEEPCHAT_CUA_VENDOR_ROOT
 const upstreamMetadataPath = path.join(vendorRoot, 'upstream.json')
 const helperBinaryName = 'cua-driver'
 const upstreamDarwinHelperAppDirName = 'CuaDriver.app'
-export const darwinHelperAppDirName = 'DeepChat Computer Use.app'
-export const darwinHelperBinaryName = 'deepchat-cua-driver'
-export const darwinHelperBundleIdentifier = 'com.deepchat.computeruse.helper'
+export const darwinHelperAppDirName = CUA_DARWIN_HELPER_APP_NAME
+export const darwinHelperBinaryName = CUA_DARWIN_HELPER_EXECUTABLE_NAME
+export const darwinHelperBundleIdentifier = CUA_DARWIN_HELPER_BUNDLE_IDENTIFIER
 const darwinHelperBundleName = 'DeepChat Computer Use'
 
 const targetAssetKeys = {
@@ -435,6 +443,51 @@ function validateDarwinArchitecture(executable, targetPlatform, targetArch) {
   }
 }
 
+export function inspectDarwinExecutable(executable, { readCommand = read } = {}) {
+  return {
+    rpaths: parseDarwinRpaths(readCommand('/usr/bin/otool', ['-l', executable])),
+    linkedLibraries: parseDarwinLinkedLibraries(
+      readCommand('/usr/bin/otool', ['-L', executable])
+    )
+  }
+}
+
+function assertAllowedDarwinLinkedLibraries(linkedLibraries, executable) {
+  const disallowed = findDisallowedDarwinLoadPaths(linkedLibraries)
+  if (disallowed.length > 0) {
+    throw new Error(
+      `CUA helper contains non-system linked libraries (${disallowed.join(', ')}): ${executable}`
+    )
+  }
+}
+
+export function sanitizeDarwinExecutable(
+  executable,
+  { inspectExecutable = inspectDarwinExecutable, runCommand = run } = {}
+) {
+  const before = inspectExecutable(executable)
+  assertAllowedDarwinLinkedLibraries(before.linkedLibraries, executable)
+
+  const removedRpaths = findDisallowedDarwinLoadPaths(before.rpaths)
+  for (const rpath of removedRpaths) {
+    runCommand('/usr/bin/install_name_tool', ['-delete_rpath', rpath, executable])
+  }
+
+  const after = inspectExecutable(executable)
+  assertAllowedDarwinLinkedLibraries(after.linkedLibraries, executable)
+  const remainingRpaths = findDisallowedDarwinLoadPaths(after.rpaths)
+  if (remainingRpaths.length > 0) {
+    throw new Error(
+      `CUA helper still contains non-system RPATHs after sanitation (${remainingRpaths.join(', ')}): ${executable}`
+    )
+  }
+
+  if (removedRpaths.length > 0) {
+    console.info(`Removed CUA helper build-machine RPATHs: ${removedRpaths.join(', ')}`)
+  }
+  return { removedRpaths }
+}
+
 async function signDarwinHelper(runtimeDir, targetPlatform) {
   if (targetPlatform !== 'darwin' || process.platform !== 'darwin') {
     return
@@ -493,6 +546,9 @@ async function main() {
 
   const { runtimeDir, executable } = await stageRuntime(targetPlatform, targetArch, extractDir)
   validateDarwinArchitecture(executable, targetPlatform, targetArch)
+  if (targetPlatform === 'darwin' && process.platform === 'darwin') {
+    sanitizeDarwinExecutable(executable)
+  }
   await signDarwinHelper(runtimeDir, targetPlatform)
   smokeCheck(executable, targetPlatform, targetArch)
 

--- a/scripts/build-cua-plugin-runtime.mjs
+++ b/scripts/build-cua-plugin-runtime.mjs
@@ -510,6 +510,7 @@ export function enforceDarwinLoadPathContract(
   {
     inspectExecutable = inspectDarwinExecutable,
     inspectArchitectures = inspectDarwinArchitectures,
+    ensureToolAvailable = ensureTool,
     runCommand = run,
     enforceSlice = (slicePath, initialInspection) =>
       enforceThinDarwinLoadPathContract(slicePath, {
@@ -531,6 +532,8 @@ export function enforceDarwinLoadPathContract(
     return { removedRpaths: [] }
   }
 
+  ensureToolAvailable('/usr/bin/install_name_tool', ['-help'])
+  ensureToolAvailable('/usr/bin/lipo', ['-info', process.execPath])
   const architectures = inspectArchitectures(executable)
   let removedRpaths
   if (architectures.length === 1) {

--- a/scripts/build-cua-plugin-runtime.mjs
+++ b/scripts/build-cua-plugin-runtime.mjs
@@ -14,7 +14,7 @@ import {
   parseDarwinLinkedLibraries,
   parseDarwinRpaths
 } from './cua-macos-contract.mjs'
-import { signMacHelperForRelease } from './sign-cua-helper.mjs'
+import { signMacHelper } from './sign-cua-helper.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const rootDir = process.env.DEEPCHAT_ROOT_DIR
@@ -488,33 +488,19 @@ export function sanitizeDarwinExecutable(
   return { removedRpaths }
 }
 
-async function signDarwinHelper(runtimeDir, targetPlatform) {
+async function signDarwinHelper(runtimeDir, targetPlatform, packagePurpose) {
   if (targetPlatform !== 'darwin' || process.platform !== 'darwin') {
     return
   }
   ensureTool('codesign', ['--version'])
   const helperAppPath = path.join(runtimeDir, darwinHelperAppDirName)
   const entitlementsPath = path.join(pluginDir, 'build', 'entitlements.plist')
-  const signedForRelease = await signMacHelperForRelease({
+  await signMacHelper({
     appPath: helperAppPath,
     entitlementsPath,
+    purpose: packagePurpose,
     cwd: rootDir
   })
-  if (!signedForRelease) {
-    run('codesign', [
-      '--force',
-      '--deep',
-      '--sign',
-      '-',
-      '--entitlements',
-      entitlementsPath,
-      '--options',
-      'runtime',
-      '--timestamp=none',
-      helperAppPath
-    ])
-  }
-  run('codesign', ['--verify', '--deep', '--strict', '--verbose=2', helperAppPath])
 }
 
 async function main() {
@@ -525,6 +511,7 @@ async function main() {
   const targetArch = String(
     args.get('arch') ?? process.env.TARGET_ARCH ?? process.arch
   ).toLowerCase()
+  const packagePurpose = args.get('purpose')
   const metadata = await readUpstreamMetadata()
   const target = getTarget(targetPlatform, targetArch, metadata)
   const cacheDir = process.env.DEEPCHAT_CUA_DOWNLOAD_CACHE
@@ -549,7 +536,7 @@ async function main() {
   if (targetPlatform === 'darwin' && process.platform === 'darwin') {
     sanitizeDarwinExecutable(executable)
   }
-  await signDarwinHelper(runtimeDir, targetPlatform)
+  await signDarwinHelper(runtimeDir, targetPlatform, packagePurpose)
   smokeCheck(executable, targetPlatform, targetArch)
 
   const relativeRuntimePath = path.relative(rootDir, runtimeDir)

--- a/scripts/build-cua-plugin-runtime.mjs
+++ b/scripts/build-cua-plugin-runtime.mjs
@@ -452,6 +452,19 @@ export function inspectDarwinExecutable(executable, { readCommand = read } = {})
   }
 }
 
+export function inspectDarwinArchitectures(executable, { readCommand = read } = {}) {
+  const architectures = readCommand('/usr/bin/lipo', ['-archs', executable])
+    .split(/\s+/)
+    .filter(Boolean)
+  if (
+    architectures.length === 0 ||
+    architectures.some((architecture) => !/^[A-Za-z0-9_]+$/.test(architecture))
+  ) {
+    throw new Error(`Unable to determine CUA helper architectures: ${executable}`)
+  }
+  return [...new Set(architectures)]
+}
+
 function assertAllowedDarwinLinkedLibraries(linkedLibraries, executable) {
   const disallowed = findDisallowedDarwinLoadPaths(linkedLibraries)
   if (disallowed.length > 0) {
@@ -461,11 +474,24 @@ function assertAllowedDarwinLinkedLibraries(linkedLibraries, executable) {
   }
 }
 
-export function sanitizeDarwinExecutable(
+function assertAllowedDarwinRpaths(rpaths, executable) {
+  const disallowed = findDisallowedDarwinLoadPaths(rpaths)
+  if (disallowed.length > 0) {
+    throw new Error(
+      `CUA helper still contains non-system RPATHs after sanitation (${disallowed.join(', ')}): ${executable}`
+    )
+  }
+}
+
+function enforceThinDarwinLoadPathContract(
   executable,
-  { inspectExecutable = inspectDarwinExecutable, runCommand = run } = {}
+  {
+    inspectExecutable = inspectDarwinExecutable,
+    runCommand = run,
+    initialInspection
+  } = {}
 ) {
-  const before = inspectExecutable(executable)
+  const before = initialInspection ?? inspectExecutable(executable)
   assertAllowedDarwinLinkedLibraries(before.linkedLibraries, executable)
 
   const removedRpaths = findDisallowedDarwinLoadPaths(before.rpaths)
@@ -475,13 +501,103 @@ export function sanitizeDarwinExecutable(
 
   const after = inspectExecutable(executable)
   assertAllowedDarwinLinkedLibraries(after.linkedLibraries, executable)
-  const remainingRpaths = findDisallowedDarwinLoadPaths(after.rpaths)
-  if (remainingRpaths.length > 0) {
-    throw new Error(
-      `CUA helper still contains non-system RPATHs after sanitation (${remainingRpaths.join(', ')}): ${executable}`
-    )
+  assertAllowedDarwinRpaths(after.rpaths, executable)
+  return { removedRpaths }
+}
+
+export function enforceDarwinLoadPathContract(
+  executable,
+  {
+    inspectExecutable = inspectDarwinExecutable,
+    inspectArchitectures = inspectDarwinArchitectures,
+    runCommand = run,
+    enforceSlice = (slicePath, initialInspection) =>
+      enforceThinDarwinLoadPathContract(slicePath, {
+        inspectExecutable,
+        runCommand,
+        initialInspection
+      }),
+    makeTemporaryDirectory = (prefix) => fsSync.mkdtempSync(prefix),
+    readMode = (targetPath) => fsSync.statSync(targetPath).mode,
+    applyMode = (targetPath, mode) => fsSync.chmodSync(targetPath, mode),
+    replaceFile = (sourcePath, targetPath) => fsSync.renameSync(sourcePath, targetPath),
+    removeTemporaryDirectory = (targetPath) =>
+      fsSync.rmSync(targetPath, { recursive: true, force: true })
+  } = {}
+) {
+  const initialInspection = inspectExecutable(executable)
+  assertAllowedDarwinLinkedLibraries(initialInspection.linkedLibraries, executable)
+  if (findDisallowedDarwinLoadPaths(initialInspection.rpaths).length === 0) {
+    return { removedRpaths: [] }
   }
 
+  const architectures = inspectArchitectures(executable)
+  let removedRpaths
+  if (architectures.length === 1) {
+    removedRpaths = enforceSlice(executable, initialInspection).removedRpaths
+  } else {
+    const temporaryDirectory = makeTemporaryDirectory(`${executable}.load-paths-`)
+    const slicePaths = []
+    let sanitationError
+    try {
+      removedRpaths = []
+      for (const architecture of architectures) {
+        const slicePath = path.join(
+          temporaryDirectory,
+          `${architecture}-${path.basename(executable)}`
+        )
+        runCommand('/usr/bin/lipo', [
+          '-thin',
+          architecture,
+          executable,
+          '-output',
+          slicePath
+        ])
+        slicePaths.push(slicePath)
+        removedRpaths.push(...enforceSlice(slicePath).removedRpaths)
+      }
+
+      const rebuiltExecutable = path.join(temporaryDirectory, path.basename(executable))
+      runCommand('/usr/bin/lipo', ['-create', ...slicePaths, '-output', rebuiltExecutable])
+      const rebuiltInspection = inspectExecutable(rebuiltExecutable)
+      assertAllowedDarwinLinkedLibraries(
+        rebuiltInspection.linkedLibraries,
+        rebuiltExecutable
+      )
+      assertAllowedDarwinRpaths(rebuiltInspection.rpaths, rebuiltExecutable)
+      const rebuiltArchitectures = inspectArchitectures(rebuiltExecutable)
+      if (
+        rebuiltArchitectures.length !== architectures.length ||
+        architectures.some(
+          (architecture) => !rebuiltArchitectures.includes(architecture)
+        )
+      ) {
+        throw new Error(
+          `CUA helper architecture set changed during sanitation: ${architectures.join(', ')} -> ${rebuiltArchitectures.join(', ')}`
+        )
+      }
+      applyMode(rebuiltExecutable, readMode(executable) & 0o777)
+      replaceFile(rebuiltExecutable, executable)
+    } catch (error) {
+      sanitationError = error
+    }
+    try {
+      removeTemporaryDirectory(temporaryDirectory)
+    } catch (cleanupError) {
+      if (sanitationError) {
+        throw new AggregateError(
+          [sanitationError, cleanupError],
+          'CUA helper sanitation failed and temporary slice cleanup was incomplete'
+        )
+      }
+      throw cleanupError
+    }
+    if (sanitationError) {
+      throw sanitationError
+    }
+  }
+
+  removedRpaths = [...new Set(removedRpaths)]
   if (removedRpaths.length > 0) {
     console.info(`Removed CUA helper build-machine RPATHs: ${removedRpaths.join(', ')}`)
   }
@@ -534,7 +650,7 @@ async function main() {
   const { runtimeDir, executable } = await stageRuntime(targetPlatform, targetArch, extractDir)
   validateDarwinArchitecture(executable, targetPlatform, targetArch)
   if (targetPlatform === 'darwin' && process.platform === 'darwin') {
-    sanitizeDarwinExecutable(executable)
+    enforceDarwinLoadPathContract(executable)
   }
   await signDarwinHelper(runtimeDir, targetPlatform, packagePurpose)
   smokeCheck(executable, targetPlatform, targetArch)

--- a/scripts/ci/assemble-release.mjs
+++ b/scripts/ci/assemble-release.mjs
@@ -57,7 +57,11 @@ function validateChecks(manifest, definition) {
   const checks = assertObject(manifest.checks, `${definition.id} checks`)
   const requiredChecks = ['packageSmoke', 'componentSize', 'installerSize']
   if (definition.platform === 'darwin') {
-    requiredChecks.push('macAppDistribution', 'macDmgDistribution')
+    requiredChecks.push(
+      'cuaMacHelperDistribution',
+      'macAppDistribution',
+      'macDmgDistribution'
+    )
   }
   assertExactKeys(checks, requiredChecks, `${definition.id} checks`)
   for (const name of requiredChecks) {
@@ -640,6 +644,7 @@ export async function assembleRelease({
         installerSize: checks.installerSize,
         ...(definition.platform === 'darwin'
           ? {
+              cuaMacHelperDistribution: checks.cuaMacHelperDistribution,
               macAppDistribution: checks.macAppDistribution,
               macDmgDistribution: checks.macDmgDistribution
             }

--- a/scripts/ci/assemble-release.mjs
+++ b/scripts/ci/assemble-release.mjs
@@ -60,6 +60,7 @@ function validateChecks(manifest, definition) {
     requiredChecks.push(
       'cuaMacHelperDistribution',
       'macAppDistribution',
+      'macZipDistribution',
       'macDmgDistribution'
     )
   }
@@ -646,6 +647,7 @@ export async function assembleRelease({
           ? {
               cuaMacHelperDistribution: checks.cuaMacHelperDistribution,
               macAppDistribution: checks.macAppDistribution,
+              macZipDistribution: checks.macZipDistribution,
               macDmgDistribution: checks.macDmgDistribution
             }
           : {})

--- a/scripts/ci/assemble-release.mjs
+++ b/scripts/ci/assemble-release.mjs
@@ -7,6 +7,7 @@ import { Scalar, stringify } from 'yaml'
 
 import {
   compareFileNames,
+  DARWIN_DISTRIBUTION_CHECK_NAMES,
   expectedReleaseAssetCount,
   getPublicRoles,
   getRoleDefinition,
@@ -57,12 +58,7 @@ function validateChecks(manifest, definition) {
   const checks = assertObject(manifest.checks, `${definition.id} checks`)
   const requiredChecks = ['packageSmoke', 'componentSize', 'installerSize']
   if (definition.platform === 'darwin') {
-    requiredChecks.push(
-      'cuaMacHelperDistribution',
-      'macAppDistribution',
-      'macZipDistribution',
-      'macDmgDistribution'
-    )
+    requiredChecks.push(...DARWIN_DISTRIBUTION_CHECK_NAMES)
   }
   assertExactKeys(checks, requiredChecks, `${definition.id} checks`)
   for (const name of requiredChecks) {
@@ -644,12 +640,9 @@ export async function assembleRelease({
         componentSize: checks.componentSize,
         installerSize: checks.installerSize,
         ...(definition.platform === 'darwin'
-          ? {
-              cuaMacHelperDistribution: checks.cuaMacHelperDistribution,
-              macAppDistribution: checks.macAppDistribution,
-              macZipDistribution: checks.macZipDistribution,
-              macDmgDistribution: checks.macDmgDistribution
-            }
+          ? Object.fromEntries(
+              DARWIN_DISTRIBUTION_CHECK_NAMES.map((name) => [name, checks[name]])
+            )
           : {})
       }
     })),

--- a/scripts/ci/classify-package-impact.mjs
+++ b/scripts/ci/classify-package-impact.mjs
@@ -64,6 +64,7 @@ const macosPackagePaths = new Set([
   'build/icon.icns',
   'resources/macTrayTemplate.png',
   'scripts/apple-notarization.js',
+  'scripts/macos-release-contract.mjs',
   'scripts/notarize-dmg.js',
   'scripts/notarize.js',
   'scripts/cua-macos-contract.mjs',

--- a/scripts/ci/classify-package-impact.mjs
+++ b/scripts/ci/classify-package-impact.mjs
@@ -66,6 +66,8 @@ const macosPackagePaths = new Set([
   'scripts/apple-notarization.js',
   'scripts/notarize-dmg.js',
   'scripts/notarize.js',
+  'scripts/cua-macos-contract.mjs',
+  'scripts/ci/verify-cua-macos-helper.mjs',
   'scripts/sign-cua-helper.mjs'
 ])
 

--- a/scripts/ci/package-contract.mjs
+++ b/scripts/ci/package-contract.mjs
@@ -1,9 +1,9 @@
 import path from 'node:path'
 
-export const PACKAGE_MANIFEST_SCHEMA_VERSION = 1
+export const PACKAGE_MANIFEST_SCHEMA_VERSION = 2
 export const PACKAGE_SIZE_BASELINE_SCHEMA_VERSION = 1
 export const PACKAGE_SIZE_POLICY_SCHEMA_VERSION = 1
-export const RELEASE_INDEX_SCHEMA_VERSION = 1
+export const RELEASE_INDEX_SCHEMA_VERSION = 2
 
 export const SOURCE_SHA_PATTERN = /^[a-f0-9]{40}$/
 export const SHA256_PATTERN = /^[a-f0-9]{64}$/

--- a/scripts/ci/package-contract.mjs
+++ b/scripts/ci/package-contract.mjs
@@ -11,6 +11,12 @@ export const SHA512_BASE64_PATTERN = /^[A-Za-z0-9+/]{86}==$/
 
 export const SUPPORTED_ARCHITECTURES = Object.freeze(['x64', 'arm64'])
 export const SUPPORTED_ARTIFACT_PURPOSES = Object.freeze(['distribution', 'verification'])
+export const DARWIN_DISTRIBUTION_CHECK_NAMES = Object.freeze([
+  'cuaMacHelperDistribution',
+  'macAppDistribution',
+  'macZipDistribution',
+  'macDmgDistribution'
+])
 
 const MIB = 1024 * 1024
 export const DEFAULT_INSTALLER_DELTA_BYTES = 90 * MIB

--- a/scripts/ci/package-manifest.mjs
+++ b/scripts/ci/package-manifest.mjs
@@ -8,6 +8,7 @@ import { promisify } from 'node:util'
 
 import { validateAppleTeamId } from '../apple-notarization.js'
 import { verifyDmgDistribution } from '../notarize-dmg.js'
+import { verifyCuaMacHelperDistribution } from './verify-cua-macos-helper.mjs'
 import {
   getMeasuredRoles,
   getTargetDefinition,
@@ -100,6 +101,10 @@ export async function verifyMacAppDistribution(
     '--type',
     'execute',
     '--verbose=4',
+    appPath
+  ])
+  await runDistributionCommand(runCommand, '/usr/bin/syspolicy_check', [
+    'distribution',
     appPath
   ])
 }
@@ -464,6 +469,7 @@ export async function createPackageManifest({
   macAppPath,
   appleTeamId,
   verifyMacApp = verifyMacAppDistribution,
+  verifyCuaMacHelper = verifyCuaMacHelperDistribution,
   verifyMacDmg = verifyDmgDistribution
 }) {
   const definition = getTargetDefinition(platform, arch)
@@ -572,8 +578,10 @@ export async function createPackageManifest({
         'DeepChat.app'
       )
     const resolvedDmgPath = path.join(resolvedDistDirectory, dmg.name)
+    await verifyCuaMacHelper(resolvedAppPath, { teamId: appleTeamId })
     await verifyMacApp(resolvedAppPath, { teamId: appleTeamId })
     await verifyMacDmg(resolvedDmgPath, { teamId: appleTeamId })
+    checks.cuaMacHelperDistribution = 'passed'
     checks.macAppDistribution = 'passed'
     checks.macDmgDistribution = 'passed'
   }

--- a/scripts/ci/package-manifest.mjs
+++ b/scripts/ci/package-manifest.mjs
@@ -20,6 +20,7 @@ import { validateAppleTeamId } from '../apple-notarization.js'
 import { verifyDmgDistribution } from '../notarize-dmg.js'
 import { verifyCuaMacHelperDistribution } from './verify-cua-macos-helper.mjs'
 import {
+  DARWIN_DISTRIBUTION_CHECK_NAMES,
   getMeasuredRoles,
   getTargetDefinition,
   getUpdaterPayloadRole,
@@ -78,7 +79,10 @@ export async function verifyMacAppDistribution(
   appPath,
   { teamId, runCommand = execFileAsync } = {}
 ) {
-  const validatedTeamId = validateAppleTeamId(assertNonEmptyString(teamId, 'Apple team ID'))
+  const validatedTeamId = validateAppleTeamId(
+    assertNonEmptyString(teamId, 'Apple team ID'),
+    'Apple team ID'
+  )
   await runDistributionCommand(runCommand, '/usr/bin/codesign', [
     '--verify',
     '--deep',
@@ -192,8 +196,8 @@ export async function verifyMacZipDistribution(
         'macOS updater ZIP root DeepChat.app must be a real application directory'
       )
     }
-    await verifyCuaMacHelper(extractedAppPath, { teamId })
-    await verifyMacApp(extractedAppPath, { teamId })
+    await verifyCuaMacHelper(extractedAppPath, { teamId, runCommand })
+    await verifyMacApp(extractedAppPath, { teamId, runCommand })
   } catch (error) {
     verificationError = error
   }
@@ -692,10 +696,9 @@ export async function createPackageManifest({
     await verifyMacApp(resolvedAppPath, { teamId: appleTeamId })
     await verifyMacZip(resolvedZipPath, { teamId: appleTeamId })
     await verifyMacDmg(resolvedDmgPath, { teamId: appleTeamId })
-    checks.cuaMacHelperDistribution = 'passed'
-    checks.macAppDistribution = 'passed'
-    checks.macZipDistribution = 'passed'
-    checks.macDmgDistribution = 'passed'
+    for (const checkName of DARWIN_DISTRIBUTION_CHECK_NAMES) {
+      checks[checkName] = 'passed'
+    }
   }
 
   const manifest = {

--- a/scripts/ci/package-manifest.mjs
+++ b/scripts/ci/package-manifest.mjs
@@ -1,7 +1,17 @@
 #!/usr/bin/env node
 
 import { execFile } from 'node:child_process'
-import { copyFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
+import {
+  copyFile,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile
+} from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
@@ -107,6 +117,101 @@ export async function verifyMacAppDistribution(
     'distribution',
     appPath
   ])
+}
+
+export function validateMacZipEntries(output) {
+  if (typeof output !== 'string') {
+    throw new TypeError('macOS updater ZIP entry list must be a string')
+  }
+  const entries = output.split(/\r?\n/).filter((entry) => entry.length > 0)
+  if (entries.length === 0) {
+    throw new Error('macOS updater ZIP must not be empty')
+  }
+
+  const seenEntries = new Set()
+  for (const entry of entries) {
+    const normalizedEntry = entry.endsWith('/') ? entry.slice(0, -1) : entry
+    const segments = normalizedEntry.split('/')
+    if (
+      normalizedEntry.length === 0 ||
+      normalizedEntry.includes('\0') ||
+      normalizedEntry.includes('\\') ||
+      path.posix.isAbsolute(normalizedEntry) ||
+      /^[A-Za-z]:/.test(normalizedEntry) ||
+      segments.some((segment) => segment === '' || segment === '.' || segment === '..') ||
+      segments[0] !== 'DeepChat.app'
+    ) {
+      throw new Error(`macOS updater ZIP contains an unsafe entry: ${JSON.stringify(entry)}`)
+    }
+    if (seenEntries.has(normalizedEntry)) {
+      throw new Error(`macOS updater ZIP contains a duplicate entry: ${normalizedEntry}`)
+    }
+    seenEntries.add(normalizedEntry)
+  }
+  return entries
+}
+
+export async function verifyMacZipDistribution(
+  zipPath,
+  {
+    teamId,
+    runCommand = execFileAsync,
+    verifyMacApp = verifyMacAppDistribution,
+    verifyCuaMacHelper = verifyCuaMacHelperDistribution
+  } = {}
+) {
+  const zipEntries = await runDistributionCommand(runCommand, '/usr/bin/unzip', [
+    '-Z1',
+    zipPath
+  ])
+  validateMacZipEntries(zipEntries.stdout)
+  const extractionRoot = await mkdtemp(
+    path.join(os.tmpdir(), 'deepchat-macos-update-zip-')
+  )
+  let verificationError
+  try {
+    await runDistributionCommand(runCommand, '/usr/bin/ditto', [
+      '-x',
+      '-k',
+      zipPath,
+      extractionRoot
+    ])
+    const entries = await readdir(extractionRoot, { withFileTypes: true })
+    if (
+      entries.length !== 1 ||
+      entries[0].name !== 'DeepChat.app' ||
+      !entries[0].isDirectory()
+    ) {
+      throw new Error('macOS updater ZIP must contain exactly one root DeepChat.app directory')
+    }
+
+    const extractedAppPath = path.join(extractionRoot, 'DeepChat.app')
+    const appStat = await lstat(extractedAppPath)
+    if (appStat.isSymbolicLink() || !appStat.isDirectory()) {
+      throw new Error(
+        'macOS updater ZIP root DeepChat.app must be a real application directory'
+      )
+    }
+    await verifyCuaMacHelper(extractedAppPath, { teamId })
+    await verifyMacApp(extractedAppPath, { teamId })
+  } catch (error) {
+    verificationError = error
+  }
+  try {
+    await rm(extractionRoot, { recursive: true, force: true })
+  } catch (cleanupError) {
+    if (verificationError) {
+      throw new AggregateError(
+        [verificationError, cleanupError],
+        'macOS updater ZIP verification failed and extraction cleanup was incomplete'
+      )
+    }
+    throw cleanupError
+  }
+  if (verificationError) {
+    throw verificationError
+  }
+  return true
 }
 
 function normalizeMetadataFiles(metadata, label) {
@@ -470,6 +575,7 @@ export async function createPackageManifest({
   appleTeamId,
   verifyMacApp = verifyMacAppDistribution,
   verifyCuaMacHelper = verifyCuaMacHelperDistribution,
+  verifyMacZip = verifyMacZipDistribution,
   verifyMacDmg = verifyDmgDistribution
 }) {
   const definition = getTargetDefinition(platform, arch)
@@ -578,11 +684,17 @@ export async function createPackageManifest({
         'DeepChat.app'
       )
     const resolvedDmgPath = path.join(resolvedDistDirectory, dmg.name)
+    const resolvedZipPath = path.join(
+      resolvedOutputDirectory,
+      updaterPayload.storagePath
+    )
     await verifyCuaMacHelper(resolvedAppPath, { teamId: appleTeamId })
     await verifyMacApp(resolvedAppPath, { teamId: appleTeamId })
+    await verifyMacZip(resolvedZipPath, { teamId: appleTeamId })
     await verifyMacDmg(resolvedDmgPath, { teamId: appleTeamId })
     checks.cuaMacHelperDistribution = 'passed'
     checks.macAppDistribution = 'passed'
+    checks.macZipDistribution = 'passed'
     checks.macDmgDistribution = 'passed'
   }
 

--- a/scripts/ci/verify-cua-macos-helper.mjs
+++ b/scripts/ci/verify-cua-macos-helper.mjs
@@ -267,13 +267,15 @@ export async function verifyCuaMacHelperDistribution(
     inspectBundle = inspectCuaHelperBundle
   } = {}
 ) {
-  const validatedTeamId = validateAppleTeamId(teamId)
+  const validatedTeamId = validateAppleTeamId(teamId, 'CUA helper Team ID')
   const helperAppPath = path.join(
     macAppPath,
     'Contents',
     'Helpers',
     CUA_DARWIN_HELPER_APP_NAME
   )
+  const teamRequirement =
+    `=anchor apple generic and certificate leaf[subject.OU] = "${validatedTeamId}"`
 
   await runCommandWithOutput(runCommand, '/usr/bin/codesign', [
     '--verify',
@@ -292,13 +294,22 @@ export async function verifyCuaMacHelperDistribution(
     '--verify',
     '--strict',
     '--test-requirement',
-    `=anchor apple generic and certificate leaf[subject.OU] = "${validatedTeamId}"`,
+    teamRequirement,
     helperAppPath
   ])
 
   const { entitlements, inspections } = await inspectBundle(helperAppPath, { runCommand })
   assertCuaEntitlements(entitlements)
   assertCuaMachOLoadPaths(inspections)
+  for (const { filePath } of inspections) {
+    await runCommandWithOutput(runCommand, '/usr/bin/codesign', [
+      '--verify',
+      '--strict',
+      '--test-requirement',
+      teamRequirement,
+      filePath
+    ])
+  }
 
   return {
     helperAppPath,

--- a/scripts/ci/verify-cua-macos-helper.mjs
+++ b/scripts/ci/verify-cua-macos-helper.mjs
@@ -1,0 +1,233 @@
+import { execFile } from 'node:child_process'
+import { lstat, mkdtemp, readdir, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+import { validateAppleTeamId } from '../apple-notarization.js'
+import {
+  CUA_DARWIN_ALLOWED_ENTITLEMENTS,
+  CUA_DARWIN_HELPER_APP_NAME,
+  CUA_DARWIN_HELPER_BUNDLE_IDENTIFIER,
+  CUA_DARWIN_HELPER_EXECUTABLE_NAME,
+  findDisallowedDarwinLoadPaths,
+  parseDarwinLinkedLibraries,
+  parseDarwinRpaths
+} from '../cua-macos-contract.mjs'
+
+const execFileAsync = promisify(execFile)
+const COMMAND_OUTPUT_LIMIT = 4 * 1024 * 1024
+
+async function runCommandWithOutput(runCommand, command, args) {
+  return await runCommand(command, args, {
+    encoding: 'utf8',
+    maxBuffer: COMMAND_OUTPUT_LIMIT
+  })
+}
+
+function commandOutput(result) {
+  return `${result?.stdout ?? ''}\n${result?.stderr ?? ''}`
+}
+
+export function assertCuaDeveloperIdMetadata(result) {
+  const details = commandOutput(result)
+  if (!/^Authority=Developer ID Application:/m.test(details)) {
+    throw new Error('CUA macOS helper is not signed with a Developer ID Application certificate')
+  }
+  const timestamp = details.match(/^Timestamp=(.+)$/m)?.[1]?.trim()
+  if (!timestamp || timestamp.toLowerCase() === 'none') {
+    throw new Error('CUA macOS helper Developer ID signature does not contain a secure timestamp')
+  }
+  if (!/^CodeDirectory\b.*\bflags=.*\([^)]*\bruntime\b[^)]*\)/m.test(details)) {
+    throw new Error('CUA macOS helper signature does not enable hardened runtime')
+  }
+  const identifier = details.match(/^Identifier=(.+)$/m)?.[1]?.trim()
+  if (identifier !== CUA_DARWIN_HELPER_BUNDLE_IDENTIFIER) {
+    throw new Error(
+      `CUA macOS helper bundle identifier mismatch: ${identifier || '<missing>'}`
+    )
+  }
+}
+
+export function assertCuaEntitlements(entitlements) {
+  if (!entitlements || typeof entitlements !== 'object' || Array.isArray(entitlements)) {
+    throw new Error('CUA macOS helper entitlements must be a dictionary')
+  }
+
+  const expectedKeys = Object.keys(CUA_DARWIN_ALLOWED_ENTITLEMENTS).sort()
+  const actualKeys = Object.keys(entitlements).sort()
+  const keysMatch =
+    expectedKeys.length === actualKeys.length &&
+    expectedKeys.every((key, index) => key === actualKeys[index])
+  const valuesMatch = expectedKeys.every(
+    (key) => entitlements[key] === CUA_DARWIN_ALLOWED_ENTITLEMENTS[key]
+  )
+  if (!keysMatch || !valuesMatch) {
+    throw new Error(
+      `CUA macOS helper entitlements must exactly match ${JSON.stringify(CUA_DARWIN_ALLOWED_ENTITLEMENTS)}, received ${JSON.stringify(entitlements)}`
+    )
+  }
+}
+
+export function assertCuaMachOLoadPaths(inspections) {
+  if (!Array.isArray(inspections) || inspections.length === 0) {
+    throw new Error('CUA macOS helper does not contain an inspectable Mach-O executable')
+  }
+
+  for (const inspection of inspections) {
+    const disallowedRpaths = findDisallowedDarwinLoadPaths(inspection.rpaths)
+    if (disallowedRpaths.length > 0) {
+      throw new Error(
+        `CUA Mach-O contains non-system RPATHs (${disallowedRpaths.join(', ')}): ${inspection.filePath}`
+      )
+    }
+    const disallowedLibraries = findDisallowedDarwinLoadPaths(inspection.linkedLibraries)
+    if (disallowedLibraries.length > 0) {
+      throw new Error(
+        `CUA Mach-O contains non-system linked libraries (${disallowedLibraries.join(', ')}): ${inspection.filePath}`
+      )
+    }
+  }
+}
+
+async function collectRegularFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true })
+  entries.sort((left, right) => left.name.localeCompare(right.name))
+  const files = []
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await collectRegularFiles(entryPath)))
+    } else if (entry.isFile()) {
+      files.push(entryPath)
+    }
+  }
+  return files
+}
+
+async function extractCuaEntitlements(
+  helperAppPath,
+  { runCommand = execFileAsync } = {}
+) {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'deepchat-cua-entitlements-'))
+  const entitlementsPath = path.join(tempRoot, 'entitlements.plist')
+  try {
+    await runCommandWithOutput(runCommand, '/usr/bin/codesign', [
+      '--display',
+      '--xml',
+      '--entitlements',
+      entitlementsPath,
+      helperAppPath
+    ])
+    const result = await runCommandWithOutput(runCommand, '/usr/bin/plutil', [
+      '-convert',
+      'json',
+      '-o',
+      '-',
+      '--',
+      entitlementsPath
+    ])
+    return JSON.parse(result.stdout)
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true })
+  }
+}
+
+export async function inspectCuaHelperBundle(
+  helperAppPath,
+  {
+    runCommand = execFileAsync,
+    readEntitlements = extractCuaEntitlements
+  } = {}
+) {
+  const helperExecutablePath = path.join(
+    helperAppPath,
+    'Contents',
+    'MacOS',
+    CUA_DARWIN_HELPER_EXECUTABLE_NAME
+  )
+  for (const directory of [
+    helperAppPath,
+    path.join(helperAppPath, 'Contents'),
+    path.join(helperAppPath, 'Contents', 'MacOS')
+  ]) {
+    const directoryStat = await lstat(directory)
+    if (!directoryStat.isDirectory()) {
+      throw new Error(`CUA macOS helper path is not a directory: ${directory}`)
+    }
+  }
+  const executableStat = await lstat(helperExecutablePath)
+  if (!executableStat.isFile()) {
+    throw new Error(`CUA macOS helper executable is not a regular file: ${helperExecutablePath}`)
+  }
+
+  const entitlements = await readEntitlements(helperAppPath, { runCommand })
+  const inspections = []
+  for (const filePath of await collectRegularFiles(helperAppPath)) {
+    const fileResult = await runCommandWithOutput(runCommand, '/usr/bin/file', ['-b', filePath])
+    if (!fileResult.stdout.includes('Mach-O')) {
+      continue
+    }
+    const [loadCommands, linkedLibraries] = await Promise.all([
+      runCommandWithOutput(runCommand, '/usr/bin/otool', ['-l', filePath]),
+      runCommandWithOutput(runCommand, '/usr/bin/otool', ['-L', filePath])
+    ])
+    inspections.push({
+      filePath,
+      rpaths: parseDarwinRpaths(loadCommands.stdout),
+      linkedLibraries: parseDarwinLinkedLibraries(linkedLibraries.stdout)
+    })
+  }
+
+  if (!inspections.some(({ filePath }) => filePath === helperExecutablePath)) {
+    throw new Error(`CUA macOS helper executable is not Mach-O: ${helperExecutablePath}`)
+  }
+  return { entitlements, inspections }
+}
+
+export async function verifyCuaMacHelperDistribution(
+  macAppPath,
+  {
+    teamId,
+    runCommand = execFileAsync,
+    inspectBundle = inspectCuaHelperBundle
+  } = {}
+) {
+  const validatedTeamId = validateAppleTeamId(teamId)
+  const helperAppPath = path.join(
+    macAppPath,
+    'Contents',
+    'Helpers',
+    CUA_DARWIN_HELPER_APP_NAME
+  )
+
+  await runCommandWithOutput(runCommand, '/usr/bin/codesign', [
+    '--verify',
+    '--deep',
+    '--strict',
+    '--verbose=2',
+    helperAppPath
+  ])
+  const metadata = await runCommandWithOutput(runCommand, '/usr/bin/codesign', [
+    '--display',
+    '--verbose=4',
+    helperAppPath
+  ])
+  assertCuaDeveloperIdMetadata(metadata)
+  await runCommandWithOutput(runCommand, '/usr/bin/codesign', [
+    '--verify',
+    '--strict',
+    '--test-requirement',
+    `=anchor apple generic and certificate leaf[subject.OU] = "${validatedTeamId}"`,
+    helperAppPath
+  ])
+
+  const { entitlements, inspections } = await inspectBundle(helperAppPath, { runCommand })
+  assertCuaEntitlements(entitlements)
+  assertCuaMachOLoadPaths(inspections)
+
+  return {
+    helperAppPath,
+    inspectedMachOCount: inspections.length
+  }
+}

--- a/scripts/ci/verify-cua-macos-helper.mjs
+++ b/scripts/ci/verify-cua-macos-helper.mjs
@@ -1,5 +1,13 @@
 import { execFile } from 'node:child_process'
-import { lstat, mkdtemp, readdir, rm } from 'node:fs/promises'
+import {
+  lstat,
+  mkdtemp,
+  open,
+  readFile,
+  readdir,
+  realpath,
+  rm
+} from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
@@ -17,6 +25,16 @@ import {
 
 const execFileAsync = promisify(execFile)
 const COMMAND_OUTPUT_LIMIT = 4 * 1024 * 1024
+const MACH_O_MAGIC = new Set([
+  'bebafeca',
+  'bfbafeca',
+  'cafebabe',
+  'cafebabf',
+  'cefaedfe',
+  'cffaedfe',
+  'feedface',
+  'feedfacf'
+])
 
 async function runCommandWithOutput(runCommand, command, args) {
   return await runCommand(command, args, {
@@ -90,22 +108,57 @@ export function assertCuaMachOLoadPaths(inspections) {
   }
 }
 
-async function collectRegularFiles(directory) {
+function isContainedPath(rootPath, candidatePath) {
+  const relative = path.relative(rootPath, candidatePath)
+  return (
+    relative === '' ||
+    (relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  )
+}
+
+async function hasMachOCandidateMagic(filePath) {
+  const handle = await open(filePath, 'r')
+  try {
+    const header = Buffer.alloc(4)
+    const { bytesRead } = await handle.read(header, 0, header.length, 0)
+    return bytesRead === header.length && MACH_O_MAGIC.has(header.toString('hex'))
+  } finally {
+    await handle.close()
+  }
+}
+
+async function collectRegularFiles(directory, bundleRootRealPath) {
   const entries = await readdir(directory, { withFileTypes: true })
   entries.sort((left, right) => left.name.localeCompare(right.name))
   const files = []
   for (const entry of entries) {
     const entryPath = path.join(directory, entry.name)
     if (entry.isDirectory()) {
-      files.push(...(await collectRegularFiles(entryPath)))
+      files.push(...(await collectRegularFiles(entryPath, bundleRootRealPath)))
     } else if (entry.isFile()) {
       files.push(entryPath)
+    } else if (entry.isSymbolicLink()) {
+      let resolvedTarget
+      try {
+        resolvedTarget = await realpath(entryPath)
+      } catch {
+        throw new Error(`CUA macOS helper contains a broken symbolic link: ${entryPath}`)
+      }
+      if (!isContainedPath(bundleRootRealPath, resolvedTarget)) {
+        throw new Error(
+          `CUA macOS helper symbolic link escapes the bundle: ${entryPath} -> ${resolvedTarget}`
+        )
+      }
+    } else {
+      throw new Error(`CUA macOS helper contains an unsupported file type: ${entryPath}`)
     }
   }
   return files
 }
 
-async function extractCuaEntitlements(
+export async function extractCuaEntitlements(
   helperAppPath,
   { runCommand = execFileAsync } = {}
 ) {
@@ -119,6 +172,15 @@ async function extractCuaEntitlements(
       entitlementsPath,
       helperAppPath
     ])
+    let entitlementBytes
+    try {
+      entitlementBytes = await readFile(entitlementsPath)
+    } catch {
+      throw new Error('CUA macOS helper signature does not contain entitlements')
+    }
+    if (entitlementBytes.length === 0) {
+      throw new Error('CUA macOS helper signature does not contain entitlements')
+    }
     const result = await runCommandWithOutput(runCommand, '/usr/bin/plutil', [
       '-convert',
       'json',
@@ -152,18 +214,30 @@ export async function inspectCuaHelperBundle(
     path.join(helperAppPath, 'Contents', 'MacOS')
   ]) {
     const directoryStat = await lstat(directory)
+    if (directoryStat.isSymbolicLink()) {
+      throw new Error(`CUA macOS helper directory must not be a symbolic link: ${directory}`)
+    }
     if (!directoryStat.isDirectory()) {
       throw new Error(`CUA macOS helper path is not a directory: ${directory}`)
     }
   }
   const executableStat = await lstat(helperExecutablePath)
+  if (executableStat.isSymbolicLink()) {
+    throw new Error(
+      `CUA macOS helper executable must not be a symbolic link: ${helperExecutablePath}`
+    )
+  }
   if (!executableStat.isFile()) {
     throw new Error(`CUA macOS helper executable is not a regular file: ${helperExecutablePath}`)
   }
 
   const entitlements = await readEntitlements(helperAppPath, { runCommand })
   const inspections = []
-  for (const filePath of await collectRegularFiles(helperAppPath)) {
+  const bundleRootRealPath = await realpath(helperAppPath)
+  for (const filePath of await collectRegularFiles(helperAppPath, bundleRootRealPath)) {
+    if (!(await hasMachOCandidateMagic(filePath))) {
+      continue
+    }
     const fileResult = await runCommandWithOutput(runCommand, '/usr/bin/file', ['-b', filePath])
     if (!fileResult.stdout.includes('Mach-O')) {
       continue

--- a/scripts/ci/verify-release-assets.mjs
+++ b/scripts/ci/verify-release-assets.mjs
@@ -117,6 +117,7 @@ function validateReleaseTargets(index) {
       requiredChecks.push(
         'cuaMacHelperDistribution',
         'macAppDistribution',
+        'macZipDistribution',
         'macDmgDistribution'
       )
     }

--- a/scripts/ci/verify-release-assets.mjs
+++ b/scripts/ci/verify-release-assets.mjs
@@ -114,7 +114,11 @@ function validateReleaseTargets(index) {
     }
     const requiredChecks = ['packageSmoke', 'componentSize', 'installerSize']
     if (definition.platform === 'darwin') {
-      requiredChecks.push('macAppDistribution', 'macDmgDistribution')
+      requiredChecks.push(
+        'cuaMacHelperDistribution',
+        'macAppDistribution',
+        'macDmgDistribution'
+      )
     }
     const checks = assertObject(target.checks, `${definition.id} checks`)
     assertExactKeys(checks, requiredChecks, `${definition.id} checks`)

--- a/scripts/ci/verify-release-assets.mjs
+++ b/scripts/ci/verify-release-assets.mjs
@@ -8,6 +8,7 @@ import { pathToFileURL } from 'node:url'
 
 import {
   compareFileNames,
+  DARWIN_DISTRIBUTION_CHECK_NAMES,
   expectedReleaseAssetCount,
   getPublicRoles,
   getRoleDefinition,
@@ -114,12 +115,7 @@ function validateReleaseTargets(index) {
     }
     const requiredChecks = ['packageSmoke', 'componentSize', 'installerSize']
     if (definition.platform === 'darwin') {
-      requiredChecks.push(
-        'cuaMacHelperDistribution',
-        'macAppDistribution',
-        'macZipDistribution',
-        'macDmgDistribution'
-      )
+      requiredChecks.push(...DARWIN_DISTRIBUTION_CHECK_NAMES)
     }
     const checks = assertObject(target.checks, `${definition.id} checks`)
     assertExactKeys(checks, requiredChecks, `${definition.id} checks`)

--- a/scripts/cua-macos-contract.mjs
+++ b/scripts/cua-macos-contract.mjs
@@ -48,7 +48,14 @@ export function parseDarwinLinkedLibraries(output) {
 }
 
 export function isAllowedDarwinLoadPath(value) {
-  if (typeof value !== 'string' || value.length === 0) {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('\0')) {
+    return false
+  }
+
+  if (
+    value.startsWith('/') &&
+    value.split('/').some((segment) => segment === '.' || segment === '..')
+  ) {
     return false
   }
 

--- a/scripts/cua-macos-contract.mjs
+++ b/scripts/cua-macos-contract.mjs
@@ -21,12 +21,24 @@ export function parseDarwinRpaths(output) {
     throw new TypeError('otool load-command output must be a string')
   }
 
-  return unique(
-    output
-      .split(/\r?\n/)
-      .map((line) => line.match(/^\s*path (.+?) \(offset \d+\)\s*$/)?.[1])
-      .filter(Boolean)
-  )
+  const rpaths = []
+  let expectsRpath = false
+  for (const line of output.split(/\r?\n/)) {
+    const command = line.match(/^\s*cmd (LC_[A-Z0-9_]+)\s*$/)?.[1]
+    if (command) {
+      expectsRpath = command === 'LC_RPATH'
+      continue
+    }
+    if (!expectsRpath) {
+      continue
+    }
+    const rpath = line.match(/^\s*path (.+?) \(offset \d+\)\s*$/)?.[1]
+    if (rpath) {
+      rpaths.push(rpath)
+      expectsRpath = false
+    }
+  }
+  return unique(rpaths)
 }
 
 export function parseDarwinLinkedLibraries(output) {

--- a/scripts/cua-macos-contract.mjs
+++ b/scripts/cua-macos-contract.mjs
@@ -1,0 +1,63 @@
+export const CUA_DARWIN_HELPER_APP_NAME = 'DeepChat Computer Use.app'
+export const CUA_DARWIN_HELPER_EXECUTABLE_NAME = 'deepchat-cua-driver'
+export const CUA_DARWIN_HELPER_BUNDLE_IDENTIFIER = 'com.deepchat.computeruse.helper'
+export const CUA_DARWIN_ALLOWED_ENTITLEMENTS = Object.freeze({
+  'com.apple.security.automation.apple-events': true
+})
+
+const RELATIVE_LOAD_PATH_PREFIXES = Object.freeze([
+  '@executable_path/',
+  '@loader_path/',
+  '@rpath/'
+])
+const SYSTEM_LOAD_PATH_PREFIXES = Object.freeze(['/System/Library/', '/usr/lib/'])
+
+function unique(values) {
+  return [...new Set(values)]
+}
+
+export function parseDarwinRpaths(output) {
+  if (typeof output !== 'string') {
+    throw new TypeError('otool load-command output must be a string')
+  }
+
+  return unique(
+    output
+      .split(/\r?\n/)
+      .map((line) => line.match(/^\s*path (.+?) \(offset \d+\)\s*$/)?.[1])
+      .filter(Boolean)
+  )
+}
+
+export function parseDarwinLinkedLibraries(output) {
+  if (typeof output !== 'string') {
+    throw new TypeError('otool linked-library output must be a string')
+  }
+
+  return unique(
+    output
+      .split(/\r?\n/)
+      .map(
+        (line) =>
+          line.match(
+            /^\s+(.+?) \((?:compatibility version|current version|offset) .+\)\s*$/
+          )?.[1]
+      )
+      .filter(Boolean)
+  )
+}
+
+export function isAllowedDarwinLoadPath(value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false
+  }
+
+  return (
+    RELATIVE_LOAD_PATH_PREFIXES.some((prefix) => value.startsWith(prefix)) ||
+    SYSTEM_LOAD_PATH_PREFIXES.some((prefix) => value.startsWith(prefix))
+  )
+}
+
+export function findDisallowedDarwinLoadPaths(values) {
+  return unique(values.filter((value) => !isAllowedDarwinLoadPath(value)))
+}

--- a/scripts/cua-macos-contract.mjs
+++ b/scripts/cua-macos-contract.mjs
@@ -11,6 +11,10 @@ const RELATIVE_LOAD_PATH_PREFIXES = Object.freeze([
   '@rpath/'
 ])
 const SYSTEM_LOAD_PATH_PREFIXES = Object.freeze(['/System/Library/', '/usr/lib/'])
+const FRAMEWORK_RELATIVE_LOAD_PATH_PREFIXES = new Set([
+  '@executable_path/',
+  '@loader_path/'
+])
 
 function unique(values) {
   return [...new Set(values)]
@@ -64,17 +68,30 @@ export function isAllowedDarwinLoadPath(value) {
     return false
   }
 
-  if (
-    value.startsWith('/') &&
-    value.split('/').some((segment) => segment === '.' || segment === '..')
-  ) {
+  const relativePrefix = RELATIVE_LOAD_PATH_PREFIXES.find((prefix) =>
+    value.startsWith(prefix)
+  )
+  if (relativePrefix) {
+    const segments = value.slice(relativePrefix.length).split('/')
+    if (segments.length === 0 || segments[0] === '') {
+      return false
+    }
+    if (!segments.some((segment) => segment === '.' || segment === '..')) {
+      return true
+    }
+    return (
+      FRAMEWORK_RELATIVE_LOAD_PATH_PREFIXES.has(relativePrefix) &&
+      segments[0] === '..' &&
+      segments[1] === 'Frameworks' &&
+      !segments.slice(2).some((segment) => segment === '.' || segment === '..')
+    )
+  }
+
+  if (value.split('/').some((segment) => segment === '.' || segment === '..')) {
     return false
   }
 
-  return (
-    RELATIVE_LOAD_PATH_PREFIXES.some((prefix) => value.startsWith(prefix)) ||
-    SYSTEM_LOAD_PATH_PREFIXES.some((prefix) => value.startsWith(prefix))
-  )
+  return SYSTEM_LOAD_PATH_PREFIXES.some((prefix) => value.startsWith(prefix))
 }
 
 export function findDisallowedDarwinLoadPaths(values) {

--- a/scripts/macos-release-contract.mjs
+++ b/scripts/macos-release-contract.mjs
@@ -1,0 +1,3 @@
+export function isReleaseNotarizationEnabled(env = process.env) {
+  return typeof env.build_for_release === 'string' && env.build_for_release.length > 0
+}

--- a/scripts/notarize-dmg.js
+++ b/scripts/notarize-dmg.js
@@ -51,7 +51,7 @@ export async function verifyDmgSignature(
   requireDeveloperIdMetadata(metadata)
 
   const teamRequirement = teamId
-    ? ` and certificate leaf[subject.OU] = "${validateAppleTeamId(teamId)}"`
+    ? ` and certificate leaf[subject.OU] = "${validateAppleTeamId(teamId, 'DMG Team ID')}"`
     : ''
   await runDistributionCommand(runCommand, '/usr/bin/codesign', [
     '--verify',

--- a/scripts/plugin.mjs
+++ b/scripts/plugin.mjs
@@ -12,6 +12,7 @@ function parseArgs(argv) {
     name: null,
     platform: process.env.TARGET_PLATFORM || process.platform,
     arch: process.env.TARGET_ARCH || process.arch,
+    purpose: null,
     pluginRoot: null
   }
   args.action = argv[0]
@@ -22,13 +23,21 @@ function parseArgs(argv) {
       args.platform = argv[++i]
     } else if (argv[i] === '--arch') {
       args.arch = argv[++i]
+    } else if (argv[i] === '--purpose') {
+      const purpose = argv[i + 1]
+      if (!purpose || purpose.startsWith('--')) {
+        console.error('Missing required value for --purpose')
+        process.exit(1)
+      }
+      args.purpose = purpose
+      i += 1
     } else if (argv[i] === '--plugin-root') {
       args.pluginRoot = path.resolve(argv[++i])
     }
   }
   if (!args.action || !['validate', 'package', 'bundle', 'verify'].includes(args.action)) {
     console.error(
-      'Usage: node scripts/plugin.mjs <validate|package|bundle|verify> [--name <plugin>] [--platform <p>] [--arch <a>] [--plugin-root <path>]'
+      'Usage: node scripts/plugin.mjs <validate|package|bundle|verify> [--name <plugin>] [--platform <p>] [--arch <a>] [--purpose <distribution|verification>] [--plugin-root <path>]'
     )
     process.exit(1)
   }
@@ -171,6 +180,7 @@ try {
     const buildArgs = [nativeBuildScript]
     if (args.platform) buildArgs.push('--platform', args.platform)
     if (args.arch) buildArgs.push('--arch', args.arch)
+    if (args.purpose) buildArgs.push('--purpose', args.purpose)
     execFileSync('node', buildArgs, { stdio: 'inherit' })
   }
 

--- a/scripts/sign-cua-helper.mjs
+++ b/scripts/sign-cua-helper.mjs
@@ -39,12 +39,23 @@ function redactSensitiveSecurityDiagnostic(value, args) {
       redacted = redacted.split(sensitiveValue).join('<redacted>')
     }
   }
+  for (const argument of args) {
+    if (isAbsoluteOrRelativeFilePath(argument)) {
+      redacted = redacted.split(argument).join('<redacted>')
+    }
+  }
   return redacted
     .replace(
       /(^|\s)(-[kPp])(?:\s+|=)(?:"[^"]*"|'[^']*'|\S+)/g,
       '$1$2 <redacted>'
     )
     .trim()
+}
+
+function boundSecurityDiagnostic(value) {
+  return value.length > SECURITY_DIAGNOSTIC_LIMIT
+    ? `${value.slice(0, SECURITY_DIAGNOSTIC_LIMIT)}…`
+    : value
 }
 
 function formatSensitiveSecurityError(error, args) {
@@ -59,13 +70,13 @@ function formatSensitiveSecurityError(error, args) {
       details.push(`${field}=${value}`)
     }
   }
+  const message = redactSensitiveSecurityDiagnostic(error.message, args)
+  if (message) {
+    details.push(`message=${boundSecurityDiagnostic(message)}`)
+  }
   const stderr = redactSensitiveSecurityDiagnostic(error.stderr, args)
   if (stderr) {
-    const boundedStderr =
-      stderr.length > SECURITY_DIAGNOSTIC_LIMIT
-        ? `${stderr.slice(0, SECURITY_DIAGNOSTIC_LIMIT)}…`
-        : stderr
-    details.push(`stderr=${boundedStderr}`)
+    details.push(`stderr=${boundSecurityDiagnostic(stderr)}`)
   }
   return details.length > 0 ? ` (${details.join('; ')})` : ''
 }

--- a/scripts/sign-cua-helper.mjs
+++ b/scripts/sign-cua-helper.mjs
@@ -25,6 +25,14 @@ async function run(command, args, options = {}) {
   })
 }
 
+async function runSensitiveSecurityCommand(args, failureMessage) {
+  try {
+    return await run('/usr/bin/security', args)
+  } catch {
+    throw new Error(failureMessage)
+  }
+}
+
 async function listUserKeychains() {
   const { stdout } = await run('/usr/bin/security', ['list-keychains', '-d', 'user'])
   return stdout
@@ -74,56 +82,103 @@ async function prepareSigningKeychain({ cwd, env }) {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'deepchat-cua-codesign-'))
   const keychainFile = path.join(tempRoot, 'deepchat-cua.keychain')
   const keychainPassword = randomBytes(32).toString('base64')
-  const certificatePath = await resolveCertificatePath(env.CSC_LINK, tempRoot, cwd)
   const certificatePassword = env.CSC_KEY_PASSWORD ?? ''
-  const existingKeychains = await listUserKeychains()
-
-  await run('/usr/bin/security', ['create-keychain', '-p', keychainPassword, keychainFile])
-  await run('/usr/bin/security', ['unlock-keychain', '-p', keychainPassword, keychainFile])
-  await run('/usr/bin/security', ['set-keychain-settings', keychainFile])
-  await run('/usr/bin/security', [
-    'list-keychains',
-    '-d',
-    'user',
-    '-s',
-    keychainFile,
-    ...existingKeychains
-  ])
-  await run('/usr/bin/security', [
-    'import',
-    certificatePath,
-    '-k',
-    keychainFile,
-    '-T',
-    '/usr/bin/codesign',
-    '-P',
-    certificatePassword
-  ])
-  await run('/usr/bin/security', [
-    'set-key-partition-list',
-    '-S',
-    'apple-tool:,apple:',
-    '-s',
-    '-k',
-    keychainPassword,
-    keychainFile
-  ])
-
-  return {
-    keychainFile,
-    cleanup: async () => {
-      if (existingKeychains.length > 0) {
-        await run('/usr/bin/security', [
-          'list-keychains',
-          '-d',
-          'user',
-          '-s',
-          ...existingKeychains
-        ]).catch(() => {})
-      }
-      await run('/usr/bin/security', ['delete-keychain', keychainFile]).catch(() => {})
-      await fs.rm(tempRoot, { recursive: true, force: true })
+  let existingKeychains = []
+  let keychainCreated = false
+  let searchListChanged = false
+  let cleaned = false
+  const cleanup = async () => {
+    if (cleaned) {
+      return
     }
+    cleaned = true
+    const cleanupErrors = []
+    if (searchListChanged) {
+      await run('/usr/bin/security', [
+        'list-keychains',
+        '-d',
+        'user',
+        '-s',
+        ...existingKeychains
+      ]).catch((error) => {
+        cleanupErrors.push(error)
+      })
+    }
+    if (keychainCreated) {
+      await run('/usr/bin/security', ['delete-keychain', keychainFile]).catch((error) => {
+        cleanupErrors.push(error)
+      })
+    }
+    await fs.rm(tempRoot, { recursive: true, force: true }).catch((error) => {
+      cleanupErrors.push(error)
+    })
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(cleanupErrors, 'Unable to fully clean the CUA signing keychain')
+    }
+  }
+
+  try {
+    const certificatePath = await resolveCertificatePath(env.CSC_LINK, tempRoot, cwd)
+    existingKeychains = await listUserKeychains()
+    await runSensitiveSecurityCommand(
+      ['create-keychain', '-p', keychainPassword, keychainFile],
+      'Unable to create the temporary CUA signing keychain'
+    )
+    keychainCreated = true
+    await runSensitiveSecurityCommand(
+      ['unlock-keychain', '-p', keychainPassword, keychainFile],
+      'Unable to unlock the temporary CUA signing keychain'
+    )
+    await run('/usr/bin/security', ['set-keychain-settings', keychainFile])
+    await runSensitiveSecurityCommand(
+      [
+        'import',
+        certificatePath,
+        '-k',
+        keychainFile,
+        '-T',
+        '/usr/bin/codesign',
+        '-P',
+        certificatePassword
+      ],
+      'Unable to import the CUA signing certificate'
+    )
+    await runSensitiveSecurityCommand(
+      [
+        'set-key-partition-list',
+        '-S',
+        'apple-tool:,apple:',
+        '-s',
+        '-k',
+        keychainPassword,
+        keychainFile
+      ],
+      'Unable to configure access to the temporary CUA signing keychain'
+    )
+    searchListChanged = true
+    await run('/usr/bin/security', [
+      'list-keychains',
+      '-d',
+      'user',
+      '-s',
+      keychainFile,
+      ...existingKeychains
+    ])
+
+    return {
+      keychainFile,
+      cleanup
+    }
+  } catch (error) {
+    try {
+      await cleanup()
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        'CUA signing keychain setup failed and cleanup was incomplete'
+      )
+    }
+    throw error
   }
 }
 
@@ -265,6 +320,7 @@ export async function signMacHelper({
   }
 
   const signingKeychain = await prepareSigningKeychain({ cwd, env })
+  let signingError
   try {
     const identity = await findDeveloperIdIdentity({
       keychainFile: signingKeychain.keychainFile,
@@ -278,12 +334,26 @@ export async function signMacHelper({
     })
     await verifyHelperSignature(appPath)
     await assertReleaseSignature(appPath)
-    console.info(`Signed CUA helper for distribution: ${appPath}`)
-    return {
-      purpose: resolvedPurpose,
-      signature: 'developer-id'
-    }
-  } finally {
+  } catch (error) {
+    signingError = error
+  }
+  try {
     await signingKeychain.cleanup()
+  } catch (cleanupError) {
+    if (signingError) {
+      throw new AggregateError(
+        [signingError, cleanupError],
+        'CUA helper signing failed and keychain cleanup was incomplete'
+      )
+    }
+    throw cleanupError
+  }
+  if (signingError) {
+    throw signingError
+  }
+  console.info(`Signed CUA helper for distribution: ${appPath}`)
+  return {
+    purpose: resolvedPurpose,
+    signature: 'developer-id'
   }
 }

--- a/scripts/sign-cua-helper.mjs
+++ b/scripts/sign-cua-helper.mjs
@@ -4,8 +4,10 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
+import { validateArtifactPurpose } from './ci/package-contract.mjs'
 
 const execFileAsync = promisify(execFile)
+const DEVELOPMENT_SIGNING_PURPOSE = 'development'
 
 function isAbsoluteOrRelativeFilePath(value) {
   return (
@@ -151,7 +153,6 @@ async function findDeveloperIdIdentity({ keychainFile, qualifier }) {
 async function signHelperApp({ appPath, entitlementsPath, identity, keychainFile }) {
   const args = [
     '--force',
-    '--deep',
     '--sign',
     identity,
     '--entitlements',
@@ -167,7 +168,6 @@ async function signHelperApp({ appPath, entitlementsPath, identity, keychainFile
 
   args.push(appPath)
   await run('/usr/bin/codesign', args)
-  await run('/usr/bin/codesign', ['--verify', '--deep', '--strict', '--verbose=2', appPath])
 }
 
 async function assertReleaseSignature(appPath) {
@@ -181,14 +181,87 @@ async function assertReleaseSignature(appPath) {
   }
 }
 
-export async function signMacHelperForRelease({
+function isCiEnvironment(env) {
+  const value = String(env.CI ?? '')
+    .trim()
+    .toLowerCase()
+  return value !== '' && value !== '0' && value !== 'false'
+}
+
+export function resolveCuaSigningPurpose(purpose, env = process.env) {
+  if (purpose !== undefined && purpose !== null && typeof purpose !== 'string') {
+    throw new TypeError('CUA signing purpose must be a string')
+  }
+  const normalizedPurpose = purpose?.trim() ?? ''
+  if (normalizedPurpose === '') {
+    if (isCiEnvironment(env)) {
+      throw new Error(
+        'CUA macOS packaging in CI requires an explicit distribution or verification purpose'
+      )
+    }
+    return DEVELOPMENT_SIGNING_PURPOSE
+  }
+  return validateArtifactPurpose(normalizedPurpose)
+}
+
+export function validateCuaSigningContext({ purpose, env = process.env }) {
+  const resolvedPurpose = resolveCuaSigningPurpose(purpose, env)
+  const environmentPurpose = String(env.PACKAGE_PURPOSE ?? '').trim()
+  if (environmentPurpose !== '') {
+    const validatedEnvironmentPurpose = validateArtifactPurpose(environmentPurpose)
+    if (validatedEnvironmentPurpose !== resolvedPurpose) {
+      throw new Error(
+        `CUA signing purpose mismatch: argument=${resolvedPurpose}, PACKAGE_PURPOSE=${validatedEnvironmentPurpose}`
+      )
+    }
+  }
+  const releaseMode = String(env.build_for_release ?? '').trim()
+  if (resolvedPurpose === 'distribution') {
+    if (releaseMode !== '2') {
+      throw new Error('CUA distribution signing requires build_for_release=2')
+    }
+  } else if (releaseMode !== '') {
+    throw new Error(
+      `CUA ${resolvedPurpose} signing must not set build_for_release (received ${releaseMode})`
+    )
+  }
+  return resolvedPurpose
+}
+
+async function signHelperAdHoc({ appPath, entitlementsPath }) {
+  await run('/usr/bin/codesign', [
+    '--force',
+    '--sign',
+    '-',
+    '--entitlements',
+    entitlementsPath,
+    '--options',
+    'runtime',
+    '--timestamp=none',
+    appPath
+  ])
+}
+
+async function verifyHelperSignature(appPath) {
+  await run('/usr/bin/codesign', ['--verify', '--deep', '--strict', '--verbose=2', appPath])
+}
+
+export async function signMacHelper({
   appPath,
   entitlementsPath,
+  purpose,
   cwd = process.cwd(),
   env = process.env
 }) {
-  if (!env.build_for_release) {
-    return false
+  const resolvedPurpose = validateCuaSigningContext({ purpose, env })
+  if (resolvedPurpose !== 'distribution') {
+    await signHelperAdHoc({ appPath, entitlementsPath })
+    await verifyHelperSignature(appPath)
+    console.info(`Signed CUA helper for ${resolvedPurpose}: ${appPath}`)
+    return {
+      purpose: resolvedPurpose,
+      signature: 'ad-hoc'
+    }
   }
 
   const signingKeychain = await prepareSigningKeychain({ cwd, env })
@@ -203,9 +276,13 @@ export async function signMacHelperForRelease({
       identity,
       keychainFile: signingKeychain.keychainFile
     })
+    await verifyHelperSignature(appPath)
     await assertReleaseSignature(appPath)
-    console.info(`Signed CUA helper for release: ${appPath}`)
-    return true
+    console.info(`Signed CUA helper for distribution: ${appPath}`)
+    return {
+      purpose: resolvedPurpose,
+      signature: 'developer-id'
+    }
   } finally {
     await signingKeychain.cleanup()
   }

--- a/scripts/sign-cua-helper.mjs
+++ b/scripts/sign-cua-helper.mjs
@@ -5,9 +5,12 @@ import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
 import { validateArtifactPurpose } from './ci/package-contract.mjs'
+import { isReleaseNotarizationEnabled } from './macos-release-contract.mjs'
 
 const execFileAsync = promisify(execFile)
 const DEVELOPMENT_SIGNING_PURPOSE = 'development'
+const SECURITY_DIAGNOSTIC_LIMIT = 1000
+const SENSITIVE_SECURITY_ARGUMENTS = new Set(['-k', '-p', '-P'])
 
 function isAbsoluteOrRelativeFilePath(value) {
   return (
@@ -25,11 +28,53 @@ async function run(command, args, options = {}) {
   })
 }
 
+function redactSensitiveSecurityDiagnostic(value, args) {
+  let redacted = String(value ?? '')
+  for (let index = 0; index < args.length - 1; index += 1) {
+    if (!SENSITIVE_SECURITY_ARGUMENTS.has(args[index])) {
+      continue
+    }
+    const sensitiveValue = args[index + 1]
+    if (sensitiveValue) {
+      redacted = redacted.split(sensitiveValue).join('<redacted>')
+    }
+  }
+  return redacted
+    .replace(
+      /(^|\s)(-[kPp])(?:\s+|=)(?:"[^"]*"|'[^']*'|\S+)/g,
+      '$1$2 <redacted>'
+    )
+    .trim()
+}
+
+function formatSensitiveSecurityError(error, args) {
+  if (!error || typeof error !== 'object') {
+    return ''
+  }
+
+  const details = []
+  for (const field of ['status', 'code', 'signal']) {
+    const value = error[field]
+    if (typeof value === 'string' || typeof value === 'number') {
+      details.push(`${field}=${value}`)
+    }
+  }
+  const stderr = redactSensitiveSecurityDiagnostic(error.stderr, args)
+  if (stderr) {
+    const boundedStderr =
+      stderr.length > SECURITY_DIAGNOSTIC_LIMIT
+        ? `${stderr.slice(0, SECURITY_DIAGNOSTIC_LIMIT)}…`
+        : stderr
+    details.push(`stderr=${boundedStderr}`)
+  }
+  return details.length > 0 ? ` (${details.join('; ')})` : ''
+}
+
 async function runSensitiveSecurityCommand(args, failureMessage) {
   try {
     return await run('/usr/bin/security', args)
-  } catch {
-    throw new Error(failureMessage)
+  } catch (error) {
+    throw new Error(`${failureMessage}${formatSensitiveSecurityError(error, args)}`)
   }
 }
 
@@ -270,14 +315,16 @@ export function validateCuaSigningContext({ purpose, env = process.env }) {
       )
     }
   }
-  const releaseMode = String(env.build_for_release ?? '').trim()
+  const releaseNotarizationEnabled = isReleaseNotarizationEnabled(env)
   if (resolvedPurpose === 'distribution') {
-    if (releaseMode !== '2') {
-      throw new Error('CUA distribution signing requires build_for_release=2')
+    if (!releaseNotarizationEnabled) {
+      throw new Error(
+        'CUA distribution signing requires build_for_release to enable release notarization'
+      )
     }
-  } else if (releaseMode !== '') {
+  } else if (releaseNotarizationEnabled) {
     throw new Error(
-      `CUA ${resolvedPurpose} signing must not set build_for_release (received ${releaseMode})`
+      `CUA ${resolvedPurpose} signing must not enable release notarization`
     )
   }
   return resolvedPurpose

--- a/test/main/plugin/pluginService.test.ts
+++ b/test/main/plugin/pluginService.test.ts
@@ -1247,7 +1247,9 @@ describe('PluginService', () => {
     expect(buildScript).toContain('isLinuxGlibcLoaderMismatch')
     expect(buildScript).toContain('host glibc loader')
     expect(buildScript).toContain("targetPlatform !== 'darwin'")
-    expect(buildScript).toContain('signDarwinHelper(runtimeDir, targetPlatform)')
+    expect(buildScript).toContain(
+      'signDarwinHelper(runtimeDir, targetPlatform, packagePurpose)'
+    )
     expect(buildScript).toContain('sourceKind')
     expect(buildScript).toContain('upstream-release')
     expect(buildScript).not.toContain('swift')

--- a/test/main/plugin/pluginService.test.ts
+++ b/test/main/plugin/pluginService.test.ts
@@ -1247,9 +1247,7 @@ describe('PluginService', () => {
     expect(buildScript).toContain('isLinuxGlibcLoaderMismatch')
     expect(buildScript).toContain('host glibc loader')
     expect(buildScript).toContain("targetPlatform !== 'darwin'")
-    expect(buildScript).toContain(
-      'signDarwinHelper(runtimeDir, targetPlatform, packagePurpose)'
-    )
+    expect(buildScript).toContain('signDarwinHelper(runtimeDir, targetPlatform, packagePurpose)')
     expect(buildScript).toContain('sourceKind')
     expect(buildScript).toContain('upstream-release')
     expect(buildScript).not.toContain('swift')

--- a/test/main/scripts/buildCuaPluginRuntime.test.ts
+++ b/test/main/scripts/buildCuaPluginRuntime.test.ts
@@ -20,6 +20,16 @@ async function loadBuildRuntime() {
     darwinHelperAppDirName: string
     darwinHelperBinaryName: string
     darwinHelperBundleIdentifier: string
+    sanitizeDarwinExecutable: (
+      executable: string,
+      options: {
+        inspectExecutable: () => {
+          rpaths: string[]
+          linkedLibraries: string[]
+        }
+        runCommand: (command: string, args: string[]) => void
+      }
+    ) => { removedRpaths: string[] }
     stageDarwinRuntime: (extractDir: string, runtimeDir: string) => Promise<void>
   }
 }
@@ -91,5 +101,74 @@ describe('build-cua-plugin-runtime', () => {
     expect(plist).toContain('<key>CFBundleName</key>\n    <string>DeepChat Computer Use</string>')
     expect(plist).toContain('<key>CFBundleDisplayName</key>')
     expect(plist).toContain(`<string>${darwinHelperBinaryName}</string>`)
+  })
+
+  it('removes duplicate build-machine RPATHs before signing', async () => {
+    const { sanitizeDarwinExecutable } = await loadBuildRuntime()
+    const executable = path.join(tempRoot, 'deepchat-cua-driver')
+    const xcodeRpath =
+      '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx'
+    const inspectExecutable = vi
+      .fn()
+      .mockReturnValueOnce({
+        rpaths: ['/usr/lib/swift', xcodeRpath, xcodeRpath],
+        linkedLibraries: [
+          '/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit',
+          '@rpath/libswiftCore.dylib'
+        ]
+      })
+      .mockReturnValueOnce({
+        rpaths: ['/usr/lib/swift'],
+        linkedLibraries: [
+          '/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit',
+          '@rpath/libswiftCore.dylib'
+        ]
+      })
+    const runCommand = vi.fn()
+
+    expect(
+      sanitizeDarwinExecutable(executable, {
+        inspectExecutable,
+        runCommand
+      })
+    ).toEqual({ removedRpaths: [xcodeRpath] })
+    expect(runCommand).toHaveBeenCalledTimes(1)
+    expect(runCommand).toHaveBeenCalledWith('/usr/bin/install_name_tool', [
+      '-delete_rpath',
+      xcodeRpath,
+      executable
+    ])
+  })
+
+  it('rejects non-system linked libraries instead of rewriting them', async () => {
+    const { sanitizeDarwinExecutable } = await loadBuildRuntime()
+    const runCommand = vi.fn()
+
+    expect(() =>
+      sanitizeDarwinExecutable('/tmp/deepchat-cua-driver', {
+        inspectExecutable: () => ({
+          rpaths: ['/usr/lib/swift'],
+          linkedLibraries: ['/Users/runner/build/libInjected.dylib']
+        }),
+        runCommand
+      })
+    ).toThrow(/non-system linked libraries.*libInjected/)
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+
+  it('fails if a disallowed RPATH remains after sanitation', async () => {
+    const { sanitizeDarwinExecutable } = await loadBuildRuntime()
+    const xcodeRpath = '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx'
+    const inspectExecutable = vi.fn(() => ({
+      rpaths: [xcodeRpath],
+      linkedLibraries: ['/usr/lib/libSystem.B.dylib']
+    }))
+
+    expect(() =>
+      sanitizeDarwinExecutable('/tmp/deepchat-cua-driver', {
+        inspectExecutable,
+        runCommand: vi.fn()
+      })
+    ).toThrow(/still contains non-system RPATHs/)
   })
 })

--- a/test/main/scripts/buildCuaPluginRuntime.test.ts
+++ b/test/main/scripts/buildCuaPluginRuntime.test.ts
@@ -20,14 +20,27 @@ async function loadBuildRuntime() {
     darwinHelperAppDirName: string
     darwinHelperBinaryName: string
     darwinHelperBundleIdentifier: string
-    sanitizeDarwinExecutable: (
+    enforceDarwinLoadPathContract: (
       executable: string,
       options: {
         inspectExecutable: () => {
           rpaths: string[]
           linkedLibraries: string[]
         }
+        inspectArchitectures: () => string[]
         runCommand: (command: string, args: string[]) => void
+        enforceSlice?: (
+          slicePath: string,
+          initialInspection?: {
+            rpaths: string[]
+            linkedLibraries: string[]
+          }
+        ) => { removedRpaths: string[] }
+        makeTemporaryDirectory?: (prefix: string) => string
+        readMode?: (targetPath: string) => number
+        applyMode?: (targetPath: string, mode: number) => void
+        replaceFile?: (sourcePath: string, targetPath: string) => void
+        removeTemporaryDirectory?: (targetPath: string) => void
       }
     ) => { removedRpaths: string[] }
     stageDarwinRuntime: (extractDir: string, runtimeDir: string) => Promise<void>
@@ -104,7 +117,7 @@ describe('build-cua-plugin-runtime', () => {
   })
 
   it('removes duplicate build-machine RPATHs before signing', async () => {
-    const { sanitizeDarwinExecutable } = await loadBuildRuntime()
+    const { enforceDarwinLoadPathContract } = await loadBuildRuntime()
     const executable = path.join(tempRoot, 'deepchat-cua-driver')
     const xcodeRpath =
       '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx'
@@ -127,8 +140,9 @@ describe('build-cua-plugin-runtime', () => {
     const runCommand = vi.fn()
 
     expect(
-      sanitizeDarwinExecutable(executable, {
+      enforceDarwinLoadPathContract(executable, {
         inspectExecutable,
+        inspectArchitectures: () => ['arm64'],
         runCommand
       })
     ).toEqual({ removedRpaths: [xcodeRpath] })
@@ -140,24 +154,147 @@ describe('build-cua-plugin-runtime', () => {
     ])
   })
 
+  it('sanitizes asymmetric universal RPATHs one architecture at a time', async () => {
+    const { enforceDarwinLoadPathContract } = await loadBuildRuntime()
+    const executable = path.join(tempRoot, 'deepchat-cua-driver')
+    const temporaryDirectory = path.join(tempRoot, 'load-path-slices')
+    const x64Slice = path.join(temporaryDirectory, 'x86_64-deepchat-cua-driver')
+    const arm64Slice = path.join(temporaryDirectory, 'arm64-deepchat-cua-driver')
+    const rebuiltExecutable = path.join(temporaryDirectory, 'deepchat-cua-driver')
+    const runCommand = vi.fn()
+    const enforceSlice = vi.fn((slicePath: string) => ({
+      removedRpaths: [
+        slicePath === x64Slice
+          ? '/Applications/Xcode-x64.app/usr/lib/swift'
+          : '/Applications/Xcode-arm64.app/usr/lib/swift'
+      ]
+    }))
+    const applyMode = vi.fn()
+    const replaceFile = vi.fn()
+    const removeTemporaryDirectory = vi.fn()
+
+    expect(
+      enforceDarwinLoadPathContract(executable, {
+        inspectExecutable: (targetPath?: string) => ({
+          rpaths:
+            targetPath === executable
+              ? ['/Applications/Xcode.app/usr/lib/swift']
+              : ['/usr/lib/swift'],
+          linkedLibraries: ['/usr/lib/libSystem.B.dylib']
+        }),
+        inspectArchitectures: () => ['x86_64', 'arm64'],
+        runCommand,
+        enforceSlice,
+        makeTemporaryDirectory: () => temporaryDirectory,
+        readMode: () => 0o100755,
+        applyMode,
+        replaceFile,
+        removeTemporaryDirectory
+      })
+    ).toEqual({
+      removedRpaths: [
+        '/Applications/Xcode-x64.app/usr/lib/swift',
+        '/Applications/Xcode-arm64.app/usr/lib/swift'
+      ]
+    })
+    expect(runCommand).toHaveBeenNthCalledWith(1, '/usr/bin/lipo', [
+      '-thin',
+      'x86_64',
+      executable,
+      '-output',
+      x64Slice
+    ])
+    expect(runCommand).toHaveBeenNthCalledWith(2, '/usr/bin/lipo', [
+      '-thin',
+      'arm64',
+      executable,
+      '-output',
+      arm64Slice
+    ])
+    expect(runCommand).toHaveBeenNthCalledWith(3, '/usr/bin/lipo', [
+      '-create',
+      x64Slice,
+      arm64Slice,
+      '-output',
+      rebuiltExecutable
+    ])
+    expect(enforceSlice).toHaveBeenCalledTimes(2)
+    expect(applyMode).toHaveBeenCalledWith(rebuiltExecutable, 0o755)
+    expect(replaceFile).toHaveBeenCalledWith(rebuiltExecutable, executable)
+    expect(removeTemporaryDirectory).toHaveBeenCalledWith(temporaryDirectory)
+  })
+
+  it('does not rewrite a universal executable that already satisfies the contract', async () => {
+    const { enforceDarwinLoadPathContract } = await loadBuildRuntime()
+    const inspectArchitectures = vi.fn(() => ['x86_64', 'arm64'])
+    const runCommand = vi.fn()
+
+    expect(
+      enforceDarwinLoadPathContract('/tmp/deepchat-cua-driver', {
+        inspectExecutable: () => ({
+          rpaths: ['/usr/lib/swift'],
+          linkedLibraries: ['/usr/lib/libSystem.B.dylib']
+        }),
+        inspectArchitectures,
+        runCommand
+      })
+    ).toEqual({ removedRpaths: [] })
+    expect(inspectArchitectures).not.toHaveBeenCalled()
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+
   it('rejects non-system linked libraries instead of rewriting them', async () => {
-    const { sanitizeDarwinExecutable } = await loadBuildRuntime()
+    const { enforceDarwinLoadPathContract } = await loadBuildRuntime()
     const runCommand = vi.fn()
 
     expect(() =>
-      sanitizeDarwinExecutable('/tmp/deepchat-cua-driver', {
+      enforceDarwinLoadPathContract('/tmp/deepchat-cua-driver', {
         inspectExecutable: () => ({
           rpaths: ['/usr/lib/swift'],
           linkedLibraries: ['/Users/runner/build/libInjected.dylib']
         }),
+        inspectArchitectures: () => ['arm64'],
         runCommand
       })
     ).toThrow(/non-system linked libraries.*libInjected/)
     expect(runCommand).not.toHaveBeenCalled()
   })
 
+  it('preserves sanitation and temporary-slice cleanup failures', async () => {
+    const { enforceDarwinLoadPathContract } = await loadBuildRuntime()
+    const sanitationError = new Error('slice sanitation failed')
+    const cleanupError = new Error('slice cleanup failed')
+
+    let error: unknown
+    try {
+      enforceDarwinLoadPathContract('/tmp/deepchat-cua-driver', {
+        inspectExecutable: () => ({
+          rpaths: ['/Applications/Xcode.app/usr/lib/swift'],
+          linkedLibraries: []
+        }),
+        inspectArchitectures: () => ['x86_64', 'arm64'],
+        runCommand: vi.fn(),
+        enforceSlice: () => {
+          throw sanitationError
+        },
+        makeTemporaryDirectory: () => '/tmp/deepchat-cua-slices',
+        readMode: () => 0o755,
+        applyMode: vi.fn(),
+        replaceFile: vi.fn(),
+        removeTemporaryDirectory: () => {
+          throw cleanupError
+        }
+      })
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toBeInstanceOf(AggregateError)
+    expect((error as AggregateError).errors).toEqual([sanitationError, cleanupError])
+  })
+
   it('fails if a disallowed RPATH remains after sanitation', async () => {
-    const { sanitizeDarwinExecutable } = await loadBuildRuntime()
+    const { enforceDarwinLoadPathContract } = await loadBuildRuntime()
     const xcodeRpath = '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx'
     const inspectExecutable = vi.fn(() => ({
       rpaths: [xcodeRpath],
@@ -165,8 +302,9 @@ describe('build-cua-plugin-runtime', () => {
     }))
 
     expect(() =>
-      sanitizeDarwinExecutable('/tmp/deepchat-cua-driver', {
+      enforceDarwinLoadPathContract('/tmp/deepchat-cua-driver', {
         inspectExecutable,
+        inspectArchitectures: () => ['arm64'],
         runCommand: vi.fn()
       })
     ).toThrow(/still contains non-system RPATHs/)

--- a/test/main/scripts/buildCuaPluginRuntime.test.ts
+++ b/test/main/scripts/buildCuaPluginRuntime.test.ts
@@ -23,11 +23,12 @@ async function loadBuildRuntime() {
     enforceDarwinLoadPathContract: (
       executable: string,
       options: {
-        inspectExecutable: () => {
+        inspectExecutable: (targetPath: string) => {
           rpaths: string[]
           linkedLibraries: string[]
         }
-        inspectArchitectures: () => string[]
+        inspectArchitectures: (targetPath: string) => string[]
+        ensureToolAvailable?: (command: string, args: string[]) => void
         runCommand: (command: string, args: string[]) => void
         enforceSlice?: (
           slicePath: string,
@@ -138,14 +139,23 @@ describe('build-cua-plugin-runtime', () => {
         ]
       })
     const runCommand = vi.fn()
+    const ensureToolAvailable = vi.fn()
 
     expect(
       enforceDarwinLoadPathContract(executable, {
         inspectExecutable,
         inspectArchitectures: () => ['arm64'],
+        ensureToolAvailable,
         runCommand
       })
     ).toEqual({ removedRpaths: [xcodeRpath] })
+    expect(ensureToolAvailable).toHaveBeenCalledWith('/usr/bin/install_name_tool', [
+      '-help'
+    ])
+    expect(ensureToolAvailable).toHaveBeenCalledWith('/usr/bin/lipo', [
+      '-info',
+      process.execPath
+    ])
     expect(runCommand).toHaveBeenCalledTimes(1)
     expect(runCommand).toHaveBeenCalledWith('/usr/bin/install_name_tool', [
       '-delete_rpath',
@@ -175,7 +185,7 @@ describe('build-cua-plugin-runtime', () => {
 
     expect(
       enforceDarwinLoadPathContract(executable, {
-        inspectExecutable: (targetPath?: string) => ({
+        inspectExecutable: (targetPath: string) => ({
           rpaths:
             targetPath === executable
               ? ['/Applications/Xcode.app/usr/lib/swift']
@@ -183,6 +193,7 @@ describe('build-cua-plugin-runtime', () => {
           linkedLibraries: ['/usr/lib/libSystem.B.dylib']
         }),
         inspectArchitectures: () => ['x86_64', 'arm64'],
+        ensureToolAvailable: vi.fn(),
         runCommand,
         enforceSlice,
         makeTemporaryDirectory: () => temporaryDirectory,
@@ -221,6 +232,39 @@ describe('build-cua-plugin-runtime', () => {
     expect(enforceSlice).toHaveBeenCalledTimes(2)
     expect(applyMode).toHaveBeenCalledWith(rebuiltExecutable, 0o755)
     expect(replaceFile).toHaveBeenCalledWith(rebuiltExecutable, executable)
+    expect(removeTemporaryDirectory).toHaveBeenCalledWith(temporaryDirectory)
+  })
+
+  it('rejects a universal rebuild that loses an architecture', async () => {
+    const { enforceDarwinLoadPathContract } = await loadBuildRuntime()
+    const executable = path.join(tempRoot, 'deepchat-cua-driver')
+    const temporaryDirectory = path.join(tempRoot, 'load-path-slices')
+    const rebuiltExecutable = path.join(temporaryDirectory, 'deepchat-cua-driver')
+    const replaceFile = vi.fn()
+    const removeTemporaryDirectory = vi.fn()
+
+    expect(() =>
+      enforceDarwinLoadPathContract(executable, {
+        inspectExecutable: (targetPath: string) => ({
+          rpaths:
+            targetPath === executable
+              ? ['/Applications/Xcode.app/usr/lib/swift']
+              : ['/usr/lib/swift'],
+          linkedLibraries: ['/usr/lib/libSystem.B.dylib']
+        }),
+        inspectArchitectures: (targetPath: string) =>
+          targetPath === rebuiltExecutable ? ['arm64'] : ['x86_64', 'arm64'],
+        ensureToolAvailable: vi.fn(),
+        runCommand: vi.fn(),
+        enforceSlice: () => ({ removedRpaths: [] }),
+        makeTemporaryDirectory: () => temporaryDirectory,
+        readMode: () => 0o100755,
+        applyMode: vi.fn(),
+        replaceFile,
+        removeTemporaryDirectory
+      })
+    ).toThrow(/architecture set changed during sanitation/)
+    expect(replaceFile).not.toHaveBeenCalled()
     expect(removeTemporaryDirectory).toHaveBeenCalledWith(temporaryDirectory)
   })
 
@@ -273,6 +317,7 @@ describe('build-cua-plugin-runtime', () => {
           linkedLibraries: []
         }),
         inspectArchitectures: () => ['x86_64', 'arm64'],
+        ensureToolAvailable: vi.fn(),
         runCommand: vi.fn(),
         enforceSlice: () => {
           throw sanitationError
@@ -305,6 +350,7 @@ describe('build-cua-plugin-runtime', () => {
       enforceDarwinLoadPathContract('/tmp/deepchat-cua-driver', {
         inspectExecutable,
         inspectArchitectures: () => ['arm64'],
+        ensureToolAvailable: vi.fn(),
         runCommand: vi.fn()
       })
     ).toThrow(/still contains non-system RPATHs/)

--- a/test/main/scripts/cuaMacosContract.test.ts
+++ b/test/main/scripts/cuaMacosContract.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  findDisallowedDarwinLoadPaths,
+  isAllowedDarwinLoadPath,
+  parseDarwinLinkedLibraries,
+  parseDarwinRpaths
+} from '../../../scripts/cua-macos-contract.mjs'
+
+describe('cua-macos-contract', () => {
+  it('deduplicates RPATHs reported for universal Mach-O slices', () => {
+    const output = `
+driver (architecture x86_64):
+          cmd LC_RPATH
+      cmdsize 32
+         path /usr/lib/swift (offset 12)
+          cmd LC_RPATH
+      cmdsize 120
+         path /Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx (offset 12)
+driver (architecture arm64):
+          cmd LC_RPATH
+      cmdsize 32
+         path /usr/lib/swift (offset 12)
+          cmd LC_RPATH
+      cmdsize 120
+         path /Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx (offset 12)
+`
+
+    expect(parseDarwinRpaths(output)).toEqual([
+      '/usr/lib/swift',
+      '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx'
+    ])
+  })
+
+  it('parses universal linked-library output without treating image headers as paths', () => {
+    const output = `
+driver (architecture x86_64):
+\t/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2685.0.0)
+\t@rpath/libswiftCore.dylib (compatibility version 0.0.0, current version 0.0.0)
+driver (architecture arm64):
+\t/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2685.0.0)
+\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)
+`
+
+    expect(parseDarwinLinkedLibraries(output)).toEqual([
+      '/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit',
+      '@rpath/libswiftCore.dylib',
+      '/usr/lib/libSystem.B.dylib'
+    ])
+  })
+
+  it('allows only system and loader-relative paths', () => {
+    for (const allowed of [
+      '/System/Library/Frameworks/AppKit.framework/AppKit',
+      '/usr/lib/swift/libswiftCore.dylib',
+      '@rpath/libswiftCore.dylib',
+      '@loader_path/../Frameworks/Example.framework/Example',
+      '@executable_path/../Frameworks/Example.framework/Example'
+    ]) {
+      expect(isAllowedDarwinLoadPath(allowed)).toBe(true)
+    }
+
+    expect(
+      findDisallowedDarwinLoadPaths([
+        '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx',
+        '/Users/runner/build/libInjected.dylib',
+        '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx'
+      ])
+    ).toEqual([
+      '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx',
+      '/Users/runner/build/libInjected.dylib'
+    ])
+  })
+})

--- a/test/main/scripts/cuaMacosContract.test.ts
+++ b/test/main/scripts/cuaMacosContract.test.ts
@@ -1,4 +1,6 @@
+import { readFile } from 'node:fs/promises'
 import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
 
 import {
   findDisallowedDarwinLoadPaths,
@@ -70,5 +72,24 @@ driver (architecture arm64):
       '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx',
       '/Users/runner/build/libInjected.dylib'
     ])
+  })
+
+  it('excludes only the managed CUA helper subtree from electron-builder signing', async () => {
+    const config = parse(await readFile('electron-builder.yml', 'utf8'))
+    expect(config.mac.signIgnore).toEqual([
+      '/Contents/Helpers/DeepChat Computer Use[.]app(?:/|$)'
+    ])
+
+    const ignored = config.mac.signIgnore.map((pattern: string) => new RegExp(pattern))
+    const matches = (filePath: string) => ignored.some((pattern: RegExp) => pattern.test(filePath))
+    const helperPath = '/tmp/DeepChat.app/Contents/Helpers/DeepChat Computer Use.app'
+
+    expect(matches(helperPath)).toBe(true)
+    expect(matches(`${helperPath}/Contents/MacOS/deepchat-cua-driver`)).toBe(true)
+    expect(matches(`${helperPath}.backup/Contents/MacOS/deepchat-cua-driver`)).toBe(false)
+    expect(matches('/tmp/DeepChat.app/Contents/Helpers/DeepChat Helper.app')).toBe(false)
+    expect(
+      matches('/tmp/DeepChat.app/Contents/Resources/DeepChat Computer Use.app')
+    ).toBe(false)
   })
 })

--- a/test/main/scripts/cuaMacosContract.test.ts
+++ b/test/main/scripts/cuaMacosContract.test.ts
@@ -66,11 +66,13 @@ driver (architecture arm64):
       findDisallowedDarwinLoadPaths([
         '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx',
         '/Users/runner/build/libInjected.dylib',
+        '/usr/lib/../../Users/runner/build/libInjected.dylib',
         '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx'
       ])
     ).toEqual([
       '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx',
-      '/Users/runner/build/libInjected.dylib'
+      '/Users/runner/build/libInjected.dylib',
+      '/usr/lib/../../Users/runner/build/libInjected.dylib'
     ])
   })
 

--- a/test/main/scripts/cuaMacosContract.test.ts
+++ b/test/main/scripts/cuaMacosContract.test.ts
@@ -26,6 +26,9 @@ driver (architecture arm64):
           cmd LC_RPATH
       cmdsize 120
          path /Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx (offset 12)
+          cmd LC_FILESET_ENTRY
+      cmdsize 48
+         path /Users/runner/not-an-rpath (offset 24)
 `
 
     expect(parseDarwinRpaths(output)).toEqual([

--- a/test/main/scripts/cuaMacosContract.test.ts
+++ b/test/main/scripts/cuaMacosContract.test.ts
@@ -59,6 +59,7 @@ driver (architecture arm64):
       '/System/Library/Frameworks/AppKit.framework/AppKit',
       '/usr/lib/swift/libswiftCore.dylib',
       '@rpath/libswiftCore.dylib',
+      '@loader_path/../Frameworks',
       '@loader_path/../Frameworks/Example.framework/Example',
       '@executable_path/../Frameworks/Example.framework/Example'
     ]) {
@@ -70,12 +71,22 @@ driver (architecture arm64):
         '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx',
         '/Users/runner/build/libInjected.dylib',
         '/usr/lib/../../Users/runner/build/libInjected.dylib',
+        '@loader_path/../../../../etc/evil.dylib',
+        '@loader_path/../Frameworks/../../etc/evil.dylib',
+        '@executable_path/../Resources/evil.dylib',
+        '@rpath/../evil.dylib',
+        '@rpath/./evil.dylib',
         '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx'
       ])
     ).toEqual([
       '/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx',
       '/Users/runner/build/libInjected.dylib',
-      '/usr/lib/../../Users/runner/build/libInjected.dylib'
+      '/usr/lib/../../Users/runner/build/libInjected.dylib',
+      '@loader_path/../../../../etc/evil.dylib',
+      '@loader_path/../Frameworks/../../etc/evil.dylib',
+      '@executable_path/../Resources/evil.dylib',
+      '@rpath/../evil.dylib',
+      '@rpath/./evil.dylib'
     ])
   })
 

--- a/test/main/scripts/notarizeDmg.test.ts
+++ b/test/main/scripts/notarizeDmg.test.ts
@@ -4,7 +4,8 @@ import { parse } from 'yaml'
 
 import {
   createNotarizationOptions,
-  notarizeReleaseArtifact
+  notarizeReleaseArtifact,
+  validateAppleTeamId
 } from '../../../scripts/apple-notarization.js'
 import {
   finalizeMacDmg,
@@ -60,6 +61,9 @@ describe('macOS distribution notarization', () => {
         DEEPCHAT_APPLE_NOTARY_TEAM_ID: 'INVALID"00'
       })
     ).toThrow(/10-character Apple team ID/)
+    expect(() => validateAppleTeamId(undefined, 'CUA helper Team ID')).toThrow(
+      /CUA helper Team ID/
+    )
 
     const notarizeImpl = vi.fn().mockResolvedValue(undefined)
     await expect(

--- a/test/main/scripts/packageContract.test.ts
+++ b/test/main/scripts/packageContract.test.ts
@@ -31,6 +31,8 @@ import {
   expectedReleaseAssetCount,
   getMeasuredRoles,
   getTargetDefinition,
+  PACKAGE_MANIFEST_SCHEMA_VERSION,
+  RELEASE_INDEX_SCHEMA_VERSION,
   SHA512_BASE64_PATTERN,
   TARGET_DEFINITIONS
 } from '../../../scripts/ci/package-contract.mjs'
@@ -65,6 +67,8 @@ describe('CI package contract', () => {
       'darwin-arm64'
     ])
     expect(expectedReleaseAssetCount()).toBe(19)
+    expect(PACKAGE_MANIFEST_SCHEMA_VERSION).toBe(2)
+    expect(RELEASE_INDEX_SCHEMA_VERSION).toBe(2)
     expect(SHA512_BASE64_PATTERN.test(Buffer.alloc(64).toString('base64'))).toBe(true)
   })
 
@@ -101,6 +105,18 @@ describe('CI package contract', () => {
       linux: false,
       macos: true
     })
+    for (const cuaMacosPath of [
+      'scripts/cua-macos-contract.mjs',
+      'scripts/ci/verify-cua-macos-helper.mjs',
+      'scripts/sign-cua-helper.mjs'
+    ]) {
+      expect(classifyPackageImpact([cuaMacosPath])).toMatchObject({
+        required: true,
+        windows: false,
+        linux: false,
+        macos: true
+      })
+    }
     for (const backgroundPath of [
       'build/dmg-background.png',
       'build/dmg-background@2x.png'
@@ -356,6 +372,11 @@ describe('CI package contract', () => {
     expect(runCommand).toHaveBeenCalledWith(
       '/usr/sbin/spctl',
       ['--assess', '--type', 'execute', '--verbose=4', appPath],
+      expect.any(Object)
+    )
+    expect(runCommand).toHaveBeenCalledWith(
+      '/usr/bin/syspolicy_check',
+      ['distribution', appPath],
       expect.any(Object)
     )
 

--- a/test/main/scripts/packageContract.test.ts
+++ b/test/main/scripts/packageContract.test.ts
@@ -424,12 +424,15 @@ describe('CI package contract', () => {
       ['-x', '-k', zipPath, extractionRoot],
       expect.any(Object)
     )
+    expect(extractionRoot).not.toBe('')
     const extractedAppPath = path.join(extractionRoot, 'DeepChat.app')
     expect(verifyCuaMacHelper).toHaveBeenCalledWith(extractedAppPath, {
-      teamId: 'Y7P5QLKLYG'
+      teamId: 'Y7P5QLKLYG',
+      runCommand
     })
     expect(verifyMacApp).toHaveBeenCalledWith(extractedAppPath, {
-      teamId: 'Y7P5QLKLYG'
+      teamId: 'Y7P5QLKLYG',
+      runCommand
     })
     await expect(lstat(extractionRoot)).rejects.toThrow()
   })
@@ -462,6 +465,7 @@ describe('CI package contract', () => {
     ).rejects.toThrow(/exactly one root DeepChat.app/)
     expect(verifyCuaMacHelper).not.toHaveBeenCalled()
     expect(verifyMacApp).not.toHaveBeenCalled()
+    expect(extractionRoot).not.toBe('')
     await expect(lstat(extractionRoot)).rejects.toThrow()
   })
 

--- a/test/main/scripts/packageContract.test.ts
+++ b/test/main/scripts/packageContract.test.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import {
   mkdir,
   mkdtemp,
+  lstat,
   readFile,
   readdir,
   rm,
@@ -38,7 +39,9 @@ import {
 } from '../../../scripts/ci/package-contract.mjs'
 import {
   createPackageManifest,
-  verifyMacAppDistribution
+  validateMacZipEntries,
+  verifyMacAppDistribution,
+  verifyMacZipDistribution
 } from '../../../scripts/ci/package-manifest.mjs'
 import { prepareReleaseContext } from '../../../scripts/ci/release-preflight.mjs'
 
@@ -389,6 +392,95 @@ describe('CI package contract', () => {
       })
     ).rejects.toThrow(/Developer ID Application/)
   })
+
+  it('verifies the updater ZIP after extracting its sole application payload', async () => {
+    const zipPath = '/tmp/DeepChat-1.2.3-mac-arm64.zip'
+    let extractionRoot = ''
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === '/usr/bin/unzip') {
+        return {
+          stdout: 'DeepChat.app/\nDeepChat.app/Contents/Info.plist\n',
+          stderr: ''
+        }
+      }
+      expect(command).toBe('/usr/bin/ditto')
+      extractionRoot = args.at(-1)!
+      await mkdir(path.join(extractionRoot, 'DeepChat.app'))
+      return { stdout: '', stderr: '' }
+    })
+    const verifyCuaMacHelper = vi.fn(async () => {})
+    const verifyMacApp = vi.fn(async () => {})
+
+    await expect(
+      verifyMacZipDistribution(zipPath, {
+        teamId: 'Y7P5QLKLYG',
+        runCommand,
+        verifyCuaMacHelper,
+        verifyMacApp
+      })
+    ).resolves.toBe(true)
+    expect(runCommand).toHaveBeenCalledWith(
+      '/usr/bin/ditto',
+      ['-x', '-k', zipPath, extractionRoot],
+      expect.any(Object)
+    )
+    const extractedAppPath = path.join(extractionRoot, 'DeepChat.app')
+    expect(verifyCuaMacHelper).toHaveBeenCalledWith(extractedAppPath, {
+      teamId: 'Y7P5QLKLYG'
+    })
+    expect(verifyMacApp).toHaveBeenCalledWith(extractedAppPath, {
+      teamId: 'Y7P5QLKLYG'
+    })
+    await expect(lstat(extractionRoot)).rejects.toThrow()
+  })
+
+  it('rejects updater ZIPs with an unexpected root payload', async () => {
+    const verifyCuaMacHelper = vi.fn(async () => {})
+    const verifyMacApp = vi.fn(async () => {})
+    let extractionRoot = ''
+
+    await expect(
+      verifyMacZipDistribution('/tmp/DeepChat.zip', {
+        teamId: 'Y7P5QLKLYG',
+        runCommand: async (command: string, args: string[]) => {
+          if (command === '/usr/bin/unzip') {
+            return {
+              stdout: 'DeepChat.app/\nDeepChat.app/Contents/Info.plist\n',
+              stderr: ''
+            }
+          }
+          extractionRoot = args.at(-1)!
+          await Promise.all([
+            mkdir(path.join(extractionRoot, 'DeepChat.app')),
+            writeFile(path.join(extractionRoot, 'unexpected.txt'), 'unexpected')
+          ])
+          return { stdout: '', stderr: '' }
+        },
+        verifyCuaMacHelper,
+        verifyMacApp
+      })
+    ).rejects.toThrow(/exactly one root DeepChat.app/)
+    expect(verifyCuaMacHelper).not.toHaveBeenCalled()
+    expect(verifyMacApp).not.toHaveBeenCalled()
+    await expect(lstat(extractionRoot)).rejects.toThrow()
+  })
+
+  it('rejects unsafe or ambiguous updater ZIP entry paths before extraction', () => {
+    expect(
+      validateMacZipEntries('DeepChat.app/\nDeepChat.app/Contents/Info.plist\n')
+    ).toEqual(['DeepChat.app/', 'DeepChat.app/Contents/Info.plist'])
+
+    for (const unsafeEntries of [
+      '../DeepChat.app/Contents/Info.plist\n',
+      '/DeepChat.app/Contents/Info.plist\n',
+      'DeepChat.app\\Contents\\Info.plist\n',
+      'Other.app/Contents/Info.plist\n',
+      'DeepChat.app/Contents/../escape\n',
+      'DeepChat.app/Contents/Info.plist\nDeepChat.app/Contents/Info.plist\n'
+    ]) {
+      expect(() => validateMacZipEntries(unsafeEntries)).toThrow(/unsafe entry|duplicate entry/)
+    }
+  })
 })
 
 describe('package-size contract', () => {
@@ -654,6 +746,44 @@ describe('package manifest staging', () => {
     return { installerName, smokePath, sizePath }
   }
 
+  async function prepareMacPackage() {
+    const dmgName = `DeepChat-${version}-mac-arm64.dmg`
+    const zipName = `DeepChat-${version}-mac-arm64.zip`
+    const zip = Buffer.from('updater zip')
+    const smokePath = path.join(distDirectory, 'light-ocr-smoke-darwin-arm64.json')
+    await Promise.all([
+      writeFile(path.join(distDirectory, dmgName), 'dmg'),
+      writeFile(path.join(distDirectory, zipName), zip),
+      writeFile(path.join(distDirectory, `${zipName}.blockmap`), 'blockmap'),
+      writeFile(
+        path.join(distDirectory, 'latest-mac.yml'),
+        stringify({
+          version,
+          files: [
+            {
+              url: zipName,
+              sha512: sha512(zip),
+              size: zip.length
+            }
+          ],
+          path: zipName,
+          sha512: sha512(zip),
+          releaseDate: '2026-07-23T00:00:00.000Z'
+        })
+      ),
+      writeFile(
+        smokePath,
+        JSON.stringify({
+          schemaVersion: 2,
+          target: { platform: 'darwin', arch: 'arm64' },
+          executed: true,
+          componentMetrics: { ocrAssets: {}, nodeRuntime: {}, otherRuntime: {} }
+        })
+      )
+    ])
+    return { dmgName, zipName, smokePath }
+  }
+
   it('stages only allowlisted files and never adds Windows signing claims', async () => {
     const { installerName, smokePath, sizePath } = await prepareWindowsPackage()
     const outputDirectory = path.join(tempDirectory, 'output')
@@ -706,5 +836,43 @@ describe('package manifest staging', () => {
         actualSourceSha: sourceSha
       })
     ).rejects.toThrow(/Duplicate diagnostic report basename/)
+  })
+
+  it('derives macOS ZIP evidence from the staged updater payload', async () => {
+    const { zipName, smokePath } = await prepareMacPackage()
+    const outputDirectory = path.join(tempDirectory, 'mac-output')
+    const verifyCuaMacHelper = vi.fn(async () => {})
+    const verifyMacApp = vi.fn(async () => {})
+    const verifyMacZip = vi.fn(async () => {})
+    const verifyMacDmg = vi.fn(async () => {})
+
+    const manifest = await createPackageManifest({
+      projectDirectory,
+      distDirectory,
+      outputDirectory,
+      platform: 'darwin',
+      arch: 'arm64',
+      sourceSha,
+      purpose: 'distribution',
+      reportPaths: [smokePath],
+      actualSourceSha: sourceSha,
+      macAppPath: '/tmp/DeepChat.app',
+      appleTeamId: 'Y7P5QLKLYG',
+      verifyCuaMacHelper,
+      verifyMacApp,
+      verifyMacZip,
+      verifyMacDmg
+    })
+
+    expect(verifyMacZip).toHaveBeenCalledWith(
+      path.join(outputDirectory, 'files', zipName),
+      { teamId: 'Y7P5QLKLYG' }
+    )
+    expect(manifest.checks).toMatchObject({
+      cuaMacHelperDistribution: 'passed',
+      macAppDistribution: 'passed',
+      macZipDistribution: 'passed',
+      macDmgDistribution: 'passed'
+    })
   })
 })

--- a/test/main/scripts/packageContract.test.ts
+++ b/test/main/scripts/packageContract.test.ts
@@ -108,6 +108,7 @@ describe('CI package contract', () => {
     for (const cuaMacosPath of [
       'scripts/cua-macos-contract.mjs',
       'scripts/ci/verify-cua-macos-helper.mjs',
+      'scripts/macos-release-contract.mjs',
       'scripts/sign-cua-helper.mjs'
     ]) {
       expect(classifyPackageImpact([cuaMacosPath])).toMatchObject({

--- a/test/main/scripts/packageWorkflow.test.ts
+++ b/test/main/scripts/packageWorkflow.test.ts
@@ -241,6 +241,9 @@ describe('native package reusable workflows', () => {
     expect(source).toContain(
       "build_for_release: ${{ inputs.artifact-purpose == 'distribution' && '2' || '' }}"
     )
+    expect(source).toContain(
+      'plugin:bundle -- --name cua --platform darwin --arch "${TARGET_ARCH}" --purpose "${PACKAGE_PURPOSE}"'
+    )
     expect(getStep(workflow, 'Create package manifest and verify distribution evidence').run).toContain(
       'scripts/ci/package-manifest.mjs'
     )

--- a/test/main/scripts/releaseAssembly.test.ts
+++ b/test/main/scripts/releaseAssembly.test.ts
@@ -188,6 +188,7 @@ describe('fail-closed release assembly', () => {
     expect(macTarget?.checks).toMatchObject({
       cuaMacHelperDistribution: 'passed',
       macAppDistribution: 'passed',
+      macZipDistribution: 'passed',
       macDmgDistribution: 'passed'
     })
   })
@@ -417,6 +418,12 @@ describe('fail-closed release assembly', () => {
 
     await resetFixtures()
     await updateManifest('darwin-arm64', (manifest) => {
+      delete manifest.checks.macZipDistribution
+    })
+    await expect(assemble()).rejects.toThrow(/macZipDistribution did not pass/)
+
+    await resetFixtures()
+    await updateManifest('darwin-arm64', (manifest) => {
       delete manifest.checks.macDmgDistribution
     })
     await expect(assemble()).rejects.toThrow(/macDmgDistribution did not pass/)
@@ -575,6 +582,7 @@ async function createOnePackageArtifact(
   if (definition.platform === 'darwin') {
     checks.cuaMacHelperDistribution = 'passed'
     checks.macAppDistribution = 'passed'
+    checks.macZipDistribution = 'passed'
     checks.macDmgDistribution = 'passed'
   }
   const manifest: PackageManifest = {

--- a/test/main/scripts/releaseAssembly.test.ts
+++ b/test/main/scripts/releaseAssembly.test.ts
@@ -212,16 +212,19 @@ describe('fail-closed release assembly', () => {
     )
     delete macTarget.checks.cuaMacHelperDistribution
     await writeFile(releaseIndexPath, JSON.stringify(releaseIndex))
-    await expect(
-      verifyReleaseAssets({
-        directory: outputDirectory,
-        sourceSha,
-        version,
-        workflowRunId,
-        workflowRunAttempt
-      })
-    ).rejects.toThrow(/cuaMacHelperDistribution/)
-    await writeFile(releaseIndexPath, originalReleaseIndex)
+    try {
+      await expect(
+        verifyReleaseAssets({
+          directory: outputDirectory,
+          sourceSha,
+          version,
+          workflowRunId,
+          workflowRunAttempt
+        })
+      ).rejects.toThrow(/cuaMacHelperDistribution/)
+    } finally {
+      await writeFile(releaseIndexPath, originalReleaseIndex)
+    }
 
     const packageAsset = verified.files.find(
       ({ name }) => name !== 'release-index.json'

--- a/test/main/scripts/releaseAssembly.test.ts
+++ b/test/main/scripts/releaseAssembly.test.ts
@@ -16,6 +16,8 @@ import { assembleRelease } from '../../../scripts/ci/assemble-release.mjs'
 import {
   getMeasuredRoles,
   getUpdaterPayloadRole,
+  PACKAGE_MANIFEST_SCHEMA_VERSION,
+  RELEASE_INDEX_SCHEMA_VERSION,
   TARGET_DEFINITIONS
 } from '../../../scripts/ci/package-contract.mjs'
 import { inspectRegularFile } from '../../../scripts/ci/package-files.mjs'
@@ -180,9 +182,11 @@ describe('fail-closed release assembly', () => {
 
     const windowsTarget = releaseIndex.targets.find(({ id }) => id === 'win32-x64')
     const macTarget = releaseIndex.targets.find(({ id }) => id === 'darwin-x64')
+    expect(releaseIndex.schemaVersion).toBe(RELEASE_INDEX_SCHEMA_VERSION)
     expect(windowsTarget?.checks).not.toHaveProperty('signed')
     expect(windowsTarget?.checks).not.toHaveProperty('macAppDistribution')
     expect(macTarget?.checks).toMatchObject({
+      cuaMacHelperDistribution: 'passed',
       macAppDistribution: 'passed',
       macDmgDistribution: 'passed'
     })
@@ -198,6 +202,25 @@ describe('fail-closed release assembly', () => {
       workflowRunAttempt
     })
     expect(verified.files).toHaveLength(19)
+
+    const releaseIndexPath = path.join(outputDirectory, 'release-index.json')
+    const originalReleaseIndex = await readFile(releaseIndexPath, 'utf8')
+    const releaseIndex = JSON.parse(originalReleaseIndex)
+    const macTarget = releaseIndex.targets.find(
+      ({ id }: { id: string }) => id === 'darwin-arm64'
+    )
+    delete macTarget.checks.cuaMacHelperDistribution
+    await writeFile(releaseIndexPath, JSON.stringify(releaseIndex))
+    await expect(
+      verifyReleaseAssets({
+        directory: outputDirectory,
+        sourceSha,
+        version,
+        workflowRunId,
+        workflowRunAttempt
+      })
+    ).rejects.toThrow(/cuaMacHelperDistribution/)
+    await writeFile(releaseIndexPath, originalReleaseIndex)
 
     const packageAsset = verified.files.find(
       ({ name }) => name !== 'release-index.json'
@@ -388,6 +411,12 @@ describe('fail-closed release assembly', () => {
 
     await resetFixtures()
     await updateManifest('darwin-arm64', (manifest) => {
+      delete manifest.checks.cuaMacHelperDistribution
+    })
+    await expect(assemble()).rejects.toThrow(/cuaMacHelperDistribution did not pass/)
+
+    await resetFixtures()
+    await updateManifest('darwin-arm64', (manifest) => {
       delete manifest.checks.macDmgDistribution
     })
     await expect(assemble()).rejects.toThrow(/macDmgDistribution did not pass/)
@@ -544,11 +573,12 @@ async function createOnePackageArtifact(
     installerSize: 'passed'
   }
   if (definition.platform === 'darwin') {
+    checks.cuaMacHelperDistribution = 'passed'
     checks.macAppDistribution = 'passed'
     checks.macDmgDistribution = 'passed'
   }
   const manifest: PackageManifest = {
-    schemaVersion: 1,
+    schemaVersion: PACKAGE_MANIFEST_SCHEMA_VERSION,
     target: {
       id: definition.id,
       platform: definition.platform,

--- a/test/main/scripts/signCuaHelper.test.ts
+++ b/test/main/scripts/signCuaHelper.test.ts
@@ -224,6 +224,7 @@ describe('sign-cua-helper', () => {
     expect(signingError).toBeInstanceOf(Error)
     expect(signingError.message).toContain('Unable to import the CUA signing certificate')
     expect(signingError.message).toContain('code=36')
+    expect(signingError.message).toContain('message=Command failed')
     expect(signingError.message).toContain('MAC verification failed')
     expect(signingError.message).toContain('<redacted>')
     expect(signingError.message).not.toContain('secret')

--- a/test/main/scripts/signCuaHelper.test.ts
+++ b/test/main/scripts/signCuaHelper.test.ts
@@ -154,13 +154,19 @@ describe('sign-cua-helper', () => {
         purpose: 'distribution',
         env: {}
       })
-    ).toThrow(/requires build_for_release=2/)
+    ).toThrow(/requires build_for_release to enable release notarization/)
+    expect(
+      validateCuaSigningContext({
+        purpose: 'distribution',
+        env: { build_for_release: '1' }
+      })
+    ).toBe('distribution')
     expect(() =>
       validateCuaSigningContext({
         purpose: 'verification',
-        env: { build_for_release: '2' }
+        env: { build_for_release: '1' }
       })
-    ).toThrow(/verification signing must not set build_for_release/)
+    ).toThrow(/verification signing must not enable release notarization/)
     expect(() =>
       validateCuaSigningContext({
         purpose: 'unknown',
@@ -192,7 +198,13 @@ describe('sign-cua-helper', () => {
           return { stdout: '"/Users/runner/Library/Keychains/login.keychain-db"\n', stderr: '' }
         }
         if (command === '/usr/bin/security' && args[0] === 'import') {
-          throw new Error(`Command failed: security import -P ${args.at(-1)}`)
+          throw Object.assign(
+            new Error(`Command failed: security import -P ${args.at(-1)}`),
+            {
+              code: 36,
+              stderr: `security: SecKeychainItemImport: MAC verification failed for ${args.at(-1)}`
+            }
+          )
         }
         return { stdout: '', stderr: '' }
       }
@@ -211,6 +223,9 @@ describe('sign-cua-helper', () => {
     }).catch((error) => error)
     expect(signingError).toBeInstanceOf(Error)
     expect(signingError.message).toContain('Unable to import the CUA signing certificate')
+    expect(signingError.message).toContain('code=36')
+    expect(signingError.message).toContain('MAC verification failed')
+    expect(signingError.message).toContain('<redacted>')
     expect(signingError.message).not.toContain('secret')
 
     const createCall = childProcessMocks.execFileAsync.mock.calls.find(

--- a/test/main/scripts/signCuaHelper.test.ts
+++ b/test/main/scripts/signCuaHelper.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'fs/promises'
+import { access, mkdtemp, rm } from 'fs/promises'
 import os from 'os'
 import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -182,5 +182,80 @@ describe('sign-cua-helper', () => {
         }
       })
     ).toThrow(/signing purpose mismatch/)
+  })
+
+  it('removes temporary certificate material when keychain setup fails', async () => {
+    const { signMacHelper } = await loadSigner()
+    childProcessMocks.execFileAsync.mockImplementation(
+      async (command: string, args: string[]) => {
+        if (command === '/usr/bin/security' && args[0] === 'list-keychains') {
+          return { stdout: '"/Users/runner/Library/Keychains/login.keychain-db"\n', stderr: '' }
+        }
+        if (command === '/usr/bin/security' && args[0] === 'import') {
+          throw new Error(`Command failed: security import -P ${args.at(-1)}`)
+        }
+        return { stdout: '', stderr: '' }
+      }
+    )
+
+    const signingError = await signMacHelper({
+      appPath: path.join(tmpDir, 'DeepChat Computer Use.app'),
+      entitlementsPath: path.join(tmpDir, 'entitlements.plist'),
+      purpose: 'distribution',
+      cwd: tmpDir,
+      env: {
+        build_for_release: '2',
+        CSC_LINK: Buffer.from('fake-p12').toString('base64'),
+        CSC_KEY_PASSWORD: 'secret'
+      }
+    }).catch((error) => error)
+    expect(signingError).toBeInstanceOf(Error)
+    expect(signingError.message).toContain('Unable to import the CUA signing certificate')
+    expect(signingError.message).not.toContain('secret')
+
+    const createCall = childProcessMocks.execFileAsync.mock.calls.find(
+      ([command, args]) => command === '/usr/bin/security' && args[0] === 'create-keychain'
+    )
+    const keychainPath = createCall?.[1].at(-1)
+    expect(keychainPath).toBeTruthy()
+    await expect(access(path.dirname(keychainPath!))).rejects.toThrow()
+    expect(childProcessMocks.execFileAsync).toHaveBeenCalledWith(
+      '/usr/bin/security',
+      ['delete-keychain', keychainPath],
+      expect.any(Object)
+    )
+  })
+
+  it('restores an originally empty user keychain search list', async () => {
+    const { signMacHelper } = await loadSigner()
+    childProcessMocks.execFileAsync.mockImplementation(
+      async (command: string, args: string[]) => {
+        if (command === '/usr/bin/security' && args[0] === 'list-keychains' && !args.includes('-s')) {
+          return { stdout: '', stderr: '' }
+        }
+        if (command === '/usr/bin/security' && args[0] === 'find-identity') {
+          throw new Error('identity lookup failed')
+        }
+        return { stdout: '', stderr: '' }
+      }
+    )
+
+    await expect(
+      signMacHelper({
+        appPath: path.join(tmpDir, 'DeepChat Computer Use.app'),
+        entitlementsPath: path.join(tmpDir, 'entitlements.plist'),
+        purpose: 'distribution',
+        cwd: tmpDir,
+        env: {
+          build_for_release: '2',
+          CSC_LINK: Buffer.from('fake-p12').toString('base64')
+        }
+      })
+    ).rejects.toThrow(/identity lookup failed/)
+    expect(childProcessMocks.execFileAsync).toHaveBeenCalledWith(
+      '/usr/bin/security',
+      ['list-keychains', '-d', 'user', '-s'],
+      expect.any(Object)
+    )
   })
 })

--- a/test/main/scripts/signCuaHelper.test.ts
+++ b/test/main/scripts/signCuaHelper.test.ts
@@ -54,29 +54,39 @@ describe('sign-cua-helper', () => {
     await rm(tmpDir, { recursive: true, force: true })
   })
 
-  it('skips signing outside release builds', async () => {
-    const { signMacHelperForRelease } = await loadSigner()
+  it('uses an ad-hoc signature for explicit verification builds', async () => {
+    const { signMacHelper } = await loadSigner()
 
     await expect(
-      signMacHelperForRelease({
+      signMacHelper({
         appPath: path.join(tmpDir, 'DeepChat Computer Use.app'),
         entitlementsPath: path.join(tmpDir, 'entitlements.plist'),
+        purpose: 'verification',
         cwd: tmpDir,
         env: {}
       })
-    ).resolves.toBe(false)
-    expect(childProcessMocks.execFileAsync).not.toHaveBeenCalled()
+    ).resolves.toEqual({
+      purpose: 'verification',
+      signature: 'ad-hoc'
+    })
+    const signingCall = childProcessMocks.execFileAsync.mock.calls.find(
+      ([command, args]) => command === '/usr/bin/codesign' && args.includes('--sign')
+    )
+    expect(signingCall?.[1]).toContain('-')
+    expect(signingCall?.[1]).toContain('--timestamp=none')
+    expect(signingCall?.[1]).not.toContain('--deep')
   })
 
   it('imports the release certificate and signs the helper before plugin packaging', async () => {
-    const { signMacHelperForRelease } = await loadSigner()
+    const { signMacHelper } = await loadSigner()
     const appPath = path.join(tmpDir, 'DeepChat Computer Use.app')
     const entitlementsPath = path.join(tmpDir, 'entitlements.plist')
 
     await expect(
-      signMacHelperForRelease({
+      signMacHelper({
         appPath,
         entitlementsPath,
+        purpose: 'distribution',
         cwd: tmpDir,
         env: {
           build_for_release: '2',
@@ -84,7 +94,10 @@ describe('sign-cua-helper', () => {
           CSC_KEY_PASSWORD: 'secret'
         }
       })
-    ).resolves.toBe(true)
+    ).resolves.toEqual({
+      purpose: 'distribution',
+      signature: 'developer-id'
+    })
 
     const calls = childProcessMocks.execFileAsync.mock.calls as Array<[string, string[]]>
     expect(
@@ -93,6 +106,12 @@ describe('sign-cua-helper', () => {
           command === '/usr/bin/security' && args[0] === 'import' && args.includes('-k')
       )
     ).toBe(true)
+    const signingCall = calls.find(
+      ([command, args]) => command === '/usr/bin/codesign' && args.includes('--sign')
+    )
+    expect(signingCall?.[1]).not.toContain('--deep')
+    expect(signingCall?.[1]).toContain('--timestamp')
+    expect(signingCall?.[1]).not.toContain('--timestamp=none')
     expect(
       calls.some(
         ([command, args]) =>
@@ -111,5 +130,57 @@ describe('sign-cua-helper', () => {
         ([command, args]) => command === '/usr/bin/security' && args[0] === 'delete-keychain'
       )
     ).toBe(true)
+  })
+
+  it('defaults to development signing only outside CI', async () => {
+    const { resolveCuaSigningPurpose, signMacHelper } = await loadSigner()
+
+    expect(resolveCuaSigningPurpose(undefined, {})).toBe('development')
+    await expect(
+      signMacHelper({
+        appPath: path.join(tmpDir, 'DeepChat Computer Use.app'),
+        entitlementsPath: path.join(tmpDir, 'entitlements.plist'),
+        cwd: tmpDir,
+        env: { CI: 'true' }
+      })
+    ).rejects.toThrow(/requires an explicit distribution or verification purpose/)
+  })
+
+  it('rejects contradictory package purpose and release mode combinations', async () => {
+    const { validateCuaSigningContext } = await loadSigner()
+
+    expect(() =>
+      validateCuaSigningContext({
+        purpose: 'distribution',
+        env: {}
+      })
+    ).toThrow(/requires build_for_release=2/)
+    expect(() =>
+      validateCuaSigningContext({
+        purpose: 'verification',
+        env: { build_for_release: '2' }
+      })
+    ).toThrow(/verification signing must not set build_for_release/)
+    expect(() =>
+      validateCuaSigningContext({
+        purpose: 'unknown',
+        env: {}
+      })
+    ).toThrow(/Unsupported artifact purpose/)
+    expect(() =>
+      validateCuaSigningContext({
+        purpose: 'development',
+        env: {}
+      })
+    ).toThrow(/Unsupported artifact purpose/)
+    expect(() =>
+      validateCuaSigningContext({
+        purpose: 'distribution',
+        env: {
+          PACKAGE_PURPOSE: 'verification',
+          build_for_release: '2'
+        }
+      })
+    ).toThrow(/signing purpose mismatch/)
   })
 })

--- a/test/main/scripts/verifyCuaMacosHelper.test.ts
+++ b/test/main/scripts/verifyCuaMacosHelper.test.ts
@@ -204,7 +204,7 @@ describe('verify-cua-macos-helper', () => {
     ).rejects.toThrow(/symbolic link escapes the bundle/)
   })
 
-  it('verifies the final managed helper identity before accepting the app', async () => {
+  it('verifies the helper and every nested Mach-O identity before accepting the app', async () => {
     const appPath = path.join(tempRoot, 'DeepChat.app')
     const helperAppPath = path.join(
       appPath,
@@ -218,16 +218,29 @@ describe('verify-cua-macos-helper', () => {
       }
       return { stdout: '', stderr: '' }
     })
+    const helperExecutablePath = path.join(
+      helperAppPath,
+      'Contents',
+      'MacOS',
+      CUA_DARWIN_HELPER_EXECUTABLE_NAME
+    )
+    const nestedMachOPath = path.join(
+      helperAppPath,
+      'Contents',
+      'Frameworks',
+      'Nested.framework',
+      'Nested'
+    )
     const inspectBundle = vi.fn(async () => ({
       entitlements: { ...CUA_DARWIN_ALLOWED_ENTITLEMENTS },
       inspections: [
         {
-          filePath: path.join(
-            helperAppPath,
-            'Contents',
-            'MacOS',
-            CUA_DARWIN_HELPER_EXECUTABLE_NAME
-          ),
+          filePath: helperExecutablePath,
+          rpaths: ['/usr/lib/swift'],
+          linkedLibraries: ['/usr/lib/libSystem.B.dylib']
+        },
+        {
+          filePath: nestedMachOPath,
           rpaths: ['/usr/lib/swift'],
           linkedLibraries: ['/usr/lib/libSystem.B.dylib']
         }
@@ -242,7 +255,7 @@ describe('verify-cua-macos-helper', () => {
       })
     ).resolves.toEqual({
       helperAppPath,
-      inspectedMachOCount: 1
+      inspectedMachOCount: 2
     })
     expect(runCommand).toHaveBeenCalledWith(
       '/usr/bin/codesign',
@@ -260,6 +273,19 @@ describe('verify-cua-macos-helper', () => {
       ],
       expect.any(Object)
     )
+    for (const filePath of [helperExecutablePath, nestedMachOPath]) {
+      expect(runCommand).toHaveBeenCalledWith(
+        '/usr/bin/codesign',
+        [
+          '--verify',
+          '--strict',
+          '--test-requirement',
+          '=anchor apple generic and certificate leaf[subject.OU] = "Y7P5QLKLYG"',
+          filePath
+        ],
+        expect.any(Object)
+      )
+    }
     expect(inspectBundle).toHaveBeenCalledWith(helperAppPath, { runCommand })
   })
 })

--- a/test/main/scripts/verifyCuaMacosHelper.test.ts
+++ b/test/main/scripts/verifyCuaMacosHelper.test.ts
@@ -1,0 +1,218 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  assertCuaDeveloperIdMetadata,
+  assertCuaEntitlements,
+  assertCuaMachOLoadPaths,
+  inspectCuaHelperBundle,
+  verifyCuaMacHelperDistribution
+} from '../../../scripts/ci/verify-cua-macos-helper.mjs'
+import {
+  CUA_DARWIN_ALLOWED_ENTITLEMENTS,
+  CUA_DARWIN_HELPER_APP_NAME,
+  CUA_DARWIN_HELPER_EXECUTABLE_NAME
+} from '../../../scripts/cua-macos-contract.mjs'
+
+const validMetadata = {
+  stdout: '',
+  stderr: [
+    'Identifier=com.deepchat.computeruse.helper',
+    'CodeDirectory v=20500 size=123 flags=0x10000(runtime) hashes=1+1 location=embedded',
+    'Authority=Developer ID Application: ThinkInAIXYZ (Y7P5QLKLYG)',
+    'TeamIdentifier=Y7P5QLKLYG',
+    'Timestamp=Jul 26, 2026 at 12:00:00'
+  ].join('\n')
+}
+
+describe('verify-cua-macos-helper', () => {
+  let tempRoot: string
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), 'deepchat-cua-verify-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true })
+  })
+
+  it('requires Developer ID, timestamp, hardened runtime, and the managed bundle ID', () => {
+    expect(() => assertCuaDeveloperIdMetadata(validMetadata)).not.toThrow()
+    for (const invalid of [
+      validMetadata.stderr.replace(
+        'Authority=Developer ID Application: ThinkInAIXYZ (Y7P5QLKLYG)',
+        'Signature=adhoc'
+      ),
+      validMetadata.stderr.replace('Timestamp=Jul 26, 2026 at 12:00:00', 'Timestamp=none'),
+      validMetadata.stderr.replace('(runtime)', '()'),
+      validMetadata.stderr.replace(
+        'Identifier=com.deepchat.computeruse.helper',
+        'Identifier=com.trycua.driver'
+      )
+    ]) {
+      expect(() => assertCuaDeveloperIdMetadata({ stdout: '', stderr: invalid })).toThrow()
+    }
+  })
+
+  it('compares helper entitlements as an exact allowlist', () => {
+    expect(() => assertCuaEntitlements({ ...CUA_DARWIN_ALLOWED_ENTITLEMENTS })).not.toThrow()
+    expect(() =>
+      assertCuaEntitlements({
+        ...CUA_DARWIN_ALLOWED_ENTITLEMENTS,
+        'com.apple.security.cs.disable-library-validation': true
+      })
+    ).toThrow(/must exactly match/)
+    expect(() =>
+      assertCuaEntitlements({
+        'com.apple.security.automation.apple-events': false
+      })
+    ).toThrow(/must exactly match/)
+    expect(() => assertCuaEntitlements({})).toThrow(/must exactly match/)
+  })
+
+  it('rejects disallowed RPATHs and linked libraries in any Mach-O', () => {
+    expect(() =>
+      assertCuaMachOLoadPaths([
+        {
+          filePath: '/tmp/helper',
+          rpaths: ['/usr/lib/swift'],
+          linkedLibraries: ['/System/Library/Frameworks/AppKit.framework/AppKit']
+        }
+      ])
+    ).not.toThrow()
+    expect(() =>
+      assertCuaMachOLoadPaths([
+        {
+          filePath: '/tmp/helper',
+          rpaths: ['/Applications/Xcode.app/Contents/Developer/usr/lib/swift/macosx'],
+          linkedLibraries: ['/usr/lib/libSystem.B.dylib']
+        }
+      ])
+    ).toThrow(/non-system RPATHs/)
+    expect(() =>
+      assertCuaMachOLoadPaths([
+        {
+          filePath: '/tmp/helper',
+          rpaths: ['/usr/lib/swift'],
+          linkedLibraries: ['/Users/runner/build/libInjected.dylib']
+        }
+      ])
+    ).toThrow(/non-system linked libraries/)
+  })
+
+  it('recursively inspects regular Mach-O files and requires the managed executable', async () => {
+    const helperAppPath = path.join(tempRoot, CUA_DARWIN_HELPER_APP_NAME)
+    const executablePath = path.join(
+      helperAppPath,
+      'Contents',
+      'MacOS',
+      CUA_DARWIN_HELPER_EXECUTABLE_NAME
+    )
+    const resourcePath = path.join(helperAppPath, 'Contents', 'Resources', 'AppIcon.icns')
+    await mkdir(path.dirname(executablePath), { recursive: true })
+    await mkdir(path.dirname(resourcePath), { recursive: true })
+    await writeFile(executablePath, 'driver')
+    await writeFile(resourcePath, 'icon')
+
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === '/usr/bin/file') {
+        return {
+          stdout: args[1] === executablePath ? 'Mach-O universal binary\n' : 'data\n',
+          stderr: ''
+        }
+      }
+      if (command === '/usr/bin/otool' && args[0] === '-l') {
+        return {
+          stdout: '          cmd LC_RPATH\n      cmdsize 32\n         path /usr/lib/swift (offset 12)\n',
+          stderr: ''
+        }
+      }
+      if (command === '/usr/bin/otool' && args[0] === '-L') {
+        return {
+          stdout:
+            `${executablePath}:\n` +
+            '\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1.0.0)\n',
+          stderr: ''
+        }
+      }
+      throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+    })
+
+    await expect(
+      inspectCuaHelperBundle(helperAppPath, {
+        runCommand,
+        readEntitlements: async () => ({ ...CUA_DARWIN_ALLOWED_ENTITLEMENTS })
+      })
+    ).resolves.toMatchObject({
+      entitlements: CUA_DARWIN_ALLOWED_ENTITLEMENTS,
+      inspections: [
+        {
+          filePath: executablePath,
+          rpaths: ['/usr/lib/swift'],
+          linkedLibraries: ['/usr/lib/libSystem.B.dylib']
+        }
+      ]
+    })
+  })
+
+  it('verifies the final managed helper identity before accepting the app', async () => {
+    const appPath = path.join(tempRoot, 'DeepChat.app')
+    const helperAppPath = path.join(
+      appPath,
+      'Contents',
+      'Helpers',
+      CUA_DARWIN_HELPER_APP_NAME
+    )
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === '/usr/bin/codesign' && args[0] === '--display') {
+        return validMetadata
+      }
+      return { stdout: '', stderr: '' }
+    })
+    const inspectBundle = vi.fn(async () => ({
+      entitlements: { ...CUA_DARWIN_ALLOWED_ENTITLEMENTS },
+      inspections: [
+        {
+          filePath: path.join(
+            helperAppPath,
+            'Contents',
+            'MacOS',
+            CUA_DARWIN_HELPER_EXECUTABLE_NAME
+          ),
+          rpaths: ['/usr/lib/swift'],
+          linkedLibraries: ['/usr/lib/libSystem.B.dylib']
+        }
+      ]
+    }))
+
+    await expect(
+      verifyCuaMacHelperDistribution(appPath, {
+        teamId: 'Y7P5QLKLYG',
+        runCommand,
+        inspectBundle
+      })
+    ).resolves.toEqual({
+      helperAppPath,
+      inspectedMachOCount: 1
+    })
+    expect(runCommand).toHaveBeenCalledWith(
+      '/usr/bin/codesign',
+      ['--verify', '--deep', '--strict', '--verbose=2', helperAppPath],
+      expect.any(Object)
+    )
+    expect(runCommand).toHaveBeenCalledWith(
+      '/usr/bin/codesign',
+      [
+        '--verify',
+        '--strict',
+        '--test-requirement',
+        '=anchor apple generic and certificate leaf[subject.OU] = "Y7P5QLKLYG"',
+        helperAppPath
+      ],
+      expect.any(Object)
+    )
+    expect(inspectBundle).toHaveBeenCalledWith(helperAppPath, { runCommand })
+  })
+})

--- a/test/main/scripts/verifyCuaMacosHelper.test.ts
+++ b/test/main/scripts/verifyCuaMacosHelper.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,6 +7,7 @@ import {
   assertCuaDeveloperIdMetadata,
   assertCuaEntitlements,
   assertCuaMachOLoadPaths,
+  extractCuaEntitlements,
   inspectCuaHelperBundle,
   verifyCuaMacHelperDistribution
 } from '../../../scripts/ci/verify-cua-macos-helper.mjs'
@@ -113,7 +114,7 @@ describe('verify-cua-macos-helper', () => {
     const resourcePath = path.join(helperAppPath, 'Contents', 'Resources', 'AppIcon.icns')
     await mkdir(path.dirname(executablePath), { recursive: true })
     await mkdir(path.dirname(resourcePath), { recursive: true })
-    await writeFile(executablePath, 'driver')
+    await writeFile(executablePath, Buffer.from('cffaedfe00000000', 'hex'))
     await writeFile(resourcePath, 'icon')
 
     const runCommand = vi.fn(async (command: string, args: string[]) => {
@@ -155,6 +156,52 @@ describe('verify-cua-macos-helper', () => {
         }
       ]
     })
+    expect(
+      runCommand.mock.calls.filter(
+        ([command]: [string, string[]]) => command === '/usr/bin/file'
+      )
+    ).toHaveLength(1)
+  })
+
+  it('reports a missing entitlement payload before invoking plutil', async () => {
+    const runCommand = vi.fn(async () => ({ stdout: '', stderr: '' }))
+
+    await expect(
+      extractCuaEntitlements(path.join(tempRoot, CUA_DARWIN_HELPER_APP_NAME), {
+        runCommand
+      })
+    ).rejects.toThrow(/does not contain entitlements/)
+    expect(
+      runCommand.mock.calls.some(
+        ([command]: [string, string[]]) => command === '/usr/bin/plutil'
+      )
+    ).toBe(false)
+  })
+
+  it('rejects symbolic links that escape the helper bundle', async () => {
+    const helperAppPath = path.join(tempRoot, CUA_DARWIN_HELPER_APP_NAME)
+    const executablePath = path.join(
+      helperAppPath,
+      'Contents',
+      'MacOS',
+      CUA_DARWIN_HELPER_EXECUTABLE_NAME
+    )
+    const resourcesPath = path.join(helperAppPath, 'Contents', 'Resources')
+    const outsidePath = path.join(tempRoot, 'outside')
+    await Promise.all([
+      mkdir(path.dirname(executablePath), { recursive: true }),
+      mkdir(resourcesPath, { recursive: true }),
+      mkdir(outsidePath)
+    ])
+    await writeFile(executablePath, Buffer.from('cffaedfe00000000', 'hex'))
+    await symlink(outsidePath, path.join(resourcesPath, 'External.framework'))
+
+    await expect(
+      inspectCuaHelperBundle(helperAppPath, {
+        runCommand: async () => ({ stdout: 'data\n', stderr: '' }),
+        readEntitlements: async () => ({ ...CUA_DARWIN_ALLOWED_ENTITLEMENTS })
+      })
+    ).rejects.toThrow(/symbolic link escapes the bundle/)
   })
 
   it('verifies the final managed helper identity before accepting the app', async () => {


### PR DESCRIPTION
## Summary

Fix the macOS clean-install Gatekeeper failure caused by the bundled CUA helper.

The failure required two conditions:

1. The upstream universal CUA executable contained absolute Xcode build-machine `LC_RPATH` entries.
2. electron-builder re-signed the already customized helper with the main application's inherited entitlements, including `disable-library-validation`.

Together, these caused `syspolicy_check distribution` to report a fatal error even though ordinary codesign, stapler, and spctl checks passed.

## Changes

- Remove disallowed build-machine RPATHs before signing.
- Sanitize universal Mach-O slices independently when their RPATHs differ.
- Reject unexpected non-system linked libraries and remaining invalid RPATHs.
- Model CUA signing through the existing package-purpose contract.
- Preserve both Apple ID and keychain-profile distribution signing modes.
- Sign the CUA helper once with its dedicated entitlement allowlist.
- Prevent electron-builder from re-signing the managed helper subtree.
- Remove `codesign --deep` from signing while retaining strict deep verification.
- Verify the final helper's:
  - Developer ID authority
  - Team ID
  - secure timestamp
  - hardened runtime
  - bundle identifier
  - exact entitlements
  - Mach-O load paths
- Run `syspolicy_check distribution` against the final application.
- Extract the staged macOS updater ZIP and apply the same application and CUA checks to its actual `DeepChat.app`.
- Record CUA and updater ZIP verification as fail-closed manifest and release-index evidence.
- Harden temporary signing-keychain cleanup and retain useful, redacted security diagnostics.
- Reject unsafe ZIP paths, escaping helper symlinks, unsupported file types, and missing entitlements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS distribution integrity checks to prevent Gatekeeper failures on clean installs.
  * Added stronger verification for the bundled Computer Use helper, including signature/Team ID, entitlements, and allowed runtime load paths.
  * Hardened updater ZIP handling by validating safe archive contents and verifying both the updater payload and the final macOS app with distribution checks.

* **Release Process**
  * Updated macOS release metadata schema/versioning and centralized macOS verification evidence generation.
  * Improved signing/notarization flow to support purpose-specific signing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->