### PR TITLE
fix(chat): correct delete-message dialog dismiss race and restore destructive styling

### DIFF
--- a/src/renderer/src/components/message/MessageToolbar.vue
+++ b/src/renderer/src/components/message/MessageToolbar.vue
@@ -211,7 +211,7 @@
                 <Button
                   variant="ghost"
                   size="icon"
-                  class="w-4 h-4 text-muted-foreground hover:text-primary hover:bg-transparent transition-colors duration-[var(--dc-motion-fast)] ease-[var(--dc-ease-out-soft)]"
+                  class="w-4 h-4 text-destructive/70 hover:text-destructive hover:bg-destructive/10 transition-colors duration-[var(--dc-motion-fast)] ease-[var(--dc-ease-out-soft)]"
                   @click="emit('delete')"
                 >
                   <Icon icon="lucide:trash-2" class="w-3 h-3" />

--- a/src/renderer/src/features/chat-page/ChatPage.vue
+++ b/src/renderer/src/features/chat-page/ChatPage.vue
@@ -289,7 +289,7 @@
           <AlertDialogCancel @click="cancelMessageDelete">
             {{ t('dialog.cancel') }}
           </AlertDialogCancel>
-          <AlertDialogAction @click="confirmMessageDelete">
+          <AlertDialogAction variant="destructive" @click.capture="confirmMessageDelete">
             {{ t('dialog.deleteMessage.confirm') }}
           </AlertDialogAction>
         </AlertDialogFooter>
@@ -1254,7 +1254,9 @@ const {
   applyRestoredSessionSummary,
   currentRestoreRequestId,
   canWriteSessionView,
-  openModelPicker: openAttachmentModelPicker
+  openModelPicker: openAttachmentModelPicker,
+  toast,
+  t
 })
 clearMessageActionsForSessionChange = clearForSessionChange
 

--- a/src/renderer/src/features/chat-page/composables/useMessageActions.ts
+++ b/src/renderer/src/features/chat-page/composables/useMessageActions.ts
@@ -9,6 +9,12 @@ import type {
 type MessageStore = ReturnType<typeof useMessageStore>
 type SessionStore = ReturnType<typeof useSessionStore>
 
+type ToastFn = (options: {
+  title: string
+  description?: string
+  variant?: 'destructive'
+}) => unknown
+
 type SessionClientLike = {
   retryMessage: (
     sessionId: string,
@@ -40,6 +46,8 @@ type UseMessageActionsOptions = {
   currentRestoreRequestId: () => number
   canWriteSessionView: (sessionId: string, requestId: number) => boolean
   openModelPicker: () => void
+  toast: ToastFn
+  t: (key: string) => string
 }
 
 /**
@@ -185,6 +193,13 @@ export function useMessageActions(options: UseMessageActionsOptions) {
       options.applyRestoredSessionSummary(restoredSession)
     } catch (error) {
       console.error('[ChatPage] delete message failed:', error)
+      if (options.canWriteSessionView(sessionId, requestId)) {
+        options.toast({
+          title: options.t('dialog.deleteMessage.title'),
+          description: options.t('common.error.requestFailed'),
+          variant: 'destructive'
+        })
+      }
     }
   }
 

--- a/src/shadcn/components/ui/alert-dialog/AlertDialogAction.vue
+++ b/src/shadcn/components/ui/alert-dialog/AlertDialogAction.vue
@@ -1,18 +1,23 @@
 <script setup lang="ts">
-import type { AlertDialogActionProps } from "reka-ui"
-import type { HTMLAttributes } from "vue"
-import { reactiveOmit } from "@vueuse/core"
-import { AlertDialogAction } from "reka-ui"
+import type { AlertDialogActionProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { AlertDialogAction } from 'reka-ui'
 import { cn } from '@shadcn/lib/utils'
-import { buttonVariants } from '@shadcn/components/ui/button'
+import { buttonVariants, type ButtonVariants } from '@shadcn/components/ui/button'
 
-const props = defineProps<AlertDialogActionProps & { class?: HTMLAttributes["class"] }>()
+const props = defineProps<
+  AlertDialogActionProps & {
+    class?: HTMLAttributes['class']
+    variant?: ButtonVariants['variant']
+  }
+>()
 
-const delegatedProps = reactiveOmit(props, "class")
+const delegatedProps = reactiveOmit(props, 'class', 'variant')
 </script>
 
 <template>
-  <AlertDialogAction v-bind="delegatedProps" :class="cn(buttonVariants(), props.class)">
+  <AlertDialogAction v-bind="delegatedProps" :class="cn(buttonVariants({ variant }), props.class)">
     <slot />
   </AlertDialogAction>
 </template>

--- a/test/renderer/features/chat-page/composables/useMessageActions.test.ts
+++ b/test/renderer/features/chat-page/composables/useMessageActions.test.ts
@@ -25,6 +25,8 @@ function createHarness() {
       id === sessionId.value && requestId === restoreRequestId.value
   )
   const openModelPicker = vi.fn()
+  const toast = vi.fn()
+  const t = vi.fn((key: string) => key)
   const scope = effectScope()
   let actions!: ReturnType<typeof useMessageActions>
 
@@ -42,7 +44,9 @@ function createHarness() {
       applyRestoredSessionSummary,
       currentRestoreRequestId: () => restoreRequestId.value,
       canWriteSessionView,
-      openModelPicker
+      openModelPicker,
+      toast,
+      t
     })
   })
 
@@ -61,6 +65,8 @@ function createHarness() {
     restoreRequestId,
     canWriteSessionView,
     openModelPicker,
+    toast,
+    t,
     stop: () => scope.stop()
   }
 }
@@ -219,6 +225,25 @@ describe('useMessageActions', () => {
     // Plan snapshots are keyed by session id, so the cleanup still runs for the
     // deleted message even though the stale view restore is skipped.
     expect(harness.clearPlanSnapshotForDeletedMessage).toHaveBeenCalledWith('s2', 'message-2')
+    consoleError.mockRestore()
+    harness.stop()
+  })
+
+  it('shows a destructive error toast when deletion fails', async () => {
+    const harness = createHarness()
+    const error = new Error('delete failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    harness.sessionClient.deleteMessage.mockRejectedValueOnce(error)
+
+    await harness.actions.onMessageDelete('message-1')
+    await harness.actions.confirmMessageDelete()
+
+    expect(consoleError).toHaveBeenCalledWith('[ChatPage] delete message failed:', error)
+    expect(harness.toast).toHaveBeenCalledWith({
+      title: 'dialog.deleteMessage.title',
+      description: 'common.error.requestFailed',
+      variant: 'destructive'
+    })
     consoleError.mockRestore()
     harness.stop()
   })


### PR DESCRIPTION
## Summary

Fixes two long-standing UX issues with the message delete action:

1. **Dialog dismiss race** — `AlertDialogAction` wraps reka-ui `DialogClose` which calls `rootContext.onOpenChange(false)` on click, closing the dialog. Our `@click` handler ran after that close, by which time `pendingDeleteMessageId` was already cleared, so `confirmMessageDelete` returned early and no deletion happened.

2. **Destructive styling** — The delete confirm button used default primary colors; the trash icon in the toolbar used muted-foreground. Both now use the destructive color palette.

## Changes

| File | Change |
|------|--------|
| `AlertDialogAction.vue` | Added optional `variant` prop, forwarded to `buttonVariants({ variant })` |
| `ChatPage.vue` | Delete confirm button: `variant="destructive"` + `@click.capture` to beat DialogClose event ordering |
| `MessageToolbar.vue` | Trash icon: `text-destructive/70 hover:text-destructive hover:bg-destructive/10` |
| `useMessageActions.ts` | Accept `toast`/`t` options; show destructive error toast on delete failure instead of silent console.error |
| `useMessageActions.test.ts` | New test covering delete-failure toast path |

## Verification

- `pnpm exec vitest run test/renderer/features/chat-page/composables/useMessageActions.test.ts test/renderer/components/ChatPage.test.ts` — 99 passed
- `pnpm run format` / `pnpm run i18n` / `pnpm run lint` — all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added destructive styling to the delete action.
  * Added destructive variants for alert-dialog action buttons.
  * Deletion failures now display a localized error notification.

* **Bug Fixes**
  * Improved delete confirmation handling to ensure actions respond reliably.

* **Tests**
  * Added coverage verifying error notifications when message deletion fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->