### PR TITLE
fix(skills): unblock startup on snapshot errors

### DIFF
--- a/docs/architecture/independent-agent-skills/plan.md
+++ b/docs/architecture/independent-agent-skills/plan.md
@@ -83,9 +83,12 @@ Migration is split because Agent settings initialize synchronously while Skill d
 7. A durable migration marker is written only after all required Agent roots commit. Re-entry
    resumes missing scopes and does not overwrite a committed private scope.
 
-The app awaits this migration before creating or restoring a chat window. macOS activation is
-ignored while startup is still in progress. Shutdown fences new Skill operations and drains both
-initialization and the background external-Agent scan before destroying Skill services.
+The app awaits this migration attempt before creating or restoring a chat window. A snapshot
+migration failure is logged but does not block startup; committed Agent roots remain available,
+missing roots stay empty and the unset completion marker causes another attempt on the next launch.
+macOS activation is ignored while startup is still in progress. Shutdown fences new Skill
+operations and drains both initialization and the background external-Agent scan before destroying
+Skill services.
 
 Plugin-owned Skills are skipped when seeding manual roots because they remain Plugin contributions.
 

--- a/docs/architecture/independent-agent-skills/spec.md
+++ b/docs/architecture/independent-agent-skills/spec.md
@@ -67,8 +67,10 @@ files and settings, and users must be able to copy selected Skills from another 
     source Agent never changes previously imported target copies.
 16. All user-facing strings use i18n and loading, empty, conflict, error and partial-success states
     are covered.
-17. Startup completes Skill migration before a chat window or background Session runtime can use
-    the catalog, and shutdown drains in-flight Skill initialization and scans before teardown.
+17. Startup attempts Skill migration before a chat window or background Session runtime can use
+    the catalog. Snapshot migration failures are logged without blocking startup, remain retryable
+    on the next launch and never fall back to another Agent's root. Shutdown drains in-flight Skill
+    initialization and scans before teardown.
 18. Agent file tools treat private Agent Skill scopes as protected paths even in `full_access`;
     only the current message's active Skill roots are exceptions.
 19. Agent deletion records durable private-Skill cleanup debt before deleting the Agent row and

--- a/src/main/skill/index.ts
+++ b/src/main/skill/index.ts
@@ -535,7 +535,11 @@ export class SkillService implements SkillServicePort {
       await this.discoverSkills(BUILTIN_SKILL_AGENT_ID)
       if (this.isServiceStopping()) return
 
-      await this.migrateLegacyAgentSkillScopes()
+      try {
+        await this.migrateLegacyAgentSkillScopes()
+      } catch (error) {
+        logger.warn('[SkillService] Agent Skill migration failed; continuing startup.', { error })
+      }
       if (this.isServiceStopping()) return
 
       await this.watchSkillFiles()

--- a/test/main/skill/skillService.test.ts
+++ b/test/main/skill/skillService.test.ts
@@ -509,6 +509,24 @@ describe('SkillService', () => {
   })
 
   describe('initialize', () => {
+    it('continues startup when Agent Skill snapshot migration fails', async () => {
+      const error = new Error('Symbolic links are not allowed in Skill snapshots')
+      const installSpy = vi.spyOn(skillService, 'installBuiltinSkills').mockResolvedValue()
+      const discoverSpy = vi.spyOn(skillService, 'discoverSkills').mockResolvedValue([])
+      vi.spyOn(skillService as any, 'migrateLegacyAgentSkillScopes').mockRejectedValue(error)
+
+      await expect(skillService.initialize()).resolves.toBeUndefined()
+
+      expect(installSpy).toHaveBeenCalledOnce()
+      expect(discoverSpy).toHaveBeenCalledOnce()
+      expect(fakeWatcherService.service.watch).toHaveBeenCalledOnce()
+      expect((skillService as any).initialized).toBe(true)
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[SkillService] Agent Skill migration failed; continuing startup.',
+        { error }
+      )
+    })
+
     it('continues when the file watcher cannot start', async () => {
       const error = new Error('File watcher utility process exited with code 1.')
       const installSpy = vi.spyOn(skillService, 'installBuiltinSkills').mockResolvedValue()


### PR DESCRIPTION
## Summary

- keep DeepChat startup available when Agent Skill snapshot migration fails
- log the migration error and preserve the incomplete migration for retry on the next launch
- document the non-blocking startup contract and add regression coverage for symbolic-link failures

## Root cause

Agent Skill migration ran inside the critical SkillService initialization path. Any snapshot copy or validation error, including a nested symbolic link, rejected `SkillService.initialize()` and prevented normal application startup.

## Impact

Snapshot safety rules remain unchanged: unsafe snapshots are still rejected. The failure is now isolated from application startup, committed Agent scopes remain available, and missing scopes stay empty until migration succeeds on a later launch.

## Validation

- `pnpm exec vitest run test/main/skill/skillService.test.ts test/main/skill/skillServiceAgentScopes.test.ts` (139 tests)
- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck:node`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now continues when Agent Skill migration fails.
  * Migration failures are logged and retried during the next launch.
  * Existing Agent roots remain available, while missing roots stay empty instead of using another root.
  * macOS activation is ignored until startup completes.
  * Shutdown continues to wait for Skill initialization and background scans before cleanup.

* **Documentation**
  * Clarified migration, startup, retry, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->