### PR TITLE
test: remove low-value test coverage

### DIFF
--- a/docs/architecture/test-suite-value-cleanup/plan.md
+++ b/docs/architecture/test-suite-value-cleanup/plan.md
@@ -1,0 +1,70 @@
+# Test Suite Value Cleanup Plan
+
+## Approach
+
+1. Inventory the full test surface, configuration, CI entry points, focused/skipped
+   tests, snapshots, assertion-free tests, duplicate titles, and weak assertions.
+2. Classify candidates by the regression signal they provide rather than by syntax
+   alone.
+3. Preserve or add the strongest nearby behavioral assertion before removing
+   redundant cases.
+4. Keep the diff test-only and prefer deletion or local table-driven assertions over
+   new helpers and abstractions.
+5. Run focused suites, then the complete main and renderer suites, followed by
+   repository quality checks.
+
+## Cleanup Slices
+
+### Vacuous tests
+
+- Delete the unrecognized-format case that computes a result but makes no assertion.
+- Delete adapter-filter loops whose assertions never use the iterated adapter.
+
+### Type and existence checks
+
+- Delete constructor-only and method-existence cases when public behavioral tests in
+  the same suite already instantiate and exercise the subject.
+- Delete checks that verify test cleanup or fixture isolation instead of product
+  behavior.
+- Keep compile-time `expectTypeOf` tests and runtime shape checks that protect actual
+  protocol boundaries.
+
+### Weak behavioral assertions
+
+- Replace non-negative collection-length assertions with fixture-derived content.
+- Strengthen error assertions when the public contract exposes a stable error.
+- Remove empty catches that allow unexpected execution errors to be hidden.
+- Replace fixed renderer sleeps with existing Vue Test Utils async settlement where
+  no real clock behavior is under test.
+- Use public lifecycle shutdown hooks for deterministic teardown instead of
+  speculative fixture delays.
+
+### Duplicate registry checks
+
+- Replace repeated built-in adapter class/lookup boilerplate with one complete
+  registry contract.
+- Keep custom registration, replacement, unknown lookup, and detection-order tests
+  because they cover distinct behavior.
+
+## Validation
+
+Run:
+
+```text
+pnpm exec vitest run --config vitest.config.ts <changed main tests>
+pnpm exec vitest run --config vitest.config.renderer.ts <changed renderer tests>
+pnpm run test:main
+pnpm run test:renderer
+pnpm run format
+pnpm run i18n
+pnpm run lint
+pnpm run typecheck
+```
+
+Packaged and live-provider end-to-end suites remain gated by their documented
+environment requirements.
+
+## Rollback
+
+The change contains no production migration. Reverting the test and documentation
+diff restores the previous suite.

--- a/docs/architecture/test-suite-value-cleanup/spec.md
+++ b/docs/architecture/test-suite-value-cleanup/spec.md
@@ -1,0 +1,98 @@
+# Test Suite Value Cleanup
+
+## Status
+
+Complete
+
+## Context
+
+The repository has a large automated test suite. A small number of tests do not
+exercise behavior, cannot fail when the claimed capability regresses, or duplicate
+stronger protection in the same suite. Removing tests based only on implementation
+coupling, mocks, or private access would discard useful regression protection, so
+cleanup must be evidence-driven.
+
+## Baseline
+
+- 709 executable test files were inventoried: 703 `*.test.*`/`*.spec.*`
+  files plus six memory performance suites.
+- Main suite: 5,574 tests, 5,299 passed and 275 environment-gated tests skipped.
+- Renderer suite: 1,596 tests passed with no skips.
+- No focused `.only` tests, Vitest snapshots, or inline snapshots were found.
+- Native SQLite/VSS, provider integration, and git-dependent skips are intentional
+  environment gates rather than dead tests.
+
+## Goal
+
+Remove tests that provide no independent failure signal and strengthen weak tests
+when they are the only protection for a user-visible or documented capability.
+
+## Acceptance Criteria
+
+1. Every test file, test configuration, and CI test entry point is included in the
+   inventory.
+2. A test is deleted only when it is vacuous, dead, or fully redundant with named
+   retained coverage.
+3. Weak assertions are replaced when the claimed behavior remains valuable.
+4. Intentional environment-gated tests remain available in supported environments.
+5. Production behavior and public interfaces do not change.
+6. Main and renderer suites pass after cleanup.
+7. Formatting, i18n validation, lint, and type checking pass.
+
+## Deletion Rules
+
+A test may be deleted when at least one of these conditions is proven:
+
+- It has no assertion or observable failure path.
+- It asserts only that the subject was constructed or that declared methods exist,
+  while behavioral tests already exercise the same subject.
+- Its assertion does not depend on the values or operation named by the test.
+- A stronger test in the same boundary detects every regression the candidate can
+  detect.
+
+Mocks, private access, a duplicate title, or low line coverage are not sufficient
+deletion evidence on their own.
+
+## Retained Protection
+
+| Candidate | Decision | Retained or replacement protection |
+| --- | --- | --- |
+| Unknown skill format conversion | Delete | No stable capability is claimed; the test has no assertion. |
+| File adapter filtering loops | Delete | Exact supported extensions/MIME types and public validation behavior remain covered. |
+| File service constructor/method existence | Delete | Public validation and fallback behavior exercise both dependency paths. |
+| Knowledge service method existence | Delete | The same suite exercises validation, listing, add, and delete behavior. |
+| Test-state isolation check | Delete | Model configuration persistence and reset behavior are already covered directly. |
+| Ambiguous model priority cases | Consolidate | A synthetic Provider DB fixture now proves provider, user override, and reset priority exactly. |
+| Skill folder tree non-negative length | Replace | Assert the exact `SKILL.md` tree node returned from the fixture. |
+| Built-in skill adapter registry boilerplate | Consolidate | Assert the complete built-in adapter ID set plus lookup behavior. |
+| Provider tests that swallow stream errors | Replace | Consume the mocked stream without an empty catch so unexpected failures surface. |
+| Provider runtime teardown sleep | Replace | Await the runtime's public `shutdown` lifecycle instead of sleeping after every test. |
+| Mermaid component fixed sleeps | Replace | Await Vue and mocked Mermaid promises directly with `flushPromises`. |
+| Telegram fatal-path sleep | Replace | Poll the complete observable failure contract with `vi.waitFor`. |
+
+## Non-Goals
+
+- Rewriting the test framework or shared fixture architecture.
+- Deleting tests merely because they use mocks or implementation details.
+- Changing product code to make cleanup metrics look better.
+- Running live-provider or packaged Electron end-to-end tests without their required
+  external environment.
+- Treating test count or coverage percentage as the primary quality measure.
+
+## Compatibility
+
+This change is limited to tests and architecture documentation. It does not alter
+runtime data, APIs, migrations, packaging, or user-facing behavior.
+
+## Validation Result
+
+- Main suite: 5,545 tests, 5,270 passed and 275 environment-gated tests skipped.
+- Renderer suite: 1,596 tests passed.
+- Focused memory behavior gate: 873 tests passed.
+- Native memory gate: 104 tests passed and 186 environment-gated tests skipped.
+- Memory evaluation gate: six tests passed and one environment-gated test skipped.
+- Memory performance suites: four passed and six native-SQLite cases skipped.
+- Playwright discovered all 31 smoke specifications.
+- The main suite has 29 fewer cases while preserving the documented contracts.
+- Provider runtime test execution fell from about 2.33 seconds to 66 milliseconds.
+- Mermaid artifact test execution fell from about 622 milliseconds to 21 milliseconds.

--- a/docs/architecture/test-suite-value-cleanup/tasks.md
+++ b/docs/architecture/test-suite-value-cleanup/tasks.md
@@ -1,0 +1,15 @@
+# Test Suite Value Cleanup Tasks
+
+- [x] Inventory all test files, configurations, and CI entry points.
+- [x] Establish passing main and renderer baselines.
+- [x] Scan for focused tests, snapshots, skips, assertion-free tests, duplicate
+      titles, tautologies, and weak assertions.
+- [x] Classify environment-gated tests.
+- [x] Document deletion criteria and retained protection.
+- [x] Delete proven vacuous tests.
+- [x] Consolidate fully redundant registry boilerplate.
+- [x] Replace weak assertions that protect meaningful behavior.
+- [x] Run focused validation.
+- [x] Run complete main and renderer suites.
+- [x] Run format, i18n, lint, and type checks.
+- [x] Review the final diff for lost behavior protection.

--- a/test/main/file/fileService.test.ts
+++ b/test/main/file/fileService.test.ts
@@ -61,24 +61,6 @@ describe('FileService Integration with FileValidationService', () => {
     fileService = new FileService(mockSettings, mockFileValidationService)
   })
 
-  describe('constructor', () => {
-    it('should initialize with provided FileValidationService', () => {
-      const customService = {
-        validateFile: vi.fn(),
-        getSupportedExtensions: vi.fn(),
-        getSupportedMimeTypes: vi.fn()
-      }
-
-      const presenter = new FileService(mockSettings, customService)
-      expect(presenter).toBeInstanceOf(FileService)
-    })
-
-    it('should initialize with default FileValidationService when none provided', () => {
-      const presenter = new FileService(mockSettings)
-      expect(presenter).toBeInstanceOf(FileService)
-    })
-  })
-
   describe('validateFileForKnowledgeBase', () => {
     it('should return validation result for supported file', async () => {
       const mockResult: FileValidationResult = {
@@ -200,23 +182,6 @@ describe('FileService Integration with FileValidationService', () => {
       expect(consoleSpy).toHaveBeenCalledWith('Error getting supported extensions:', error)
 
       consoleSpy.mockRestore()
-    })
-  })
-
-  describe('integration with existing FileService functionality', () => {
-    it('should not interfere with existing methods', async () => {
-      // Test that existing functionality still works
-      expect(typeof fileService.getMimeType).toBe('function')
-      expect(typeof fileService.createFileAdapter).toBe('function')
-      expect(typeof fileService.prepareFile).toBe('function')
-      expect(typeof fileService.isDirectory).toBe('function')
-    })
-
-    it('should maintain backward compatibility', () => {
-      // Ensure new methods don't break existing interface
-      const presenter = new FileService(mockSettings)
-      expect(presenter).toHaveProperty('validateFileForKnowledgeBase')
-      expect(presenter).toHaveProperty('getSupportedExtensions')
     })
   })
 })

--- a/test/main/file/fileValidationService.test.ts
+++ b/test/main/file/fileValidationService.test.ts
@@ -247,41 +247,6 @@ describe('FileValidationService', () => {
     })
   })
 
-  describe('adapter filtering logic', () => {
-    it('should correctly identify excluded adapters', () => {
-      const excludedAdapters = [
-        'AudioFileAdapter',
-        'ImageFileAdapter',
-        'UnsupportFileAdapter',
-        'DirectoryAdapter'
-      ]
-
-      // Test that these adapters are properly excluded
-      excludedAdapters.forEach((adapterName) => {
-        // We can't directly test the private method, but we can test the behavior
-        // through the public validateFile method
-        expect(service).toBeDefined()
-      })
-    })
-
-    it('should correctly identify supported adapters', () => {
-      const supportedAdapters = [
-        'TextFileAdapter',
-        'CodeFileAdapter',
-        'PdfFileAdapter',
-        'DocFileAdapter',
-        'PptFileAdapter',
-        'ExcelFileAdapter',
-        'CsvFileAdapter'
-      ]
-
-      // These should be supported (not in excluded list)
-      supportedAdapters.forEach((adapterName) => {
-        expect(service).toBeDefined()
-      })
-    })
-  })
-
   describe('error handling and edge cases', () => {
     it('should handle empty MIME type gracefully', async () => {
       vi.mocked(detectMimeType).mockResolvedValue('')
@@ -324,36 +289,6 @@ describe('FileValidationService', () => {
       expect(result.isSupported).toBe(false)
       expect(result.suggestedExtensions).toBeDefined()
       expect(result.suggestedExtensions!.length).toBeGreaterThan(0)
-    })
-  })
-
-  describe('constructor options', () => {
-    it('should create service instance', () => {
-      const defaultService = new FileValidationService()
-      expect(defaultService).toBeDefined()
-    })
-  })
-
-  describe('integration with existing adapter system', () => {
-    it('should work with the actual adapter map structure', async () => {
-      // Clear all mocks and use real implementation
-      vi.clearAllMocks()
-
-      // Import and use the real function directly
-      const { getMimeTypeAdapterMap: realGetMimeTypeAdapterMap } =
-        await import('../../../src/main/file/mime')
-
-      // Mock with real implementation
-      vi.mocked(getMimeTypeAdapterMap).mockImplementation(realGetMimeTypeAdapterMap)
-
-      const realService = new FileValidationService()
-      const extensions = realService.getSupportedExtensions()
-      const mimeTypes = realService.getSupportedMimeTypes()
-
-      expect(extensions).toBeInstanceOf(Array)
-      expect(mimeTypes).toBeInstanceOf(Array)
-      expect(extensions.length).toBeGreaterThan(0)
-      expect(mimeTypes.length).toBeGreaterThan(0)
     })
   })
 })

--- a/test/main/knowledge/knowledgeService.test.ts
+++ b/test/main/knowledge/knowledgeService.test.ts
@@ -422,14 +422,5 @@ describe('KnowledgeService Validation Methods', () => {
       expect(close).toHaveBeenCalled()
       expect((knowledgeService as any).knowledgeBases.has(config.id)).toBe(false)
     })
-
-    it('should not interfere with existing KnowledgeService functionality', () => {
-      // Verify that the new methods don't break existing functionality
-      expect(typeof knowledgeService.validateFile).toBe('function')
-      expect(typeof knowledgeService.getSupportedFileExtensions).toBe('function')
-      expect(typeof knowledgeService.addFile).toBe('function')
-      expect(typeof knowledgeService.deleteFile).toBe('function')
-      expect(typeof knowledgeService.listFiles).toBe('function')
-    })
   })
 })

--- a/test/main/provider/modelConfig.test.ts
+++ b/test/main/provider/modelConfig.test.ts
@@ -162,140 +162,65 @@ describe('ModelConfigHelper', () => {
     })
   })
 
-  describe('Complete Configuration Priority Chain', () => {
-    // Test with a model that has both default and provider-specific configurations
-    const testModelId = 'gpt-4' // This model should have default settings
-    const testProviderId = 'openai' // This provider should have specific settings for gpt-4
+  describe('Configuration Priority', () => {
+    it('uses provider metadata until a user config overrides it', () => {
+      const providerId = 'test-provider'
+      const modelId = 'provider-model'
+      const getDbSpy = vi.spyOn(providerDbLoader, 'getDb').mockReturnValue({
+        providers: {
+          [providerId]: {
+            id: providerId,
+            models: [
+              {
+                id: modelId,
+                modalities: { input: ['text', 'image'], output: ['text'] },
+                limit: { context: 32768, output: 8192 },
+                tool_call: false,
+                reasoning: { supported: false },
+                type: 'chat'
+              }
+            ]
+          }
+        }
+      } as any)
 
-    it('should return default configuration when no provider is specified', () => {
-      // Get configuration without provider - should use default pattern matching
-      const configWithoutProvider = modelConfigHelper.getModelConfig(testModelId)
+      try {
+        expect(modelConfigHelper.getModelConfig(modelId, providerId)).toMatchObject({
+          maxTokens: 8192,
+          contextLength: 32768,
+          vision: true,
+          functionCall: false,
+          reasoning: false,
+          type: ModelType.Chat,
+          isUserDefined: false
+        })
 
-      // Should return a valid configuration (from default settings)
-      expect(configWithoutProvider).toBeDefined()
-      expect(configWithoutProvider.maxTokens).toBeGreaterThan(0)
-      expect(configWithoutProvider.contextLength).toBeGreaterThan(0)
-      expect(typeof configWithoutProvider.temperature).toBe('number')
-      expect(typeof configWithoutProvider.vision).toBe('boolean')
-      expect(typeof configWithoutProvider.functionCall).toBe('boolean')
-      expect(typeof configWithoutProvider.reasoning).toBe('boolean')
-      expect(configWithoutProvider.type).toBe(ModelType.Chat)
-    })
+        const userConfig: ModelConfig = {
+          maxTokens: 9999,
+          contextLength: 65536,
+          temperature: 0.2,
+          vision: false,
+          functionCall: true,
+          reasoning: true,
+          type: ModelType.Chat
+        }
+        modelConfigHelper.setModelConfig(modelId, providerId, userConfig)
 
-    it('should return provider-specific configuration when provider is specified', () => {
-      // Get configuration with provider - should use provider-specific settings if available
-      const configWithProvider = modelConfigHelper.getModelConfig(testModelId, testProviderId)
-      const configWithoutProvider = modelConfigHelper.getModelConfig(testModelId)
+        expect(modelConfigHelper.getModelConfig(modelId, providerId)).toMatchObject({
+          ...userConfig,
+          isUserDefined: true
+        })
 
-      // Both should be valid configurations
-      expect(configWithProvider).toBeDefined()
-      expect(configWithoutProvider).toBeDefined()
+        modelConfigHelper.resetModelConfig(modelId, providerId)
 
-      // They might be the same or different depending on whether provider-specific config exists
-      // But both should be valid configurations
-      expect(configWithProvider.maxTokens).toBeGreaterThan(0)
-      expect(configWithProvider.contextLength).toBeGreaterThan(0)
-    })
-
-    it('should prioritize user config over provider config over default config', () => {
-      // Step 1: Get baseline configurations
-      const defaultConfig = modelConfigHelper.getModelConfig(testModelId) // No provider
-      const providerConfig = modelConfigHelper.getModelConfig(testModelId, testProviderId) // With provider
-
-      console.log('Default config maxTokens:', defaultConfig.maxTokens)
-      console.log('Provider config maxTokens:', providerConfig.maxTokens)
-
-      // Step 2: Set user configuration with unique values
-      const userConfig: ModelConfig = {
-        maxTokens: 99999, // Unique value to identify user config
-        contextLength: 88888, // Unique value
-        temperature: 0.123, // Unique value
-        vision: true,
-        functionCall: true,
-        reasoning: true,
-        type: ModelType.Chat
+        expect(modelConfigHelper.getModelConfig(modelId, providerId)).toMatchObject({
+          maxTokens: 8192,
+          contextLength: 32768,
+          isUserDefined: false
+        })
+      } finally {
+        getDbSpy.mockRestore()
       }
-
-      modelConfigHelper.setModelConfig(testModelId, testProviderId, userConfig)
-
-      // Step 3: Verify user config takes priority
-      const retrievedConfig = modelConfigHelper.getModelConfig(testModelId, testProviderId)
-      expect(retrievedConfig).toMatchObject(userConfig)
-      expect(retrievedConfig.isUserDefined).toBe(true)
-      expect(retrievedConfig.maxTokens).toBe(99999) // Should be user config value
-      expect(retrievedConfig.contextLength).toBe(88888) // Should be user config value
-      expect(retrievedConfig.temperature).toBe(0.123) // Should be user config value
-    })
-
-    it('should fall back to provider config after user config reset', () => {
-      // Step 1: Set user configuration
-      const userConfig: ModelConfig = {
-        maxTokens: 77777,
-        contextLength: 66666,
-        temperature: 0.999,
-        vision: false,
-        functionCall: false,
-        reasoning: false,
-        type: ModelType.Chat
-      }
-
-      modelConfigHelper.setModelConfig(testModelId, testProviderId, userConfig)
-
-      // Step 2: Verify user config is active
-      const configWithUserSettings = modelConfigHelper.getModelConfig(testModelId, testProviderId)
-      expect(configWithUserSettings.maxTokens).toBe(77777)
-
-      // Step 3: Get expected fallback config (provider or default)
-      const expectedFallbackConfig = modelConfigHelper.getModelConfig(testModelId, testProviderId)
-
-      // Step 4: Reset user configuration
-      modelConfigHelper.resetModelConfig(testModelId, testProviderId)
-
-      // Step 5: Verify fallback to provider/default config
-      const configAfterReset = modelConfigHelper.getModelConfig(testModelId, testProviderId)
-      expect(configAfterReset.maxTokens).not.toBe(77777) // Should not be user config
-      expect(configAfterReset.maxTokens).toBeGreaterThan(0) // Should be valid config
-
-      // Should match the provider config or default config
-      expect(configAfterReset.contextLength).toBeGreaterThan(0)
-      expect(typeof configAfterReset.temperature).toBe('number')
-      expect(typeof configAfterReset.vision).toBe('boolean')
-    })
-
-    it('should handle configuration priority with different model types', () => {
-      // Test with a model that should match default patterns
-      const chatModelId = 'gpt-3.5-turbo'
-      const visionModelId = 'gpt-4-vision'
-
-      // Get configurations for different model types
-      const chatConfig = modelConfigHelper.getModelConfig(chatModelId, testProviderId)
-      const visionConfig = modelConfigHelper.getModelConfig(visionModelId, testProviderId)
-
-      // Both should be valid
-      expect(chatConfig).toBeDefined()
-      expect(visionConfig).toBeDefined()
-
-      // Vision model might have different default settings
-      expect(chatConfig.type).toBe(ModelType.Chat)
-      expect(visionConfig.type).toBe(ModelType.Chat) // Both should be chat type by default
-
-      // Test user override
-      const customVisionConfig: ModelConfig = {
-        maxTokens: 12000,
-        contextLength: 24000,
-        temperature: 0.7,
-        vision: true, // Enable vision for this model
-        functionCall: false,
-        reasoning: false,
-        type: ModelType.Chat
-      }
-
-      modelConfigHelper.setModelConfig(visionModelId, testProviderId, customVisionConfig)
-      const retrievedVisionConfig = modelConfigHelper.getModelConfig(visionModelId, testProviderId)
-
-      expect(retrievedVisionConfig).toMatchObject(customVisionConfig)
-      expect(retrievedVisionConfig.isUserDefined).toBe(true)
-      expect(retrievedVisionConfig.vision).toBe(true) // User setting should override
     })
 
     it('should maintain configuration isolation between different providers', () => {
@@ -430,35 +355,20 @@ describe('ModelConfigHelper', () => {
   })
 
   describe('Edge Cases and Error Handling', () => {
-    it('should handle edge cases gracefully', () => {
-      // Empty model ID
-      const configEmptyModel = modelConfigHelper.getModelConfig('', 'test-provider')
-      expect(configEmptyModel).toBeDefined()
-      expect(configEmptyModel.maxTokens).toBeGreaterThan(0)
-
-      // Undefined provider ID
-      const configUndefinedProvider = modelConfigHelper.getModelConfig('test-model', undefined)
-      expect(configUndefinedProvider).toBeDefined()
-      expect(configUndefinedProvider.maxTokens).toBeGreaterThan(0)
-    })
-
-    it('should verify test state isolation', () => {
-      const testKey = 'test-state-isolation'
-      const testProvider = 'test-provider'
-
-      // Set configuration
-      modelConfigHelper.setModelConfig(testKey, testProvider, {
-        maxTokens: 999,
-        contextLength: 999,
-        temperature: 0.9,
-        vision: true,
+    it.each([
+      { label: 'empty model IDs', modelId: '', providerId: 'test-provider' },
+      { label: 'missing provider IDs', modelId: 'test-model', providerId: undefined }
+    ])('returns safe defaults for $label', ({ modelId, providerId }) => {
+      expect(modelConfigHelper.getModelConfig(modelId, providerId)).toMatchObject({
+        maxTokens: 4096,
+        contextLength: 16000,
+        temperature: 0.6,
+        vision: false,
         functionCall: true,
-        reasoning: true,
-        type: ModelType.Chat
+        reasoning: false,
+        type: ModelType.Chat,
+        isUserDefined: false
       })
-
-      expect(modelConfigHelper.hasUserConfig(testKey, testProvider)).toBe(true)
-      // Note: afterEach will clean this up for subsequent tests
     })
   })
 

--- a/test/main/provider/openAIResponsesProvider.test.ts
+++ b/test/main/provider/openAIResponsesProvider.test.ts
@@ -72,25 +72,23 @@ describe('OpenAIResponsesProvider', () => {
     const provider = new AiSdkProvider(createProvider(), createProviderSettings())
     ;(provider as any).isInitialized = true
 
-    try {
-      for await (const _event of provider.coreStream(
-        [{ role: 'user', content: 'hello' }],
-        'gpt-4o',
-        {
-          maxTokens: 1024,
-          contextLength: 8192,
-          vision: false,
-          functionCall: false,
-          reasoning: false,
-          type: 'chat'
-        } as ModelConfig,
-        0.7,
-        256,
-        []
-      )) {
-        break
-      }
-    } catch {}
+    for await (const _event of provider.coreStream(
+      [{ role: 'user', content: 'hello' }],
+      'gpt-4o',
+      {
+        maxTokens: 1024,
+        contextLength: 8192,
+        vision: false,
+        functionCall: false,
+        reasoning: false,
+        type: 'chat'
+      } as ModelConfig,
+      0.7,
+      256,
+      []
+    )) {
+      break
+    }
 
     const context = mockRunAiSdkCoreStream.mock.calls.at(-1)?.[0]
 
@@ -115,26 +113,24 @@ describe('OpenAIResponsesProvider', () => {
     )
     ;(provider as any).isInitialized = true
 
-    try {
-      for await (const _event of provider.coreStream(
-        [{ role: 'user', content: 'paint' }],
-        'gpt-image-1',
-        {
-          apiEndpoint: 'image',
-          maxTokens: 1024,
-          contextLength: 8192,
-          vision: false,
-          functionCall: false,
-          reasoning: false,
-          type: 'chat'
-        } as ModelConfig,
-        0.7,
-        256,
-        []
-      )) {
-        break
-      }
-    } catch {}
+    for await (const _event of provider.coreStream(
+      [{ role: 'user', content: 'paint' }],
+      'gpt-image-1',
+      {
+        apiEndpoint: 'image',
+        maxTokens: 1024,
+        contextLength: 8192,
+        vision: false,
+        functionCall: false,
+        reasoning: false,
+        type: 'chat'
+      } as ModelConfig,
+      0.7,
+      256,
+      []
+    )) {
+      break
+    }
 
     const context = mockRunAiSdkCoreStream.mock.calls.at(-1)?.[0]
 

--- a/test/main/provider/providerRuntime.test.ts
+++ b/test/main/provider/providerRuntime.test.ts
@@ -209,14 +209,7 @@ describe('ProviderRuntime Integration Tests', () => {
   })
 
   afterEach(async () => {
-    // Stop all active streams after each test
-    const activeStreams = (providerRuntime as any).activeStreams as Map<string, any>
-    for (const [eventId] of activeStreams) {
-      await providerRuntime.stopStream(eventId)
-    }
-
-    // Wait for any pending async operations to complete
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    await providerRuntime.shutdown()
     vi.unstubAllGlobals()
   })
 
@@ -375,7 +368,6 @@ describe('ProviderRuntime Integration Tests', () => {
 
       expect(typeof response).toBe('string')
       expect(response.length).toBeGreaterThan(0)
-      console.log('Completion response:', response.substring(0, 100))
     }, 15000)
 
     it('forwards text-generation cancellation options to the provider', async () => {
@@ -610,7 +602,6 @@ describe('ProviderRuntime Integration Tests', () => {
 
       expect(typeof title).toBe('string')
       expect(title.length).toBeGreaterThan(0)
-      console.log('Generated title:', title)
     }, 15000)
   })
 

--- a/test/main/remote/telegramPoller.test.ts
+++ b/test/main/remote/telegramPoller.test.ts
@@ -137,15 +137,14 @@ describe('TelegramPoller', () => {
 
     await vi.waitFor(() => {
       expect(poller.getStatusSnapshot().state).toBe('error')
+      expect(client.getUpdates).toHaveBeenCalledTimes(1)
+      expect(poller.getStatusSnapshot().lastError).toContain(
+        'terminated by other getUpdates request'
+      )
+      expect(onFatalError).toHaveBeenCalledWith(
+        expect.stringContaining('terminated by other getUpdates request')
+      )
     })
-
-    await new Promise((resolve) => setTimeout(resolve, 20))
-
-    expect(client.getUpdates).toHaveBeenCalledTimes(1)
-    expect(poller.getStatusSnapshot().lastError).toContain('terminated by other getUpdates request')
-    expect(onFatalError).toHaveBeenCalledWith(
-      expect.stringContaining('terminated by other getUpdates request')
-    )
   })
 
   it('keeps retrying transient failures without auto-disable callback', async () => {

--- a/test/main/skill/skillService.test.ts
+++ b/test/main/skill/skillService.test.ts
@@ -2380,22 +2380,15 @@ describe('SkillService', () => {
     })
 
     it('should return folder tree for existing skill', async () => {
-      // Reset readdirSync to return files for the skill folder
-      let callCount = 0
-      ;(fs.readdirSync as Mock).mockImplementation(() => {
-        callCount++
-        if (callCount === 1) {
-          // First call is for discovering skills
-          return [{ name: 'test-skill', isDirectory: () => true }]
-        }
-        // Subsequent calls are for building tree - return empty to prevent recursion
-        return [{ name: 'SKILL.md', isDirectory: () => false }]
-      })
-
       const tree = await skillService.getSkillFolderTree('test-skill')
 
-      expect(Array.isArray(tree)).toBe(true)
-      expect(tree.length).toBeGreaterThanOrEqual(0)
+      expect(tree).toEqual([
+        {
+          name: 'SKILL.md',
+          type: 'file',
+          path: `${DEFAULT_SKILLS_DIR}/test-skill/SKILL.md`
+        }
+      ])
     })
   })
 

--- a/test/main/skill/sync/adapters/index.test.ts
+++ b/test/main/skill/sync/adapters/index.test.ts
@@ -1,18 +1,23 @@
 /**
  * Adapters Registry Unit Tests
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import {
   getAdapter,
   getAllAdapters,
   registerAdapter,
   detectAdapter,
   ClaudeCodeAdapter,
+  CodexAdapter,
   CursorAdapter,
   WindsurfAdapter,
   CopilotAdapter,
   KiroAdapter,
   AntigravityAdapter,
+  OpenCodeAdapter,
+  GooseAdapter,
+  KiloCodeAdapter,
+  CopilotUserAdapter,
   AgentsAdapter
 } from '../../../../../src/main/skill/sync/adapters'
 import type {
@@ -23,75 +28,34 @@ import type {
 } from '../../../../../src/shared/types/skillSync'
 
 describe('Adapters Registry', () => {
-  describe('getAdapter', () => {
-    it('should return ClaudeCodeAdapter for claude-code id', () => {
-      const adapter = getAdapter('claude-code')
-      expect(adapter).toBeInstanceOf(ClaudeCodeAdapter)
-    })
+  const builtinAdapters = [
+    ['claude-code', ClaudeCodeAdapter],
+    ['codex', CodexAdapter],
+    ['cursor', CursorAdapter],
+    ['windsurf', WindsurfAdapter],
+    ['copilot', CopilotAdapter],
+    ['kiro', KiroAdapter],
+    ['antigravity', AntigravityAdapter],
+    ['opencode', OpenCodeAdapter],
+    ['goose', GooseAdapter],
+    ['kilocode', KiloCodeAdapter],
+    ['copilot-user', CopilotUserAdapter],
+    ['agents', AgentsAdapter]
+  ] as const
 
-    it('should return CursorAdapter for cursor id', () => {
-      const adapter = getAdapter('cursor')
-      expect(adapter).toBeInstanceOf(CursorAdapter)
-    })
+  describe('built-in adapters', () => {
+    it('should register every exported built-in adapter', () => {
+      expect(getAllAdapters().map((adapter) => adapter.id)).toEqual(
+        builtinAdapters.map(([id]) => id)
+      )
 
-    it('should return WindsurfAdapter for windsurf id', () => {
-      const adapter = getAdapter('windsurf')
-      expect(adapter).toBeInstanceOf(WindsurfAdapter)
-    })
-
-    it('should return CopilotAdapter for copilot id', () => {
-      const adapter = getAdapter('copilot')
-      expect(adapter).toBeInstanceOf(CopilotAdapter)
-    })
-
-    it('should return KiroAdapter for kiro id', () => {
-      const adapter = getAdapter('kiro')
-      expect(adapter).toBeInstanceOf(KiroAdapter)
-    })
-
-    it('should return AntigravityAdapter for antigravity id', () => {
-      const adapter = getAdapter('antigravity')
-      expect(adapter).toBeInstanceOf(AntigravityAdapter)
-    })
-
-    it('should return AgentsAdapter for agents id', () => {
-      const adapter = getAdapter('agents')
-      expect(adapter).toBeInstanceOf(AgentsAdapter)
+      for (const [id, Adapter] of builtinAdapters) {
+        expect(getAdapter(id)).toBeInstanceOf(Adapter)
+      }
     })
 
     it('should return undefined for unknown id', () => {
-      const adapter = getAdapter('unknown-adapter')
-      expect(adapter).toBeUndefined()
-    })
-  })
-
-  describe('getAllAdapters', () => {
-    it('should return all registered adapters', () => {
-      const adapters = getAllAdapters()
-
-      expect(adapters.length).toBeGreaterThanOrEqual(6)
-
-      const ids = adapters.map((a) => a.id)
-      expect(ids).toContain('claude-code')
-      expect(ids).toContain('cursor')
-      expect(ids).toContain('windsurf')
-      expect(ids).toContain('copilot')
-      expect(ids).toContain('kiro')
-      expect(ids).toContain('antigravity')
-      expect(ids).toContain('agents')
-    })
-
-    it('should return array of IFormatAdapter instances', () => {
-      const adapters = getAllAdapters()
-
-      for (const adapter of adapters) {
-        expect(adapter.id).toBeDefined()
-        expect(adapter.name).toBeDefined()
-        expect(typeof adapter.parse).toBe('function')
-        expect(typeof adapter.serialize).toBe('function')
-        expect(typeof adapter.detect).toBe('function')
-        expect(typeof adapter.getCapabilities).toBe('function')
-      }
+      expect(getAdapter('unknown-adapter')).toBeUndefined()
     })
   })
 
@@ -242,50 +206,6 @@ No specific format here.`
 
       const adapter = detectAdapter(content)
       expect(adapter).toBeUndefined()
-    })
-  })
-
-  describe('exported adapter classes', () => {
-    it('should export ClaudeCodeAdapter', () => {
-      expect(ClaudeCodeAdapter).toBeDefined()
-      const instance = new ClaudeCodeAdapter()
-      expect(instance.id).toBe('claude-code')
-    })
-
-    it('should export CursorAdapter', () => {
-      expect(CursorAdapter).toBeDefined()
-      const instance = new CursorAdapter()
-      expect(instance.id).toBe('cursor')
-    })
-
-    it('should export WindsurfAdapter', () => {
-      expect(WindsurfAdapter).toBeDefined()
-      const instance = new WindsurfAdapter()
-      expect(instance.id).toBe('windsurf')
-    })
-
-    it('should export CopilotAdapter', () => {
-      expect(CopilotAdapter).toBeDefined()
-      const instance = new CopilotAdapter()
-      expect(instance.id).toBe('copilot')
-    })
-
-    it('should export KiroAdapter', () => {
-      expect(KiroAdapter).toBeDefined()
-      const instance = new KiroAdapter()
-      expect(instance.id).toBe('kiro')
-    })
-
-    it('should export AntigravityAdapter', () => {
-      expect(AntigravityAdapter).toBeDefined()
-      const instance = new AntigravityAdapter()
-      expect(instance.id).toBe('antigravity')
-    })
-
-    it('should export AgentsAdapter', () => {
-      expect(AgentsAdapter).toBeDefined()
-      const instance = new AgentsAdapter()
-      expect(instance.id).toBe('agents')
     })
   })
 })

--- a/test/main/skill/sync/formatConverter.test.ts
+++ b/test/main/skill/sync/formatConverter.test.ts
@@ -298,20 +298,6 @@ description: A test prompt
 
       expect(result).not.toBeNull()
     })
-
-    it('should return null for unrecognized format', () => {
-      const content = `Just plain text without any structure`
-
-      const context = {
-        filePath: '/path/to/file.txt',
-        folderPath: '/path/to'
-      }
-
-      const result = converter.autoDetectAndParse(content, context)
-
-      // May or may not be null depending on adapter detection logic
-      // Some adapters may accept plain markdown
-    })
   })
 
   describe('getToolCapabilities', () => {

--- a/test/renderer/components/MermaidArtifact.test.ts
+++ b/test/renderer/components/MermaidArtifact.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 import MermaidArtifact from '@/components/artifacts/MermaidArtifact.vue'
 
@@ -35,8 +35,7 @@ describe('MermaidArtifact', () => {
         attachTo: document.body
       })
 
-      // Wait for component to mount and initialize
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      await flushPromises()
 
       const mermaidRef = wrapper.get('[data-testid="mermaid-artifact-preview"]')
       expect(mermaidRef.exists()).toBe(true)
@@ -61,8 +60,7 @@ describe('MermaidArtifact', () => {
         attachTo: document.body
       })
 
-      // Wait for component to mount and initialize
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      await flushPromises()
 
       const mermaidRef = wrapper.get('[data-testid="mermaid-artifact-preview"]')
       expect(mermaidRef.exists()).toBe(true)
@@ -89,7 +87,7 @@ describe('MermaidArtifact', () => {
         attachTo: document.body
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      await flushPromises()
 
       const mermaidRef = wrapper.get('[data-testid="mermaid-artifact-preview"]')
       expect(mermaidRef.element.innerHTML).not.toContain('<script>')
@@ -111,7 +109,7 @@ describe('MermaidArtifact', () => {
         attachTo: document.body
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      await flushPromises()
 
       const mermaidRef = wrapper.get('[data-testid="mermaid-artifact-preview"]')
       expect(mermaidRef.element.innerHTML).not.toContain('onclick')
@@ -132,7 +130,7 @@ describe('MermaidArtifact', () => {
         attachTo: document.body
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      await flushPromises()
 
       const mermaidRef = wrapper.get('[data-testid="mermaid-artifact-preview"]')
       expect(mermaidRef.element.innerHTML).not.toContain('javascript:')
@@ -154,7 +152,7 @@ describe('MermaidArtifact', () => {
         attachTo: document.body
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      await flushPromises()
 
       const mermaidRef = wrapper.get('[data-testid="mermaid-artifact-preview"]')
       // The img tag should be completely removed

--- a/test/renderer/composables/useArtifactExport.test.ts
+++ b/test/renderer/composables/useArtifactExport.test.ts
@@ -30,7 +30,9 @@ describe('useArtifactExport', () => {
 
   it('throws for invalid svg content', async () => {
     const api = useArtifactExport(vi.fn())
-    await expect(api.exportSVG(mkArtifact('image/svg+xml', 'NOT_SVG', 'bad'))).rejects.toBeTruthy()
+    await expect(api.exportSVG(mkArtifact('image/svg+xml', 'NOT_SVG', 'bad'))).rejects.toThrow(
+      'Invalid SVG content'
+    )
   })
 
   it('exports code and copies content', async () => {


### PR DESCRIPTION
## Summary

- audit all 709 executable test files and document evidence-based deletion criteria
- remove 29 vacuous, test-infrastructure-only, or fully redundant cases
- replace ambiguous assertions with exact behavior contracts for model priority, Skill folder trees, and built-in adapter registration
- replace swallowed errors and fixed sleeps with deterministic async synchronization

## Why

The suite contained cases that could not fail when their claimed behavior regressed, including assertion-free tests, loops whose assertions ignored the iterated value, constructor/method-existence checks duplicated by behavioral coverage, and test-state isolation checks. Other valuable tests used weak assertions or speculative delays.

Mocks, private access, duplicate titles, and environment-gated skips were not treated as deletion evidence. Native SQLite/VSS and provider-dependent coverage remains intact.

## Impact

Test and architecture documentation only. There are no production code, API, migration, packaging, or user-facing behavior changes.

The ProviderRuntime suite dropped from about 2.33 seconds to 66 milliseconds, and MermaidArtifact tests dropped from about 622 milliseconds to 21 milliseconds in focused runs.

## Validation

- main: 5,270 passed, 275 environment-gated skipped
- renderer: 1,596 passed
- memory behavior: 873 passed
- memory native: 104 passed, 186 environment-gated skipped
- memory eval: 6 passed, 1 environment-gated skipped
- memory performance: 4 passed, 6 native-SQLite skipped
- Playwright: all 31 smoke specs discovered with `--list`
- `pnpm run format`
- `pnpm run format:check`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a plan, specification, and task checklist for improving test-suite value and maintainability.

* **Tests**
  * Removed redundant, vacuous, and weak coverage while preserving key behavioral checks.
  * Strengthened assertions for configuration, file trees, export errors, registry adapters, and Telegram polling failures.
  * Replaced timing-based waits with deterministic async synchronization.
  * Simplified provider, file, knowledge, and format-detection test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->