### PR TITLE
feat(settings): separate debug tools

### DIFF
--- a/docs/features/debug-settings-tools/plan.md
+++ b/docs/features/debug-settings-tools/plan.md
@@ -1,0 +1,28 @@
+# Development Debug Settings Tools Plan
+
+## Settings Surface
+
+Add `settings-debug` to the shared settings navigation metadata as a `developmentOnly` item.
+Settings renderer callers explicitly opt in with `import.meta.env.DEV`, so production builds neither
+register the route nor display a sidebar link.
+
+Move the existing About-page mock controls into `DebugSettings.vue`. The page reuses the established
+clients and upgrade store:
+
+```text
+Debug settings -> WindowClient -> typed window route -> DEV_EVENTS
+Debug settings -> DebugClient -> typed app route -> mock chat session
+Debug settings -> UpgradeClient -> typed upgrade routes -> mock update state
+```
+
+## Security
+
+Renderer hiding is not an authorization boundary. The main process rejects guided onboarding and
+mock-update calls unless it is an unpackaged development runtime. The existing mock-chat route
+already applies the same gate.
+
+## Validation
+
+- Verify the settings navigation filters development-only entries by default and when opted in.
+- Verify the three mock route handlers return disabled results outside development.
+- Run format, i18n validation, lint, and focused test/type checks.

--- a/docs/features/debug-settings-tools/spec.md
+++ b/docs/features/debug-settings-tools/spec.md
@@ -1,0 +1,35 @@
+# Development Debug Settings Tools
+
+## User Need
+
+Development-only mock controls are currently embedded in the About settings page. Developers need a
+clear, dedicated surface for exercising onboarding, mock chat, and update states without exposing
+those controls in release builds.
+
+## Goals
+
+- Add a development-only `Debug` settings route and sidebar entry.
+- Move the existing onboarding, mock-chat, and mock-update actions from About into that page.
+- Reject onboarding and mock-update route invocations outside development or in packaged apps.
+- Keep the existing mock-chat main-process gate intact.
+
+## Acceptance Criteria
+
+- Debug tools appear only in renderer development builds.
+- The About page no longer exposes development mock controls.
+- The Debug page can start guided onboarding, create a mock chat, and add or clear a mock update.
+- Main-process onboarding and update mock routes return safe disabled results in production-like
+  environments.
+- User-facing copy is present in every supported locale.
+
+## Constraints
+
+- Do not add startup splash preview functionality; it is a separate change.
+- Do not expose credentials, passwords, or other secret values.
+- Keep existing typed route, renderer client, Vue Composition API, shadcn-vue, and i18n conventions.
+
+## Non-Goals
+
+- Persisting debug preferences.
+- Adding production diagnostics tools.
+- Changing real onboarding, session, or update behavior.

--- a/docs/features/debug-settings-tools/tasks.md
+++ b/docs/features/debug-settings-tools/tasks.md
@@ -1,0 +1,7 @@
+# Development Debug Settings Tools Tasks
+
+- [x] Define a development-only settings navigation item and route.
+- [x] Move existing mock controls from About to a Debug page.
+- [x] Gate onboarding and mock-update routes in the main process.
+- [ ] Add focused tests for navigation and route gates.
+- [ ] Format, validate i18n, lint, and run focused checks.

--- a/docs/features/debug-settings-tools/tasks.md
+++ b/docs/features/debug-settings-tools/tasks.md
@@ -3,5 +3,5 @@
 - [x] Define a development-only settings navigation item and route.
 - [x] Move existing mock controls from About to a Debug page.
 - [x] Gate onboarding and mock-update routes in the main process.
-- [ ] Add focused tests for navigation and route gates.
-- [ ] Format, validate i18n, lint, and run focused checks.
+- [x] Add focused tests for navigation and route gates.
+- [x] Format, validate i18n, lint, and run focused checks.

--- a/src/main/desktop/routes.ts
+++ b/src/main/desktop/routes.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import type {
   IShortcutPresenter,
   ITabPresenter,
@@ -314,6 +314,9 @@ export function createDesktopRoutes(deps: {
       windowStartGuidedOnboardingRoute.name,
       async (rawInput) => {
         windowStartGuidedOnboardingRoute.input.parse(rawInput)
+        if (!import.meta.env.DEV || app.isPackaged) {
+          return windowStartGuidedOnboardingRoute.output.parse({ started: false, focused: false })
+        }
         await windowPresenter.sendToAllWindows(DEV_EVENTS.START_GUIDED_ONBOARDING)
         return windowStartGuidedOnboardingRoute.output.parse({
           started: true,

--- a/src/main/upgrade/routes.ts
+++ b/src/main/upgrade/routes.ts
@@ -1,3 +1,4 @@
+import { app } from 'electron'
 import type { UpgradeService } from './index'
 import type { UpdateSettings } from './settings'
 import {
@@ -77,6 +78,9 @@ export function createUpgradeRoutes(deps: {
       upgradeMockDownloadedRoute.name,
       async (rawInput) => {
         upgradeMockDownloadedRoute.input.parse(rawInput)
+        if (!import.meta.env.DEV || app.isPackaged) {
+          return upgradeMockDownloadedRoute.output.parse({ updated: false })
+        }
         return upgradeMockDownloadedRoute.output.parse({ updated: upgrade.mockDownloadedUpdate() })
       }
     ],
@@ -84,6 +88,9 @@ export function createUpgradeRoutes(deps: {
       upgradeClearMockRoute.name,
       async (rawInput) => {
         upgradeClearMockRoute.input.parse(rawInput)
+        if (!import.meta.env.DEV || app.isPackaged) {
+          return upgradeClearMockRoute.output.parse({ updated: false })
+        }
         return upgradeClearMockRoute.output.parse({ updated: upgrade.clearMockUpdate() })
       }
     ],

--- a/src/renderer/settings/App.vue
+++ b/src/renderer/settings/App.vue
@@ -478,23 +478,35 @@ const settings: Ref<
     path: string
   }[]
 > = ref(
-  getSettingsRouteItems(runtimePlatform, runtimeArch).map((item) => ({
+  getSettingsRouteItems(runtimePlatform, runtimeArch, import.meta.env.DEV).map((item) => ({
     title: item.titleKey,
     name: item.routeName,
     icon: item.icon,
-    path: resolveSettingsNavigationPath(item.routeName, undefined, runtimePlatform, runtimeArch)
+    path: resolveSettingsNavigationPath(
+      item.routeName,
+      undefined,
+      runtimePlatform,
+      runtimeArch,
+      import.meta.env.DEV
+    )
   }))
 )
 
 const settingGroups = ref(
-  getSettingsNavigationGroups(runtimePlatform, runtimeArch).map((group) => ({
+  getSettingsNavigationGroups(runtimePlatform, runtimeArch, import.meta.env.DEV).map((group) => ({
     key: group.key,
     titleKey: group.titleKey,
     items: group.items.map((item) => ({
       title: item.titleKey,
       name: item.routeName,
       icon: item.icon,
-      path: resolveSettingsNavigationPath(item.routeName, undefined, runtimePlatform, runtimeArch)
+      path: resolveSettingsNavigationPath(
+        item.routeName,
+        undefined,
+        runtimePlatform,
+        runtimeArch,
+        import.meta.env.DEV
+      )
     }))
   }))
 )

--- a/src/renderer/settings/components/AboutUsSettings.vue
+++ b/src/renderer/settings/components/AboutUsSettings.vue
@@ -116,52 +116,6 @@
         </Button>
 
         <Button
-          v-if="showMockUpdateControls && !upgrade.isMockUpdate"
-          variant="outline"
-          size="sm"
-          class="mb-2 text-xs"
-          @click="handleMockDownloadedUpdate"
-        >
-          {{ t('about.mockUpdateButton') }}
-        </Button>
-
-        <Button
-          v-if="showMockUpdateControls && upgrade.isMockUpdate"
-          variant="outline"
-          size="sm"
-          class="mb-2 text-xs"
-          @click="handleClearMockUpdate"
-        >
-          {{ t('about.clearMockUpdateButton') }}
-        </Button>
-
-        <Button
-          v-if="showMockUpdateControls"
-          variant="outline"
-          size="sm"
-          class="mb-2 text-xs"
-          @click="handleStartMockOnboarding"
-        >
-          {{ t('about.mockOnboardingButton') }}
-        </Button>
-
-        <Button
-          v-if="showMockUpdateControls"
-          variant="outline"
-          size="sm"
-          class="mb-2 text-xs"
-          :disabled="isCreatingMockChat"
-          @click="handleCreateMockChat"
-        >
-          <Icon
-            icon="lucide:database"
-            class="mr-1 h-3 w-3"
-            :class="{ 'animate-pulse': isCreatingMockChat }"
-          />
-          {{ isCreatingMockChat ? t('about.mockChatCreating') : t('about.mockChatButton') }}
-        </Button>
-
-        <Button
           v-if="upgrade.showManualDownloadOptions"
           variant="outline"
           size="sm"
@@ -242,7 +196,6 @@
 <script setup lang="ts">
 import { createBrowserClient } from '@api/BrowserClient'
 import { createConfigClient } from '@api/ConfigClient'
-import { createDebugClient } from '@api/DebugClient'
 import { createDeviceClient } from '@api/DeviceClient'
 import { createWindowClient } from '@api/WindowClient'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
@@ -281,15 +234,12 @@ const languageStore = useLanguageStore()
 const route = useRoute()
 const browserClient = createBrowserClient()
 const configClient = createConfigClient()
-const debugClient = createDebugClient()
 const deviceClient = createDeviceClient()
 const windowClient = createWindowClient()
 const appVersion = ref('')
 const upgrade = useUpgradeStore()
 const updateChannel = ref('stable')
 const isDisclaimerOpen = ref(false)
-const isCreatingMockChat = ref(false)
-const showMockUpdateControls = computed(() => import.meta.env.DEV)
 let cleanupCheckForUpdates: (() => void) | null = null
 
 const formattedUpdateVersion = computed(() => {
@@ -348,52 +298,6 @@ const handlePrimaryAction = async () => {
 
 const handleManualDownload = async (type: 'github' | 'official') => {
   await upgrade.handleUpdate(type)
-}
-
-const handleMockDownloadedUpdate = async () => {
-  const status = await upgrade.mockDownloadedUpdate()
-  if (status === 'error' && upgrade.updateError) {
-    showUpdateErrorToast(upgrade.updateError)
-  }
-}
-
-const handleClearMockUpdate = async () => {
-  const status = await upgrade.clearMockUpdate()
-  if (status === 'error' && upgrade.updateError) {
-    showUpdateErrorToast(upgrade.updateError)
-  }
-}
-
-const handleStartMockOnboarding = async () => {
-  await windowClient.startGuidedOnboarding()
-}
-
-const handleCreateMockChat = async () => {
-  if (isCreatingMockChat.value) {
-    return
-  }
-
-  isCreatingMockChat.value = true
-  try {
-    const result = await debugClient.createMockChatSession()
-    if (!result.created || !result.sessionId) {
-      showUpdateErrorToast(t('about.mockChatCreateUnavailable'))
-      return
-    }
-
-    toast({
-      title: t('about.mockChatCreated'),
-      description: t('about.mockChatCreatedDesc', {
-        title: result.title ?? result.sessionId,
-        count: result.messageCount
-      })
-    })
-  } catch (error) {
-    console.error('mockChatCreateError:', error)
-    showUpdateErrorToast(error instanceof Error ? error.message : t('about.mockChatCreateFailed'))
-  } finally {
-    isCreatingMockChat.value = false
-  }
 }
 
 const handleExternalCheckUpdate = async () => {

--- a/src/renderer/settings/components/DebugSettings.vue
+++ b/src/renderer/settings/components/DebugSettings.vue
@@ -1,0 +1,134 @@
+<template>
+  <SettingsPageShell
+    :title="t('routes.settings-debug')"
+    :description="t('settings.debug.description')"
+    :eyebrow="t('settings.controlCenter.groups.system')"
+    data-testid="settings-debug-page"
+  >
+    <section class="rounded-xl border border-border bg-card p-4">
+      <div class="flex flex-col gap-1">
+        <h2 class="text-base font-semibold text-foreground">
+          {{ t('settings.debug.guidance.title') }}
+        </h2>
+        <p class="text-sm text-muted-foreground">{{ t('settings.debug.guidance.description') }}</p>
+      </div>
+
+      <div class="mt-4 flex flex-wrap gap-2">
+        <Button variant="outline" @click="startGuidedOnboarding">
+          <Icon icon="lucide:route" class="mr-2 size-4" />
+          {{ t('about.mockOnboardingButton') }}
+        </Button>
+        <Button variant="outline" :disabled="isCreatingMockChat" @click="createMockChat">
+          <Spinner v-if="isCreatingMockChat" class="mr-2 size-4" />
+          <Icon v-else icon="lucide:database" class="mr-2 size-4" />
+          {{ isCreatingMockChat ? t('about.mockChatCreating') : t('about.mockChatButton') }}
+        </Button>
+        <Button v-if="!upgrade.isMockUpdate" variant="outline" @click="mockDownloadedUpdate">
+          <Icon icon="lucide:download" class="mr-2 size-4" />
+          {{ t('about.mockUpdateButton') }}
+        </Button>
+        <Button v-else variant="outline" @click="clearMockUpdate">
+          <Icon icon="lucide:rotate-ccw" class="mr-2 size-4" />
+          {{ t('about.clearMockUpdateButton') }}
+        </Button>
+      </div>
+    </section>
+  </SettingsPageShell>
+</template>
+
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Button } from '@shadcn/components/ui/button'
+import { Spinner } from '@shadcn/components/ui/spinner'
+import { useToast } from '@/components/use-toast'
+import { createDebugClient } from '@api/DebugClient'
+import { createUpgradeClient } from '@api/UpgradeClient'
+import { createWindowClient } from '@api/WindowClient'
+import { useUpgradeStore } from '@/stores/upgrade'
+import SettingsPageShell from './control-center/SettingsPageShell.vue'
+
+const { t } = useI18n()
+const { toast } = useToast()
+const debugClient = createDebugClient()
+const upgradeClient = createUpgradeClient()
+const windowClient = createWindowClient()
+const upgrade = useUpgradeStore()
+const isCreatingMockChat = ref(false)
+
+const showToastError = (description: string) => {
+  toast({
+    title: t('common.error.operationFailed'),
+    description,
+    variant: 'destructive'
+  })
+}
+
+const startGuidedOnboarding = async () => {
+  try {
+    const result = await windowClient.startGuidedOnboarding()
+    if (!result.started) {
+      showToastError(t('settings.debug.unavailableDescription'))
+    }
+  } catch (error) {
+    console.error('[DebugSettings] Failed to start guided onboarding', error)
+    showToastError(error instanceof Error ? error.message : t('settings.debug.guidance.failed'))
+  }
+}
+
+const createMockChat = async () => {
+  if (isCreatingMockChat.value) {
+    return
+  }
+
+  isCreatingMockChat.value = true
+  try {
+    const result = await debugClient.createMockChatSession()
+    if (!result.created || !result.sessionId) {
+      showToastError(t('about.mockChatCreateUnavailable'))
+      return
+    }
+    toast({
+      title: t('about.mockChatCreated'),
+      description: t('about.mockChatCreatedDesc', {
+        title: result.title ?? result.sessionId,
+        count: result.messageCount
+      })
+    })
+  } catch (error) {
+    console.error('[DebugSettings] Failed to create mock chat', error)
+    showToastError(error instanceof Error ? error.message : t('about.mockChatCreateFailed'))
+  } finally {
+    isCreatingMockChat.value = false
+  }
+}
+
+const mockDownloadedUpdate = async () => {
+  try {
+    const updated = await upgradeClient.mockDownloadedUpdate()
+    if (!updated) {
+      showToastError(t('settings.debug.unavailableDescription'))
+    }
+  } catch (error) {
+    console.error('[DebugSettings] Failed to create mock update', error)
+    showToastError(error instanceof Error ? error.message : t('settings.debug.guidance.failed'))
+  }
+}
+
+const clearMockUpdate = async () => {
+  try {
+    const updated = await upgradeClient.clearMockUpdate()
+    if (!updated) {
+      showToastError(t('settings.debug.unavailableDescription'))
+    }
+  } catch (error) {
+    console.error('[DebugSettings] Failed to clear mock update', error)
+    showToastError(error instanceof Error ? error.message : t('settings.debug.guidance.failed'))
+  }
+}
+
+onMounted(() => {
+  void upgrade.refreshStatus()
+})
+</script>

--- a/src/renderer/settings/main.ts
+++ b/src/renderer/settings/main.ts
@@ -14,7 +14,7 @@ import { settingsRouteComponents } from './settingsRouteComponents'
 
 const runtimePlatform = getRuntimePlatform()
 const runtimeArch = getRuntimeArch()
-const settingsRouteItems = getSettingsRouteItems(runtimePlatform, runtimeArch)
+const settingsRouteItems = getSettingsRouteItems(runtimePlatform, runtimeArch, import.meta.env.DEV)
 
 // Create router instance specifically for settings
 const router = createRouter({

--- a/src/renderer/settings/settingsRouteComponents.ts
+++ b/src/renderer/settings/settingsRouteComponents.ts
@@ -19,7 +19,8 @@ export const settingsRouteComponents = {
   'settings-knowledge-base': () => import('./components/KnowledgeBaseSettings.vue'),
   'settings-database': () => import('./components/DataSettings.vue'),
   'settings-shortcut': () => import('./components/ShortcutSettings.vue'),
-  'settings-about': () => import('./components/AboutUsSettings.vue')
+  'settings-about': () => import('./components/AboutUsSettings.vue'),
+  'settings-debug': () => import('./components/DebugSettings.vue')
 } as const
 
 export function preloadSettingsRoute(routeName: string): Promise<unknown> | null {

--- a/src/renderer/src/i18n/da-DK/routes.json
+++ b/src/renderer/src/i18n/da-DK/routes.json
@@ -24,5 +24,6 @@
   "settings-plugins": "Plugins",
   "settings-overview": "Indstillingsoversigt",
   "settings-memory": "Hukommelse",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/da-DK/settings.json
+++ b/src/renderer/src/i18n/da-DK/settings.json
@@ -1861,7 +1861,10 @@
       "sourceError": "Kunne ikke indlæse Agent-kilder",
       "emptySources": "Ingen importkilder",
       "emptySourcesDescription": "Der blev ikke fundet andre Agenter med tilgængelige Skills.",
-      "sourceKind": { "internal": "DeepChat", "external": "Ekstern" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "Ekstern"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills der skal importeres",
       "selectedCount": "{count} valgt",
@@ -1871,8 +1874,16 @@
       "previewError": "Kunne ikke forhåndsvise Skills",
       "emptyPreview": "Ingen tilgængelige Skills",
       "emptyPreviewDescription": "Denne Agent har ingen Skills, der kan importeres.",
-      "status": { "ready": "Klar", "conflict": "Konflikt", "unavailable": "Utilgængelig" },
-      "strategy": { "skip": "Spring over", "rename": "Omdøb", "overwrite": "Overskriv" },
+      "status": {
+        "ready": "Klar",
+        "conflict": "Konflikt",
+        "unavailable": "Utilgængelig"
+      },
+      "strategy": {
+        "skip": "Spring over",
+        "rename": "Omdøb",
+        "overwrite": "Overskriv"
+      },
       "renameTarget": "Importeres som {name}",
       "executeError": "Kunne ikke importere Skills",
       "importing": "Importerer...",
@@ -3173,5 +3184,23 @@
     "scopeGlobalPlugins": "Denne side er app-global: installation, aktivering og processtatus for officielle plugins deles af alle DeepChat-agenter.",
     "scopeCurrentAgent": "Denne side er agentpolitik: ændringer påvirker kun Skills/MCP-tilgængelighed for “{agent}”, ikke globale installationer.",
     "currentAgentFallback": "aktuel agent"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/de-DE/routes.json
+++ b/src/renderer/src/i18n/de-DE/routes.json
@@ -24,5 +24,6 @@
   "settings-overview": "Einstellungsübersicht",
   "settings-scheduled-tasks": "Geplante Aufgaben",
   "settings-memory": "Gedächtnis",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/de-DE/settings.json
+++ b/src/renderer/src/i18n/de-DE/settings.json
@@ -2229,7 +2229,10 @@
       "sourceError": "Agent-Quellen konnten nicht geladen werden",
       "emptySources": "Keine Importquellen",
       "emptySourcesDescription": "Kein anderer Agent mit verfügbaren Skills gefunden.",
-      "sourceKind": { "internal": "DeepChat", "external": "Extern" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "Extern"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Zu importierende Skills",
       "selectedCount": "{count} ausgewählt",
@@ -2239,8 +2242,16 @@
       "previewError": "Skills konnten nicht angezeigt werden",
       "emptyPreview": "Keine Skills verfügbar",
       "emptyPreviewDescription": "Dieser Agent hat keine importierbaren Skills.",
-      "status": { "ready": "Bereit", "conflict": "Konflikt", "unavailable": "Nicht verfügbar" },
-      "strategy": { "skip": "Überspringen", "rename": "Umbenennen", "overwrite": "Überschreiben" },
+      "status": {
+        "ready": "Bereit",
+        "conflict": "Konflikt",
+        "unavailable": "Nicht verfügbar"
+      },
+      "strategy": {
+        "skip": "Überspringen",
+        "rename": "Umbenennen",
+        "overwrite": "Überschreiben"
+      },
       "renameTarget": "Wird als {name} importiert",
       "executeError": "Skills konnten nicht importiert werden",
       "importing": "Wird importiert...",
@@ -3164,5 +3175,23 @@
     "scopeGlobalPlugins": "Diese Seite ist app-weit: Installation, Aktivierung und Prozessstatus offizieller Plugins gelten für alle DeepChat-Agenten.",
     "scopeCurrentAgent": "Diese Seite ist Agent-Richtlinie: Änderungen betreffen nur die Skills/MCP-Verfügbarkeit von „{agent}“, nicht die globalen Installationen.",
     "currentAgentFallback": "aktueller Agent"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/en-US/routes.json
+++ b/src/renderer/src/i18n/en-US/routes.json
@@ -24,5 +24,6 @@
   "settings-remote": "Remote",
   "settings-plugins": "Plugins",
   "settings-overview": "Settings Overview",
-  "settings-memory": "Memory"
+  "settings-memory": "Memory",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/en-US/settings.json
+++ b/src/renderer/src/i18n/en-US/settings.json
@@ -2284,7 +2284,10 @@
       "sourceError": "Failed to load Agent sources",
       "emptySources": "No import sources",
       "emptySourcesDescription": "No other Agent with available Skills was found.",
-      "sourceKind": { "internal": "DeepChat", "external": "External" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "External"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills to import",
       "selectedCount": "{count} selected",
@@ -2294,8 +2297,16 @@
       "previewError": "Failed to preview Skills",
       "emptyPreview": "No Skills available",
       "emptyPreviewDescription": "This Agent has no Skills that can be imported.",
-      "status": { "ready": "Ready", "conflict": "Conflict", "unavailable": "Unavailable" },
-      "strategy": { "skip": "Skip", "rename": "Rename", "overwrite": "Overwrite" },
+      "status": {
+        "ready": "Ready",
+        "conflict": "Conflict",
+        "unavailable": "Unavailable"
+      },
+      "strategy": {
+        "skip": "Skip",
+        "rename": "Rename",
+        "overwrite": "Overwrite"
+      },
       "renameTarget": "Will be imported as {name}",
       "executeError": "Failed to import Skills",
       "importing": "Importing...",
@@ -3164,6 +3175,24 @@
         "memory-persona-anchor": "Updated persona anchor",
         "memory-reindex": "Reindexed memory"
       }
+    }
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
     }
   }
 }

--- a/src/renderer/src/i18n/es-ES/routes.json
+++ b/src/renderer/src/i18n/es-ES/routes.json
@@ -24,5 +24,6 @@
   "settings-overview": "Descripción general de la configuración",
   "settings-scheduled-tasks": "Tareas programadas",
   "settings-memory": "Memoria",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/es-ES/settings.json
+++ b/src/renderer/src/i18n/es-ES/settings.json
@@ -2229,7 +2229,10 @@
       "sourceError": "No se pudieron cargar los Agents de origen",
       "emptySources": "No hay orígenes de importación",
       "emptySourcesDescription": "No se encontró otro Agent con Skills disponibles.",
-      "sourceKind": { "internal": "DeepChat", "external": "Externo" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "Externo"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills para importar",
       "selectedCount": "{count} seleccionados",
@@ -2239,8 +2242,16 @@
       "previewError": "No se pudieron previsualizar los Skills",
       "emptyPreview": "No hay Skills disponibles",
       "emptyPreviewDescription": "Este Agent no tiene Skills que se puedan importar.",
-      "status": { "ready": "Listo", "conflict": "Conflicto", "unavailable": "No disponible" },
-      "strategy": { "skip": "Omitir", "rename": "Renombrar", "overwrite": "Sobrescribir" },
+      "status": {
+        "ready": "Listo",
+        "conflict": "Conflicto",
+        "unavailable": "No disponible"
+      },
+      "strategy": {
+        "skip": "Omitir",
+        "rename": "Renombrar",
+        "overwrite": "Sobrescribir"
+      },
       "renameTarget": "Se importará como {name}",
       "executeError": "No se pudieron importar los Skills",
       "importing": "Importando...",
@@ -3164,5 +3175,23 @@
     "scopeGlobalPlugins": "Esta página es global de la app: la instalación, habilitación y estado de proceso de los plugins oficiales se comparten entre todos los agentes DeepChat.",
     "scopeCurrentAgent": "Esta página es política del agente: los cambios solo afectan la disponibilidad de Skills/MCP de «{agent}», no las instalaciones globales.",
     "currentAgentFallback": "agente actual"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/fa-IR/routes.json
+++ b/src/renderer/src/i18n/fa-IR/routes.json
@@ -24,5 +24,6 @@
   "settings-plugins": "افزونه‌ها",
   "settings-overview": "نمای کلی تنظیمات",
   "settings-memory": "حافظه",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/fa-IR/settings.json
+++ b/src/renderer/src/i18n/fa-IR/settings.json
@@ -1928,7 +1928,10 @@
       "sourceError": "بارگذاری مبدأهای Agent ناموفق بود",
       "emptySources": "مبدأی برای وارد کردن وجود ندارد",
       "emptySourcesDescription": "Agent دیگری با Skillهای قابل استفاده پیدا نشد.",
-      "sourceKind": { "internal": "DeepChat", "external": "خارجی" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "خارجی"
+      },
       "skillCount": "{count} Skill",
       "previewTitle": "Skillهای قابل وارد کردن",
       "selectedCount": "{count} انتخاب شده",
@@ -1938,8 +1941,16 @@
       "previewError": "پیش‌نمایش Skillها ناموفق بود",
       "emptyPreview": "Skill قابل استفاده‌ای وجود ندارد",
       "emptyPreviewDescription": "این Agent هیچ Skill قابل وارد کردنی ندارد.",
-      "status": { "ready": "آماده", "conflict": "تعارض", "unavailable": "در دسترس نیست" },
-      "strategy": { "skip": "رد کردن", "rename": "تغییر نام", "overwrite": "جایگزینی" },
+      "status": {
+        "ready": "آماده",
+        "conflict": "تعارض",
+        "unavailable": "در دسترس نیست"
+      },
+      "strategy": {
+        "skip": "رد کردن",
+        "rename": "تغییر نام",
+        "overwrite": "جایگزینی"
+      },
       "renameTarget": "با نام {name} وارد می‌شود",
       "executeError": "وارد کردن Skillها ناموفق بود",
       "importing": "در حال وارد کردن...",
@@ -3173,5 +3184,23 @@
     "scopeGlobalPlugins": "این صفحه سراسری برنامه است: نصب، فعال‌سازی و وضعیت فرایند افزونه‌های رسمی بین همه عامل‌های DeepChat مشترک است.",
     "scopeCurrentAgent": "این صفحه سیاست عامل است: تغییرات فقط روی در دسترس بودن Skills/MCP برای «{agent}» اثر می‌گذارد، نه روی نصب‌های سراسری.",
     "currentAgentFallback": "عامل فعلی"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/fr-FR/routes.json
+++ b/src/renderer/src/i18n/fr-FR/routes.json
@@ -24,5 +24,6 @@
   "settings-plugins": "Plugins",
   "settings-overview": "Aperçu des paramètres",
   "settings-memory": "Mémoire",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/fr-FR/settings.json
+++ b/src/renderer/src/i18n/fr-FR/settings.json
@@ -1928,7 +1928,10 @@
       "sourceError": "Impossible de charger les Agents sources",
       "emptySources": "Aucune source d’import",
       "emptySourcesDescription": "Aucun autre Agent avec des Skills disponibles n’a été trouvé.",
-      "sourceKind": { "internal": "DeepChat", "external": "Externe" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "Externe"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills à importer",
       "selectedCount": "{count} sélectionnés",
@@ -1938,8 +1941,16 @@
       "previewError": "Impossible de prévisualiser les Skills",
       "emptyPreview": "Aucun Skill disponible",
       "emptyPreviewDescription": "Cet Agent ne possède aucun Skill importable.",
-      "status": { "ready": "Prêt", "conflict": "Conflit", "unavailable": "Indisponible" },
-      "strategy": { "skip": "Ignorer", "rename": "Renommer", "overwrite": "Remplacer" },
+      "status": {
+        "ready": "Prêt",
+        "conflict": "Conflit",
+        "unavailable": "Indisponible"
+      },
+      "strategy": {
+        "skip": "Ignorer",
+        "rename": "Renommer",
+        "overwrite": "Remplacer"
+      },
       "renameTarget": "Sera importé sous le nom {name}",
       "executeError": "Impossible d’importer les Skills",
       "importing": "Import en cours...",
@@ -3173,5 +3184,23 @@
     "scopeGlobalPlugins": "Cette page est globale à l’application : l’installation, l’activation et l’état des processus des plugins officiels sont partagés par tous les agents DeepChat.",
     "scopeCurrentAgent": "Cette page est une politique d’agent : les modifications n’affectent que la disponibilité Skills/MCP de « {agent} », pas les installations globales.",
     "currentAgentFallback": "agent actuel"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/he-IL/routes.json
+++ b/src/renderer/src/i18n/he-IL/routes.json
@@ -24,5 +24,6 @@
   "settings-plugins": "Plugins",
   "settings-overview": "סקירת ההגדרות",
   "settings-memory": "זיכרון",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/he-IL/settings.json
+++ b/src/renderer/src/i18n/he-IL/settings.json
@@ -1928,7 +1928,10 @@
       "sourceError": "טעינת מקורות ה-Agent נכשלה",
       "emptySources": "אין מקורות לייבוא",
       "emptySourcesDescription": "לא נמצא Agent אחר עם Skills זמינים.",
-      "sourceKind": { "internal": "DeepChat", "external": "חיצוני" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "חיצוני"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills לייבוא",
       "selectedCount": "{count} נבחרו",
@@ -1938,8 +1941,16 @@
       "previewError": "תצוגה מקדימה של Skills נכשלה",
       "emptyPreview": "אין Skills זמינים",
       "emptyPreviewDescription": "ל-Agent הזה אין Skills שניתן לייבא.",
-      "status": { "ready": "מוכן", "conflict": "התנגשות", "unavailable": "לא זמין" },
-      "strategy": { "skip": "דלג", "rename": "שנה שם", "overwrite": "החלף" },
+      "status": {
+        "ready": "מוכן",
+        "conflict": "התנגשות",
+        "unavailable": "לא זמין"
+      },
+      "strategy": {
+        "skip": "דלג",
+        "rename": "שנה שם",
+        "overwrite": "החלף"
+      },
       "renameTarget": "ייובא בשם {name}",
       "executeError": "ייבוא Skills נכשל",
       "importing": "מייבא...",
@@ -3173,5 +3184,23 @@
     "scopeGlobalPlugins": "עמוד זה הוא גלובלי לאפליקציה: התקנה, הפעלה ומצב תהליך של תוספים רשמיים משותפים לכל סוכני DeepChat.",
     "scopeCurrentAgent": "עמוד זה הוא מדיניות סוכן: השינויים משפיעים רק על זמינות Skills/MCP של „{agent}”, לא על התקנות גלובליות.",
     "currentAgentFallback": "הסוכן הנוכחי"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/id-ID/routes.json
+++ b/src/renderer/src/i18n/id-ID/routes.json
@@ -24,5 +24,6 @@
   "settings-overview": "Ikhtisar pengaturan",
   "settings-scheduled-tasks": "Tugas terjadwal",
   "settings-memory": "Memori",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/id-ID/settings.json
+++ b/src/renderer/src/i18n/id-ID/settings.json
@@ -2229,7 +2229,10 @@
       "sourceError": "Gagal memuat Agent sumber",
       "emptySources": "Tidak ada sumber impor",
       "emptySourcesDescription": "Tidak ditemukan Agent lain dengan Skills yang tersedia.",
-      "sourceKind": { "internal": "DeepChat", "external": "Eksternal" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "Eksternal"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills yang akan diimpor",
       "selectedCount": "{count} dipilih",
@@ -2239,8 +2242,16 @@
       "previewError": "Gagal menampilkan pratinjau Skills",
       "emptyPreview": "Tidak ada Skills tersedia",
       "emptyPreviewDescription": "Agent ini tidak memiliki Skills yang dapat diimpor.",
-      "status": { "ready": "Siap", "conflict": "Konflik", "unavailable": "Tidak tersedia" },
-      "strategy": { "skip": "Lewati", "rename": "Ganti nama", "overwrite": "Timpa" },
+      "status": {
+        "ready": "Siap",
+        "conflict": "Konflik",
+        "unavailable": "Tidak tersedia"
+      },
+      "strategy": {
+        "skip": "Lewati",
+        "rename": "Ganti nama",
+        "overwrite": "Timpa"
+      },
       "renameTarget": "Akan diimpor sebagai {name}",
       "executeError": "Gagal mengimpor Skills",
       "importing": "Mengimpor...",
@@ -3164,5 +3175,23 @@
     "scopeGlobalPlugins": "Halaman ini bersifat global aplikasi: instalasi, pengaktifan, dan status proses plugin resmi dibagikan ke semua agen DeepChat.",
     "scopeCurrentAgent": "Halaman ini adalah kebijakan agen: perubahan hanya memengaruhi ketersediaan Skills/MCP untuk “{agent}”, bukan instalasi global.",
     "currentAgentFallback": "agen saat ini"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/it-IT/routes.json
+++ b/src/renderer/src/i18n/it-IT/routes.json
@@ -24,5 +24,6 @@
   "settings-overview": "Panoramica impostazioni",
   "settings-scheduled-tasks": "Attività pianificate",
   "settings-memory": "Memoria",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/it-IT/settings.json
+++ b/src/renderer/src/i18n/it-IT/settings.json
@@ -2229,7 +2229,10 @@
       "sourceError": "Impossibile caricare gli Agents di origine",
       "emptySources": "Nessuna origine di importazione",
       "emptySourcesDescription": "Non è stato trovato nessun altro Agent con Skills disponibili.",
-      "sourceKind": { "internal": "DeepChat", "external": "Esterno" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "Esterno"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills da importare",
       "selectedCount": "{count} selezionati",
@@ -2239,8 +2242,16 @@
       "previewError": "Impossibile visualizzare l’anteprima degli Skills",
       "emptyPreview": "Nessuno Skill disponibile",
       "emptyPreviewDescription": "Questo Agent non ha Skills importabili.",
-      "status": { "ready": "Pronto", "conflict": "Conflitto", "unavailable": "Non disponibile" },
-      "strategy": { "skip": "Ignora", "rename": "Rinomina", "overwrite": "Sovrascrivi" },
+      "status": {
+        "ready": "Pronto",
+        "conflict": "Conflitto",
+        "unavailable": "Non disponibile"
+      },
+      "strategy": {
+        "skip": "Ignora",
+        "rename": "Rinomina",
+        "overwrite": "Sovrascrivi"
+      },
       "renameTarget": "Verrà importato come {name}",
       "executeError": "Impossibile importare gli Skills",
       "importing": "Importazione...",
@@ -3164,5 +3175,23 @@
     "scopeGlobalPlugins": "Questa pagina è globale all’app: installazione, abilitazione e stato dei processi dei plugin ufficiali sono condivisi da tutti gli agenti DeepChat.",
     "scopeCurrentAgent": "Questa pagina è policy dell’agente: le modifiche riguardano solo la disponibilità Skills/MCP di «{agent}», non le installazioni globali.",
     "currentAgentFallback": "agente corrente"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/ja-JP/routes.json
+++ b/src/renderer/src/i18n/ja-JP/routes.json
@@ -24,5 +24,6 @@
   "settings-plugins": "プラグイン",
   "settings-overview": "設定の概要",
   "settings-memory": "メモリ",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "デバッグ"
 }

--- a/src/renderer/src/i18n/ja-JP/settings.json
+++ b/src/renderer/src/i18n/ja-JP/settings.json
@@ -1928,7 +1928,10 @@
       "sourceError": "Agent の読み込みに失敗しました",
       "emptySources": "インポート元がありません",
       "emptySourcesDescription": "利用可能な Skills を持つ他の Agent が見つかりませんでした。",
-      "sourceKind": { "internal": "DeepChat", "external": "外部" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "外部"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "インポートする Skills",
       "selectedCount": "{count} 件選択中",
@@ -1938,8 +1941,16 @@
       "previewError": "Skills のプレビューに失敗しました",
       "emptyPreview": "利用可能な Skills がありません",
       "emptyPreviewDescription": "この Agent にはインポート可能な Skills がありません。",
-      "status": { "ready": "準備完了", "conflict": "競合", "unavailable": "利用不可" },
-      "strategy": { "skip": "スキップ", "rename": "名前を変更", "overwrite": "上書き" },
+      "status": {
+        "ready": "準備完了",
+        "conflict": "競合",
+        "unavailable": "利用不可"
+      },
+      "strategy": {
+        "skip": "スキップ",
+        "rename": "名前を変更",
+        "overwrite": "上書き"
+      },
       "renameTarget": "{name} としてインポートされます",
       "executeError": "Skills のインポートに失敗しました",
       "importing": "インポート中...",
@@ -3173,5 +3184,23 @@
     "scopeGlobalPlugins": "このページはアプリ全体設定です。公式プラグインのインストール・有効化・プロセス状態は、すべての DeepChat エージェントで共有されます。",
     "scopeCurrentAgent": "このページはエージェント方針です。変更は「{agent}」の Skills/MCP 利用可否にのみ影響し、グローバルなインストールには影響しません。",
     "currentAgentFallback": "現在のエージェント"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/ko-KR/routes.json
+++ b/src/renderer/src/i18n/ko-KR/routes.json
@@ -24,5 +24,6 @@
   "settings-plugins": "Plugins",
   "settings-overview": "설정 개요",
   "settings-memory": "메모리",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "디버그"
 }

--- a/src/renderer/src/i18n/ko-KR/settings.json
+++ b/src/renderer/src/i18n/ko-KR/settings.json
@@ -1926,7 +1926,10 @@
       "sourceError": "Failed to load Agent sources",
       "emptySources": "No import sources",
       "emptySourcesDescription": "No other Agent with available Skills was found.",
-      "sourceKind": { "internal": "DeepChat", "external": "External" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "External"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills to import",
       "selectedCount": "{count} selected",
@@ -1936,8 +1939,16 @@
       "previewError": "Failed to preview Skills",
       "emptyPreview": "No Skills available",
       "emptyPreviewDescription": "This Agent has no Skills that can be imported.",
-      "status": { "ready": "Ready", "conflict": "Conflict", "unavailable": "Unavailable" },
-      "strategy": { "skip": "Skip", "rename": "Rename", "overwrite": "Overwrite" },
+      "status": {
+        "ready": "Ready",
+        "conflict": "Conflict",
+        "unavailable": "Unavailable"
+      },
+      "strategy": {
+        "skip": "Skip",
+        "rename": "Rename",
+        "overwrite": "Overwrite"
+      },
       "renameTarget": "Will be imported as {name}",
       "executeError": "Failed to import Skills",
       "importing": "Importing...",
@@ -3173,5 +3184,23 @@
     "scopeGlobalPlugins": "이 페이지는 앱 전역 설정입니다. 공식 플러그인의 설치·활성화·프로세스 상태는 모든 DeepChat 에이전트에서 공유됩니다.",
     "scopeCurrentAgent": "이 페이지는 에이전트 정책입니다. 변경 사항은 “{agent}”의 Skills/MCP 사용 가능 여부에만 영향을 주며, 전역 설치에는 영향을 주지 않습니다.",
     "currentAgentFallback": "현재 에이전트"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/ms-MY/routes.json
+++ b/src/renderer/src/i18n/ms-MY/routes.json
@@ -24,5 +24,6 @@
   "settings-overview": "Gambaran keseluruhan tetapan",
   "settings-scheduled-tasks": "Tugasan berjadual",
   "settings-memory": "Memori",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/ms-MY/settings.json
+++ b/src/renderer/src/i18n/ms-MY/settings.json
@@ -2229,7 +2229,10 @@
       "sourceError": "Failed to load Agent sources",
       "emptySources": "No import sources",
       "emptySourcesDescription": "No other Agent with available Skills was found.",
-      "sourceKind": { "internal": "DeepChat", "external": "External" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "External"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills to import",
       "selectedCount": "{count} selected",
@@ -2239,8 +2242,16 @@
       "previewError": "Failed to preview Skills",
       "emptyPreview": "No Skills available",
       "emptyPreviewDescription": "This Agent has no Skills that can be imported.",
-      "status": { "ready": "Ready", "conflict": "Conflict", "unavailable": "Unavailable" },
-      "strategy": { "skip": "Skip", "rename": "Rename", "overwrite": "Overwrite" },
+      "status": {
+        "ready": "Ready",
+        "conflict": "Conflict",
+        "unavailable": "Unavailable"
+      },
+      "strategy": {
+        "skip": "Skip",
+        "rename": "Rename",
+        "overwrite": "Overwrite"
+      },
       "renameTarget": "Will be imported as {name}",
       "executeError": "Failed to import Skills",
       "importing": "Importing...",
@@ -3164,5 +3175,23 @@
     "scopeGlobalPlugins": "Halaman ini bersifat global aplikasi: pemasangan, pengaktifan dan status proses plugin rasmi dikongsi oleh semua ejen DeepChat.",
     "scopeCurrentAgent": "Halaman ini ialah polisi ejen: perubahan hanya menjejaskan ketersediaan Skills/MCP untuk “{agent}”, bukan pemasangan global.",
     "currentAgentFallback": "ejen semasa"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/pl-PL/routes.json
+++ b/src/renderer/src/i18n/pl-PL/routes.json
@@ -24,5 +24,6 @@
   "settings-overview": "Przegląd ustawień",
   "settings-scheduled-tasks": "Zaplanowane zadania",
   "settings-memory": "Pamięć",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/pl-PL/settings.json
+++ b/src/renderer/src/i18n/pl-PL/settings.json
@@ -2229,7 +2229,10 @@
       "sourceError": "Failed to load Agent sources",
       "emptySources": "No import sources",
       "emptySourcesDescription": "No other Agent with available Skills was found.",
-      "sourceKind": { "internal": "DeepChat", "external": "External" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "External"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills to import",
       "selectedCount": "{count} selected",
@@ -2239,8 +2242,16 @@
       "previewError": "Failed to preview Skills",
       "emptyPreview": "No Skills available",
       "emptyPreviewDescription": "This Agent has no Skills that can be imported.",
-      "status": { "ready": "Ready", "conflict": "Conflict", "unavailable": "Unavailable" },
-      "strategy": { "skip": "Skip", "rename": "Rename", "overwrite": "Overwrite" },
+      "status": {
+        "ready": "Ready",
+        "conflict": "Conflict",
+        "unavailable": "Unavailable"
+      },
+      "strategy": {
+        "skip": "Skip",
+        "rename": "Rename",
+        "overwrite": "Overwrite"
+      },
       "renameTarget": "Will be imported as {name}",
       "executeError": "Failed to import Skills",
       "importing": "Importing...",
@@ -3164,5 +3175,23 @@
     "scopeGlobalPlugins": "Ta strona jest globalna dla aplikacji: instalacja, włączanie i stan procesów oficjalnych wtyczek są wspólne dla wszystkich agentów DeepChat.",
     "scopeCurrentAgent": "Ta strona to polityka agenta: zmiany dotyczą tylko dostępności Skills/MCP dla „{agent}”, a nie globalnych instalacji.",
     "currentAgentFallback": "bieżący agent"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/pt-BR/routes.json
+++ b/src/renderer/src/i18n/pt-BR/routes.json
@@ -24,5 +24,6 @@
   "settings-plugins": "Plugins",
   "settings-overview": "Visão geral das configurações",
   "settings-memory": "Memória",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/pt-BR/settings.json
+++ b/src/renderer/src/i18n/pt-BR/settings.json
@@ -1928,7 +1928,10 @@
       "sourceError": "Failed to load Agent sources",
       "emptySources": "No import sources",
       "emptySourcesDescription": "No other Agent with available Skills was found.",
-      "sourceKind": { "internal": "DeepChat", "external": "External" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "External"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills to import",
       "selectedCount": "{count} selected",
@@ -1938,8 +1941,16 @@
       "previewError": "Failed to preview Skills",
       "emptyPreview": "No Skills available",
       "emptyPreviewDescription": "This Agent has no Skills that can be imported.",
-      "status": { "ready": "Ready", "conflict": "Conflict", "unavailable": "Unavailable" },
-      "strategy": { "skip": "Skip", "rename": "Rename", "overwrite": "Overwrite" },
+      "status": {
+        "ready": "Ready",
+        "conflict": "Conflict",
+        "unavailable": "Unavailable"
+      },
+      "strategy": {
+        "skip": "Skip",
+        "rename": "Rename",
+        "overwrite": "Overwrite"
+      },
       "renameTarget": "Will be imported as {name}",
       "executeError": "Failed to import Skills",
       "importing": "Importing...",
@@ -3173,5 +3184,23 @@
     "scopeGlobalPlugins": "Esta página é global do app: instalação, ativação e estado de processo dos plugins oficiais são compartilhados por todos os agentes DeepChat.",
     "scopeCurrentAgent": "Esta página é política do agente: as alterações afetam apenas a disponibilidade de Skills/MCP de “{agent}”, não as instalações globais.",
     "currentAgentFallback": "agente atual"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/ru-RU/routes.json
+++ b/src/renderer/src/i18n/ru-RU/routes.json
@@ -24,5 +24,6 @@
   "settings-plugins": "Plugins",
   "settings-overview": "Обзор настроек",
   "settings-memory": "Память",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/ru-RU/settings.json
+++ b/src/renderer/src/i18n/ru-RU/settings.json
@@ -1928,7 +1928,10 @@
       "sourceError": "Failed to load Agent sources",
       "emptySources": "No import sources",
       "emptySourcesDescription": "No other Agent with available Skills was found.",
-      "sourceKind": { "internal": "DeepChat", "external": "External" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "External"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills to import",
       "selectedCount": "{count} selected",
@@ -1938,8 +1941,16 @@
       "previewError": "Failed to preview Skills",
       "emptyPreview": "No Skills available",
       "emptyPreviewDescription": "This Agent has no Skills that can be imported.",
-      "status": { "ready": "Ready", "conflict": "Conflict", "unavailable": "Unavailable" },
-      "strategy": { "skip": "Skip", "rename": "Rename", "overwrite": "Overwrite" },
+      "status": {
+        "ready": "Ready",
+        "conflict": "Conflict",
+        "unavailable": "Unavailable"
+      },
+      "strategy": {
+        "skip": "Skip",
+        "rename": "Rename",
+        "overwrite": "Overwrite"
+      },
       "renameTarget": "Will be imported as {name}",
       "executeError": "Failed to import Skills",
       "importing": "Importing...",
@@ -3173,5 +3184,23 @@
     "scopeGlobalPlugins": "Эта страница глобальна для приложения: установка, включение и состояние процессов официальных плагинов общие для всех агентов DeepChat.",
     "scopeCurrentAgent": "Эта страница — политика агента: изменения влияют только на доступность Skills/MCP у «{agent}», а не на глобальные установки.",
     "currentAgentFallback": "текущий агент"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/tr-TR/routes.json
+++ b/src/renderer/src/i18n/tr-TR/routes.json
@@ -24,5 +24,6 @@
   "settings-overview": "Ayarlara Genel Bakış",
   "settings-scheduled-tasks": "Zamanlanmış görevler",
   "settings-memory": "Bellek",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/tr-TR/settings.json
+++ b/src/renderer/src/i18n/tr-TR/settings.json
@@ -2229,7 +2229,10 @@
       "sourceError": "Agent kaynakları yüklenemedi",
       "emptySources": "İçe aktarma kaynağı yok",
       "emptySourcesDescription": "Kullanılabilir Skills öğelerine sahip başka bir Agent bulunamadı.",
-      "sourceKind": { "internal": "DeepChat", "external": "Harici" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "Harici"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "İçe aktarılacak Skills",
       "selectedCount": "{count} seçildi",
@@ -2239,8 +2242,16 @@
       "previewError": "Skills önizlemesi yüklenemedi",
       "emptyPreview": "Kullanılabilir Skills yok",
       "emptyPreviewDescription": "Bu Agent’ın içe aktarılabilir Skills öğesi yok.",
-      "status": { "ready": "Hazır", "conflict": "Çakışma", "unavailable": "Kullanılamıyor" },
-      "strategy": { "skip": "Atla", "rename": "Yeniden adlandır", "overwrite": "Üzerine yaz" },
+      "status": {
+        "ready": "Hazır",
+        "conflict": "Çakışma",
+        "unavailable": "Kullanılamıyor"
+      },
+      "strategy": {
+        "skip": "Atla",
+        "rename": "Yeniden adlandır",
+        "overwrite": "Üzerine yaz"
+      },
       "renameTarget": "{name} olarak içe aktarılacak",
       "executeError": "Skills içe aktarılamadı",
       "importing": "İçe aktarılıyor...",
@@ -3164,5 +3175,23 @@
     "scopeGlobalPlugins": "Bu sayfa uygulama genelindedir: resmi eklentilerin kurulumu, etkinleştirilmesi ve süreç durumu tüm DeepChat ajanları arasında paylaşılır.",
     "scopeCurrentAgent": "Bu sayfa ajan politikasıdır: değişiklikler yalnızca “{agent}” için Skills/MCP kullanılabilirliğini etkiler, global kurulumları etkilemez.",
     "currentAgentFallback": "geçerli ajan"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/vi-VN/routes.json
+++ b/src/renderer/src/i18n/vi-VN/routes.json
@@ -24,5 +24,6 @@
   "settings-overview": "Tổng quan về cài đặt",
   "settings-scheduled-tasks": "Tác vụ đã lên lịch",
   "settings-memory": "Bộ nhớ",
-  "plugins": "Plugins"
+  "plugins": "Plugins",
+  "settings-debug": "Debug"
 }

--- a/src/renderer/src/i18n/vi-VN/settings.json
+++ b/src/renderer/src/i18n/vi-VN/settings.json
@@ -2229,7 +2229,10 @@
       "sourceError": "Không thể tải các Agent nguồn",
       "emptySources": "Không có nguồn nhập",
       "emptySourcesDescription": "Không tìm thấy Agent nào khác có Skills khả dụng.",
-      "sourceKind": { "internal": "DeepChat", "external": "Bên ngoài" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "Bên ngoài"
+      },
       "skillCount": "{count} Skills",
       "previewTitle": "Skills sẽ nhập",
       "selectedCount": "Đã chọn {count}",
@@ -2239,8 +2242,16 @@
       "previewError": "Không thể xem trước Skills",
       "emptyPreview": "Không có Skills khả dụng",
       "emptyPreviewDescription": "Agent này không có Skills có thể nhập.",
-      "status": { "ready": "Sẵn sàng", "conflict": "Xung đột", "unavailable": "Không khả dụng" },
-      "strategy": { "skip": "Bỏ qua", "rename": "Đổi tên", "overwrite": "Ghi đè" },
+      "status": {
+        "ready": "Sẵn sàng",
+        "conflict": "Xung đột",
+        "unavailable": "Không khả dụng"
+      },
+      "strategy": {
+        "skip": "Bỏ qua",
+        "rename": "Đổi tên",
+        "overwrite": "Ghi đè"
+      },
       "renameTarget": "Sẽ được nhập với tên {name}",
       "executeError": "Không thể nhập Skills",
       "importing": "Đang nhập...",
@@ -3164,5 +3175,23 @@
     "scopeGlobalPlugins": "Trang này mang tính toàn ứng dụng: cài đặt, bật/tắt và trạng thái tiến trình của plugin chính thức được chia sẻ cho mọi tác nhân DeepChat.",
     "scopeCurrentAgent": "Trang này là chính sách tác nhân: thay đổi chỉ ảnh hưởng đến khả dụng Skills/MCP của “{agent}”, không ảnh hưởng cài đặt toàn cục.",
     "currentAgentFallback": "tác nhân hiện tại"
+  },
+  "debug": {
+    "description": "Development-only tools for previewing mock states and guided flows.",
+    "unavailableTitle": "Debug tools unavailable",
+    "unavailableDescription": "This action is available only in development mode.",
+    "splash": {
+      "title": "Splash window",
+      "description": "Preview startup-window states without starting a real database unlock flow.",
+      "loading": "Preview loading",
+      "systemUnlock": "Preview system unlock",
+      "unlock": "Preview manual unlock",
+      "failed": "Unable to show the splash scenario."
+    },
+    "guidance": {
+      "title": "Guidance and data",
+      "description": "Create development-only onboarding, conversation, and update mocks.",
+      "failed": "Unable to start the debug guided flow."
+    }
   }
 }

--- a/src/renderer/src/i18n/zh-CN/routes.json
+++ b/src/renderer/src/i18n/zh-CN/routes.json
@@ -24,5 +24,6 @@
   "settings-remote": "远程",
   "settings-plugins": "插件",
   "settings-overview": "设置概览",
-  "settings-memory": "记忆"
+  "settings-memory": "记忆",
+  "settings-debug": "调试"
 }

--- a/src/renderer/src/i18n/zh-CN/settings.json
+++ b/src/renderer/src/i18n/zh-CN/settings.json
@@ -2283,7 +2283,10 @@
       "sourceError": "加载 Agent 来源失败",
       "emptySources": "没有可导入的来源",
       "emptySourcesDescription": "未找到其他包含可用 Skills 的 Agent。",
-      "sourceKind": { "internal": "DeepChat", "external": "外部" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "外部"
+      },
       "skillCount": "{count} 个 Skills",
       "previewTitle": "要导入的 Skills",
       "selectedCount": "已选择 {count} 个",
@@ -2293,8 +2296,16 @@
       "previewError": "预览 Skills 失败",
       "emptyPreview": "没有可用的 Skills",
       "emptyPreviewDescription": "此 Agent 没有可导入的 Skills。",
-      "status": { "ready": "可导入", "conflict": "冲突", "unavailable": "不可用" },
-      "strategy": { "skip": "跳过", "rename": "重命名", "overwrite": "覆盖" },
+      "status": {
+        "ready": "可导入",
+        "conflict": "冲突",
+        "unavailable": "不可用"
+      },
+      "strategy": {
+        "skip": "跳过",
+        "rename": "重命名",
+        "overwrite": "覆盖"
+      },
       "renameTarget": "将导入为 {name}",
       "executeError": "导入 Skills 失败",
       "importing": "正在导入...",
@@ -3163,6 +3174,24 @@
         "memory-persona-anchor": "更新人格锚点",
         "memory-reindex": "重建记忆索引"
       }
+    }
+  },
+  "debug": {
+    "description": "仅在开发模式下显示的场景与引导调试工具。",
+    "unavailableTitle": "调试工具不可用",
+    "unavailableDescription": "此操作仅在开发模式下可用。",
+    "splash": {
+      "title": "启动窗口",
+      "description": "在不触发真实数据库解锁流程的情况下预览启动窗口状态。",
+      "loading": "预览加载中",
+      "systemUnlock": "预览系统解锁",
+      "unlock": "预览手动解锁",
+      "failed": "无法显示启动窗口场景。"
+    },
+    "guidance": {
+      "title": "引导与数据",
+      "description": "创建仅供开发环境使用的引导、会话和更新模拟。",
+      "failed": "无法启动调试引导。"
     }
   }
 }

--- a/src/renderer/src/i18n/zh-HK/routes.json
+++ b/src/renderer/src/i18n/zh-HK/routes.json
@@ -24,5 +24,6 @@
   "settings-plugins": "插件",
   "settings-overview": "設定概覽",
   "settings-memory": "記憶",
-  "plugins": "插件"
+  "plugins": "插件",
+  "settings-debug": "偵錯"
 }

--- a/src/renderer/src/i18n/zh-HK/settings.json
+++ b/src/renderer/src/i18n/zh-HK/settings.json
@@ -1928,7 +1928,10 @@
       "sourceError": "載入 Agent 來源失敗",
       "emptySources": "沒有可匯入的來源",
       "emptySourcesDescription": "找不到其他包含可用 Skills 的 Agent。",
-      "sourceKind": { "internal": "DeepChat", "external": "外部" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "外部"
+      },
       "skillCount": "{count} 個 Skills",
       "previewTitle": "要匯入的 Skills",
       "selectedCount": "已選擇 {count} 個",
@@ -1938,8 +1941,16 @@
       "previewError": "預覽 Skills 失敗",
       "emptyPreview": "沒有可用的 Skills",
       "emptyPreviewDescription": "此 Agent 沒有可匯入的 Skills。",
-      "status": { "ready": "可匯入", "conflict": "衝突", "unavailable": "不可用" },
-      "strategy": { "skip": "略過", "rename": "重新命名", "overwrite": "覆寫" },
+      "status": {
+        "ready": "可匯入",
+        "conflict": "衝突",
+        "unavailable": "不可用"
+      },
+      "strategy": {
+        "skip": "略過",
+        "rename": "重新命名",
+        "overwrite": "覆寫"
+      },
       "renameTarget": "將匯入為 {name}",
       "executeError": "匯入 Skills 失敗",
       "importing": "正在匯入...",
@@ -3173,5 +3184,23 @@
     "scopeGlobalPlugins": "目前頁面為應用全域：官方外掛的安裝、啟用與程序對所有 DeepChat Agent 共用。",
     "scopeCurrentAgent": "目前頁面為 Agent 策略：僅影響「{agent}」可用的 Skills / MCP，不會全域停用資源。",
     "currentAgentFallback": "目前 Agent"
+  },
+  "debug": {
+    "description": "僅在開發模式下顯示的情境與引導偵錯工具。",
+    "unavailableTitle": "偵錯工具無法使用",
+    "unavailableDescription": "此操作僅能在開發模式下使用。",
+    "splash": {
+      "title": "啟動視窗",
+      "description": "不觸發真實資料庫解鎖流程，即可預覽啟動視窗狀態。",
+      "loading": "預覽載入中",
+      "systemUnlock": "預覽系統解鎖",
+      "unlock": "預覽手動解鎖",
+      "failed": "無法顯示啟動視窗情境。"
+    },
+    "guidance": {
+      "title": "引導與資料",
+      "description": "建立僅供開發環境使用的引導、對話和更新模擬。",
+      "failed": "無法啟動偵錯引導。"
+    }
   }
 }

--- a/src/renderer/src/i18n/zh-TW/routes.json
+++ b/src/renderer/src/i18n/zh-TW/routes.json
@@ -24,5 +24,6 @@
   "settings-plugins": "插件",
   "settings-overview": "設定概覽",
   "settings-memory": "記憶",
-  "plugins": "插件"
+  "plugins": "插件",
+  "settings-debug": "偵錯"
 }

--- a/src/renderer/src/i18n/zh-TW/settings.json
+++ b/src/renderer/src/i18n/zh-TW/settings.json
@@ -1928,7 +1928,10 @@
       "sourceError": "載入 Agent 來源失敗",
       "emptySources": "沒有可匯入的來源",
       "emptySourcesDescription": "找不到其他包含可用 Skills 的 Agent。",
-      "sourceKind": { "internal": "DeepChat", "external": "外部" },
+      "sourceKind": {
+        "internal": "DeepChat",
+        "external": "外部"
+      },
       "skillCount": "{count} 個 Skills",
       "previewTitle": "要匯入的 Skills",
       "selectedCount": "已選擇 {count} 個",
@@ -1938,8 +1941,16 @@
       "previewError": "預覽 Skills 失敗",
       "emptyPreview": "沒有可用的 Skills",
       "emptyPreviewDescription": "此 Agent 沒有可匯入的 Skills。",
-      "status": { "ready": "可匯入", "conflict": "衝突", "unavailable": "不可用" },
-      "strategy": { "skip": "略過", "rename": "重新命名", "overwrite": "覆寫" },
+      "status": {
+        "ready": "可匯入",
+        "conflict": "衝突",
+        "unavailable": "不可用"
+      },
+      "strategy": {
+        "skip": "略過",
+        "rename": "重新命名",
+        "overwrite": "覆寫"
+      },
       "renameTarget": "將匯入為 {name}",
       "executeError": "匯入 Skills 失敗",
       "importing": "正在匯入...",
@@ -3173,5 +3184,23 @@
     "scopeGlobalPlugins": "目前頁面為應用全域：官方外掛的安裝、啟用與程序對所有 DeepChat Agent 共用。",
     "scopeCurrentAgent": "目前頁面為 Agent 策略：僅影響「{agent}」可用的 Skills / MCP，不會全域停用資源。",
     "currentAgentFallback": "目前 Agent"
+  },
+  "debug": {
+    "description": "僅在開發模式下顯示的情境與引導偵錯工具。",
+    "unavailableTitle": "偵錯工具無法使用",
+    "unavailableDescription": "此操作僅能在開發模式下使用。",
+    "splash": {
+      "title": "啟動視窗",
+      "description": "不觸發真實資料庫解鎖流程，即可預覽啟動視窗狀態。",
+      "loading": "預覽載入中",
+      "systemUnlock": "預覽系統解鎖",
+      "unlock": "預覽手動解鎖",
+      "failed": "無法顯示啟動視窗情境。"
+    },
+    "guidance": {
+      "title": "引導與資料",
+      "description": "建立僅供開發環境使用的引導、對話和更新模擬。",
+      "failed": "無法啟動偵錯引導。"
+    }
   }
 }

--- a/src/shared/contracts/events/settings.events.ts
+++ b/src/shared/contracts/events/settings.events.ts
@@ -23,7 +23,8 @@ const SettingsRouteNameSchema = z.enum([
   'settings-knowledge-base',
   'settings-database',
   'settings-shortcut',
-  'settings-about'
+  'settings-about',
+  'settings-debug'
 ])
 
 export const SettingsNavigationPayloadSchema = z.object({

--- a/src/shared/contracts/routes/system.routes.ts
+++ b/src/shared/contracts/routes/system.routes.ts
@@ -22,7 +22,8 @@ export const SettingsRouteNameSchema = z.enum([
   'settings-knowledge-base',
   'settings-database',
   'settings-shortcut',
-  'settings-about'
+  'settings-about',
+  'settings-debug'
 ])
 
 export const systemOpenSettingsRoute = defineRouteContract({

--- a/src/shared/settingsNavigation.ts
+++ b/src/shared/settingsNavigation.ts
@@ -21,6 +21,7 @@ export interface SettingsNavigationItem {
     | 'settings-database'
     | 'settings-shortcut'
     | 'settings-about'
+    | 'settings-debug'
   path: string
   titleKey: string
   icon: string
@@ -30,6 +31,7 @@ export interface SettingsNavigationItem {
   supportedPlatforms?: string[]
   supportedTargets?: string[]
   hiddenInSidebar?: boolean
+  developmentOnly?: boolean
 }
 
 export type SettingsNavigationGroupKey =
@@ -294,6 +296,16 @@ export const SETTINGS_NAVIGATION_ITEMS: SettingsNavigationItem[] = [
     position: 11,
     groupKey: 'system',
     keywords: ['about', 'version', 'info', '关于', '版本']
+  },
+  {
+    routeName: 'settings-debug',
+    path: '/debug',
+    titleKey: 'routes.settings-debug',
+    icon: 'lucide:bug',
+    position: 12,
+    groupKey: 'system',
+    developmentOnly: true,
+    keywords: ['debug', 'mock', 'development', '调试', '模拟']
   }
 ]
 
@@ -343,22 +355,32 @@ export const isSettingsNavigationItemSupported = (
   )
 }
 
-export const getSettingsRouteItems = (platform?: string, arch?: string): SettingsNavigationItem[] =>
-  SETTINGS_NAVIGATION_ITEMS.filter((item) =>
-    isSettingsNavigationItemSupported(item, platform, arch)
+export const getSettingsRouteItems = (
+  platform?: string,
+  arch?: string,
+  includeDevelopmentItems = false
+): SettingsNavigationItem[] =>
+  SETTINGS_NAVIGATION_ITEMS.filter(
+    (item) =>
+      isSettingsNavigationItemSupported(item, platform, arch) &&
+      (includeDevelopmentItems || !item.developmentOnly)
   )
 
 export const getSettingsNavigationItems = (
   platform?: string,
-  arch?: string
+  arch?: string,
+  includeDevelopmentItems = false
 ): SettingsNavigationItem[] =>
-  getSettingsRouteItems(platform, arch).filter((item) => !item.hiddenInSidebar)
+  getSettingsRouteItems(platform, arch, includeDevelopmentItems).filter(
+    (item) => !item.hiddenInSidebar
+  )
 
 export const getSettingsNavigationGroups = (
   platform?: string,
-  arch?: string
+  arch?: string,
+  includeDevelopmentItems = false
 ): SettingsNavigationGroup[] => {
-  const items = getSettingsNavigationItems(platform, arch)
+  const items = getSettingsNavigationItems(platform, arch, includeDevelopmentItems)
 
   return SETTINGS_NAVIGATION_GROUPS.map((group) => ({
     ...group,
@@ -372,9 +394,10 @@ export const resolveSettingsNavigationPath = (
   routeName: SettingsNavigationItem['routeName'],
   params?: Record<string, string>,
   platform?: string,
-  arch?: string
+  arch?: string,
+  includeDevelopmentItems = false
 ): string => {
-  const item = getSettingsRouteItems(platform, arch).find(
+  const item = getSettingsRouteItems(platform, arch, includeDevelopmentItems).find(
     (navigationItem) => navigationItem.routeName === routeName
   )
   if (!item) {

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -1960,6 +1960,7 @@ declare module 'vue-i18n' {
     'settings-deepchat-agents': string
     'settings-database': string
     'settings-about': string
+    'settings-debug': string
     'settings-shortcut': string
     'settings-display': string
     'settings-knowledge-base': string

--- a/test/main/routes/dispatcher.test.ts
+++ b/test/main/routes/dispatcher.test.ts
@@ -118,6 +118,9 @@ const { browserWindowState } = vi.hoisted(() => {
 })
 
 vi.mock('electron', () => ({
+  app: {
+    isPackaged: false
+  },
   BrowserWindow: {
     fromId: (windowId: number) => browserWindowState.windows.get(windowId) ?? null,
     fromWebContents: (webContents: { id: number }) =>

--- a/test/main/shared/settingsNavigation.test.ts
+++ b/test/main/shared/settingsNavigation.test.ts
@@ -22,6 +22,22 @@ describe('settings navigation helpers', () => {
     expect(getSettingsNavigationGroups()[0]?.key).toBe('overview')
   })
 
+  it('keeps development-only routes hidden unless explicitly enabled', () => {
+    expect(getSettingsRouteItems().some((item) => item.routeName === 'settings-debug')).toBe(false)
+    expect(getSettingsNavigationItems().some((item) => item.routeName === 'settings-debug')).toBe(
+      false
+    )
+    expect(
+      getSettingsRouteItems(undefined, undefined, true).some(
+        (item) => item.routeName === 'settings-debug'
+      )
+    ).toBe(true)
+    expect(resolveSettingsNavigationPath('settings-debug')).toBe('/overview')
+    expect(
+      resolveSettingsNavigationPath('settings-debug', undefined, undefined, undefined, true)
+    ).toBe('/debug')
+  })
+
   it('resolves provider routes with params', () => {
     expect(
       resolveSettingsNavigationPath('settings-provider', {

--- a/test/renderer/components/AboutUsSettings.test.ts
+++ b/test/renderer/components/AboutUsSettings.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, nextTick } from 'vue'
+import { defineComponent } from 'vue'
 import { flushPromises, mount } from '@vue/test-utils'
 
 const buttonStub = defineComponent({
@@ -28,12 +28,7 @@ const deviceClientMock = vi.hoisted(() => ({
 const browserClientMock = vi.hoisted(() => ({
   openExternal: vi.fn()
 }))
-const debugClientMock = vi.hoisted(() => ({
-  createMockChatSession: vi.fn()
-}))
-const toastMock = vi.hoisted(() => vi.fn())
 const windowClientMock = vi.hoisted(() => ({
-  startGuidedOnboarding: vi.fn(),
   onSettingsCheckForUpdates: vi.fn().mockImplementation((listener: () => void) => {
     const wrapped = () => listener()
     window.electron?.ipcRenderer?.on('settings:check-for-updates', wrapped)
@@ -54,12 +49,9 @@ const upgradeStoreMock = {
   isRestarting: false,
   updateProgress: null,
   isReadyToInstall: false,
-  isMockUpdate: false,
   updateState: 'error',
   refreshStatus: vi.fn().mockResolvedValue('error'),
   checkUpdate: vi.fn().mockResolvedValue('error'),
-  mockDownloadedUpdate: vi.fn().mockResolvedValue('downloaded'),
-  clearMockUpdate: vi.fn().mockResolvedValue('not-available'),
   handleUpdate: vi.fn().mockResolvedValue(undefined)
 }
 
@@ -71,9 +63,6 @@ vi.mock('@api/DeviceClient', () => ({
 }))
 vi.mock('@api/BrowserClient', () => ({
   createBrowserClient: () => browserClientMock
-}))
-vi.mock('@api/DebugClient', () => ({
-  createDebugClient: () => debugClientMock
 }))
 vi.mock('@api/WindowClient', () => ({
   createWindowClient: () => windowClientMock
@@ -95,15 +84,9 @@ vi.mock('@/stores/theme', () => ({
   })
 }))
 
-vi.mock('@/components/use-toast', () => ({
-  useToast: () => ({
-    toast: toastMock
-  })
-}))
-
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string, params?: { version?: string; title?: string; count?: number }) => {
+    t: (key: string, params?: { version?: string }) => {
       const messages: Record<string, string> = {
         'about.title': 'DeepChat',
         'about.description': 'DeepChat description',
@@ -115,15 +98,6 @@ vi.mock('vue-i18n', () => ({
         'about.disclaimerButton': '免责声明',
         'about.checkUpdateButton': '检查更新',
         'about.disclaimerTitle': '免责声明',
-        'about.mockUpdateButton': '模拟已下载更新',
-        'about.clearMockUpdateButton': '清除模拟更新',
-        'about.mockOnboardingButton': '模拟首次进入引导',
-        'about.mockChatButton': '创建长会话Mock数据',
-        'about.mockChatCreating': '创建中...',
-        'about.mockChatCreated': 'Mock会话已创建',
-        'about.mockChatCreatedDesc': `已创建${params?.title ?? ''}，共${params?.count ?? ''}条消息`,
-        'about.mockChatCreateFailed': '创建Mock会话失败',
-        'about.mockChatCreateUnavailable': 'Mock会话只在开发模式可用',
         'update.versionAvailable': `${params?.version ?? ''} 可用`,
         'update.autoUpdateFailed': '自动更新可能不稳定，请手动下载更新',
         'update.githubDownload': 'GitHub 下载',
@@ -152,13 +126,6 @@ describe('AboutUsSettings', () => {
     configClientMock.setUpdateChannel.mockResolvedValue('stable')
     deviceClientMock.getAppVersion.mockResolvedValue('1.0.0-beta.3')
     browserClientMock.openExternal.mockResolvedValue(undefined)
-    debugClientMock.createMockChatSession.mockResolvedValue({
-      created: true,
-      sessionId: 'debug-long-chat-test',
-      title: 'Debug long chat test',
-      messageCount: 200
-    })
-    windowClientMock.startGuidedOnboarding.mockResolvedValue({ started: true, focused: true })
     Object.assign(upgradeStoreMock, {
       shouldShowUpdateNotes: true,
       updateInfo: {
@@ -172,7 +139,6 @@ describe('AboutUsSettings', () => {
       isRestarting: false,
       updateProgress: null,
       isReadyToInstall: false,
-      isMockUpdate: false,
       updateState: 'error'
     })
     Object.assign(window, {
@@ -216,16 +182,7 @@ describe('AboutUsSettings', () => {
     await flushPromises()
 
     const buttons = wrapper.findAll('button').map((button) => button.text())
-    expect(buttons).toEqual([
-      '意见反馈',
-      '免责声明',
-      '模拟已下载更新',
-      '模拟首次进入引导',
-      '创建长会话Mock数据',
-      'GitHub 下载',
-      '官网下载',
-      '关闭'
-    ])
+    expect(buttons).toEqual(['意见反馈', '免责声明', 'GitHub 下载', '官网下载', '关闭'])
     expect(wrapper.text()).not.toContain('检查更新')
 
     const officialButton = wrapper.findAll('button').find((button) => button.text() === '官网下载')
@@ -325,153 +282,5 @@ describe('AboutUsSettings', () => {
     expect(upgradeStoreMock.checkUpdate).not.toHaveBeenCalled()
 
     wrapper.unmount()
-  })
-
-  it('renders the mock update button and injects the mock downloaded state', async () => {
-    upgradeStoreMock.showManualDownloadOptions = false
-    upgradeStoreMock.updateError = null
-    upgradeStoreMock.updateState = 'idle'
-
-    const { default: AboutUsSettings } =
-      await import('../../../src/renderer/settings/components/AboutUsSettings.vue')
-
-    const wrapper = mount(AboutUsSettings, {
-      global: {
-        stubs: {
-          Button: buttonStub,
-          Icon: true,
-          Dialog: passthroughStub('Dialog'),
-          DialogContent: passthroughStub('DialogContent'),
-          DialogDescription: passthroughStub('DialogDescription'),
-          DialogFooter: passthroughStub('DialogFooter'),
-          DialogHeader: passthroughStub('DialogHeader'),
-          DialogTitle: passthroughStub('DialogTitle'),
-          Select: passthroughStub('Select'),
-          SelectContent: passthroughStub('SelectContent'),
-          SelectItem: passthroughStub('SelectItem'),
-          SelectTrigger: passthroughStub('SelectTrigger'),
-          SelectValue: passthroughStub('SelectValue'),
-          NodeRenderer: passthroughStub('NodeRenderer')
-        }
-      }
-    })
-
-    await flushPromises()
-
-    const mockButton = wrapper
-      .findAll('button')
-      .find((button) => button.text() === '模拟已下载更新')
-    expect(mockButton).toBeTruthy()
-
-    await mockButton!.trigger('click')
-
-    expect(upgradeStoreMock.mockDownloadedUpdate).toHaveBeenCalledTimes(1)
-  })
-
-  it('starts the dev onboarding guide from the about page', async () => {
-    const { default: AboutUsSettings } =
-      await import('../../../src/renderer/settings/components/AboutUsSettings.vue')
-
-    const wrapper = mount(AboutUsSettings, {
-      global: {
-        stubs: {
-          Button: buttonStub,
-          Icon: true,
-          Dialog: passthroughStub('Dialog'),
-          DialogContent: passthroughStub('DialogContent'),
-          DialogDescription: passthroughStub('DialogDescription'),
-          DialogFooter: passthroughStub('DialogFooter'),
-          DialogHeader: passthroughStub('DialogHeader'),
-          DialogTitle: passthroughStub('DialogTitle'),
-          Select: passthroughStub('Select'),
-          SelectContent: passthroughStub('SelectContent'),
-          SelectItem: passthroughStub('SelectItem'),
-          SelectTrigger: passthroughStub('SelectTrigger'),
-          SelectValue: passthroughStub('SelectValue'),
-          NodeRenderer: passthroughStub('NodeRenderer')
-        }
-      }
-    })
-
-    await flushPromises()
-
-    const onboardingButton = wrapper
-      .findAll('button')
-      .find((button) => button.text() === '模拟首次进入引导')
-
-    expect(onboardingButton).toBeTruthy()
-
-    await onboardingButton!.trigger('click')
-
-    expect(windowClientMock.startGuidedOnboarding).toHaveBeenCalledTimes(1)
-  })
-
-  it('creates mock long chat data from the about page', async () => {
-    let resolveCreateMockChat!: (value: {
-      created: boolean
-      sessionId: string
-      title: string
-      messageCount: number
-    }) => void
-    debugClientMock.createMockChatSession.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveCreateMockChat = resolve
-      })
-    )
-
-    const { default: AboutUsSettings } =
-      await import('../../../src/renderer/settings/components/AboutUsSettings.vue')
-
-    const wrapper = mount(AboutUsSettings, {
-      global: {
-        stubs: {
-          Button: buttonStub,
-          Icon: true,
-          Dialog: passthroughStub('Dialog'),
-          DialogContent: passthroughStub('DialogContent'),
-          DialogDescription: passthroughStub('DialogDescription'),
-          DialogFooter: passthroughStub('DialogFooter'),
-          DialogHeader: passthroughStub('DialogHeader'),
-          DialogTitle: passthroughStub('DialogTitle'),
-          Select: passthroughStub('Select'),
-          SelectContent: passthroughStub('SelectContent'),
-          SelectItem: passthroughStub('SelectItem'),
-          SelectTrigger: passthroughStub('SelectTrigger'),
-          SelectValue: passthroughStub('SelectValue'),
-          NodeRenderer: passthroughStub('NodeRenderer')
-        }
-      }
-    })
-
-    await flushPromises()
-
-    const mockChatButton = wrapper
-      .findAll('button')
-      .find((button) => button.text() === '创建长会话Mock数据')
-
-    expect(mockChatButton).toBeTruthy()
-
-    await mockChatButton!.trigger('click')
-    await nextTick()
-
-    expect(debugClientMock.createMockChatSession).toHaveBeenCalledTimes(1)
-    const pendingButton = wrapper.findAll('button').find((button) => button.text() === '创建中...')
-    expect(pendingButton?.attributes('disabled')).toBeDefined()
-
-    resolveCreateMockChat({
-      created: true,
-      sessionId: 'debug-long-chat-test',
-      title: 'Debug long chat test',
-      messageCount: 200
-    })
-    await flushPromises()
-
-    expect(toastMock).toHaveBeenCalledWith({
-      title: 'Mock会话已创建',
-      description: '已创建Debug long chat test，共200条消息'
-    })
-    expect(wrapper.findAll('button').some((button) => button.text() === '创建长会话Mock数据')).toBe(
-      true
-    )
   })
 })

--- a/test/renderer/components/DebugSettings.test.ts
+++ b/test/renderer/components/DebugSettings.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const buttonStub = defineComponent({
+  name: 'Button',
+  emits: ['click'],
+  template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>'
+})
+
+const passthroughStub = (name: string) =>
+  defineComponent({
+    name,
+    template: '<div><slot /></div>'
+  })
+
+const debugClientMock = vi.hoisted(() => ({
+  createMockChatSession: vi.fn()
+}))
+const upgradeClientMock = vi.hoisted(() => ({
+  mockDownloadedUpdate: vi.fn(),
+  clearMockUpdate: vi.fn()
+}))
+const windowClientMock = vi.hoisted(() => ({
+  startGuidedOnboarding: vi.fn()
+}))
+const toastMock = vi.hoisted(() => vi.fn())
+
+const upgradeStoreMock = {
+  isMockUpdate: false,
+  refreshStatus: vi.fn()
+}
+
+vi.mock('@api/DebugClient', () => ({
+  createDebugClient: () => debugClientMock
+}))
+vi.mock('@api/UpgradeClient', () => ({
+  createUpgradeClient: () => upgradeClientMock
+}))
+vi.mock('@api/WindowClient', () => ({
+  createWindowClient: () => windowClientMock
+}))
+vi.mock('@/stores/upgrade', () => ({
+  useUpgradeStore: () => upgradeStoreMock
+}))
+vi.mock('@/components/use-toast', () => ({
+  useToast: () => ({ toast: toastMock })
+}))
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: { title?: string; count?: number }) => {
+      const messages: Record<string, string> = {
+        'routes.settings-debug': 'Debug',
+        'settings.debug.description': 'Development-only tools',
+        'settings.controlCenter.groups.system': 'System',
+        'settings.debug.guidance.title': 'Guidance and data',
+        'settings.debug.guidance.description': 'Create development mocks',
+        'settings.debug.guidance.failed': 'Unable to start the debug guided flow.',
+        'settings.debug.unavailableDescription':
+          'This action is available only in development mode.',
+        'common.error.operationFailed': 'Operation failed',
+        'about.mockOnboardingButton': 'Start mock onboarding',
+        'about.mockChatButton': 'Create mock chat',
+        'about.mockChatCreating': 'Creating...',
+        'about.mockChatCreated': 'Mock chat created',
+        'about.mockChatCreatedDesc': `Created ${params?.title ?? ''} with ${params?.count ?? ''} messages`,
+        'about.mockChatCreateUnavailable': 'Mock chat unavailable',
+        'about.mockChatCreateFailed': 'Unable to create mock chat',
+        'about.mockUpdateButton': 'Mock downloaded update',
+        'about.clearMockUpdateButton': 'Clear mock update'
+      }
+      return messages[key] ?? key
+    }
+  })
+}))
+
+describe('DebugSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.assign(upgradeStoreMock, {
+      isMockUpdate: false,
+      refreshStatus: vi.fn().mockResolvedValue(undefined)
+    })
+    debugClientMock.createMockChatSession.mockResolvedValue({
+      created: true,
+      sessionId: 'debug-long-chat-test',
+      title: 'Debug long chat test',
+      messageCount: 200
+    })
+    upgradeClientMock.mockDownloadedUpdate.mockResolvedValue(true)
+    upgradeClientMock.clearMockUpdate.mockResolvedValue(true)
+    windowClientMock.startGuidedOnboarding.mockResolvedValue({ started: true, focused: true })
+  })
+
+  const mountSettings = async () => {
+    const { default: DebugSettings } =
+      await import('../../../src/renderer/settings/components/DebugSettings.vue')
+    return mount(DebugSettings, {
+      global: {
+        stubs: {
+          Button: buttonStub,
+          Icon: true,
+          Spinner: true,
+          SettingsPageShell: passthroughStub('SettingsPageShell')
+        }
+      }
+    })
+  }
+
+  it('renders the development mock controls and refreshes update status', async () => {
+    const wrapper = await mountSettings()
+    await flushPromises()
+
+    expect(wrapper.attributes('data-testid')).toBe('settings-debug-page')
+    expect(wrapper.findAll('button').map((button) => button.text())).toEqual([
+      'Start mock onboarding',
+      'Create mock chat',
+      'Mock downloaded update'
+    ])
+    expect(upgradeStoreMock.refreshStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes the debug clients and reports a created mock chat', async () => {
+    const wrapper = await mountSettings()
+    await flushPromises()
+
+    const buttons = wrapper.findAll('button')
+    await buttons[0]!.trigger('click')
+    await buttons[1]!.trigger('click')
+    await buttons[2]!.trigger('click')
+    await flushPromises()
+
+    expect(windowClientMock.startGuidedOnboarding).toHaveBeenCalledTimes(1)
+    expect(debugClientMock.createMockChatSession).toHaveBeenCalledTimes(1)
+    expect(upgradeClientMock.mockDownloadedUpdate).toHaveBeenCalledTimes(1)
+    expect(toastMock).toHaveBeenCalledWith({
+      title: 'Mock chat created',
+      description: 'Created Debug long chat test with 200 messages'
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a development-only Debug settings route for onboarding, mock chat, and mock update actions
- remove these mock controls from About and gate onboarding/update mock routes in the main process
- add navigation, renderer component, and route-guard coverage

## UI layout

BEFORE
```text
Settings › About
├─ product and update information
└─ development mock actions
```

AFTER
```text
Settings › About                 Settings › Debug (development only)
└─ product and update information ├─ mock onboarding
                                ├─ mock chat
                                └─ mock update
```

## Validation
- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck:web`
- `pnpm exec vitest run test/main/shared/settingsNavigation.test.ts test/renderer/components/AboutUsSettings.test.ts test/renderer/components/DebugSettings.test.ts test/main/routes/dispatcher.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development-only Debug settings page with guided onboarding, mock chat, and mock update tools.
  * Added localized navigation labels and interface text across supported languages.
* **Bug Fixes**
  * Removed development mock controls from About settings and restored the standard update workflow.
  * Prevented debug actions from running in production or packaged applications.
* **Tests**
  * Added coverage for Debug settings interactions, navigation visibility, and production safeguards.
* **Documentation**
  * Added planning, specification, and task documentation for the Debug settings tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->