### PR TITLE
fix(skills): patch disabled state in place to stop skill list flicker

### DIFF
--- a/src/main/skill/index.ts
+++ b/src/main/skill/index.ts
@@ -1332,6 +1332,7 @@ export class SkillService implements SkillServicePort {
       this.publishEvent('skills.catalog.changed', {
         reason: 'disabled-updated',
         name,
+        disabled,
         agentIds: [normalizedAgentId],
         version: Date.now()
       })

--- a/src/renderer/api/SkillClient.ts
+++ b/src/renderer/api/SkillClient.ts
@@ -261,6 +261,7 @@ export function createSkillClient(bridge: DeepchatBridge = getDeepchatBridge()) 
         | 'git-installed'
         | 'sync-directory-updated'
       name?: string
+      disabled?: boolean
       agentIds?: string[]
       version: number
     }) => void

--- a/src/renderer/settings/components/skills/SkillsSettings.vue
+++ b/src/renderer/settings/components/skills/SkillsSettings.vue
@@ -405,13 +405,36 @@ onUnmounted(() => {
   }
 })
 
+const patchScopedSkillDisabled = (name: string, disabled: boolean) => {
+  const targetSkill = scopedSkills.value.find((s) => s.name === name)
+  if (targetSkill) {
+    targetSkill.disabled = disabled
+    targetSkill.deepchatDisabled = disabled
+  }
+}
+
 const setupEventListeners = () => {
-  const handleSkillEvent = (payload: { agentIds?: string[] }) => {
+  const handleSkillEvent = (payload: {
+    reason?: string
+    name?: string
+    disabled?: boolean
+    agentIds?: string[]
+  }) => {
     // The Pinia store owns the built-in catalog refresh. This page only owns
     // the separately loaded Agent-scoped catalog.
     if (!isAgentScope.value) return
-    const affectedAgentId = isAgentScope.value ? targetAgentId.value : 'deepchat'
+    const affectedAgentId = targetAgentId.value
     if (payload.agentIds?.length && !payload.agentIds.includes(affectedAgentId)) {
+      return
+    }
+    // A disable/enable toggle only flips one flag; patch it in place so the
+    // list does not flash the loading skeleton.
+    if (
+      payload.reason === 'disabled-updated' &&
+      payload.name &&
+      typeof payload.disabled === 'boolean'
+    ) {
+      patchScopedSkillDisabled(payload.name, payload.disabled)
       return
     }
     void loadSkills()
@@ -547,6 +570,10 @@ const updateAgentSkillPolicy = async (skill: UnifiedSkillItem, disabled: boolean
   }
 
   const requestedAgentId = targetAgent.value.id
+  const previousDisabled =
+    scopedSkills.value.find((s) => s.name === skill.name)?.deepchatDisabled ?? false
+  // Optimistic update; the catalog-changed event confirms it without a reload.
+  patchScopedSkillDisabled(skill.name, disabled)
   try {
     await skillClient.setSkillDisabled(skill.name, disabled, requestedAgentId)
     if (requestedAgentId !== targetAgentId.value) return false
@@ -559,6 +586,7 @@ const updateAgentSkillPolicy = async (skill: UnifiedSkillItem, disabled: boolean
     return true
   } catch (error) {
     if (requestedAgentId !== targetAgentId.value) return false
+    patchScopedSkillDisabled(skill.name, previousDisabled)
     toast({
       title: disabled ? t('settings.skills.disable.failed') : t('settings.skills.enable.failed'),
       description: error instanceof Error ? error.message : String(error),

--- a/src/renderer/src/stores/skillsStore.ts
+++ b/src/renderer/src/stores/skillsStore.ts
@@ -247,8 +247,27 @@ export const useSkillsStore = defineStore('skills', () => {
     await loadSkillRuntime(name)
   }
 
+  const patchSkillDisabled = (agentId: string, name: string, disabled: boolean) => {
+    const targetSkill = skillCatalogs.value[agentId]?.find((s) => s.name === name)
+    if (targetSkill) {
+      targetSkill.disabled = disabled
+      targetSkill.deepchatDisabled = disabled
+    }
+  }
+
   const setSkillDisabled = async (name: string, disabled: boolean): Promise<void> => {
-    await skillClient.setSkillDisabled(name, disabled)
+    const previousDisabled =
+      skillCatalogs.value[BUILTIN_AGENT_ID]?.find((s) => s.name === name)?.deepchatDisabled ?? false
+
+    // Optimistic update: reloading the whole catalog here would flash the
+    // loading skeleton over the list, so patch the item in place instead.
+    patchSkillDisabled(BUILTIN_AGENT_ID, name, disabled)
+    try {
+      await skillClient.setSkillDisabled(name, disabled)
+    } catch (e) {
+      patchSkillDisabled(BUILTIN_AGENT_ID, name, previousDisabled)
+      throw e
+    }
   }
 
   const saveSkillWithExtension = async (
@@ -284,6 +303,20 @@ export const useSkillsStore = defineStore('skills', () => {
               ...Object.keys(catalogLoading.value)
             ])
           )
+
+      // A disable/enable toggle only flips one flag; patch it in place so the
+      // list does not flash the loading skeleton. This also keeps windows that
+      // did not initiate the toggle in sync.
+      if (
+        payload.reason === 'disabled-updated' &&
+        payload.name &&
+        typeof payload.disabled === 'boolean'
+      ) {
+        for (const agentId of affectedAgentIds) {
+          patchSkillDisabled(agentId, payload.name, payload.disabled)
+        }
+        return
+      }
 
       for (const agentId of affectedAgentIds) {
         if (agentId === BUILTIN_AGENT_ID || isSkillsLoaded(agentId) || isSkillsLoading(agentId)) {

--- a/src/shared/contracts/events/skills.events.ts
+++ b/src/shared/contracts/events/skills.events.ts
@@ -18,6 +18,7 @@ export const skillsCatalogChangedEvent = defineEventContract({
       'sync-directory-updated'
     ]),
     name: z.string().optional(),
+    disabled: z.boolean().optional(),
     agentIds: z.array(EntityIdSchema).optional(),
     skill: SkillMetadataSchema.optional(),
     skills: z.array(SkillMetadataSchema).optional(),


### PR DESCRIPTION
## Problem

Toggling a skill's disabled switch made the whole skill list flicker: the `skills.catalog.changed` event (reason `disabled-updated`) triggered a full catalog reload in both the Pinia store and the Agent-scoped settings page, replacing the rendered list with the loading skeleton on every toggle.

## Solution

A disable/enable toggle only flips one flag, so listeners now patch the affected item in place instead of reloading the catalog:

- **Event payload** (`skills.events.ts`, `main/skill/index.ts`): `disabled-updated` now carries the toggled `disabled` value alongside `name` and `agentIds`.
- **Store** (`skillsStore.ts`): optimistic update with rollback on error in `setSkillDisabled`; the catalog listener patches `disabled`/`deepchatDisabled` in place for `disabled-updated` and keeps the full reload for every other reason. If the payload ever lacks `name`/`disabled`, it falls through to the full reload so state can never go stale.
- **Agent scope** (`SkillsSettings.vue`): same in-place patch for the separately loaded scoped catalog, plus an optimistic update with rollback in `updateAgentSkillPolicy` (previously the scoped list was only refreshed by the event-driven reload).

## Agent isolation

- Per-agent disabled storage in the main process (`state.agents[agentId].skills[name].disabled`) is untouched; only the published event payload gained a field.
- The event always carries the single affected `agentId`; the store patches only the catalogs listed in `agentIds`, and the agent-scoped page ignores events whose `agentIds` don't include the current target agent.
- Windows that did not initiate the toggle stay in sync through the same broadcast event (the optimistic update on the initiating side is idempotent with it).

## Test plan

- [x] `pnpm run typecheck`
- [x] `oxlint` on changed files
- [ ] Manual: toggle skills in global library — no skeleton flash, switch state sticks
- [ ] Manual: toggle skills in agent scope — switch state sticks and stays isolated per agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Skill enable/disable changes now update immediately in settings and skill lists.
  * Changes remain synchronized across open windows without unnecessary refreshes or UI flashing.
  * If an update fails, the interface restores the previous setting and displays an error notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->