### PR TITLE
fix(pip): lazy-load NativeKit

### DIFF
--- a/docs/architecture/nativekit-agent-browser-pip/plan.md
+++ b/docs/architecture/nativekit-agent-browser-pip/plan.md
@@ -6,9 +6,9 @@ Implemented on 2026-07-23 through Phase 4. The macOS arm64 packaging and native-
 of Phase 5 is complete; physical cross-platform interaction and performance measurements remain
 open release QA.
 
-This plan implements the contract in `spec.md` with the smallest stable change: one main-process
-NativeKit adapter, one surface-selection branch in `YoBrowserPresenter`, two typed contract
-extensions, and the existing Canvas retained intact as fallback.
+This plan implements the contract in `spec.md` with one process-global NativeKit coordinator,
+on-demand loading at the first concrete preview target, and source-specific unavailable behavior:
+Browser opens its existing side panel and Computer Use exposes no PiP.
 
 ## Selected Approach
 
@@ -22,11 +22,12 @@ existing page/session/capture owner
               |
        completed JPEG frame
               |
-       +------+------+
-       |             |
-       v             v
-NativeKit adapter   existing renderer event
-supported runtime   compatibility fallback
+       +------+----------------+
+       |                       |
+       v                       v
+NativeKit adapter       native unavailable
+supported runtime       Browser -> side panel
+                        Computer Use -> no PiP
 ```
 
 DeepChat does not need a second browser page, a second Electron window, a new preload capability,
@@ -37,21 +38,23 @@ the renderer Canvas and owns only the native panel.
 
 ### Dependency and packaging
 
-- Pin `"@zerob13/nativekit": "0.6.2"` in `package.json` and refresh the local install metadata.
+- Pin `"@zerob13/nativekit": "0.6.3"` in `package.json` and refresh the local install metadata.
 - Add `@zerob13/nativekit: false` to `pnpm-workspace.yaml` `allowBuilds`; the published prebuild
   should load directly, and an unsupported target should not silently become a local source build.
 - Keep the package external to the Electron main bundle.
 - Add `node_modules/@zerob13/nativekit/prebuilds/**/*` to `asarUnpack`.
 - Extend the packaging validation to require the matching prebuild only for supported target
   tuples.
-- Treat Windows arm64 as intentionally unsupported by NativeKit 0.6.2 rather than a packaging
-  error.
+- Treat Windows arm64 as intentionally unsupported by NativeKit 0.6.3 rather than a packaging
+  error; Browser uses its side panel and Computer Use runs without PiP.
 
-### Main-process adapter
+### Main-process coordinator
 
-Add `src/main/desktop/browser/AgentBrowserNativeOverlay.ts`. The adapter owns:
+Use `src/main/desktop/preview/AgentPreviewCoordinator.ts` as the shared native owner. The
+coordinator owns:
 
-- lazy dynamic import, process-stable capability state, and one-time warning;
+- lazy dynamic import on the first concrete preview target, process-stable capability state, and
+  one-time warning;
 - `start`, first-host validation, host refresh, visibility, image replacement, image removal, and
   shutdown;
 - the single active logical target;
@@ -63,26 +66,27 @@ Add `src/main/desktop/browser/AgentBrowserNativeOverlay.ts`. The adapter owns:
   presentation;
 - timing around synchronous `pushImage()` calls.
 
-The adapter exposes a narrow DeepChat-facing API:
+The coordinator exposes a narrow DeepChat-facing API:
 
 ```ts
-type NativeOverlayTarget = {
+type AgentPreviewTarget = {
+  source: 'browser' | 'computer-use'
   windowId: number
   sessionId: string
   runId: string
-  captureEpoch: number
+  epoch: number
+  claimSequence: number
 }
 
-type NativeOverlayCapability = 'available' | 'unavailable'
-
-interface AgentBrowserNativeOverlay {
-  initialize(): Promise<NativeOverlayCapability>
-  attachHost(window: BrowserWindow): boolean
-  updateTarget(target: NativeOverlayTarget): void
-  present(frame: Buffer): boolean
-  setVisible(visible: boolean): boolean
-  removeTarget(): void
-  detachHost(windowId: number): void
+interface AgentPreviewCoordinator {
+  initialize(): Promise<boolean>
+  isAvailable(): boolean
+  claim(input: { source: AgentPreviewSource; sessionId: string; runId: string }): number
+  prepare(target: AgentPreviewTarget, host: BrowserWindow): AgentPreviewSurface
+  present(target: AgentPreviewTarget, frame: Buffer): boolean
+  hide(target?: AgentPreviewTargetRef): void
+  removeTarget(target?: AgentPreviewTargetRef): void
+  releaseClaim(target: AgentPreviewTargetRef): void
   shutdown(): void
 }
 ```
@@ -99,15 +103,20 @@ Extend `YoBrowserPresenter` preview state with:
 - native logical target and visibility;
 - existing capture epoch as the stale-frame guard.
 
-The presenter performs these operations in order:
+The Browser presenter performs these operations in order:
 
 1. Resolve and validate the owning `BrowserWindow`.
-2. Select the process-stable surface.
-3. Keep the existing page in the 1280 x 800 render host.
-4. Capture, resize, and encode with one frame in flight.
-5. Revalidate session, run, window, mode, surface, and epoch.
-6. Present to exactly one destination.
-7. Schedule the next capture only after presentation returns.
+2. Load NativeKit only for `capturing`; `rendering` and application startup do not load it.
+3. Select the process-stable surface.
+4. Keep the existing page in the 1280 x 800 render host.
+5. Capture, resize, and encode with one frame in flight.
+6. Revalidate session, run, window, mode, surface, and epoch.
+7. Present to exactly one destination.
+8. Schedule the next capture only after presentation returns.
+
+Computer Use records eligibility without loading NativeKit. Its first concrete target initializes
+the coordinator. A failed initialization removes the preview state while leaving CUA execution
+unchanged.
 
 For the first native frame, `present()` runs while hidden and `setVisible(true)` follows only after
 success. Temporary ineligibility hides the panel without removing the presentation. Terminal
@@ -148,6 +157,9 @@ The renderer accepts a native action only when `windowId`, `sessionId`, and `run
 current state. Activation opens the existing Browser panel. Dismissal updates the existing
 run-scoped dismissal state.
 
+When Browser receives `none` because the coordinator is unavailable, main reuses the typed
+activation event to open the same Browser panel. Computer Use remains headless on `none`.
+
 ### Host and lifecycle synchronization
 
 - Attach with `BrowserWindow.getContentBounds()` and `getNativeWindowHandle()`.
@@ -168,8 +180,8 @@ run-scoped dismissal state.
 4. Extend configuration and `afterPack` tests for the published prebuild matrix.
 5. Verify dynamic import in an unpackaged development build.
 
-Exit condition: unsupported runtimes select fallback without startup failure, while supported
-packaged targets fail validation if their prebuild is absent.
+Exit condition: unsupported runtimes do not load during startup and use source-specific unavailable
+behavior, while supported packaged targets fail validation if their prebuild is absent.
 
 ### Phase 2: Native adapter
 
@@ -185,12 +197,13 @@ Exit condition: the adapter never exposes NativeKit outside main and every failu
 
 ### Phase 3: Presenter routing
 
-1. Initialize the adapter with `YoBrowserPresenter`.
-2. return the selected surface from `setPreviewMode`.
-3. Route completed frames directly to native or renderer, never both.
-4. Add host visibility and bounds synchronization.
-5. Preserve capture epoch and one-in-flight scheduling across surface changes.
-6. Start with the existing 4 FPS active interval; raise to at most 8 FPS only after profiling.
+1. Remove NativeKit initialization from application startup.
+2. Initialize the coordinator from the first Browser capture or concrete Computer Use target.
+3. Return the selected surface from `setPreviewMode`.
+4. Route completed frames directly to native or renderer, never both.
+5. Add host visibility and bounds synchronization.
+6. Preserve capture epoch and one-in-flight scheduling across surface changes.
+7. Start with the existing 4 FPS active interval; raise to at most 8 FPS only after profiling.
 
 Exit condition: supported runtime traffic contains no renderer frame payload on the native path.
 
@@ -210,22 +223,25 @@ Exit condition: native activation and **Open in panel** open the same Browser pa
 2. Verify full out-of-window movement and work-area clamping.
 3. Measure first-frame latency, frame age, `pushImage()` duration, and main-thread long tasks.
 4. Repeat interaction smoke tests on Windows x64 and Linux X11/XWayland.
-5. Verify Canvas fallback on Windows arm64 and native Wayland.
+5. Verify Browser side-panel handoff and absence of Computer Use PiP on Windows arm64 and native
+   Wayland.
 6. Build packaged artifacts and inspect the unpacked prebuild.
 
 Exit condition: every acceptance criterion in `spec.md` has recorded evidence.
 
-## Expected File Map
+## Relevant File Map
 
-Likely touched files:
+The implemented behavior is owned by:
 
 - `package.json`
 - `pnpm-lock.yaml`
 - `pnpm-workspace.yaml`
 - `electron-builder.yml`
 - `scripts/afterPack.js`
-- `src/main/desktop/browser/AgentBrowserNativeOverlay.ts`
+- `src/main/app/composition.ts`
+- `src/main/desktop/preview/AgentPreviewCoordinator.ts`
 - `src/main/desktop/browser/YoBrowserPresenter.ts`
+- `src/main/desktop/computerUse/ComputerUsePreviewPresenter.ts`
 - `src/main/desktop/routes.ts`
 - `src/shared/contracts/routes/browser.routes.ts`
 - `src/shared/contracts/events/browser.events.ts`
@@ -241,9 +257,9 @@ No preload file, persisted-settings schema, database migration, or new renderer 
 ### Automated
 
 - adapter capability, lifecycle, stale-target, failure, and callback tests;
-- presenter native/fallback selection and exclusive frame-routing tests;
+- presenter native/unavailable selection and exclusive frame-routing tests;
 - route and event schema tests;
-- renderer native/no-DOM, Canvas fallback, activate, and run-scoped dismiss tests;
+- renderer native/no-DOM, unavailable activation, and run-scoped dismiss tests;
 - ASAR configuration and platform-aware `afterPack` tests;
 - existing `YoBrowserPresenter` and `AgentBrowserPiP` regression suites.
 
@@ -273,16 +289,17 @@ For each supported native platform:
 8. Start a later run and verify PiP can appear again.
 9. Exercise blur, minimize, display change, session switch, page close, and app quit.
 
-For each fallback platform, repeat the product flow and verify the current in-chat Canvas remains.
+For each unavailable platform, verify Browser opens the existing side panel and Computer Use
+continues without PiP.
 
 ## Rollout and Rollback
 
-Land the adapter and Canvas fallback together. Do not remove the renderer frame path in this
-migration.
+Keep the renderer frame path source-compatible, but do not select it after native capability
+failure.
 
-If performance or native stability misses the gate, keep surface selection on
-`renderer-canvas`. Full rollback removes the adapter, dependency, and packaging rule without
-touching page ownership or stored data.
+If performance or native stability misses the gate, disable native PiP with the same source-specific
+behavior. Full rollback removes the adapter, dependency, and packaging rule without touching page
+ownership or stored data.
 
 ## Complexity Limits
 

--- a/docs/architecture/nativekit-agent-browser-pip/plan.md
+++ b/docs/architecture/nativekit-agent-browser-pip/plan.md
@@ -79,9 +79,12 @@ type AgentPreviewTarget = {
 }
 
 interface AgentPreviewCoordinator {
+  register(source: AgentPreviewSource, handler: AgentPreviewActionHandler): () => void
   initialize(): Promise<boolean>
   isAvailable(): boolean
+  isCurrent(target: AgentPreviewTarget): boolean
   claim(input: { source: AgentPreviewSource; sessionId: string; runId: string }): number
+  dismiss(target: AgentPreviewTargetRef): boolean
   prepare(target: AgentPreviewTarget, host: BrowserWindow): AgentPreviewSurface
   present(target: AgentPreviewTarget, frame: Buffer): boolean
   hide(target?: AgentPreviewTargetRef): void

--- a/docs/architecture/nativekit-agent-browser-pip/spec.md
+++ b/docs/architecture/nativekit-agent-browser-pip/spec.md
@@ -2,8 +2,10 @@
 
 ## Status
 
-Implemented on 2026-07-23. DeepChat now prefers NativeKit for the Agent browser PiP on supported
-runtimes and retains the renderer Canvas as the compatibility fallback.
+Implemented on 2026-07-23. DeepChat uses NativeKit for Agent preview PiP on supported runtimes.
+NativeKit is dynamically imported only when Browser first requests capture or Computer Use first
+has a concrete preview target. If the addon cannot load, Browser opens the existing side-panel
+browser and Computer Use runs without PiP.
 
 The dependency was upgraded from 0.5.1 to 0.5.2 on 2026-07-23. Version 0.5.1's published macOS
 arm64 and x64 binaries declared macOS 15.0 as their deployment target. Version 0.5.2 corrects both
@@ -41,18 +43,23 @@ the circular bezel. NativeKit now draws a style-aware layer background and borde
 template image while retaining native button input, tooltip, accessibility, hover, and pressed
 behavior. The JavaScript API and five-prebuild architecture matrix remain unchanged.
 
+Version 0.6.3 statically links the MSVC runtime into the Windows x64 prebuild so loading the addon
+does not depend on a separately installed dynamic runtime. The JavaScript API and five-prebuild
+architecture matrix remain unchanged.
+
 Automated integration, a real NativeKit addon smoke test, and a packaged macOS arm64 build are
 complete. Cross-platform interaction runs and the 60/120 Hz latency gates remain release QA work;
 they are tracked explicitly in `tasks.md` and are not implied by implementation completion.
 
-The migration pins `@zerob13/nativekit` to exactly `0.6.2`. The reviewed source is tag
-[`v0.6.2`](https://github.com/zerob13/nativekit/tree/v0.6.2), commit `b40e63d`. The npm registry
-exposes `0.6.2` with Electron `>=28.0.0` and Node `>=18` compatibility.
+The migration pins `@zerob13/nativekit` to exactly `0.6.3`. The reviewed source is tag
+[`v0.6.3`](https://github.com/zerob13/nativekit/tree/v0.6.3), commit `aa58266`. The npm registry
+exposes `0.6.3` with Electron `>=28.0.0` and Node `>=18` compatibility.
 
 This architecture supersedes only the user-facing PiP surface and frame-delivery path in
 `docs/features/agent-browser-pip/spec.md`. The existing Agent-page ownership, fixed background
 viewport, read-only preview, panel handoff, run-scoped dismissal, and single-page identity
-contracts remain in force. The current renderer Canvas remains the compatibility fallback.
+contracts remain in force. The renderer Canvas implementation remains source-compatible, but
+native capability failure no longer selects it as a product fallback.
 
 GitHub issue sync was not requested and was not performed.
 
@@ -70,7 +77,7 @@ The reviewed implementations move the native window directly inside AppKit, Win3
 not route drag samples through renderer state or IPC.
 
 That confirmed window-motion result is separate from the remote page's content refresh rate.
-NativeKit 0.6.2 still accepts complete PNG/JPEG data URLs through a synchronous
+NativeKit 0.6.3 still accepts complete PNG/JPEG data URLs through a synchronous
 `overlay.pushImage()` call, decodes each image natively, and exposes no shared texture, raw-buffer
 stream, partial update, or animation API.
 
@@ -120,7 +127,8 @@ half of the path:
 - the PiP disappears with the app content region and cannot use native work-area clamping.
 
 The correct ownership layer for the floating surface is the Electron main process plus NativeKit.
-The renderer should retain only eligibility coordination and the compatibility Canvas.
+The renderer owns eligibility coordination and Browser side-panel handoff when NativeKit is
+unavailable.
 
 ## User Need
 
@@ -132,11 +140,11 @@ When an Agent operates YoBrowser in the background, the user needs a preview tha
 - remains read-only and cannot forward input to the remote page;
 - opens the existing Browser panel on deliberate activation;
 - dismisses only the current run;
-- fails safely on platforms where NativeKit 0.6.2 cannot provide an overlay.
+- fails safely on platforms where NativeKit 0.6.3 cannot provide an overlay.
 
 ## Goals
 
-- Use exact dependency version `@zerob13/nativekit@0.6.2`.
+- Use exact dependency version `@zerob13/nativekit@0.6.3`.
 - Make NativeKit the preferred PiP surface on its supported runtime matrix.
 - Allow the PiP to be dragged anywhere inside the current display work area, including completely
   outside the DeepChat window.
@@ -146,8 +154,9 @@ When an Agent operates YoBrowser in the background, the user needs a preview tha
 - Let AppKit, Win32, or XCB own drag, work-area clamping, z-order, and native panel controls.
 - Preserve one in-flight capture, epoch/run validation, last-valid-frame retention, and bounded
   image size.
-- Preserve the current Canvas PiP as a graceful fallback instead of forcing Linux onto X11 or
-  breaking Windows arm64.
+- Keep NativeKit out of application startup and load it only for a concrete PiP request.
+- When NativeKit is unavailable, open Browser in the existing side panel and suppress Computer Use
+  PiP without affecting either Agent tool.
 - Hide the native panel synchronously on stale session, panel visibility, host blur/hide/minimize,
   run terminal state, page destruction, or app shutdown.
 - Add packaging validation so a supported packaged build cannot silently omit its `.node` prebuild.
@@ -167,7 +176,7 @@ When an Agent operates YoBrowser in the background, the user needs a preview tha
 - Completing the deferred multi-tab or Fit-desktop work from the original feature SDD.
 - Adding a generic native-capability framework around one NativeKit consumer.
 
-## NativeKit 0.6.2 Contract
+## NativeKit 0.6.3 Contract
 
 ### Useful API
 
@@ -199,7 +208,7 @@ this migration. One visible PiP and one current target make them unnecessary.
   presents with `UpdateLayeredWindow`.
 - Linux synchronously updates its dedicated XCB overlay thread and decodes through GdkPixbuf.
 - Dragging stays inside the platform implementation and emits no renderer `mousemove` IPC.
-- Movement and transitions are immediate; 0.6.2 has no animation API.
+- Movement and transitions are immediate; 0.6.3 has no animation API.
 - The native `control` event carries the caller-defined ID but no presentation ID. This is safe
   only while DeepChat enforces the one-visible-PiP invariant.
 
@@ -209,11 +218,11 @@ this migration. One visible PiP and one current target make them unnecessary.
 | --- | --- | --- |
 | macOS arm64/x64 | Native overlay | Published prebuild; non-activating `NSPanel` |
 | Windows x64 | Native overlay | Published prebuild; owned layered topmost `HWND` |
-| Windows arm64 | Canvas fallback | NativeKit 0.6.2 publishes no win32-arm64 prebuild |
+| Windows arm64 | Browser side panel; no Computer Use PiP | NativeKit 0.6.3 publishes no win32-arm64 prebuild |
 | Linux x64/arm64 under X11/integrated XWayland | Native overlay | Published prebuild and global XCB window model |
 | Linux x64/arm64 under `xwayland-satellite` | Native overlay | 0.5.4 embeds the XCB panel in the Electron host; dragging is clipped to host bounds |
-| Linux native Wayland | Canvas fallback | No global positioning or compatible X11 window handle |
-| Missing/corrupt addon or native startup failure | Canvas fallback | App startup and Agent tools must remain usable |
+| Linux native Wayland | Browser side panel; no Computer Use PiP | No global positioning or compatible X11 window handle |
+| Missing/corrupt addon or native startup failure | Browser side panel; no Computer Use PiP | App startup and Agent tools remain usable |
 
 DeepChat will not change the user's Linux display backend merely to enable PiP.
 
@@ -233,13 +242,13 @@ focusless render-host BaseWindow -> Agent WebContentsView at 1280 x 800
                                              |
                          +-------------------+-------------------+
                          |                                       |
-                 native capability                        fallback capability
+                 native capability                   native unavailable
                          |                                       |
-                         v                                       v
-              JPEG Buffer -> base64 data URL          typed preview-frame event
-                         |                                       |
-                         v                                       v
-              @zerob13/nativekit overlay              existing Vue Canvas PiP
+                         v                              +--------+--------+
+              JPEG Buffer -> base64 data URL           |                 |
+                         |                              v                 v
+                         v                    Browser activate event   Computer Use
+              @zerob13/nativekit overlay      -> existing side panel   no PiP
                          |
                AppKit / Win32 / XCB panel
 ```
@@ -250,7 +259,8 @@ focusless render-host BaseWindow -> Agent WebContentsView at 1280 x 800
 
 - remains authoritative for page, run, render-host, capture epoch, and preview mode;
 - validates the sender's `BrowserWindow` and current Agent run;
-- selects `native-overlay`, `renderer-canvas`, or `none`;
+- selects `native-overlay` or `none` for native capability handling;
+- requests the existing Browser side panel when native capability is unavailable;
 - branches completed frames to exactly one surface;
 - stops capture and clears the surface on every existing lifecycle edge.
 
@@ -279,10 +289,10 @@ cross-native abstraction.
 
 - current-session, panel, run, and window eligibility derivation;
 - the existing `setPreviewMode` request coalescing;
-- current Canvas rendering and drag only when main selects `renderer-canvas`;
 - handling typed native actions for open-panel and run dismissal.
 
 On `native-overlay`, it renders no PiP DOM and receives no frame bytes.
+On native capability failure, the same typed activation path opens the Browser side panel.
 
 ## Surface Selection Contract
 
@@ -297,14 +307,18 @@ type BrowserPreviewModeResult = {
 }
 ```
 
-Selection is process-stable after NativeKit initialization:
+Selection is process-stable after on-demand NativeKit initialization:
 
-1. Dynamically import `@zerob13/nativekit`.
-2. Start the overlay and keep it globally hidden.
-3. On the first eligible host, validate `attachHost()` with the real
+1. Do not import NativeKit from application startup, Browser background rendering, or Computer Use
+   eligibility alone.
+2. Dynamically import `@zerob13/nativekit` on the first concrete Browser capture or Computer Use
+   target.
+3. Start the overlay and keep it globally hidden.
+4. On the first eligible host, validate `attachHost()` with the real
    `BrowserWindow.getNativeWindowHandle()`.
-4. Use `native-overlay` after both steps succeed.
-5. Otherwise record one redacted capability warning and use `renderer-canvas` for the process.
+5. Use `native-overlay` after both steps succeed.
+6. Otherwise record one redacted capability warning, keep the capability disabled for the process,
+   open Browser in its existing side panel, and expose no Computer Use PiP.
 
 A transient bad frame does not switch surfaces. NativeKit keeps the previous valid presentation,
 and the next bounded capture retries.
@@ -365,7 +379,7 @@ debounced path.
 
 ## Interaction Contract
 
-NativeKit 0.6.2 defines the native interaction surface:
+NativeKit 0.6.3 defines the native interaction surface:
 
 - drag any image area outside the toolbar buttons;
 - double-click the image to activate;
@@ -427,11 +441,12 @@ forward clicks into the remote page.
 Controls are configured left-to-right as **Open in panel** then **Close**. The actual NativeKit
 symbols are platform-native. The diagram shows structure, not exact icons.
 
-### Compatibility fallback
+### Native capability unavailable
 
 ```text
 Windows arm64 / native Wayland / unavailable addon
-  -> keep the existing in-conversation Canvas card and controls
+  -> Browser: open the existing side-panel browser
+  -> Computer Use: continue without PiP
 ```
 
 ## Lifecycle Matrix
@@ -481,7 +496,7 @@ Native feel is split into two measurable promises.
 - no main-process task longer than 50 ms attributable to PiP frame presentation.
 
 The initial implementation may fall back to the current 4 FPS active cap if the synchronous
-NativeKit decode/present gate fails. It must not raise the cap above 8 FPS with NativeKit 0.6.2.
+NativeKit decode/present gate fails. It must not raise the cap above 8 FPS with NativeKit 0.6.3.
 
 These are release gates, not runtime promises for arbitrary hardware. The visible claim is
 "native movement with a fresh read-only preview," not "native-rate browser video."
@@ -503,20 +518,20 @@ These are release gates, not runtime promises for arbitrary hardware. The visibl
 
 ## Packaging and Compatibility
 
-- Add exact dependency `"@zerob13/nativekit": "0.6.2"`.
+- Add exact dependency `"@zerob13/nativekit": "0.6.3"`.
 - Mark `@zerob13/nativekit` as a disallowed install-time build in `pnpm-workspace.yaml`; published
-  prebuilds are resolved at runtime, and unsupported targets must fall back instead of compiling a
-  local addon.
+  prebuilds are resolved at runtime, and unsupported targets must disable native PiP instead of
+  compiling a local addon.
 - Keep it external to the Electron main bundle so `node-gyp-build` resolves the packaged native
   addon.
 - Unpack `node_modules/@zerob13/nativekit/prebuilds/**/*` from ASAR.
 - Verify `node.napi.armv8.node` after packaging for darwin-arm64 and linux-arm64, and verify
   `node.napi.node` for darwin-x64, win32-x64, and linux-x64.
-- Do not make win32-arm64 packaging fail; that target intentionally uses Canvas fallback with
-  version 0.6.2.
+- Do not make win32-arm64 packaging fail; that target intentionally uses the source-specific
+  unavailable behavior with version 0.6.3.
 - Do not source-build the addon as part of a normal DeepChat release.
-- A missing supported prebuild is a packaging failure. An unsupported runtime is a capability
-  fallback.
+- A missing supported prebuild is a packaging failure. An unsupported runtime disables native PiP
+  without blocking application startup or Agent tools.
 
 No persisted data or settings schema changes are required.
 
@@ -533,8 +548,11 @@ so rollback does not navigate pages, migrate user data, or change stored setting
 
 ## Failure Semantics
 
-- Dynamic import or `overlay.start()` failure: log once and use Canvas for the process.
-- First real-host `attachHost()` failure: mark the native capability unavailable and use Canvas.
+- Dynamic import or `overlay.start()` failure: log once and disable native PiP for the process.
+- First real-host `attachHost()` failure: mark the native capability unavailable for the process.
+- Browser native capability failure: publish the existing activate action and open the side panel.
+- Computer Use native capability failure: expose no preview surface and keep tool execution
+  unchanged.
 - Frame capture/resize/encode failure: retain the previous frame and retry on the next bounded tick.
 - `pushImage()` failure: NativeKit transactionally retains its previous presentation; log a
   rate-limited warning and retry.
@@ -542,12 +560,12 @@ so rollback does not navigate pages, migrate user data, or change stored setting
 - Native action with no current logical target: ignore.
 - Panel activation timeout: keep or restore the native PiP; never lose the live page.
 - Host close or addon shutdown: cleanup is idempotent.
-- Fallback Canvas failure: preserve the existing last-frame and placeholder behavior.
 
 ## Acceptance Criteria
 
-- Supported platforms load exactly NativeKit 0.6.2 and use its native overlay.
-- Windows arm64, native Wayland, and unavailable-addon cases keep the existing Canvas PiP.
+- Supported platforms load exactly NativeKit 0.6.3 and use its native overlay.
+- Windows arm64, native Wayland, and unavailable-addon cases open Browser in the existing side
+  panel and show no Computer Use PiP.
 - The preferred path sends no `browser.preview.frame` payload to the renderer.
 - The remote page retains the same `WebContents`, `WebContentsView`, session, URL, DOM state,
   scroll state, cookies, and CDP target across native PiP and Browser panel handoff.
@@ -568,18 +586,18 @@ so rollback does not navigate pages, migrate user data, or change stored setting
   capped at 4 FPS.
 - The packaged app contains the correct prebuild on every supported target.
 - Renderer/preload security boundaries remain unchanged.
-- Existing Canvas PiP tests remain as fallback coverage; native adapter, presenter selection,
-  action mapping, packaging, and packaged smoke tests are added.
+- Tests cover on-demand loading, process-stable disablement, Browser side-panel handoff, Computer
+  Use no-surface behavior, native adapter selection, action mapping, and packaging.
 - `pnpm run format`, `pnpm run i18n`, `pnpm run lint`, typecheck, focused tests, build, and packaged
   platform checks pass after implementation.
 
 ## Implementation Evidence
 
-Recorded on 2026-07-23:
+Recorded through 2026-07-29:
 
-- `@zerob13/nativekit` is pinned to `0.6.2`, remains external to the main bundle, and its prebuilds
+- `@zerob13/nativekit` is pinned to `0.6.3`, remains external to the main bundle, and its prebuilds
   are unpacked from ASAR.
-- NativeKit 0.6.2 configures a fixed dark custom toolbar with larger caller-provided transparent
+- NativeKit 0.6.3 configures a fixed dark custom toolbar with larger caller-provided transparent
   PNG templates for `open-panel` and `close`, emits their IDs through `control`, sizes the native
   panel to 360 x 225 DIP, and keeps root-level sizing independent of host bounds.
 - The published 0.5.5 tarball uses `node.napi.node` for all five prebuilds. This matches
@@ -595,6 +613,8 @@ Recorded on 2026-07-23:
   Platform addon and packaged application validation are delegated to CI.
 - The published 0.6.2 package contains the reviewed macOS contrast fix and all five expected
   prebuilds. ARM64 uses `node.napi.armv8.node`; x64 uses `node.napi.node`.
+- The published 0.6.3 package contains the same five prebuilds and statically links the Windows
+  x64 prebuild to the MSVC runtime.
 - The published 0.5.4 macOS arm64 and x64 binaries both report `minos 12.0`; the previous 0.5.1
   prebuilds reported `minos 15.0`.
 - A real Electron smoke test loaded NativeKit 0.5.4 and completed
@@ -612,7 +632,8 @@ Recorded on 2026-07-23:
   `app.asar.unpacked/node_modules/@zerob13/nativekit/prebuilds/darwin-arm64/nativekit.napi.node`
   was present, byte-identical to the installed 0.5.4 prebuild, and reported `minos 12.0`. The
   packaged DeepChat executable and `LSMinimumSystemVersion` also report macOS 12.0.
-- Focused NativeKit adapter, packaging configuration, and Canvas fallback tests pass all 23 tests,
+- Focused NativeKit adapter, packaging configuration, and renderer Canvas regression tests pass all
+  23 tests,
   including configured control mapping and unknown-control rejection.
 - After merging `origin/dev` at `011407ab6`, the merge-focused suite passes all 90 tests and the
   current full main suite passes 405 files and 4,636 tests, with 19 files and 233 tests skipped.
@@ -622,14 +643,16 @@ Recorded on 2026-07-23:
   `App.startup.test.ts` mock returns `undefined` from `initAppStores()` while production chains
   `.then()`. That baseline mismatch leaves 15 unrelated startup tests failing and is outside this
   migration.
-- Windows, Linux, macOS x64, native Wayland fallback, out-of-window visual interaction, and
+- Windows, Linux, macOS x64, native Wayland unavailable behavior, out-of-window visual interaction,
+  and
   60/120 Hz performance measurements remain unverified on physical target environments.
 
 ## Resolved Decisions
 
-- NativeKit version is exactly 0.6.2.
+- NativeKit version is exactly 0.6.3.
 - Native movement is the primary smoothness win; the page remains a bounded snapshot stream.
-- The current Canvas is retained only as a compatibility fallback.
+- NativeKit is never loaded by application startup or eligibility-only state.
+- Native capability failure opens Browser in the existing side panel and disables Computer Use PiP.
 - Linux display backend is not forced.
 - NativeKit's caller-configured toolbar is used; no companion Vue/native toolbar window is added.
 - One visible PiP makes NativeKit's unscoped action callbacks safe.

--- a/docs/architecture/nativekit-agent-browser-pip/tasks.md
+++ b/docs/architecture/nativekit-agent-browser-pip/tasks.md
@@ -21,19 +21,21 @@ remain open.
 
 ## Dependency and packaging
 
-- [x] Add exact dependency `@zerob13/nativekit@0.6.2`.
+- [x] Add exact dependency `@zerob13/nativekit@0.6.3`.
 - [x] Refresh `pnpm-lock.yaml`.
 - [x] Disable NativeKit install-time source builds in `pnpm-workspace.yaml`.
 - [x] Keep NativeKit external to the Electron main bundle.
 - [x] Add the NativeKit prebuild glob to `asarUnpack`.
 - [x] Extend `afterPack` validation for supported target tuples.
-- [x] Keep Windows arm64 packaging valid with Canvas fallback.
+- [x] Keep Windows arm64 packaging valid without requiring a NativeKit prebuild.
 - [x] Add or update packaging configuration tests.
 
 ## Native overlay adapter
 
 - [x] Add focused `AgentBrowserNativeOverlay` main-process adapter.
-- [x] Dynamically import and start NativeKit without blocking app startup.
+- [x] Remove the NativeKit initialization task from app startup.
+- [x] Dynamically import and start NativeKit only for the first Browser capture or concrete Computer
+      Use target.
 - [x] Detect unsupported runtime, import failure, startup failure, and first-host attach failure.
 - [x] Enforce one active host, presentation, and logical target.
 - [x] Convert bounded JPEG buffers to data URLs only at the native boundary.
@@ -51,8 +53,10 @@ remain open.
 
 ## Presenter integration
 
-- [x] Initialize and shut down the adapter with `YoBrowserPresenter`.
-- [x] Select `native-overlay`, `renderer-canvas`, or `none` process-stably.
+- [x] Route on-demand initialization and shutdown through the main-process presenters.
+- [x] Select `native-overlay` or `none` process-stably after on-demand initialization.
+- [x] Open Browser in its existing side panel when NativeKit is unavailable.
+- [x] Disable Computer Use PiP when NativeKit is unavailable without changing CUA execution.
 - [x] Return the selected surface from `setPreviewMode`.
 - [x] Route each completed frame to exactly one surface.
 - [x] Revalidate window, session, run, mode, surface, and epoch before presentation.
@@ -62,7 +66,7 @@ remain open.
 - [x] Hide on blur, hide, minimize, panel open, and preview stop.
 - [x] Remove on run terminal, target replacement, page/session destruction, and host close.
 - [x] Retain the fixed 1280 x 800 render host and same live page identity.
-- [x] Add presenter native/fallback routing and lifecycle tests.
+- [x] Add presenter native/unavailable routing and lifecycle tests.
 
 ## Contracts and renderer
 
@@ -71,7 +75,7 @@ remain open.
 - [x] Update desktop routes and `BrowserClient`.
 - [x] Track the acknowledged surface in `AgentBrowserPiP.vue`.
 - [x] Render no PiP DOM and decode no frame on the native path.
-- [x] Keep the current Canvas UI and frame path unchanged as fallback.
+- [x] Keep the current Canvas UI and frame path source-compatible.
 - [x] Validate exact window/session/run before native activate or dismiss handling.
 - [x] Open the existing Browser panel on activate.
 - [x] Reuse current run-scoped dismissal on hide.
@@ -90,8 +94,9 @@ remain open.
 - [x] Keep active capture at 4 FPS unless profiling clears an increase, capped at 8 FPS.
 - [x] Smoke-test macOS arm64 through the upstream demo and DeepChat addon sequence.
 - [ ] Smoke-test macOS x64, Windows x64, and Linux X11/XWayland.
-- [x] Verify Canvas fallback selection for Windows arm64 in automated coverage.
-- [ ] Verify Canvas fallback on a physical native Wayland session.
+- [x] Verify Browser side-panel handoff and Computer Use no-surface behavior for unavailable
+      NativeKit in automated coverage.
+- [ ] Verify the same unavailable behavior on a physical native Wayland session.
 - [x] Inspect the macOS arm64 packaged artifact for the correct unpacked prebuild.
 
 ## Final validation

--- a/docs/features/agent-browser-pip/spec.md
+++ b/docs/features/agent-browser-pip/spec.md
@@ -9,7 +9,7 @@ size and shows a low-frame-rate, read-only Canvas mirror in PiP. A visible multi
 Fit-desktop emulation remain deferred. Packaged Windows and Linux validation remains open.
 
 On 2026-07-23, the
-[NativeKit 0.6.0 surface migration](../../architecture/nativekit-agent-browser-pip/spec.md) was
+[NativeKit 0.6.3 surface migration](../../architecture/nativekit-agent-browser-pip/spec.md) was
 implemented. That architecture supersedes this document's renderer-owned PiP surface and
 frame-delivery path: supported runtimes use a native, out-of-window draggable panel. When the
 native addon is unavailable, Browser opens in the existing side panel instead of selecting the
@@ -49,7 +49,7 @@ The requested behavior is:
 - keep a closed right-side panel closed while native PiP is available; open it automatically only
   when the native PiP capability is unavailable;
 - show the Agent-operated page in the existing Browser panel when that surface is already visible;
-- otherwise show it as a draggable in-chat floating preview;
+- otherwise, when native PiP is available, show it as a draggable native floating preview;
 - make the floating preview read-only while the Agent operates the same live page in a normal-size
   background render host;
 - move the same live page between the background render host and panel without reload or state

--- a/docs/features/agent-browser-pip/spec.md
+++ b/docs/features/agent-browser-pip/spec.md
@@ -11,16 +11,17 @@ Fit-desktop emulation remain deferred. Packaged Windows and Linux validation rem
 On 2026-07-23, the
 [NativeKit 0.6.0 surface migration](../../architecture/nativekit-agent-browser-pip/spec.md) was
 implemented. That architecture supersedes this document's renderer-owned PiP surface and
-frame-delivery path: supported runtimes use a native, out-of-window draggable panel, while the
-Canvas described here remains the compatibility fallback. This document's page ownership, fixed
-background viewport, read-only preview, panel handoff, and run-scoped dismissal contracts remain
-authoritative.
+frame-delivery path: supported runtimes use a native, out-of-window draggable panel. When the
+native addon is unavailable, Browser opens in the existing side panel instead of selecting the
+Canvas described here. This document's page ownership, fixed background viewport, read-only
+preview, panel handoff, and run-scoped dismissal contracts remain authoritative.
 
 On 2026-07-28, a
 [Computer Use latest-snapshot PiP extension](../computer-use-snapshot-pip/spec.md) was implemented.
 It shares only process-global NativeKit presentation ownership; it does not generalize Browser
 page, capture, panel-handoff, or public feature contracts. Browser keeps **Open in panel** plus
-**Close**, continuous bounded capture, and its existing Canvas compatibility behavior.
+**Close**, continuous bounded native capture, and side-panel handoff when native PiP is
+unavailable.
 
 The referenced screenshot was not available in the current task context, so the interaction and
 layout are specified here while exact visual styling remains provisional.
@@ -45,7 +46,8 @@ is a compatibility defect and must not become part of a new adaptive-surface des
 
 The requested behavior is:
 
-- never open a closed right-side panel merely because an Agent uses YoBrowser;
+- keep a closed right-side panel closed while native PiP is available; open it automatically only
+  when the native PiP capability is unavailable;
 - show the Agent-operated page in the existing Browser panel when that surface is already visible;
 - otherwise show it as a draggable in-chat floating preview;
 - make the floating preview read-only while the Agent operates the same live page in a normal-size

--- a/docs/features/computer-use-snapshot-pip/plan.md
+++ b/docs/features/computer-use-snapshot-pip/plan.md
@@ -6,7 +6,7 @@ Implemented on branch `codex/computer-use-snapshot-pip` on 2026-07-28.
 
 Phases 1-5 are implemented with focused automated coverage, and the complete renderer suite passes.
 The complete main suite retains one isolated, unrelated provider-metadata expectation failure.
-Performance measurement and packaged native and fallback platform QA remain open; the exact
+Performance measurement and packaged native and native-unavailable platform QA remain open; the exact
 remaining work is recorded in `tasks.md`.
 
 CUA runtime, plugin, policy, skill, and asset updates are explicitly out of scope. The plan consumes
@@ -20,8 +20,8 @@ configuration is global, so implementing a second standalone overlay adapter fir
 known Browser/Computer race.
 
 Then carry existing Agent run identity through the MCP execution path and observe only resolved,
-trusted CUA calls. Build the snapshot transform and renderer fallback after those identities are
-available. Finish with arbitration, lifecycle hardening, and Browser regression verification.
+trusted CUA calls. Build the bounded snapshot transform after those identities are available.
+Finish with arbitration, lifecycle hardening, and Browser regression verification.
 
 ```text
 shared NativeKit owner
@@ -30,7 +30,7 @@ shared NativeKit owner
         |
         +--> Computer Use observer -> presenter -> snapshot producer
                                             |
-                                  native or Canvas surface
+                                  native or no PiP surface
 ```
 
 ## Phase 1: Shared PiP Ownership
@@ -42,7 +42,7 @@ one coordinator instantiated in `src/main/app/composition.ts`.
 
 Keep the extraction narrow:
 
-- one dynamic NativeKit import and capability result;
+- one on-demand NativeKit import and process-stable capability result;
 - one `overlay.start()` and `overlay.stop()` lifecycle;
 - one host attachment and host/display listener set;
 - one visible presentation;
@@ -50,8 +50,8 @@ Keep the extraction narrow:
 - source-specific activation/control callbacks;
 - common visibility, removal, prepaint, and latency behavior.
 
-The Browser presenter remains authoritative for Browser page/run/capture state. Migrate its current
-native adapter calls to the coordinator without changing Browser contracts or fallback behavior.
+The Browser presenter remains authoritative for Browser page/run/capture state. Native
+unavailability uses the existing Browser activation event to open the side panel.
 
 ### 2. Add explicit toolbar profiles
 
@@ -176,12 +176,12 @@ In main:
 5. Encode JPEG quality 72.
 6. Reject output larger than 512 KiB.
 7. Revalidate epoch and claim.
-8. Present to NativeKit or emit the Canvas fallback frame.
+8. Present to NativeKit when available; otherwise expose no preview surface.
 
 Keep one transform in flight and one replaceable latest pending result. Add rate-limited,
 metadata-only warnings for validation and latency failures.
 
-## Phase 4: Typed Desktop Contracts and Renderer Fallback
+## Phase 4: Typed Desktop Contracts and Renderer Coordination
 
 ### 9. Add routes and events
 
@@ -192,7 +192,8 @@ Add Computer Use preview schemas beside the existing desktop/browser contract or
 - `computerUse.preview.frame`.
 
 Expose them through the existing typed preload/client boundary. Validate route sender and session
-binding in main. Emit frame events only for Canvas fallback.
+binding in main. Keep the bounded frame event source-compatible, but do not publish it when native
+capability is unavailable.
 
 ### 10. Add the renderer controller
 
@@ -205,20 +206,17 @@ Derive:
 - current route;
 - host focus.
 
-Send `eligible`, `suspended`, or `stopped` only when the derived mode changes. On native surfaces,
-render nothing and never subscribe to image payloads.
+Send `eligible`, `suspended`, or `stopped` only when the derived mode changes. On
+`native-overlay` or `none`, render nothing and never subscribe to image payloads.
 
-### 11. Add the Canvas fallback
+### 11. Handle native unavailability
 
-For fallback only:
+When NativeKit is unavailable:
 
-- render one bounded Canvas card;
-- expose one existing translated **Close** button;
-- make non-control surface points draggable with pointer capture;
-- decode a frame before replacing current Canvas pixels;
-- reject stale session/run/sequence events;
-- release image resources on replacement and unmount;
-- forward no input to the target application.
+- return `none` for Computer Use preview mode;
+- subscribe to no renderer frame bytes;
+- render no Computer Use PiP DOM;
+- leave CUA tool execution, results, and target input unchanged.
 
 Do not add a generic Browser/Computer Vue component unless the completed implementation has
 meaningful stable duplication.
@@ -264,8 +262,8 @@ Add the smallest tests for:
 - successful, failed, aborted, and out-of-order observer callbacks;
 - presenter run/target/epoch transitions;
 - image validation, resize, output limit, and latest-wins behavior;
-- native delivery versus Canvas-only frame publication;
-- renderer focus/session modes, close, frame retention, and cleanup.
+- native delivery versus unavailable no-surface behavior;
+- renderer focus/session modes, close, unavailable no-DOM behavior, and cleanup.
 
 ### 16. Measure performance
 
@@ -284,16 +282,17 @@ Verify:
 Verify at least:
 
 - one packaged native-overlay runtime;
-- one packaged Canvas-fallback runtime;
+- one packaged native-unavailable runtime;
 - host focus/minimize/restore;
 - target application foreground transition;
 - Browser-to-Computer and Computer-to-Browser claims;
 - native toolbar profile switching;
+- Browser side-panel handoff and Computer Use no-surface behavior when NativeKit is unavailable;
 - run close/restart and session switching;
 - malformed and oversized image handling.
 
-Keep the feature behind an internal gate until both surface paths pass if the platform matrix cannot
-complete in the implementation change.
+Keep the feature behind an internal gate until native and unavailable behavior pass if the platform
+matrix cannot complete in the implementation change.
 
 ### 18. Close documentation
 

--- a/docs/features/computer-use-snapshot-pip/spec.md
+++ b/docs/features/computer-use-snapshot-pip/spec.md
@@ -213,8 +213,8 @@ The existing `common.close` translation is sufficient. This feature adds no user
 - Added an `epoch` to Computer Use surface and frame events so a later target in the same run cannot
   accept an in-flight frame from the prior target.
 - The shared coordinator permanently disables native PiP after a NativeKit load, startup, toolbar,
-  host-attach, or frame-push failure for the current process. Computer Use then exposes no preview
-  surface and does not repeatedly retry during Agent work.
+  or host-attach failure for the current process. A frame-push failure retains the previous native
+  presentation and retries on the next valid snapshot.
 - An eligible successful official CUA `click` schedules one non-blocking private
   `get_window_state({ pid, window_id })` call. The private response is routed only to the preview
   observer and is never published as an MCP result or returned to the Agent.
@@ -576,8 +576,9 @@ The feature follows the existing NativeKit support matrix:
 No platform capture permission is added because both Agent-requested and private snapshots use the
 existing Computer Use tool. Existing CUA permission behavior is unchanged.
 
-If NativeKit fails after initialization, hide/remove the native presentation, disable preview
-state, and continue the Agent without interruption.
+If toolbar configuration or host attachment fails after initialization, hide/remove the native
+presentation, disable preview state, and continue the Agent without interruption. A frame-push
+failure retains the previous presentation and retries without interrupting the Agent.
 
 ## Performance Budget
 

--- a/docs/features/computer-use-snapshot-pip/spec.md
+++ b/docs/features/computer-use-snapshot-pip/spec.md
@@ -7,7 +7,7 @@ Implemented on branch `codex/computer-use-snapshot-pip` on 2026-07-28.
 Format, i18n, lint, typecheck, focused main/renderer coverage, and the complete renderer suite pass.
 The complete main suite has one unrelated provider-metadata expectation failure in
 `test/main/provider/modelConfig.test.ts`; the same test fails in isolation and neither it nor its
-implementation is changed by this feature. Packaged native-overlay and Canvas-fallback QA,
+implementation is changed by this feature. Packaged native-overlay and native-unavailable QA,
 cross-platform interaction checks, and the 150 ms p95 result-to-visible measurement remain open and
 are tracked in `tasks.md`.
 
@@ -58,7 +58,7 @@ The snapshot PiP is feasible without changing CUA.
 | Can the existing PiP surface be reused? | NativeKit accepts PNG/JPEG data URLs and supports repeated toolbar reconfiguration. | Share one native owner and switch explicit Browser/Computer profiles. |
 | Can a result be tied to the correct Agent run? | The Agent runtime has a stable `runId`, but the MCP branch currently drops it. | Forward internal execution metadata through the MCP service path. |
 | Can stale pixels be isolated? | ToolManager knows the resolved plugin source, original tool, prepared target arguments, and tool-call identity. | Observe at that boundary and validate run, target, claim, and epoch before display. |
-| Does every platform have a native overlay? | No; the existing NativeKit matrix has Windows arm64, native Wayland, and load-failure gaps. | Preserve a small renderer Canvas fallback. |
+| Does every platform have a native overlay? | No; the existing NativeKit matrix has Windows arm64, native Wayland, and load-failure gaps. | Disable Computer Use PiP without changing CUA execution. |
 
 The main engineering risk is not screenshot performance. It is ownership: NativeKit is
 process-global, while Browser and Computer Use have different controls and lifecycles. A shared
@@ -136,8 +136,8 @@ The existing `common.close` translation is sufficient. This feature adds no user
 - Update the PiP after each later valid snapshot for the same active target.
 - Keep the last valid image visible between snapshots without showing stale images from another
   run, session, or target.
-- Prefer the existing NativeKit overlay on supported runtimes and preserve the renderer Canvas
-  fallback elsewhere.
+- Use the existing NativeKit overlay on supported runtimes and expose no Computer Use PiP when the
+  native capability is unavailable.
 - Share one process-global native overlay safely between Browser and Computer Use.
 - Preserve Browser PiP's existing **Open in panel** plus **Close** controls.
 - Give Computer Use exactly one **Close** control and ignore native activation.
@@ -190,7 +190,7 @@ The existing `common.close` translation is sufficient. This feature adds no user
 - NativeKit provides one process-global overlay manager. Starting a second independent adapter
   would replace global toolbar configuration.
 - `AgentBrowserPiP.vue`, mounted by `ChatTabView.vue`, coordinates Browser preview eligibility and
-  renders the Canvas fallback.
+  opens the existing Browser side panel when native PiP is unavailable.
 - The Agent runtime already passes `io.requestId` as `ToolCallOptions.runId`.
 - `ToolService` forwards `runId` to built-in Agent tools but currently drops it on the MCP path
   before `McpService.callTool`.
@@ -212,9 +212,9 @@ The existing `common.close` translation is sufficient. This feature adds no user
   polling.
 - Added an `epoch` to Computer Use surface and frame events so a later target in the same run cannot
   accept an in-flight frame from the prior target.
-- The shared coordinator permanently falls back to Canvas after a NativeKit load, startup, toolbar,
-  host-attach, or frame-push failure for the current process. It does not repeatedly retry a failed
-  native path during Agent work.
+- The shared coordinator permanently disables native PiP after a NativeKit load, startup, toolbar,
+  host-attach, or frame-push failure for the current process. Computer Use then exposes no preview
+  surface and does not repeatedly retry during Agent work.
 - An eligible successful official CUA `click` schedules one non-blocking private
   `get_window_state({ pid, window_id })` call. The private response is routed only to the preview
   observer and is never published as an MCP result or returned to the Agent.
@@ -322,9 +322,9 @@ ToolService -> McpService -> ToolManager
           +------+------------------+
           |                         |
           v                         v
-  NativeKit overlay          renderer Canvas fallback
-  main-process image         typed bounded frame event
-  Computer toolbar: Close    Computer toolbar: Close
+  NativeKit overlay          native unavailable
+  main-process image         no Computer Use PiP
+  Computer toolbar: Close    CUA execution unchanged
 ```
 
 ### Shared Native Overlay Ownership
@@ -336,14 +336,14 @@ Extract the process-global concerns currently inside `AgentBrowserNativeOverlay`
 The shared owner is responsible for:
 
 - one NativeKit `start()` / `stop()` lifecycle;
-- capability detection and Canvas fallback selection;
+- on-demand capability detection and process-stable disablement;
 - one attached host and one visible presentation;
 - toolbar profile switching before a source is presented;
 - display, host move/resize, focus, show/hide, minimize/restore, and close listeners;
 - one eligible source claim and monotonic claim sequence per host/session;
 - shared run-scoped dismissal;
 - prepaint-before-show ordering;
-- NativeKit latency instrumentation and failure fallback.
+- NativeKit latency instrumentation and failure disablement.
 
 Source profiles remain explicit:
 
@@ -449,10 +449,10 @@ The presenter:
 - keeps at most one transform in flight per active target;
 - drops queued intermediate work and retains only the latest pending result;
 - revalidates session, run, target, tool call, claim, and epoch before presentation;
-- sends a data URL directly to NativeKit or a typed byte event only to the Canvas fallback;
+- sends a data URL directly to NativeKit when the native capability is available;
 - owns stop, suspend, resume, dismiss, and shutdown cleanup.
 
-### Renderer Coordination and Fallback
+### Renderer Coordination
 
 Add a focused `AgentComputerUsePiP.vue` beside `AgentBrowserPiP.vue` in `ChatTabView.vue`.
 
@@ -463,9 +463,8 @@ On the native path it is a headless lifecycle controller:
 - call typed mode routes only when derived state changes;
 - render no image DOM and receive no frame bytes.
 
-On the fallback path it renders a small Canvas card with exactly one **Close** button. It retains
-the previous Canvas pixels until a fully decoded new frame is ready and revokes all object URLs and
-image resources on replacement/unmount.
+When NativeKit is unavailable, it receives `none`, subscribes to no frame bytes, and renders no PiP
+DOM.
 
 Keep the Computer Use component separate from `AgentBrowserPiP.vue`. Extract shared renderer logic
 only if implementation reveals stable duplication; the source rules and controls are intentionally
@@ -507,7 +506,7 @@ type DismissComputerUsePreviewOutput = {
 authoritative for actual visibility. `suspended` retains the current valid frame while hiding it.
 `stopped` removes presenter state for that session.
 
-### Fallback Event
+### Renderer Frame Event
 
 ```ts
 type ComputerUsePreviewFrame = {
@@ -522,8 +521,8 @@ type ComputerUsePreviewFrame = {
 }
 ```
 
-Publish `computerUse.preview.frame` only when the selected surface is `renderer-canvas`. The native
-path must not send image bytes to the renderer.
+The typed `computerUse.preview.frame` contract remains bounded, but native capability failure does
+not select `renderer-canvas` or publish image bytes to the renderer.
 
 ## Image Pipeline
 
@@ -569,16 +568,16 @@ The feature follows the existing NativeKit support matrix:
 | --- | --- |
 | macOS arm64/x64 | Native overlay |
 | Windows x64 | Native overlay |
-| Windows arm64 | Renderer Canvas fallback |
+| Windows arm64 | No Computer Use PiP |
 | Linux x64/arm64 under X11 or supported XWayland | Native overlay |
-| Linux native Wayland | Renderer Canvas fallback |
-| Missing/corrupt addon or native startup failure | Renderer Canvas fallback |
+| Linux native Wayland | No Computer Use PiP |
+| Missing/corrupt addon or native startup failure | No Computer Use PiP |
 
 No platform capture permission is added because both Agent-requested and private snapshots use the
 existing Computer Use tool. Existing CUA permission behavior is unchanged.
 
-If NativeKit fails after initialization, hide/remove the native presentation and publish the
-retained valid current frame to Canvas fallback without interrupting the Agent.
+If NativeKit fails after initialization, hide/remove the native presentation, disable preview
+state, and continue the Agent without interruption.
 
 ## Performance Budget
 
@@ -607,7 +606,7 @@ These are acceptance budgets, not claims that every CUA action produces a snapsh
 | Oversized image | Reject frame and record a rate-limited metadata-only warning |
 | Stale/out-of-order result | Drop by claim, epoch, run, target, and tool-call validation |
 | Target changes | Hide/remove old presentation; wait for first valid new-target frame |
-| Native overlay unavailable | Use Canvas fallback |
+| Native overlay unavailable | Show no Computer Use PiP; continue CUA normally |
 | Host loses focus | Hide while retaining current valid frame |
 | Session/run stops | Remove presentation and release frame state |
 | Presenter shutdown | Unsubscribe listeners, remove image, detach host, stop shared owner once |
@@ -619,13 +618,13 @@ Preview failures never change the MCP tool result or Agent execution outcome.
 ### User Behavior
 
 - A successful current-run `get_window_state` image produces one read-only latest-snapshot PiP when
-  the active DeepChat chat is foreground and working.
+  the active DeepChat chat is foreground, working, and NativeKit is available.
 - The PiP is never blank and appears only after its first valid frame.
 - Later valid snapshots for the same target replace the visible image.
 - An eligible successful `click` schedules a private PiP-only snapshot and may refresh the visible
   image without adding screenshot content to the Agent response.
 - The Computer Use PiP contains exactly one **Close** button.
-- Dragging is native on supported platforms and renderer-local on fallback platforms.
+- Dragging is native on supported platforms; unavailable platforms show no Computer Use PiP.
 - Close suppresses only the current run and never changes the Agent or target application.
 - A later run may show a new PiP after its first valid snapshot.
 - Host blur/hide/minimize and route/session switch hide the PiP without leaking another session's
@@ -656,11 +655,11 @@ Preview failures never change the MCP tool result or Agent execution outcome.
   responses.
 - Image pipeline tests cover PNG/JPEG, malformed base64, unsupported MIME, dimension/input/output
   limits, aspect ratio, no upscale, and latest-wins scheduling.
-- Renderer tests cover native headless mode, Canvas fallback frame retention, close, focus,
-  unmount cleanup, and session switching.
+- Renderer tests cover native headless mode, unavailable no-surface behavior, close, focus, unmount
+  cleanup, and session switching.
 - Browser regression tests cover toolbar profile switching, activation, dismissal, capture refresh,
   and panel handoff.
-- Packaged QA covers the existing NativeKit native/fallback platform matrix.
+- Packaged QA covers one NativeKit runtime and one native-unavailable runtime.
 
 ## Rollout
 
@@ -669,5 +668,5 @@ change. The gate must disable only the Computer Use preview observer/presenter; 
 CUA tool execution or Browser PiP.
 
 Do not call the feature complete until Browser regression coverage and at least one native plus one
-Canvas fallback packaged run pass. Update this status and the linked Browser NativeKit architecture
-document after implementation.
+native-unavailable packaged run pass. Update this status and the linked Browser NativeKit
+architecture document after implementation.

--- a/docs/features/computer-use-snapshot-pip/tasks.md
+++ b/docs/features/computer-use-snapshot-pip/tasks.md
@@ -68,6 +68,12 @@ measurement and packaged platform QA are still open.
   - Reject stale frame sequences and release renderer resources on teardown.
   - Reuse `common.close` without adding new copy.
 
+- [x] T09a - Disable fallback UI when NativeKit is unavailable
+  - Load NativeKit only when a concrete Computer Use target exists.
+  - Return `none` after a process-stable native load failure.
+  - Subscribe to no renderer frames and render no Computer Use PiP.
+  - Preserve CUA tool execution and results.
+
 - [x] T10 - Complete lifecycle and privacy cleanup
   - Hide on host blur/hide/minimize and inactive route/session.
   - Remove on terminal run/session, target change, host close, and shutdown.
@@ -112,7 +118,8 @@ measurement and packaged platform QA are still open.
 
 - [ ] T15 - Run packaged platform QA
   - Verify one NativeKit native-overlay runtime.
-  - Verify one renderer Canvas-fallback runtime.
+  - Verify one native-unavailable runtime.
+  - Verify Browser opens its existing side panel and Computer Use shows no PiP.
   - Exercise host focus/minimize/restore and target-app foreground behavior.
   - Exercise Browser/Computer source transitions and toolbar profile changes.
   - Exercise close, later run, route/session switch, and app shutdown.
@@ -153,8 +160,7 @@ measurement and packaged platform QA are still open.
 - Computer Use PiP has only **Close**, is read-only, and never affects the Agent or target
   application.
 - Run, target, session, host, and epoch validation prevent stale pixel disclosure.
-- Native delivery avoids renderer image traffic; unsupported runtimes use the bounded Canvas
-  fallback.
+- Native delivery avoids renderer image traffic; unsupported runtimes expose no Computer Use PiP.
 - Image work is memory-only, bounded, latest-wins, and covered by focused tests.
 - Browser PiP behavior remains regression-tested.
-- Required checks and at least one native plus one fallback packaged QA run pass.
+- Required checks and at least one native plus one native-unavailable packaged QA run pass.

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@larksuiteoapi/node-sdk": "^1.64.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@parcel/watcher": "^2.5.6",
-    "@zerob13/nativekit": "0.6.2",
+    "@zerob13/nativekit": "0.6.3",
     "ai": "^7.0.37",
     "axios": "^1.18.1",
     "better-sqlite3-multiple-ciphers": "12.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^2.5.6
         version: 2.6.0
       '@zerob13/nativekit':
-        specifier: 0.6.2
-        version: 0.6.2(electron@40.10.5)
+        specifier: 0.6.3
+        version: 0.6.3(electron@40.10.5)
       ai:
         specifier: ^7.0.37
         version: 7.0.37(zod@4.4.3)
@@ -3295,8 +3295,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@zerob13/nativekit@0.6.2':
-    resolution: {integrity: sha512-8CuHX/vRRMq64/59vz5SrpIeJXsaNAqz1WcNuGCLSoprBPfDK22yxlccbBQiIZN1do9s9v5CgUQNw7M9rgCO1A==}
+  '@zerob13/nativekit@0.6.3':
+    resolution: {integrity: sha512-RDzp4//FKrQkNt2OgL74ClQBDxWzt32JRXW1vDFAgm/ri5ipyL1v78Izwt8tQpZ3y+K18S5MThiD5Vm4hWqmCQ==}
     engines: {node: '>=18'}
     cpu: [arm64, x64]
     os: [darwin, linux, win32]
@@ -9958,7 +9958,7 @@ snapshots:
   '@yuuang/ffi-rs-win32-x64-msvc@1.3.2':
     optional: true
 
-  '@zerob13/nativekit@0.6.2(electron@40.10.5)':
+  '@zerob13/nativekit@0.6.3(electron@40.10.5)':
     dependencies:
       electron: 40.10.5
       node-addon-api: 8.9.0

--- a/resources/acp-registry/registry.json
+++ b/resources/acp-registry/registry.json
@@ -122,7 +122,7 @@
     {
       "id": "cline",
       "name": "Cline",
-      "version": "3.0.46",
+      "version": "3.0.47",
       "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
       "repository": "https://github.com/cline/cline",
       "website": "https://cline.bot/cli",
@@ -133,7 +133,7 @@
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/cline.svg",
       "distribution": {
         "npx": {
-          "package": "cline@3.0.46",
+          "package": "cline@3.0.47",
           "args": [
             "--acp"
           ]
@@ -508,7 +508,7 @@
     {
       "id": "factory-droid",
       "name": "Factory Droid",
-      "version": "0.181.0",
+      "version": "0.182.0",
       "description": "Factory Droid - AI coding agent powered by Factory AI",
       "website": "https://factory.ai/product/cli",
       "authors": [
@@ -517,7 +517,7 @@
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "droid@0.181.0",
+          "package": "droid@0.182.0",
           "args": [
             "exec",
             "--output-format",
@@ -555,7 +555,7 @@
     {
       "id": "gemini",
       "name": "Gemini CLI",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "description": "Google's official CLI for Gemini",
       "repository": "https://github.com/google-gemini/gemini-cli",
       "website": "https://geminicli.com",
@@ -565,7 +565,7 @@
       "license": "Apache-2.0",
       "distribution": {
         "npx": {
-          "package": "@google/gemini-cli@0.52.0",
+          "package": "@google/gemini-cli@0.53.0",
           "args": [
             "--acp"
           ]
@@ -671,7 +671,7 @@
     {
       "id": "grok-build",
       "name": "Grok Build",
-      "version": "0.2.112",
+      "version": "0.2.113",
       "description": "xAI's coding agent and CLI",
       "website": "https://x.ai/cli",
       "authors": [
@@ -680,7 +680,7 @@
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "@xai-official/grok@0.2.112",
+          "package": "@xai-official/grok@0.2.113",
           "args": [
             "agent",
             "stdio"
@@ -953,7 +953,7 @@
     {
       "id": "mistral-vibe",
       "name": "Mistral Vibe",
-      "version": "2.22.0",
+      "version": "2.23.1",
       "description": "Mistral's open-source coding assistant",
       "repository": "https://github.com/mistralai/mistral-vibe",
       "website": "https://mistral.ai/products/vibe",
@@ -965,29 +965,29 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-darwin-aarch64-2.22.0.zip",
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.1/vibe-acp-darwin-aarch64-2.23.1.zip",
             "cmd": "./vibe-acp",
-            "sha256": "832db06d29a28aa4473f4ce560ee80d95aa3debd337b9a3883c899f14eebea8c"
+            "sha256": "12a0d7cedf6e17bb3ce41c70c8712d5694090f4e9ba51ec46434f790418034b8"
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-darwin-x86_64-2.22.0.zip",
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.1/vibe-acp-darwin-x86_64-2.23.1.zip",
             "cmd": "./vibe-acp",
-            "sha256": "7de9b102bcde6ed487a7d341cbe57fbca6815e49a723efc70cbb1730d0ec8f3b"
+            "sha256": "8373432bf786ca49a05dff33238a459ef7b0ae0cb317325e07f9b377fae69bc3"
           },
           "linux-aarch64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-linux-aarch64-2.22.0.zip",
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.1/vibe-acp-linux-aarch64-2.23.1.zip",
             "cmd": "./vibe-acp",
-            "sha256": "48953c3b77aa73e3d3719da0140fc321f2e267cbf392cb85e95aac38b3fe5547"
+            "sha256": "94d5760a99be7ac080e8fcf5e7d82c17db66ed96ac155995795689d6112369df"
           },
           "linux-x86_64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-linux-x86_64-2.22.0.zip",
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.1/vibe-acp-linux-x86_64-2.23.1.zip",
             "cmd": "./vibe-acp",
-            "sha256": "69d1ae692ddd2b01b9564d7dd328bf2181177044fbf4a2aaff24c53071d9ec1b"
+            "sha256": "446d2401a944f8765417072a14890343786a170da7e4046ee432cce12fc1f5a2"
           },
           "windows-x86_64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-windows-x86_64-2.22.0.zip",
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.1/vibe-acp-windows-x86_64-2.23.1.zip",
             "cmd": "./vibe-acp.exe",
-            "sha256": "5fbd5162b46feb6f355cca8435f61902cccff2208db1fcaa1e769306e44f9c89"
+            "sha256": "a3cff1667ed9d77664909a9a360f2402bcd315444d2ce405939f199327afe40c"
           }
         }
       }
@@ -1016,7 +1016,7 @@
     {
       "id": "opencode",
       "name": "OpenCode",
-      "version": "1.18.8",
+      "version": "1.18.9",
       "description": "The open source coding agent",
       "repository": "https://github.com/anomalyco/opencode",
       "website": "https://opencode.ai",
@@ -1028,52 +1028,52 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-darwin-arm64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.9/opencode-darwin-arm64.zip",
             "cmd": "./opencode",
             "args": [
               "acp"
             ],
-            "sha256": "0fb2e11a819dd97949f0f7e0348e0e0c4fd8c42b3a5ed7aee1f0d437c94b9f0c"
+            "sha256": "6f998b7dabb9425bb348fd0d88afeb92a14422771231cec9b0f4374b947397e6"
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-darwin-x64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.9/opencode-darwin-x64.zip",
             "cmd": "./opencode",
             "args": [
               "acp"
             ],
-            "sha256": "0193ed3f295bb93f073ae0e8fa0737e9b31f167464761901589401fd278d4cc4"
+            "sha256": "b9e6081f4db1f2066910f121258c23c8243438d22b1b80987d1569c5e40ef00e"
           },
           "linux-aarch64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-linux-arm64.tar.gz",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.9/opencode-linux-arm64.tar.gz",
             "cmd": "./opencode",
             "args": [
               "acp"
             ],
-            "sha256": "3e1b4f3bd12764c911f9211910608f85429b6209900a662c7ed27196c9033b93"
+            "sha256": "b16bd7593ea960a25d9c6849b3023bcd9b9244a6f51675341fd2052043b0670f"
           },
           "linux-x86_64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-linux-x64.tar.gz",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.9/opencode-linux-x64.tar.gz",
             "cmd": "./opencode",
             "args": [
               "acp"
             ],
-            "sha256": "b72014b8b53427fdb5a628d2433569ee7ccd289bd5c4490636064b24791c1305"
+            "sha256": "a0fa4b7b8bdacbd013e79a5f69d4220d36b545cd3ea296ba765f3016fa501b5b"
           },
           "windows-aarch64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-windows-arm64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.9/opencode-windows-arm64.zip",
             "cmd": "./opencode",
             "args": [
               "acp"
             ],
-            "sha256": "3a2c5a6f246bd0fdb395b35d8cc60f1be86f7f794a22cb517d2fe8de9aa951b4"
+            "sha256": "1f2c650b517d725635e56da080c73c641c250696a3d7e6cdbada96af8f31a6d3"
           },
           "windows-x86_64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-windows-x64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.9/opencode-windows-x64.zip",
             "cmd": "./opencode.exe",
             "args": [
               "acp"
             ],
-            "sha256": "85baa5de531db8d611fb5d9a62ffee00f6de69ae26e4845ec091dd2da4eb5fd1"
+            "sha256": "1becf92ceb23edd7d951e7e3d8efcbe9c9808f5cc728f1b75277d5f951ada5c2"
           }
         }
       }
@@ -1183,7 +1183,7 @@
     {
       "id": "qwen-code",
       "name": "Qwen Code",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "description": "Alibaba's Qwen coding assistant",
       "repository": "https://github.com/QwenLM/qwen-code",
       "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
@@ -1193,7 +1193,7 @@
       "license": "Apache-2.0",
       "distribution": {
         "npx": {
-          "package": "@qwen-code/qwen-code@0.21.0",
+          "package": "@qwen-code/qwen-code@0.21.1",
           "args": [
             "--acp",
             "--experimental-skills"

--- a/resources/model-db/providers.json
+++ b/resources/model-db/providers.json
@@ -83796,6 +83796,34 @@
           "type": "chat"
         },
         {
+          "id": "gemini-embedding",
+          "name": "Gemini Embedding 001",
+          "display_name": "Gemini Embedding 001",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 2048,
+            "output": 1
+          },
+          "temperature": false,
+          "tool_call": false,
+          "reasoning": {
+            "supported": false
+          },
+          "attachment": false,
+          "open_weights": false,
+          "knowledge": "2025-05",
+          "release_date": "2025-05-20",
+          "last_updated": "2025-05-20",
+          "type": "chat"
+        },
+        {
           "id": "gpt-5-mini",
           "name": "gpt-5-mini",
           "display_name": "gpt-5-mini",
@@ -85417,43 +85445,6 @@
           "type": "chat"
         },
         {
-          "id": "zai-org/glm-5.1",
-          "name": "GLM-5.1",
-          "display_name": "GLM-5.1",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 200000,
-            "output": 131072
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true
-            }
-          },
-          "attachment": false,
-          "open_weights": true,
-          "release_date": "2026-04-07",
-          "last_updated": "2026-04-07",
-          "cost": {
-            "input": 1.4,
-            "output": 4.4
-          },
-          "type": "chat"
-        },
-        {
           "id": "zai-org/glm-5.2",
           "name": "GLM-5.2",
           "display_name": "GLM-5.2",
@@ -85618,46 +85609,6 @@
           "cost": {
             "input": 1,
             "output": 2.5
-          },
-          "type": "chat"
-        },
-        {
-          "id": "moonshotai/kimi-k2.6",
-          "name": "Kimi K2.6",
-          "display_name": "Kimi K2.6",
-          "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 262144,
-            "output": 262144
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true
-            }
-          },
-          "attachment": true,
-          "open_weights": true,
-          "knowledge": "2025-01",
-          "release_date": "2026-04-21",
-          "last_updated": "2026-04-21",
-          "cost": {
-            "input": 0.85,
-            "output": 3.5
           },
           "type": "chat"
         },
@@ -104712,38 +104663,6 @@
           "type": "chat"
         },
         {
-          "id": "nvidia-nemotron-cascade-2-30b-a3b",
-          "name": "Nemotron Cascade 2 30B A3B",
-          "display_name": "Nemotron Cascade 2 30B A3B",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 256000,
-            "output": 32768
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "attachment": false,
-          "open_weights": true,
-          "release_date": "2026-03-24",
-          "last_updated": "2026-06-11",
-          "cost": {
-            "input": 0.14,
-            "output": 0.8
-          },
-          "type": "chat"
-        },
-        {
           "id": "openai-gpt-54-pro",
           "name": "GPT-5.4 Pro",
           "display_name": "GPT-5.4 Pro",
@@ -119715,6 +119634,61 @@
         }
       ]
     },
+    "modal": {
+      "id": "modal",
+      "name": "Modal",
+      "display_name": "Modal",
+      "api": "https://inference.us-west.modal.direct/v1",
+      "doc": "https://modal.com/docs/guide/endpoints",
+      "models": [
+        {
+          "id": "thinkingmachines/Inkling-NVFP4",
+          "name": "Inkling",
+          "display_name": "Inkling",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 262144
+          },
+          "temperature": true,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": true,
+          "release_date": "2026-07-15",
+          "last_updated": "2026-07-15",
+          "cost": {
+            "input": 1.2,
+            "output": 5,
+            "cache_read": 0.27
+          },
+          "type": "chat"
+        }
+      ]
+    },
     "qihang-ai": {
       "id": "qihang-ai",
       "name": "QiHang",
@@ -120497,6 +120471,50 @@
             "input": 0.83,
             "output": 3.85,
             "cache_read": 0.16
+          },
+          "type": "chat"
+        },
+        {
+          "id": "moonshotai/Kimi-K3",
+          "name": "Kimi K3",
+          "display_name": "Kimi K3",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 327680,
+            "output": 32768
+          },
+          "temperature": false,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": true,
+          "release_date": "2026-07-27",
+          "last_updated": "2026-07-28",
+          "cost": {
+            "input": 3,
+            "output": 15
           },
           "type": "chat"
         },
@@ -160962,8 +160980,7 @@
           "modalities": {
             "input": [
               "text",
-              "image",
-              "video"
+              "image"
             ],
             "output": [
               "text"
@@ -161032,9 +161049,9 @@
           "release_date": "2026-04-13",
           "last_updated": "2026-07-22",
           "cost": {
-            "input": 0.91,
-            "output": 2.814,
-            "cache_write": 0.455
+            "input": 0.81,
+            "output": 2.624,
+            "cache_write": 0.405
           },
           "type": "chat"
         },
@@ -161070,9 +161087,9 @@
           "release_date": "2026-06-04",
           "last_updated": "2026-07-22",
           "cost": {
-            "input": 1.52425,
-            "output": 4.7905,
-            "cache_read": 0.283075
+            "input": 1.52432,
+            "output": 4.79072,
+            "cache_read": 0.283088
           },
           "type": "chat"
         },
@@ -161153,15 +161170,15 @@
               ]
             }
           },
-          "attachment": true,
+          "attachment": false,
           "open_weights": true,
           "knowledge": "2025-01",
           "release_date": "2026-04-13",
           "last_updated": "2026-07-22",
           "cost": {
-            "input": 0.53,
-            "output": 2.66,
-            "cache_write": 0.265
+            "input": 0.528,
+            "output": 2.79,
+            "cache_write": 0.264
           },
           "type": "chat"
         },
@@ -161202,9 +161219,9 @@
           "release_date": "2026-06-05",
           "last_updated": "2026-07-22",
           "cost": {
-            "input": 0.42,
-            "output": 1.62,
-            "cache_write": 0.21
+            "input": 0.348,
+            "output": 1.332,
+            "cache_write": 0.174
           },
           "type": "chat"
         },
@@ -161221,8 +161238,8 @@
             ]
           },
           "limit": {
-            "context": 1048576,
-            "output": 131072
+            "context": 1000000,
+            "output": 128000
           },
           "temperature": true,
           "tool_call": true,
@@ -161395,9 +161412,9 @@
           "release_date": "2026-04-30",
           "last_updated": "2026-07-22",
           "cost": {
-            "input": 0.2675,
-            "output": 0.9175,
-            "cache_write": 0.13375
+            "input": 0.284,
+            "output": 0.934,
+            "cache_write": 0.142
           },
           "type": "chat"
         },
@@ -161432,9 +161449,9 @@
           "release_date": "2026-04-30",
           "last_updated": "2026-07-22",
           "cost": {
-            "input": 0.114,
-            "output": 0.398,
-            "cache_write": 0.057
+            "input": 0.13,
+            "output": 0.424,
+            "cache_write": 0.065
           },
           "type": "chat"
         },
@@ -161548,9 +161565,9 @@
           "release_date": "2026-04-13",
           "last_updated": "2026-07-22",
           "cost": {
-            "input": 0.178,
-            "output": 0.68,
-            "cache_write": 0.089
+            "input": 0.176,
+            "output": 0.652,
+            "cache_write": 0.088
           },
           "type": "chat"
         },
@@ -161568,8 +161585,8 @@
             ]
           },
           "limit": {
-            "context": 262000,
-            "output": 262000
+            "context": 256000,
+            "output": 16000
           },
           "temperature": false,
           "tool_call": true,
@@ -161665,9 +161682,9 @@
           "release_date": "2026-04-30",
           "last_updated": "2026-07-22",
           "cost": {
-            "input": 0.601,
-            "output": 2.085,
-            "cache_write": 0.3005
+            "input": 0.569,
+            "output": 2.135,
+            "cache_write": 0.2845
           },
           "type": "chat"
         },
@@ -161744,9 +161761,9 @@
           "release_date": "2026-04-30",
           "last_updated": "2026-07-22",
           "cost": {
-            "input": 0.12188,
-            "output": 1.145,
-            "cache_write": 0.06094
+            "input": 0.1175,
+            "output": 1.136,
+            "cache_write": 0.05875
           },
           "type": "chat"
         }
@@ -168106,81 +168123,12 @@
           "attachment": true,
           "open_weights": false,
           "knowledge": "2025-01",
-          "release_date": "2025-11-18",
+          "release_date": "2026-02-19",
           "last_updated": "2026-02-19",
           "cost": {
             "input": 2,
             "output": 12,
             "cache_read": 0.2
-          },
-          "type": "chat"
-        },
-        {
-          "id": "google/gemini-3-pro-preview",
-          "name": "Gemini 3 Pro Preview",
-          "display_name": "Gemini 3 Pro Preview",
-          "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 1000000,
-            "output": 64000
-          },
-          "temperature": true,
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true,
-              "default_enabled": true,
-              "mode": "level",
-              "level": "high",
-              "level_options": [
-                "low",
-                "high"
-              ],
-              "summaries": true,
-              "visibility": "summary",
-              "continuation": [
-                "thought_signatures"
-              ]
-            }
-          },
-          "attachment": true,
-          "open_weights": false,
-          "knowledge": "2025-01",
-          "release_date": "2025-11-18",
-          "last_updated": "2025-11-18",
-          "cost": {
-            "input": 2,
-            "output": 12,
-            "cache_read": 0.2,
-            "tiers": [
-              {
-                "input": 4,
-                "output": 18,
-                "cache_read": 0.4,
-                "tier": {
-                  "type": "context",
-                  "size": 200000
-                }
-              }
-            ],
-            "context_over_200k": {
-              "input": 4,
-              "output": 18,
-              "cache_read": 0.4
-            }
           },
           "type": "chat"
         },
@@ -207182,6 +207130,70 @@
       "doc": "https://www.xpersona.co/docs",
       "models": [
         {
+          "id": "claude-sonnet-4-6",
+          "name": "Claude Sonnet 4.6",
+          "display_name": "Claude Sonnet 4.6",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 200000,
+            "output": 128000
+          },
+          "temperature": true,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "mixed",
+              "budget": {
+                "min": 1024,
+                "unit": "tokens"
+              },
+              "effort": "high",
+              "effort_options": [
+                "low",
+                "medium",
+                "high",
+                "max"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ],
+              "notes": [
+                "Anthropic recommends adaptive thinking with effort for Claude 4.6; budget_tokens remains a deprecated compatibility path.",
+                "Anthropic API defaults effort to high; lower effort levels should be chosen per workload."
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": false,
+          "knowledge": "2025-08-31",
+          "release_date": "2026-02-17",
+          "last_updated": "2026-03-13",
+          "cost": {
+            "input": 0.9,
+            "output": 5.55,
+            "reasoning": 5.55,
+            "cache_read": 0.09
+          },
+          "type": "chat"
+        },
+        {
           "id": "xpersona-frieren-coder",
           "name": "Xpersona Frieren 1",
           "display_name": "Xpersona Frieren 1",
@@ -207213,6 +207225,183 @@
             "input": 1.5,
             "output": 6,
             "reasoning": 6,
+            "cache_read": 0.15
+          },
+          "type": "chat"
+        },
+        {
+          "id": "gemini-3.5-flash",
+          "name": "Gemini 3.5 Flash",
+          "display_name": "Gemini 3.5 Flash",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "temperature": true,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "level",
+              "level": "high",
+              "level_options": [
+                "minimal",
+                "low",
+                "medium",
+                "high"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": false,
+          "knowledge": "2025-01",
+          "release_date": "2026-05-19",
+          "last_updated": "2026-05-19",
+          "cost": {
+            "input": 1.55,
+            "output": 12.2,
+            "reasoning": 12.2,
+            "cache_read": 0.155
+          },
+          "type": "chat"
+        },
+        {
+          "id": "claude-haiku-4-5",
+          "name": "Claude Haiku 4.5 (latest)",
+          "display_name": "Claude Haiku 4.5 (latest)",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 200000,
+            "output": 128000
+          },
+          "temperature": true,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "budget",
+              "budget": {
+                "min": 1024,
+                "unit": "tokens"
+              },
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ],
+              "notes": [
+                "Claude 4 manual thinking uses thinking.type = \"enabled\" with budget_tokens.",
+                "Interleaved thinking requires the interleaved-thinking-2025-05-14 beta header for this model family."
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": false,
+          "knowledge": "2025-02-28",
+          "release_date": "2025-10-15",
+          "last_updated": "2025-10-15",
+          "cost": {
+            "input": 0.6,
+            "output": 3.7,
+            "reasoning": 3.7,
+            "cache_read": 0.06
+          },
+          "type": "chat"
+        },
+        {
+          "id": "gpt-5.6-sol",
+          "name": "GPT-5.6 Sol",
+          "display_name": "GPT-5.6 Sol",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 372000,
+            "output": 128000
+          },
+          "temperature": false,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "effort",
+              "effort": "medium",
+              "effort_options": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ],
+              "verbosity": "medium",
+              "verbosity_options": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": false,
+          "knowledge": "2026-02-16",
+          "release_date": "2026-07-09",
+          "last_updated": "2026-07-09",
+          "cost": {
+            "input": 1.5,
+            "output": 12,
+            "reasoning": 12,
             "cache_read": 0.15
           },
           "type": "chat"
@@ -207273,9 +207462,196 @@
           "last_updated": "2026-06-09",
           "cost": {
             "input": 3,
-            "output": 18,
-            "reasoning": 18,
+            "output": 18.5,
+            "reasoning": 18.5,
             "cache_read": 0.3
+          },
+          "type": "chat"
+        },
+        {
+          "id": "claude-opus-4-8",
+          "name": "Claude Opus 4.8",
+          "display_name": "Claude Opus 4.8",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 200000,
+            "output": 128000
+          },
+          "temperature": false,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "effort",
+              "effort": "high",
+              "effort_options": [
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ],
+              "notes": [
+                "Claude Opus 4.7 and newer Opus models require thinking.type = \"adaptive\" to enable thinking explicitly.",
+                "Manual budget_tokens requests return 400 on Claude Opus 4.7 and newer adaptive-only Opus models.",
+                "task_budget is separate from thinking control and should not be treated as a thinking budget."
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": false,
+          "knowledge": "2026-01",
+          "release_date": "2026-05-28",
+          "last_updated": "2026-05-28",
+          "cost": {
+            "input": 1.5,
+            "output": 9.25,
+            "reasoning": 9.25,
+            "cache_read": 0.15
+          },
+          "type": "chat"
+        },
+        {
+          "id": "gpt-5.5",
+          "name": "GPT-5.5",
+          "display_name": "GPT-5.5",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "temperature": false,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "effort",
+              "effort": "medium",
+              "effort_options": [
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ],
+              "verbosity": "medium",
+              "verbosity_options": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": false,
+          "knowledge": "2025-12-01",
+          "release_date": "2026-04-23",
+          "last_updated": "2026-04-23",
+          "cost": {
+            "input": 1.5,
+            "output": 12,
+            "reasoning": 12,
+            "cache_read": 0.15
+          },
+          "type": "chat"
+        },
+        {
+          "id": "gpt-5.4",
+          "name": "GPT-5.4",
+          "display_name": "GPT-5.4",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "temperature": false,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "effort",
+              "effort": "none",
+              "effort_options": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ],
+              "verbosity": "medium",
+              "verbosity_options": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": false,
+          "knowledge": "2025-08-31",
+          "release_date": "2026-03-05",
+          "last_updated": "2026-03-05",
+          "cost": {
+            "input": 0.75,
+            "output": 6,
+            "reasoning": 6,
+            "cache_read": 0.075
           },
           "type": "chat"
         },
@@ -207323,6 +207699,197 @@
             "output": 18,
             "reasoning": 18,
             "cache_read": 0.3
+          },
+          "type": "chat"
+        },
+        {
+          "id": "gpt-5.4-mini",
+          "name": "GPT-5.4 mini",
+          "display_name": "GPT-5.4 mini",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "temperature": false,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "effort",
+              "effort": "none",
+              "effort_options": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ],
+              "verbosity": "medium",
+              "verbosity_options": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": false,
+          "knowledge": "2025-08-31",
+          "release_date": "2026-03-17",
+          "last_updated": "2026-03-17",
+          "cost": {
+            "input": 0.375,
+            "output": 4,
+            "reasoning": 4,
+            "cache_read": 0.0375
+          },
+          "type": "chat"
+        },
+        {
+          "id": "gpt-5.6",
+          "name": "GPT-5.6",
+          "display_name": "GPT-5.6",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 372000,
+            "output": 128000
+          },
+          "temperature": false,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "effort",
+              "effort": "medium",
+              "effort_options": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ],
+              "verbosity": "medium",
+              "verbosity_options": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": false,
+          "knowledge": "2026-02-16",
+          "release_date": "2026-07-09",
+          "last_updated": "2026-07-09",
+          "cost": {
+            "input": 1.5,
+            "output": 12,
+            "reasoning": 12,
+            "cache_read": 0.15
+          },
+          "type": "chat"
+        },
+        {
+          "id": "gpt-5.6-terra",
+          "name": "GPT-5.6 Terra",
+          "display_name": "GPT-5.6 Terra",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 372000,
+            "output": 128000
+          },
+          "temperature": false,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "effort",
+              "effort": "medium",
+              "effort_options": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ],
+              "verbosity": "medium",
+              "verbosity_options": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ]
+            }
+          },
+          "attachment": true,
+          "open_weights": false,
+          "knowledge": "2026-02-16",
+          "release_date": "2026-07-09",
+          "last_updated": "2026-07-09",
+          "cost": {
+            "input": 1.5,
+            "output": 2,
+            "reasoning": 2,
+            "cache_read": 0.15
           },
           "type": "chat"
         }
@@ -261755,9 +262322,106 @@
           "type": "imageGeneration"
         },
         {
+          "id": "anthropic/claude-fable-5:batch",
+          "name": "Anthropic: Claude Fable 5 (batch)",
+          "display_name": "Anthropic: Claude Fable 5 (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "effort",
+              "effort": "high",
+              "effort_options": [
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "omitted",
+              "continuation": [
+                "thinking_blocks"
+              ],
+              "notes": [
+                "Adaptive thinking is always on for Claude Fable 5 and Claude Mythos 5; thinking.type = \"disabled\" is rejected.",
+                "Manual budget_tokens requests return 400 on Claude Fable 5 and Claude Mythos 5.",
+                "thinking.display defaults to omitted; set display to summarized to receive readable thinking summaries."
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "anthropic/claude-haiku-4.5",
           "name": "Anthropic: Claude Haiku 4.5",
           "display_name": "Anthropic: Claude Haiku 4.5",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 200000,
+            "output": 64000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "budget",
+              "budget": {
+                "min": 1024,
+                "unit": "tokens"
+              },
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ],
+              "notes": [
+                "Claude 4 manual thinking uses thinking.type = \"enabled\" with budget_tokens.",
+                "Interleaved thinking requires the interleaved-thinking-2025-05-14 beta header for this model family."
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "anthropic/claude-haiku-4.5:batch",
+          "name": "Anthropic: Claude Haiku 4.5 (batch)",
+          "display_name": "Anthropic: Claude Haiku 4.5 (batch)",
           "modalities": {
             "input": [
               "text",
@@ -261893,6 +262557,52 @@
           "type": "imageGeneration"
         },
         {
+          "id": "anthropic/claude-opus-4.1:batch",
+          "name": "Anthropic: Claude Opus 4.1 (batch)",
+          "display_name": "Anthropic: Claude Opus 4.1 (batch)",
+          "modalities": {
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 200000,
+            "output": 32000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "budget",
+              "budget": {
+                "min": 1024,
+                "unit": "tokens"
+              },
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ],
+              "notes": [
+                "Claude 4 manual thinking uses thinking.type = \"enabled\" with budget_tokens.",
+                "Interleaved thinking requires the interleaved-thinking-2025-05-14 beta header for this model family."
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "anthropic/claude-opus-4.5",
           "name": "Anthropic: Claude Opus 4.5",
           "display_name": "Anthropic: Claude Opus 4.5",
@@ -261945,9 +262655,114 @@
           "type": "imageGeneration"
         },
         {
+          "id": "anthropic/claude-opus-4.5:batch",
+          "name": "Anthropic: Claude Opus 4.5 (batch)",
+          "display_name": "Anthropic: Claude Opus 4.5 (batch)",
+          "modalities": {
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 200000,
+            "output": 64000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "mixed",
+              "budget": {
+                "min": 1024,
+                "unit": "tokens"
+              },
+              "effort": "high",
+              "effort_options": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ],
+              "notes": [
+                "Claude Opus 4.5 uses manual thinking.type = \"enabled\" with budget_tokens; effort can be used alongside the thinking budget.",
+                "Interleaved thinking requires the interleaved-thinking-2025-05-14 beta header."
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "anthropic/claude-opus-4.6",
           "name": "Anthropic: Claude Opus 4.6",
           "display_name": "Anthropic: Claude Opus 4.6",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "mixed",
+              "budget": {
+                "min": 1024,
+                "unit": "tokens"
+              },
+              "effort": "high",
+              "effort_options": [
+                "low",
+                "medium",
+                "high",
+                "max"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ],
+              "notes": [
+                "Anthropic recommends adaptive thinking with effort for Claude 4.6; budget_tokens remains a deprecated compatibility path.",
+                "Anthropic API defaults effort to high; lower effort levels should be chosen per workload."
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "anthropic/claude-opus-4.6:batch",
+          "name": "Anthropic: Claude Opus 4.6 (batch)",
+          "display_name": "Anthropic: Claude Opus 4.6 (batch)",
           "modalities": {
             "input": [
               "text",
@@ -262100,6 +262915,57 @@
           "type": "imageGeneration"
         },
         {
+          "id": "anthropic/claude-opus-4.7:batch",
+          "name": "Anthropic: Claude Opus 4.7 (batch)",
+          "display_name": "Anthropic: Claude Opus 4.7 (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "effort",
+              "effort": "high",
+              "effort_options": [
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "omitted",
+              "continuation": [
+                "thinking_blocks"
+              ],
+              "notes": [
+                "Claude Opus 4.7 and newer Opus models require thinking.type = \"adaptive\" to enable thinking explicitly.",
+                "Manual budget_tokens requests return 400 on Claude Opus 4.7 and newer adaptive-only Opus models.",
+                "task_budget is separate from thinking control and should not be treated as a thinking budget."
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "anthropic/claude-opus-4.8",
           "name": "Anthropic: Claude Opus 4.8",
           "display_name": "Anthropic: Claude Opus 4.8",
@@ -262154,6 +263020,57 @@
           "id": "anthropic/claude-opus-4.8-fast",
           "name": "Anthropic: Claude Opus 4.8 (Fast)",
           "display_name": "Anthropic: Claude Opus 4.8 (Fast)",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "effort",
+              "effort": "high",
+              "effort_options": [
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ],
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "omitted",
+              "continuation": [
+                "thinking_blocks"
+              ],
+              "notes": [
+                "Claude Opus 4.7 and newer Opus models require thinking.type = \"adaptive\" to enable thinking explicitly.",
+                "Manual budget_tokens requests return 400 on Claude Opus 4.7 and newer adaptive-only Opus models.",
+                "task_budget is separate from thinking control and should not be treated as a thinking budget."
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "anthropic/claude-opus-4.8:batch",
+          "name": "Anthropic: Claude Opus 4.8 (batch)",
+          "display_name": "Anthropic: Claude Opus 4.8 (batch)",
           "modalities": {
             "input": [
               "text",
@@ -262350,6 +263267,53 @@
           "type": "imageGeneration"
         },
         {
+          "id": "anthropic/claude-sonnet-4.5:batch",
+          "name": "Anthropic: Claude Sonnet 4.5 (batch)",
+          "display_name": "Anthropic: Claude Sonnet 4.5 (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 64000
+          },
+          "temperature": true,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "budget",
+              "budget": {
+                "min": 1024,
+                "unit": "tokens"
+              },
+              "interleaved": true,
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thinking_blocks"
+              ],
+              "notes": [
+                "Claude 4 manual thinking uses thinking.type = \"enabled\" with budget_tokens.",
+                "Interleaved thinking requires the interleaved-thinking-2025-05-14 beta header for this model family."
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "anthropic/claude-sonnet-4.6",
           "name": "Anthropic: Claude Sonnet 4.6",
           "display_name": "Anthropic: Claude Sonnet 4.6",
@@ -262428,6 +263392,31 @@
             "reasoning": {
               "supported": true
             }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "anthropic/claude-sonnet-5:batch",
+          "name": "Anthropic: Claude Sonnet 5 (batch)",
+          "display_name": "Anthropic: Claude Sonnet 5 (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
           },
           "attachment": true,
           "type": "imageGeneration"
@@ -263207,6 +264196,99 @@
           "type": "imageGeneration"
         },
         {
+          "id": "google/gemini-2.5-flash-lite:batch",
+          "name": "Google: Gemini 2.5 Flash Lite (batch)",
+          "display_name": "Google: Gemini 2.5 Flash Lite (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65535
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "budget",
+              "budget": {
+                "default": -1,
+                "min": 512,
+                "max": 24576,
+                "auto": -1,
+                "unit": "tokens"
+              },
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thought_signatures"
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "google/gemini-2.5-flash:batch",
+          "name": "Google: Gemini 2.5 Flash (batch)",
+          "display_name": "Google: Gemini 2.5 Flash (batch)",
+          "modalities": {
+            "input": [
+              "image",
+              "text",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65535
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "budget",
+              "budget": {
+                "default": -1,
+                "min": 0,
+                "max": 24576,
+                "auto": -1,
+                "off": 0,
+                "unit": "tokens"
+              },
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thought_signatures"
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "google/gemini-2.5-pro",
           "name": "Google: Gemini 2.5 Pro",
           "display_name": "Google: Gemini 2.5 Pro",
@@ -263344,9 +264426,101 @@
           "type": "imageGeneration"
         },
         {
+          "id": "google/gemini-2.5-pro:batch",
+          "name": "Google: Gemini 2.5 Pro (batch)",
+          "display_name": "Google: Gemini 2.5 Pro (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "budget",
+              "budget": {
+                "default": -1,
+                "min": 128,
+                "max": 32768,
+                "auto": -1,
+                "unit": "tokens"
+              },
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thought_signatures"
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "google/gemini-3-flash-preview",
           "name": "Google: Gemini 3 Flash Preview",
           "display_name": "Google: Gemini 3 Flash Preview",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65535
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "level",
+              "level": "high",
+              "level_options": [
+                "minimal",
+                "low",
+                "medium",
+                "high"
+              ],
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thought_signatures"
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "google/gemini-3-flash-preview:batch",
+          "name": "Google: Gemini 3 Flash Preview (batch)",
+          "display_name": "Google: Gemini 3 Flash Preview (batch)",
           "modalities": {
             "input": [
               "text",
@@ -263628,6 +264802,33 @@
           "type": "imageGeneration"
         },
         {
+          "id": "google/gemini-3.1-flash-lite:batch",
+          "name": "Google: Gemini 3.1 Flash Lite (batch)",
+          "display_name": "Google: Gemini 3.1 Flash Lite (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "google/gemini-3.1-pro-preview",
           "name": "Google: Gemini 3.1 Pro Preview",
           "display_name": "Google: Gemini 3.1 Pro Preview",
@@ -263680,6 +264881,50 @@
               "text",
               "audio",
               "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "level",
+              "level": "high",
+              "level_options": [
+                "low",
+                "high"
+              ],
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thought_signatures"
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "google/gemini-3.1-pro-preview:batch",
+          "name": "Google: Gemini 3.1 Pro Preview (batch)",
+          "display_name": "Google: Gemini 3.1 Pro Preview (batch)",
+          "modalities": {
+            "input": [
+              "audio",
+              "image",
+              "text",
               "video"
             ],
             "output": [
@@ -263794,9 +265039,128 @@
           "type": "imageGeneration"
         },
         {
+          "id": "google/gemini-3.5-flash-lite:batch",
+          "name": "Google: Gemini 3.5 Flash Lite (batch)",
+          "display_name": "Google: Gemini 3.5 Flash Lite (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "google/gemini-3.5-flash:batch",
+          "name": "Google: Gemini 3.5 Flash (batch)",
+          "display_name": "Google: Gemini 3.5 Flash (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "level",
+              "level": "high",
+              "level_options": [
+                "minimal",
+                "low",
+                "medium",
+                "high"
+              ],
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thought_signatures"
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "google/gemini-3.6-flash",
           "name": "Google: Gemini 3.6 Flash",
           "display_name": "Google: Gemini 3.6 Flash",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": true,
+              "mode": "level",
+              "level": "high",
+              "level_options": [
+                "minimal",
+                "low",
+                "medium",
+                "high"
+              ],
+              "summaries": true,
+              "visibility": "summary",
+              "continuation": [
+                "thought_signatures"
+              ]
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "google/gemini-3.6-flash:batch",
+          "name": "Google: Gemini 3.6 Flash (batch)",
+          "display_name": "Google: Gemini 3.6 Flash (batch)",
           "modalities": {
             "input": [
               "text",
@@ -264884,6 +266248,32 @@
             "reasoning": {
               "supported": true
             }
+          },
+          "type": "imageGeneration"
+        },
+        {
+          "id": "minimax/minimax-m3:batch",
+          "name": "MiniMax: MiniMax M3 (batch)",
+          "display_name": "MiniMax: MiniMax M3 (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 524288,
+            "output": 524288
+          },
+          "temperature": true,
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
           },
           "type": "imageGeneration"
         },
@@ -266552,6 +267942,31 @@
           "type": "imageGeneration"
         },
         {
+          "id": "openai/gpt-5-mini:batch",
+          "name": "OpenAI: GPT-5 Mini (batch)",
+          "display_name": "OpenAI: GPT-5 Mini (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "openai/gpt-5-nano",
           "name": "OpenAI: GPT-5 Nano",
           "display_name": "OpenAI: GPT-5 Nano",
@@ -266600,6 +268015,31 @@
           "type": "imageGeneration"
         },
         {
+          "id": "openai/gpt-5-nano:batch",
+          "name": "OpenAI: GPT-5 Nano (batch)",
+          "display_name": "OpenAI: GPT-5 Nano (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "openai/gpt-5-pro",
           "name": "OpenAI: GPT-5 Pro",
           "display_name": "OpenAI: GPT-5 Pro",
@@ -266637,6 +268077,31 @@
               ],
               "visibility": "hidden"
             }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "openai/gpt-5:batch",
+          "name": "OpenAI: GPT-5 (batch)",
+          "display_name": "OpenAI: GPT-5 (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
           },
           "attachment": true,
           "type": "imageGeneration"
@@ -266855,6 +268320,31 @@
           "type": "imageGeneration"
         },
         {
+          "id": "openai/gpt-5.1:batch",
+          "name": "OpenAI: GPT-5.1 (batch)",
+          "display_name": "OpenAI: GPT-5.1 (batch)",
+          "modalities": {
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "openai/gpt-5.2",
           "name": "OpenAI: GPT-5.2",
           "display_name": "OpenAI: GPT-5.2",
@@ -267017,6 +268507,31 @@
               ],
               "visibility": "hidden"
             }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "openai/gpt-5.2:batch",
+          "name": "OpenAI: GPT-5.2 (batch)",
+          "display_name": "OpenAI: GPT-5.2 (batch)",
+          "modalities": {
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
           },
           "attachment": true,
           "type": "imageGeneration"
@@ -267242,9 +268757,107 @@
           "type": "imageGeneration"
         },
         {
+          "id": "openai/gpt-5.4-mini:batch",
+          "name": "OpenAI: GPT-5.4 Mini (batch)",
+          "display_name": "OpenAI: GPT-5.4 Mini (batch)",
+          "modalities": {
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false,
+            "effort": "none",
+            "verbosity": "medium"
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "effort",
+              "effort": "none",
+              "effort_options": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ],
+              "verbosity": "medium",
+              "verbosity_options": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "visibility": "hidden"
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "openai/gpt-5.4-nano",
           "name": "OpenAI: GPT-5.4 Nano",
           "display_name": "OpenAI: GPT-5.4 Nano",
+          "modalities": {
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": false,
+            "effort": "none",
+            "verbosity": "medium"
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true,
+              "default_enabled": false,
+              "mode": "effort",
+              "effort": "none",
+              "effort_options": [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ],
+              "verbosity": "medium",
+              "verbosity_options": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "visibility": "hidden"
+            }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "openai/gpt-5.4-nano:batch",
+          "name": "OpenAI: GPT-5.4 Nano (batch)",
+          "display_name": "OpenAI: GPT-5.4 Nano (batch)",
           "modalities": {
             "input": [
               "image",
@@ -267338,6 +268951,31 @@
           "type": "imageGeneration"
         },
         {
+          "id": "openai/gpt-5.4:batch",
+          "name": "OpenAI: GPT-5.4 (batch)",
+          "display_name": "OpenAI: GPT-5.4 (batch)",
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
           "id": "openai/gpt-5.5",
           "name": "OpenAI: GPT-5.5",
           "display_name": "OpenAI: GPT-5.5",
@@ -267411,6 +269049,31 @@
             "reasoning": {
               "supported": true
             }
+          },
+          "attachment": true,
+          "type": "imageGeneration"
+        },
+        {
+          "id": "openai/gpt-5.5:batch",
+          "name": "OpenAI: GPT-5.5 (batch)",
+          "display_name": "OpenAI: GPT-5.5 (batch)",
+          "modalities": {
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
           },
           "attachment": true,
           "type": "imageGeneration"
@@ -268509,57 +270172,6 @@
           "type": "imageGeneration"
         },
         {
-          "id": "poolside/laguna-m.1",
-          "name": "Poolside: Laguna M.1",
-          "display_name": "Poolside: Laguna M.1",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 262144,
-            "output": 32768
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "extra_capabilities": {
-            "reasoning": {
-              "supported": true
-            }
-          },
-          "type": "chat"
-        },
-        {
-          "id": "poolside/laguna-m.1:free",
-          "name": "Poolside: Laguna M.1 (free)",
-          "display_name": "Poolside: Laguna M.1 (free)",
-          "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
-          },
-          "limit": {
-            "context": 262144,
-            "output": 32768
-          },
-          "tool_call": true,
-          "reasoning": {
-            "supported": true,
-            "default": true
-          },
-          "type": "chat"
-        },
-        {
           "id": "poolside/laguna-s-2.1",
           "name": "Poolside: Laguna S 2.1",
           "display_name": "Poolside: Laguna S 2.1",
@@ -269251,7 +270863,7 @@
           },
           "limit": {
             "context": 262144,
-            "output": 32768
+            "output": 65536
           },
           "temperature": true,
           "tool_call": true,
@@ -269285,7 +270897,7 @@
           },
           "limit": {
             "context": 262144,
-            "output": 32768
+            "output": 65536
           },
           "tool_call": true,
           "reasoning": {
@@ -281567,6 +283179,36 @@
             "output": 1.88,
             "cache_read": 0.032,
             "cache_write": 0.4
+          },
+          "type": "chat"
+        },
+        {
+          "id": "qwen/qwen3.7-flash",
+          "name": "Qwen: Qwen3.7-Flash",
+          "display_name": "Qwen: Qwen3.7-Flash",
+          "modalities": {
+            "input": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 991000,
+            "output": 991000
+          },
+          "tool_call": true,
+          "reasoning": {
+            "supported": true,
+            "default": true
+          },
+          "extra_capabilities": {
+            "reasoning": {
+              "supported": true
+            }
+          },
+          "cost": {
+            "input": 0.282,
+            "output": 1.128,
+            "cache_read": 0.0564
           },
           "type": "chat"
         },

--- a/src/main/app/composition.ts
+++ b/src/main/app/composition.ts
@@ -1404,18 +1404,6 @@ export async function createMainProcessControl(dependencies: {
     })
 
     void startupWorkloadCoordinator.scheduleTask({
-      id: 'main:yo-browser',
-      target: 'main',
-      phase: 'background',
-      resource: 'io',
-      labelKey: 'startup.main.yoBrowser',
-      runId: mainRunId,
-      run: async () => {
-        await initializeYoBrowser()
-      }
-    })
-
-    void startupWorkloadCoordinator.scheduleTask({
       id: 'main:skills-sync-scan',
       target: 'main',
       phase: 'background',
@@ -1481,15 +1469,6 @@ export async function createMainProcessControl(dependencies: {
       logger.info('FloatingButtonPresenter initialized successfully')
     } catch (error) {
       console.error('Failed to initialize FloatingButtonPresenter:', error)
-    }
-  }
-
-  async function initializeYoBrowser() {
-    try {
-      await yoBrowserPresenter.initialize()
-      logger.info('YoBrowserPresenter initialized')
-    } catch (error) {
-      console.error('Failed to initialize YoBrowserPresenter:', error)
     }
   }
 

--- a/src/main/desktop/browser/YoBrowserPresenter.ts
+++ b/src/main/desktop/browser/YoBrowserPresenter.ts
@@ -119,10 +119,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
     this.toolHandler = new YoBrowserToolHandler(this)
   }
 
-  async initialize(): Promise<void> {
-    await this.previewCoordinator.initialize()
-  }
-
   async getBrowserStatus(sessionId: string): Promise<YoBrowserStatus> {
     return this.toStatus(this.sessionBrowsers.get(sessionId) ?? null)
   }
@@ -303,11 +299,15 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       return { updated: false, surface: 'none' }
     }
 
-    await this.previewCoordinator.initialize()
-
     const targetWindow = hostWindowId == null ? null : BrowserWindow.fromId(hostWindowId)
     if (hostWindowId != null && (!targetWindow || targetWindow.isDestroyed())) {
       return { updated: false, surface: 'none' }
+    }
+    if (mode === 'capturing') {
+      await this.previewCoordinator.initialize()
+      if (targetWindow?.isDestroyed()) {
+        return { updated: false, surface: 'none' }
+      }
     }
 
     if (mode === 'rendering') {
@@ -327,9 +327,6 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
 
     if (mode === 'rendering') {
       this.previewCoordinator.hide(this.nativeTargetRef(state))
-      state.previewSurface = this.previewCoordinator.isAvailable()
-        ? 'native-overlay'
-        : 'renderer-canvas'
       return { updated: true, surface: state.previewSurface }
     }
 
@@ -337,6 +334,9 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       return { updated: false, surface: 'none' }
     }
     this.resumeClaimedPreview(state)
+    if (state.previewSurface === 'none') {
+      this.openBrowserPanelForUnavailablePreview(state)
+    }
     return {
       updated: true,
       surface: state.previewSurface
@@ -1525,6 +1525,9 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
             state.previewSurface =
               host && !host.isDestroyed() ? this.previewCoordinator.prepare(target, host) : 'none'
             this.emitPreviewSurface(state)
+            if (state.previewSurface === 'none') {
+              this.openBrowserPanelForUnavailablePreview(state)
+            }
           }
         }
         if (state.previewSurface === 'renderer-canvas') {
@@ -1597,6 +1600,16 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       source: 'browser',
       sessionId: state.sessionId,
       ...(state.agentRunId ? { runId: state.agentRunId } : {})
+    }
+  }
+
+  private openBrowserPanelForUnavailablePreview(state: SessionBrowserState): void {
+    if (this.previewCoordinator.isAvailable()) {
+      return
+    }
+    const target = this.nativeTarget(state)
+    if (target) {
+      this.handleNativePreviewAction('activate', target)
     }
   }
 

--- a/src/main/desktop/computerUse/ComputerUsePreviewPresenter.ts
+++ b/src/main/desktop/computerUse/ComputerUsePreviewPresenter.ts
@@ -51,6 +51,7 @@ type ComputerUsePreviewState = {
   nextFrameSequence: number
   transformActive: boolean
   pendingSnapshot: PendingSnapshot | null
+  nativeInitialization: Promise<boolean> | null
 }
 
 const FRAME_MAX_WIDTH = 480
@@ -149,7 +150,7 @@ export class ComputerUsePreviewPresenter
 
     if (state.mode === 'eligible') {
       if (targetChanged || state.surface === 'none') {
-        this.presentCurrent(state)
+        this.requestCurrentPresentation(state)
       } else {
         this.prepareCurrent(state)
       }
@@ -217,14 +218,6 @@ export class ComputerUsePreviewPresenter
     }
 
     this.stopOtherSessionsForHost(normalizedSessionId, host.id)
-    await this.previewCoordinator.initialize()
-    if (host.isDestroyed()) {
-      const state = this.states.get(normalizedSessionId)
-      if (state && (state.hostWindowId == null || state.hostWindowId === host.id)) {
-        this.stopState(state)
-      }
-      return { updated: false, surface: 'none' }
-    }
     const state = this.states.get(normalizedSessionId) ?? this.createState(normalizedSessionId)
     this.bindHost(state, host)
     state.mode = mode
@@ -239,7 +232,7 @@ export class ComputerUsePreviewPresenter
       return { updated: true, surface: 'none' }
     }
 
-    const surface = this.presentCurrent(state, true)
+    const surface = this.requestCurrentPresentation(state, true)
     return { updated: true, surface }
   }
 
@@ -289,7 +282,8 @@ export class ComputerUsePreviewPresenter
       frame: null,
       nextFrameSequence: 0,
       transformActive: false,
-      pendingSnapshot: null
+      pendingSnapshot: null,
+      nativeInitialization: null
     }
     this.states.set(sessionId, state)
     return state
@@ -494,6 +488,40 @@ export class ComputerUsePreviewPresenter
       return 'none'
     }
     return this.setSurface(state, this.previewCoordinator.prepare(target, host), announceSurface)
+  }
+
+  private requestCurrentPresentation(
+    state: ComputerUsePreviewState,
+    announceSurface = false
+  ): ComputerUsePreviewSurface {
+    if (!this.previewTarget(state) || state.mode !== 'eligible') {
+      return this.setSurface(state, 'none', announceSurface)
+    }
+    if (this.previewCoordinator.isAvailable()) {
+      return this.presentCurrent(state, announceSurface)
+    }
+    if (!state.nativeInitialization) {
+      const initialization = this.previewCoordinator.initialize()
+      state.nativeInitialization = initialization
+      void initialization
+        .then((available) => {
+          if (this.states.get(state.sessionId) !== state || state.mode !== 'eligible') {
+            return
+          }
+          if (!available) {
+            this.setSurface(state, 'none', true)
+            this.stopState(state)
+            return
+          }
+          this.presentCurrent(state, true)
+        })
+        .finally(() => {
+          if (state.nativeInitialization === initialization) {
+            state.nativeInitialization = null
+          }
+        })
+    }
+    return this.setSurface(state, 'none', announceSurface)
   }
 
   private presentCurrent(

--- a/src/main/desktop/computerUse/ComputerUsePreviewPresenter.ts
+++ b/src/main/desktop/computerUse/ComputerUsePreviewPresenter.ts
@@ -529,6 +529,10 @@ export class ComputerUsePreviewPresenter
     announceSurface = false
   ): ComputerUsePreviewSurface {
     const surface = this.prepareCurrent(state, announceSurface)
+    if (surface === 'none' && !this.previewCoordinator.isAvailable()) {
+      this.stopState(state)
+      return surface
+    }
     const frame = state.frame
     const target = this.previewTarget(state)
     if (surface === 'none' || !frame || !target || state.hostWindowId == null) {

--- a/src/main/desktop/preview/AgentPreviewCoordinator.ts
+++ b/src/main/desktop/preview/AgentPreviewCoordinator.ts
@@ -233,15 +233,15 @@ export class AgentPreviewCoordinator {
     this.desiredVisible = true
 
     if (!this.available || !this.overlay) {
-      return 'renderer-canvas'
+      return 'none'
     }
     if (!this.configureToolbar(target.source)) {
       this.disableNative('toolbar_update_failed')
-      return 'renderer-canvas'
+      return 'none'
     }
     if (!this.attachHost(host)) {
       this.disableNative('host_attach_failed')
-      return 'renderer-canvas'
+      return 'none'
     }
     return 'native-overlay'
   }

--- a/src/main/desktop/preview/AgentPreviewCoordinator.ts
+++ b/src/main/desktop/preview/AgentPreviewCoordinator.ts
@@ -263,7 +263,6 @@ export class AgentPreviewCoordinator {
       this.recordPushDuration(performance.now() - startedAt)
       if (!pushed) {
         this.warnFramePush(new Error('pushImage returned false'))
-        this.disableNative('frame_push_failed')
         return false
       }
 
@@ -283,7 +282,6 @@ export class AgentPreviewCoordinator {
     } catch (error) {
       this.recordPushDuration(performance.now() - startedAt)
       this.warnFramePush(error)
-      this.disableNative('frame_push_failed')
       return false
     }
   }

--- a/src/shared/types/desktop.ts
+++ b/src/shared/types/desktop.ts
@@ -103,7 +103,6 @@ export type ShortcutKeySetting = Record<string, string>
 export type ShortcutKey = string
 
 export interface IYoBrowserPresenter {
-  initialize(): Promise<void>
   getBrowserStatus(sessionId: string): Promise<YoBrowserStatus>
   loadUrl(
     sessionId: string,

--- a/test/main/app/compositionBoundaries.test.ts
+++ b/test/main/app/compositionBoundaries.test.ts
@@ -2,6 +2,17 @@ import path from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 describe('session boundary composition', () => {
+  it('does not load NativeKit from the application startup workload', async () => {
+    const { readFileSync } = await vi.importActual<typeof import('node:fs')>('node:fs')
+    const compositionSource = readFileSync(
+      path.resolve(process.cwd(), 'src/main/app/composition.ts'),
+      'utf8'
+    )
+
+    expect(compositionSource).not.toContain('main:yo-browser')
+    expect(compositionSource).not.toContain('yoBrowserPresenter.initialize()')
+  })
+
   it('reuses one default LegacyChatImportService across startup and skill repair', async () => {
     const { readFileSync } = await vi.importActual<typeof import('node:fs')>('node:fs')
     const compositionSource = readFileSync(

--- a/test/main/build/electronBuilderConfig.test.ts
+++ b/test/main/build/electronBuilderConfig.test.ts
@@ -85,7 +85,7 @@ describe('electron-builder config', () => {
   it('pins NativeKit to the reviewed native overlay release', async () => {
     const packageJson = await readPackageJson()
 
-    expect(packageJson.dependencies?.['@zerob13/nativekit']).toBe('0.6.2')
+    expect(packageJson.dependencies?.['@zerob13/nativekit']).toBe('0.6.3')
   })
 
   it('pins the OpenDAL facade and native packages to the same release', async () => {

--- a/test/main/desktop/browser/YoBrowserPresenter.test.ts
+++ b/test/main/desktop/browser/YoBrowserPresenter.test.ts
@@ -569,6 +569,72 @@ describe('YoBrowserPresenter', () => {
     expect(previewHosts[0].destroyed).toBe(true)
   })
 
+  it('loads NativeKit only when Browser capture is requested', async () => {
+    const { presenter, windows, getSessionWebContents } = await setupPresenter()
+    windows.set(1, new MockBrowserWindow(1))
+
+    const loadPromise = presenter.loadUrl(
+      'session-a',
+      'https://example.com',
+      undefined,
+      1,
+      'agent',
+      'run-1'
+    )
+    await Promise.resolve()
+    getSessionWebContents('session-a')?.emitDomReady()
+    await loadPromise
+
+    expect(nativeInitializeMock).not.toHaveBeenCalled()
+
+    await presenter.setPreviewMode('session-a', 'rendering', 1, 'run-1')
+    expect(nativeInitializeMock).not.toHaveBeenCalled()
+
+    await presenter.setPreviewMode('session-a', 'capturing', 1, 'run-1')
+    expect(nativeInitializeMock).toHaveBeenCalledOnce()
+  })
+
+  it('opens Browser in the side panel when NativeKit is unavailable', async () => {
+    const { presenter, windows, windowPresenter, getSessionWebContents } = await setupPresenter()
+    windows.set(1, new MockBrowserWindow(1))
+    nativePrepareMock.mockReturnValue('none')
+
+    const loadPromise = presenter.loadUrl(
+      'session-a',
+      'https://example.com',
+      undefined,
+      1,
+      'agent',
+      'run-1'
+    )
+    await Promise.resolve()
+    getSessionWebContents('session-a')?.emitDomReady()
+    await loadPromise
+    sendToAllWindowsMock.mockClear()
+
+    await expect(presenter.setPreviewMode('session-a', 'capturing', 1, 'run-1')).resolves.toEqual({
+      updated: true,
+      surface: 'none'
+    })
+
+    expect(windowPresenter.show).toHaveBeenCalledWith(1, true)
+    expect(sendToAllWindowsMock).toHaveBeenCalledWith(
+      'deepchat:event',
+      expect.objectContaining({
+        name: 'browser.preview.action',
+        payload: {
+          action: 'activate',
+          windowId: 1,
+          sessionId: 'session-a',
+          runId: 'run-1'
+        }
+      }),
+      1
+    )
+    await vi.advanceTimersByTimeAsync(1)
+    expect(getSessionWebContents('session-a')?.capturePage).not.toHaveBeenCalled()
+  })
+
   it('rejects preview capture for a stale Agent run', async () => {
     const { presenter, windows, getSessionWebContents } = await setupPresenter()
     windows.set(1, new MockBrowserWindow(1))
@@ -597,7 +663,6 @@ describe('YoBrowserPresenter', () => {
     nativeInitializeMock.mockResolvedValue(true)
     nativeIsAvailableMock.mockReturnValue(true)
     nativePrepareMock.mockReturnValue('native-overlay')
-    await presenter.initialize()
 
     const loadPromise = presenter.loadUrl(
       'session-a',

--- a/test/main/desktop/computerUse/ComputerUsePreviewPresenter.test.ts
+++ b/test/main/desktop/computerUse/ComputerUsePreviewPresenter.test.ts
@@ -24,7 +24,7 @@ describe('ComputerUsePreviewPresenter', () => {
   })
 
   const setup = async (
-    nativeSurface: 'native-overlay' | 'renderer-canvas' | 'none' = 'renderer-canvas'
+    nativeSurface: 'native-overlay' | 'renderer-canvas' | 'none' = 'native-overlay'
   ) => {
     const windows = new Map<number, MockBrowserWindow>([[7, new MockBrowserWindow(7)]])
     vi.doMock('electron', () => ({
@@ -213,7 +213,7 @@ describe('ComputerUsePreviewPresenter', () => {
   })
 
   it('publishes a bounded Canvas frame only after a valid current snapshot', async () => {
-    const { presenter, coordinator, windowPresenter } = await setup()
+    const { presenter, coordinator, windowPresenter } = await setup('renderer-canvas')
     await expect(presenter.setPreviewMode('session-1', 'eligible', 7)).resolves.toEqual({
       updated: true,
       surface: 'none'
@@ -266,7 +266,7 @@ describe('ComputerUsePreviewPresenter', () => {
   })
 
   it('clears the old target epoch and rejects an out-of-order result', async () => {
-    const { presenter, windowPresenter } = await setup()
+    const { presenter, windowPresenter } = await setup('renderer-canvas')
     await presenter.setPreviewMode('session-1', 'eligible', 7)
     const first = call('tool-1')
     presenter.started(first)
@@ -328,8 +328,30 @@ describe('ComputerUsePreviewPresenter', () => {
     ).toBe(false)
   })
 
+  it('stops preview when frame preparation disables NativeKit', async () => {
+    const { presenter, coordinator } = await setup()
+    await presenter.setPreviewMode('session-1', 'eligible', 7)
+    const currentCall = call('tool-native-failure')
+    presenter.started(currentCall)
+
+    coordinator.prepare.mockImplementationOnce(() => {
+      coordinator.isAvailable.mockReturnValue(false)
+      return 'none'
+    })
+    await completeWithImage(presenter, currentCall, await createPng(320, 200))
+    await vi.waitFor(() => expect(coordinator.prepare).toHaveBeenCalledTimes(2))
+
+    expect(coordinator.present).not.toHaveBeenCalled()
+    expect(coordinator.releaseClaim).toHaveBeenCalledWith({
+      source: 'computer-use',
+      sessionId: 'session-1',
+      runId: 'run-1'
+    })
+    expect(presenter.shouldCaptureAfterClick(call('click', { toolName: 'click' }))).toBe(false)
+  })
+
   it('rejects malformed images and keeps the last valid same-target frame', async () => {
-    const { presenter, windowPresenter } = await setup()
+    const { presenter, windowPresenter } = await setup('renderer-canvas')
     await presenter.setPreviewMode('session-1', 'eligible', 7)
     const validCall = call('tool-valid')
     presenter.started(validCall)
@@ -365,7 +387,7 @@ describe('ComputerUsePreviewPresenter', () => {
   })
 
   it('enforces image bounds without upscaling the last valid frame', async () => {
-    const { presenter, windowPresenter } = await setup()
+    const { presenter, windowPresenter } = await setup('renderer-canvas')
     await presenter.setPreviewMode('session-1', 'eligible', 7)
     const validCall = call('tool-small')
     presenter.started(validCall)
@@ -429,7 +451,7 @@ describe('ComputerUsePreviewPresenter', () => {
   })
 
   it('drops intermediate transforms and publishes only the latest overlapping snapshot', async () => {
-    const { presenter, windowPresenter } = await setup()
+    const { presenter, windowPresenter } = await setup('renderer-canvas')
     await presenter.setPreviewMode('session-1', 'eligible', 7)
     const first = call('tool-first')
     const intermediate = call('tool-intermediate')
@@ -463,7 +485,7 @@ describe('ComputerUsePreviewPresenter', () => {
   })
 
   it('retains the last valid frame after failed and aborted snapshot calls', async () => {
-    const { presenter, windowPresenter } = await setup()
+    const { presenter, windowPresenter } = await setup('renderer-canvas')
     await presenter.setPreviewMode('session-1', 'eligible', 7)
     const valid = call('tool-valid')
     presenter.started(valid)
@@ -492,7 +514,7 @@ describe('ComputerUsePreviewPresenter', () => {
   })
 
   it('dismisses only the current run and permits a later run', async () => {
-    const { presenter, coordinator, windowPresenter } = await setup()
+    const { presenter, coordinator, windowPresenter } = await setup('renderer-canvas')
     await presenter.setPreviewMode('session-1', 'eligible', 7)
     const first = call('tool-1')
     presenter.started(first)

--- a/test/main/desktop/computerUse/ComputerUsePreviewPresenter.test.ts
+++ b/test/main/desktop/computerUse/ComputerUsePreviewPresenter.test.ts
@@ -23,7 +23,9 @@ describe('ComputerUsePreviewPresenter', () => {
     vi.restoreAllMocks()
   })
 
-  const setup = async (nativeSurface: 'native-overlay' | 'renderer-canvas' = 'renderer-canvas') => {
+  const setup = async (
+    nativeSurface: 'native-overlay' | 'renderer-canvas' | 'none' = 'renderer-canvas'
+  ) => {
     const windows = new Map<number, MockBrowserWindow>([[7, new MockBrowserWindow(7)]])
     vi.doMock('electron', () => ({
       BrowserWindow: {
@@ -57,7 +59,8 @@ describe('ComputerUsePreviewPresenter', () => {
           return vi.fn()
         }
       ),
-      initialize: vi.fn(async () => nativeSurface === 'native-overlay'),
+      initialize: vi.fn(async () => nativeSurface !== 'none'),
+      isAvailable: vi.fn(() => nativeSurface !== 'none'),
       claim: vi.fn(() => ++nextClaimSequence),
       releaseClaim: vi.fn(),
       dismiss: vi.fn(() => true),
@@ -159,6 +162,33 @@ describe('ComputerUsePreviewPresenter', () => {
     await presenter.setPreviewMode('session-1', 'eligible', 7)
     expect(presenter.dismissPreview('session-1', 'run-1')).toBe(true)
     expect(presenter.shouldCaptureAfterClick(click)).toBe(false)
+  })
+
+  it('loads NativeKit for the first concrete target and disables preview when loading fails', async () => {
+    const { presenter, coordinator, windowPresenter } = await setup('none')
+
+    await expect(presenter.setPreviewMode('session-1', 'eligible', 7)).resolves.toEqual({
+      updated: true,
+      surface: 'none'
+    })
+    expect(coordinator.initialize).not.toHaveBeenCalled()
+
+    const currentCall = call('snapshot')
+    presenter.started(currentCall)
+
+    await vi.waitFor(() => expect(coordinator.initialize).toHaveBeenCalledOnce())
+    expect(presenter.shouldCaptureAfterClick(call('click', { toolName: 'click' }))).toBe(false)
+
+    await completeWithImage(presenter, currentCall, await createPng())
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(coordinator.prepare).not.toHaveBeenCalled()
+    expect(coordinator.present).not.toHaveBeenCalled()
+    expect(
+      windowPresenter.sendToWindow.mock.calls.some(
+        ([, , envelope]) => (envelope as { name?: string }).name === 'computerUse.preview.frame'
+      )
+    ).toBe(false)
   })
 
   it('releases preview state when the host closes without renderer cleanup', async () => {

--- a/test/main/desktop/preview/AgentPreviewCoordinator.test.ts
+++ b/test/main/desktop/preview/AgentPreviewCoordinator.test.ts
@@ -200,6 +200,26 @@ describe('AgentPreviewCoordinator', () => {
     coordinator.shutdown()
   })
 
+  it('keeps NativeKit available after a transient frame push failure', async () => {
+    const { coordinator, browserTarget, overlay, host } = await setup()
+    const target = browserTarget()
+
+    await coordinator.initialize()
+    expect(coordinator.prepare(target, host as never)).toBe('native-overlay')
+    expect(coordinator.present(target, Buffer.from('frame-1'))).toBe(true)
+
+    overlay.pushImage.mockReturnValueOnce(false)
+    expect(coordinator.present(target, Buffer.from('frame-2'))).toBe(false)
+    expect(coordinator.isAvailable()).toBe(true)
+    expect(overlay.stop).not.toHaveBeenCalled()
+    expect(overlay.removeImage).not.toHaveBeenCalled()
+
+    expect(coordinator.prepare(target, host as never)).toBe('native-overlay')
+    expect(coordinator.present(target, Buffer.from('frame-3'))).toBe(true)
+
+    coordinator.shutdown()
+  })
+
   it('switches to the close-only Computer Use toolbar and ignores activation', async () => {
     const { coordinator, browserAction, browserTarget, computerAction, overlay, host } =
       await setup()

--- a/test/main/desktop/preview/AgentPreviewCoordinator.test.ts
+++ b/test/main/desktop/preview/AgentPreviewCoordinator.test.ts
@@ -110,6 +110,15 @@ describe('AgentPreviewCoordinator', () => {
     }
   }
 
+  it('does not start NativeKit until initialization is requested', async () => {
+    const { coordinator, overlay } = await setup()
+
+    expect(overlay.start).not.toHaveBeenCalled()
+
+    await expect(coordinator.initialize()).resolves.toBe(true)
+    expect(overlay.start).toHaveBeenCalledOnce()
+  })
+
   it('pushes a current JPEG before showing the native panel', async () => {
     const { coordinator, browserTarget, overlay, host } = await setup()
     const target = browserTarget()
@@ -266,21 +275,21 @@ describe('AgentPreviewCoordinator', () => {
     coordinator.shutdown()
   })
 
-  it('returns Canvas fallback when native startup fails', async () => {
+  it('disables preview when native startup fails', async () => {
     const { coordinator, browserTarget, overlay, host } = await setup(false)
     const target = browserTarget(1)
 
     await expect(coordinator.initialize()).resolves.toBe(false)
-    expect(coordinator.prepare(target, host as never)).toBe('renderer-canvas')
+    expect(coordinator.prepare(target, host as never)).toBe('none')
     expect(overlay.attachHost).not.toHaveBeenCalled()
   })
 
-  it('falls back permanently when the first real host cannot attach', async () => {
+  it('disables preview permanently when the first real host cannot attach', async () => {
     const { coordinator, browserTarget, overlay, host } = await setup()
     overlay.attachHost.mockReturnValue(false)
     await coordinator.initialize()
 
-    expect(coordinator.prepare(browserTarget(1), host as never)).toBe('renderer-canvas')
+    expect(coordinator.prepare(browserTarget(1), host as never)).toBe('none')
     expect(coordinator.isAvailable()).toBe(false)
     await expect(coordinator.initialize()).resolves.toBe(false)
     expect(overlay.stop).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary

- remove NativeKit initialization from the application startup workload
- load NativeKit only for the first Browser capture or concrete Computer Use target
- disable native PiP process-wide after loading or startup fails
- open the existing side Browser automatically when Browser PiP is unavailable
- keep Computer Use running without PiP when native preview is unavailable
- upgrade `@zerob13/nativekit` from `0.6.2` to `0.6.3`
- retain the provider and ACP registry refresh produced by the normal build

## Root cause

The package import was dynamic, but the startup workload immediately called the preview initializer, so NativeKit was effectively loaded eagerly. A missing native dependency could therefore affect application startup, and the failure path selected the renderer Canvas fallback for both Browser and Computer Use.

## User impact

```text
BEFORE  NativeKit load failed
├─ Browser      -> Canvas PiP
└─ Computer Use -> Canvas PiP

AFTER   NativeKit load failed
├─ Browser      -> existing side Browser opens
└─ Computer Use -> no PiP; tools continue normally
```

NativeKit `0.6.3` also statically links the Windows x64 MSVC runtime, reducing deployment-time dynamic runtime failures.

## Verification

- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`
- focused main tests: 73 passed
- focused renderer tests: 20 passed
- built main output retains `await import('@zerob13/nativekit')`

Physical Windows packaged smoke testing remains release QA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native picture-in-picture now uses NativeKit 0.6.3 when supported.
  * If native PiP isn’t available, Browser automatically opens the existing side panel, and Computer Use shows no PiP.

* **Bug Fixes**
  * Native PiP loading is deferred until a preview is actually requested.
  * Tightened “native unavailable” behavior and removed the prior canvas-based fallback path.

* **Chores**
  * Updated PiP migration documentation and pinned NativeKit to 0.6.3.
  * Refreshed agent/model catalog entries.

* **Tests**
  * Added/updated tests to cover native-available vs native-unavailable flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->