### PR TITLE
refactor(settings): redesign usage dashboard with soft panels

### DIFF
--- a/src/renderer/settings/components/DashboardSettings.vue
+++ b/src/renderer/settings/components/DashboardSettings.vue
@@ -6,7 +6,7 @@
         class="flex flex-col gap-3 px-2 py-2 sm:flex-row sm:items-start sm:justify-between"
       >
         <div class="min-w-0 flex-1">
-          <h2 class="text-sm font-medium text-foreground">
+          <h2 class="text-sm font-bold text-foreground">
             {{ t('settings.dashboard.title') }}
           </h2>
           <p class="mt-1 max-w-3xl text-xs leading-5 text-muted-foreground">
@@ -29,12 +29,12 @@
       <section
         v-if="dashboard?.backfillStatus.status === 'running'"
         data-testid="dashboard-backfill-banner"
-        class="rounded-2xl border border-primary/20 bg-primary/10 px-4 py-3 text-sm text-foreground"
+        class="rounded-lg border border-primary/20 bg-primary/10 px-4 py-3 text-sm text-foreground"
       >
         <div class="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
           <span class="h-2 w-2 animate-pulse rounded-full bg-primary"></span>
           <div class="flex-1">
-            <p class="font-medium">{{ t('settings.dashboard.backfill.runningTitle') }}</p>
+            <p class="font-bold">{{ t('settings.dashboard.backfill.runningTitle') }}</p>
             <p class="text-muted-foreground">
               {{ t('settings.dashboard.backfill.runningDescription') }}
             </p>
@@ -44,9 +44,9 @@
 
       <section
         v-else-if="dashboard?.backfillStatus.status === 'failed'"
-        class="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm"
+        class="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm"
       >
-        <p class="font-medium text-destructive">
+        <p class="font-bold text-destructive">
           {{ t('settings.dashboard.backfill.failedTitle') }}
         </p>
         <p class="text-muted-foreground">
@@ -56,260 +56,166 @@
 
       <section
         v-if="errorMessage"
-        class="rounded-2xl border border-destructive/30 bg-destructive/10 p-4"
+        class="rounded-lg border border-destructive/30 bg-destructive/10 p-4"
       >
-        <p class="font-medium text-destructive">{{ t('settings.dashboard.error.title') }}</p>
+        <p class="font-bold text-destructive">{{ t('settings.dashboard.error.title') }}</p>
         <p class="mt-1 text-sm text-muted-foreground">{{ errorMessage }}</p>
       </section>
 
-      <section v-if="isLoading && !dashboard" class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-        <div
-          :class="[
-            'h-68 animate-pulse rounded-2xl border border-border bg-muted/40 md:col-span-2',
-            props.hideNostalgia ? 'xl:col-span-4' : 'xl:col-span-3'
-          ]"
-        ></div>
-        <div
-          v-if="!props.hideNostalgia"
-          class="h-68 animate-pulse rounded-2xl border border-border bg-muted/40 md:col-span-2 xl:col-span-1"
-        ></div>
+      <section v-if="isLoading && !dashboard">
+        <div class="h-68 animate-pulse rounded-xl bg-accent"></div>
       </section>
 
       <template v-else-if="dashboard">
-        <section v-if="hasData" class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-          <Card
-            v-if="tokenUsageCard"
-            data-testid="summary-card-tokenUsage"
-            :class="[
-              'h-full overflow-hidden border-border/70 bg-card/90 backdrop-blur-sm md:col-span-2',
-              props.hideNostalgia ? 'xl:col-span-4' : 'xl:col-span-3'
-            ]"
-          >
-            <CardHeader class="space-y-1 pb-1">
-              <CardDescription>{{ t('settings.dashboard.summary.tokenUsage') }}</CardDescription>
-            </CardHeader>
-            <CardContent class="space-y-4 pt-0">
+        <section v-if="hasData">
+          <Card data-testid="usage-summary-panel" class="border-none bg-accent py-5 shadow-none">
+            <CardContent :class="['grid gap-6', props.hideNostalgia ? '' : 'lg:grid-cols-2']">
+              <UsageNostalgiaCard
+                v-if="!props.hideNostalgia"
+                :dashboard="dashboard"
+                class="min-w-0"
+              />
+
               <div
-                data-testid="token-usage-trend-chart"
-                class="token-usage-trend-grid rounded-xl border border-border/40 bg-muted/10 px-2 py-2.5 sm:px-3 sm:py-3"
+                v-if="tokenUsageCard"
+                data-testid="summary-card-tokenUsage"
+                :class="[
+                  'flex min-w-0 flex-col gap-3',
+                  props.hideNostalgia ? '' : 'lg:border-l lg:border-border lg:pl-6'
+                ]"
               >
-                <ChartContainer :config="tokenUsageChartConfig" class="aspect-auto h-46 w-full">
-                  <VisXYContainer
-                    :data="tokenUsageCard.chartData"
-                    :height="TOKEN_USAGE_CHART_HEIGHT"
-                    :padding="{ top: 12, bottom: 14, left: 0, right: 0 }"
-                    :margin="{ top: 0, bottom: 0, left: 0, right: 0 }"
-                    :x-domain="[0, Math.max(tokenUsageCard.chartData.length - 1, 1)]"
-                    :y-domain="tokenUsageCard.yDomain"
-                  >
-                    <ChartCrosshair
-                      :data="tokenUsageCard.chartData"
-                      :hide-when-far-from-pointer="true"
-                      :tooltip="tokenUsageTooltip?.component"
-                      :template="tokenUsageTooltipTemplate"
-                      :x="tokenTrendXAccessor"
-                      :y="tokenTrendYAccessors"
-                    />
-                    <ChartTooltip
-                      ref="tokenUsageTooltip"
-                      :attributes="{ 'data-testid': 'token-usage-tooltip' }"
-                    />
-                    <VisArea
-                      :x="tokenTrendXAccessor"
-                      :y="tokenTrendInputAccessor"
-                      :curve-type="CurveType.MonotoneX"
-                      :color="tokenTrendAreaColor('input')"
-                      :opacity="0.08"
-                      :line="true"
-                      :line-color="tokenTrendLineColor('input')"
-                      :line-width="2.2"
-                    />
-                    <VisArea
-                      :x="tokenTrendXAccessor"
-                      :y="tokenTrendOutputAccessor"
-                      :curve-type="CurveType.MonotoneX"
-                      :color="tokenTrendAreaColor('output')"
-                      :opacity="0.04"
-                      :line="true"
-                      :line-color="tokenTrendLineColor('output')"
-                      :line-width="1.9"
-                    />
-                    <VisArea
-                      :x="tokenTrendXAccessor"
-                      :y="tokenTrendCachedAccessor"
-                      :curve-type="CurveType.MonotoneX"
-                      :color="tokenTrendAreaColor('cached')"
-                      :opacity="0.05"
-                      :line="true"
-                      :line-color="tokenTrendLineColor('cached')"
-                      :line-width="1.9"
-                    />
-                    <VisArea
-                      :x="tokenTrendXAccessor"
-                      :y="tokenTrendCostAccessor"
-                      :curve-type="CurveType.MonotoneX"
-                      :color="tokenTrendAreaColor('cost')"
-                      :opacity="0.04"
-                      :line="true"
-                      :line-color="tokenTrendLineColor('cost')"
-                      :line-width="1.9"
-                    />
-                  </VisXYContainer>
-                </ChartContainer>
-              </div>
-
-              <div data-testid="token-usage-list" class="dashboard-token-usage-list grid gap-2">
+                <p class="text-sm text-muted-foreground">
+                  {{ t('settings.dashboard.summary.tokenUsage') }}
+                </p>
                 <div
-                  data-testid="token-usage-total-row"
-                  class="rounded-lg border border-border/30 bg-muted/5 px-3 py-2.5"
+                  data-testid="token-usage-list"
+                  class="dashboard-token-usage-list flex flex-col gap-3"
                 >
-                  <p
-                    class="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground"
-                  >
-                    {{ t('settings.dashboard.summary.totalTokens') }}
-                  </p>
-                  <p
-                    class="mt-1 text-sm font-semibold tracking-tight"
-                    :title="formatFullTokens(tokenUsageCard.totalTokens)"
-                  >
-                    {{ formatTokens(tokenUsageCard.totalTokens) }}
-                  </p>
-                </div>
-
-                <div
-                  data-testid="total-tokens-input-row"
-                  class="rounded-lg border border-border/30 bg-muted/5 px-3 py-2.5"
-                >
-                  <div class="flex min-w-0 items-center gap-2">
-                    <span
-                      data-testid="token-usage-input-dot"
-                      class="h-2.5 w-2.5 shrink-0 rounded-full border border-card shadow-[0_0_0_1px_hsl(var(--border)/0.18)]"
-                      :style="tokenUsageMetricDotStyle('input')"
-                    ></span>
-                    <span
-                      class="truncate text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground"
+                  <div data-testid="token-usage-total-row">
+                    <p class="text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
+                      {{ t('settings.dashboard.summary.totalTokens') }}
+                    </p>
+                    <p
+                      class="mt-1 text-2xl font-bold tabular-nums tracking-tight"
+                      :title="formatFullTokens(tokenUsageCard.totalTokens)"
                     >
-                      {{ t('settings.dashboard.summary.inputTokensLabel') }}
-                    </span>
+                      {{ formatTokens(tokenUsageCard.totalTokens) }}
+                    </p>
                   </div>
-                  <p
-                    class="mt-1 text-sm font-semibold tracking-tight"
-                    :title="formatFullTokens(tokenUsageCard.inputTokens)"
-                  >
-                    {{ formatTokens(tokenUsageCard.inputTokens) }}
-                  </p>
-                  <p
-                    data-testid="total-tokens-input-ratio"
-                    class="text-[11px] font-medium text-muted-foreground"
-                  >
-                    {{ formatPercent(tokenUsageCard.inputRatio) }}
-                  </p>
-                </div>
 
-                <div
-                  data-testid="total-tokens-output-row"
-                  class="rounded-lg border border-border/30 bg-muted/5 px-3 py-2.5"
-                >
-                  <div class="flex min-w-0 items-center gap-2">
-                    <span
-                      data-testid="token-usage-output-dot"
-                      class="h-2.5 w-2.5 shrink-0 rounded-full border border-card shadow-[0_0_0_1px_hsl(var(--border)/0.18)]"
-                      :style="tokenUsageMetricDotStyle('output')"
-                    ></span>
-                    <span
-                      class="truncate text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground"
+                  <div class="flex flex-col">
+                    <div
+                      data-testid="total-tokens-input-row"
+                      class="flex items-center justify-between gap-3 border-b border-border py-1.5"
                     >
-                      {{ t('settings.dashboard.summary.outputTokensLabel') }}
-                    </span>
-                  </div>
-                  <p
-                    class="mt-1 text-sm font-semibold tracking-tight"
-                    :title="formatFullTokens(tokenUsageCard.outputTokens)"
-                  >
-                    {{ formatTokens(tokenUsageCard.outputTokens) }}
-                  </p>
-                  <p
-                    data-testid="total-tokens-output-ratio"
-                    class="text-[11px] font-medium text-muted-foreground"
-                  >
-                    {{ formatPercent(tokenUsageCard.outputRatio) }}
-                  </p>
-                </div>
+                      <div class="flex min-w-0 items-center gap-2">
+                        <span
+                          data-testid="token-usage-input-dot"
+                          class="h-2 w-2 shrink-0 rounded-full"
+                          :style="tokenUsageMetricDotStyle('input')"
+                        ></span>
+                        <span
+                          class="truncate text-[11px] uppercase tracking-[0.08em] text-muted-foreground"
+                        >
+                          {{ t('settings.dashboard.summary.inputTokensLabel') }}
+                        </span>
+                      </div>
+                      <div class="flex shrink-0 items-baseline gap-3">
+                        <span
+                          class="text-sm font-bold tabular-nums tracking-tight"
+                          :title="formatFullTokens(tokenUsageCard.inputTokens)"
+                        >
+                          {{ formatTokens(tokenUsageCard.inputTokens) }}
+                        </span>
+                        <span
+                          data-testid="total-tokens-input-ratio"
+                          class="w-12 text-right text-[11px] tabular-nums text-muted-foreground"
+                        >
+                          {{ formatPercent(tokenUsageCard.inputRatio) }}
+                        </span>
+                      </div>
+                    </div>
 
-                <div
-                  data-testid="cached-tokens-cached-row"
-                  class="rounded-lg border border-border/30 bg-muted/5 px-3 py-2.5"
-                >
-                  <div class="flex min-w-0 items-center gap-2">
-                    <span
-                      data-testid="token-usage-cached-dot"
-                      class="h-2.5 w-2.5 shrink-0 rounded-full border border-card shadow-[0_0_0_1px_hsl(var(--border)/0.18)]"
-                      :style="tokenUsageMetricDotStyle('cached')"
-                    ></span>
-                    <span
-                      class="truncate text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground"
+                    <div
+                      data-testid="total-tokens-output-row"
+                      class="flex items-center justify-between gap-3 border-b border-border py-1.5"
                     >
-                      {{ t('settings.dashboard.summary.cachedTokensCachedLabel') }}
-                    </span>
-                  </div>
-                  <p
-                    class="mt-1 text-sm font-semibold tracking-tight"
-                    :title="formatFullTokens(tokenUsageCard.cachedTokens)"
-                  >
-                    {{ formatTokens(tokenUsageCard.cachedTokens) }}
-                  </p>
-                  <p
-                    data-testid="cached-tokens-cached-ratio"
-                    class="text-[11px] font-medium text-muted-foreground"
-                  >
-                    {{ formatPercent(tokenUsageCard.cachedRatio) }}
-                  </p>
-                </div>
+                      <div class="flex min-w-0 items-center gap-2">
+                        <span
+                          data-testid="token-usage-output-dot"
+                          class="h-2 w-2 shrink-0 rounded-full"
+                          :style="tokenUsageMetricDotStyle('output')"
+                        ></span>
+                        <span
+                          class="truncate text-[11px] uppercase tracking-[0.08em] text-muted-foreground"
+                        >
+                          {{ t('settings.dashboard.summary.outputTokensLabel') }}
+                        </span>
+                      </div>
+                      <div class="flex shrink-0 items-baseline gap-3">
+                        <span
+                          class="text-sm font-bold tabular-nums tracking-tight"
+                          :title="formatFullTokens(tokenUsageCard.outputTokens)"
+                        >
+                          {{ formatTokens(tokenUsageCard.outputTokens) }}
+                        </span>
+                        <span
+                          data-testid="total-tokens-output-ratio"
+                          class="w-12 text-right text-[11px] tabular-nums text-muted-foreground"
+                        >
+                          {{ formatPercent(tokenUsageCard.outputRatio) }}
+                        </span>
+                      </div>
+                    </div>
 
-                <div
-                  data-testid="token-usage-cost-row"
-                  class="rounded-lg border border-border/30 bg-muted/5 px-3 py-2.5"
-                >
-                  <div class="flex min-w-0 items-center gap-2">
-                    <span
-                      data-testid="token-usage-cost-dot"
-                      class="h-2.5 w-2.5 shrink-0 rounded-full border border-card shadow-[0_0_0_1px_hsl(var(--border)/0.18)]"
-                      :style="tokenUsageMetricDotStyle('cost')"
-                    ></span>
-                    <span
-                      class="truncate text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground"
+                    <div
+                      data-testid="cached-tokens-cached-row"
+                      class="flex items-center justify-between gap-3 py-1.5"
                     >
-                      {{ t('settings.dashboard.summary.estimatedCost') }}
-                    </span>
+                      <div class="flex min-w-0 items-center gap-2">
+                        <span
+                          data-testid="token-usage-cached-dot"
+                          class="h-2 w-2 shrink-0 rounded-full"
+                          :style="tokenUsageMetricDotStyle('cached')"
+                        ></span>
+                        <span
+                          class="truncate text-[11px] uppercase tracking-[0.08em] text-muted-foreground"
+                        >
+                          {{ t('settings.dashboard.summary.cachedTokensCachedLabel') }}
+                        </span>
+                      </div>
+                      <div class="flex shrink-0 items-baseline gap-3">
+                        <span
+                          class="text-sm font-bold tabular-nums tracking-tight"
+                          :title="formatFullTokens(tokenUsageCard.cachedTokens)"
+                        >
+                          {{ formatTokens(tokenUsageCard.cachedTokens) }}
+                        </span>
+                        <span
+                          data-testid="cached-tokens-cached-ratio"
+                          class="w-12 text-right text-[11px] tabular-nums text-muted-foreground"
+                        >
+                          {{ formatPercent(tokenUsageCard.cachedRatio) }}
+                        </span>
+                      </div>
+                    </div>
                   </div>
-                  <p class="mt-1 text-sm font-semibold tracking-tight">
-                    {{ formatCurrency(tokenUsageCard.totalCost) }}
-                  </p>
-                  <p class="text-[11px] font-medium text-muted-foreground">
-                    {{ t('settings.dashboard.summary.estimatedCostTrendLabel') }}
-                  </p>
                 </div>
               </div>
             </CardContent>
           </Card>
-
-          <UsageNostalgiaCard
-            v-if="!props.hideNostalgia"
-            :dashboard="dashboard"
-            class="md:col-span-2 xl:col-span-1"
-          />
         </section>
 
         <section
           v-else
           data-testid="dashboard-empty"
-          class="rounded-3xl border border-dashed border-border/80 bg-card/80 p-8 text-center"
+          class="rounded-xl border border-dashed border-border p-8 text-center"
         >
           <div class="mx-auto max-w-xl space-y-3">
-            <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-muted">
+            <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-xl bg-muted">
               <Icon icon="lucide:layout-dashboard" class="h-7 w-7 text-muted-foreground" />
             </div>
-            <h3 class="text-lg font-semibold">{{ t('settings.dashboard.empty.title') }}</h3>
+            <h3 class="text-lg font-bold">{{ t('settings.dashboard.empty.title') }}</h3>
             <p class="text-sm text-muted-foreground">
               {{ t('settings.dashboard.empty.description') }}
             </p>
@@ -319,7 +225,7 @@
           </div>
         </section>
 
-        <Card class="overflow-hidden border-border/70 bg-card/90 backdrop-blur-sm">
+        <Card class="overflow-hidden border-none bg-accent shadow-none">
           <CardHeader class="pb-4">
             <div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
               <div class="space-y-1">
@@ -332,23 +238,23 @@
                 <span>{{ t('settings.dashboard.calendar.legend') }}</span>
                 <div class="flex items-center gap-1">
                   <span
-                    class="h-3 w-3 rounded-sm border border-border/70"
+                    class="h-3 w-3 rounded-sm border border-border"
                     :style="calendarCellStyles[0]"
                   ></span>
                   <span
-                    class="h-3 w-3 rounded-sm border border-border/70"
+                    class="h-3 w-3 rounded-sm border border-border"
                     :style="calendarCellStyles[1]"
                   ></span>
                   <span
-                    class="h-3 w-3 rounded-sm border border-border/70"
+                    class="h-3 w-3 rounded-sm border border-border"
                     :style="calendarCellStyles[2]"
                   ></span>
                   <span
-                    class="h-3 w-3 rounded-sm border border-border/70"
+                    class="h-3 w-3 rounded-sm border border-border"
                     :style="calendarCellStyles[3]"
                   ></span>
                   <span
-                    class="h-3 w-3 rounded-sm border border-border/70"
+                    class="h-3 w-3 rounded-sm border border-border"
                     :style="calendarCellStyles[4]"
                   ></span>
                 </div>
@@ -401,23 +307,37 @@
                         v-for="(day, dayIndex) in week"
                         :key="day ? day.date : `blank-${weekIndex}-${dayIndex}`"
                         data-testid="calendar-cell"
-                        class="calendar-cell rounded-sm border border-border/70"
+                        class="calendar-cell rounded-sm border border-border"
                         :class="day ? 'opacity-100' : 'opacity-0'"
                         :style="day ? day.cellStyle : undefined"
-                        :title="day ? day.title : ''"
+                        @mouseenter="day && showCalendarTooltip(day, $event)"
+                        @mousemove="day && moveCalendarTooltip($event)"
+                        @mouseleave="hideCalendarTooltip"
                       ></div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
+            <Teleport to="body">
+              <div
+                v-if="calendarTooltip"
+                data-testid="calendar-tooltip"
+                class="pointer-events-none fixed z-50"
+                :style="calendarTooltipStyle"
+              >
+                <ChartTooltipContent
+                  :config="tokenUsageChartConfig"
+                  :x="calendarTooltip.date"
+                  :label-formatter="tokenUsageTooltipDateLabel"
+                  :payload="calendarTooltip.payload"
+                />
+              </div>
+            </Teleport>
           </CardContent>
         </Card>
 
-        <Card
-          data-testid="rtk-card"
-          class="overflow-hidden border-border/70 bg-card/90 backdrop-blur-sm"
-        >
+        <Card data-testid="rtk-card" class="overflow-hidden border-none bg-accent shadow-none">
           <CardHeader class="pb-4">
             <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
               <div class="space-y-1">
@@ -451,68 +371,48 @@
             <div
               v-if="rtkStatusDescription"
               data-testid="rtk-status-copy"
-              class="rounded-2xl border border-border/40 bg-muted/10 px-4 py-3 text-sm text-muted-foreground"
+              class="rounded-lg bg-card/60 px-4 py-3 text-sm text-muted-foreground"
             >
               <p>{{ rtkStatusDescription }}</p>
             </div>
 
             <div class="dashboard-rtk-summary-grid grid gap-3">
-              <div
-                data-testid="rtk-summary-saved"
-                class="rounded-xl border border-border/40 bg-muted/5 px-4 py-3"
-              >
-                <p
-                  class="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground"
-                >
+              <div data-testid="rtk-summary-saved" class="rounded-lg bg-card/60 px-4 py-3">
+                <p class="text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
                   {{ t('settings.dashboard.rtk.summary.savedTokens') }}
                 </p>
                 <p
-                  class="mt-1 text-lg font-semibold tracking-tight"
+                  class="mt-1 text-lg font-bold tracking-tight"
                   :title="formatFullTokens(dashboard.rtk.summary.totalSavedTokens)"
                 >
                   {{ formatTokens(dashboard.rtk.summary.totalSavedTokens) }}
                 </p>
               </div>
 
-              <div
-                data-testid="rtk-summary-commands"
-                class="rounded-xl border border-border/40 bg-muted/5 px-4 py-3"
-              >
-                <p
-                  class="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground"
-                >
+              <div data-testid="rtk-summary-commands" class="rounded-lg bg-card/60 px-4 py-3">
+                <p class="text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
                   {{ t('settings.dashboard.rtk.summary.commands') }}
                 </p>
-                <p class="mt-1 text-lg font-semibold tracking-tight">
+                <p class="mt-1 text-lg font-bold tracking-tight">
                   {{ formatCount(dashboard.rtk.summary.totalCommands) }}
                 </p>
               </div>
 
-              <div
-                data-testid="rtk-summary-rate"
-                class="rounded-xl border border-border/40 bg-muted/5 px-4 py-3"
-              >
-                <p
-                  class="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground"
-                >
+              <div data-testid="rtk-summary-rate" class="rounded-lg bg-card/60 px-4 py-3">
+                <p class="text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
                   {{ t('settings.dashboard.rtk.summary.avgSavingsPct') }}
                 </p>
-                <p class="mt-1 text-lg font-semibold tracking-tight">
+                <p class="mt-1 text-lg font-bold tracking-tight">
                   {{ formatPercent(dashboard.rtk.summary.avgSavingsPct / 100) }}
                 </p>
               </div>
 
-              <div
-                data-testid="rtk-summary-output"
-                class="rounded-xl border border-border/40 bg-muted/5 px-4 py-3"
-              >
-                <p
-                  class="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground"
-                >
+              <div data-testid="rtk-summary-output" class="rounded-lg bg-card/60 px-4 py-3">
+                <p class="text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
                   {{ t('settings.dashboard.rtk.summary.outputTokens') }}
                 </p>
                 <p
-                  class="mt-1 text-lg font-semibold tracking-tight"
+                  class="mt-1 text-lg font-bold tracking-tight"
                   :title="formatFullTokens(dashboard.rtk.summary.totalOutputTokens)"
                 >
                   {{ formatTokens(dashboard.rtk.summary.totalOutputTokens) }}
@@ -523,7 +423,7 @@
         </Card>
 
         <div class="grid gap-4 xl:grid-cols-2">
-          <Card class="border-border/70 bg-card/90 backdrop-blur-sm">
+          <Card class="border-none bg-accent shadow-none">
             <CardHeader class="pb-4">
               <CardTitle>{{ t('settings.dashboard.breakdown.providerTitle') }}</CardTitle>
               <CardDescription>
@@ -533,7 +433,7 @@
             <CardContent>
               <div
                 v-if="dashboard.providerBreakdown.length === 0"
-                class="rounded-2xl border border-dashed border-border/70 p-4 text-sm text-muted-foreground"
+                class="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground"
               >
                 {{ t('settings.dashboard.breakdown.empty') }}
               </div>
@@ -546,13 +446,13 @@
                   <div
                     v-for="item in providerBreakdownCard.rows"
                     :key="item.id"
-                    class="border-b border-border/40 py-3 last:border-b-0"
+                    class="border-b border-border py-3 last:border-b-0"
                   >
                     <div
                       class="space-y-2.5 lg:grid lg:grid-cols-[minmax(0,9.5rem)_minmax(0,1fr)_minmax(4.75rem,auto)] lg:items-center lg:gap-3 lg:space-y-0 xl:grid-cols-[minmax(0,10.5rem)_minmax(0,1fr)_88px]"
                     >
                       <div class="min-w-0">
-                        <p class="truncate text-sm font-medium">{{ item.label }}</p>
+                        <p class="truncate text-sm">{{ item.label }}</p>
                         <p class="text-xs text-muted-foreground">
                           {{
                             t('settings.dashboard.breakdown.messages', {
@@ -582,7 +482,7 @@
             </CardContent>
           </Card>
 
-          <Card class="border-border/70 bg-card/90 backdrop-blur-sm">
+          <Card class="border-none bg-accent shadow-none">
             <CardHeader class="pb-4">
               <CardTitle>{{ t('settings.dashboard.breakdown.modelTitle') }}</CardTitle>
               <CardDescription>
@@ -592,7 +492,7 @@
             <CardContent>
               <div
                 v-if="dashboard.modelBreakdown.length === 0"
-                class="rounded-2xl border border-dashed border-border/70 p-4 text-sm text-muted-foreground"
+                class="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground"
               >
                 {{ t('settings.dashboard.breakdown.empty') }}
               </div>
@@ -605,13 +505,13 @@
                   <div
                     v-for="item in modelBreakdownCard.rows"
                     :key="item.id"
-                    class="border-b border-border/40 py-3 last:border-b-0"
+                    class="border-b border-border py-3 last:border-b-0"
                   >
                     <div
                       class="space-y-2.5 lg:grid lg:grid-cols-[minmax(0,9.5rem)_minmax(0,1fr)_minmax(4.75rem,auto)] lg:items-center lg:gap-3 lg:space-y-0 xl:grid-cols-[minmax(0,10.5rem)_minmax(0,1fr)_88px]"
                     >
                       <div class="min-w-0">
-                        <p class="truncate text-sm font-medium">{{ item.label }}</p>
+                        <p class="truncate text-sm">{{ item.label }}</p>
                         <p
                           v-if="item.secondaryLabel"
                           class="truncate text-xs text-muted-foreground"
@@ -646,14 +546,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, h, onBeforeUnmount, onMounted, render, shallowRef, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, shallowRef, watch } from 'vue'
 import type { CSSProperties } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useDocumentVisibility, useTimeoutFn, useWindowFocus } from '@vueuse/core'
 import { Icon } from '@iconify/vue'
-import { CurveType } from '@unovis/ts'
-import type { Tooltip as UnovisTooltip } from '@unovis/ts'
-import { VisArea, VisXYContainer } from '@unovis/vue'
 import { ScrollArea } from '@shadcn/components/ui/scroll-area'
 import { Button } from '@shadcn/components/ui/button'
 import { Badge } from '@shadcn/components/ui/badge'
@@ -664,12 +561,7 @@ import {
   CardHeader,
   CardTitle
 } from '@shadcn/components/ui/card'
-import {
-  ChartContainer,
-  ChartCrosshair,
-  ChartTooltip,
-  ChartTooltipContent
-} from '@shadcn/components/ui/chart'
+import { ChartTooltipContent } from '@shadcn/components/ui/chart'
 import type { ChartConfig } from '@shadcn/components/ui/chart'
 import { Spinner } from '@shadcn/components/ui/spinner'
 import type { UsageDashboardCalendarDay, UsageDashboardData } from '@shared/types/agent-interface'
@@ -678,21 +570,12 @@ import UsageNostalgiaCard from './control-center/UsageNostalgiaCard.vue'
 
 type CalendarDayView = UsageDashboardCalendarDay & {
   cellStyle: CSSProperties
-  title: string
 }
 type CalendarCell = CalendarDayView | null
-type TokenUsageTrendKey = 'input' | 'output' | 'cached' | 'cost'
-type TokenUsageTrendPoint = {
-  index: number
-  date: string
-  inputTokens: number
-  outputTokens: number
-  cachedTokens: number
-  cost: number
-  inputValue: number
-  outputValue: number
-  cachedValue: number
-  costValue: number
+type TokenUsageTrendKey = 'input' | 'output' | 'cached'
+type CalendarTooltipState = {
+  date: Date
+  payload: Record<string, string>
 }
 type BreakdownChartRow = {
   id: string
@@ -721,7 +604,8 @@ const isLoading = shallowRef(true)
 const isRetryingRtk = shallowRef(false)
 const errorMessage = shallowRef('')
 const dashboard = shallowRef<UsageDashboardData | null>(null)
-const tokenUsageTooltip = shallowRef<{ component?: UnovisTooltip } | null>(null)
+const calendarTooltip = shallowRef<CalendarTooltipState | null>(null)
+const calendarTooltipPosition = shallowRef({ x: 0, y: 0 })
 const documentVisibility = useDocumentVisibility()
 const isWindowFocused = useWindowFocus()
 let isDashboardMounted = false
@@ -739,12 +623,10 @@ const { start: startRefreshTimer, stop: stopRefreshTimer } = useTimeoutFn(
 let dashboardLoadPromise: Promise<void> | null = null
 let lastDashboardLoadCompletedAt: number | null = null
 
-const COST_TREND_DAYS = 30
-const TOKEN_USAGE_CHART_HEIGHT = 184
 const BACKFILL_REFRESH_INTERVAL_MS = 3_000
 const STABLE_REFRESH_INTERVAL_MS = 60_000
 const calendarCellStyles: Record<UsageDashboardCalendarDay['level'], CSSProperties> = {
-  0: { backgroundColor: 'var(--muted)' },
+  0: { backgroundColor: 'transparent' },
   1: { backgroundColor: 'hsl(var(--usage-low) / 0.35)' },
   2: { backgroundColor: 'hsl(var(--usage-low) / 0.75)' },
   3: { backgroundColor: 'hsl(var(--usage-mid))' },
@@ -845,10 +727,6 @@ const tokenUsageChartConfig = computed<ChartConfig>(() => ({
   cached: {
     label: t('settings.dashboard.summary.cachedTokensCachedLabel'),
     color: 'hsl(var(--usage-low) / 0.92)'
-  },
-  cost: {
-    label: t('settings.dashboard.summary.estimatedCost'),
-    color: 'hsl(162 72% 48%)'
   }
 }))
 
@@ -858,75 +736,27 @@ const tokenUsageCard = computed(() => {
   }
 
   const summary = dashboard.value.summary
-  const recentDays = dashboard.value.calendar.slice(-COST_TREND_DAYS)
-  const normalizedDays =
-    recentDays.length >= 2
-      ? recentDays
-      : recentDays.length === 1
-        ? [recentDays[0], recentDays[0]]
-        : [
-            {
-              date: '',
-              inputTokens: 0,
-              outputTokens: 0,
-              cachedInputTokens: 0,
-              estimatedCostUsd: null
-            },
-            {
-              date: '',
-              inputTokens: 0,
-              outputTokens: 0,
-              cachedInputTokens: 0,
-              estimatedCostUsd: null
-            }
-          ]
   const inputTokens = Math.max(summary.inputTokens, 0)
   const outputTokens = Math.max(summary.outputTokens, 0)
   const totalTokens = Math.max(summary.totalTokens, 0)
   const cachedTokens = Math.min(inputTokens, Math.max(summary.cachedInputTokens, 0))
   const totalDenominator = Math.max(totalTokens, 1)
-  const rawPoints = normalizedDays.map((day, index) => ({
-    index,
-    date: day.date,
-    inputTokens: Math.max(day.inputTokens ?? 0, 0),
-    outputTokens: Math.max(day.outputTokens ?? 0, 0),
-    cachedTokens: Math.max(day.cachedInputTokens ?? 0, 0),
-    cost: Math.max(day.estimatedCostUsd ?? 0, 0)
-  }))
-  const maxInput = Math.max(...rawPoints.map((point) => point.inputTokens), 0)
-  const maxOutput = Math.max(...rawPoints.map((point) => point.outputTokens), 0)
-  const maxCached = Math.max(...rawPoints.map((point) => point.cachedTokens), 0)
-  const maxCost = Math.max(...rawPoints.map((point) => point.cost), 0)
-  const chartData = rawPoints.map((point) => ({
-    ...point,
-    inputValue: maxInput > 0 ? (point.inputTokens / maxInput) * 100 : 0,
-    outputValue: maxOutput > 0 ? (point.outputTokens / maxOutput) * 100 : 0,
-    cachedValue: maxCached > 0 ? (point.cachedTokens / maxCached) * 100 : 0,
-    costValue: maxCost > 0 ? (point.cost / maxCost) * 100 : 0
-  }))
 
   return {
     totalTokens,
     inputTokens,
     outputTokens,
     cachedTokens,
-    totalCost: summary.estimatedCostUsd,
     inputRatio: inputTokens / totalDenominator,
     outputRatio: outputTokens / totalDenominator,
-    cachedRatio: inputTokens > 0 ? cachedTokens / inputTokens : 0,
-    chartData,
-    yDomain: [0, 108] as [number, number]
+    cachedRatio: inputTokens > 0 ? cachedTokens / inputTokens : 0
   }
 })
 
 const calendarDays = computed<CalendarDayView[]>(() =>
   (dashboard.value?.calendar ?? []).map((day) => ({
     ...day,
-    cellStyle: calendarCellStyles[day.level],
-    title: t('settings.dashboard.calendar.tooltip', {
-      date: formatDateKey(day.date),
-      tokens: formatFullTokens(day.totalTokens)
-    })
+    cellStyle: calendarCellStyles[day.level]
   }))
 )
 
@@ -1171,35 +1001,6 @@ function formatCurrency(value: number | null): string {
   return formatter.format(value)
 }
 
-function formatDateKey(dateKey: string): string {
-  return localeFormatters.value.date.format(new Date(`${dateKey}T00:00:00`))
-}
-
-const tokenTrendXAccessor = (point: TokenUsageTrendPoint): number => point.index
-const tokenTrendInputAccessor = (point: TokenUsageTrendPoint): number => point.inputValue
-const tokenTrendOutputAccessor = (point: TokenUsageTrendPoint): number => point.outputValue
-const tokenTrendCachedAccessor = (point: TokenUsageTrendPoint): number => point.cachedValue
-const tokenTrendCostAccessor = (point: TokenUsageTrendPoint): number => point.costValue
-const tokenTrendYAccessors = [
-  tokenTrendInputAccessor,
-  tokenTrendOutputAccessor,
-  tokenTrendCachedAccessor,
-  tokenTrendCostAccessor
-]
-
-function tokenTrendAreaColor(series: TokenUsageTrendKey): string {
-  switch (series) {
-    case 'input':
-      return 'var(--primary-600)'
-    case 'output':
-      return 'hsl(278 72% 72%)'
-    case 'cached':
-      return 'hsl(var(--usage-low) / 0.92)'
-    case 'cost':
-      return 'hsl(162 72% 48%)'
-  }
-}
-
 function tokenTrendLineColor(series: TokenUsageTrendKey): string {
   switch (series) {
     case 'input':
@@ -1208,8 +1009,6 @@ function tokenTrendLineColor(series: TokenUsageTrendKey): string {
       return 'hsl(278 72% 72%)'
     case 'cached':
       return 'hsl(var(--usage-low) / 0.92)'
-    case 'cost':
-      return 'hsl(162 72% 48%)'
   }
 }
 
@@ -1227,44 +1026,36 @@ function tokenUsageTooltipDateLabel(value: number | Date): string {
   return t('settings.dashboard.unavailable')
 }
 
-function renderTokenUsageTooltipContent(point: TokenUsageTrendPoint): HTMLElement {
-  const container = document.createElement('div')
+const CALENDAR_TOOLTIP_OFFSET = 12
 
-  render(
-    h(ChartTooltipContent, {
-      config: tokenUsageChartConfig.value,
-      x: point.date ? new Date(`${point.date}T00:00:00`) : new Date('invalid'),
-      labelFormatter: tokenUsageTooltipDateLabel,
-      payload: {
-        input: point.inputTokens,
-        output: point.outputTokens,
-        cached: point.cachedTokens,
-        cost: formatCurrency(point.cost)
-      }
-    }),
-    container
-  )
+const calendarTooltipStyle = computed<CSSProperties>(() => ({
+  left: `${calendarTooltipPosition.value.x}px`,
+  top: `${calendarTooltipPosition.value.y}px`
+}))
 
-  return (container.firstElementChild as HTMLElement | null) ?? container
+function showCalendarTooltip(day: CalendarDayView, event: MouseEvent): void {
+  calendarTooltip.value = {
+    date: new Date(`${day.date}T00:00:00`),
+    payload: {
+      input: formatFullTokens(Math.max(day.inputTokens, 0)),
+      output: formatFullTokens(Math.max(day.outputTokens, 0)),
+      cached: formatFullTokens(Math.max(day.cachedInputTokens, 0))
+    }
+  }
+  moveCalendarTooltip(event)
 }
 
-function tokenUsageTooltipTemplate(
-  datum: TokenUsageTrendPoint | undefined,
-  _x: number | Date,
-  data: TokenUsageTrendPoint[],
-  leftNearestDatumIndex?: number
-): HTMLElement | undefined {
-  const point =
-    datum ??
-    (typeof leftNearestDatumIndex === 'number' && leftNearestDatumIndex >= 0
-      ? data[leftNearestDatumIndex]
-      : undefined)
-
-  if (!point) {
-    return undefined
+function moveCalendarTooltip(event: MouseEvent): void {
+  const maxX = window.innerWidth - 200
+  const maxY = window.innerHeight - 160
+  calendarTooltipPosition.value = {
+    x: Math.min(event.clientX + CALENDAR_TOOLTIP_OFFSET, Math.max(maxX, 0)),
+    y: Math.min(event.clientY + CALENDAR_TOOLTIP_OFFSET, Math.max(maxY, 0))
   }
+}
 
-  return renderTokenUsageTooltipContent(point)
+function hideCalendarTooltip(): void {
+  calendarTooltip.value = null
 }
 
 function breakdownBarStyle(barRatio: number): { width: string } {
@@ -1305,10 +1096,6 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-.dashboard-token-usage-list {
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 10.5rem), 1fr));
-}
-
 .dashboard-rtk-summary-grid {
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 11rem), 1fr));
 }
@@ -1387,18 +1174,6 @@ onBeforeUnmount(() => {
   white-space: nowrap;
 }
 
-.token-usage-trend-grid {
-  background-image:
-    linear-gradient(to right, hsl(var(--border) / 0.2) 1px, transparent 1px),
-    linear-gradient(to bottom, hsl(var(--border) / 0.2) 1px, transparent 1px);
-  background-size:
-    48px 100%,
-    100% 34px;
-  background-position:
-    0 0,
-    0 100%;
-}
-
 @media (min-width: 640px) {
   .calendar-heatmap {
     --calendar-column-gap: 2px;
@@ -1424,16 +1199,5 @@ onBeforeUnmount(() => {
     --calendar-row-gap: 4px;
     --calendar-weekday-width: 2.5rem;
   }
-
-  .token-usage-trend-grid {
-    background-size:
-      64px 100%,
-      100% 38px;
-  }
-}
-
-:deep([data-slot='chart']) .unovis-xy-container,
-:deep([data-slot='chart']) .unovis-single-container {
-  overflow: visible;
 }
 </style>

--- a/src/renderer/settings/components/SettingsOverview.vue
+++ b/src/renderer/settings/components/SettingsOverview.vue
@@ -53,7 +53,7 @@
         interactive
         @select="openRoute('settings-deepchat-agents')"
       />
-      <Card class="min-w-0">
+      <Card class="min-w-0 border-none bg-accent shadow-none">
         <CardHeader class="gap-2 pb-2">
           <div class="flex items-center justify-between gap-3">
             <CardDescription class="truncate">
@@ -68,7 +68,7 @@
               v-for="task in quickTasks"
               :key="task.key"
               type="button"
-              class="flex h-8 min-w-0 items-center gap-2 rounded-md border border-border/70 bg-background/70 px-2 text-start text-xs transition-colors hover:bg-accent"
+              class="flex h-8 min-w-0 items-center gap-2 rounded-md bg-card/60 px-2 text-start text-xs transition-colors hover:bg-card"
               :title="t(task.descriptionKey)"
               @click="openRoute(task.routeName)"
             >
@@ -77,7 +77,7 @@
                 class="size-4 shrink-0"
                 :class="task.done ? 'text-emerald-500' : 'text-muted-foreground'"
               />
-              <span class="min-w-0 truncate font-medium">{{ t(task.labelKey) }}</span>
+              <span class="min-w-0 truncate">{{ t(task.labelKey) }}</span>
             </button>
           </div>
         </CardContent>
@@ -87,12 +87,13 @@
     <section
       ref="usageDashboardRef"
       data-testid="settings-overview-usage-dashboard"
-      class="min-h-[640px] overflow-hidden rounded-lg border border-border"
+      class="min-h-[640px] overflow-hidden rounded-xl"
     >
       <DashboardSettings />
     </section>
 
     <SettingsSectionCard
+      class="border-none bg-accent shadow-none"
       :title="t('settings.controlCenter.activity.title')"
       :description="t('settings.controlCenter.activity.description')"
     >
@@ -108,7 +109,7 @@
           <TableRow
             v-for="activity in activities"
             :key="activity.id"
-            class=""
+            class="cursor-pointer"
             @click="openActivity(activity)"
           >
             <TableCell class="whitespace-nowrap text-xs text-muted-foreground">

--- a/src/renderer/settings/components/control-center/StatusMetricCard.vue
+++ b/src/renderer/settings/components/control-center/StatusMetricCard.vue
@@ -1,9 +1,9 @@
 <template>
   <Card
     :class="[
-      'min-w-0',
+      'min-w-0 border-none bg-accent shadow-none',
       interactive
-        ? ' transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+        ? ' transition-colors hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
         : ''
     ]"
     :role="interactive ? 'button' : undefined"

--- a/src/renderer/settings/components/control-center/UsageNostalgiaCard.vue
+++ b/src/renderer/settings/components/control-center/UsageNostalgiaCard.vue
@@ -1,68 +1,58 @@
 <template>
-  <Card
-    data-testid="summary-card-nostalgia"
-    class="flex h-full flex-col overflow-hidden border-border/70 bg-card/90 backdrop-blur-sm"
-  >
-    <CardHeader class="space-y-1 pb-1">
-      <CardTitle class="wrap-break-word whitespace-normal text-base leading-tight">
-        {{ t('settings.dashboard.summary.nostalgiaLabel') }}
-      </CardTitle>
-    </CardHeader>
-    <CardContent
-      v-if="nostalgiaCard"
-      class="flex flex-1 flex-col gap-3 pt-0 lg:grid lg:grid-cols-[minmax(0,13rem)_minmax(0,1fr)] lg:items-start lg:gap-4 xl:flex xl:flex-col"
-    >
-      <div class="flex min-h-18 items-start sm:min-h-20">
+  <div data-testid="summary-card-nostalgia" class="flex h-full min-w-0 flex-col gap-3">
+    <p class="text-sm text-muted-foreground">
+      {{ t('settings.dashboard.summary.nostalgiaLabel') }}
+    </p>
+    <template v-if="nostalgiaCard">
+      <div class="flex min-h-10 items-start">
         <Transition name="nostalgia-fade" mode="out-in">
-          <CardTitle
+          <p
             :key="activeNostalgiaStat?.id ?? 'unavailable'"
             data-testid="nostalgia-rotating-value"
-            class="wrap-break-word whitespace-normal text-2xl font-semibold leading-tight tracking-tight sm:text-3xl"
+            class="wrap-break-word whitespace-normal text-xl font-bold leading-tight tracking-tight"
           >
             {{ activeNostalgiaStat?.value ?? t('settings.dashboard.unavailable') }}
-          </CardTitle>
+          </p>
         </Transition>
       </div>
 
-      <div data-testid="nostalgia-details" class="space-y-2 lg:pt-0.5">
+      <div data-testid="nostalgia-details" class="space-y-2">
         <div
           v-for="item in nostalgiaCard.details"
           :key="item.id"
           :data-testid="`nostalgia-detail-${item.id}`"
-          class="rounded-lg border border-border/30 bg-muted/5 px-3 py-2.5"
         >
-          <p class="wrap-break-word whitespace-normal text-sm leading-6">
+          <p class="wrap-break-word whitespace-normal text-sm leading-5 text-muted-foreground">
             {{ item.content }}
           </p>
         </div>
       </div>
-    </CardContent>
-    <CardContent v-else-if="isPending" class="flex flex-1 flex-col justify-center gap-4 pt-0">
-      <div class="h-9 w-32 animate-pulse rounded-md bg-muted"></div>
+    </template>
+    <template v-else-if="isPending">
+      <div class="h-7 w-32 animate-pulse rounded-md bg-card/70"></div>
       <div class="space-y-2">
-        <div class="h-9 animate-pulse rounded-lg bg-muted/70"></div>
-        <div class="h-9 animate-pulse rounded-lg bg-muted/50"></div>
-        <div class="h-9 animate-pulse rounded-lg bg-muted/30"></div>
+        <div class="h-5 animate-pulse rounded-md bg-card/60"></div>
+        <div class="h-5 animate-pulse rounded-md bg-card/45"></div>
+        <div class="h-5 animate-pulse rounded-md bg-card/30"></div>
       </div>
-    </CardContent>
-    <CardContent v-else class="flex flex-1 flex-col justify-center gap-3 pt-0">
-      <CardTitle
+    </template>
+    <template v-else>
+      <p
         data-testid="nostalgia-rotating-value"
-        class="wrap-break-word whitespace-normal text-2xl font-semibold leading-tight tracking-tight sm:text-3xl"
+        class="wrap-break-word whitespace-normal text-xl font-bold leading-tight tracking-tight"
       >
         {{ t('settings.dashboard.unavailable') }}
-      </CardTitle>
+      </p>
       <p class="text-sm leading-6 text-muted-foreground">
         {{ t('settings.dashboard.empty.description') }}
       </p>
-    </CardContent>
-  </Card>
+    </template>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { Card, CardContent, CardHeader, CardTitle } from '@shadcn/components/ui/card'
 import type { UsageDashboardData } from '@shared/types/agent-interface'
 
 type NostalgiaRotatingStat = {

--- a/test/renderer/components/DashboardSettings.test.ts
+++ b/test/renderer/components/DashboardSettings.test.ts
@@ -554,21 +554,16 @@ describe('DashboardSettings', () => {
     expect(header.classes()).toContain('sm:flex-row')
     expect(wrapper.find('[data-testid="summary-card-tokenUsage"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="summary-card-nostalgia"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="token-usage-trend-chart"]').exists()).toBe(true)
-    expect(wrapper.findComponent({ name: 'ChartTooltip' }).exists()).toBe(true)
-    expect(wrapper.findComponent({ name: 'ChartCrosshair' }).exists()).toBe(true)
+    expect(wrapper.find('[data-testid="token-usage-trend-chart"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="token-usage-input-dot"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="token-usage-input-dot"]').attributes('style')).toContain(
       'var(--primary-600)'
     )
     expect(wrapper.find('[data-testid="token-usage-output-dot"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="token-usage-cached-dot"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="token-usage-cost-dot"]').exists()).toBe(true)
-    expect(wrapper.findAllComponents({ name: 'VisArea' })).toHaveLength(4)
+    expect(wrapper.find('[data-testid="token-usage-cost-dot"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="token-usage-total-row"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="token-usage-cost-row"]').text()).toContain(
-      'Trend over the last 30 days'
-    )
+    expect(wrapper.find('[data-testid="token-usage-cost-row"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="token-usage-list"]').text()).not.toContain('Uncached')
     expect(wrapper.find('[data-testid="cached-tokens-bar"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="provider-breakdown-chart"]').exists()).toBe(true)
@@ -583,10 +578,8 @@ describe('DashboardSettings', () => {
     expect(wrapper.find('[data-testid="summary-card-nostalgia"]').html()).toContain(
       'whitespace-normal'
     )
-    expect(wrapper.find('[data-testid="summary-card-nostalgia"]').html()).toContain('md:col-span-2')
-    expect(wrapper.find('[data-testid="summary-card-nostalgia"]').html()).toContain(
-      'lg:grid-cols-[minmax(0,13rem)_minmax(0,1fr)]'
-    )
+    expect(wrapper.find('[data-testid="usage-summary-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="summary-card-tokenUsage"]').html()).toContain('lg:border-l')
     expect(wrapper.find('[data-testid="nostalgia-details"]').html()).toContain('space-y-2')
     expect(wrapper.find('[data-testid="nostalgia-rotating-value"]').text()).toBe('17 days')
 
@@ -631,7 +624,7 @@ describe('DashboardSettings', () => {
     expect(getUsageDashboard).toHaveBeenCalledTimes(2)
   })
 
-  it('renders token usage tooltip content with raw values for all series', async () => {
+  it('renders calendar tooltip content with raw values for all series on hover', async () => {
     const { wrapper } = await setup(
       buildDashboard({
         calendar: [
@@ -659,49 +652,16 @@ describe('DashboardSettings', () => {
       })
     )
 
-    const crosshair = wrapper.getComponent({ name: 'ChartCrosshair' })
-    const template = crosshair.props('template') as (
-      datum: {
-        index: number
-        date: string
-        inputTokens: number
-        outputTokens: number
-        cachedTokens: number
-        cost: number
-        inputValue: number
-        outputValue: number
-        cachedValue: number
-        costValue: number
-      },
-      x: number | Date,
-      data: unknown[],
-      leftNearestDatumIndex?: number
-    ) => HTMLElement | undefined
+    const cells = wrapper.findAll('[data-testid="calendar-cell"].opacity-100')
+    await cells[cells.length - 1].trigger('mouseenter', { clientX: 40, clientY: 40 })
 
-    const tooltip = template(
-      {
-        index: 1,
-        date: '2026-03-02',
-        inputTokens: 25,
-        outputTokens: 5,
-        cachedTokens: 4,
-        cost: 0.0007,
-        inputValue: 50,
-        outputValue: 25,
-        cachedValue: 40,
-        costValue: 58.3
-      },
-      1,
-      [],
-      1
-    )
-
-    expect(tooltip).toBeInstanceOf(HTMLElement)
+    const tooltip = document.body.querySelector('[data-testid="calendar-tooltip"]')
+    expect(tooltip).not.toBeNull()
     expect(tooltip?.textContent).toContain('Mar 2, 2026')
     expect(tooltip?.textContent).toContain('input:25')
     expect(tooltip?.textContent).toContain('output:5')
     expect(tooltip?.textContent).toContain('cached:4')
-    expect(tooltip?.textContent).toContain('cost:$0.0007')
+    expect(tooltip?.textContent).not.toContain('$0.0007')
     expect(tooltip?.textContent).not.toContain('input:50')
   })
 
@@ -726,7 +686,6 @@ describe('DashboardSettings', () => {
     )
 
     expect(wrapper.find('[data-testid="summary-card-tokenUsage"]').text()).toContain('0')
-    expect(wrapper.find('[data-testid="token-usage-trend-chart"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="total-tokens-input-ratio"]').text()).toBe('0%')
     expect(wrapper.find('[data-testid="total-tokens-output-ratio"]').text()).toBe('0%')
     expect(wrapper.find('[data-testid="cached-tokens-cached-ratio"]').text()).toBe('0%')
@@ -757,7 +716,7 @@ describe('DashboardSettings', () => {
     expect(wrapper.find('[data-testid="cached-tokens-uncached-ratio"]').exists()).toBe(false)
   })
 
-  it('keeps the merged token usage chart when the last 30 days have no cost data', async () => {
+  it('keeps the token usage summary when the last 30 days have no cost data', async () => {
     const { wrapper } = await setup(
       buildDashboard({
         calendar: Array.from({ length: 28 }, (_, index) => ({
@@ -773,10 +732,8 @@ describe('DashboardSettings', () => {
       })
     )
 
-    expect(wrapper.find('[data-testid="token-usage-trend-chart"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="token-usage-cost-row"]').text()).toContain(
-      'Trend over the last 30 days'
-    )
+    expect(wrapper.find('[data-testid="token-usage-trend-chart"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="token-usage-cost-row"]').exists()).toBe(false)
   })
 
   it('renders N/A for days together when the first usage record is unavailable', async () => {


### PR DESCRIPTION
## 概述

按照 `docs/design-system.md` 的视觉语言重构 Settings 用量仪表盘与 Overview 页的卡片风格，同时精简 Token 消耗面板的信息结构。

## 主要改动

### Token 消耗面板
- 移除趋势 chart（unovis VisArea/Crosshair 整套），hover 明细面板移植到贡献日历：悬停某天显示 日期 + 输入/输出/缓存命中（`Teleport` 到 body、跟随鼠标、防视口溢出）
- Token 消耗与「前尘往事」合并为一个 1:1 双列面板（往事在左，宽度不足时竖排堆叠），`hideNostalgia` 时退化为单列
- 去掉估算价格区块与日历 tooltip 中的价格项，面板只保留：总量大数字 + 输入/输出/缓存三行明细（数值 + 占比）

### 视觉语言收敛（design-system）
- 所有仪表盘/Overview 卡片（含 Providers、DeepChat Agents 指标卡、快速开始、最近设置变更）以 hover 背景 token 为基准：无边框 `bg-accent` 软面板，内部小块用 `bg-card/60` 抬升，大面板不再使用 `backdrop-blur`
- 字重收敛为 400/700 两档（去除 `font-medium`/`font-semibold`）
- 圆角按层级下调（`rounded-2xl/3xl` → `rounded-lg/xl`），分隔以 1px 发丝线代替色块描边
- 可点击指标卡 hover 反馈改为 `hover:bg-foreground/10`（软底上加深而非变淡）

## 测试

- `test/renderer/components/DashboardSettings.test.ts` 同步更新（19 个用例全部通过），tooltip 用例改为真实 hover 日历格子后断言 teleport 内容
- `vue-tsc --noEmit -p tsconfig.web.json` 无报错，`oxfmt` / `oxlint` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a simplified token-usage summary showing total, input, output, and cached tokens.
  * Added hover tooltips to calendar activity cells with daily usage details.

* **UI Improvements**
  * Refreshed dashboard, activity, quick-start, status, and usage card styling.
  * Improved loading, empty, and error states with cleaner layouts.
  * Added clearer click indicators to activity rows.

* **Bug Fixes**
  * Improved token percentage calculations, including zero-usage scenarios.
  * Removed unavailable cost metrics from token-usage displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->