### PR TITLE
fix(provider): use file parts for image inputs

### DIFF
--- a/src/main/provider/aiSdk/messageMapper.ts
+++ b/src/main/provider/aiSdk/messageMapper.ts
@@ -1,6 +1,6 @@
-import type { ChatMessage } from '@shared/types/core/chat-message'
+import type { ChatMessage, ChatMessageContent } from '@shared/types/core/chat-message'
 import type { MCPToolDefinition } from '@shared/types/mcp'
-import { generateId, type ModelMessage } from 'ai'
+import { generateId, type FilePart, type ModelMessage, type TextPart } from 'ai'
 import { applyLegacyFunctionCallPrompt } from './middlewares/legacyFunctionCallMiddleware'
 import {
   buildFunctionCallRecordContent,
@@ -16,16 +16,9 @@ type PendingToolCall = {
   args?: string
 }
 
-type AssistantProviderOptions = Record<string, Record<string, unknown>>
-type UserAudioContentPart = {
-  type: 'input_audio'
-  input_audio: {
-    data: string
-    media_type: string
-    filename?: string
-  }
-  provider_options?: Record<string, unknown>
-}
+type AiSdkProviderOptions = NonNullable<ModelMessage['providerOptions']>
+type MappedUserContentPart = TextPart | FilePart
+type UserAudioContentPart = Extract<ChatMessageContent, { type: 'input_audio' }>
 
 const OPENAI_AUDIO_MEDIA_TYPES = new Set(['audio/wav', 'audio/mp3', 'audio/mpeg'])
 const OPENAI_COMPATIBLE_AUDIO_FALLBACK_MEDIA_TYPE = 'audio/mpeg'
@@ -41,34 +34,20 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function sanitizeProviderOptions(
   providerOptions: Record<string, unknown> | undefined
-): AssistantProviderOptions | undefined {
+): AiSdkProviderOptions | undefined {
   if (!isPlainObject(providerOptions)) {
     return undefined
   }
 
-  const sanitized = Object.fromEntries(
-    Object.entries(providerOptions).filter((entry): entry is [string, Record<string, unknown>] =>
-      isPlainObject(entry[1])
-    )
+  const sanitizedEntries = Object.entries(providerOptions).filter(
+    (entry): entry is [string, AiSdkProviderOptions[string]] => isPlainObject(entry[1])
   )
 
-  return Object.keys(sanitized).length > 0 ? sanitized : undefined
+  return sanitizedEntries.length > 0 ? Object.fromEntries(sanitizedEntries) : undefined
 }
 
 function hasOwnReasoningContent(message: ChatMessage): boolean {
   return Object.prototype.hasOwnProperty.call(message, 'reasoning_content')
-}
-
-function resolveBinaryData(value: string): string | URL {
-  if (value.startsWith('data:')) {
-    return value
-  }
-
-  try {
-    return new URL(value)
-  } catch {
-    return value
-  }
 }
 
 function resolveImageMediaType(value: string): string | undefined {
@@ -84,6 +63,33 @@ function resolveImageMediaType(value: string): string | undefined {
   if (normalized.endsWith('.gif')) return 'image/gif'
 
   return undefined
+}
+
+function resolveImageFileData(value: string): FilePart['data'] {
+  if (value.startsWith('data:')) {
+    return value
+  }
+
+  try {
+    return new URL(value)
+  } catch {
+    return value
+  }
+}
+
+function mapImageUserContentPart(
+  part: Extract<ChatMessageContent, { type: 'image_url' }>
+): FilePart | null {
+  const imageUrl = part.image_url?.url
+  if (typeof imageUrl !== 'string' || !imageUrl) {
+    return null
+  }
+
+  return {
+    type: 'file',
+    data: resolveImageFileData(imageUrl),
+    mediaType: resolveImageMediaType(imageUrl) ?? 'image'
+  }
 }
 
 function normalizeAudioMediaType(value: string | undefined): string | undefined {
@@ -113,7 +119,7 @@ function buildAudioProviderOptions(
   part: UserAudioContentPart,
   options: MapMessagesToModelMessagesOptions,
   mediaType: string
-): AssistantProviderOptions | undefined {
+): AiSdkProviderOptions | undefined {
   if (!options.preferOpenAICompatibleAudioDataUrl) {
     return sanitizeProviderOptions(part.provider_options)
   }
@@ -137,13 +143,7 @@ function buildAudioProviderOptions(
 function mapAudioUserContentPart(
   part: UserAudioContentPart,
   options: MapMessagesToModelMessagesOptions
-): {
-  type: 'file'
-  data: string
-  mediaType: string
-  filename?: string
-  providerOptions?: AssistantProviderOptions
-} | null {
+): FilePart | null {
   const actualMediaType = normalizeAudioMediaType(part.input_audio.media_type)
   if (!actualMediaType?.startsWith('audio/') || !part.input_audio.data) {
     return null
@@ -171,7 +171,7 @@ function mapAudioUserContentPart(
 function mapUserContent(
   content: ChatMessage['content'],
   options: MapMessagesToModelMessagesOptions
-): any[] {
+): MappedUserContentPart[] {
   if (typeof content === 'string' || content == null) {
     return [
       {
@@ -181,51 +181,46 @@ function mapUserContent(
     ]
   }
 
-  return content
-    .map((part) => {
-      if (part.type === 'text') {
-        return {
-          type: 'text',
-          text: part.text
+  const mappedContent: MappedUserContentPart[] = []
+  for (const part of content) {
+    if (typeof part !== 'object' || part === null) {
+      continue
+    }
+
+    switch (part.type) {
+      case 'text': {
+        if (typeof part.text === 'string') {
+          mappedContent.push({
+            type: 'text',
+            text: part.text
+          })
         }
+        continue
       }
-
-      if (
-        part.type === 'image_url' &&
-        part.image_url &&
-        typeof part.image_url.url === 'string' &&
-        part.image_url.url
-      ) {
-        const imageUrl = part.image_url.url
-        const mediaType = resolveImageMediaType(imageUrl)
-
-        return {
-          type: 'image',
-          image: resolveBinaryData(imageUrl),
-          ...(mediaType ? { mediaType } : {})
+      case 'image_url': {
+        const mappedImage = mapImageUserContentPart(part)
+        if (mappedImage) {
+          mappedContent.push(mappedImage)
         }
+        continue
       }
-
-      if (part.type === 'input_audio') {
-        return mapAudioUserContentPart(part, options)
+      case 'input_audio': {
+        if (part.input_audio) {
+          const mappedAudio = mapAudioUserContentPart(part, options)
+          if (mappedAudio) {
+            mappedContent.push(mappedAudio)
+          }
+        }
+        continue
       }
+      default: {
+        const exhaustiveCheck: never = part
+        void exhaustiveCheck
+      }
+    }
+  }
 
-      return null
-    })
-    .filter(
-      (
-        part
-      ): part is
-        | { type: 'text'; text: string }
-        | { type: 'image'; image: string | URL; mediaType?: string }
-        | {
-            type: 'file'
-            data: string
-            mediaType: string
-            filename?: string
-            providerOptions?: AssistantProviderOptions
-          } => part !== null
-    )
+  return mappedContent
 }
 
 function mapAssistantTextAndReasoning(message: ChatMessage): any[] {
@@ -284,7 +279,7 @@ export interface MapMessagesToModelMessagesOptions {
 function buildAssistantProviderOptions(
   message: ChatMessage,
   options: MapMessagesToModelMessagesOptions
-): AssistantProviderOptions | undefined {
+): AiSdkProviderOptions | undefined {
   if (!options.preserveOpenAICompatibleReasoningContent || !hasOwnReasoningContent(message)) {
     return undefined
   }
@@ -353,7 +348,7 @@ export function mapMessagesToModelMessages(
       acc.push({
         role: 'user',
         content: mapUserContent(message.content, options)
-      } as ModelMessage)
+      })
       return acc
     }
 

--- a/test/main/provider/aiSdkMessageMapper.test.ts
+++ b/test/main/provider/aiSdkMessageMapper.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { modelMessageSchema } from 'ai'
+import { generateText, modelMessageSchema } from 'ai'
+import { MockLanguageModelV4 } from 'ai/test'
 import { mapMessagesToModelMessages } from '@/provider/aiSdk/messageMapper'
 
 function convertToOpenAICompatibleChatMessagesForTest(messages: any[]) {
@@ -38,15 +39,27 @@ describe('AI SDK message mapper', () => {
     value = true
   }
 
-  it('skips malformed non-text user content parts instead of throwing', () => {
+  it('maps images to canonical file parts and skips malformed user content', () => {
     const result = mapMessagesToModelMessages(
       [
         {
           role: 'user',
           content: [
             { type: 'text', text: 'hello' },
-            { type: 'image_url', image_url: { url: 'https://example.com/a.png' } },
+            {
+              type: 'image_url',
+              image_url: { url: 'https://example.com/a.png' }
+            },
+            {
+              type: 'image_url',
+              image_url: { url: 'data:image/webp;base64,UklGRg==' }
+            },
+            {
+              type: 'image_url',
+              image_url: { url: 'https://example.com/a.png?format=webp' }
+            },
             { type: 'image_url' },
+            null,
             { type: 'unknown', value: 'ignored' }
           ] as any
         }
@@ -63,13 +76,90 @@ describe('AI SDK message mapper', () => {
         content: [
           { type: 'text', text: 'hello' },
           {
-            type: 'image',
-            image: new URL('https://example.com/a.png'),
+            type: 'file',
+            data: new URL('https://example.com/a.png'),
             mediaType: 'image/png'
+          },
+          {
+            type: 'file',
+            data: 'data:image/webp;base64,UklGRg==',
+            mediaType: 'image/webp'
+          },
+          {
+            type: 'file',
+            data: new URL('https://example.com/a.png?format=webp'),
+            mediaType: 'image'
           }
         ]
       }
     ])
+    expect(result.every((message) => modelMessageSchema.safeParse(message).success)).toBe(true)
+  })
+
+  it('passes mapped image files through AI SDK without deprecation warnings', async () => {
+    const messages = mapMessagesToModelMessages(
+      [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: { url: 'data:image/png;base64,QUJD' }
+            }
+          ]
+        }
+      ],
+      {
+        tools: [],
+        supportsNativeTools: true
+      }
+    )
+    const model = new MockLanguageModelV4({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: 'ok' }],
+        finishReason: { unified: 'stop', raw: undefined },
+        usage: {
+          inputTokens: {
+            total: 1,
+            noCache: 1,
+            cacheRead: undefined,
+            cacheWrite: undefined
+          },
+          outputTokens: {
+            total: 1,
+            text: 1,
+            reasoning: undefined
+          }
+        },
+        warnings: []
+      })
+    })
+    const previousWarningLogger = globalThis.AI_SDK_LOG_WARNINGS
+    const loggedWarnings: unknown[] = []
+    globalThis.AI_SDK_LOG_WARNINGS = ({ warnings }) => loggedWarnings.push(...warnings)
+
+    try {
+      await generateText({ model, messages })
+    } finally {
+      globalThis.AI_SDK_LOG_WARNINGS = previousWarningLogger
+    }
+
+    expect(loggedWarnings).not.toContainEqual(
+      expect.objectContaining({
+        type: 'deprecated',
+        setting: '"image" content part'
+      })
+    )
+    expect(model.doGenerateCalls[0]?.prompt[0]).toMatchObject({
+      role: 'user',
+      content: [
+        {
+          type: 'file',
+          data: { type: 'data', data: 'QUJD' },
+          mediaType: 'image/png'
+        }
+      ]
+    })
   })
 
   it('maps input_audio parts to AI SDK file parts for supported audio media types', () => {


### PR DESCRIPTION
## Summary

- Migrate user image messages from the deprecated AI SDK `ImagePart` shape to canonical `FilePart`.
- Preserve existing data URL and remote URL behavior without decoding or copying image payloads.
- Use specific image MIME types when reliably known and fall back to `image` otherwise.
- Replace the loosely typed `any[]` mapping with an exhaustive, typed, single-pass mapper.
- Keep MCP image content unchanged; only the AI SDK message boundary is affected.

## Root Cause

After migrating to AI SDK v7, DeepChat still converted internal `image_url` content into the deprecated `{ type: 'image', image: ... }` shape.

AI SDK v7 accepts this shape for backward compatibility but emits a deprecation warning. CUA `get_window_state` exposed the problem because screenshot grounding passes images through this mapping path.

## Compatibility and Performance

- Produces the same provider-level prompt as AI SDK's legacy compatibility conversion.
- Keeps data URLs as strings without decoding or re-encoding them.
- Keeps remote images as `URL` objects.
- Uses the generic `image` media type when a specific MIME type cannot be determined safely.
- Avoids misidentifying query-negotiated formats such as `?format=webp`.
- Uses a single-pass mapper without an intermediate `map`/`filter` allocation.
- Uses exhaustive content dispatch so future `ChatMessageContent` variants fail type checking instead of being silently dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image content in AI-powered messages.
  * Valid image URLs and data URLs are now converted into the correct file format, including images with query parameters.
  * Invalid or unsupported image content is safely skipped.
  * Prevented deprecated image content warnings during text generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->