### PR TITLE
fix(ci): restore scheduled package regression

### DIFF
--- a/.github/workflows/_package-macos.yml
+++ b/.github/workflows/_package-macos.yml
@@ -89,13 +89,29 @@ jobs:
           DEEPCHAT_APPLE_NOTARY_PASSWORD: ${{ secrets.DEEPCHAT_APPLE_NOTARY_PASSWORD }}
         run: |
           node --input-type=module -e "const contract = await import('./scripts/ci/package-contract.mjs'); contract.validateSourceSha(process.env.SOURCE_SHA); contract.validateArtifactPurpose(process.env.PACKAGE_PURPOSE); contract.getTargetDefinition(process.env.TARGET_PLATFORM, process.env.TARGET_ARCH);"
+          apple_credentials=(
+            CSC_LINK
+            CSC_KEY_PASSWORD
+            DEEPCHAT_APPLE_NOTARY_USERNAME
+            DEEPCHAT_APPLE_NOTARY_TEAM_ID
+            DEEPCHAT_APPLE_NOTARY_PASSWORD
+          )
           if [[ "${PACKAGE_PURPOSE}" == 'distribution' ]]; then
             missing=()
-            for name in CSC_LINK CSC_KEY_PASSWORD DEEPCHAT_APPLE_NOTARY_USERNAME DEEPCHAT_APPLE_NOTARY_TEAM_ID DEEPCHAT_APPLE_NOTARY_PASSWORD; do
+            for name in "${apple_credentials[@]}"; do
               [[ -n "${!name}" ]] || missing+=("${name}")
             done
             if (( ${#missing[@]} > 0 )); then
               printf 'Missing required macOS distribution secrets: %s\n' "${missing[*]}" >&2
+              exit 1
+            fi
+          else
+            unexpected=()
+            for name in "${apple_credentials[@]}"; do
+              [[ -z "${!name}" ]] || unexpected+=("${name}")
+            done
+            if (( ${#unexpected[@]} > 0 )); then
+              printf 'macOS verification must not receive Apple credentials: %s\n' "${unexpected[*]}" >&2
               exit 1
             fi
           fi
@@ -136,6 +152,11 @@ jobs:
 
       - name: Build and package macOS
         run: |
+          if [[ "${PACKAGE_PURPOSE}" == 'verification' ]]; then
+            unset CSC_LINK CSC_KEY_PASSWORD
+            unset DEEPCHAT_APPLE_NOTARY_USERNAME DEEPCHAT_APPLE_NOTARY_TEAM_ID
+            unset DEEPCHAT_APPLE_NOTARY_PASSWORD
+          fi
           pnpm run build
           pnpm run plugin:bundle -- --name cua --platform darwin --arch "${TARGET_ARCH}" --purpose "${PACKAGE_PURPOSE}"
           pnpm run plugin:bundle -- --name feishu --platform darwin --arch "${TARGET_ARCH}"

--- a/.github/workflows/package-regression.yml
+++ b/.github/workflows/package-regression.yml
@@ -83,3 +83,72 @@ jobs:
       DC_GITHUB_CLIENT_ID: ${{ secrets.DC_GITHUB_CLIENT_ID }}
       DC_GITHUB_CLIENT_SECRET: ${{ secrets.DC_GITHUB_CLIENT_SECRET }}
       DC_GITHUB_REDIRECT_URI: ${{ secrets.DC_GITHUB_REDIRECT_URI }}
+
+  scheduled-status:
+    name: scheduled-regression-status
+    if: ${{ always() && github.event_name == 'schedule' }}
+    needs:
+      - package-windows
+      - package-linux
+      - package-macos
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Update scheduled package regression issue
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: '[CI] Scheduled package regression is failing'
+          WINDOWS_RESULT: ${{ needs.package-windows.result }}
+          LINUX_RESULT: ${{ needs.package-linux.result }}
+          MACOS_RESULT: ${{ needs.package-macos.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          open_issue_numbers="$(
+            gh issue list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --state open \
+              --search "\"${ISSUE_TITLE}\" in:title" \
+              --limit 100 \
+              --json number,title \
+              --jq '.[] | select(.title == env.ISSUE_TITLE) | .number'
+          )"
+          issue_number="${open_issue_numbers%%$'\n'*}"
+
+          if [[ "${WINDOWS_RESULT}" == 'success' &&
+                "${LINUX_RESULT}" == 'success' &&
+                "${MACOS_RESULT}" == 'success' ]]; then
+            if [[ -n "${issue_number}" ]]; then
+              gh issue close "${issue_number}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --reason completed \
+                --comment "Recovered in [run #${GITHUB_RUN_NUMBER}](${RUN_URL})."
+            fi
+            exit 0
+          fi
+
+          body_path="${RUNNER_TEMP}/package-regression-status.md"
+          {
+            printf 'The scheduled package regression did not complete successfully.\n\n'
+            printf -- '- Run: [#%s](%s)\n' "${GITHUB_RUN_NUMBER}" "${RUN_URL}"
+            printf -- '- Commit: `%s`\n' "${GITHUB_SHA}"
+            printf -- '- Windows: `%s`\n' "${WINDOWS_RESULT}"
+            printf -- '- Linux: `%s`\n' "${LINUX_RESULT}"
+            printf -- '- macOS: `%s`\n' "${MACOS_RESULT}"
+          } > "${body_path}"
+
+          if [[ -n "${issue_number}" ]]; then
+            gh issue comment "${issue_number}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --body-file "${body_path}"
+          else
+            gh issue create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${ISSUE_TITLE}" \
+              --body-file "${body_path}"
+          fi

--- a/.github/workflows/package-regression.yml
+++ b/.github/workflows/package-regression.yml
@@ -87,6 +87,9 @@ jobs:
   scheduled-status:
     name: scheduled-regression-status
     if: ${{ always() && github.event_name == 'schedule' }}
+    concurrency:
+      group: scheduled-package-regression-issue
+      queue: max
     needs:
       - package-windows
       - package-linux

--- a/docs/architecture/ci-release-packaging/plan.md
+++ b/docs/architecture/ci-release-packaging/plan.md
@@ -93,7 +93,8 @@ files, and disable redundant artifact compression.
 `package-regression.yml` supports `workflow_call`, `workflow_dispatch`, and a daily 18:37 UTC
 schedule. It invokes all six targets with `verification`, enforces installer size, and passes only the
 runtime token and existing non-signing build configuration. It is the full nightly/manual regression
-suite and is not nested inside the fast PR workflow.
+suite and is not nested inside the fast PR workflow. Scheduled failures share one open GitHub issue,
+which is updated on repeated failures and closed after recovery.
 
 `prcheck.yml` keeps only static, main, renderer, Native Memory, source-build, and aggregate jobs for
 PRs targeting `dev`. `pr-required` therefore reports as soon as fast code-quality checks complete.

--- a/docs/architecture/ci-release-packaging/spec.md
+++ b/docs/architecture/ci-release-packaging/spec.md
@@ -119,6 +119,8 @@ assembly fails closed against an explicit six-target contract.
 - Windows EXE, Linux AppImage and tarball, and macOS ZIP and DMG enforce upper and lower delta bounds.
 - `package-regression.yml` supports reusable, manual, and scheduled execution, always covers all six
   targets, and uploads reports rather than complete unsigned installers.
+- A scheduled failure opens or updates one package-regression issue; the next fully successful
+  scheduled run closes it.
 - Scheduled and manually dispatched package regression remain independent from pull-request checks.
 
 ### AC-7 — Pull-Request Package Gate

--- a/test/main/scripts/packageWorkflow.test.ts
+++ b/test/main/scripts/packageWorkflow.test.ts
@@ -58,6 +58,10 @@ type PackageJobName = 'package-windows' | 'package-linux' | 'package-macos'
 interface RegressionStatusJob {
   name: string
   if: string
+  concurrency: {
+    group: string
+    queue: string
+  }
   needs: PackageJobName[]
   'runs-on': string
   'timeout-minutes': number
@@ -510,6 +514,10 @@ describe('Package Regression caller', () => {
         contents: 'read',
         issues: 'write'
       }
+    })
+    expect(scheduledStatus.concurrency).toEqual({
+      group: 'scheduled-package-regression-issue',
+      queue: 'max'
     })
     expect(scheduledStatus.steps).toHaveLength(1)
     expect(scheduledStatus.steps[0]).toMatchObject({

--- a/test/main/scripts/packageWorkflow.test.ts
+++ b/test/main/scripts/packageWorkflow.test.ts
@@ -1,14 +1,19 @@
+import os from 'node:os'
 import path from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { parse } from 'yaml'
 
 const fs = await vi.importActual<typeof import('node:fs')>('node:fs')
+const { spawnSync } =
+  await vi.importActual<typeof import('node:child_process')>('node:child_process')
 
 interface WorkflowStep {
   name?: string
   uses?: string
   if?: string
   run?: string
+  shell?: string
+  env?: Record<string, string>
   with?: Record<string, unknown>
 }
 
@@ -48,7 +53,19 @@ interface BuildWorkflow {
   jobs: Record<string, BuildWorkflowJob>
 }
 
-interface RegressionWorkflow extends BuildWorkflow {
+type PackageJobName = 'package-windows' | 'package-linux' | 'package-macos'
+
+interface RegressionStatusJob {
+  name: string
+  if: string
+  needs: PackageJobName[]
+  'runs-on': string
+  'timeout-minutes': number
+  permissions: Record<string, string>
+  steps: WorkflowStep[]
+}
+
+interface RegressionWorkflow {
   on: {
     workflow_call: {
       inputs: Record<string, { required: boolean; type: string }>
@@ -56,6 +73,10 @@ interface RegressionWorkflow extends BuildWorkflow {
     }
     workflow_dispatch: Record<string, never>
     schedule: Array<{ cron: string }>
+  }
+  permissions: Record<string, string>
+  jobs: Record<PackageJobName, BuildWorkflowJob> & {
+    'scheduled-status': RegressionStatusJob
   }
 }
 
@@ -125,6 +146,16 @@ const getStep = (workflow: ReusableWorkflow, name: string) => {
   if (!step) throw new Error(`Missing workflow step: ${name}`)
   return step
 }
+
+const runBashStep = (script: string, env: NodeJS.ProcessEnv) =>
+  spawnSync('bash', ['-e', '-o', 'pipefail', '-c', script], {
+    cwd: path.resolve('.'),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...env
+    }
+  })
 
 describe('native package reusable workflows', () => {
   it('owns the fixed runner mapping and a shared immutable input contract', () => {
@@ -249,6 +280,130 @@ describe('native package reusable workflows', () => {
     )
     expect(source).not.toContain('signed:')
   })
+
+  it('rejects Apple credentials for verification and requires them for distribution', () => {
+    const workflow = readWorkflow<ReusableWorkflow>(reusableWorkflows.macos.name)
+    const script = getStep(workflow, 'Validate package request and signing inputs').run!
+    const credentialNames = [
+      'CSC_LINK',
+      'CSC_KEY_PASSWORD',
+      'DEEPCHAT_APPLE_NOTARY_USERNAME',
+      'DEEPCHAT_APPLE_NOTARY_TEAM_ID',
+      'DEEPCHAT_APPLE_NOTARY_PASSWORD'
+    ]
+    const emptyCredentials = Object.fromEntries(
+      credentialNames.map((name) => [name, ''])
+    )
+    const runValidation = (
+      purpose: 'distribution' | 'verification',
+      credentials: Record<string, string>
+    ) =>
+      runBashStep(script, {
+        SOURCE_SHA: 'a'.repeat(40),
+        TARGET_PLATFORM: 'darwin',
+        TARGET_ARCH: 'x64',
+        PACKAGE_PURPOSE: purpose,
+        ...emptyCredentials,
+        ...credentials
+      })
+
+    expect(runValidation('verification', {}).status).toBe(0)
+
+    const unexpectedCredentials = Object.fromEntries(
+      credentialNames.map((name) => [name, `unexpected-${name}`])
+    )
+    const verification = runValidation('verification', unexpectedCredentials)
+    expect(verification.status).toBe(1)
+    expect(verification.stderr).toContain(
+      `macOS verification must not receive Apple credentials: ${credentialNames.join(' ')}`
+    )
+
+    const distribution = runValidation('distribution', unexpectedCredentials)
+    expect(distribution.status).toBe(0)
+
+    const missingDistributionCredential = runValidation('distribution', {
+      ...unexpectedCredentials,
+      CSC_KEY_PASSWORD: ''
+    })
+    expect(missingDistributionCredential.status).toBe(1)
+    expect(missingDistributionCredential.stderr).toContain(
+      'Missing required macOS distribution secrets: CSC_KEY_PASSWORD'
+    )
+  })
+
+  it('removes Apple credentials from the verification package process', () => {
+    const workflow = readWorkflow<ReusableWorkflow>(reusableWorkflows.macos.name)
+    const script = getStep(workflow, 'Build and package macOS').run!
+    const temporaryDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'deepchat-package-workflow-')
+    )
+    const fakeBinDirectory = path.join(temporaryDirectory, 'bin')
+    const fakePnpmPath = path.join(fakeBinDirectory, 'pnpm')
+    const credentialNames = [
+      'CSC_LINK',
+      'CSC_KEY_PASSWORD',
+      'DEEPCHAT_APPLE_NOTARY_USERNAME',
+      'DEEPCHAT_APPLE_NOTARY_TEAM_ID',
+      'DEEPCHAT_APPLE_NOTARY_PASSWORD'
+    ]
+    fs.mkdirSync(fakeBinDirectory)
+    fs.writeFileSync(
+      fakePnpmPath,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == 'exec' && "\${2:-}" == 'electron-builder' ]]; then
+  {
+    for name in ${credentialNames.join(' ')} CSC_IDENTITY_AUTO_DISCOVERY; do
+      if [[ -n "\${!name+x}" ]]; then
+        printf '%s=set:%s\\n' "\${name}" "\${!name}"
+      else
+        printf '%s=unset\\n' "\${name}"
+      fi
+    done
+  } > "\${CAPTURE_PATH}"
+fi
+`
+    )
+    fs.chmodSync(fakePnpmPath, 0o755)
+
+    const baseEnvironment = {
+      PATH: `${fakeBinDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
+      TARGET_ARCH: 'x64',
+      CSC_IDENTITY_AUTO_DISCOVERY: 'false',
+      ...Object.fromEntries(credentialNames.map((name) => [name, `secret-${name}`]))
+    }
+
+    try {
+      const verificationCapture = path.join(temporaryDirectory, 'verification.txt')
+      const verification = runBashStep(script, {
+        ...baseEnvironment,
+        PACKAGE_PURPOSE: 'verification',
+        CAPTURE_PATH: verificationCapture
+      })
+      expect(verification.status, verification.stderr).toBe(0)
+      const verificationEnvironment = fs.readFileSync(verificationCapture, 'utf8')
+      for (const name of credentialNames) {
+        expect(verificationEnvironment).toContain(`${name}=unset`)
+      }
+      expect(verificationEnvironment).toContain(
+        'CSC_IDENTITY_AUTO_DISCOVERY=set:false'
+      )
+
+      const distributionCapture = path.join(temporaryDirectory, 'distribution.txt')
+      const distribution = runBashStep(script, {
+        ...baseEnvironment,
+        PACKAGE_PURPOSE: 'distribution',
+        CAPTURE_PATH: distributionCapture
+      })
+      expect(distribution.status, distribution.stderr).toBe(0)
+      const distributionEnvironment = fs.readFileSync(distributionCapture, 'utf8')
+      for (const name of credentialNames) {
+        expect(distributionEnvironment).toContain(`${name}=set:secret-${name}`)
+      }
+    } finally {
+      fs.rmSync(temporaryDirectory, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('Build Application caller', () => {
@@ -304,6 +459,11 @@ describe('Build Application caller', () => {
 describe('Package Regression caller', () => {
   const workflow = readWorkflow<RegressionWorkflow>('package-regression.yml')
   const source = readWorkflowSource('package-regression.yml')
+  const packageJobNames: PackageJobName[] = [
+    'package-windows',
+    'package-linux',
+    'package-macos'
+  ]
 
   it('supports reusable, manual, and daily six-target verification', () => {
     expect(workflow.on.workflow_call.inputs).toMatchObject({
@@ -313,23 +473,23 @@ describe('Package Regression caller', () => {
     expect(workflow.on.schedule).toEqual([{ cron: '37 18 * * *' }])
     expect(workflow.permissions).toEqual({ contents: 'read' })
     expect(Object.keys(workflow.jobs)).toEqual([
-      'package-windows',
-      'package-linux',
-      'package-macos'
+      ...packageJobNames,
+      'scheduled-status'
     ])
 
-    const expectedUses = {
+    const expectedUses: Record<PackageJobName, string> = {
       'package-windows': './.github/workflows/_package-windows.yml',
       'package-linux': './.github/workflows/_package-linux.yml',
       'package-macos': './.github/workflows/_package-macos.yml'
     }
-    for (const [name, job] of Object.entries(workflow.jobs)) {
+    for (const name of packageJobNames) {
+      const job = workflow.jobs[name]
       expect(job.permissions).toEqual({ contents: 'read' })
       expect(job.strategy).toEqual({
         'fail-fast': false,
         matrix: { arch: ['x64', 'arm64'] }
       })
-      expect(job.uses).toBe(expectedUses[name as keyof typeof expectedUses])
+      expect(job.uses).toBe(expectedUses[name])
       expect(job.with).toEqual({
         'source-sha': '${{ inputs.source-sha || github.sha }}',
         arch: '${{ matrix.arch }}',
@@ -338,6 +498,30 @@ describe('Package Regression caller', () => {
       })
       expect(Object.keys(job.secrets!)).toEqual(Object.keys(commonSecrets))
     }
+
+    const scheduledStatus = workflow.jobs['scheduled-status']
+    expect(scheduledStatus).toMatchObject({
+      name: 'scheduled-regression-status',
+      if: "${{ always() && github.event_name == 'schedule' }}",
+      needs: packageJobNames,
+      'runs-on': 'ubuntu-24.04',
+      'timeout-minutes': 5,
+      permissions: {
+        contents: 'read',
+        issues: 'write'
+      }
+    })
+    expect(scheduledStatus.steps).toHaveLength(1)
+    expect(scheduledStatus.steps[0]).toMatchObject({
+      name: 'Update scheduled package regression issue',
+      shell: 'bash',
+      env: {
+        GH_TOKEN: '${{ github.token }}',
+        WINDOWS_RESULT: '${{ needs.package-windows.result }}',
+        LINUX_RESULT: '${{ needs.package-linux.result }}',
+        MACOS_RESULT: '${{ needs.package-macos.result }}'
+      }
+    })
   })
 
   it('cannot receive or forward Apple signing credentials', () => {
@@ -345,6 +529,102 @@ describe('Package Regression caller', () => {
     expect(source).not.toContain('DEEPCHAT_CSC')
     expect(source).not.toContain('DEEPCHAT_APPLE')
     expect(source).not.toContain('secrets: inherit')
+  })
+
+  it('creates one scheduled failure issue, updates it, and closes it on recovery', () => {
+    const script = workflow.jobs['scheduled-status'].steps[0].run!
+    const temporaryDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'deepchat-regression-status-')
+    )
+    const fakeBinDirectory = path.join(temporaryDirectory, 'bin')
+    const fakeGhPath = path.join(fakeBinDirectory, 'gh')
+    fs.mkdirSync(fakeBinDirectory)
+    fs.writeFileSync(
+      fakeGhPath,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == 'issue' && "\${2:-}" == 'list' ]]; then
+  printf '%s' "\${FAKE_OPEN_ISSUES:-}"
+  exit 0
+fi
+printf 'ARGS:' >> "\${GH_CALLS_PATH}"
+printf ' %q' "\${@}" >> "\${GH_CALLS_PATH}"
+printf '\\n' >> "\${GH_CALLS_PATH}"
+previous=''
+for argument in "\${@}"; do
+  if [[ "\${previous}" == '--body-file' ]]; then
+    printf '%s\\n' 'BODY:' >> "\${GH_CALLS_PATH}"
+    while IFS= read -r line || [[ -n "\${line}" ]]; do
+      printf '%s\\n' "\${line}" >> "\${GH_CALLS_PATH}"
+    done < "\${argument}"
+  fi
+  previous="\${argument}"
+done
+`
+    )
+    fs.chmodSync(fakeGhPath, 0o755)
+
+    const runStatus = (
+      results: {
+        windows: string
+        linux: string
+        macos: string
+      },
+      openIssues: string
+    ) => {
+      const callsPath = path.join(temporaryDirectory, 'gh-calls.txt')
+      fs.writeFileSync(callsPath, '')
+      const result = runBashStep(script, {
+        PATH: `${fakeBinDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
+        GH_TOKEN: 'test-token',
+        GH_CALLS_PATH: callsPath,
+        FAKE_OPEN_ISSUES: openIssues,
+        GITHUB_REPOSITORY: 'ThinkInAIXYZ/deepchat',
+        GITHUB_RUN_NUMBER: '123',
+        GITHUB_SHA: 'b'.repeat(40),
+        ISSUE_TITLE: '[CI] Scheduled package regression is failing',
+        RUNNER_TEMP: temporaryDirectory,
+        RUN_URL: 'https://github.com/ThinkInAIXYZ/deepchat/actions/runs/123',
+        WINDOWS_RESULT: results.windows,
+        LINUX_RESULT: results.linux,
+        MACOS_RESULT: results.macos
+      })
+      return {
+        result,
+        calls: fs.readFileSync(callsPath, 'utf8')
+      }
+    }
+
+    try {
+      const firstFailure = runStatus(
+        { windows: 'failure', linux: 'success', macos: 'success' },
+        ''
+      )
+      expect(firstFailure.result.status, firstFailure.result.stderr).toBe(0)
+      expect(firstFailure.calls).toContain('ARGS: issue create')
+      expect(firstFailure.calls).toContain('Windows: `failure`')
+      expect(firstFailure.calls).toContain(
+        'https://github.com/ThinkInAIXYZ/deepchat/actions/runs/123'
+      )
+
+      const repeatedFailure = runStatus(
+        { windows: 'success', linux: 'success', macos: 'failure' },
+        '42'
+      )
+      expect(repeatedFailure.result.status, repeatedFailure.result.stderr).toBe(0)
+      expect(repeatedFailure.calls).toContain('ARGS: issue comment 42')
+      expect(repeatedFailure.calls).not.toContain('issue create')
+
+      const recovery = runStatus(
+        { windows: 'success', linux: 'success', macos: 'success' },
+        '42'
+      )
+      expect(recovery.result.status, recovery.result.stderr).toBe(0)
+      expect(recovery.calls).toContain('ARGS: issue close 42')
+      expect(recovery.calls).toContain('--reason completed')
+    } finally {
+      fs.rmSync(temporaryDirectory, { recursive: true, force: true })
+    }
   })
 })
 

--- a/test/main/scripts/packageWorkflow.test.ts
+++ b/test/main/scripts/packageWorkflow.test.ts
@@ -540,7 +540,10 @@ describe('Package Regression caller', () => {
   })
 
   it('creates one scheduled failure issue, updates it, and closes it on recovery', () => {
-    const script = workflow.jobs['scheduled-status'].steps[0].run!
+    const statusStep = workflow.jobs['scheduled-status'].steps[0]
+    const script = statusStep.run!
+    const issueTitle = statusStep.env?.ISSUE_TITLE
+    if (!issueTitle) throw new Error('Missing scheduled regression issue title')
     const temporaryDirectory = fs.mkdtempSync(
       path.join(os.tmpdir(), 'deepchat-regression-status-')
     )
@@ -551,13 +554,11 @@ describe('Package Regression caller', () => {
       fakeGhPath,
       `#!/usr/bin/env bash
 set -euo pipefail
+printf 'ARG:%s\\n' "\${@}" >> "\${GH_CALLS_PATH}"
 if [[ "\${1:-}" == 'issue' && "\${2:-}" == 'list' ]]; then
   printf '%s' "\${FAKE_OPEN_ISSUES:-}"
   exit 0
 fi
-printf 'ARGS:' >> "\${GH_CALLS_PATH}"
-printf ' %q' "\${@}" >> "\${GH_CALLS_PATH}"
-printf '\\n' >> "\${GH_CALLS_PATH}"
 previous=''
 for argument in "\${@}"; do
   if [[ "\${previous}" == '--body-file' ]]; then
@@ -590,7 +591,7 @@ done
         GITHUB_REPOSITORY: 'ThinkInAIXYZ/deepchat',
         GITHUB_RUN_NUMBER: '123',
         GITHUB_SHA: 'b'.repeat(40),
-        ISSUE_TITLE: '[CI] Scheduled package regression is failing',
+        ISSUE_TITLE: issueTitle,
         RUNNER_TEMP: temporaryDirectory,
         RUN_URL: 'https://github.com/ThinkInAIXYZ/deepchat/actions/runs/123',
         WINDOWS_RESULT: results.windows,
@@ -609,7 +610,16 @@ done
         ''
       )
       expect(firstFailure.result.status, firstFailure.result.stderr).toBe(0)
-      expect(firstFailure.calls).toContain('ARGS: issue create')
+      expect(firstFailure.calls).toContain('ARG:issue\nARG:list\n')
+      expect(firstFailure.calls).toContain('ARG:--state\nARG:open\n')
+      expect(firstFailure.calls).toContain(
+        `ARG:--search\nARG:"${issueTitle}" in:title\n`
+      )
+      expect(firstFailure.calls).toContain('ARG:--json\nARG:number,title\n')
+      expect(firstFailure.calls).toContain(
+        'ARG:--jq\nARG:.[] | select(.title == env.ISSUE_TITLE) | .number\n'
+      )
+      expect(firstFailure.calls).toContain('ARG:issue\nARG:create\n')
       expect(firstFailure.calls).toContain('Windows: `failure`')
       expect(firstFailure.calls).toContain(
         'https://github.com/ThinkInAIXYZ/deepchat/actions/runs/123'
@@ -620,16 +630,16 @@ done
         '42'
       )
       expect(repeatedFailure.result.status, repeatedFailure.result.stderr).toBe(0)
-      expect(repeatedFailure.calls).toContain('ARGS: issue comment 42')
-      expect(repeatedFailure.calls).not.toContain('issue create')
+      expect(repeatedFailure.calls).toContain('ARG:issue\nARG:comment\nARG:42\n')
+      expect(repeatedFailure.calls).not.toContain('ARG:issue\nARG:create\n')
 
       const recovery = runStatus(
         { windows: 'success', linux: 'success', macos: 'success' },
         '42'
       )
       expect(recovery.result.status, recovery.result.stderr).toBe(0)
-      expect(recovery.calls).toContain('ARGS: issue close 42')
-      expect(recovery.calls).toContain('--reason completed')
+      expect(recovery.calls).toContain('ARG:issue\nARG:close\nARG:42\n')
+      expect(recovery.calls).toContain('ARG:--reason\nARG:completed\n')
     } finally {
       fs.rmSync(temporaryDirectory, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary

- Remove Apple signing and notarization variables from macOS verification packaging while preserving the distribution signing path.
- Fail fast if verification jobs receive Apple credentials or distribution jobs are missing required credentials.
- Add a schedule-only GitHub Issue notification that updates one failure issue and closes it after recovery.
- Add behavioral workflow tests and update the packaging contract documentation.

## Root Cause

GitHub Actions exposes unset secrets as empty environment variables. `electron-builder@26.15.3` treats an empty `CSC_LINK` as an explicitly configured certificate path and resolves it to the project directory.

Pull request runs avoided this path because electron-builder detects the PR environment. Scheduled and manually dispatched verification runs attempted certificate import and failed with:

> `<project directory> not a file`

The artifact upload warnings were downstream symptoms because packaging stopped before the manifest and reports were generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS signing/notarization credential handling: verification now fails if Apple credentials are present, and credential environment variables are removed during verification packaging; distribution validates required credentials.
* **New Features**
  * Added scheduled regression status reporting that waits for packaging jobs, updates a shared status issue on failures, and closes it after recovery.
  * Added serialization to prevent overlapping scheduled status updates.
* **Documentation**
  * Clarified scheduled regression issue behavior and acceptance criteria.
* **Tests**
  * Expanded workflow tests to cover credential rules, scheduled status configuration (including concurrency), and the full issue lifecycle via CLI call assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->