### PR TITLE
feat(mcp): add McDonald's server

### DIFF
--- a/src/main/mcp/mcpClient.ts
+++ b/src/main/mcp/mcpClient.ts
@@ -418,7 +418,7 @@ export class McpClient {
 
   private async performConnect(attempt: number, phase: McpServerStatusPhase): Promise<void> {
     try {
-      console.info(`Starting MCP server ${this.serverName}...`, this.serverConfig)
+      console.info(`Starting MCP server ${this.serverName}...`)
 
       // Handle customHeaders and AuthProvider
       let authProvider: SimpleOAuthProvider | null = null

--- a/src/main/mcp/settings.ts
+++ b/src/main/mcp/settings.ts
@@ -273,6 +273,21 @@ const DEFAULT_MCP_SERVERS = {
       customHeaders: {
         APP: 'DeepChat'
       }
+    },
+    'mcd-mcp': {
+      command: '',
+      args: [],
+      env: {},
+      descriptions:
+        '麦当劳中国官方 MCP 服务。请前往 https://open.mcd.cn/mcp/doc 申请 MCP Token 后填入 Authorization 请求头。',
+      icons: '🍔',
+      autoApprove: [],
+      disable: false,
+      type: 'http' as MCPServerType,
+      baseUrl: 'https://mcp.mcd.cn',
+      customHeaders: {
+        Authorization: 'Bearer YOUR_MCP_TOKEN'
+      }
     }
   } satisfies Record<string, Omit<MCPServerConfig, 'enabled'>>,
   mcpEnabled: false // MCP functionality is disabled by default

--- a/test/main/mcp/settings.test.ts
+++ b/test/main/mcp/settings.test.ts
@@ -134,6 +134,25 @@ describe('McpSettings', () => {
     )
   })
 
+  it("adds the disabled McDonald's MCP server with a token placeholder for existing users", async () => {
+    const { McpSettings } = await loadHelper('darwin')
+    const helper = new McpSettings()
+    const mcpStore = (helper as any).mcpStore
+
+    mcpStore.set('mcpServers', {})
+
+    const servers = await helper.getMcpServers()
+
+    expect(servers['mcd-mcp']).toMatchObject({
+      type: 'http',
+      baseUrl: 'https://mcp.mcd.cn',
+      customHeaders: {
+        Authorization: 'Bearer YOUR_MCP_TOKEN'
+      },
+      enabled: false
+    })
+  })
+
   it('does not recreate the Apple built-in server after the user removed it', async () => {
     const { McpSettings } = await loadHelper('darwin')
     const helper = new McpSettings()


### PR DESCRIPTION

<img width="2378" height="1808" alt="754e01badd298b424aba72cb8a87499c" src="https://github.com/user-attachments/assets/c7bbf1bf-8cdb-4ae1-8bb4-e6a933695896" />
<img width="1189" height="904" alt="image" src="https://github.com/user-attachments/assets/8287f13b-1f92-4fdf-9f57-81de4c22a4e5" />


## Summary
- add the official McDonald's China Streamable HTTP MCP as a disabled built-in server
- preconfigure the documented endpoint and a token placeholder, without automatic tool approval
- omit MCP configurations from connection logs to prevent Authorization values from being logged

## Verification
- pnpm vitest run --config vitest.config.ts test/main/mcp/settings.test.ts
- pnpm run format:check
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck

## UI
No UI changes.