### PR TITLE
fix(mcp): tolerate invalid output schema

### DIFF
--- a/src/main/mcp/schemaValidation.ts
+++ b/src/main/mcp/schemaValidation.ts
@@ -223,6 +223,16 @@ function cloneMetadata(
 
 export function validateAndCloneMcpTool(tool: Tool, serverName: string): Tool {
   const label = `MCP tool ${serverName}/${tool.name}`
+  let outputSchema: Record<string, unknown> | undefined
+  if (tool.outputSchema !== undefined) {
+    try {
+      outputSchema = validateAndCloneJsonSchema(tool.outputSchema, `${label} outputSchema`)
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      console.warn(`Ignoring invalid ${label} outputSchema: ${reason}`)
+    }
+  }
+
   return {
     name: tool.name,
     title: tool.title,
@@ -233,9 +243,7 @@ export function validateAndCloneMcpTool(tool: Tool, serverName: string): Tool {
         }) as Tool['icons'])
       : undefined,
     inputSchema: validateAndCloneJsonSchema(tool.inputSchema, `${label} inputSchema`),
-    outputSchema: tool.outputSchema
-      ? validateAndCloneJsonSchema(tool.outputSchema, `${label} outputSchema`)
-      : undefined,
+    outputSchema,
     annotations: cloneMetadata(tool.annotations, `${label} annotations`),
     _meta: cloneMetadata(tool._meta, `${label} metadata`),
     execution: cloneMetadata(tool.execution, `${label} execution`)


### PR DESCRIPTION
## Summary

- Keep MCP tool discovery working when an optional output schema is malformed.
- Preserve strict input schema validation and warn when an invalid output schema is dropped.

## Root cause

The built-in McDonald's MCP server returns an invalid output schema for `mall-order-list` at `#/properties/data/items/properties/list/items/properties/type`. The previous validation path rejected the entire tool list because of this optional field.

## Validation

- `pnpm exec vitest run --config vitest.config.ts test/main/mcp/schemaValidation.test.ts`
- `pnpm exec vitest run --config vitest.config.ts test/main/mcp/mcpClient.test.ts`
- `pnpm run typecheck:node`
- `pnpm run lint`
- `pnpm run i18n`
- `pnpm exec oxfmt --check src/main/mcp/schemaValidation.ts test/main/mcp/schemaValidation.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid tool output schemas.
  * Tools with invalid schemas can now continue loading, with the problematic schema omitted and a warning recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->