### PR TITLE
fix(chat): keep composer width on long tokens

### DIFF
--- a/src/renderer/src/components/chat/ChatInputBox.vue
+++ b/src/renderer/src/components/chat/ChatInputBox.vue
@@ -889,4 +889,11 @@ defineExpose({
   height: 0;
   pointer-events: none;
 }
+
+/* ProseMirror injects an unlayered `.ProseMirror { overflow-wrap: break-word }` rule, which
+   wins over layered utilities. `anywhere` (unlike `break-word`) also collapses intrinsic
+   min-content, so long unbroken tokens (e.g. pasted paths) wrap instead of widening the composer. */
+:deep(.chat-input-editor .tiptap) {
+  overflow-wrap: anywhere;
+}
 </style>

--- a/src/renderer/src/features/chat-page/ChatPage.vue
+++ b/src/renderer/src/features/chat-page/ChatPage.vue
@@ -125,7 +125,7 @@
       <div
         v-if="!isReadOnlySession"
         data-testid="chat-composer-region"
-        class="chat-capture-hide relative w-full px-6 pb-3 pt-3"
+        class="chat-capture-hide relative w-full min-w-0 px-6 pb-3 pt-3"
         style="z-index: var(--dc-z-sticky)"
       >
         <div class="mx-auto flex w-full max-w-5xl min-w-0 flex-col items-center">

--- a/test/e2e/specs/32-composer-width.smoke.spec.ts
+++ b/test/e2e/specs/32-composer-width.smoke.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '../fixtures/electronApp'
+import { createNewChat, selectAgent, selectModel, sendMessage } from '../helpers/chat'
+import {
+  createExactReplyPrompt,
+  createSmokeToken,
+  E2E_TARGET_MODEL_ID,
+  E2E_TARGET_PROVIDER_ID
+} from '../helpers/testData'
+import { waitForAppReady, waitForGenerationDone } from '../helpers/wait'
+
+test('输入框输入长英文/长路径时不顶开宽度 @smoke', async ({ app }) => {
+  test.skip(
+    process.env.RUN_PROVIDER_INTEGRATION !== 'true',
+    'Set RUN_PROVIDER_INTEGRATION=true to run the real ChatPage composer width check.'
+  )
+
+  await waitForAppReady(app.page)
+
+  // 窄窗口下才能复现：宽窗口里输入框已达 max-w-4xl，不存在被长文本顶开的空间
+  await app.electronApp.evaluate(({ BrowserWindow }) => {
+    const mainWindow = BrowserWindow.getAllWindows().find(
+      (win) => !win.isDestroyed() && win.getTitle() === 'DeepChat'
+    )
+    mainWindow?.setSize(800, 640)
+  })
+  await app.page.waitForTimeout(500)
+
+  await selectAgent(app.page)
+  await createNewChat(app.page)
+  await selectModel(app.page, E2E_TARGET_MODEL_ID, E2E_TARGET_PROVIDER_ID)
+  await sendMessage(app.page, createExactReplyPrompt(createSmokeToken('E2E_WIDTH')))
+  await waitForGenerationDone(app.page)
+
+  const box = app.page.getByTestId('chat-input-box')
+  await expect(box).toBeVisible({ timeout: 30_000 })
+  const before = await box.boundingBox()
+  expect(before).not.toBeNull()
+
+  const editor = app.page
+    .getByTestId('chat-input-editor')
+    .locator('[contenteditable="true"]')
+    .first()
+  await editor.click()
+  const longPath =
+    '/Users/ssa-user/Desktop/study/github/deepchat/src/renderer/src/components/chat/ChatInputBox.vue'
+  await editor.fill(longPath.repeat(2))
+  await app.page.waitForTimeout(250)
+
+  const after = await box.boundingBox()
+  expect(after).not.toBeNull()
+  expect(Math.round(after!.width)).toBe(Math.round(before!.width))
+
+  const regionBox = await app.page.getByTestId('chat-composer-region').boundingBox()
+  const shellBox = await app.page.getByTestId('chat-page-shell').boundingBox()
+  expect(regionBox).not.toBeNull()
+  expect(shellBox).not.toBeNull()
+  expect(Math.round(regionBox!.width)).toBeLessThanOrEqual(Math.round(shellBox!.width) + 1)
+})


### PR DESCRIPTION
## 问题

聊天输入框里输入全英文的长文本（尤其是长文件路径）时，输入框宽度会被顶开，窄窗口下明显超出窗口/内容区域。

## 根因

两处叠加（仅会话页 ChatPage 布局受影响，新线程页布局不同所以未出现）：

1. `chat-composer-region` 是 `chat-page-shell` grid 的 grid item，缺少 `min-w-0`，其自动最小宽度 = 内容的最小内容宽度（min-content）；
2. ProseMirror 注入的 unlayered `.ProseMirror { overflow-wrap: break-word }` 规则优先级高于 Tailwind layer 工具类，而 `break-word` **不会**压缩内在 min-content —— 长无空格 token 的 min-content 仍是整串宽度，直接撑爆网格项，输入框随之变宽。

## 修改

- `ChatInputBox.vue`：scoped 规则给编辑器加 `overflow-wrap: anywhere`（`anywhere` 会压缩 min-content，长 token 换行而不是撑宽容器）
- `ChatPage.vue`：composer region 加 `min-w-0`（grid item 允许收缩，防御其他子内容顶开）
- 新增 e2e 回归测试 `32-composer-width.smoke.spec.ts`（沿用 `RUN_PROVIDER_INTEGRATION` 开关，与 31-chat-scroll-ownership 同模式）

## 验证

真实 App（生产构建 + 窄窗口）CDP 实测：95 字符路径与 285 字符 token 输入后输入框宽度保持不变、文本正常换行；`01-launch` e2e 通过，format / lint / i18n / typecheck 全绿。

### BEFORE（输入长路径后）

```
│ window right edge →│
│  ┌───────────────────────────────────────────────┐
│  │ /Users/.../deepchat/src/renderer/src/component │  ← 输入框被顶开，超出内容区
│  └───────────────────────────────────────────────┘
```

### AFTER

```
│  ┌───────────────────────────┐
│  │ /Users/.../ChatInputBox.v │  ← 宽度不变，文本自动换行
│  │ ue                         │
│  └───────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat composer behavior so long unbroken text, such as pasted file paths, wraps within the available width instead of expanding the interface.

* **Tests**
  * Added coverage to verify composer width remains stable in narrow windows when entering lengthy text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->