### PR TITLE
chore(ocr): upgrade Light OCR to 0.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@ai-sdk/openai": "^4.0.20",
     "@ai-sdk/openai-compatible": "^3.0.14",
     "@ai-sdk/provider": "^4.0.3",
-    "@arcships/light-ocr": "0.5.6",
+    "@arcships/light-ocr": "0.5.7",
     "@aws-sdk/client-bedrock": "^3.1057.0",
     "@aws-sdk/credential-providers": "^3.1057.0",
     "@duckdb/node-api": "1.5.4-r.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       '@arcships/light-ocr':
-        specifier: 0.5.6
-        version: 0.5.6
+        specifier: 0.5.7
+        version: 0.5.7
       '@aws-sdk/client-bedrock':
         specifier: ^3.1057.0
         version: 3.1093.0
@@ -541,27 +541,27 @@ packages:
   '@antv/util@3.3.11':
     resolution: {integrity: sha512-FII08DFM4ABh2q5rPYdr0hMtKXRgeZazvXaFYCs7J7uTcWDHUhczab2qOCJLNDugoj8jFag1djb7wS9ehaRYBg==}
 
-  '@arcships/light-ocr-darwin-arm64@0.5.6':
-    resolution: {integrity: sha512-cZ3EpnHKPfZ55lMzZ0MrRm4bttyijnR/1SONaEp3gJDwtLMhZDA/dc0l7GAk1ocPcrHHfUApBe7SCODlcdkudA==}
+  '@arcships/light-ocr-darwin-arm64@0.5.7':
+    resolution: {integrity: sha512-q/jum+vD5mpq/iIFjDcoBDfALoQ3+hJyqe+0wW6u+TKaEqHFXkbd/WE/dXlqT8GN0EB2uBcpZBImbyhWQ2NDrQ==}
     engines: {node: ^22.0.0 || ^24.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@arcships/light-ocr-darwin-x64@0.5.6':
-    resolution: {integrity: sha512-zs7wCFpjw6oX9P/BRQfSd6pl+Vp+ZQX9rYUHVRopOAXPz+ldJrjNv9YyMWNrTWdYeD47bTkTji96WDHo4hGB2w==}
+  '@arcships/light-ocr-darwin-x64@0.5.7':
+    resolution: {integrity: sha512-JJ/wIf/AvMeCbuHpFdjTJbfpMXzlp+xfkxmf9eEJHBDLEZmTndM4ANQGGIHMVuOQobrWyRaVEsH5xiER2qj1Qw==}
     engines: {node: ^22.0.0 || ^24.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@arcships/light-ocr-linux-arm64-gnu@0.5.6':
-    resolution: {integrity: sha512-x/ZIeDDiaFk6cvF/zeputYadMYGMCyvosknjfDhyxfj6TCI+zM2PpFmwADXaai33b8nUJ52EVemg7dM+OaO3Uw==}
+  '@arcships/light-ocr-linux-arm64-gnu@0.5.7':
+    resolution: {integrity: sha512-wn2pYT9Z9WjTBhdrx2xpFd745ghGjP0kMx70/RjVPzbHYQfcOLMb/ZHy3mPzOxVf5hARgCyrftJfTTmtw0qJ2Q==}
     engines: {node: ^22.0.0 || ^24.0.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@arcships/light-ocr-linux-x64-gnu@0.5.6':
-    resolution: {integrity: sha512-EKuy1RPtQVvkrIk2162Xy5+6lF5IQikDP9rOz6m1kTyM7eBhsNA7CxOFFDvJoWfYZYLuQl2/6caHxToQ0DfCjA==}
+  '@arcships/light-ocr-linux-x64-gnu@0.5.7':
+    resolution: {integrity: sha512-THX6VGRLSocqqINHpy8GrO/DZTnvMLbO7u8TypPl72xUahrUAy3UyqcOeRR+h+7FtX/MJwW9nXV7Yrv9UPIwQA==}
     engines: {node: ^22.0.0 || ^24.0.0}
     cpu: [x64]
     os: [linux]
@@ -570,24 +570,24 @@ packages:
   '@arcships/light-ocr-model-ppocrv6-small@0.3.4':
     resolution: {integrity: sha512-F2Rjx3xoiKw1eUc/DW5k5/t1AlvWfReUDTdpRdQKNCDz5Y8YYif+15CHdPz7Wdt/Nza7drDOM3NTGUIuA20ERw==}
 
-  '@arcships/light-ocr-runtime@0.1.6':
-    resolution: {integrity: sha512-1ItPTTVVrMm1edjDOAibZ40wAEA20ZqNKgWK3ygseg5N+V1JbzszUxGY5/MOwcH88scznRTR7LNgGcQPonQkDg==}
+  '@arcships/light-ocr-runtime@0.1.7':
+    resolution: {integrity: sha512-WM4425YzRaU3dsgF19psrGjUiU4wTZl/thuw+f89Cm/t1vvfxVOnyjWexe+ZAxf9bSFNjr+b1D52IWa/lx8iNw==}
     engines: {node: ^22.0.0 || ^24.0.0}
 
-  '@arcships/light-ocr-win32-arm64@0.5.6':
-    resolution: {integrity: sha512-cc85gWqowcNwx4TmuQIpevFYZxc5R/oj5rkQNrreA5VRHvW524PbIavFWSZiFLcIQkAnIuHawxsLGyYjUvEgzg==}
+  '@arcships/light-ocr-win32-arm64@0.5.7':
+    resolution: {integrity: sha512-Krjtp49+b5fGa/362GohimElzH0oWS7CVK9fpS4dEhC2LZAymyPkCt61h8FujMT0Uksar10ypnjukY5aNT3HMw==}
     engines: {node: ^22.0.0 || ^24.0.0}
     cpu: [arm64]
     os: [win32]
 
-  '@arcships/light-ocr-win32-x64@0.5.6':
-    resolution: {integrity: sha512-sBGDgjkvY9ll6rVAp3le7Dpr22XyvYO0q2P6UMivHbSw1A8w9dwqu4urrhgqakqqjDMuVhEobmJFuNnaU6e/Ng==}
+  '@arcships/light-ocr-win32-x64@0.5.7':
+    resolution: {integrity: sha512-GW4HBYgkOhNYaxZDh0Vf+ekzNLEuoHsColeOG4ihcT2OfRDtpkZly50/rHyjRbb+HXXo+WDtcu6BpWW2w4PQWA==}
     engines: {node: ^22.0.0 || ^24.0.0}
     cpu: [x64]
     os: [win32]
 
-  '@arcships/light-ocr@0.5.6':
-    resolution: {integrity: sha512-WDK6S1fsNB34SaMm88x2Ps0G3QhZ5P+ZJR7vp+blJtCbTxLgztZlQ3ULVyabwiU3Yoa0jFU9yxByR22i48PY4Q==}
+  '@arcships/light-ocr@0.5.7':
+    resolution: {integrity: sha512-YzkPQyoTBanEcKFqvIDfWW6Gb8Jy5SXAoLWC6zEI9pwqVhxqp2PiVYaBNcLYA1JccTninECn99tnLAMVsSAXDw==}
     engines: {node: ^22.0.0 || ^24.0.0}
     hasBin: true
 
@@ -7270,39 +7270,39 @@ snapshots:
       gl-matrix: 3.4.4
       tslib: 2.8.1
 
-  '@arcships/light-ocr-darwin-arm64@0.5.6':
+  '@arcships/light-ocr-darwin-arm64@0.5.7':
     optional: true
 
-  '@arcships/light-ocr-darwin-x64@0.5.6':
+  '@arcships/light-ocr-darwin-x64@0.5.7':
     optional: true
 
-  '@arcships/light-ocr-linux-arm64-gnu@0.5.6':
+  '@arcships/light-ocr-linux-arm64-gnu@0.5.7':
     optional: true
 
-  '@arcships/light-ocr-linux-x64-gnu@0.5.6':
+  '@arcships/light-ocr-linux-x64-gnu@0.5.7':
     optional: true
 
   '@arcships/light-ocr-model-ppocrv6-small@0.3.4': {}
 
-  '@arcships/light-ocr-runtime@0.1.6':
+  '@arcships/light-ocr-runtime@0.1.7':
     optionalDependencies:
-      '@arcships/light-ocr-darwin-arm64': 0.5.6
-      '@arcships/light-ocr-darwin-x64': 0.5.6
-      '@arcships/light-ocr-linux-arm64-gnu': 0.5.6
-      '@arcships/light-ocr-linux-x64-gnu': 0.5.6
-      '@arcships/light-ocr-win32-arm64': 0.5.6
-      '@arcships/light-ocr-win32-x64': 0.5.6
+      '@arcships/light-ocr-darwin-arm64': 0.5.7
+      '@arcships/light-ocr-darwin-x64': 0.5.7
+      '@arcships/light-ocr-linux-arm64-gnu': 0.5.7
+      '@arcships/light-ocr-linux-x64-gnu': 0.5.7
+      '@arcships/light-ocr-win32-arm64': 0.5.7
+      '@arcships/light-ocr-win32-x64': 0.5.7
 
-  '@arcships/light-ocr-win32-arm64@0.5.6':
+  '@arcships/light-ocr-win32-arm64@0.5.7':
     optional: true
 
-  '@arcships/light-ocr-win32-x64@0.5.6':
+  '@arcships/light-ocr-win32-x64@0.5.7':
     optional: true
 
-  '@arcships/light-ocr@0.5.6':
+  '@arcships/light-ocr@0.5.7':
     dependencies:
       '@arcships/light-ocr-model-ppocrv6-small': 0.3.4
-      '@arcships/light-ocr-runtime': 0.1.6
+      '@arcships/light-ocr-runtime': 0.1.7
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:

--- a/resources/runtime-versions.json
+++ b/resources/runtime-versions.json
@@ -25,12 +25,12 @@
   "uv": "0.9.18",
   "rtk": "v0.43.0",
   "lightOcr": {
-    "facadeVersion": "0.5.6",
+    "facadeVersion": "0.5.7",
     "runtimePackage": "@arcships/light-ocr-runtime",
-    "runtimeVersion": "0.1.6",
+    "runtimeVersion": "0.1.7",
     "modelPackage": "@arcships/light-ocr-model-ppocrv6-small",
     "modelVersion": "0.3.4",
-    "nativeVersion": "0.5.6",
+    "nativeVersion": "0.5.7",
     "bundleId": "ppocrv6-small-native-20260719.1",
     "nativePackages": {
       "darwin-x64": "@arcships/light-ocr-darwin-x64",

--- a/test/main/ocr/ocrRuntimeAssetResolver.test.ts
+++ b/test/main/ocr/ocrRuntimeAssetResolver.test.ts
@@ -5,10 +5,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { OcrRuntimeAssetResolver } from '../../../src/main/ocr/ocrRuntimeAssetResolver'
 
-const lightOcrVersion = '0.5.6'
-const runtimeVersion = '0.1.6'
+const lightOcrVersion = '0.5.7'
+const runtimeVersion = '0.1.7'
 const modelVersion = '0.3.4'
-const nativeVersion = '0.5.6'
+const nativeVersion = '0.5.7'
 const bundleId = 'ppocrv6-small-native-20260719.1'
 const runtimePackage = '@arcships/light-ocr-runtime'
 const modelPackage = '@arcships/light-ocr-model-ppocrv6-small'

--- a/test/main/ocr/ocrRuntimeService.test.ts
+++ b/test/main/ocr/ocrRuntimeService.test.ts
@@ -22,7 +22,7 @@ describe('OcrRuntimeService', () => {
       availability: {
         status: 'unavailable',
         reason: 'unsupported_platform',
-        lightOcrVersion: '0.5.6',
+        lightOcrVersion: '0.5.7',
         bundleId: 'ppocrv6-small-native-20260719.1'
       },
       process: null,
@@ -39,7 +39,7 @@ describe('OcrRuntimeService', () => {
     await expect(service.getAvailability()).resolves.toEqual({
       status: 'unavailable',
       reason: 'service_closed',
-      lightOcrVersion: '0.5.6',
+      lightOcrVersion: '0.5.7',
       bundleId: 'ppocrv6-small-native-20260719.1'
     })
   })

--- a/test/main/scripts/afterPack.test.ts
+++ b/test/main/scripts/afterPack.test.ts
@@ -117,12 +117,12 @@ const testRuntimeVersions = {
     ])
   ),
   lightOcr: {
-    facadeVersion: '0.5.6',
+    facadeVersion: '0.5.7',
     runtimePackage: '@arcships/light-ocr-runtime',
-    runtimeVersion: '0.1.6',
+    runtimeVersion: '0.1.7',
     modelPackage: '@arcships/light-ocr-model-ppocrv6-small',
     modelVersion: '0.3.4',
-    nativeVersion: '0.5.6',
+    nativeVersion: '0.5.7',
     bundleId: 'ppocrv6-small-native-20260719.1',
     nativePackages: {
       'darwin-arm64': '@arcships/light-ocr-darwin-arm64',
@@ -163,7 +163,7 @@ const seedLightOcrPrerequisites = async (
   await mkdir(projectDir, { recursive: true })
   await writeFile(
     path.join(projectDir, 'package.json'),
-    JSON.stringify({ dependencies: { '@arcships/light-ocr': '0.5.6' } })
+    JSON.stringify({ dependencies: { '@arcships/light-ocr': '0.5.7' } })
   )
   await writeTestRuntimeVersions(projectDir)
   const virtualNodeModules = path.join(projectDir, 'node_modules', '.pnpm', 'node_modules')
@@ -192,7 +192,7 @@ const seedLightOcrPrerequisites = async (
   const pdfiumLibrary = 'pdfium-library'
   const nativePackageJson = `${JSON.stringify({
     name: nativePackage,
-    version: '0.5.6',
+    version: '0.5.7',
     main: 'native/addon.node',
     exports: {
       '.': './native/addon.node',
@@ -203,10 +203,10 @@ const seedLightOcrPrerequisites = async (
   await writeVirtualPackage(projectDir, '@arcships/light-ocr', {
     'package.json': JSON.stringify({
       name: '@arcships/light-ocr',
-      version: '0.5.6',
+      version: '0.5.7',
       main: 'src/index.cjs',
       dependencies: {
-        '@arcships/light-ocr-runtime': '0.1.6',
+        '@arcships/light-ocr-runtime': '0.1.7',
         [modelPackage]: '0.3.4'
       }
     }),
@@ -217,9 +217,9 @@ const seedLightOcrPrerequisites = async (
   await writeVirtualPackage(projectDir, '@arcships/light-ocr-runtime', {
     'package.json': JSON.stringify({
       name: '@arcships/light-ocr-runtime',
-      version: '0.1.6',
+      version: '0.1.7',
       main: 'src/index.cjs',
-      optionalDependencies: { [nativePackage]: '0.5.6' }
+      optionalDependencies: { [nativePackage]: '0.5.7' }
     }),
     LICENSE: 'runtime license',
     NOTICE: 'runtime notice',
@@ -541,10 +541,10 @@ describe('afterPack', () => {
     expect(manifest).toMatchObject({
       schemaVersion: 3,
       supported: true,
-      facadeVersion: '0.5.6',
-      runtimeVersion: '0.1.6',
+      facadeVersion: '0.5.7',
+      runtimeVersion: '0.1.7',
       modelVersion: '0.3.4',
-      nativeVersion: '0.5.6',
+      nativeVersion: '0.5.7',
       pdfSupport: true,
       nodeVersion: 'v24.14.1',
       nodeSha256: sha256('node'),
@@ -1088,7 +1088,7 @@ describe('afterPack', () => {
     await seedLightOcrPrerequisites(projectDir, nodeModulesDir, 'linux', 'x64')
     await writeFile(
       path.join(projectDir, 'package.json'),
-      JSON.stringify({ dependencies: { '@arcships/light-ocr': '^0.5.6' } })
+      JSON.stringify({ dependencies: { '@arcships/light-ocr': '^0.5.7' } })
     )
 
     await expect(
@@ -1098,6 +1098,6 @@ describe('afterPack', () => {
         arch: 'x64',
         packager: { projectDir }
       })
-    ).rejects.toThrow('DeepChat must depend on exactly @arcships/light-ocr@0.5.6')
+    ).rejects.toThrow('DeepChat must depend on exactly @arcships/light-ocr@0.5.7')
   })
 })

--- a/test/main/scripts/smokeLightOcr.test.ts
+++ b/test/main/scripts/smokeLightOcr.test.ts
@@ -52,13 +52,13 @@ const runtimeVersions = {
     }
   },
   lightOcr: {
-    facadeVersion: '0.5.6',
+    facadeVersion: '0.5.7',
     runtimePackage: '@arcships/light-ocr-runtime',
-    runtimeVersion: '0.1.6',
+    runtimeVersion: '0.1.7',
     bundleId: 'ppocrv6-small-native-20260719.1',
     modelPackage: '@arcships/light-ocr-model-ppocrv6-small',
     modelVersion: '0.3.4',
-    nativeVersion: '0.5.6',
+    nativeVersion: '0.5.7',
     nativePackages: {
       'darwin-arm64': '@arcships/light-ocr-darwin-arm64',
       'darwin-x64': '@arcships/light-ocr-darwin-x64',
@@ -228,18 +228,18 @@ describe('smoke-light-ocr', () => {
       'out/main/lightOcrHelper.js': 'helper',
       'node_modules/@arcships/light-ocr/package.json': JSON.stringify({
         name: '@arcships/light-ocr',
-        version: '0.5.6',
+        version: '0.5.7',
         dependencies: {
-          '@arcships/light-ocr-runtime': '0.1.6',
+          '@arcships/light-ocr-runtime': '0.1.7',
           '@arcships/light-ocr-model-ppocrv6-small': '0.3.4'
         }
       }),
       'node_modules/@arcships/light-ocr/src/index.cjs': 'module.exports = {}',
       'node_modules/@arcships/light-ocr-runtime/package.json': JSON.stringify({
         name: '@arcships/light-ocr-runtime',
-        version: '0.1.6',
+        version: '0.1.7',
         optionalDependencies: {
-          '@arcships/light-ocr-darwin-arm64': '0.5.6'
+          '@arcships/light-ocr-darwin-arm64': '0.5.7'
         }
       }),
       'node_modules/@arcships/light-ocr-runtime/src/index.cjs': 'module.exports = {}',
@@ -255,7 +255,7 @@ describe('smoke-light-ocr', () => {
       ].join('\n'),
       'node_modules/@arcships/light-ocr-darwin-arm64/package.json': JSON.stringify({
         name: '@arcships/light-ocr-darwin-arm64',
-        version: '0.5.6'
+        version: '0.5.7'
       }),
       'node_modules/@arcships/light-ocr-darwin-arm64/native/addon.node.gz.b64': gzipSync(
         nativePayload
@@ -311,10 +311,10 @@ describe('smoke-light-ocr', () => {
         supported: true,
         platform: 'darwin',
         arch: 'arm64',
-        facadeVersion: '0.5.6',
-        runtimeVersion: '0.1.6',
+        facadeVersion: '0.5.7',
+        runtimeVersion: '0.1.7',
         modelVersion: '0.3.4',
-        nativeVersion: '0.5.6',
+        nativeVersion: '0.5.7',
         pdfSupport: true,
         bundleId: runtimeVersions.lightOcr.bundleId,
         nodeVersion: runtimeVersions.node,
@@ -506,17 +506,17 @@ describe('smoke-light-ocr', () => {
       'out/main/lightOcrHelper.js': 'helper',
       'node_modules/@arcships/light-ocr/package.json': JSON.stringify({
         name: '@arcships/light-ocr',
-        version: '0.5.6',
+        version: '0.5.7',
         dependencies: {
-          '@arcships/light-ocr-runtime': '0.1.6',
+          '@arcships/light-ocr-runtime': '0.1.7',
           '@arcships/light-ocr-model-ppocrv6-small': '0.3.4'
         }
       }),
       'node_modules/@arcships/light-ocr/src/index.cjs': 'module.exports = {}',
       'node_modules/@arcships/light-ocr-runtime/package.json': JSON.stringify({
         name: '@arcships/light-ocr-runtime',
-        version: '0.1.6',
-        optionalDependencies: { [nativePackage]: '0.5.6' }
+        version: '0.1.7',
+        optionalDependencies: { [nativePackage]: '0.5.7' }
       }),
       'node_modules/@arcships/light-ocr-runtime/src/index.cjs': 'module.exports = {}',
       'node_modules/@arcships/light-ocr-model-ppocrv6-small/package.json': JSON.stringify({
@@ -531,7 +531,7 @@ describe('smoke-light-ocr', () => {
       ].join('\n'),
       [`node_modules/${nativePackage}/package.json`]: JSON.stringify({
         name: nativePackage,
-        version: '0.5.6'
+        version: '0.5.7'
       }),
       [`node_modules/${nativePackage}/native/addon.node`]: nativePayload,
       [`node_modules/${nativePackage}/native/runtime-descriptor.json`]: nativeDescriptor,
@@ -584,10 +584,10 @@ describe('smoke-light-ocr', () => {
         supported: true,
         platform: 'linux',
         arch: 'arm64',
-        facadeVersion: '0.5.6',
-        runtimeVersion: '0.1.6',
+        facadeVersion: '0.5.7',
+        runtimeVersion: '0.1.7',
         modelVersion: '0.3.4',
-        nativeVersion: '0.5.6',
+        nativeVersion: '0.5.7',
         pdfSupport: true,
         bundleId: runtimeVersions.lightOcr.bundleId,
         nodeVersion: runtimeVersions.node,
@@ -627,10 +627,10 @@ describe('smoke-light-ocr', () => {
         supported: true,
         platform: 'darwin',
         arch: 'arm64',
-        facadeVersion: '0.5.6',
-        runtimeVersion: '0.1.6',
+        facadeVersion: '0.5.7',
+        runtimeVersion: '0.1.7',
         modelVersion: '0.3.4',
-        nativeVersion: '0.5.6',
+        nativeVersion: '0.5.7',
         pdfSupport: true,
         bundleId: runtimeVersions.lightOcr.bundleId,
         nodeVersion: runtimeVersions.node,
@@ -667,10 +667,10 @@ describe('smoke-light-ocr', () => {
         reason: 'unsupported_platform',
         platform: 'win32',
         arch: 'ia32',
-        facadeVersion: '0.5.6',
-        runtimeVersion: '0.1.6',
+        facadeVersion: '0.5.7',
+        runtimeVersion: '0.1.7',
         modelVersion: '0.3.4',
-        nativeVersion: '0.5.6',
+        nativeVersion: '0.5.7',
         pdfSupport: false,
         bundleId: runtimeVersions.lightOcr.bundleId
       })


### PR DESCRIPTION
## Summary

- Upgrade `@arcships/light-ocr` from `0.5.6` to `0.5.7`
- Align the runtime and six native packages with `0.1.7` / `0.5.7`
- Update OCR runtime manifests, lockfile entries, and version-sensitive test fixtures

## Compatibility

Light OCR 0.5.7 preserves the public API, model bundle, Node.js requirements, and non-macOS behavior.

The primary change supports downstream re-signed macOS native artifacts. DeepChat's existing packaging flow still verifies, encodes, and restores native assets against their declared SHA-256 hashes, so the new signature fallback is not used during the normal path.

Versioned OCR cache entries will miss once and be recomputed after the upgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Light OCR components to version 0.5.7.
  * Updated the OCR runtime and native components to version 0.1.7.
  * Retained model version 0.3.4.
  * Refreshed packaged OCR metadata and compatibility checks for supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->