### PR TITLE
fix(provider): raise provider DB payload limit

### DIFF
--- a/scripts/fetch-provider-db.mjs
+++ b/scripts/fetch-provider-db.mjs
@@ -9,6 +9,7 @@ import { pathToFileURL } from 'node:url'
 
 const DEFAULT_URL =
   'https://raw.githubusercontent.com/ThinkInAIXYZ/PublicProviderConf/refs/heads/dev/dist/all.json'
+const MAX_PROVIDER_DB_PAYLOAD_BYTES = 10 * 1024 * 1024
 
 const log = (...args) => console.log('[fetch-provider-db]', ...args)
 const warn = (...args) => console.warn('[fetch-provider-db]', ...args)
@@ -267,8 +268,10 @@ async function main() {
     process.exit(1)
   }
 
-  if (text.length > 5 * 1024 * 1024) {
-    error('Downloaded file too large (>5MB). Aborting.')
+  if (Buffer.byteLength(text, 'utf8') > MAX_PROVIDER_DB_PAYLOAD_BYTES) {
+    error(
+      `Downloaded file exceeds ${MAX_PROVIDER_DB_PAYLOAD_BYTES / (1024 * 1024)} MiB limit. Aborting.`
+    )
     if (!fs.existsSync(outFile)) process.exit(1)
     return
   }

--- a/scripts/fetch-provider-db.mjs
+++ b/scripts/fetch-provider-db.mjs
@@ -15,6 +15,36 @@ const log = (...args) => console.log('[fetch-provider-db]', ...args)
 const warn = (...args) => console.warn('[fetch-provider-db]', ...args)
 const error = (...args) => console.error('[fetch-provider-db]', ...args)
 
+async function readResponseTextWithLimit(response, maxBytes) {
+  if (!response.body) {
+    const text = await response.text()
+    return Buffer.byteLength(text, 'utf8') <= maxBytes ? text : null
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  const textChunks = []
+  let bytesRead = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      bytesRead += value.byteLength
+      if (bytesRead > maxBytes) {
+        await reader.cancel().catch(() => undefined)
+        return null
+      }
+      textChunks.push(decoder.decode(value, { stream: true }))
+    }
+    textChunks.push(decoder.decode())
+    return textChunks.join('')
+  } finally {
+    reader.releaseLock()
+  }
+}
+
 async function ensureDir(dir) {
   await fsp.mkdir(dir, { recursive: true })
 }
@@ -250,14 +280,13 @@ async function main() {
   await ensureDir(outDir)
 
   let text
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 20000)
   try {
     log('Fetching', url)
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), 20000)
     const res = await fetch(url, { signal: controller.signal })
-    clearTimeout(timeout)
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    text = await res.text()
+    text = await readResponseTextWithLimit(res, MAX_PROVIDER_DB_PAYLOAD_BYTES)
   } catch (e) {
     warn('Fetch failed:', e?.message || e)
     if (fs.existsSync(outFile)) {
@@ -266,9 +295,11 @@ async function main() {
     }
     error('No existing snapshot found. Failing the build step.')
     process.exit(1)
+  } finally {
+    clearTimeout(timeout)
   }
 
-  if (Buffer.byteLength(text, 'utf8') > MAX_PROVIDER_DB_PAYLOAD_BYTES) {
+  if (text === null) {
     error(
       `Downloaded file exceeds ${MAX_PROVIDER_DB_PAYLOAD_BYTES / (1024 * 1024)} MiB limit. Aborting.`
     )

--- a/src/main/provider/providerDbLoader.ts
+++ b/src/main/provider/providerDbLoader.ts
@@ -11,6 +11,7 @@ import { resolveProviderId } from './providerId'
 
 const DEFAULT_PROVIDER_DB_URL =
   'https://raw.githubusercontent.com/ThinkInAIXYZ/PublicProviderConf/refs/heads/dev/dist/all.json'
+const MAX_PROVIDER_DB_PAYLOAD_BYTES = 10 * 1024 * 1024
 
 type MetaFile = {
   sourceUrl: string
@@ -279,8 +280,7 @@ export class ProviderDbLoader {
       }
 
       const text = await res.text()
-      // Size guard (≈ 5MB)
-      if (text.length > 5 * 1024 * 1024) {
+      if (Buffer.byteLength(text, 'utf8') > MAX_PROVIDER_DB_PAYLOAD_BYTES) {
         const meta = this.createAttemptMeta(prevMeta, url, now)
         if (meta) this.writeMeta(meta)
         return this.createResult('error', meta, 'Provider DB payload exceeds size limit')

--- a/src/main/provider/providerDbLoader.ts
+++ b/src/main/provider/providerDbLoader.ts
@@ -13,6 +13,39 @@ const DEFAULT_PROVIDER_DB_URL =
   'https://raw.githubusercontent.com/ThinkInAIXYZ/PublicProviderConf/refs/heads/dev/dist/all.json'
 const MAX_PROVIDER_DB_PAYLOAD_BYTES = 10 * 1024 * 1024
 
+async function readResponseTextWithLimit(
+  response: Response,
+  maxBytes: number
+): Promise<string | null> {
+  if (!response.body) {
+    const text = await response.text()
+    return Buffer.byteLength(text, 'utf8') <= maxBytes ? text : null
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  const textChunks: string[] = []
+  let bytesRead = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      bytesRead += value.byteLength
+      if (bytesRead > maxBytes) {
+        await reader.cancel().catch(() => undefined)
+        return null
+      }
+      textChunks.push(decoder.decode(value, { stream: true }))
+    }
+    textChunks.push(decoder.decode())
+    return textChunks.join('')
+  } finally {
+    reader.releaseLock()
+  }
+}
+
 type MetaFile = {
   sourceUrl: string
   etag?: string
@@ -279,8 +312,8 @@ export class ProviderDbLoader {
         return this.createResult('error', meta, `Request failed with status ${res.status}`)
       }
 
-      const text = await res.text()
-      if (Buffer.byteLength(text, 'utf8') > MAX_PROVIDER_DB_PAYLOAD_BYTES) {
+      const text = await readResponseTextWithLimit(res, MAX_PROVIDER_DB_PAYLOAD_BYTES)
+      if (text === null) {
         const meta = this.createAttemptMeta(prevMeta, url, now)
         if (meta) this.writeMeta(meta)
         return this.createResult('error', meta, 'Provider DB payload exceeds size limit')


### PR DESCRIPTION
## Summary

- increase the Provider DB payload limit from 5 MiB to 10 MiB
- apply the same limit to runtime refreshes and build-time snapshot generation
- measure payload size using UTF-8 bytes instead of JavaScript string length
- keep the build error message synchronized with the configured limit

## Context

The current `PublicProviderConf/dist/all.json` payload is approximately 5.25 MiB, which exceeds DeepChat's previous 5 MiB limit. This prevents Provider DB updates and model refreshes for DB-backed providers such as Doubao, while builds continue using stale snapshots.


Closes #2087

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 10 MiB limit for downloaded provider database data.
  * Improved size validation for content containing multi-byte characters.
  * Oversized downloads are stopped promptly and return a clear error.
  * Existing fallback behavior is preserved when a provider database download cannot be completed.
  * Improved timeout handling during both downloading and response processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->