### PR TITLE
fix(cron): stabilize scheduler restart

### DIFF
--- a/src/main/scheduler/schedulerProcessManager.ts
+++ b/src/main/scheduler/schedulerProcessManager.ts
@@ -151,6 +151,10 @@ export class SchedulerProcessManager {
     this.hostReady = this.spawnHost()
     try {
       return await this.hostReady
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.updateStatus({ state: 'error', pid: null, lastError: message })
+      throw error
     } finally {
       this.hostReady = null
     }
@@ -158,9 +162,12 @@ export class SchedulerProcessManager {
 
   private async spawnHost(): Promise<SchedulerUtilityProcess> {
     const host = this.deps.spawnHost ? await this.deps.spawnHost() : await this.spawnDefaultHost()
-    host.on('message', (message) => this.handleHostMessage(message))
-    host.on('exit', (code) => this.handleHostExit(code))
+    host.on('message', (message) => this.handleHostMessage(host, message))
+    host.on('exit', (code) => this.handleHostExit(host, code))
     host.on('error', (type, location) => {
+      if (this.host !== host) {
+        return
+      }
       const message = `Scheduler utility process error: ${type} at ${location}`
       console.error('[CronJobs] Scheduler utility process error:', { type, location })
       this.updateStatus({ state: 'error', lastError: message })
@@ -235,7 +242,10 @@ export class SchedulerProcessManager {
     return candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates[0]
   }
 
-  private handleHostMessage(message: unknown): void {
+  private handleHostMessage(host: SchedulerUtilityProcess, message: unknown): void {
+    if (this.host !== host) {
+      return
+    }
     const event = unwrapSchedulerEvent(message)
     if (!event) {
       return
@@ -300,7 +310,10 @@ export class SchedulerProcessManager {
     }
   }
 
-  private handleHostExit(code: number): void {
+  private handleHostExit(host: SchedulerUtilityProcess, code: number): void {
+    if (this.host !== host) {
+      return
+    }
     const message = `Cron scheduler utility exited with code ${code}.`
     const hasEnabledJobs = this.deps.getSnapshot().enabledJobCount > 0
     const expectedExit = this.shuttingDown || !hasEnabledJobs

--- a/src/renderer/settings/components/CronJobsSettings.vue
+++ b/src/renderer/settings/components/CronJobsSettings.vue
@@ -1359,7 +1359,7 @@ const runJobNow = async (id: string) => {
     }
     void refreshRunDeliveries(response.run.id)
     setSchedulerStatus(response.schedulerStatus)
-    if (response.run.status !== 'completed') {
+    if (response.run.status === 'failed' || response.run.status === 'cancelled') {
       notifyRenderer({
         kind: 'error',
         code: 'settings.cronJobs.runFailed',
@@ -1369,8 +1369,14 @@ const runJobNow = async (id: string) => {
     }
     notifyRenderer({
       kind: 'success',
-      code: 'settings.cronJobs.runCompleted',
-      title: t('settings.cronJobs.runNowSuccess'),
+      code:
+        response.run.status === 'completed'
+          ? 'settings.cronJobs.runCompleted'
+          : 'settings.cronJobs.runStarted',
+      title:
+        response.run.status === 'completed'
+          ? t('settings.cronJobs.runNowSuccess')
+          : t('settings.cronJobs.actions.runNow'),
       description: response.job.name
     })
   } catch (error) {

--- a/src/renderer/settings/components/DeepChatAgentsSettings.vue
+++ b/src/renderer/settings/components/DeepChatAgentsSettings.vue
@@ -701,6 +701,7 @@ import { DcSubmitButton, useDcFormSubmit } from '@dc-ui/components/form'
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@shadcn/components/ui/dropdown-menu'

--- a/test/main/scheduler/schedulerService.test.ts
+++ b/test/main/scheduler/schedulerService.test.ts
@@ -1568,6 +1568,78 @@ describeIfSqlite('Cron Jobs persistence and service', () => {
     }
   })
 
+  it('ignores a stale utility exit after restarting the scheduler', async () => {
+    class FakeHost extends EventEmitter {
+      constructor(readonly pid: number) {
+        super()
+      }
+
+      posted: unknown[] = []
+
+      postMessage(message: unknown): void {
+        this.posted.push(message)
+      }
+
+      kill(): boolean {
+        return true
+      }
+    }
+
+    const snapshot = {
+      enabledJobCount: 1,
+      nextRunAt: 100
+    }
+    const firstHost = new FakeHost(123)
+    const secondHost = new FakeHost(456)
+    let spawnCount = 0
+    const spawnHost = vi.fn(async () => {
+      spawnCount += 1
+      return spawnCount === 1 ? firstHost : secondHost
+    })
+    const manager = new SchedulerProcessManagerCtor({
+      dbPath: ':memory:',
+      getSnapshot: () => snapshot,
+      onRunDue: vi.fn(),
+      spawnHost: spawnHost as never
+    })
+
+    await manager.reconcile('initial')
+    await manager.restart()
+    firstHost.emit('exit', 0)
+
+    expect(manager.getStatus()).toEqual(
+      expect.objectContaining({
+        state: 'running',
+        pid: 456,
+        lastError: null
+      })
+    )
+    await manager.reconcile('after-stale-exit')
+    expect(spawnHost).toHaveBeenCalledTimes(2)
+  })
+
+  it('records a utility spawn failure in scheduler status', async () => {
+    const manager = new SchedulerProcessManagerCtor({
+      dbPath: ':memory:',
+      getSnapshot: () => ({ enabledJobCount: 1, nextRunAt: 100 }),
+      onRunDue: vi.fn(),
+      spawnHost: vi.fn(async () => {
+        throw new Error('Failed to spawn scheduler host.')
+      }) as never
+    })
+
+    await expect(manager.reconcile('spawn-failure')).rejects.toThrow(
+      'Failed to spawn scheduler host.'
+    )
+    expect(manager.getStatus()).toEqual(
+      expect.objectContaining({
+        state: 'error',
+        pid: null,
+        lastError: 'Failed to spawn scheduler host.'
+      })
+    )
+  })
+
   it('does not surface utility exit errors after the last job is disabled', async () => {
     class FakeHost extends EventEmitter {
       pid = 123

--- a/test/renderer/components/CronJobsSettings.test.ts
+++ b/test/renderer/components/CronJobsSettings.test.ts
@@ -476,6 +476,26 @@ describe('CronJobsSettings', () => {
     expect(wrapper.text()).not.toContain('provider secret')
   })
 
+  it('reports a started manual run without treating it as a failure', async () => {
+    const { wrapper, notifyRenderer } = await setup({
+      runNow: async () => ({
+        job: cloneJob(),
+        run: { ...structuredClone(RUN_FIXTURE), status: 'running', completedAt: null },
+        schedulerStatus: cloneStatus()
+      })
+    })
+
+    await wrapper.get('button[title="Run now"]').trigger('click')
+    await flushPromises()
+
+    expect(notifyRenderer).toHaveBeenCalledWith({
+      kind: 'success',
+      code: 'settings.cronJobs.runStarted',
+      title: 'Run now',
+      description: 'Morning report'
+    })
+  })
+
   it('reports a completed manual run without adding inline feedback', async () => {
     const { wrapper, notifyRenderer } = await setup()
 


### PR DESCRIPTION
## Summary
- retain the new scheduler utility host when the old host exits after a restart
- persist scheduler spawn failures in the status for diagnostics
- treat a successfully started manual run as started rather than failed

## Validation
- `pnpm exec vitest run --config vitest.config.ts test/main/scheduler/schedulerService.test.ts test/renderer/components/CronJobsSettings.test.ts test/main/scheduler/runSessionStarter.test.ts test/main/session/assignmentPolicy.test.ts`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck:node` *(timed out after 120s without diagnostics in this environment)*
- `pnpm run typecheck:web` *(timed out after 120s without diagnostics in this environment)*

## UI
Before:
```
[Run now] -> task starts -> Operation failed
```
After:
```
[Run now] -> task starts -> Run now
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated scheduler processes from overwriting the status of active replacements.
  * Improved handling and reporting of scheduler startup failures.
  * Corrected manual job-run notifications for jobs that are starting or still running.
  * Failed or cancelled runs continue to display error notifications, while successful and in-progress runs show appropriate status messages.
  * Improved settings menu reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->