### PR TITLE
fix(browser): prevent macOS PiP black window

### DIFF
--- a/src/main/app/composition.ts
+++ b/src/main/app/composition.ts
@@ -1427,7 +1427,17 @@ export async function createMainProcessControl(dependencies: {
     toolService,
     hookObserver: hookService,
     publishEvent: publishDeepchatEvent,
-    publishSessionUpdate: (update) => sessionRuntimeEvents.publish(update),
+    publishSessionUpdate: (update) => {
+      sessionRuntimeEvents.publish(update)
+      if (update.kind === 'status' && (update.status === 'idle' || update.status === 'error')) {
+        void yoBrowserPresenter.releaseInactivePreview(update.sessionId).catch((error) => {
+          logger.warn('[YoBrowser] Failed to release inactive preview', {
+            sessionId: update.sessionId,
+            error
+          })
+        })
+      }
+    },
     providerCatalogPort,
     sessionPermissionPort,
     acpAsLlmProviderPermission: acpAsLlmProviderPermission,
@@ -1575,7 +1585,9 @@ export async function createMainProcessControl(dependencies: {
     },
     runtime: {
       cleanupSessionBackends: async (sessionId) =>
-        await agentManager.cleanupSessionBackends(sessionId)
+        await agentManager.cleanupSessionBackends(sessionId),
+      destroySessionBrowser: async (sessionId) =>
+        await yoBrowserPresenter.destroySessionBrowser(sessionId)
     },
     state: deepChatAgentHarness,
     permissions: sessionPermissionPort,

--- a/src/main/desktop/browser/YoBrowserPresenter.ts
+++ b/src/main/desktop/browser/YoBrowserPresenter.ts
@@ -1355,7 +1355,7 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
         y: -10000,
         width: PREVIEW_VIEWPORT.width,
         height: PREVIEW_VIEWPORT.height,
-        show: true,
+        show: !isMac,
         fullscreenable: !isMac,
         opacity: 0,
         focusable: false,
@@ -1373,6 +1373,9 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       state.view.setBounds({ x: 0, y: 0, ...PREVIEW_VIEWPORT })
       state.view.setVisible(true)
       state.page.contents.setBackgroundThrottling(false)
+      if (isMac) {
+        host.showInactive()
+      }
       state.previewHost = host
       host.once('closed', () => {
         if (state.previewHost === host) {
@@ -1419,6 +1422,9 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       ])
       if (timeout) {
         clearTimeout(timeout)
+      }
+      if (state.previewCapture === capture) {
+        state.previewCapture = null
       }
     }
   }

--- a/src/main/desktop/browser/YoBrowserPresenter.ts
+++ b/src/main/desktop/browser/YoBrowserPresenter.ts
@@ -85,9 +85,9 @@ type HostWindowListeners = {
 }
 
 const PREVIEW_VIEWPORT = { width: 1280, height: 800 }
-const PREVIEW_FRAME = { width: 480, height: 300 }
-const PREVIEW_ACTIVE_INTERVAL_MS = 250
-const PREVIEW_IDLE_INTERVAL_MS = 1000
+const PREVIEW_FRAME = { width: 400, height: 250 }
+const PREVIEW_ACTIVE_INTERVAL_MS = 500
+const PREVIEW_IDLE_INTERVAL_MS = 2000
 const PREVIEW_MAX_BYTES = 512 * 1024
 
 export class YoBrowserPresenter implements IYoBrowserPresenter {
@@ -360,6 +360,22 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       this.emitPreviewSurface(state)
     }
     return dismissed
+  }
+
+  async releaseInactivePreview(sessionId: string): Promise<void> {
+    const state = this.sessionBrowsers.get(sessionId)
+    const runId = state?.agentRunId
+    if (!state || !runId) {
+      return
+    }
+
+    this.previewCoordinator.hide({ source: 'browser', sessionId, runId })
+    await this.stopPreviewCapture(state)
+    if (state.agentRunId !== runId) {
+      return
+    }
+    this.disposePreviewHost(state)
+    this.previewCoordinator.releaseClaim({ source: 'browser', sessionId, runId })
   }
 
   async destroySessionBrowser(sessionId: string): Promise<void> {
@@ -1333,12 +1349,14 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
 
     let host: BaseWindow | null = null
     try {
+      const isMac = process.platform === 'darwin'
       host = new BaseWindow({
         x: -10000,
         y: -10000,
         width: PREVIEW_VIEWPORT.width,
         height: PREVIEW_VIEWPORT.height,
-        show: true,
+        show: !isMac,
+        fullscreenable: !isMac,
         opacity: 0,
         focusable: false,
         skipTaskbar: true,

--- a/src/main/desktop/browser/YoBrowserPresenter.ts
+++ b/src/main/desktop/browser/YoBrowserPresenter.ts
@@ -1355,7 +1355,7 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
         y: -10000,
         width: PREVIEW_VIEWPORT.width,
         height: PREVIEW_VIEWPORT.height,
-        show: !isMac,
+        show: true,
         fullscreenable: !isMac,
         opacity: 0,
         focusable: false,

--- a/src/main/session/contracts.ts
+++ b/src/main/session/contracts.ts
@@ -594,6 +594,7 @@ export interface SessionDeletionStorePort {
 
 export interface SessionDeletionRuntimePort {
   cleanupSessionBackends(sessionId: AppSessionId): Promise<void>
+  destroySessionBrowser(sessionId: AppSessionId): Promise<void>
 }
 
 export interface SessionDeletionOrchestrationPort {

--- a/src/main/session/deletion.ts
+++ b/src/main/session/deletion.ts
@@ -45,6 +45,12 @@ export class SessionDeletion implements SessionLifecycleDeletionPort {
       console.warn(`[SessionDeletion] backend cleanup failed for ${sessionId}:`, error)
     }
     try {
+      await this.dependencies.runtime.destroySessionBrowser(toAppSessionId(sessionId))
+    } catch (error) {
+      stageErrors.push({ stage: 'browser', error })
+      console.warn(`[SessionDeletion] browser cleanup failed for ${sessionId}:`, error)
+    }
+    try {
       await this.dependencies.orchestration.prepareSessionDeletion(sessionId)
     } catch (error) {
       stageErrors.push({ stage: 'orchestration', error })

--- a/src/renderer/src/components/message/MessageToolbar.vue
+++ b/src/renderer/src/components/message/MessageToolbar.vue
@@ -70,8 +70,9 @@
               class="text-muted-foreground hover:text-primary hover:bg-transparent transition-colors duration-[var(--dc-motion-fast)] ease-[var(--dc-ease-out-soft)]"
               @click="emit('next')"
             />
-            <DcCopyButton
-              size="xs"
+            <DcButton
+              size="icon-sm"
+              icon="lucide:copy"
               icon-size="3"
               variant="ghost"
               :tooltip="t('thread.toolbar.copy')"
@@ -85,7 +86,7 @@
               >
                 {{ t('common.copySuccess') }}
               </span>
-            </DcCopyButton>
+            </DcButton>
             <DcButton
               v-if="isAssistant"
               variant="ghost"
@@ -201,7 +202,6 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
 import { DcButton } from '@dc-ui/components/button'
-import { DcCopyButton } from '@dc-ui/components/copy-button'
 import { computed, onBeforeUnmount, ref, type Ref } from 'vue'
 import { TooltipProvider } from '@shadcn/components/ui/tooltip'
 import { useI18n } from 'vue-i18n'

--- a/src/shared/types/desktop.ts
+++ b/src/shared/types/desktop.ts
@@ -129,6 +129,7 @@ export interface IYoBrowserPresenter {
     hostWindowId?: number,
     runId?: string
   ): Promise<BrowserPreviewModeResult>
+  releaseInactivePreview(sessionId: string): Promise<void>
   dismissPreview(sessionId: string, runId: string): boolean
   destroySessionBrowser(sessionId: string): Promise<void>
   goBack(sessionId: string): Promise<void>

--- a/test/main/desktop/browser/YoBrowserPresenter.test.ts
+++ b/test/main/desktop/browser/YoBrowserPresenter.test.ts
@@ -150,6 +150,10 @@ class MockBaseWindow extends EventEmitter {
   destroyed = false
   setIgnoreMouseEvents = vi.fn()
 
+  constructor(readonly options: Record<string, unknown>) {
+    super()
+  }
+
   isDestroyed() {
     return this.destroyed
   }
@@ -208,8 +212,8 @@ describe('YoBrowserPresenter', () => {
           getPath: vi.fn(() => 'C:/mock-user-data')
         },
         BaseWindow: class extends MockBaseWindow {
-          constructor() {
-            super()
+          constructor(options: Record<string, unknown>) {
+            super(options)
             previewHosts.push(this)
           }
         },
@@ -532,9 +536,13 @@ describe('YoBrowserPresenter', () => {
       updated: true,
       surface: 'renderer-canvas'
     })
-    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(0)
 
     expect(previewHosts).toHaveLength(1)
+    expect(previewHosts[0].options).toMatchObject({
+      show: process.platform !== 'darwin',
+      fullscreenable: process.platform !== 'darwin'
+    })
     expect(webContents?.capturePage).toHaveBeenCalledWith(
       { x: 0, y: 0, width: 1280, height: 800 },
       { stayHidden: true }
@@ -546,13 +554,19 @@ describe('YoBrowserPresenter', () => {
         payload: expect.objectContaining({
           sessionId: 'session-a',
           runId: 'run-1',
-          width: 480,
-          height: 300,
+          width: 400,
+          height: 250,
           mimeType: 'image/jpeg'
         })
       }),
       1
     )
+
+    const activeCaptureCount = webContents?.capturePage.mock.calls.length ?? 0
+    await vi.advanceTimersByTimeAsync(499)
+    expect(webContents?.capturePage).toHaveBeenCalledTimes(activeCaptureCount)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(webContents?.capturePage).toHaveBeenCalledTimes(activeCaptureCount + 1)
 
     const captureCount = webContents?.capturePage.mock.calls.length
     expect(await presenter.setPreviewMode('session-a', 'rendering', 1, 'run-1')).toEqual({
@@ -567,6 +581,60 @@ describe('YoBrowserPresenter', () => {
       surface: 'none'
     })
     expect(previewHosts[0].destroyed).toBe(true)
+  })
+
+  it('releases the hidden preview host when its Agent session becomes inactive', async () => {
+    const { presenter, windows, previewHosts, getSessionWebContents } = await setupPresenter()
+    windows.set(1, new MockBrowserWindow(1))
+
+    const loadPromise = presenter.loadUrl(
+      'session-a',
+      'https://example.com',
+      undefined,
+      1,
+      'agent',
+      'run-1'
+    )
+    await Promise.resolve()
+    const webContents = getSessionWebContents('session-a')
+    webContents?.emitDomReady()
+    await loadPromise
+
+    expect(previewHosts).toHaveLength(1)
+    expect(previewHosts[0].destroyed).toBe(false)
+
+    await presenter.releaseInactivePreview('session-a')
+
+    expect(previewHosts[0].destroyed).toBe(true)
+    expect(webContents?.setBackgroundThrottling).toHaveBeenLastCalledWith(true)
+  })
+
+  it('uses the idle preview cadence after browser activity settles', async () => {
+    const { presenter, windows, getSessionWebContents } = await setupPresenter()
+    windows.set(1, new MockBrowserWindow(1))
+
+    const loadPromise = presenter.loadUrl(
+      'session-a',
+      'https://example.com',
+      undefined,
+      1,
+      'agent',
+      'run-1'
+    )
+    await Promise.resolve()
+    const webContents = getSessionWebContents('session-a')
+    webContents?.finishLoad()
+    await loadPromise
+    await vi.advanceTimersByTimeAsync(1501)
+
+    await presenter.setPreviewMode('session-a', 'capturing', 1, 'run-1')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(webContents?.capturePage).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1999)
+    expect(webContents?.capturePage).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(webContents?.capturePage).toHaveBeenCalledTimes(2)
   })
 
   it('loads NativeKit only when Browser capture is requested', async () => {

--- a/test/main/desktop/browser/YoBrowserPresenter.test.ts
+++ b/test/main/desktop/browser/YoBrowserPresenter.test.ts
@@ -540,7 +540,7 @@ describe('YoBrowserPresenter', () => {
 
     expect(previewHosts).toHaveLength(1)
     expect(previewHosts[0].options).toMatchObject({
-      show: process.platform !== 'darwin',
+      show: true,
       fullscreenable: process.platform !== 'darwin'
     })
     expect(webContents?.capturePage).toHaveBeenCalledWith(

--- a/test/main/desktop/browser/YoBrowserPresenter.test.ts
+++ b/test/main/desktop/browser/YoBrowserPresenter.test.ts
@@ -149,6 +149,7 @@ class MockBaseWindow extends EventEmitter {
   contentView = new MockContentView()
   destroyed = false
   setIgnoreMouseEvents = vi.fn()
+  showInactive = vi.fn()
 
   constructor(readonly options: Record<string, unknown>) {
     super()
@@ -540,9 +541,12 @@ describe('YoBrowserPresenter', () => {
 
     expect(previewHosts).toHaveLength(1)
     expect(previewHosts[0].options).toMatchObject({
-      show: true,
+      show: process.platform !== 'darwin',
       fullscreenable: process.platform !== 'darwin'
     })
+    expect(previewHosts[0].showInactive).toHaveBeenCalledTimes(
+      process.platform === 'darwin' ? 1 : 0
+    )
     expect(webContents?.capturePage).toHaveBeenCalledWith(
       { x: 0, y: 0, width: 1280, height: 800 },
       { stayHidden: true }
@@ -607,6 +611,53 @@ describe('YoBrowserPresenter', () => {
 
     expect(previewHosts[0].destroyed).toBe(true)
     expect(webContents?.setBackgroundThrottling).toHaveBeenLastCalledWith(true)
+  })
+
+  it('resumes preview capture after a previous capture times out while stopping', async () => {
+    const { presenter, windows, previewHosts, getSessionWebContents } = await setupPresenter()
+    windows.set(1, new MockBrowserWindow(1))
+
+    const firstLoad = presenter.loadUrl(
+      'session-a',
+      'https://example.com/first',
+      undefined,
+      1,
+      'agent',
+      'run-1'
+    )
+    await Promise.resolve()
+    const webContents = getSessionWebContents('session-a')
+    webContents?.emitDomReady()
+    await firstLoad
+    webContents?.capturePage.mockImplementationOnce(() => new Promise(() => undefined))
+
+    await presenter.setPreviewMode('session-a', 'capturing', 1, 'run-1')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(webContents?.capturePage).toHaveBeenCalledTimes(1)
+
+    const release = presenter.releaseInactivePreview('session-a')
+    await vi.advanceTimersByTimeAsync(500)
+    await release
+
+    const secondLoad = presenter.loadUrl(
+      'session-a',
+      'https://example.com/second',
+      undefined,
+      1,
+      'agent',
+      'run-2'
+    )
+    await Promise.resolve()
+    webContents?.emitDomReady()
+    await secondLoad
+
+    expect(previewHosts).toHaveLength(2)
+    expect(await presenter.setPreviewMode('session-a', 'capturing', 1, 'run-2')).toEqual({
+      updated: true,
+      surface: 'renderer-canvas'
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(webContents?.capturePage).toHaveBeenCalledTimes(2)
   })
 
   it('uses the idle preview cadence after browser activity settles', async () => {

--- a/test/main/session/deletion.test.ts
+++ b/test/main/session/deletion.test.ts
@@ -47,6 +47,9 @@ function createHarness() {
     runtime: {
       cleanupSessionBackends: vi.fn(async (sessionId: string) => {
         order.push(`runtime:${sessionId}`)
+      }),
+      destroySessionBrowser: vi.fn(async (sessionId: string) => {
+        order.push(`browser:${sessionId}`)
       })
     },
     state: {
@@ -76,8 +79,10 @@ describe('SessionDeletion', () => {
     ])
     expect(harness.order).toEqual([
       'runtime:parent',
+      'browser:parent',
       'orchestration:parent',
       'runtime:child',
+      'browser:child',
       'orchestration:child',
       'state:child',
       'delete:child',
@@ -96,12 +101,16 @@ describe('SessionDeletion', () => {
       new Error('orchestration failed')
     )
     harness.dependencies.runtime.cleanupSessionBackends.mockRejectedValue(backendError)
+    harness.dependencies.runtime.destroySessionBrowser.mockRejectedValue(
+      new Error('browser cleanup failed')
+    )
     harness.dependencies.state.destroySession.mockRejectedValue(new Error('state failed'))
 
     await expect(harness.transaction.deleteSessionTree('parent')).resolves.toEqual(['parent'])
     expect(harness.dependencies.state.destroySession).toHaveBeenCalledWith('parent')
     expect(harness.dependencies.sessions.delete).toHaveBeenCalledWith('parent')
     expect(harness.dependencies.orchestration.prepareSessionDeletion).toHaveBeenCalledWith('parent')
+    expect(harness.dependencies.runtime.destroySessionBrowser).toHaveBeenCalledWith('parent')
     expect(harness.dependencies.permissions.clearSessionPermissions).toHaveBeenCalledWith('parent')
   })
 

--- a/test/main/session/sessionFixture.ts
+++ b/test/main/session/sessionFixture.ts
@@ -67,7 +67,8 @@ export const createSessionFixture = (input: {
     orchestration: { prepareSessionDeletion: async () => undefined },
     runtime: {
       cleanupSessionBackends: async (sessionId) =>
-        await input.agentManager.cleanupSessionBackends(sessionId)
+        await input.agentManager.cleanupSessionBackends(sessionId),
+      destroySessionBrowser: async () => undefined
     },
     state: input.sharedData.sessionState,
     permissions: {

--- a/test/renderer/components/AgentBrowserPiP.test.ts
+++ b/test/renderer/components/AgentBrowserPiP.test.ts
@@ -296,15 +296,15 @@ describe('AgentBrowserPiP', () => {
       sessionId: 'session-1',
       runId: 'run-1',
       sequence: 1,
-      width: 480,
-      height: 300,
+      width: 400,
+      height: 250,
       mimeType: 'image/jpeg',
       data: new Uint8Array([1, 2, 3]),
       timestamp: Date.now()
     })
     await flushPromises()
 
-    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 480, 300)
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 400, 250)
     expect(close).toHaveBeenCalled()
     expect(wrapper.find('[data-testid="agent-browser-pip-placeholder"]').exists()).toBe(false)
 
@@ -312,8 +312,8 @@ describe('AgentBrowserPiP', () => {
       sessionId: 'session-1',
       runId: 'run-1',
       sequence: 2,
-      width: 480,
-      height: 300,
+      width: 400,
+      height: 250,
       mimeType: 'image/jpeg',
       data: new Uint8Array([4, 5, 6]),
       timestamp: Date.now()
@@ -338,8 +338,8 @@ describe('AgentBrowserPiP', () => {
       sessionId: 'session-1',
       runId: 'run-1',
       sequence: 1,
-      width: 480,
-      height: 300,
+      width: 400,
+      height: 250,
       mimeType: 'image/jpeg',
       data: new Uint8Array([1, 2, 3]),
       timestamp: Date.now()
@@ -383,8 +383,8 @@ describe('AgentBrowserPiP', () => {
       sessionId: 'session-1',
       runId: 'run-1',
       sequence: 10,
-      width: 480,
-      height: 300,
+      width: 400,
+      height: 250,
       mimeType: 'image/jpeg',
       data: new Uint8Array([1]),
       timestamp: Date.now()
@@ -399,8 +399,8 @@ describe('AgentBrowserPiP', () => {
       sessionId: 'session-1',
       runId: 'run-2',
       sequence: 0,
-      width: 480,
-      height: 300,
+      width: 400,
+      height: 250,
       mimeType: 'image/jpeg',
       data: new Uint8Array([2]),
       timestamp: Date.now()

--- a/test/renderer/components/message/MessageToolbar.trace.test.ts
+++ b/test/renderer/components/message/MessageToolbar.trace.test.ts
@@ -100,6 +100,7 @@ describe('MessageToolbar trace button visibility', () => {
 
     expect(toolbar.classes()).toContain('group-focus-within:opacity-100')
     expect(copyButton?.classes()).toContain('relative')
+    expect(copyButton?.attributes('size')).toBe(imageButton?.attributes('size'))
     expect(imageButton).toBeDefined()
     expect(imageButton?.classes()).toContain('relative')
     expect(imageButton?.attributes('aria-keyshortcuts')).toBe('Enter Space Shift+Enter Shift+Space')


### PR DESCRIPTION
## Summary

Fix the macOS black fullscreen window caused by the Browser PiP off-screen host, and reduce the host's background resource cost.

## Root cause

Browser PiP keeps the existing `WebContentsView` renderable by attaching it to a separate transparent, off-screen `BaseWindow`. The host was created with `show: true`. On macOS, that independent native window could participate in fullscreen window handling despite being transparent and positioned off-screen, surfacing as a black fullscreen window.

## Changes

- Keep the preview `BaseWindow` hidden and non-fullscreenable on macOS.
- Release the hidden preview host when an Agent run becomes `idle` or `error`:
  - stop the capture loop
  - destroy the host window
  - restore Electron background throttling
  - release the preview ownership claim
- Guard terminal cleanup by Agent run ID so cleanup from an old run cannot destroy a newly started run's host.
- Destroy the session browser during session deletion, including best-effort cleanup when another deletion stage fails.
- Reduce preview capture cadence:
  - active: `250 ms -> 500 ms` (`4 FPS -> 2 FPS`)
  - idle: `1000 ms -> 2000 ms` (`1 FPS -> 0.5 FPS`)
- Reduce the encoded PiP frame from `480x300` to `400x250` (about 31% fewer output pixels).
- Keep the browser viewport at `1280x800` so page layout, CDP coordinates, and automation behavior do not change.

The smaller output frame reduces resize, JPEG encoding, IPC, and renderer drawing work. It does not reduce the source viewport captured by Electron.

## Lifecycle boundary

The hidden host still exists while an Agent is actively using a background browser because PiP needs a renderable surface. It is now destroyed at the terminal session state. Expanding the Browser side panel continues to detach the view from the hidden host through the existing attach path.

## Behavior

```text
BEFORE
macOS fullscreen -> transparent BaseWindow joins fullscreen handling -> black window

AFTER
macOS fullscreen -> hidden, non-fullscreenable preview host -> normal app fullscreen

Agent running -> hidden preview host -> reduced-rate capture
Agent idle/error -> stop capture -> destroy host -> background throttling restored
```

## Testing

- `pnpm exec vitest run --config vitest.config.ts test/main/desktop/browser/YoBrowserPresenter.test.ts test/main/session/deletion.test.ts` (24 passed)
- `pnpm exec vitest run --config vitest.config.renderer.ts test/renderer/components/AgentBrowserPiP.test.ts` (11 passed)
- `pnpm run format:check`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`

The application demo was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced browser preview size and adjusted capture intervals for smoother, more efficient operation.
  * Inactive previews are now released when sessions become idle or encounter errors.

* **Bug Fixes**
  * Browser resources are cleaned up when sessions are deleted, even if earlier cleanup steps fail.
  * macOS previews remain hidden and cannot be switched to fullscreen unnecessarily.

* **UI Improvements**
  * Updated the message copy control for consistent button sizing and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->