### PR TITLE
fix(settings): validate provider forms

### DIFF
--- a/src/dc-ui/components/form/DcForm.vue
+++ b/src/dc-ui/components/form/DcForm.vue
@@ -5,6 +5,8 @@ import { Form } from '@shadcn/components/ui/form'
 import { DC_FORM_INJECTION_KEY, type DcFormContext } from './useDcForm'
 import { useDcFormSubmit } from './useDcFormSubmit'
 
+defineOptions({ inheritAttrs: false })
+
 interface Props {
   successDuration?: number
   errorDuration?: number

--- a/src/renderer/settings/components/AddCustomProviderDialog.vue
+++ b/src/renderer/settings/components/AddCustomProviderDialog.vue
@@ -7,83 +7,111 @@
           {{ t('settings.provider.dialog.addCustomProvider.description') }}
         </DialogDescription>
       </DialogHeader>
-      <DcForm class="grid gap-4 py-4" @submit="handleSubmit" @error="handleSubmitError">
-        <div class="grid grid-cols-4 items-center gap-4">
-          <Label for="name" class="text-right">
-            {{ t('settings.provider.dialog.addCustomProvider.name') }}
-          </Label>
-          <Input
-            id="name"
-            v-model="formData.name"
-            class="col-span-3"
-            :placeholder="t('settings.provider.dialog.addCustomProvider.namePlaceholder')"
-            required
-          />
-        </div>
-        <div class="grid grid-cols-4 items-center gap-4">
-          <Label for="apiType" class="text-right">
-            {{ t('settings.provider.dialog.addCustomProvider.apiType') }}
-          </Label>
-          <Select v-model="formData.apiType" required>
-            <SelectTrigger class="col-span-3">
-              <SelectValue
-                :placeholder="t('settings.provider.dialog.addCustomProvider.apiTypePlaceholder')"
-              />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="openai">OpenAI</SelectItem>
-              <SelectItem value="openai-completions">OpenAI Completions</SelectItem>
-              <SelectItem value="gemini">Gemini</SelectItem>
-              <SelectItem value="anthropic">Anthropic</SelectItem>
-              <SelectItem value="ollama">Ollama</SelectItem>
-              <SelectItem value="mistral">Mistral AI</SelectItem>
-              <!-- <SelectItem value="groq">Groq</SelectItem>
-                <SelectItem value="cohere">Cohere</SelectItem>
-                <SelectItem value="zhinao">智脑</SelectItem>
-                <SelectItem value="custom">自定义</SelectItem> -->
-            </SelectContent>
-          </Select>
-        </div>
-        <div class="grid grid-cols-4 items-center gap-4">
-          <Label for="apiKey" class="text-right">
-            {{ t('settings.provider.dialog.addCustomProvider.apiKey') }}
-          </Label>
-          <Input
-            id="apiKey"
-            v-model="formData.apiKey"
-            class="col-span-3"
-            :placeholder="t('settings.provider.dialog.addCustomProvider.apiKeyPlaceholder')"
-            :required="formData.apiType !== 'ollama'"
-          />
-        </div>
-        <div class="grid grid-cols-4 items-center gap-4">
-          <Label for="baseUrl" class="text-right">
-            {{ t('settings.provider.dialog.addCustomProvider.baseUrl') }}
-          </Label>
-          <span class="col-span-3 flex flex-col">
-            <Input
-              id="baseUrl"
-              v-model="formData.baseUrl"
-              class="col-span-3"
-              :placeholder="t('settings.provider.dialog.addCustomProvider.baseUrlPlaceholder')"
-              required
-            />
-            <div v-if="apiEndpointSuffix" class="text-xs text-muted-foreground mt-1">
-              {{ `${formData.baseUrl ?? ''}${apiEndpointSuffix}` }}
+      <DcForm
+        class="grid gap-4 py-4"
+        :validation-schema="validationSchema"
+        @submit="handleSubmit"
+        @error="handleSubmitError"
+      >
+        <FormField v-slot="{ componentField }" v-model="formData.name" name="name">
+          <FormItem class="grid grid-cols-4 items-start gap-4">
+            <FormLabel class="pt-2 text-right">
+              {{ t('settings.provider.dialog.addCustomProvider.name') }}
+            </FormLabel>
+            <div class="col-span-3 grid gap-2">
+              <FormControl>
+                <Input
+                  v-bind="componentField"
+                  :placeholder="t('settings.provider.dialog.addCustomProvider.namePlaceholder')"
+                />
+              </FormControl>
+              <FormMessage />
             </div>
-          </span>
-        </div>
-        <div class="grid grid-cols-4 items-center gap-4">
-          <Label for="enable" class="text-right">
-            {{ t('settings.provider.dialog.addCustomProvider.enable') }}
-          </Label>
-          <div class="flex items-center space-x-2 col-span-3">
-            <Switch id="enable" v-model="formData.enable" />
-            <Label for="enable">{{
-              formData.enable ? t('common.enabled') : t('common.disabled')
-            }}</Label>
-          </div>
-        </div>
+          </FormItem>
+        </FormField>
+        <FormField v-slot="{ componentField }" v-model="formData.apiType" name="apiType">
+          <FormItem class="grid grid-cols-4 items-start gap-4">
+            <FormLabel class="pt-2 text-right">
+              {{ t('settings.provider.dialog.addCustomProvider.apiType') }}
+            </FormLabel>
+            <div class="col-span-3 grid gap-2">
+              <Select v-bind="componentField">
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue
+                      :placeholder="
+                        t('settings.provider.dialog.addCustomProvider.apiTypePlaceholder')
+                      "
+                    />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="openai">OpenAI</SelectItem>
+                  <SelectItem value="openai-completions">OpenAI Completions</SelectItem>
+                  <SelectItem value="gemini">Gemini</SelectItem>
+                  <SelectItem value="anthropic">Anthropic</SelectItem>
+                  <SelectItem value="ollama">Ollama</SelectItem>
+                  <SelectItem value="mistral">Mistral AI</SelectItem>
+                  <!-- <SelectItem value="groq">Groq</SelectItem>
+                    <SelectItem value="cohere">Cohere</SelectItem>
+                    <SelectItem value="zhinao">智脑</SelectItem>
+                    <SelectItem value="custom">自定义</SelectItem> -->
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </div>
+          </FormItem>
+        </FormField>
+        <FormField v-slot="{ componentField }" v-model="formData.apiKey" name="apiKey">
+          <FormItem class="grid grid-cols-4 items-start gap-4">
+            <FormLabel class="pt-2 text-right">
+              {{ t('settings.provider.dialog.addCustomProvider.apiKey') }}
+            </FormLabel>
+            <div class="col-span-3 grid gap-2">
+              <FormControl>
+                <Input
+                  v-bind="componentField"
+                  :placeholder="t('settings.provider.dialog.addCustomProvider.apiKeyPlaceholder')"
+                />
+              </FormControl>
+              <FormMessage />
+            </div>
+          </FormItem>
+        </FormField>
+        <FormField v-slot="{ componentField }" v-model="formData.baseUrl" name="baseUrl">
+          <FormItem class="grid grid-cols-4 items-start gap-4">
+            <FormLabel class="pt-2 text-right">
+              {{ t('settings.provider.dialog.addCustomProvider.baseUrl') }}
+            </FormLabel>
+            <div class="col-span-3 grid gap-2">
+              <FormControl>
+                <Input
+                  v-bind="componentField"
+                  :placeholder="t('settings.provider.dialog.addCustomProvider.baseUrlPlaceholder')"
+                />
+              </FormControl>
+              <div v-if="apiEndpointSuffix" class="text-xs text-muted-foreground">
+                {{ `${formData.baseUrl ?? ''}${apiEndpointSuffix}` }}
+              </div>
+              <FormMessage />
+            </div>
+          </FormItem>
+        </FormField>
+        <FormField v-slot="{ componentField }" v-model="formData.enable" name="enable">
+          <FormItem class="grid grid-cols-4 items-center gap-4">
+            <FormLabel class="text-right">
+              {{ t('settings.provider.dialog.addCustomProvider.enable') }}
+            </FormLabel>
+            <div class="col-span-3 flex items-center space-x-2">
+              <FormControl>
+                <Switch id="enable" v-bind="componentField" />
+              </FormControl>
+              <Label for="enable">
+                {{ formData.enable ? t('common.enabled') : t('common.disabled') }}
+              </Label>
+            </div>
+          </FormItem>
+        </FormField>
         <DialogFooter>
           <DcFormActions
             :cancel-label="t('dialog.cancel')"
@@ -110,6 +138,13 @@ import {
 } from '@shadcn/components/ui/dialog'
 import { DcForm } from '@dc-ui/components/form'
 import { DcFormActions } from '@dc-ui/components/form-actions'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from '@shadcn/components/ui/form'
 import { Input } from '@shadcn/components/ui/input'
 import { Label } from '@shadcn/components/ui/label'
 import { Switch } from '@shadcn/components/ui/switch'
@@ -121,10 +156,22 @@ import {
   SelectValue
 } from '@shadcn/components/ui/select'
 import type { LLM_PROVIDER } from '@shared/types/provider'
+import type { GenericValidateFunction } from 'vee-validate'
 import { useProviderStore } from '@/stores/providerStore'
 
 const { t } = useI18n()
 const providerStore = useProviderStore()
+const hasText = (value: unknown) => typeof value === 'string' && value.trim().length > 0
+const requiredRule: GenericValidateFunction = (value) =>
+  hasText(value) || t('components.promptParamsDialog.required')
+const apiKeyRule: GenericValidateFunction = (value, { form }) =>
+  form.apiType === 'ollama' || hasText(value) || t('components.promptParamsDialog.required')
+const validationSchema = {
+  name: requiredRule,
+  apiType: requiredRule,
+  apiKey: apiKeyRule,
+  baseUrl: requiredRule
+}
 
 const props = defineProps<{
   open: boolean

--- a/src/renderer/src/components/mcp-config/components/McpEnterpriseProfiles.vue
+++ b/src/renderer/src/components/mcp-config/components/McpEnterpriseProfiles.vue
@@ -6,6 +6,13 @@ import { useI18n } from 'vue-i18n'
 import { DcForm } from '@dc-ui/components/form'
 import { DcFormActions } from '@dc-ui/components/form-actions'
 import { DcButton } from '@dc-ui/components/button'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from '@shadcn/components/ui/form'
 import { Input } from '@shadcn/components/ui/input'
 import { Label } from '@shadcn/components/ui/label'
 import { Spinner } from '@shadcn/components/ui/spinner'
@@ -27,9 +34,18 @@ import {
 import type { McpEnterpriseIdentityProfile, McpEnterpriseIdentityStatus } from '@shared/types/mcp'
 import { createMcpClient } from '@api/McpClient'
 import { notifyRenderer } from '@renderer-notifications/rendererNotificationPort'
+import type { GenericValidateFunction } from 'vee-validate'
 
 const { t } = useI18n()
 const mcpClient = createMcpClient()
+const hasText = (value: unknown) => typeof value === 'string' && value.trim().length > 0
+const requiredRule: GenericValidateFunction = (value) =>
+  hasText(value) || t('components.promptParamsDialog.required')
+const validationSchema = {
+  label: requiredRule,
+  issuer: requiredRule,
+  clientId: requiredRule
+}
 
 const isOpen = ref(false)
 const isLoading = ref(false)
@@ -221,31 +237,36 @@ onBeforeUnmount(() => {
         v-else-if="editingProfile"
         class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto"
         :success-duration="1600"
+        :validation-schema="validationSchema"
         @submit="handleProfileSubmit"
       >
-        <div class="space-y-2">
-          <Label for="enterprise-profile-label">
-            {{ t('settings.mcp.enterpriseProfiles.label') }}
-          </Label>
-          <Input id="enterprise-profile-label" v-model="editingProfile.label" required />
-        </div>
-        <div class="space-y-2">
-          <Label for="enterprise-profile-issuer">
-            {{ t('settings.mcp.enterpriseProfiles.issuer') }}
-          </Label>
-          <Input
-            id="enterprise-profile-issuer"
-            v-model="editingProfile.issuer"
-            placeholder="https://id.example.com"
-            required
-          />
-        </div>
-        <div class="space-y-2">
-          <Label for="enterprise-profile-client-id">
-            {{ t('settings.mcp.enterpriseProfiles.clientId') }}
-          </Label>
-          <Input id="enterprise-profile-client-id" v-model="editingProfile.clientId" required />
-        </div>
+        <FormField v-slot="{ componentField }" v-model="editingProfile.label" name="label">
+          <FormItem class="space-y-2">
+            <FormLabel>{{ t('settings.mcp.enterpriseProfiles.label') }}</FormLabel>
+            <FormControl>
+              <Input v-bind="componentField" />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        </FormField>
+        <FormField v-slot="{ componentField }" v-model="editingProfile.issuer" name="issuer">
+          <FormItem class="space-y-2">
+            <FormLabel>{{ t('settings.mcp.enterpriseProfiles.issuer') }}</FormLabel>
+            <FormControl>
+              <Input v-bind="componentField" placeholder="https://id.example.com" />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        </FormField>
+        <FormField v-slot="{ componentField }" v-model="editingProfile.clientId" name="clientId">
+          <FormItem class="space-y-2">
+            <FormLabel>{{ t('settings.mcp.enterpriseProfiles.clientId') }}</FormLabel>
+            <FormControl>
+              <Input v-bind="componentField" />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        </FormField>
         <div class="space-y-2">
           <Label for="enterprise-profile-scopes">
             {{ t('settings.mcp.enterpriseProfiles.scopes') }}

--- a/test/renderer/components/AddCustomProviderDialog.test.ts
+++ b/test/renderer/components/AddCustomProviderDialog.test.ts
@@ -1,0 +1,133 @@
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { addCustomProvider } = vi.hoisted(() => ({
+  addCustomProvider: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@/stores/providerStore', () => ({
+  useProviderStore: () => ({ addCustomProvider })
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key
+  })
+}))
+
+vi.mock('nanoid', () => ({
+  nanoid: () => 'provider-id'
+}))
+
+const passthrough = (name: string) =>
+  defineComponent({
+    name,
+    template: '<div><slot /></div>'
+  })
+
+const selectStub = defineComponent({
+  name: 'Select',
+  props: {
+    modelValue: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['update:modelValue'],
+  template: `
+    <div>
+      <button type="button" data-testid="select-ollama" @click="$emit('update:modelValue', 'ollama')">
+        Ollama
+      </button>
+      <slot />
+    </div>
+  `
+})
+
+const switchStub = defineComponent({
+  name: 'Switch',
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:modelValue'],
+  template: '<button type="button" role="switch" :aria-checked="modelValue" />'
+})
+
+const formActionsStub = defineComponent({
+  name: 'DcFormActions',
+  emits: ['cancel'],
+  template: '<button type="submit">submit</button>'
+})
+
+const mountDialog = async () => {
+  const AddCustomProviderDialog = (
+    await import('../../../src/renderer/settings/components/AddCustomProviderDialog.vue')
+  ).default
+
+  const wrapper = mount(AddCustomProviderDialog, {
+    props: {
+      open: true
+    },
+    global: {
+      stubs: {
+        Dialog: passthrough('Dialog'),
+        DialogContent: passthrough('DialogContent'),
+        DialogDescription: passthrough('DialogDescription'),
+        DialogFooter: passthrough('DialogFooter'),
+        DialogHeader: passthrough('DialogHeader'),
+        DialogTitle: passthrough('DialogTitle'),
+        DcFormActions: formActionsStub,
+        Select: selectStub,
+        SelectContent: passthrough('SelectContent'),
+        SelectItem: passthrough('SelectItem'),
+        SelectTrigger: passthrough('SelectTrigger'),
+        SelectValue: passthrough('SelectValue'),
+        Switch: switchStub
+      }
+    }
+  })
+
+  return wrapper
+}
+
+describe('AddCustomProviderDialog', () => {
+  beforeEach(() => {
+    addCustomProvider.mockClear()
+  })
+
+  it('shows vee-validate errors and rejects missing required fields', async () => {
+    const wrapper = await mountDialog()
+
+    await wrapper.get('form').trigger('submit')
+    await vi.waitFor(() => {
+      expect(wrapper.findAll('[data-slot="form-message"]')).toHaveLength(3)
+    })
+
+    expect(addCustomProvider).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('components.promptParamsDialog.required')
+  })
+
+  it('allows Ollama without an API key and uses its default base URL', async () => {
+    const wrapper = await mountDialog()
+
+    await wrapper.get('[data-testid="select-ollama"]').trigger('click')
+    await wrapper.get('input[name="name"]').setValue('Local Ollama')
+    await wrapper.get('form').trigger('submit')
+    await vi.waitFor(() => {
+      expect(addCustomProvider).toHaveBeenCalledOnce()
+    })
+
+    expect(addCustomProvider).toHaveBeenCalledWith({
+      id: 'provider-id',
+      name: 'Local Ollama',
+      apiType: 'ollama',
+      apiKey: '',
+      baseUrl: 'http://localhost:11434',
+      enable: true
+    })
+  })
+})

--- a/test/renderer/components/McpEnterpriseProfiles.test.ts
+++ b/test/renderer/components/McpEnterpriseProfiles.test.ts
@@ -1,0 +1,123 @@
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { listEnterpriseProfiles, saveEnterpriseProfile } = vi.hoisted(() => ({
+  listEnterpriseProfiles: vi.fn().mockResolvedValue([]),
+  saveEnterpriseProfile: vi.fn(async (profile) => profile)
+}))
+
+vi.mock('@api/McpClient', () => ({
+  createMcpClient: () => ({
+    listEnterpriseProfiles,
+    saveEnterpriseProfile,
+    getEnterpriseProfileStatus: vi.fn(),
+    setEnterpriseProfileClientSecret: vi.fn(),
+    startEnterpriseProfileAuth: vi.fn(),
+    completeEnterpriseProfileAuth: vi.fn(),
+    logoutEnterpriseProfile: vi.fn(),
+    removeEnterpriseProfile: vi.fn(),
+    onEnterpriseAuthChanged: vi.fn(() => vi.fn())
+  })
+}))
+
+vi.mock('@renderer-notifications/rendererNotificationPort', () => ({
+  notifyRenderer: vi.fn()
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key
+  })
+}))
+
+vi.mock('nanoid', () => ({
+  nanoid: () => 'profile-id'
+}))
+
+const passthrough = (name: string) =>
+  defineComponent({
+    name,
+    template: '<div><slot /></div>'
+  })
+
+const formActionsStub = defineComponent({
+  name: 'DcFormActions',
+  emits: ['cancel'],
+  template: '<button type="submit">common.save</button>'
+})
+
+const mountProfiles = async () => {
+  const McpEnterpriseProfiles = (
+    await import('../../../src/renderer/src/components/mcp-config/components/McpEnterpriseProfiles.vue')
+  ).default
+
+  return mount(McpEnterpriseProfiles, {
+    global: {
+      stubs: {
+        Dialog: passthrough('Dialog'),
+        DialogContent: passthrough('DialogContent'),
+        DialogDescription: passthrough('DialogDescription'),
+        DialogHeader: passthrough('DialogHeader'),
+        DialogTitle: passthrough('DialogTitle'),
+        DialogTrigger: passthrough('DialogTrigger'),
+        DcFormActions: formActionsStub,
+        Icon: true,
+        Select: passthrough('Select'),
+        SelectContent: passthrough('SelectContent'),
+        SelectItem: passthrough('SelectItem'),
+        SelectTrigger: passthrough('SelectTrigger'),
+        SelectValue: passthrough('SelectValue')
+      }
+    }
+  })
+}
+
+const startCreate = async (wrapper: Awaited<ReturnType<typeof mountProfiles>>) => {
+  const addButton = wrapper.findAll('button').find((button) => button.text().includes('common.add'))
+
+  expect(addButton).toBeDefined()
+  await addButton!.trigger('click')
+}
+
+describe('McpEnterpriseProfiles', () => {
+  beforeEach(() => {
+    listEnterpriseProfiles.mockClear()
+    saveEnterpriseProfile.mockClear()
+  })
+
+  it('shows vee-validate errors and rejects missing required fields', async () => {
+    const wrapper = await mountProfiles()
+    await startCreate(wrapper)
+
+    await wrapper.get('form').trigger('submit')
+    await vi.waitFor(() => {
+      expect(wrapper.findAll('[data-slot="form-message"]')).toHaveLength(3)
+    })
+
+    expect(saveEnterpriseProfile).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('components.promptParamsDialog.required')
+  })
+
+  it('saves a complete profile with the existing defaults', async () => {
+    const wrapper = await mountProfiles()
+    await startCreate(wrapper)
+
+    await wrapper.get('input[name="label"]').setValue('Corporate SSO')
+    await wrapper.get('input[name="issuer"]').setValue('https://id.example.com')
+    await wrapper.get('input[name="clientId"]').setValue('deepchat-desktop')
+    await wrapper.get('form').trigger('submit')
+
+    await vi.waitFor(() => {
+      expect(saveEnterpriseProfile).toHaveBeenCalledOnce()
+    })
+    expect(saveEnterpriseProfile).toHaveBeenCalledWith({
+      id: 'enterprise-profile-id',
+      label: 'Corporate SSO',
+      issuer: 'https://id.example.com',
+      clientId: 'deepchat-desktop',
+      scopes: ['openid'],
+      clientAuthentication: 'none'
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- register custom provider fields with vee-validate and show localized field errors
- require provider name, API type, and Base URL while keeping the API key optional for Ollama
- register enterprise profile label, issuer, and client ID with vee-validate before saving
- prevent DcForm from forwarding submit listeners twice

## UI

BEFORE

```text
Custom provider
Name      [ input, native required only ]
API Key   [ input, native required only ]
Base URL  [ input, native required only ]

Enterprise profile
Label     [ input, native required only ]
Issuer    [ input, native required only ]
Client ID [ input, native required only ]
```

AFTER

```text
Custom provider
Name      [ validated input ]
          [ localized field error ]
API Key   [ conditionally validated input ]
          [ localized field error ]
Base URL  [ validated input ]
          [ endpoint preview / localized field error ]

Enterprise profile
Label     [ validated input ]
          [ localized field error ]
Issuer    [ validated input ]
          [ localized field error ]
Client ID [ validated input ]
          [ localized field error ]
```

## Verification

- `pnpm run format:check`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test:renderer` (250 files, 2036 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the custom provider form with structured fields and inline validation messages.
  - Added validation for provider name, API type, and base URL, including whitespace checks.
  - API keys are required for most providers but optional for Ollama.
  - Ollama providers now use the default base URL when none is provided.

- **Bug Fixes**
  - Prevented invalid custom provider details from being submitted.
  - Improved form behavior to ensure only valid configurations are saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->