### PR TITLE
refactor(settings): remove ineffective required

### DIFF
--- a/src/renderer/settings/components/BuiltinKnowledgeSettings.vue
+++ b/src/renderer/settings/components/BuiltinKnowledgeSettings.vue
@@ -165,7 +165,6 @@
                 <Input
                   id="edit-builtin-config-description"
                   v-model="editingBuiltinConfig.description"
-                  required
                   :placeholder="t('settings.knowledgeBase.descriptionPlaceholder')"
                 />
               </div>


### PR DESCRIPTION
## Summary

- remove the ineffective native `required` attribute from the built-in knowledge description input
- keep validation centralized in `isEditingBuiltinConfigValid` and the save guard
- avoid implying browser constraint validation in a dialog that does not submit through a form

## UI

BEFORE

```text
Description [ input: required attribute ]
             (no native form submission)
Save        [ disabled by computed validation ]
```

AFTER

```text
Description [ input ]
Save        [ disabled by computed validation ]
             (save handler repeats the same guard)
```

No visual or behavior change.

## Verification

- `pnpm exec vitest run --config vitest.config.renderer.ts test/renderer/components/BuiltinKnowledgeSettings.test.ts` (11 tests)
- `pnpm run format:check`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made the built-in knowledge description field optional, allowing users to save settings without entering a description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->