### PR TITLE
fix(chat): render resolved permission outcomes instead of generic Continued

### DIFF
--- a/.github/workflows/prcheck.yml
+++ b/.github/workflows/prcheck.yml
@@ -100,6 +100,10 @@ jobs:
 
       - name: Test renderer
         run: pnpm run test:renderer
+        env:
+          # Reused jsdom workers accumulate heap across suites and breach the
+          # 4GB Node default on 16GB runners; 6GB keeps two workers in budget.
+          NODE_OPTIONS: --max-old-space-size=6144
 
   build:
     runs-on: ubuntu-24.04

--- a/src/renderer/src/components/message/LiveDelegationToolCallCard.vue
+++ b/src/renderer/src/components/message/LiveDelegationToolCallCard.vue
@@ -15,6 +15,21 @@
         </p>
       </div>
       <span
+        v-if="permissionStatus"
+        data-testid="tool-call-permission-badge"
+        :data-permission-status="permissionStatus"
+        :class="[
+          'shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-medium',
+          permissionStatus === 'granted'
+            ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+            : 'border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-300'
+        ]"
+      >
+        {{
+          permissionStatus === 'granted' ? t('toolCall.badge.allowed') : t('toolCall.badge.denied')
+        }}
+      </span>
+      <span
         class="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium"
         :class="statusBadgeClass"
         aria-live="polite"
@@ -98,6 +113,7 @@ const props = defineProps<{
   detailsId: string
   detailsExpanded: boolean
   readOnly?: boolean
+  permissionStatus?: 'granted' | 'denied'
 }>()
 
 const emit = defineEmits<{ toggleDetails: [] }>()

--- a/src/renderer/src/components/message/MessageBlockAction.vue
+++ b/src/renderer/src/components/message/MessageBlockAction.vue
@@ -35,7 +35,24 @@
       {{ t('components.messageBlockAction.continue') }}
     </DcButton>
     <div
-      v-if="!block.extra?.needContinue && block.action_type !== 'rate_limit'"
+      v-if="resolvedPermissionStatus"
+      data-testid="permission-resolved-label"
+      :data-permission-status="resolvedPermissionStatus"
+      class="text-xs flex flex-row gap-2 items-center"
+      :class="resolvedPermissionStatus === 'granted' ? 'text-emerald-600' : 'text-red-500'"
+    >
+      <Icon
+        :icon="resolvedPermissionStatus === 'granted' ? 'lucide:shield-check' : 'lucide:shield-x'"
+        class="w-4 h-4"
+      />
+      {{
+        resolvedPermissionStatus === 'granted'
+          ? t('components.messageBlockPermissionRequest.granted')
+          : t('components.messageBlockPermissionRequest.denied')
+      }}
+    </div>
+    <div
+      v-else-if="!block.extra?.needContinue && block.action_type !== 'rate_limit'"
       class="text-xs text-gray-500 flex flex-row gap-2 items-center"
     >
       <Icon icon="lucide:check" class="w-4 h-4" />{{ t('components.messageBlockAction.continued') }}
@@ -48,7 +65,10 @@ import { useI18n } from 'vue-i18n'
 import { Icon } from '@iconify/vue'
 import { DcButton } from '@dc-ui/components/button'
 import { computed, ref, onMounted, onUnmounted } from 'vue'
-import type { DisplayAssistantMessageBlock } from '@/features/chat-page/model/displayMessage'
+import {
+  type DisplayAssistantMessageBlock,
+  getResolvedPermissionStatus
+} from '@/features/chat-page/model/displayMessage'
 
 const { t } = useI18n()
 
@@ -67,6 +87,7 @@ const progressTimer = ref<number | null>(null)
 const currentTime = ref(Date.now())
 const isReadOnly = computed(() => props.isReadOnly === true)
 const isRateLimitBlock = computed(() => props.block.action_type === 'rate_limit')
+const resolvedPermissionStatus = computed(() => getResolvedPermissionStatus(props.block))
 const elapsedSeconds = computed(() => {
   if (!isRateLimitBlock.value) {
     return 0

--- a/src/renderer/src/components/message/MessageBlockActivityGroup.vue
+++ b/src/renderer/src/components/message/MessageBlockActivityGroup.vue
@@ -51,6 +51,9 @@
             :thread-id="threadId"
             :read-only="readOnly"
             render-mode="tool-only"
+            :permission-status="
+              block.tool_call?.id ? permissionStatusByToolCallId?.[block.tool_call.id] : undefined
+            "
           />
           <MessageBlockSearch
             v-else-if="block.type === 'search'"
@@ -69,7 +72,8 @@ import { Icon } from '@iconify/vue'
 import { useI18n } from 'vue-i18n'
 import type {
   DisplayAssistantMessageBlock,
-  DisplayMessageUsage
+  DisplayMessageUsage,
+  ResolvedPermissionStatus
 } from '@/features/chat-page/model/displayMessage'
 import { formatActivityDuration } from './messageActivityGroups'
 import MessageBlockThink from './MessageBlockThink.vue'
@@ -85,6 +89,7 @@ const props = defineProps<{
   reasoningCount: number
   toolCallCount: number
   readOnly?: boolean
+  permissionStatusByToolCallId?: Record<string, ResolvedPermissionStatus>
 }>()
 
 const emit = defineEmits<{

--- a/src/renderer/src/components/message/MessageBlockToolCall.vue
+++ b/src/renderer/src/components/message/MessageBlockToolCall.vue
@@ -44,6 +44,21 @@
         </span>
       </div>
       <span
+        v-if="permissionStatus"
+        data-testid="tool-call-permission-badge"
+        :data-permission-status="permissionStatus"
+        :class="[
+          'shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-medium',
+          permissionStatus === 'granted'
+            ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+            : 'border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-300'
+        ]"
+      >
+        {{
+          permissionStatus === 'granted' ? t('toolCall.badge.allowed') : t('toolCall.badge.denied')
+        }}
+      </span>
+      <span
         v-if="showRtkBadge"
         data-testid="tool-call-rtk-badge"
         class="shrink-0 rounded border border-emerald-500/20 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-emerald-700 dark:text-emerald-300"
@@ -263,6 +278,7 @@ const props = defineProps<{
   threadId?: string
   readOnly?: boolean
   renderMode?: 'full' | 'tool-only' | 'app-only'
+  permissionStatus?: 'granted' | 'denied'
 }>()
 
 type ExpansionSource = 'auto' | 'manual' | null

--- a/src/renderer/src/components/message/MessageBlockToolCall.vue
+++ b/src/renderer/src/components/message/MessageBlockToolCall.vue
@@ -8,6 +8,7 @@
       :details-id="detailsId"
       :details-expanded="isExpanded"
       :read-only="readOnly"
+      :permission-status="permissionStatus"
       @toggle-details="toggleExpanded"
     />
     <button

--- a/src/renderer/src/components/message/MessageItemAssistant.vue
+++ b/src/renderer/src/components/message/MessageItemAssistant.vue
@@ -48,6 +48,7 @@
                 :reasoning-count="item.reasoningCount"
                 :tool-call-count="item.toolCallCount"
                 :read-only="isReadOnly"
+                :permission-status-by-tool-call-id="permissionStatusByToolCallId"
                 @toggle-collapse="handleCollapseToggle"
               />
               <MessageBlockToolCall
@@ -88,6 +89,11 @@
                 :thread-id="currentThreadId"
                 :read-only="isReadOnly"
                 :render-mode="item.block.tool_call?.mcpResult?.app ? 'tool-only' : 'full'"
+                :permission-status="
+                  item.block.tool_call?.id
+                    ? permissionStatusByToolCallId[item.block.tool_call.id]
+                    : undefined
+                "
               />
               <MessageBlockQuestionRequest
                 v-else-if="
@@ -217,7 +223,9 @@ import { ref, computed, watch } from 'vue'
 import {
   type DisplayAssistantMessage,
   type DisplayAssistantMessageBlock,
+  buildResolvedPermissionStatusByToolCallId,
   filterRenderableAssistantBlocks,
+  getResolvedPermissionStatus,
   isInternalAssistantToolCallBlock
 } from '@/features/chat-page/model/displayMessage'
 import MessageBlockContent from './MessageBlockContent.vue'
@@ -437,9 +445,23 @@ const shouldGroupActivity = computed(() => {
   return currentMessage.value.status !== 'pending'
 })
 
+const permissionStatusByToolCallId = computed(() =>
+  buildResolvedPermissionStatusByToolCallId(currentContent.value)
+)
+
+// Resolved permission outcomes merge into their tool card; the standalone
+// action card only remains as a fallback when the tool card is missing.
+const currentVisibleContent = computed(() =>
+  currentContent.value.filter((block) => {
+    const status = getResolvedPermissionStatus(block)
+    const toolCallId = block.tool_call?.id
+    return !(status && toolCallId && permissionStatusByToolCallId.value[toolCallId])
+  })
+)
+
 const currentRenderItems = computed(() =>
   buildAssistantRenderItems({
-    blocks: currentContent.value,
+    blocks: currentVisibleContent.value,
     messageId: currentMessage.value.id,
     messageUpdatedAt: currentMessage.value.updatedAt,
     shouldGroup: shouldGroupActivity.value,

--- a/src/renderer/src/features/chat-page/model/displayMessage.ts
+++ b/src/renderer/src/features/chat-page/model/displayMessage.ts
@@ -239,6 +239,43 @@ export function isInternalAssistantToolCallBlock(block: DisplayAssistantMessageB
   )
 }
 
+export type ResolvedPermissionStatus = 'granted' | 'denied'
+
+export function getResolvedPermissionStatus(
+  block: DisplayAssistantMessageBlock
+): ResolvedPermissionStatus | null {
+  if (block.type !== 'action' || block.action_type !== 'tool_call_permission') {
+    return null
+  }
+  return block.status === 'granted' || block.status === 'denied' ? block.status : null
+}
+
+/**
+ * Maps tool call ids to their broker-resolved permission outcome, restricted to
+ * permission blocks whose tool card exists in the same block list so the outcome
+ * can be merged into that card instead of rendering a separate action card.
+ */
+export function buildResolvedPermissionStatusByToolCallId(
+  blocks: DisplayAssistantMessageBlock[]
+): Record<string, ResolvedPermissionStatus> {
+  const toolCallIds = new Set<string>()
+  for (const block of blocks) {
+    if (block.type === 'tool_call' && block.tool_call?.id) {
+      toolCallIds.add(block.tool_call.id)
+    }
+  }
+
+  const statusByToolCallId: Record<string, ResolvedPermissionStatus> = {}
+  for (const block of blocks) {
+    const status = getResolvedPermissionStatus(block)
+    const toolCallId = block.tool_call?.id
+    if (status && toolCallId && toolCallIds.has(toolCallId)) {
+      statusByToolCallId[toolCallId] = status
+    }
+  }
+  return statusByToolCallId
+}
+
 export function isRenderableAssistantBlock(block: DisplayAssistantMessageBlock): boolean {
   if (block.type === 'plan') {
     return false

--- a/src/renderer/src/i18n/da-DK/toolCall.json
+++ b/src/renderer/src/i18n/da-DK/toolCall.json
@@ -19,7 +19,9 @@
   "title": "Værktøjskald",
   "terminalOutput": "Terminaludgang",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Tilladt",
+    "denied": "Afvist"
   },
   "replacementsCount": "Udført {count} erstatninger"
 }

--- a/src/renderer/src/i18n/de-DE/toolCall.json
+++ b/src/renderer/src/i18n/de-DE/toolCall.json
@@ -13,7 +13,9 @@
   "imagePreviewCount": "Keine Bildvorschau | {count} Bildvorschau | {count} Bildvorschauen",
   "terminalOutput": "Terminalausgabe",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Erlaubt",
+    "denied": "Abgelehnt"
   },
   "replacementsCount": "{count} Ersetzungen abgeschlossen",
   "fileOperation": "Dateivorgang",

--- a/src/renderer/src/i18n/en-US/toolCall.json
+++ b/src/renderer/src/i18n/en-US/toolCall.json
@@ -13,7 +13,9 @@
   "imagePreviewCount": "No image previews | One image preview | {count} image previews",
   "terminalOutput": "Terminal Output",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Allowed",
+    "denied": "Denied"
   },
   "replacementsCount": "Completed {count} replacements",
   "fileOperation": "File Operation",

--- a/src/renderer/src/i18n/es-ES/toolCall.json
+++ b/src/renderer/src/i18n/es-ES/toolCall.json
@@ -13,7 +13,9 @@
   "imagePreviewCount": "No hay vistas previas de imágenes | Vista previa de una imagen | {count} vistas previas de imágenes",
   "terminalOutput": "Salida terminal",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Permitido",
+    "denied": "Denegado"
   },
   "replacementsCount": "Reemplazos {count} completados",
   "fileOperation": "Operación de archivos",

--- a/src/renderer/src/i18n/fa-IR/toolCall.json
+++ b/src/renderer/src/i18n/fa-IR/toolCall.json
@@ -19,7 +19,9 @@
   "title": "تماس ابزار",
   "terminalOutput": "خروجی ترمینال",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "مجاز شد",
+    "denied": "رد شد"
   },
   "replacementsCount": "{count} مورد جایگزین شد"
 }

--- a/src/renderer/src/i18n/fr-FR/toolCall.json
+++ b/src/renderer/src/i18n/fr-FR/toolCall.json
@@ -19,7 +19,9 @@
   "title": "Appel d'outil",
   "terminalOutput": "Sortie terminale",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Autorisé",
+    "denied": "Refusé"
   },
   "replacementsCount": "Terminé {count} remplacement(s)"
 }

--- a/src/renderer/src/i18n/he-IL/toolCall.json
+++ b/src/renderer/src/i18n/he-IL/toolCall.json
@@ -19,7 +19,9 @@
   "success": "הַצלָחָה",
   "terminalOutput": "פלט מסוף",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "אושר",
+    "denied": "נדחה"
   },
   "replacementsCount": "הושלמו {count} החלפות"
 }

--- a/src/renderer/src/i18n/id-ID/toolCall.json
+++ b/src/renderer/src/i18n/id-ID/toolCall.json
@@ -13,7 +13,9 @@
   "imagePreviewCount": "Tidak ada pratinjau gambar | {count} pratinjau gambar | {count} pratinjau gambar",
   "terminalOutput": "Keluaran terminal",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Diizinkan",
+    "denied": "Ditolak"
   },
   "replacementsCount": "Penggantian selesai di {count}",
   "fileOperation": "Operasi berkas",

--- a/src/renderer/src/i18n/it-IT/toolCall.json
+++ b/src/renderer/src/i18n/it-IT/toolCall.json
@@ -13,7 +13,9 @@
   "imagePreviewCount": "Nessuna anteprima immagine | {count} anteprima immagine | {count} anteprime immagine",
   "terminalOutput": "Output terminale",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Consentito",
+    "denied": "Negato"
   },
   "replacementsCount": "{count} sostituzioni completate",
   "fileOperation": "Operazione file",

--- a/src/renderer/src/i18n/ja-JP/toolCall.json
+++ b/src/renderer/src/i18n/ja-JP/toolCall.json
@@ -19,7 +19,9 @@
   "title": "ツール呼び出し",
   "terminalOutput": "端子出力",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "許可済み",
+    "denied": "拒否済み"
   },
   "replacementsCount": "{count}か所の置換を完了しました"
 }

--- a/src/renderer/src/i18n/ko-KR/toolCall.json
+++ b/src/renderer/src/i18n/ko-KR/toolCall.json
@@ -19,7 +19,9 @@
   "title": "도구 호출",
   "terminalOutput": "터미널 출력",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "허용됨",
+    "denied": "거부됨"
   },
   "replacementsCount": "{count}개 치환 완료"
 }

--- a/src/renderer/src/i18n/ms-MY/toolCall.json
+++ b/src/renderer/src/i18n/ms-MY/toolCall.json
@@ -13,7 +13,9 @@
   "imagePreviewCount": "Tiada pratonton gambar | Pratonton gambar {count} | Pratonton gambar {count}",
   "terminalOutput": "Keluaran terminal",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Dibenarkan",
+    "denied": "Ditolak"
   },
   "replacementsCount": "Selesai penggantian di {count}",
   "fileOperation": "Operasi fail",

--- a/src/renderer/src/i18n/pl-PL/toolCall.json
+++ b/src/renderer/src/i18n/pl-PL/toolCall.json
@@ -13,7 +13,9 @@
   "imagePreviewCount": "Brak podglądów obrazów | Jeden podgląd obrazu | {count} podglądy obrazów | {count} podglądów obrazów",
   "terminalOutput": "Wyjście terminala",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Zezwolono",
+    "denied": "Odmówiono"
   },
   "replacementsCount": "Zakończono wymianę {count}",
   "fileOperation": "Operacja na pliku",

--- a/src/renderer/src/i18n/pt-BR/toolCall.json
+++ b/src/renderer/src/i18n/pt-BR/toolCall.json
@@ -19,7 +19,9 @@
   "title": "Chamada de ferramenta",
   "terminalOutput": "Saída terminal",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Permitido",
+    "denied": "Negado"
   },
   "replacementsCount": "Substituídas {count} ocorrências"
 }

--- a/src/renderer/src/i18n/ru-RU/toolCall.json
+++ b/src/renderer/src/i18n/ru-RU/toolCall.json
@@ -19,7 +19,9 @@
   "title": "Вызов инструмента",
   "terminalOutput": "Выходной терминал",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Разрешено",
+    "denied": "Отклонено"
   },
   "replacementsCount": "Выполнено {count} замен"
 }

--- a/src/renderer/src/i18n/tr-TR/toolCall.json
+++ b/src/renderer/src/i18n/tr-TR/toolCall.json
@@ -13,7 +13,9 @@
   "imagePreviewCount": "Resim önizlemesi yok | {count} resim önizlemesi | {count} resim önizlemesi",
   "terminalOutput": "Terminal Çıkışı",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "İzin verildi",
+    "denied": "Reddedildi"
   },
   "replacementsCount": "{count} değiştirmeleri tamamlandı",
   "fileOperation": "Dosya İşlemi",

--- a/src/renderer/src/i18n/vi-VN/toolCall.json
+++ b/src/renderer/src/i18n/vi-VN/toolCall.json
@@ -13,7 +13,9 @@
   "imagePreviewCount": "Không có bản xem trước hình ảnh | Xem trước một hình ảnh | Xem trước hình ảnh {count}",
   "terminalOutput": "Đầu ra thiết bị đầu cuối",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "Đã cho phép",
+    "denied": "Đã từ chối"
   },
   "replacementsCount": "Đã hoàn thành việc thay thế {count}",
   "fileOperation": "Thao tác với tệp",

--- a/src/renderer/src/i18n/zh-CN/toolCall.json
+++ b/src/renderer/src/i18n/zh-CN/toolCall.json
@@ -13,7 +13,9 @@
   "imagePreviewCount": "无图片预览 | {count} 张图片预览 | {count} 张图片预览",
   "terminalOutput": "终端输出",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "已允许",
+    "denied": "已拒绝"
   },
   "replacementsCount": "已完成 {count} 处替换",
   "fileOperation": "文件操作",

--- a/src/renderer/src/i18n/zh-HK/toolCall.json
+++ b/src/renderer/src/i18n/zh-HK/toolCall.json
@@ -19,7 +19,9 @@
   "title": "工具調用",
   "terminalOutput": "終端輸出",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "已允許",
+    "denied": "已拒絕"
   },
   "replacementsCount": "已完成 {count} 處替換"
 }

--- a/src/renderer/src/i18n/zh-TW/toolCall.json
+++ b/src/renderer/src/i18n/zh-TW/toolCall.json
@@ -19,7 +19,9 @@
   "title": "工具調用",
   "terminalOutput": "終端輸出",
   "badge": {
-    "rtk": "RTK"
+    "rtk": "RTK",
+    "allowed": "已允許",
+    "denied": "已拒絕"
   },
   "replacementsCount": "已完成 {count} 處替換"
 }

--- a/src/renderer/src/lib/icons/icon-collections.generated.ts
+++ b/src/renderer/src/lib/icons/icon-collections.generated.ts
@@ -649,6 +649,9 @@ export const lucideIconCollection = {
     'shield-off': {
       body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m2 2l20 20M5 5a1 1 0 0 0-1 1v7c0 5 3.5 7.5 7.67 8.94a1 1 0 0 0 .67.01c2.35-.82 4.48-1.97 5.9-3.71M9.309 3.652A12.3 12.3 0 0 0 11.24 2.28a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1v7a10 10 0 0 1-.08 1.264"/>'
     },
+    'shield-x': {
+      body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1zm-5.5-3.5l-5 5m0-5l5 5"/>'
+    },
     'shopping-bag': {
       body: '<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M16 10a4 4 0 0 1-8 0M3.103 6.034h17.794"/><path d="M3.4 5.467a2 2 0 0 0-.4 1.2V20a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6.667a2 2 0 0 0-.4-1.2l-2-2.667A2 2 0 0 0 17 2H7a2 2 0 0 0-1.6.8z"/></g>'
     },

--- a/src/renderer/src/lib/icons/icon-whitelist.generated.ts
+++ b/src/renderer/src/lib/icons/icon-whitelist.generated.ts
@@ -223,6 +223,7 @@ export const GENERATED_ICON_WHITELIST: Record<GeneratedIconCollectionKey, readon
     'shield-alert',
     'shield-check',
     'shield-off',
+    'shield-x',
     'shopping-bag',
     'sliders-horizontal',
     'smartphone',

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -1400,6 +1400,9 @@ declare module 'vue-i18n' {
     history: string
     minimize: string
     maximize: string
+    showValue: string
+    hideValue: string
+    scrollToBottom: string
     restore: string
     browser: {
       back: string
@@ -2138,6 +2141,29 @@ declare module 'vue-i18n' {
     'settings-memory': string
     'settings-debug': string
     common: {
+      commandShell: {
+        title: string
+        auto: string
+        windowsPowerShell: string
+        gitBash: string
+        executable: string
+        autoDetect: string
+        browse: string
+        clearOverride: string
+        checking: string
+        available: string
+        refresh: string
+        updateFailed: string
+        checkFailed: string
+        browseFailed: string
+        loadFailed: string
+        errors: {
+          'unsupported-platform': string
+          'override-invalid': string
+          'not-found': string
+          'validation-failed': string
+        }
+      }
       title: string
       resetData: string
       language: string
@@ -2363,6 +2389,16 @@ declare module 'vue-i18n' {
       subagentLimit: string
       addSubagentSlot: string
       toolsTitle: string
+      outputLimitsTitle: string
+      outputLimitsDescription: string
+      outputLimitsSafetyHint: string
+      outputLimitsReset: string
+      outputLimitsReadFile: string
+      outputLimitsReadFileHint: string
+      outputLimitsTool: string
+      outputLimitsToolHint: string
+      outputLimitsCommand: string
+      outputLimitsCommandHint: string
       compactionTitle: string
       compactionEnabled: string
       compactionDescription: string
@@ -4196,6 +4232,8 @@ declare module 'vue-i18n' {
     terminalOutput: string
     badge: {
       rtk: string
+      allowed: string
+      denied: string
     }
     replacementsCount: string
     fileOperation: string

--- a/test/renderer/components/message/MessageBlockBasics.test.ts
+++ b/test/renderer/components/message/MessageBlockBasics.test.ts
@@ -77,6 +77,76 @@ describe('MessageBlock basics', () => {
     expect(wrapper.emitted('continue')).toEqual([['s1', 'm1']])
   })
 
+  const createPermissionBlock = (
+    status: DisplayAssistantMessageBlock['status'],
+    overrides: Partial<DisplayAssistantMessageBlock> = {}
+  ): DisplayAssistantMessageBlock =>
+    createBlock({
+      action_type: 'tool_call_permission',
+      status,
+      tool_call: { id: 'tc1', name: 'run_command' },
+      ...overrides
+    })
+
+  it('renders granted permission outcome instead of the generic continued label', () => {
+    const wrapper = mount(MessageBlockAction, {
+      props: {
+        messageId: 'm1',
+        conversationId: 's1',
+        block: createPermissionBlock('granted')
+      }
+    })
+
+    const label = wrapper.find('[data-testid="permission-resolved-label"]')
+    expect(label.exists()).toBe(true)
+    expect(label.attributes('data-permission-status')).toBe('granted')
+    expect(wrapper.text()).toContain('components.messageBlockPermissionRequest.granted')
+    expect(wrapper.text()).not.toContain('components.messageBlockAction.continued')
+  })
+
+  it('renders denied permission outcome without any success affordance', () => {
+    const wrapper = mount(MessageBlockAction, {
+      props: {
+        messageId: 'm1',
+        conversationId: 's1',
+        block: createPermissionBlock('denied', { content: 'User denied the request.' })
+      }
+    })
+
+    const label = wrapper.find('[data-testid="permission-resolved-label"]')
+    expect(label.attributes('data-permission-status')).toBe('denied')
+    expect(wrapper.text()).toContain('components.messageBlockPermissionRequest.denied')
+    expect(wrapper.text()).not.toContain('components.messageBlockAction.continued')
+    expect(wrapper.findAll('button')).toHaveLength(0)
+  })
+
+  it('keeps denied rendering identical in read-only history', () => {
+    const wrapper = mount(MessageBlockAction, {
+      props: {
+        messageId: 'm1',
+        conversationId: 's1',
+        isReadOnly: true,
+        block: createPermissionBlock('denied')
+      }
+    })
+
+    expect(
+      wrapper.find('[data-testid="permission-resolved-label"]').attributes('data-permission-status')
+    ).toBe('denied')
+  })
+
+  it('does not mark pending permission requests as resolved', () => {
+    const wrapper = mount(MessageBlockAction, {
+      props: {
+        messageId: 'm1',
+        conversationId: 's1',
+        block: createPermissionBlock('pending', { extra: { needsUserAction: true } })
+      }
+    })
+
+    expect(wrapper.find('[data-testid="permission-resolved-label"]').exists()).toBe(false)
+  })
+
   it('renders a compact rate limit status block', () => {
     const wrapper = mount(MessageBlockAction, {
       props: {

--- a/test/renderer/components/message/MessageBlockToolCall.test.ts
+++ b/test/renderer/components/message/MessageBlockToolCall.test.ts
@@ -1110,4 +1110,81 @@ describe('MessageBlockToolCall', () => {
 
     expect(wrapper.find('[data-testid="tool-call-permission-badge"]').exists()).toBe(false)
   })
+
+  it('renders the granted outcome inside the live delegation card', () => {
+    const wrapper = mount(MessageBlockToolCall, {
+      props: {
+        threadId: 'parent-1',
+        permissionStatus: 'granted',
+        block: createBlock({
+          extra: { toolSource: 'agent' },
+          tool_call: {
+            id: 'spawn-1',
+            name: LIVE_DELEGATION_AGENT_TOOL_NAME,
+            server_name: LIVE_DELEGATION_AGENT_TOOL_SERVER_NAME,
+            params: JSON.stringify({
+              operation: 'spawn',
+              slotId: 'reviewer',
+              title: 'Review architecture',
+              prompt: 'Inspect module boundaries.'
+            }),
+            response: JSON.stringify({
+              delegation: {
+                schemaVersion: 1,
+                id: 'delegation-1',
+                parentSessionId: 'parent-1',
+                childSessionId: 'child-1',
+                slotId: 'reviewer',
+                targetAgentId: 'deepchat',
+                title: 'Review architecture',
+                status: 'running',
+                lastTurnSeq: 1,
+                createdAt: 10,
+                updatedAt: 20,
+                revision: 2,
+                summaryPreview: null,
+                errorPreview: null
+              },
+              turns: []
+            })
+          }
+        })
+      }
+    })
+
+    const card = wrapper.get('[data-testid="live-delegation-tool-card-delegation-1"]')
+    const badge = card.get('[data-testid="tool-call-permission-badge"]')
+    expect(badge.attributes('data-permission-status')).toBe('granted')
+    expect(badge.text()).toBe('toolCall.badge.allowed')
+  })
+
+  it('renders the denied outcome inside the live delegation card', () => {
+    const wrapper = mount(MessageBlockToolCall, {
+      props: {
+        threadId: 'parent-1',
+        permissionStatus: 'denied',
+        block: createBlock({
+          status: 'error',
+          extra: { toolSource: 'agent' },
+          tool_call: {
+            id: 'spawn-1',
+            name: LIVE_DELEGATION_AGENT_TOOL_NAME,
+            server_name: LIVE_DELEGATION_AGENT_TOOL_SERVER_NAME,
+            params: JSON.stringify({
+              operation: 'spawn',
+              slotId: 'reviewer',
+              title: 'Review architecture',
+              prompt: 'Inspect module boundaries.'
+            }),
+            response: ''
+          }
+        })
+      }
+    })
+
+    const card = wrapper.get('[data-testid="live-delegation-tool-card-pending"]')
+    const badge = card.get('[data-testid="tool-call-permission-badge"]')
+    expect(badge.attributes('data-permission-status')).toBe('denied')
+    expect(badge.text()).toBe('toolCall.badge.denied')
+  })
 })

--- a/test/renderer/components/message/MessageBlockToolCall.test.ts
+++ b/test/renderer/components/message/MessageBlockToolCall.test.ts
@@ -1073,4 +1073,41 @@ describe('MessageBlockToolCall', () => {
 
     expect(selectSessionMock).toHaveBeenCalledWith('child-alpha')
   })
+
+  it('renders the resolved permission badge on the tool pill', () => {
+    const wrapper = mount(MessageBlockToolCall, {
+      props: {
+        block: createBlock(),
+        permissionStatus: 'granted'
+      }
+    })
+
+    const badge = wrapper.find('[data-testid="tool-call-permission-badge"]')
+    expect(badge.exists()).toBe(true)
+    expect(badge.attributes('data-permission-status')).toBe('granted')
+    expect(badge.text()).toBe('toolCall.badge.allowed')
+  })
+
+  it('renders a denied permission badge distinct from success styling', () => {
+    const wrapper = mount(MessageBlockToolCall, {
+      props: {
+        block: createBlock({ status: 'error' }),
+        permissionStatus: 'denied'
+      }
+    })
+
+    const badge = wrapper.find('[data-testid="tool-call-permission-badge"]')
+    expect(badge.attributes('data-permission-status')).toBe('denied')
+    expect(badge.text()).toBe('toolCall.badge.denied')
+  })
+
+  it('renders no permission badge when no permission outcome is associated', () => {
+    const wrapper = mount(MessageBlockToolCall, {
+      props: {
+        block: createBlock()
+      }
+    })
+
+    expect(wrapper.find('[data-testid="tool-call-permission-badge"]').exists()).toBe(false)
+  })
 })

--- a/test/renderer/components/message/MessageItemAssistant.test.ts
+++ b/test/renderer/components/message/MessageItemAssistant.test.ts
@@ -807,6 +807,20 @@ describe('MessageItemAssistant', () => {
       ).toBe('denied')
     })
 
+    it('merges the outcome only into the tool call with the matching id', () => {
+      const wrapper = mountWith([
+        createPermissionActionBlock('granted', 'tc2'),
+        createToolCallBlock({ tool_call: { id: 'tc1', name: 'run_command' } }),
+        createToolCallBlock({ tool_call: { id: 'tc2', name: 'write_file' } })
+      ])
+
+      expect(wrapper.findComponent({ name: 'MessageBlockAction' }).exists()).toBe(false)
+      const stubs = wrapper.findAll('[data-testid="tool-call-stub"]')
+      expect(stubs).toHaveLength(2)
+      expect(stubs[0].attributes('data-permission-status')).toBe('')
+      expect(stubs[1].attributes('data-permission-status')).toBe('granted')
+    })
+
     it('keeps the standalone action card when the tool card is missing', () => {
       const wrapper = mountWith([createPermissionActionBlock('denied', 'tc-missing')])
 

--- a/test/renderer/components/message/MessageItemAssistant.test.ts
+++ b/test/renderer/components/message/MessageItemAssistant.test.ts
@@ -742,4 +742,87 @@ describe('MessageItemAssistant', () => {
 
     expect(memoryActivity.openTurnMemories).not.toHaveBeenCalled()
   })
+
+  describe('resolved permission projection', () => {
+    const createPermissionActionBlock = (
+      status: DisplayAssistantMessageBlock['status'],
+      toolCallId = 'tc1'
+    ): DisplayAssistantMessageBlock => ({
+      type: 'action',
+      action_type: 'tool_call_permission',
+      status,
+      timestamp: 1,
+      tool_call: { id: toolCallId, name: 'run_command' }
+    })
+
+    const ToolCallStub = defineComponent({
+      name: 'MessageBlockToolCall',
+      props: {
+        permissionStatus: {
+          type: String,
+          default: undefined
+        }
+      },
+      template:
+        '<div data-testid="tool-call-stub" :data-permission-status="permissionStatus ?? \'\'" />'
+    })
+
+    const mountWith = (content: DisplayAssistantMessageBlock[]) =>
+      mount(MessageItemAssistant, {
+        props: {
+          message: createMessage('pending', content),
+          isCapturingImage: false,
+          isInGeneratingThread: true
+        },
+        global: {
+          ...global,
+          stubs: {
+            ...global.stubs,
+            MessageBlockToolCall: ToolCallStub
+          }
+        }
+      })
+
+    it('merges the granted outcome into the tool card and hides the action card', () => {
+      const wrapper = mountWith([
+        createPermissionActionBlock('granted'),
+        createToolCallBlock({ tool_call: { id: 'tc1', name: 'run_command' } })
+      ])
+
+      expect(wrapper.findComponent({ name: 'MessageBlockAction' }).exists()).toBe(false)
+      expect(
+        wrapper.find('[data-testid="tool-call-stub"]').attributes('data-permission-status')
+      ).toBe('granted')
+    })
+
+    it('merges the denied outcome into the tool card', () => {
+      const wrapper = mountWith([
+        createPermissionActionBlock('denied'),
+        createToolCallBlock({ tool_call: { id: 'tc1', name: 'run_command' } })
+      ])
+
+      expect(wrapper.findComponent({ name: 'MessageBlockAction' }).exists()).toBe(false)
+      expect(
+        wrapper.find('[data-testid="tool-call-stub"]').attributes('data-permission-status')
+      ).toBe('denied')
+    })
+
+    it('keeps the standalone action card when the tool card is missing', () => {
+      const wrapper = mountWith([createPermissionActionBlock('denied', 'tc-missing')])
+
+      expect(wrapper.findComponent({ name: 'MessageBlockAction' }).exists()).toBe(true)
+    })
+
+    it('keeps pending permission action blocks visible and unmerged', () => {
+      const wrapper = mountWith([
+        createPermissionActionBlock('pending'),
+        createToolCallBlock({ tool_call: { id: 'tc1', name: 'run_command' } })
+      ])
+
+      expect(wrapper.findComponent({ name: 'MessageBlockAction' }).exists()).toBe(true)
+      expect(
+        wrapper.find('[data-testid="tool-call-stub"]').attributes('data-permission-status')
+      ).toBe('')
+    })
+  })
 })


### PR DESCRIPTION
Closes #2117

## Summary

Resolved tool-permission action blocks previously rendered the generic checkmark + "Continued" label regardless of the persisted outcome, so a denial could look successful. The renderer now faithfully projects the broker-owned decision (`block.status = 'granted' | 'denied'`) and merges it into the associated tool card.

- `displayMessage.ts`: new `getResolvedPermissionStatus()` and `buildResolvedPermissionStatusByToolCallId()` helpers; the map only includes permission blocks whose tool card exists in the same message.
- `MessageItemAssistant.vue`: resolved permission action blocks with a matching tool card are no longer rendered as a separate card; their outcome is passed to `MessageBlockToolCall` via the new `permissionStatus` prop. Missing-tool-card cases fall back to a compact standalone label.
- `MessageBlockToolCall.vue`: renders an `Allowed` (emerald) / `Denied` (red) badge on the tool pill, styled like the existing RTK badge.
- `MessageBlockActivityGroup.vue`: forwards the permission map so tool cards inside collapsed activity groups show the badge too.
- `MessageBlockAction.vue`: fallback rendering uses shield-check "Permission granted" / shield-x "Permission denied" (existing i18n keys) instead of "Continued". Rate-limit, legacy needContinue and other action types keep their behavior.
- i18n: added `toolCall.badge.allowed` / `toolCall.badge.denied` to all 20 locales.

## Layout

```text
BEFORE                          AFTER (grant)                  AFTER (deny)
[check] Continued               [run_command  Allowed >]       [run_command  Denied >]
[run_command  >]  Completed
```

## Acceptance criteria

- [x] Granted requests render as Allowed/Granted, never Continued
- [x] Denied requests render as Denied and cannot appear successful
- [x] The status is associated with the correct tool call (matched by `tool_call.id`)
- [x] Pending permissions remain actionable and accessible (overlay flow untouched)
- [x] Question actions and legacy continue actions retain their distinct semantics
- [x] Renderer tests cover pending, granted, denied, read-only, and missing-tool-card fallbacks

## Verification

- `vitest run test/renderer/components/message` — 16 files, 151 tests passed
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format`, `pnpm run i18n` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tool-call cards and activity history now display clear “Allowed” or “Denied” permission badges with status-specific icons and colors.
  - Permission outcomes appear directly on standard and live tool-call cards.
  - Pending or unmatched permission requests remain visible without misleading resolution labels.

- **Localization**
  - Added translated permission-status labels across supported languages.

- **Tests**
  - Added coverage for granted, denied, pending, unmatched, read-only, live, and error-state permission displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->