### PR TITLE
fix: address #2131 review follow-ups

### DIFF
--- a/src/dc-ui/components/button/DcCopyButton.vue
+++ b/src/dc-ui/components/button/DcCopyButton.vue
@@ -67,13 +67,18 @@ export default defineComponent({
       const { copyText: _copyText, ...buttonProps } = props
       const accessibleName = inheritedAttrs.label ?? inheritedAttrs.tooltip ?? _copyText
       const inheritedClick = inheritedAttrs.onClick
+      const fallbackSlots = {
+        ...slots,
+        default:
+          slots.default ??
+          (() => (typeof inheritedAttrs.label === 'string' ? inheritedAttrs.label : undefined))
+      }
 
       return h(
         DcButton,
         {
           ...inheritedAttrs,
           ...buttonProps,
-          key: icon.value,
           icon: icon.value,
           iconClass: cn(
             inheritedAttrs.iconClass,
@@ -90,7 +95,7 @@ export default defineComponent({
             void copyText()
           }
         },
-        slots
+        fallbackSlots
       )
     }
   }

--- a/src/renderer/src/features/chat-page/composables/useComposerSubmit.ts
+++ b/src/renderer/src/features/chat-page/composables/useComposerSubmit.ts
@@ -212,10 +212,30 @@ export function useComposerSubmit(options: UseComposerSubmitOptions) {
   let pendingHandleRestoreSessionId: string | null = null
   let searchCapabilityRequestId = 0
 
-  const initialDraft = createEmptyComposerDraft()
+  const storedInitialDraft = loadComposerDraftFromStorage(activeDraftSessionId)
+  const initialDraft = storedInitialDraft ?? createEmptyComposerDraft()
+  if (storedInitialDraft) {
+    sessionDrafts.set(activeDraftSessionId, copyComposerDraft(storedInitialDraft))
+  }
   draftRevisions.set(activeDraftSessionId, initialDraft.revision)
   observedDraftFingerprints.set(activeDraftSessionId, composerDraftFingerprint(initialDraft))
-  observedSkillSelections.set(activeDraftSessionId, [])
+  observedSkillSelections.set(activeDraftSessionId, [...initialDraft.activeSkills])
+  if (storedInitialDraft) {
+    message.value = storedInitialDraft.rawMessage
+    attachedFiles.value = copyComposerFiles(storedInitialDraft.files)
+    if (chatInputRef.value) {
+      if (storedInitialDraft.activeSkills.length === 0) {
+        chatInputRef.value.clearPendingSkills?.()
+      } else {
+        chatInputRef.value.setPendingSkills?.([...storedInitialDraft.activeSkills])
+      }
+      chatInputRef.value.restoreDocumentSnapshot?.(
+        copyComposerDocument(storedInitialDraft.document)
+      )
+    } else {
+      pendingHandleRestoreSessionId = activeDraftSessionId
+    }
+  }
 
   const attachmentPreparationSummary = computed(
     () => blockedComposerAttempts.get(options.sessionId())?.summary ?? null

--- a/src/renderer/src/features/chat-page/model/composerDraftPersistence.ts
+++ b/src/renderer/src/features/chat-page/model/composerDraftPersistence.ts
@@ -86,6 +86,32 @@ function isMessageFile(value: unknown): value is MessageFile {
   )
 }
 
+function toPersistableFile(file: MessageFile): MessageFile {
+  return {
+    name: file.name,
+    path: file.path,
+    ...(file.type !== undefined ? { type: file.type } : {}),
+    ...(file.size !== undefined ? { size: file.size } : {}),
+    ...(file.mimeType !== undefined ? { mimeType: file.mimeType } : {}),
+    ...(file.token !== undefined ? { token: file.token } : {}),
+    ...(file.requestedRepresentation !== undefined
+      ? { requestedRepresentation: file.requestedRepresentation }
+      : {}),
+    ...(file.pdfTextCoverage !== undefined ? { pdfTextCoverage: file.pdfTextCoverage } : {}),
+    ...(file.metadata !== undefined ? { metadata: file.metadata } : {})
+  }
+}
+
+function toPersistableDraft(draft: ComposerSessionDraft): ComposerSessionDraft {
+  return {
+    revision: draft.revision,
+    rawMessage: draft.rawMessage,
+    files: draft.files.map(toPersistableFile),
+    activeSkills: [...draft.activeSkills],
+    document: draft.document
+  }
+}
+
 function parseComposerDraft(value: unknown): ComposerSessionDraft | null {
   if (
     !isRecord(value) ||
@@ -139,7 +165,7 @@ export function saveComposerDraftToStorage(sessionId: string, draft: ComposerSes
       storage.removeItem(storageKey(sessionId))
       return
     }
-    storage.setItem(storageKey(sessionId), JSON.stringify(draft))
+    storage.setItem(storageKey(sessionId), JSON.stringify(toPersistableDraft(draft)))
   } catch {
     // Storage can be unavailable (private mode, quota). Draft persistence is best-effort.
   }

--- a/test/renderer/components/DcCopyButton.test.ts
+++ b/test/renderer/components/DcCopyButton.test.ts
@@ -29,30 +29,50 @@ describe('DcCopyButton', () => {
   })
 
   afterEach(() => {
+    document.body.innerHTML = ''
     vi.useRealTimers()
   })
 
-  it('copies copyText, emits copied, and resets the success state', async () => {
+  it('renders label as visible fallback text', () => {
+    const wrapper = mount(DcCopyButton, {
+      props: {
+        copyText: 'hello'
+      },
+      attrs: {
+        label: 'Copy visible text'
+      }
+    })
+
+    expect(wrapper.text()).toContain('Copy visible text')
+  })
+
+  it('copies copyText, emits copied, preserves focus, and resets the success state', async () => {
     const wrapper = mount(DcCopyButton, {
       props: {
         copyText: 'hello'
       },
       attrs: {
         label: 'Copy'
-      }
+      },
+      attachTo: document.body
     })
 
-    await wrapper.get('button').trigger('click')
+    const button = wrapper.get('button')
+    button.element.focus()
+
+    await button.trigger('click')
 
     await vi.waitFor(() => expect(copyMock).toHaveBeenCalledWith('hello'))
     await vi.waitFor(() => expect(wrapper.emitted('copied')).toHaveLength(1))
     expect(wrapper.find('[data-icon="lucide:check"]').exists()).toBe(true)
     expect(wrapper.get('button').classes()).toContain('text-emerald-600')
+    expect(document.activeElement).toBe(button.element)
 
     await vi.advanceTimersByTimeAsync(1200)
     await nextTick()
 
     expect(wrapper.find('[data-icon="lucide:copy"]').exists()).toBe(true)
+    expect(document.activeElement).toBe(button.element)
   })
 
   it('emits error when clipboard copying fails', async () => {

--- a/test/renderer/features/chat-page/composables/useComposerSubmit.test.ts
+++ b/test/renderer/features/chat-page/composables/useComposerSubmit.test.ts
@@ -2,7 +2,10 @@ import { computed, effectScope, nextTick, ref, shallowReactive } from 'vue'
 import type { JSONContent } from '@tiptap/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useComposerSubmit } from '@/features/chat-page/composables/useComposerSubmit'
-import { saveComposerDraftToStorage } from '@/features/chat-page/model/composerDraftPersistence'
+import {
+  loadComposerDraftFromStorage,
+  saveComposerDraftToStorage
+} from '@/features/chat-page/model/composerDraftPersistence'
 import type {
   AttachmentPreparationSummary,
   ChatMessageRecord,
@@ -1032,6 +1035,27 @@ describe('useComposerSubmit attachment preflight', () => {
       harness.stop()
       vi.useRealTimers()
     }
+  })
+
+  it('restores a persisted draft during initial mount', () => {
+    saveComposerDraftToStorage('s1', {
+      revision: 2,
+      rawMessage: 'draft from previous mount',
+      files: [],
+      activeSkills: [],
+      document: {
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'draft from previous mount' }] }
+        ]
+      }
+    })
+
+    const harness = createHarness()
+
+    expect(harness.actions.message.value).toBe('draft from previous mount')
+    harness.stop()
+    expect(loadComposerDraftFromStorage('s1')?.rawMessage).toBe('draft from previous mount')
   })
 
   it('restores a persisted draft when switching to its session', () => {

--- a/test/renderer/features/chat-page/model/composerDraftPersistence.test.ts
+++ b/test/renderer/features/chat-page/model/composerDraftPersistence.test.ts
@@ -32,6 +32,32 @@ describe('composerDraftPersistence', () => {
     expect(loadComposerDraftFromStorage('s1')).toEqual(draft)
   })
 
+  it('stores only bounded attachment descriptors', () => {
+    saveComposerDraftToStorage('s1', {
+      ...createDraft('with file'),
+      files: [
+        {
+          name: 'image.png',
+          path: '/tmp/image.png',
+          mimeType: 'image/png',
+          content: 'raw-base64-image',
+          thumbnail: 'raw-base64-thumbnail',
+          resolvedRepresentation: { kind: 'image' }
+        }
+      ]
+    })
+
+    const raw = localStorage.getItem('deepchat.composerDraft.v1.s1') ?? ''
+    expect(raw).not.toContain('raw-base64-image')
+    expect(raw).not.toContain('raw-base64-thumbnail')
+    const loaded = loadComposerDraftFromStorage('s1')
+    expect(loaded?.files[0]).toEqual({
+      name: 'image.png',
+      path: '/tmp/image.png',
+      mimeType: 'image/png'
+    })
+  })
+
   it('does not store empty drafts and clears an existing key', () => {
     saveComposerDraftToStorage('s1', createDraft('filled'))
     saveComposerDraftToStorage('s1', createEmptyComposerDraft())


### PR DESCRIPTION
## 概述

#2131 合并时仍有 4 条未处理的 review 评论(另有 1 条已 resolve 但修复代码未随之落地),本 PR 作为 follow-up 逐条处理。

### [P1] 构建时恢复持久化草稿(useComposerSubmit)

`loadComposerDraftFromStorage()` 此前只能经 `switchComposerSession()` 触达,而 `ChatPage.vue` 的 immediate session watcher 在 composable 构建前运行(拿到的是初始 no-op),`ChatTabView` 又按 session ID 重建 `ChatPage`,导致重开会话时草稿从不恢复,且下一次 `dispose()` 可能用空的 live state 覆盖并删除已存草稿。

现在在 composable 构建期间直接从 storage 初始化 message / files / fingerprints;input handle 尚未就绪时经 `pendingHandleRestoreSessionId` 延迟恢复 document 与 skills(`captureDraftForPersistence` / `captureLiveDraft` 在该窗口内也改从恢复的 `sessionDrafts` 取值,不会把空状态 flush 回去)。测试按真实 remount 路径覆盖(不手动调 `switchComposerSession`),并断言 `dispose()` 后 storage 草稿仍在。

### [P1] localStorage 只存有界的附件描述符(composerDraftPersistence)

`ComposerSessionDraft.files` 含完整 `MessageFile`(图片的 base64 `content` + `thumbnail`、文本附件全文),同步写入 localStorage 可能超配额或卡渲染进程,catch 会静默丢弃整个草稿。现持久化前经 `toPersistableFile()` 剥离 `content` / `thumbnail` / `resolvedRepresentation`,只保留 name / path / mimeType 等描述符(`isMessageFile` 校验仍通过)。回归测试断言序列化结果不含 base64 payload。

### [P2] DcCopyButton 恢复 label 可见文字 fallback

重构成 render 函数时丢了原模板的 `<slot>{{ label }}</slot>` 兜底,`CodeArtifact` / `McpJsonViewer` / `McpServers` / `TraceDialog` 这类只传 `label` 的消费方从「图标 + 文字」退化成纯图标。现以 `fallbackSlots` 恢复兜底:无默认插槽时渲染 `label` 文字。

```
BEFORE(回归后,icon-only):      AFTER(恢复文字):
┌────┐                           ┌────────────┐
│ ⧉  │                           │ ⧉ Copy     │
└────┘                           └────────────┘
```

### [P2] 移除组件级 icon key,保持键盘焦点

`key: icon.value` 使 `copied` 切换时整个 DcButton 卸载重建,键盘触发复制后 `<button>` 节点被移除、焦点掉回 `<body>`,tooltip 聚焦态同时丢失。DcButton 内部 `Icon` 自带元素级 `:key="icon"`,zoom 动画不依赖组件级 key;移除后按钮 DOM 全程稳定。测试补了 `document.activeElement` 断言(`attachTo: document.body`,覆盖成功态与 1200ms 回落后)。

### [style] MessageToolbar 补齐 `icon-size="3"`

对应已 resolve 的「Preserve the toolbar's 12 px icon contract」评论,修复当时未随 #2131 落地,一并带上并在 trace 测试中断言。

## 验证

- Vitest(DcCopyButton / MessageToolbar.trace / useComposerSubmit / composerDraftPersistence):54/54 通过
- `format:check` / `oxlint` / `typecheck` / `i18n` 全部通过
- 注:本地 Node 26 需 `NODE_OPTIONS=--no-experimental-webstorage` 才能让 jsdom 提供 `localStorage`(engines 要求 node >=24.18 <25,CI 不受影响)

Relates to #2131.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restored saved message drafts, attachments, skills, and editor content when reopening an active chat.
  * Preserved draft attachment details while reducing unnecessary stored data.
  * Improved copy button labels and retained focus after copying.
* **Improvements**
  * Standardized icon sizing across message toolbar actions.
  * Improved button fallback text when no custom label is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->