### PR TITLE
fix(cli): return only final run answer

### DIFF
--- a/src/main/cli/runService.ts
+++ b/src/main/cli/runService.ts
@@ -108,7 +108,12 @@ function messageText(message: ChatMessageRecord): string {
   if (message.status !== 'sent') return ''
   try {
     const blocks = AssistantMessageBlocksSchema.safeParse(JSON.parse(message.content))
-    return blocks.success ? projectFinalAssistantAnswer(blocks.data as AssistantMessageBlock[]) : ''
+    if (!blocks.success) return ''
+    const validatedBlocks = blocks.data as AssistantMessageBlock[]
+    if (validatedBlocks.some((block) => block.type === 'content' && block.status !== 'success')) {
+      return ''
+    }
+    return projectFinalAssistantAnswer(validatedBlocks)
   } catch {
     return ''
   }

--- a/src/main/cli/runService.ts
+++ b/src/main/cli/runService.ts
@@ -19,6 +19,7 @@ import {
   type RunDetachedInput,
   type RunGetInput
 } from '@shared/contracts/routes'
+import { AssistantMessageBlockSchema } from '@shared/contracts/common'
 import {
   runsCancelRequestedEvent,
   runsCreatedEvent,
@@ -27,7 +28,7 @@ import {
   runsTurnFailedEvent
 } from '@shared/contracts/events'
 import { extractUserMessageInput } from '@/session/data/userMessageContent'
-import { buildAssistantResponseMarkdown } from '@/agent/deepchat/runtime/sessionUpdates'
+import { projectFinalAssistantAnswer } from '@shared/lib/assistantDeliverySegments'
 import type { AssistantMessageBlock } from '@shared/types/agent-interface'
 import {
   createRouteMap,
@@ -43,6 +44,7 @@ import type { CliStreamEmitter } from './server'
 const DEFAULT_MESSAGE_LIMIT = 50
 const RUN_SNAPSHOT_MESSAGE_BUDGET_BYTES = 8 * 1024 * 1024
 const RUN_START_FAILURE_MESSAGE = 'Detached Agent run could not start'
+const AssistantMessageBlocksSchema = AssistantMessageBlockSchema.array()
 
 type RunLifecyclePort = Readonly<{
   createDetachedSession(input: CreateDetachedSessionInput): Promise<SessionWithState>
@@ -103,11 +105,12 @@ function truncateUtf8(value: string, maxBytes: number): { value: string; truncat
 
 function messageText(message: ChatMessageRecord): string {
   if (message.role === 'user') return extractUserMessageInput(message.content).text
+  if (message.status !== 'sent') return ''
   try {
-    const blocks = JSON.parse(message.content) as AssistantMessageBlock[]
-    return Array.isArray(blocks) ? buildAssistantResponseMarkdown(blocks) : message.content
+    const blocks = AssistantMessageBlocksSchema.safeParse(JSON.parse(message.content))
+    return blocks.success ? projectFinalAssistantAnswer(blocks.data as AssistantMessageBlock[]) : ''
   } catch {
-    return message.content
+    return ''
   }
 }
 

--- a/test/main/cli/runService.test.ts
+++ b/test/main/cli/runService.test.ts
@@ -246,7 +246,9 @@ describe('CliRunService', () => {
           id: 'message-2',
           orderSeq: 2,
           role: 'assistant',
-          content: JSON.stringify([{ type: 'content', content: oversized }])
+          content: JSON.stringify([
+            { type: 'content', status: 'success', timestamp: 1, content: oversized }
+          ])
         })
       ]
     })
@@ -261,6 +263,168 @@ describe('CliRunService', () => {
       RUN_MESSAGE_MAX_TEXT_BYTES
     )
     expect(JSON.stringify(result)).not.toContain('private-provider-detail')
+  })
+
+  it('returns only the final assistant answer without exposing process blocks', async () => {
+    const { service } = createHarness({
+      messages: [
+        createMessage({
+          role: 'assistant',
+          content: JSON.stringify([
+            {
+              type: 'reasoning_content',
+              status: 'success',
+              timestamp: 1,
+              content: 'private reasoning'
+            },
+            {
+              type: 'content',
+              status: 'success',
+              timestamp: 2,
+              content: 'I will inspect the file first.'
+            },
+            {
+              type: 'tool_call',
+              status: 'success',
+              timestamp: 3,
+              tool_call: {
+                id: 'tool-1',
+                name: 'read_file',
+                params: '{"path":"/private/input.txt"}',
+                response: 'private tool response'
+              },
+              extra: { toolCallArgsComplete: true }
+            },
+            {
+              type: 'tool_call',
+              status: 'error',
+              timestamp: 4,
+              tool_call: {
+                id: 'tool-2',
+                name: 'exec',
+                params: '{"command":"inspect"}',
+                response: 'private tool error'
+              },
+              extra: { toolCallArgsComplete: true }
+            },
+            {
+              type: 'action',
+              action_type: 'tool_call_permission',
+              status: 'denied',
+              timestamp: 5,
+              content: 'private permission copy'
+            },
+            {
+              type: 'error',
+              status: 'error',
+              timestamp: 6,
+              content: 'private internal error'
+            },
+            {
+              type: 'content',
+              status: 'success',
+              timestamp: 7,
+              content: 'Final answer'
+            }
+          ])
+        })
+      ]
+    })
+
+    const result = runsGetRoute.output.parse(
+      await invokeRoute(service, runsGetRoute.name, { runId: 'run-1' })
+    )
+
+    expect(result.messages[0]).toMatchObject({
+      role: 'assistant',
+      text: 'Final answer',
+      textTruncated: false
+    })
+    expect(JSON.stringify(result)).not.toContain('private')
+  })
+
+  it('keeps pending and failed assistant text empty while preserving statuses', async () => {
+    const failedSession = { ...baseSession, status: 'error' as const }
+    const { service } = createHarness({
+      session: failedSession,
+      messages: [
+        createMessage({
+          role: 'assistant',
+          status: 'pending',
+          content: JSON.stringify([
+            {
+              type: 'content',
+              status: 'pending',
+              timestamp: 1,
+              content: 'private partial answer'
+            },
+            {
+              type: 'action',
+              action_type: 'question_request',
+              status: 'pending',
+              timestamp: 2,
+              content: 'private pending question'
+            }
+          ])
+        }),
+        createMessage({
+          id: 'message-2',
+          orderSeq: 2,
+          role: 'assistant',
+          status: 'error',
+          content: JSON.stringify([
+            {
+              type: 'content',
+              status: 'success',
+              timestamp: 1,
+              content: 'private partial answer'
+            },
+            {
+              type: 'error',
+              status: 'error',
+              timestamp: 2,
+              content: 'private failure detail'
+            }
+          ])
+        })
+      ]
+    })
+
+    const result = runsGetRoute.output.parse(
+      await invokeRoute(service, runsGetRoute.name, { runId: 'run-1' })
+    )
+
+    expect(result.status).toBe('error')
+    expect(result.messages).toEqual([
+      expect.objectContaining({ role: 'assistant', status: 'pending', text: '' }),
+      expect.objectContaining({ role: 'assistant', status: 'error', text: '' })
+    ])
+  })
+
+  it('fails closed for malformed sent assistant payloads', async () => {
+    const { service } = createHarness({
+      messages: [
+        createMessage({
+          role: 'assistant',
+          content: JSON.stringify([{ type: 'content', content: 'private malformed block content' }])
+        }),
+        createMessage({
+          id: 'message-2',
+          orderSeq: 2,
+          role: 'assistant',
+          content: JSON.stringify({ content: 'private non-array content' })
+        })
+      ]
+    })
+
+    const result = runsGetRoute.output.parse(
+      await invokeRoute(service, runsGetRoute.name, { runId: 'run-1' })
+    )
+
+    expect(result.messages).toEqual([
+      expect.objectContaining({ role: 'assistant', status: 'sent', text: '' }),
+      expect.objectContaining({ role: 'assistant', status: 'sent', text: '' })
+    ])
   })
 
   it('enforces the public message limit in UTF-8 bytes', () => {
@@ -294,7 +458,12 @@ describe('CliRunService', () => {
         orderSeq: index + 1,
         role: 'assistant',
         content: JSON.stringify([
-          { type: 'content', content: '\0'.repeat(RUN_MESSAGE_MAX_TEXT_BYTES) }
+          {
+            type: 'content',
+            status: 'success',
+            timestamp: index + 1,
+            content: '\0'.repeat(RUN_MESSAGE_MAX_TEXT_BYTES)
+          }
         ])
       })
     )

--- a/test/main/cli/runService.test.ts
+++ b/test/main/cli/runService.test.ts
@@ -343,7 +343,7 @@ describe('CliRunService', () => {
     expect(JSON.stringify(result)).not.toContain('private')
   })
 
-  it('keeps pending and failed assistant text empty while preserving statuses', async () => {
+  it('keeps non-final assistant text empty while preserving statuses', async () => {
     const failedSession = { ...baseSession, status: 'error' as const }
     const { service } = createHarness({
       session: failedSession,
@@ -386,6 +386,32 @@ describe('CliRunService', () => {
               content: 'private failure detail'
             }
           ])
+        }),
+        createMessage({
+          id: 'message-3',
+          orderSeq: 3,
+          role: 'assistant',
+          content: JSON.stringify([
+            {
+              type: 'content',
+              status: 'pending',
+              timestamp: 1,
+              content: 'private pending content in sent message'
+            }
+          ])
+        }),
+        createMessage({
+          id: 'message-4',
+          orderSeq: 4,
+          role: 'assistant',
+          content: JSON.stringify([
+            {
+              type: 'content',
+              status: 'error',
+              timestamp: 1,
+              content: 'private errored content in sent message'
+            }
+          ])
         })
       ]
     })
@@ -397,7 +423,9 @@ describe('CliRunService', () => {
     expect(result.status).toBe('error')
     expect(result.messages).toEqual([
       expect.objectContaining({ role: 'assistant', status: 'pending', text: '' }),
-      expect.objectContaining({ role: 'assistant', status: 'error', text: '' })
+      expect.objectContaining({ role: 'assistant', status: 'error', text: '' }),
+      expect.objectContaining({ role: 'assistant', status: 'sent', text: '' }),
+      expect.objectContaining({ role: 'assistant', status: 'sent', text: '' })
     ])
   })
 
@@ -413,6 +441,12 @@ describe('CliRunService', () => {
           orderSeq: 2,
           role: 'assistant',
           content: JSON.stringify({ content: 'private non-array content' })
+        }),
+        createMessage({
+          id: 'message-3',
+          orderSeq: 3,
+          role: 'assistant',
+          content: '{'
         })
       ]
     })
@@ -422,6 +456,7 @@ describe('CliRunService', () => {
     )
 
     expect(result.messages).toEqual([
+      expect.objectContaining({ role: 'assistant', status: 'sent', text: '' }),
       expect.objectContaining({ role: 'assistant', status: 'sent', text: '' }),
       expect.objectContaining({ role: 'assistant', status: 'sent', text: '' })
     ])


### PR DESCRIPTION
## Summary

- Return only the final assistant answer in public `runs.get` message text.
- Exclude reasoning, tool responses, action text, and internal errors from the public answer.
- Fail closed with empty text for pending, failed, malformed, or non-block assistant messages.
- Preserve structured run/message statuses, UTF-8 truncation, renderer previews, and persisted blocks.

## Root Cause

The detached run projection reused `buildAssistantResponseMarkdown()`, which is intended for renderer and debug previews and therefore concatenates text from every assistant block type.

Public run results now use the existing answer-oriented `projectFinalAssistantAnswer()` projection instead.

## Validation

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run i18n`
- `pnpm run typecheck`
- `pnpm exec vitest run --config vitest.config.ts test/main/cli/runService.test.ts`

All 18 focused tests pass.

Closes #2114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated CLI responses to display only the assistant’s final answer.
  - Internal reasoning, tool activity, action details, errors, and private content are no longer exposed.
  - Pending or failed responses now remain blank instead of showing incomplete content.
  - Malformed or unreadable assistant messages fail safely with empty output rather than displaying raw or formatted content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->