### PR TITLE
fix(cli): make model outputs JSON-safe

### DIFF
--- a/src/main/cli/providerModelAdminRoutes.ts
+++ b/src/main/cli/providerModelAdminRoutes.ts
@@ -11,7 +11,7 @@ import {
   type PublicProviderSummary,
   type SettingsActivityInput
 } from '@shared/contracts/routes'
-import type { LLM_PROVIDER } from '@shared/types/provider'
+import type { LLM_PROVIDER, ModelConfig } from '@shared/types/provider'
 import type { ProviderRuntime } from '@/provider'
 import type { ProviderQueryScheduler } from '@/provider/providerService'
 import type { ProviderSettingsPort } from '@/provider/settings'
@@ -71,6 +71,129 @@ export function toPublicProviderSummary(provider: LLM_PROVIDER): PublicProviderS
     enabled: provider.enable,
     custom: provider.custom === true,
     storedCredentialConfigured: hasStoredCredential(provider)
+  })
+}
+
+function toPublicModelConfig(config: ModelConfig) {
+  const imageGeneration =
+    config.imageGeneration === undefined
+      ? undefined
+      : {
+          ...(config.imageGeneration.size !== undefined
+            ? { size: config.imageGeneration.size }
+            : {}),
+          ...(config.imageGeneration.quality !== undefined
+            ? { quality: config.imageGeneration.quality }
+            : {}),
+          ...(config.imageGeneration.outputFormat !== undefined
+            ? { outputFormat: config.imageGeneration.outputFormat }
+            : {}),
+          ...(config.imageGeneration.outputCompression !== undefined
+            ? { outputCompression: config.imageGeneration.outputCompression }
+            : {}),
+          ...(config.imageGeneration.background !== undefined
+            ? { background: config.imageGeneration.background }
+            : {}),
+          ...(config.imageGeneration.moderation !== undefined
+            ? { moderation: config.imageGeneration.moderation }
+            : {})
+        }
+  const videoGeneration =
+    config.videoGeneration === undefined
+      ? undefined
+      : {
+          ...(config.videoGeneration.seconds !== undefined
+            ? { seconds: config.videoGeneration.seconds }
+            : {}),
+          ...(config.videoGeneration.size !== undefined
+            ? { size: config.videoGeneration.size }
+            : {}),
+          ...(config.videoGeneration.ratio !== undefined
+            ? { ratio: config.videoGeneration.ratio }
+            : {}),
+          ...(config.videoGeneration.duration !== undefined
+            ? { duration: config.videoGeneration.duration }
+            : {}),
+          ...(config.videoGeneration.resolution !== undefined
+            ? { resolution: config.videoGeneration.resolution }
+            : {}),
+          ...(config.videoGeneration.watermark !== undefined
+            ? { watermark: config.videoGeneration.watermark }
+            : {}),
+          ...(config.videoGeneration.generateAudio !== undefined
+            ? { generateAudio: config.videoGeneration.generateAudio }
+            : {}),
+          ...(config.videoGeneration.inputReference !== undefined
+            ? {
+                inputReference:
+                  typeof config.videoGeneration.inputReference === 'string'
+                    ? config.videoGeneration.inputReference
+                    : {
+                        data: config.videoGeneration.inputReference.data,
+                        ...(config.videoGeneration.inputReference.mimeType !== undefined
+                          ? { mimeType: config.videoGeneration.inputReference.mimeType }
+                          : {})
+                      }
+              }
+            : {}),
+          ...(config.videoGeneration.references !== undefined
+            ? {
+                references: config.videoGeneration.references.map((reference) => ({
+                  type: reference.type,
+                  ...(reference.url !== undefined ? { url: reference.url } : {}),
+                  ...(reference.data !== undefined ? { data: reference.data } : {}),
+                  ...(reference.mimeType !== undefined ? { mimeType: reference.mimeType } : {})
+                }))
+              }
+            : {})
+        }
+  const tts =
+    config.tts === undefined
+      ? undefined
+      : {
+          ...(config.tts.voice !== undefined ? { voice: config.tts.voice } : {}),
+          ...(config.tts.responseFormat !== undefined
+            ? { responseFormat: config.tts.responseFormat }
+            : {}),
+          ...(config.tts.speed !== undefined ? { speed: config.tts.speed } : {}),
+          ...(config.tts.instructions !== undefined
+            ? { instructions: config.tts.instructions }
+            : {})
+        }
+
+  return PublicModelConfigSchema.parse({
+    maxTokens: config.maxTokens,
+    contextLength: config.contextLength,
+    vision: config.vision,
+    functionCall: config.functionCall,
+    reasoning: config.reasoning,
+    type: config.type,
+    ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
+    ...(config.topP !== undefined ? { topP: config.topP } : {}),
+    ...(config.speechRecognition !== undefined
+      ? { speechRecognition: config.speechRecognition }
+      : {}),
+    ...(config.isUserDefined !== undefined ? { isUserDefined: config.isUserDefined } : {}),
+    ...(config.thinkingBudget !== undefined ? { thinkingBudget: config.thinkingBudget } : {}),
+    ...(config.forceInterleavedThinkingCompat !== undefined
+      ? { forceInterleavedThinkingCompat: config.forceInterleavedThinkingCompat }
+      : {}),
+    ...(config.reasoningEffort !== undefined ? { reasoningEffort: config.reasoningEffort } : {}),
+    ...(config.reasoningVisibility !== undefined
+      ? { reasoningVisibility: config.reasoningVisibility }
+      : {}),
+    ...(config.verbosity !== undefined ? { verbosity: config.verbosity } : {}),
+    ...(config.maxCompletionTokens !== undefined
+      ? { maxCompletionTokens: config.maxCompletionTokens }
+      : {}),
+    ...(config.apiEndpoint !== undefined ? { apiEndpoint: config.apiEndpoint } : {}),
+    ...(config.endpointType !== undefined ? { endpointType: config.endpointType } : {}),
+    ...(config.enableSearch !== undefined ? { enableSearch: config.enableSearch } : {}),
+    ...(config.forcedSearch !== undefined ? { forcedSearch: config.forcedSearch } : {}),
+    ...(config.searchStrategy !== undefined ? { searchStrategy: config.searchStrategy } : {}),
+    ...(imageGeneration !== undefined ? { imageGeneration } : {}),
+    ...(videoGeneration !== undefined ? { videoGeneration } : {}),
+    ...(tts !== undefined ? { tts } : {})
   })
 }
 
@@ -258,7 +381,7 @@ export function createCliProviderModelAdminRoutes(
         const input = modelsGetPublicConfigRoute.input.parse(rawInput)
         requireModel(input.providerId, input.modelId)
         return modelsGetPublicConfigRoute.output.parse({
-          config: PublicModelConfigSchema.parse(
+          config: toPublicModelConfig(
             dependencies.providerSettings.getModelConfig(input.modelId, input.providerId)
           )
         })
@@ -277,7 +400,7 @@ export function createCliProviderModelAdminRoutes(
             input.config
           )
         )
-        const config = PublicModelConfigSchema.parse(
+        const config = toPublicModelConfig(
           dependencies.providerSettings.getModelConfig(input.modelId, input.providerId)
         )
         return modelsSetPublicConfigRoute.output.parse({ config })

--- a/src/main/cli/providerModelAdminRoutes.ts
+++ b/src/main/cli/providerModelAdminRoutes.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto'
 import {
-  PublicModelConfigSchema,
   PublicProviderSummarySchema,
   modelsGetPublicConfigRoute,
   modelsSetPublicConfigRoute,
@@ -11,11 +10,16 @@ import {
   type PublicProviderSummary,
   type SettingsActivityInput
 } from '@shared/contracts/routes'
-import type { LLM_PROVIDER, ModelConfig } from '@shared/types/provider'
+import type { LLM_PROVIDER } from '@shared/types/provider'
 import type { ProviderRuntime } from '@/provider'
 import type { ProviderQueryScheduler } from '@/provider/providerService'
 import type { ProviderSettingsPort } from '@/provider/settings'
-import { createRouteMap, type DeepchatRouteMap, type RouteCaller } from '@/routes/routeRegistry'
+import {
+  createRouteMap,
+  projectJsonRouteOutput,
+  type DeepchatRouteMap,
+  type RouteCaller
+} from '@/routes/routeRegistry'
 import { CliRequestError } from './errors'
 
 type PublicProviderSettings = Pick<
@@ -71,129 +75,6 @@ export function toPublicProviderSummary(provider: LLM_PROVIDER): PublicProviderS
     enabled: provider.enable,
     custom: provider.custom === true,
     storedCredentialConfigured: hasStoredCredential(provider)
-  })
-}
-
-function toPublicModelConfig(config: ModelConfig) {
-  const imageGeneration =
-    config.imageGeneration === undefined
-      ? undefined
-      : {
-          ...(config.imageGeneration.size !== undefined
-            ? { size: config.imageGeneration.size }
-            : {}),
-          ...(config.imageGeneration.quality !== undefined
-            ? { quality: config.imageGeneration.quality }
-            : {}),
-          ...(config.imageGeneration.outputFormat !== undefined
-            ? { outputFormat: config.imageGeneration.outputFormat }
-            : {}),
-          ...(config.imageGeneration.outputCompression !== undefined
-            ? { outputCompression: config.imageGeneration.outputCompression }
-            : {}),
-          ...(config.imageGeneration.background !== undefined
-            ? { background: config.imageGeneration.background }
-            : {}),
-          ...(config.imageGeneration.moderation !== undefined
-            ? { moderation: config.imageGeneration.moderation }
-            : {})
-        }
-  const videoGeneration =
-    config.videoGeneration === undefined
-      ? undefined
-      : {
-          ...(config.videoGeneration.seconds !== undefined
-            ? { seconds: config.videoGeneration.seconds }
-            : {}),
-          ...(config.videoGeneration.size !== undefined
-            ? { size: config.videoGeneration.size }
-            : {}),
-          ...(config.videoGeneration.ratio !== undefined
-            ? { ratio: config.videoGeneration.ratio }
-            : {}),
-          ...(config.videoGeneration.duration !== undefined
-            ? { duration: config.videoGeneration.duration }
-            : {}),
-          ...(config.videoGeneration.resolution !== undefined
-            ? { resolution: config.videoGeneration.resolution }
-            : {}),
-          ...(config.videoGeneration.watermark !== undefined
-            ? { watermark: config.videoGeneration.watermark }
-            : {}),
-          ...(config.videoGeneration.generateAudio !== undefined
-            ? { generateAudio: config.videoGeneration.generateAudio }
-            : {}),
-          ...(config.videoGeneration.inputReference !== undefined
-            ? {
-                inputReference:
-                  typeof config.videoGeneration.inputReference === 'string'
-                    ? config.videoGeneration.inputReference
-                    : {
-                        data: config.videoGeneration.inputReference.data,
-                        ...(config.videoGeneration.inputReference.mimeType !== undefined
-                          ? { mimeType: config.videoGeneration.inputReference.mimeType }
-                          : {})
-                      }
-              }
-            : {}),
-          ...(config.videoGeneration.references !== undefined
-            ? {
-                references: config.videoGeneration.references.map((reference) => ({
-                  type: reference.type,
-                  ...(reference.url !== undefined ? { url: reference.url } : {}),
-                  ...(reference.data !== undefined ? { data: reference.data } : {}),
-                  ...(reference.mimeType !== undefined ? { mimeType: reference.mimeType } : {})
-                }))
-              }
-            : {})
-        }
-  const tts =
-    config.tts === undefined
-      ? undefined
-      : {
-          ...(config.tts.voice !== undefined ? { voice: config.tts.voice } : {}),
-          ...(config.tts.responseFormat !== undefined
-            ? { responseFormat: config.tts.responseFormat }
-            : {}),
-          ...(config.tts.speed !== undefined ? { speed: config.tts.speed } : {}),
-          ...(config.tts.instructions !== undefined
-            ? { instructions: config.tts.instructions }
-            : {})
-        }
-
-  return PublicModelConfigSchema.parse({
-    maxTokens: config.maxTokens,
-    contextLength: config.contextLength,
-    vision: config.vision,
-    functionCall: config.functionCall,
-    reasoning: config.reasoning,
-    type: config.type,
-    ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
-    ...(config.topP !== undefined ? { topP: config.topP } : {}),
-    ...(config.speechRecognition !== undefined
-      ? { speechRecognition: config.speechRecognition }
-      : {}),
-    ...(config.isUserDefined !== undefined ? { isUserDefined: config.isUserDefined } : {}),
-    ...(config.thinkingBudget !== undefined ? { thinkingBudget: config.thinkingBudget } : {}),
-    ...(config.forceInterleavedThinkingCompat !== undefined
-      ? { forceInterleavedThinkingCompat: config.forceInterleavedThinkingCompat }
-      : {}),
-    ...(config.reasoningEffort !== undefined ? { reasoningEffort: config.reasoningEffort } : {}),
-    ...(config.reasoningVisibility !== undefined
-      ? { reasoningVisibility: config.reasoningVisibility }
-      : {}),
-    ...(config.verbosity !== undefined ? { verbosity: config.verbosity } : {}),
-    ...(config.maxCompletionTokens !== undefined
-      ? { maxCompletionTokens: config.maxCompletionTokens }
-      : {}),
-    ...(config.apiEndpoint !== undefined ? { apiEndpoint: config.apiEndpoint } : {}),
-    ...(config.endpointType !== undefined ? { endpointType: config.endpointType } : {}),
-    ...(config.enableSearch !== undefined ? { enableSearch: config.enableSearch } : {}),
-    ...(config.forcedSearch !== undefined ? { forcedSearch: config.forcedSearch } : {}),
-    ...(config.searchStrategy !== undefined ? { searchStrategy: config.searchStrategy } : {}),
-    ...(imageGeneration !== undefined ? { imageGeneration } : {}),
-    ...(videoGeneration !== undefined ? { videoGeneration } : {}),
-    ...(tts !== undefined ? { tts } : {})
   })
 }
 
@@ -380,10 +261,8 @@ export function createCliProviderModelAdminRoutes(
         requireCliCaller(context.caller)
         const input = modelsGetPublicConfigRoute.input.parse(rawInput)
         requireModel(input.providerId, input.modelId)
-        return modelsGetPublicConfigRoute.output.parse({
-          config: toPublicModelConfig(
-            dependencies.providerSettings.getModelConfig(input.modelId, input.providerId)
-          )
+        return projectJsonRouteOutput(modelsGetPublicConfigRoute.output, {
+          config: dependencies.providerSettings.getModelConfig(input.modelId, input.providerId)
         })
       }
     ],
@@ -400,10 +279,9 @@ export function createCliProviderModelAdminRoutes(
             input.config
           )
         )
-        const config = toPublicModelConfig(
-          dependencies.providerSettings.getModelConfig(input.modelId, input.providerId)
-        )
-        return modelsSetPublicConfigRoute.output.parse({ config })
+        return projectJsonRouteOutput(modelsSetPublicConfigRoute.output, {
+          config: dependencies.providerSettings.getModelConfig(input.modelId, input.providerId)
+        })
       }
     ]
   ])

--- a/src/main/cli/server.ts
+++ b/src/main/cli/server.ts
@@ -873,17 +873,25 @@ export class CliServer {
     rawOutput: unknown,
     routeMethod: string
   ): JsonValue {
-    const parsedOutput = entry.contract.output.safeParse(rawOutput)
-    const parsedResult = parsedOutput.success
-      ? JsonValueSchema.safeParse(parsedOutput.data)
-      : { success: false as const }
-    if (!parsedOutput.success || !parsedResult.success) {
-      this.log.error('[CLI] Route returned invalid output', { method: routeMethod })
+    const fail = (stage: 'route' | 'json', error: z.ZodError): never => {
+      this.log.error('[CLI] Route returned invalid output', {
+        method: routeMethod,
+        stage,
+        issueCount: error.issues.length,
+        issueCodes: Array.from(new Set(error.issues.slice(0, 16).map((issue) => issue.code)))
+      })
       throw new CliRequestError('internal_error', 'Route returned an invalid result', {
         httpStatus: 500
       })
     }
-    return parsedResult.data as JsonValue
+
+    const parsedOutput = entry.contract.output.safeParse(rawOutput)
+    if (!parsedOutput.success) return fail('route', parsedOutput.error)
+
+    const parsedResult = JsonValueSchema.safeParse(parsedOutput.data)
+    if (!parsedResult.success) return fail('json', parsedResult.error)
+
+    return parsedResult.data
   }
 
   private async dispatchStreamResponse(

--- a/src/main/provider/routes.ts
+++ b/src/main/provider/routes.ts
@@ -1,6 +1,7 @@
 import type { ProviderSettingsPort } from '@/provider/settings'
 import type { OAuthServicePort } from '@shared/types/oauth'
 import type { AcpProviderAdminPort } from '@/provider/ports'
+import type { MODEL_META } from '@shared/types/provider'
 import {
   configGetAwsBedrockCredentialRoute,
   configGetAzureApiVersionRoute,
@@ -73,6 +74,33 @@ import type { ProviderImportService } from './providerImportService'
 import { ProviderService, type ProviderQueryScheduler } from './providerService'
 import type { ProviderRuntime } from '.'
 import { CliRequestError } from '@/cli/errors'
+
+function toRuntimeModelDto(model: MODEL_META): MODEL_META {
+  return {
+    id: model.id,
+    name: model.name,
+    group: model.group,
+    providerId: model.providerId,
+    ...(model.enabled !== undefined ? { enabled: model.enabled } : {}),
+    ...(model.isCustom !== undefined ? { isCustom: model.isCustom } : {}),
+    ...(model.vision !== undefined ? { vision: model.vision } : {}),
+    ...(model.functionCall !== undefined ? { functionCall: model.functionCall } : {}),
+    ...(model.reasoning !== undefined ? { reasoning: model.reasoning } : {}),
+    ...(model.enableSearch !== undefined ? { enableSearch: model.enableSearch } : {}),
+    ...(model.type !== undefined ? { type: model.type } : {}),
+    ...(model.contextLength !== undefined ? { contextLength: model.contextLength } : {}),
+    ...(model.maxTokens !== undefined ? { maxTokens: model.maxTokens } : {}),
+    ...(model.description !== undefined ? { description: model.description } : {}),
+    ...(model.supportedEndpointTypes !== undefined
+      ? { supportedEndpointTypes: model.supportedEndpointTypes }
+      : {}),
+    ...(model.selectableEndpointTypes !== undefined
+      ? { selectableEndpointTypes: model.selectableEndpointTypes }
+      : {}),
+    ...(model.endpointType !== undefined ? { endpointType: model.endpointType } : {}),
+    ...(model.ownedBy !== undefined ? { ownedBy: model.ownedBy } : {})
+  }
+}
 
 export function createProviderRoutes(deps: {
   providerSettings: ProviderSettingsPort
@@ -520,7 +548,7 @@ export function createProviderRoutes(deps: {
       async (rawInput) => {
         const input = modelsListRuntimeRoute.input.parse(rawInput)
         return modelsListRuntimeRoute.output.parse({
-          models: await providerRuntime.getModelList(input.providerId)
+          models: (await providerRuntime.getModelList(input.providerId)).map(toRuntimeModelDto)
         })
       }
     ],

--- a/src/main/provider/routes.ts
+++ b/src/main/provider/routes.ts
@@ -1,7 +1,6 @@
 import type { ProviderSettingsPort } from '@/provider/settings'
 import type { OAuthServicePort } from '@shared/types/oauth'
 import type { AcpProviderAdminPort } from '@/provider/ports'
-import type { MODEL_META } from '@shared/types/provider'
 import {
   configGetAwsBedrockCredentialRoute,
   configGetAzureApiVersionRoute,
@@ -67,6 +66,7 @@ import {
 } from '@shared/contracts/routes'
 import {
   createRouteMap,
+  projectJsonRouteOutput,
   requireRendererCaller,
   type DeepchatRouteMap
 } from '@/routes/routeRegistry'
@@ -74,33 +74,6 @@ import type { ProviderImportService } from './providerImportService'
 import { ProviderService, type ProviderQueryScheduler } from './providerService'
 import type { ProviderRuntime } from '.'
 import { CliRequestError } from '@/cli/errors'
-
-function toRuntimeModelDto(model: MODEL_META): MODEL_META {
-  return {
-    id: model.id,
-    name: model.name,
-    group: model.group,
-    providerId: model.providerId,
-    ...(model.enabled !== undefined ? { enabled: model.enabled } : {}),
-    ...(model.isCustom !== undefined ? { isCustom: model.isCustom } : {}),
-    ...(model.vision !== undefined ? { vision: model.vision } : {}),
-    ...(model.functionCall !== undefined ? { functionCall: model.functionCall } : {}),
-    ...(model.reasoning !== undefined ? { reasoning: model.reasoning } : {}),
-    ...(model.enableSearch !== undefined ? { enableSearch: model.enableSearch } : {}),
-    ...(model.type !== undefined ? { type: model.type } : {}),
-    ...(model.contextLength !== undefined ? { contextLength: model.contextLength } : {}),
-    ...(model.maxTokens !== undefined ? { maxTokens: model.maxTokens } : {}),
-    ...(model.description !== undefined ? { description: model.description } : {}),
-    ...(model.supportedEndpointTypes !== undefined
-      ? { supportedEndpointTypes: model.supportedEndpointTypes }
-      : {}),
-    ...(model.selectableEndpointTypes !== undefined
-      ? { selectableEndpointTypes: model.selectableEndpointTypes }
-      : {}),
-    ...(model.endpointType !== undefined ? { endpointType: model.endpointType } : {}),
-    ...(model.ownedBy !== undefined ? { ownedBy: model.ownedBy } : {})
-  }
-}
 
 export function createProviderRoutes(deps: {
   providerSettings: ProviderSettingsPort
@@ -547,8 +520,8 @@ export function createProviderRoutes(deps: {
       modelsListRuntimeRoute.name,
       async (rawInput) => {
         const input = modelsListRuntimeRoute.input.parse(rawInput)
-        return modelsListRuntimeRoute.output.parse({
-          models: (await providerRuntime.getModelList(input.providerId)).map(toRuntimeModelDto)
+        return projectJsonRouteOutput(modelsListRuntimeRoute.output, {
+          models: await providerRuntime.getModelList(input.providerId)
         })
       }
     ],

--- a/src/main/routes/routeRegistry.ts
+++ b/src/main/routes/routeRegistry.ts
@@ -1,5 +1,6 @@
 import type { DeepchatRouteName } from '@shared/contracts/routes'
 import type { LocalControlScope } from '@shared/contracts/localControl'
+import type { z } from 'zod'
 
 export type RendererRouteCaller = Readonly<{
   kind: 'renderer'
@@ -67,6 +68,19 @@ export function requireRendererCaller(context: RouteContext): RendererRouteCalle
 export type DeepchatRouteHandler = (rawInput: unknown, context: RouteContext) => Promise<unknown>
 
 export type DeepchatRouteMap = ReadonlyMap<DeepchatRouteName, DeepchatRouteHandler>
+
+export function projectJsonRouteOutput<OutputSchema extends z.ZodType>(
+  outputSchema: OutputSchema,
+  rawOutput: unknown
+): z.output<OutputSchema> {
+  // Project through the public contract before serialization can observe unknown/private fields.
+  const publicOutput = outputSchema.parse(rawOutput)
+  const serializedOutput = JSON.stringify(publicOutput)
+  if (serializedOutput === undefined) {
+    throw new TypeError('Route output cannot be represented as JSON')
+  }
+  return outputSchema.parse(JSON.parse(serializedOutput))
+}
 
 export function createRouteMap(
   entries: ReadonlyArray<readonly [DeepchatRouteName, DeepchatRouteHandler]>

--- a/test/main/cli/providerModelAdminRoutes.test.ts
+++ b/test/main/cli/providerModelAdminRoutes.test.ts
@@ -7,6 +7,7 @@ import {
   providersTestPublicConnectionRoute,
   providersUpdatePublicRoute
 } from '@shared/contracts/routes'
+import { JsonValueSchema } from '@shared/contracts/json'
 import type { LLM_PROVIDER, ModelConfig } from '@shared/types/provider'
 import { createCliProviderModelAdminRoutes } from '@/cli/providerModelAdminRoutes'
 import type { CliRouteCaller, RouteContext } from '@/routes/routeRegistry'
@@ -255,7 +256,7 @@ describe('CLI provider administration routes', () => {
     ).toBe(true)
   })
 
-  it('uses strict public model config input and strips main-owned identity fields', async () => {
+  it('returns sparse public model configs as redacted JSON values', async () => {
     const provider: LLM_PROVIDER = {
       id: 'provider-1',
       name: 'Provider',
@@ -291,17 +292,62 @@ describe('CLI provider administration routes', () => {
       }).success
     ).toBe(false)
 
-    harness.modelConfigs.set(`${provider.id}:model-1`, {
+    const sparseStoredConfig = {
       ...config,
+      temperature: undefined,
+      topP: undefined,
+      imageGeneration: {
+        size: undefined,
+        quality: 'high'
+      },
+      videoGeneration: {
+        seconds: undefined,
+        watermark: false,
+        inputReference: { data: 'reference-image', mimeType: undefined },
+        references: [
+          {
+            type: 'image',
+            url: 'https://example.com/reference.png',
+            data: undefined,
+            mimeType: undefined
+          }
+        ]
+      },
+      tts: { voice: undefined, speed: 1 },
       conversationId: 'private-session',
-      ownedBy: 'internal-owner'
-    } as ModelConfig)
+      ownedBy: 'internal-owner',
+      futureSecret: 'secret'
+    } as ModelConfig & { futureSecret: string }
+    const publicSparseConfig = {
+      ...config,
+      imageGeneration: { quality: 'high' as const },
+      videoGeneration: {
+        watermark: false,
+        inputReference: { data: 'reference-image' },
+        references: [{ type: 'image' as const, url: 'https://example.com/reference.png' }]
+      },
+      tts: { speed: 1 }
+    }
+    harness.modelConfigs.set(`${provider.id}:model-1`, sparseStoredConfig)
     const result = await harness.invoke(modelsGetPublicConfigRoute.name, {
       providerId: provider.id,
       modelId: 'model-1'
     })
-    expect(result).toEqual({ config })
+    expect(result).toEqual({ config: publicSparseConfig })
+    expect(JsonValueSchema.safeParse(result).success).toBe(true)
     expect(JSON.stringify(result)).not.toContain('private-session')
+    expect(JSON.stringify(result)).not.toContain('futureSecret')
+
+    harness.setModelConfig.mockImplementationOnce((modelId, providerId) => {
+      harness.modelConfigs.set(`${providerId}:${modelId}`, sparseStoredConfig)
+    })
+    const setResult = await harness.invoke(modelsSetPublicConfigRoute.name, {
+      providerId: provider.id,
+      modelId: 'model-1',
+      config
+    })
+    expect(setResult).toEqual({ config: publicSparseConfig })
+    expect(JsonValueSchema.safeParse(setResult).success).toBe(true)
   })
 
   it('normalizes mutation storage failures without exposing their details', async () => {

--- a/test/main/cli/server.test.ts
+++ b/test/main/cli/server.test.ts
@@ -3,8 +3,10 @@ import { request as httpRequest } from 'node:http'
 import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import { z } from 'zod'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cliVersionRoute, type DeepchatRouteName } from '@shared/contracts/routes'
+import { defineRouteContract } from '@shared/contracts/contract'
 import type { JsonValue } from '@shared/contracts/json'
 import {
   LOCAL_CONTROL_PROTOCOL_VERSION,
@@ -277,6 +279,7 @@ async function createTestServer(
   dispatch: ReturnType<typeof vi.fn>
   dispatchUpload: ReturnType<typeof vi.fn>
   authorize: ReturnType<typeof vi.fn>
+  log: Readonly<{ warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> }>
 }> {
   const userDataPath = await createTemporaryDirectory()
   let server: CliServer
@@ -295,6 +298,7 @@ async function createTestServer(
   )
   const dispatchUpload = vi.fn(options.dispatchUpload ?? (async () => ({})))
   const authorize = vi.fn(options.authorize ?? (async () => ({ release: () => undefined })))
+  const log = { warn: vi.fn(), error: vi.fn() }
   server = new CliServer({
     userDataPath,
     appVersion: '1.2.3',
@@ -326,11 +330,11 @@ async function createTestServer(
     dispatchUpload,
     ...(options.authorize ? { authorize } : {}),
     surface: options.surface,
-    log: { warn: vi.fn(), error: vi.fn() }
+    log
   })
   servers.push(server)
   const descriptor = await server.start()
-  return { userDataPath, server, descriptor, dispatch, dispatchUpload, authorize }
+  return { userDataPath, server, descriptor, dispatch, dispatchUpload, authorize, log }
 }
 
 afterEach(async () => {
@@ -504,6 +508,55 @@ describe('CLI local transport', () => {
       status: 500,
       body: { ok: false, error: { code: 'internal_error' } }
     })
+  })
+
+  it('rejects route output that passes its contract but is not a JSON value', async () => {
+    const sentinel = 'secret-route-key'
+    const contract = defineRouteContract({
+      name: 'test.optionalRecord',
+      input: z.object({}).default({}),
+      output: z.object({ values: z.record(z.string(), z.string().optional()) })
+    })
+    const output = { values: { [sentinel]: undefined } }
+    const surface = new Map<string, CliSurfaceEntry>([
+      [
+        contract.name,
+        {
+          contract,
+          effect: 'read',
+          callers: ['human'],
+          scopes: ['system:read'],
+          transport: 'rpc',
+          approval: 'never',
+          limits: { maxBodyBytes: 1024, timeoutMs: 5_000 }
+        }
+      ]
+    ])
+    expect(contract.output.safeParse(output).success).toBe(true)
+    const { descriptor, log } = await createTestServer({
+      surface,
+      dispatchOutput: () => output
+    })
+
+    const response = await rpcRequest(descriptor, {
+      method: contract.name,
+      params: {}
+    })
+
+    expect(response).toMatchObject({
+      status: 500,
+      body: { ok: false, error: { code: 'internal_error' } }
+    })
+    expect(log.error).toHaveBeenCalledWith(
+      '[CLI] Route returned invalid output',
+      expect.objectContaining({
+        method: contract.name,
+        stage: 'json',
+        issueCount: expect.any(Number),
+        issueCodes: expect.any(Array)
+      })
+    )
+    expect(JSON.stringify(log.error.mock.calls)).not.toContain(sentinel)
   })
 
   it('releases policy admission after a route contract failure', async () => {

--- a/test/main/provider/routes.test.ts
+++ b/test/main/provider/routes.test.ts
@@ -4,6 +4,7 @@ import { createProviderRoutes } from '@/provider/routes'
 import {
   modelsGetCapabilitiesRoute,
   modelsGetProviderCatalogRoute,
+  modelsListRuntimeRoute,
   modelsSetStatusRoute,
   providersImportApplyRoute,
   providersImportScanRoute,
@@ -11,6 +12,7 @@ import {
   providersRemoveRoute,
   providersUpdateRoute
 } from '@shared/contracts/routes'
+import { JsonValueSchema } from '@shared/contracts/json'
 import { ModelType } from '@shared/model'
 
 const context = createRendererRouteContext(42, 7)
@@ -79,6 +81,101 @@ describe('Provider routes', () => {
       )
     ).rejects.toMatchObject({ code: 'not_found' })
     expect(updateModelStatus).not.toHaveBeenCalled()
+  })
+
+  it('returns JSON-safe runtime models across providers', async () => {
+    const getModelList = vi.fn(async (providerId: string) => {
+      if (providerId === 'empty-provider') return []
+      if (providerId === 'custom-provider') {
+        return [
+          {
+            id: 'custom-model',
+            name: 'Custom model',
+            group: 'custom',
+            providerId,
+            enabled: false,
+            isCustom: true,
+            vision: false,
+            functionCall: true,
+            reasoning: false,
+            enableSearch: true,
+            type: ModelType.Chat,
+            contextLength: 128_000,
+            maxTokens: 16_384,
+            description: 'User-defined model',
+            supportedEndpointTypes: ['openai-response', 'anthropic'],
+            selectableEndpointTypes: ['openai-response'],
+            endpointType: 'openai-response',
+            ownedBy: 'model-owner',
+            internalCredential: 'must-not-leak'
+          }
+        ]
+      }
+      return [
+        {
+          id: 'builtin-model',
+          name: 'Built-in model',
+          group: 'default',
+          providerId,
+          enabled: undefined,
+          isCustom: undefined,
+          vision: undefined,
+          functionCall: undefined,
+          reasoning: undefined,
+          enableSearch: undefined,
+          contextLength: undefined,
+          maxTokens: undefined,
+          description: undefined
+        }
+      ]
+    })
+    const routes = createRoutes({ providerSettings: {}, providerRuntime: { getModelList } })
+    const invoke = async (providerId: string) =>
+      await routes.get(modelsListRuntimeRoute.name)?.({ providerId }, context)
+
+    const builtinResult = await invoke('builtin-provider')
+    const customResult = await invoke('custom-provider')
+    const emptyResult = await invoke('empty-provider')
+
+    expect(builtinResult).toEqual({
+      models: [
+        {
+          id: 'builtin-model',
+          name: 'Built-in model',
+          group: 'default',
+          providerId: 'builtin-provider'
+        }
+      ]
+    })
+    expect(customResult).toEqual({
+      models: [
+        {
+          id: 'custom-model',
+          name: 'Custom model',
+          group: 'custom',
+          providerId: 'custom-provider',
+          enabled: false,
+          isCustom: true,
+          vision: false,
+          functionCall: true,
+          reasoning: false,
+          enableSearch: true,
+          type: ModelType.Chat,
+          contextLength: 128_000,
+          maxTokens: 16_384,
+          description: 'User-defined model',
+          supportedEndpointTypes: ['openai-response', 'anthropic'],
+          selectableEndpointTypes: ['openai-response'],
+          endpointType: 'openai-response',
+          ownedBy: 'model-owner'
+        }
+      ]
+    })
+    expect(emptyResult).toEqual({ models: [] })
+    for (const result of [builtinResult, customResult, emptyResult]) {
+      expect(JsonValueSchema.safeParse(result).success).toBe(true)
+      expect(JSON.stringify(result)).not.toContain('must-not-leak')
+    }
   })
 
   it('returns one authoritative capability snapshot and forwards draft route metadata', async () => {

--- a/test/main/routes/routeRegistry.test.ts
+++ b/test/main/routes/routeRegistry.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
 import {
   createRendererRouteCaller,
   createRendererRouteContext,
+  projectJsonRouteOutput,
   requireRendererCaller,
   type RouteContext
 } from '@/routes/routeRegistry'
@@ -28,6 +30,28 @@ describe('route caller context', () => {
     const context = createRendererRouteContext(42, 7)
 
     expect(requireRendererCaller(context)).toBe(context.caller)
+  })
+
+  it('projects route outputs before normalizing them for JSON', () => {
+    const outputSchema = z.object({
+      required: z.string(),
+      optional: z.string().optional(),
+      nested: z.object({ optional: z.boolean().optional() })
+    })
+    const privateValue = {
+      toJSON: () => {
+        throw new Error('Private values must be removed before serialization')
+      }
+    }
+
+    expect(
+      projectJsonRouteOutput(outputSchema, {
+        required: 'visible',
+        optional: undefined,
+        nested: { optional: undefined, privateValue },
+        privateValue
+      })
+    ).toEqual({ required: 'visible', nested: {} })
   })
 
   it.each<RouteContext>([


### PR DESCRIPTION
## Summary

- Project runtime model entries into an explicit JSON-safe DTO before returning `models.listRuntime`.
- Project public model configuration field by field for both `models.getPublicConfig` and `models.setPublicConfig`.
- Omit explicitly `undefined` properties, including nested image, video, and TTS options.
- Keep the CLI route boundary fail-closed for schema-valid outputs that are not valid JSON.
- Log bounded validation metadata without exposing route values or dynamic record keys.

## Root Cause

Zod preserves optional properties when the input explicitly contains those properties with an `undefined` value.

The affected model routes passed their domain schemas, but their parsed results then failed `JsonValueSchema` validation in the CLI server because `undefined` is not a valid JSON value. As a result, `model list` and `model config-get` returned `internal_error`.

## Compatibility

- Preserves all existing renderer-visible runtime model fields, including falsy values.
- Does not normalize, clamp, or add defaults to model configuration values.
- Continues stripping private and unknown configuration fields.
- Does not change the public CLI protocol or command syntax.

## Testing

- Covered empty model lists, multiple providers, and custom models.
- Covered every currently exposed optional runtime model field.
- Covered sparse public configuration for both config-get and config-set.
- Covered nested image, video, and TTS properties containing explicit `undefined`.
- Covered unknown/private field redaction.
- Added a generic CLI boundary test for schema-valid but non-JSON output.
- Verified validation logging does not expose dynamic output keys.

Validation completed:

- `pnpm run format:check`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- 40 focused Vitest tests

Fixes #2120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model configuration responses now expose only approved, JSON-safe settings, excluding private or unknown fields for both retrieval and updates.
  * Runtime model listings no longer expose internal credentials or runtime-only fields.
  * Invalid route responses are rejected safely with improved diagnostics, without leaking sensitive values or being treated as successful responses.

* **Tests**
  * Expanded coverage for configuration redaction, runtime model responses, JSON safety, and invalid route output handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->