### PR TITLE
feat(sidebar): add workspace management

### DIFF
--- a/docs/features/complete-directory-management/spec.md
+++ b/docs/features/complete-directory-management/spec.md
@@ -17,7 +17,8 @@ management never deletes real files.
   [`sidebar-workspace-registration`](../sidebar-workspace-registration/spec.md).
 - Active non-temporary directories support persisted reorder from Settings and project-group sidebar mode.
 - A directory newly registered or reactivated through the directory picker is persisted at the top of the
-  active order. Selecting an already-active directory does not change its position.
+  active order in the same database transaction as recent-project registration, without projecting or
+  checking every unrelated directory. Selecting an already-active directory does not change its position.
 - Sidebar reorder is disabled outside project grouping or while search is active; sessions inside a group keep
   their normal activity ordering.
 - The Chat and project-group section actions create a new draft with the relevant workspace context.
@@ -29,8 +30,9 @@ management never deletes real files.
 - Archive hides a directory from active management/project picker surfaces but preserves Session data and
   filesystem content.
 - Active workspace rows expose Archive behind a confirmation dialog even when reorder is unavailable. A
-  zero-Session row disappears after archive; existing Session history remains discoverable as a non-active
-  historical group.
+  zero-Session row disappears after the archive mutation's exact Project snapshot version commits; existing
+  Session history remains discoverable as a non-active historical group. A failed or incomplete refresh keeps
+  the row and confirmation visible.
 - Restore returns it to the active list near the top.
 - Remove requires confirmation and means “remove from DeepChat”, never filesystem deletion.
 - Removing a regular directory clears `projectDir` on associated regular Sessions.
@@ -42,7 +44,8 @@ management never deletes real files.
 
 The default workspace is optional, persisted by Project, and used when creating a draft without an explicit
 project. Users can set, clear or change it from environment settings. An invalid/missing default must not
-block opening DeepChat; the UI exposes the missing state and lets the user recover.
+block opening DeepChat; the UI exposes the missing state and lets the user recover. A lifecycle snapshot that
+archives or removes a manually selected draft workspace clears that selection before another draft is created.
 
 ## UI and compatibility
 

--- a/docs/features/complete-directory-management/spec.md
+++ b/docs/features/complete-directory-management/spec.md
@@ -11,7 +11,13 @@ management never deletes real files.
 ## Active directory behavior
 
 - Existing users without custom order see default directory first, then recent usage, then stable path order.
+- Active managed directories are sidebar entities independently of Session history. In project grouping, an
+  eligible zero-Session directory remains visible and can start its first scoped draft. The sidebar registration
+  and merge contract is maintained in
+  [`sidebar-workspace-registration`](../sidebar-workspace-registration/spec.md).
 - Active non-temporary directories support persisted reorder from Settings and project-group sidebar mode.
+- A directory newly registered or reactivated through the directory picker is persisted at the top of the
+  active order. Selecting an already-active directory does not change its position.
 - Sidebar reorder is disabled outside project grouping or while search is active; sessions inside a group keep
   their normal activity ordering.
 - The Chat and project-group section actions create a new draft with the relevant workspace context.
@@ -22,6 +28,9 @@ management never deletes real files.
 
 - Archive hides a directory from active management/project picker surfaces but preserves Session data and
   filesystem content.
+- Active workspace rows expose Archive behind a confirmation dialog even when reorder is unavailable. A
+  zero-Session row disappears after archive; existing Session history remains discoverable as a non-active
+  historical group.
 - Restore returns it to the active list near the top.
 - Remove requires confirmation and means “remove from DeepChat”, never filesystem deletion.
 - Removing a regular directory clears `projectDir` on associated regular Sessions.
@@ -37,9 +46,10 @@ block opening DeepChat; the UI exposes the missing state and lets the user recov
 
 ## UI and compatibility
 
-Settings provides active/archived views, accessible move actions and confirmation dialogs. Drag is only a
-shortcut; keyboard/menu actions must produce the same order. All strings use i18n and the route/client/store
-path remains typed.
+Settings provides active/archived views and the full lifecycle surface. The project-group sidebar exposes
+active reorder and confirmed Archive; Restore and Remove remain in Settings. Drag is only a shortcut;
+keyboard/menu actions must produce the same order. All strings use i18n and the route/client/store path
+remains typed.
 
 Existing `new_environments` usage data is migrated without losing Session/project associations. Derived usage
 rows are not the sole source of archive/remove/order truth.

--- a/docs/features/sidebar-workspace-registration/plan.md
+++ b/docs/features/sidebar-workspace-registration/plan.md
@@ -61,8 +61,9 @@ openFolderPicker(options?: { select?: boolean }): Promise<string | null>
 Add an idempotent `sessionStore.setGroupMode(mode)` action and keep `toggleGroupMode()` as its UI
 wrapper. Add success needs a deterministic project-mode request after a modal picker; calling a
 toggle based on stale pre-picker state can switch in the wrong direction if the user or another
-window changes the setting while the picker is open. Reuse the current serialized persistence and
-rollback behavior.
+window changes the setting while the picker is open. Serialize requested writes, track the last
+persisted mode separately, and return the exact in-flight promise to same-target callers. A failed
+write rolls back only the latest visible request to the last successfully persisted mode.
 
 ## Sidebar View Model
 
@@ -83,9 +84,9 @@ at render time. Do not add this renderer-only metadata to shared contracts.
 1. Build filtered Session groups exactly as today, retaining only groups with at least one matching
    Session when search is active.
 2. Extract the Chat/no-project groups before the workspace merge.
-3. Build exact-path maps for active, archived, and removed Project summaries. Continue using the
-   current path normalization only for the built-in Chat comparison; do not introduce unsafe
-   cross-platform case folding in the renderer.
+3. Build path-identity maps for active, archived, and removed Project summaries. Comparison removes
+   trailing separators from ordinary paths while preserving POSIX and Windows drive roots. Do not
+   introduce unsafe cross-platform case folding or separator rewriting in the renderer.
 4. Once Project metadata is ready and Session search is empty, iterate active environments in
    persisted order:
    - skip `defaultChatWorkspacePath`;
@@ -96,8 +97,9 @@ at render time. Do not add this renderer-only metadata to shared contracts.
 5. Mark consumed Session groups by path, then append remaining Session-derived workspace groups in
    their existing stable order. Classify known archived/removed paths as historical and disable
    reorder/new-conversation actions.
-6. If Project metadata is not ready, fall back to the current Session-only rendering and keep
-   reorder disabled. Never fabricate active metadata from a failed snapshot.
+6. Use the Project store's committed-snapshot readiness as the only metadata readiness signal. If
+   Project metadata is not ready, fall back to the current Session-only rendering and keep reorder
+   disabled. Never fabricate active metadata from a failed snapshot.
 7. During Session search, do not synthesize active rows without matching children. Existing active
    matches still use Project order; historical matches remain after active matches.
 
@@ -145,8 +147,8 @@ not roll it back.
   Keep move items disabled through `canMoveProjectGroup`; place Archive after a separator.
 - Archive opens a local guarded confirmation dialog using the existing
   `settings.environments.confirm.*`, `actions.archive`, and `errors.archiveTitle` copy. On confirm,
-  call `projectStore.archiveEnvironment(path)` and let the versioned Project refresh determine
-  whether the row disappears or becomes historical.
+  call `projectStore.archiveEnvironment(path)` and keep the dialog open until the archive route's
+  returned snapshot version is committed and the path is projected as archived.
 - Keep the dialog open and notify on archive failure. Disable cancel and confirmation while the
   request is pending so the mutation cannot be submitted twice.
 - Use `sessions.length > 0` as a safety override when a Session event arrives before the updated
@@ -158,26 +160,31 @@ Session route is required.
 
 ## Main Process And Contracts
 
-A small main-process ordering change is required without changing the shared route:
+A small main-process ordering change is required:
 
-- Before mutation, `ProjectService.selectDirectory()` reads the current active paths in their
-  authoritative order.
-- It upserts the recent project and marks the selected preference active as before.
-- If the path was not already active, it persists `[selectedPath, ...currentActivePaths]` through
-  the existing `reorderActive` owner. A duplicate active selection skips this reorder.
-- It increments the snapshot version and returns the selected path as before.
+- `NewEnvironmentPreferencesTable.activateAtTop()` uses one upsert to preserve an already-active
+  path's order or assign a newly active path before the current minimum explicit order.
+- `ProjectService.selectDirectory()` wraps recent-project upsert and preference activation in one
+  database transaction. It does not call `getEnvironments()` or synchronously check unrelated
+  filesystem paths.
+- It increments the snapshot version and returns that exact version with the selected path.
 - `ProjectService.getSnapshot()` already unions usage with preferences, so a selected zero-Session
   path appears in `environments`.
-- `project.selectDirectory` already publishes a versioned `select` event.
+- `project.selectDirectory` publishes the same version in its `select` event.
 - first non-draft Session persistence already refreshes environment usage and notifies the Project
   snapshot owner.
 
 Keep the ordering decision in Project rather than synthesizing a temporary renderer order. Do not
 add a parallel `workspace.add` route or another table.
 
-Sidebar archive needs no main-process, store, shared-contract, or i18n-key change. It reuses the
-existing typed `project.archiveEnvironment` route, `projectStore.archiveEnvironment`, Project
-snapshot refresh, and directory-management translations.
+Sidebar archive adds the mutation version to the existing typed `project.archiveEnvironment`
+result. The Project store requires that version and the archived lifecycle projection before the
+dialog can close. No new route or i18n key is required.
+
+`ProjectSnapshot` also carries `defaultChatWorkspacePath`. The Project store marks snapshot
+readiness when it commits that complete projection; the sidebar does not maintain a second local
+readiness flag. A committed lifecycle snapshot clears a manually selected path when that path is
+archived or removed.
 
 ## Compatibility And Edge Cases
 
@@ -213,14 +220,19 @@ snapshot refresh, and directory-management translations.
 Expected implementation surface:
 
 - `src/main/project/index.ts`
+- `src/main/project/data/tables/newEnvironmentPreferences.ts`
+- `src/main/project/routes.ts`
 - `src/renderer/src/components/WindowSideBar.vue`
 - `src/renderer/src/stores/ui/project.ts`
 - `src/renderer/src/stores/ui/session.ts`
 - `src/renderer/src/pages/NewThreadPage.vue`
+- `src/shared/contracts/routes/project.routes.ts`
+- `src/shared/utils/filesystem.ts`
 - `src/renderer/src/i18n/*/chat.json`
 - focused renderer and Project service tests
 
-No shared contract or schema change is required.
+The archive result and Project snapshot gain required fields. No database schema or new route is
+required.
 
 ## Test Strategy
 
@@ -237,7 +249,9 @@ No shared contract or schema change is required.
 
 - `setGroupMode('project')` is idempotent and persists once;
 - concurrent set/toggle requests serialize and the last requested mode wins;
-- persistence failure rolls back only the corresponding current request.
+- persistence failure rolls back only the corresponding current request;
+- consecutive failed writes roll back to the last persisted mode, and same-target callers observe
+  the in-flight failure.
 
 ### Sidebar Component
 
@@ -257,6 +271,18 @@ No shared contract or schema change is required.
   Session history;
 - Session-first and Project-first first-Session updates produce one populated row and preserve
   collapse identity.
+- POSIX and Windows drive roots remain workspace identities rather than collapsing into Chat or a
+  drive-relative path.
+- initial Project failure followed by a later successful store refresh enables the merged
+  projection without remounting the sidebar.
+
+### Project Main Process
+
+- selecting a directory performs no environment projection or unrelated filesystem existence
+  checks;
+- recent-project and preference activation execute in one transaction;
+- new/reactivated paths sort first while duplicate active selection retains its explicit order;
+- archive responses expose the exact committed snapshot version.
 
 ### Main And Integration
 

--- a/docs/features/sidebar-workspace-registration/plan.md
+++ b/docs/features/sidebar-workspace-registration/plan.md
@@ -1,0 +1,292 @@
+# Sidebar Workspace Registration Plan
+
+## Previous Data Flow
+
+```text
+project.selectDirectory
+  -> new_projects upsert + environment preference active (no explicit top insertion)
+  -> Project snapshot version + environments-changed event
+  -> projectStore.environments
+                                  \
+                                   X  WindowSideBar uses only order metadata
+                                  /
+paginated Session store -> filtered Session groups -> remove empty groups -> sidebar rows
+```
+
+The main process already persists zero-Session selections, but a new preference receives the
+fallback sort order and therefore appears after explicitly ordered workspaces. The missing behavior
+spans the Project ordering mutation and the renderer projection. It does not require another
+persistence entity.
+
+## Target Data Flow
+
+```text
+Add workspace
+  -> Project picker/register + prepend newly active path
+     (without changing current draft selection)
+  -> versioned projectStore snapshot
+  -> reveal policy: clear search + set project grouping
+                                      |
+projectStore active environments -----+----> local sidebar workspace view model
+Session store visible groups ---------+        |
+                                               +-> empty row
+                                               +-> populated row + Sessions
+                                               +-> historical Session-only row
+
+Empty row activation
+  -> projectStore.selectProject(path, 'manual')
+  -> sessionStore.startNewConversation({ refresh: true, projectDir: path })
+  -> one-shot intent survives active-session teardown
+  -> first non-draft Session updates both Session and Project projections
+```
+
+## Renderer Store Changes
+
+Extend `projectStore.openFolderPicker` with the minimum caller control needed to separate adding a
+sidebar workspace from selecting the current New Thread workspace:
+
+```ts
+openFolderPicker(options?: { select?: boolean }): Promise<string | null>
+```
+
+- Default `select` to `true` so New Thread keeps its current behavior.
+- Return `null` only for native picker cancellation.
+- On selection, wait for `refreshProjectSnapshot()` and return the committed path.
+- When `select !== false`, preserve the current `selectProject(path, 'manual')` behavior.
+- On a real failure, set the store error and rethrow so the caller can notify the user. Update the
+  New Thread caller to handle that rejection rather than leaving a fire-and-forget promise.
+- Let the existing refresh owner coalesce the route response and the potentially earlier
+  `project:environments-changed` event. Do not create a second event listener in the sidebar.
+
+Add an idempotent `sessionStore.setGroupMode(mode)` action and keep `toggleGroupMode()` as its UI
+wrapper. Add success needs a deterministic project-mode request after a modal picker; calling a
+toggle based on stale pre-picker state can switch in the wrong direction if the user or another
+window changes the setting while the picker is open. Reuse the current serialized persistence and
+rollback behavior.
+
+## Sidebar View Model
+
+Keep the merged type local to `WindowSideBar.vue` unless tests show a second real consumer. It needs
+enough metadata to avoid inferring domain state from visible children:
+
+```ts
+type SidebarWorkspaceGroup = SessionGroup & {
+  environment?: EnvironmentSummary
+}
+```
+
+True-empty, lifecycle, availability, and action state are derived from this optional environment
+at render time. Do not add this renderer-only metadata to shared contracts.
+
+### Project-Mode Merge
+
+1. Build filtered Session groups exactly as today, retaining only groups with at least one matching
+   Session when search is active.
+2. Extract the Chat/no-project groups before the workspace merge.
+3. Build exact-path maps for active, archived, and removed Project summaries. Continue using the
+   current path normalization only for the built-in Chat comparison; do not introduce unsafe
+   cross-platform case folding in the renderer.
+4. Once Project metadata is ready and Session search is empty, iterate active environments in
+   persisted order:
+   - skip `defaultChatWorkspacePath`;
+   - attach the matching visible Session group or `[]`;
+   - use `environment.name` for a zero-Session row;
+   - set `isTrueEmpty` only when `sessionCount === 0 && sessions.length === 0`;
+   - set `canStartConversation` only for active, existing paths.
+5. Mark consumed Session groups by path, then append remaining Session-derived workspace groups in
+   their existing stable order. Classify known archived/removed paths as historical and disable
+   reorder/new-conversation actions.
+6. If Project metadata is not ready, fall back to the current Session-only rendering and keep
+   reorder disabled. Never fabricate active metadata from a failed snapshot.
+7. During Session search, do not synthesize active rows without matching children. Existing active
+   matches still use Project order; historical matches remain after active matches.
+
+Date grouping remains Session-only. The successful Add handler switches to project grouping before
+attempting to focus the result.
+
+### Ordering And Drag
+
+- Iterate active environments in their Project order rather than sorting a Session-derived subset.
+- Keep the Chat workspace outside the draggable list and preserve its hidden position when sending
+  a full reorder payload, matching the current visible-subset merge.
+- Include true empty and missing active rows in active reorder.
+- Keep historical groups after active groups and outside reorder.
+- Keep reorder disabled during Session search, initial loading, pin animation, and drag, as today.
+- Preserve path-keyed collapse state across reorder and the empty-to-populated transition.
+
+## Sidebar Interaction Changes
+
+### Header Action
+
+Add `isAddingWorkspace` and a guarded `handleAddWorkspace`:
+
+1. capture no pre-picker grouping or selection assumptions;
+2. call `projectStore.openFolderPicker({ select: false })`;
+3. return without side effects on `null`;
+4. clear `sessionSearchQuery` after success;
+5. await `sessionStore.setGroupMode('project')`;
+6. await the reactive render, find the path-keyed row, and `scrollIntoView({ block: 'nearest' })`;
+7. focus the row and apply a brief, reduced-motion-safe reveal state;
+8. if the path is `defaultChatWorkspacePath`, reveal/focus Chat instead;
+9. notify on picker, snapshot, or grouping failure and always release the busy guard.
+
+The selected path is already durable before reveal. A grouping-persistence or focus failure must
+not roll it back.
+
+### Group Row
+
+- True empty and existing: omit `aria-expanded`; primary activation and the always-visible plus
+  call `handleNewChatForProject(path)`.
+- Populated active: retain folder click-to-collapse and the hover/focus plus action.
+- Active missing: show a warning icon and localized unavailable tooltip; omit/disable the plus and
+  do not interpret row activation as a draft request.
+- Historical: retain collapse and Session access, but hide new-conversation and reorder affordances.
+- Show the ellipsis menu for every active managed group rather than coupling it to the reorder gate.
+  Keep move items disabled through `canMoveProjectGroup`; place Archive after a separator.
+- Archive opens a local guarded confirmation dialog using the existing
+  `settings.environments.confirm.*`, `actions.archive`, and `errors.archiveTitle` copy. On confirm,
+  call `projectStore.archiveEnvironment(path)` and let the versioned Project refresh determine
+  whether the row disappears or becomes historical.
+- Keep the dialog open and notify on archive failure. Disable cancel and confirmation while the
+  request is pending so the mutation cannot be submitted twice.
+- Use `sessions.length > 0` as a safety override when a Session event arrives before the updated
+  Project snapshot, so a temporarily stale `sessionCount === 0` cannot turn a populated header into
+  a new-conversation action.
+
+The new conversation continues through the existing sidebar helper and one-shot intent. No new
+Session route is required.
+
+## Main Process And Contracts
+
+A small main-process ordering change is required without changing the shared route:
+
+- Before mutation, `ProjectService.selectDirectory()` reads the current active paths in their
+  authoritative order.
+- It upserts the recent project and marks the selected preference active as before.
+- If the path was not already active, it persists `[selectedPath, ...currentActivePaths]` through
+  the existing `reorderActive` owner. A duplicate active selection skips this reorder.
+- It increments the snapshot version and returns the selected path as before.
+- `ProjectService.getSnapshot()` already unions usage with preferences, so a selected zero-Session
+  path appears in `environments`.
+- `project.selectDirectory` already publishes a versioned `select` event.
+- first non-draft Session persistence already refreshes environment usage and notifies the Project
+  snapshot owner.
+
+Keep the ordering decision in Project rather than synthesizing a temporary renderer order. Do not
+add a parallel `workspace.add` route or another table.
+
+Sidebar archive needs no main-process, store, shared-contract, or i18n-key change. It reuses the
+existing typed `project.archiveEnvironment` route, `projectStore.archiveEnvironment`, Project
+snapshot refresh, and directory-management translations.
+
+## Compatibility And Edge Cases
+
+- **Duplicate active selection:** one path-keyed row; explicit order survives; focus the existing
+  row.
+- **Archived/removed selection:** `markActive` clears the lifecycle state and the selection mutation
+  places the reactivated path first. Regular Sessions cleared during remove remain unassigned;
+  preserved ACP workdir remains an existing Session concern.
+- **Default Chat selection:** no Workspace duplicate; reveal Chat.
+- **Missing after registration:** the committed active row remains visible with unavailable state;
+  starting a conversation is blocked until the path exists again, but Archive remains available.
+- **Single active workspace:** its menu remains available for Archive while all four move actions
+  are disabled.
+- **Archive with Session history:** the active affordances disappear after the snapshot, while the
+  Session-derived historical group remains navigable.
+- **Archive without Session history:** the synthetic active row disappears after the snapshot.
+- **Archive failure:** keep the dialog and row, suppress exception details from user copy, and allow
+  an explicit retry or cancel.
+- **Pinned-only or agent-filtered workspace:** active row remains but is not called Empty when the
+  durable count is non-zero.
+- **Pagination:** active headers may render before their Session page. Scroll loading remains driven
+  by the existing container; headers must not trigger duplicate Session fetches.
+- **Event ordering:** path identity and the safety override make Session-first and Project-first
+  updates converge on one row.
+- **Multiple windows:** every renderer receives the versioned Project event. Only the initiating
+  sidebar changes its local search, grouping, scroll, and focus.
+- **Temporary paths:** a zero-Session environment can exist only through durable preference
+  metadata. The built-in Chat path is excluded; existing Session-derived temporary behavior stays
+  unchanged.
+
+## Affected Files
+
+Expected implementation surface:
+
+- `src/main/project/index.ts`
+- `src/renderer/src/components/WindowSideBar.vue`
+- `src/renderer/src/stores/ui/project.ts`
+- `src/renderer/src/stores/ui/session.ts`
+- `src/renderer/src/pages/NewThreadPage.vue`
+- `src/renderer/src/i18n/*/chat.json`
+- focused renderer and Project service tests
+
+No shared contract or schema change is required.
+
+## Test Strategy
+
+### Project Store
+
+- picker cancellation returns `null` and changes neither selection nor snapshot state;
+- sidebar registration mode returns the path without changing `selectedProjectPath`;
+- New Thread default mode still selects the path;
+- an event arriving before the route response coalesces into the requested snapshot version;
+- picker/snapshot failure is rethrown after setting store error;
+- duplicate, archived, and removed selection converge on one active snapshot row.
+
+### Session Store
+
+- `setGroupMode('project')` is idempotent and persists once;
+- concurrent set/toggle requests serialize and the last requested mode wins;
+- persistence failure rolls back only the corresponding current request.
+
+### Sidebar Component
+
+- header action accessibility, busy guard, cancellation, failure, and success;
+- success from date mode and active search reveals/focuses the selected project row;
+- active zero-Session environment renders without a Session-derived group;
+- default Chat is not duplicated;
+- exact path identity preserves same-named workspaces;
+- search hides empty rows; agent filtering, pinning, and pagination do not mislabel non-empty paths;
+- empty row and plus dispatch the exact one-shot `projectDir` flow;
+- active missing and historical groups cannot start a new conversation;
+- empty groups participate in persisted reorder;
+- one active group still exposes Archive while move items are disabled;
+- archive confirmation dispatches the exact path, prevents duplicate submission, and preserves the
+  row/dialog on failure;
+- archived rows converge to hidden zero-Session or navigable historical presentation according to
+  Session history;
+- Session-first and Project-first first-Session updates produce one populated row and preserve
+  collapse identity.
+
+### Main And Integration
+
+- selected directory with no usage appears in the active snapshot with `sessionCount: 0`;
+- a newly selected or reactivated directory is persisted before every previously active path;
+- duplicate active selection does not create duplicate preference/project rows or reset explicit
+  order;
+- archived/removed selection reactivates the path and advances the version;
+- first regular and ACP non-draft Session updates advance the environment projection;
+- a renderer-level integration test covers event-driven empty-row appearance without remounting.
+
+## Validation
+
+During implementation, run the smallest relevant Project, store, New Thread, and sidebar Vitest
+suites. Before handoff run:
+
+```text
+pnpm run format
+pnpm run i18n
+pnpm run lint
+pnpm run typecheck
+```
+
+Manually verify native picker cancellation/success, keyboard focus, add from date/search modes,
+duplicate selection, missing path recovery, active-session teardown, and DeepChat/ACP first-Session
+transitions on at least Windows plus one POSIX platform.
+
+## Rollback
+
+The feature adds no schema or persisted workspace entity. Removing the header action and merged
+renderer projection restores the previous UI; directories selected while the feature was enabled
+remain valid managed environments in Settings and New Thread, and their latest persisted order
+remains intact.

--- a/docs/features/sidebar-workspace-registration/spec.md
+++ b/docs/features/sidebar-workspace-registration/spec.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented on `codex/issue-2115-workspace-sidebar-spec` on 2026-08-10. Native Windows and POSIX
+Implemented on `codex/issue-2115-workspace-sidebar-spec` as of 2026-08-11. Native Windows and POSIX
 manual validation remains pending. Linked GitHub issue:
 [#2115](https://github.com/ThinkInAIXYZ/deepchat/issues/2115).
 
@@ -100,8 +100,8 @@ visible rather than hover-only so the next step is apparent.
    one sidebar cannot open competing pickers.
 3. Cancellation changes no selection, search query, grouping mode, or persisted state.
 4. Successful selection registers or reactivates the path through `project.selectDirectory`, moves
-   a newly active path to the top of the persisted active order, and waits for the versioned Project
-   snapshot.
+   a newly active path to the top of the persisted active order without scanning every managed path,
+   and waits for the versioned Project snapshot.
 5. The sidebar clears its Session search, switches deterministically to project grouping, scrolls
    the resulting row into view, and returns focus to that row.
 6. The action does **not** create a draft and does **not** replace the current New Thread project
@@ -125,7 +125,8 @@ step fails.
 3. Archive opens the same confirmation contract used by directory Settings. The description states
    that Sessions, messages, and the real folder are retained.
 4. Confirmation calls the existing `projectStore.archiveEnvironment(path)` action and waits for the
-   committed Project snapshot. It never edits Session rows or filesystem content in the renderer.
+   exact mutation version to be committed by the Project snapshot. It never edits Session rows or
+   filesystem content in the renderer.
 5. A successful zero-Session archive disappears from Workspace. A workspace with Session history
    remains as the existing historical group, outside active reorder and new-conversation actions.
 6. Failure keeps the confirmation open, keeps the active row intact, and reports a localized error.
@@ -189,6 +190,18 @@ conversation.
    single row, search, loading, or animation while the active row remains archivable.
 10. Sidebar archive is the existing reversible Project lifecycle mutation. It must confirm first
     and must not delete Sessions, messages, or filesystem content.
+11. Project snapshot readiness is Project-store state. The same snapshot carries the built-in Chat
+    workspace identity, so the sidebar cannot synthesize a duplicate while startup bootstrap and
+    Project refresh race.
+12. Workspace identity removes trailing separators only for comparison and preserves POSIX and
+    Windows drive roots. It does not case-fold or rewrite separator style.
+13. Archiving or removing the manually selected New Thread workspace invalidates that selection;
+    the next draft must not reuse a non-active path.
+14. Group-mode persistence is serialized. On failure, the visible mode rolls back to the latest
+    successfully persisted mode, and every caller observes the failure of the write it awaited.
+15. Directory registration writes recent-project and active-order state in one database
+    transaction. Reactivation/new registration moves to the top with one preference-table write;
+    selecting an already-active path preserves its order.
 
 ## Acceptance Criteria
 
@@ -207,7 +220,8 @@ conversation.
 - Every active managed workspace has a keyboard-accessible Archive menu action, including a single
   workspace and an active missing workspace.
 - Archive requires confirmation, uses the existing typed Project action, preserves Session and
-  filesystem data, and reports failures without dismissing the dialog or hiding the row.
+  filesystem data, and dismisses the dialog only after the exact archive snapshot version commits.
+  Failures keep the dialog and row visible.
 - Archived zero-Session rows disappear; archived rows with Session history retain only historical
   navigation behavior.
 - A true empty, existing workspace opens a new draft with the exact path carried through the
@@ -218,6 +232,11 @@ conversation.
 - Search, agent filtering, pinning, pagination, project reorder, archived history, removed
   tombstones, missing paths, and default Chat behavior follow the matrix above.
 - Picker, snapshot, and grouping-persistence failures are observable and do not fabricate a row.
+- A failed pair of concurrent group-mode writes restores the last persisted mode, and a coalesced
+  caller receives the same write failure instead of a false success.
+- `/` and Windows drive roots remain valid workspace groups; trailing separators do not create a
+  duplicate group for ordinary paths.
+- Archiving or removing the current manual New Thread workspace clears that draft selection.
 - Focus, disabled state, unavailable state, and Empty text are accessible without relying on hover
   or color alone.
 
@@ -228,6 +247,7 @@ conversation.
 - Add no database table or schema migration; current environment preferences already persist a
   selected zero-Session path.
 - Preserve the versioned Project snapshot/event owner and its stale-read fencing.
+- Keep directory-picker registration free of synchronous existence checks over unrelated paths.
 - Use vue-i18n and existing `DcButton`, tooltip, notification, dropdown, and draggable primitives.
 - Preserve the existing Sidebar pagination, scroll restoration, shortcut badges, pin animation,
   and drag gates.

--- a/docs/features/sidebar-workspace-registration/spec.md
+++ b/docs/features/sidebar-workspace-registration/spec.md
@@ -1,0 +1,243 @@
+# Sidebar Workspace Registration
+
+## Status
+
+Implemented on `codex/issue-2115-workspace-sidebar-spec` on 2026-08-10. Native Windows and POSIX
+manual validation remains pending. Linked GitHub issue:
+[#2115](https://github.com/ThinkInAIXYZ/deepchat/issues/2115).
+
+This specification refines the issue where its proposed UI conflicts with the current Chat/Workspace
+sidebar split, paginated Session projection, or persisted directory lifecycle.
+
+## Problem
+
+The main sidebar exposes workspace-backed Sessions, but it does not expose every managed workspace.
+`WindowSideBar.vue` starts from Session groups and removes groups whose filtered Session list is
+empty. `projectStore.environments` only influences the order of groups that already exist.
+
+The Project domain already persists a selected directory independently of Session history. A newly
+selected directory can therefore be active, ordered, and available to new conversations while the
+sidebar still omits it. Adding only a folder-picker button would leave the following broken flow:
+
+1. the user selects a directory;
+2. Project persists and publishes the active environment;
+3. the directory has no non-draft Session;
+4. the Session-derived sidebar renders no row, so the action appears to have failed.
+
+The issue's numeric Session-count mockup is not adopted. `EnvironmentSummary.sessionCount` is a
+global durable count, while the sidebar can show a selected agent, only loaded pages, search
+matches, and a separate pinned section. Rendering the global number beside that filtered list would
+make the visible hierarchy internally inconsistent.
+
+## Goal
+
+Let users register a workspace from the place where workspaces are navigated, show active managed
+workspaces before their first Session exists, and start a correctly scoped draft from an empty
+workspace without changing existing directory lifecycle or Session-discovery behavior.
+
+## Ownership And Terminology
+
+- **Managed workspace**: an active `EnvironmentSummary` owned by `src/main/project/` and projected
+  through `projectStore.environments`.
+- **Chat workspace**: `defaultChatWorkspacePath`, represented by the dedicated Chat section and
+  never duplicated under Workspace.
+- **Session group**: the currently loaded and filtered Sessions grouped by `projectDir`.
+- **True empty workspace**: an active managed workspace with `sessionCount === 0` and no visible
+  Session. A group that is empty only because of agent filtering, pinning, search, or pagination is
+  not a true empty workspace.
+- **Historical group**: a Session-derived group whose path is archived, removed, or otherwise not
+  in the active managed projection. It exists only to keep existing Sessions discoverable.
+
+Project remains the source of workspace identity, active order, status, existence, and durable
+count. Session remains the source of visible Session membership. The sidebar owns only the merged
+view model. Workspace filesystem access remains owned by the Workspace domain.
+
+## User Experience
+
+### Layout
+
+Before:
+
+```text
+Workspace                                      [Group]
+  project-a                                      [+] [...]
+    Session A
+  project-b                                      [+] [...]
+    Session B
+```
+
+After:
+
+```text
+Workspace                               [Add] [Group]
+  new-project                         Empty      [+] [...]
+  project-a                                      [+] [...]
+    Session A
+  project-b                                      [+] [...]
+    Session B
+
+  [...]
+    Move to Top
+    Move Up
+    Move Down
+    Move to Bottom
+    ----------------
+    Archive
+```
+
+`Add` is a compact `folder-plus` icon button with an accessible **Add workspace** name and tooltip.
+It appears in the expanded sidebar in both date and project grouping modes. The existing grouping
+toggle remains the final header action.
+
+An empty row uses the same folder identity and persisted position as a populated row. It shows a
+muted **Empty** label instead of a misleading Session count. Its new-conversation action remains
+visible rather than hover-only so the next step is apparent.
+
+### Add Workspace Flow
+
+1. The user activates **Add workspace**.
+2. The existing typed Project directory picker opens. The action is disabled until it settles so
+   one sidebar cannot open competing pickers.
+3. Cancellation changes no selection, search query, grouping mode, or persisted state.
+4. Successful selection registers or reactivates the path through `project.selectDirectory`, moves
+   a newly active path to the top of the persisted active order, and waits for the versioned Project
+   snapshot.
+5. The sidebar clears its Session search, switches deterministically to project grouping, scrolls
+   the resulting row into view, and returns focus to that row.
+6. The action does **not** create a draft and does **not** replace the current New Thread project
+   selection. Registration and starting work remain two explicit user actions.
+
+If the selected path is already active, no duplicate row is created and its explicit persisted
+order is not disturbed. The existing row is revealed and focused. If it is archived or removed,
+the existing Project route reactivates it at the top and clears the lifecycle tombstone. If it is
+the built-in Chat workspace, the Chat section is revealed instead of creating a duplicate Workspace
+row.
+
+Picker or snapshot failures leave the current list intact and produce the existing destructive
+renderer notification. A successful registration remains durable even if the later reveal/focus
+step fails.
+
+### Archive Workspace Flow
+
+1. Every active managed workspace exposes its ellipsis menu, even when movement is unavailable
+   because it is the only row or reorder is temporarily disabled.
+2. Move actions retain their existing gates. A separator places **Archive** after the move actions.
+3. Archive opens the same confirmation contract used by directory Settings. The description states
+   that Sessions, messages, and the real folder are retained.
+4. Confirmation calls the existing `projectStore.archiveEnvironment(path)` action and waits for the
+   committed Project snapshot. It never edits Session rows or filesystem content in the renderer.
+5. A successful zero-Session archive disappears from Workspace. A workspace with Session history
+   remains as the existing historical group, outside active reorder and new-conversation actions.
+6. Failure keeps the confirmation open, keeps the active row intact, and reports a localized error.
+   Cancel and repeated confirmation are disabled while the archive request is pending.
+
+The built-in Chat section and historical groups never expose this Archive action. Restore and
+Remove remain in Settings, where archived lifecycle state is managed.
+
+### Empty Workspace Flow
+
+- Activating the primary row of a true empty, existing workspace starts a new conversation with
+  that path as the explicit `projectDir`.
+- The visible plus action performs the same operation.
+- The sidebar must call the existing unified `startNewConversation({ projectDir })` path. It must
+  not create a Session directly. The one-shot project intent is required so an active Session can
+  close without an agent or global default overwriting the clicked workspace.
+- DeepChat continues to persist a Session on first submission. ACP may ensure its existing draft
+  Session, but draft rows remain excluded from the sidebar and environment usage count.
+- When the first non-draft Session and Project snapshot arrive in either order, the row keeps the
+  same path identity, gains the Session, drops the Empty label, and adopts normal collapse behavior.
+
+A true empty row has no collapse state. Populated rows retain click-to-collapse and their existing
+new-conversation action. A workspace whose durable count is non-zero but whose currently loaded
+children are empty remains a populated row; it never changes a header click into an implicit new
+conversation.
+
+### Lifecycle And Visibility Matrix
+
+| State | Sidebar behavior |
+| --- | --- |
+| Project grouping, no search | Merge every eligible active managed workspace with loaded Session groups. |
+| Date grouping | Keep date groups unchanged. A successful Add switches to project grouping to reveal the result. |
+| Session search active | Show only groups containing matching loaded Sessions; do not synthesize empty rows. Add success clears search before reveal. |
+| Agent filter, pinned-only children, or unloaded pages | Keep active workspace rows; attach only currently visible Sessions. Durable count determines true emptiness. |
+| Active and existing | Show, reorder, allow new conversations, and expose Archive. |
+| Active but missing | Show with an unavailable indicator; keep ordering and Archive, but disable new conversations. |
+| Archived with Session history | Keep the existing historical group discoverable; do not synthesize an empty row or allow a new conversation. |
+| Archived without Session history | Hide from the sidebar; manage it in Settings. |
+| Removed | Never synthesize a row. Residual ACP Session discovery follows the existing Session projection but gains no add, reorder, or new-conversation affordance. |
+| Built-in Chat path | Render only in Chat, never as a Workspace duplicate. |
+
+## Business Rules
+
+1. A path is the stable group identity. Display names can collide and must never be used for merge,
+   collapse, reorder, or draft intent.
+2. Active Project order is authoritative. `ProjectService.selectDirectory()` prepends a path when
+   selection makes it newly active. The renderer consumes the committed order and must not
+   independently front-insert a path or derive order from Session activity.
+3. Empty rows exist only in project grouping without an active Session search. Search remains a
+   Session search rather than silently expanding into workspace-name search.
+4. An explicit Project order survives duplicate selection. Selecting the same active path is
+   idempotent for membership; fallback recency may change only where no explicit order exists.
+5. Missing, archived, and removed paths cannot create new conversations from the sidebar.
+6. The built-in Chat path is fixed outside workspace reorder even when it is present in the active
+   Project snapshot.
+7. A first Session replaces the empty presentation in place. There must never be one synthetic row
+   and one Session-derived row for the same path.
+8. Renderer-local optimistic state may reveal mode or focus changes, but only a committed versioned
+   Project snapshot may add, reactivate, or remove a workspace row.
+9. Archive availability is independent of reorder availability. Reorder may be disabled for a
+   single row, search, loading, or animation while the active row remains archivable.
+10. Sidebar archive is the existing reversible Project lifecycle mutation. It must confirm first
+    and must not delete Sessions, messages, or filesystem content.
+
+## Acceptance Criteria
+
+- The expanded Workspace header has a keyboard-accessible Add workspace action with localized
+  label and tooltip.
+- Choosing a directory registers or reactivates exactly one managed environment through the
+  existing typed Project route.
+- Canceling the picker is a no-op; concurrent activation cannot open a second picker.
+- A newly registered zero-Session workspace appears immediately after the committed Project
+  snapshot at the top of the Workspace list, including when Add started in date grouping or during
+  search.
+- Selecting an archived or removed workspace reactivates it at the top of the persisted active
+  order.
+- The built-in Chat path never appears twice.
+- Duplicate active selection reveals one existing row and preserves explicit order.
+- Every active managed workspace has a keyboard-accessible Archive menu action, including a single
+  workspace and an active missing workspace.
+- Archive requires confirmation, uses the existing typed Project action, preserves Session and
+  filesystem data, and reports failures without dismissing the dialog or hiding the row.
+- Archived zero-Session rows disappear; archived rows with Session history retain only historical
+  navigation behavior.
+- A true empty, existing workspace opens a new draft with the exact path carried through the
+  one-shot workspace intent.
+- Starting from an active Session cannot let agent or global defaults overwrite that path.
+- First non-draft Session creation converts the same row to a normal populated group without a
+  duplicate or collapse-state reset.
+- Search, agent filtering, pinning, pagination, project reorder, archived history, removed
+  tombstones, missing paths, and default Chat behavior follow the matrix above.
+- Picker, snapshot, and grouping-persistence failures are observable and do not fabricate a row.
+- Focus, disabled state, unavailable state, and Empty text are accessible without relying on hover
+  or color alone.
+
+## Constraints
+
+- Keep native directory selection behind the existing typed Project route and context-isolated
+  bridge.
+- Add no database table or schema migration; current environment preferences already persist a
+  selected zero-Session path.
+- Preserve the versioned Project snapshot/event owner and its stale-read fencing.
+- Use vue-i18n and existing `DcButton`, tooltip, notification, dropdown, and draggable primitives.
+- Preserve the existing Sidebar pagination, scroll restoration, shortcut badges, pin animation,
+  and drag gates.
+
+## Non-Goals
+
+- Displaying global Session counts in the filtered/paginated sidebar.
+- Creating a filesystem directory without the native picker.
+- Automatically creating a conversation immediately after directory selection.
+- Adding lifecycle management to the Workspace header, or adding Restore, Remove, rename,
+  default-workspace, or bulk-archive actions to workspace rows.
+- Searching workspace names, nested workspace hierarchy, or bulk workspace operations.
+- Changing the dedicated Chat section or the Settings directory-management surface.

--- a/docs/features/sidebar-workspace-registration/tasks.md
+++ b/docs/features/sidebar-workspace-registration/tasks.md
@@ -1,0 +1,85 @@
+# Sidebar Workspace Registration Tasks
+
+## Specification
+
+- [x] Reclassify #2115 as a user-visible capability change rather than a local sidebar defect.
+- [x] Audit current Chat/Workspace layout, Project snapshot ownership, Session grouping, draft
+  intent, lifecycle, pagination, and reorder behavior.
+- [x] Define true empty workspace semantics independently of visible filtered children.
+- [x] Reject unfiltered numeric Session counts in the filtered/paginated sidebar.
+- [x] Define add, reveal, duplicate, default Chat, missing, archived, and removed behavior.
+- [x] Update the maintained complete-directory-management contract.
+
+## Picker And Store Semantics
+
+- [x] Let `projectStore.openFolderPicker` return the selected path and support registration without
+  replacing the current New Thread selection.
+- [x] Surface real picker/snapshot failures while keeping cancellation a no-op.
+- [x] Add idempotent persisted `sessionStore.setGroupMode(mode)` behavior and retain the toggle UI.
+- [x] Add focused Project and Session store tests for cancellation, selection mode, event races,
+  duplicate selection, serialization, and rollback.
+
+## Sidebar Projection And UX
+
+- [x] Add the accessible, guarded Add workspace header action.
+- [x] Merge active Project environments with visible Session groups in persisted path order.
+- [x] Exclude the built-in Chat path and keep historical groups Session-derived only.
+- [x] Render true empty and missing states without global Session counts.
+- [x] Reveal successful additions by clearing search, setting project grouping, scrolling, and
+  focusing the path-keyed row.
+- [x] Route empty-row activation through the existing one-shot workspace intent.
+- [x] Disable new-conversation for missing groups and both new/reorder affordances for historical
+  groups.
+- [x] Preserve drag, collapse, pagination, pin animation, shortcuts, and reduced-motion behavior.
+- [x] Add localized Add workspace, Empty, unavailable, and failure copy.
+
+## Regression Coverage
+
+- [x] Cover zero-Session rendering and event-driven refresh without remounting.
+- [x] Cover add from date grouping and Session search, plus cancellation and failure.
+- [x] Cover duplicate, archived/removed reactivation, missing paths, and default Chat deduplication.
+- [x] Cover agent-filtered, pinned-only, paginated, searched, and reordered workspace groups.
+- [x] Cover exact project intent through active-session teardown for DeepChat and ACP.
+- [x] Cover both first-Session event orderings and assert one stable populated row.
+- [x] Keep committed tests focused on observable cross-domain contracts.
+
+## Ordering Follow-up
+
+- [x] Define newly selected/reactivated paths as first while keeping duplicate active selection
+  order-idempotent.
+- [x] Persist the ordering rule in `ProjectService.selectDirectory()`.
+- [x] Cover new, reactivated, and duplicate active selection in focused Project service tests.
+- [x] Assert that the sidebar renders the committed newly selected path first.
+- [x] Synchronize the feature and maintained directory-management contracts.
+
+## Sidebar Archive Follow-up
+
+- [x] Define Archive availability independently from reorder availability.
+- [x] Reuse the existing Project archive route, store action, confirmation copy, and lifecycle
+  projection without a new contract or i18n key.
+- [x] Add Archive after the move actions in every active workspace row menu.
+- [x] Add guarded confirmation, pending state, and localized failure feedback.
+- [x] Cover single-row availability, successful lifecycle projection, and failure retention.
+- [x] Run focused and repository validation.
+
+## Validation
+
+- [x] Run focused main and renderer Vitest suites.
+- [x] Run `pnpm run format`.
+- [x] Run `pnpm run i18n`.
+- [x] Run `pnpm run lint`.
+- [x] Run `pnpm run typecheck`.
+- [ ] Complete Windows and POSIX manual validation from the plan.
+
+## Validation Notes
+
+- Renderer validation passes: Project store 13/13, full Session store 80/80 (with an 8 GB Node
+  heap because the default 4 GB runner exhausts memory), sidebar 62/62, and New Thread 43/43.
+- Focused Project service validation for environment projection and directory selection passes 9/9,
+  including new/reactivated top insertion and duplicate active order stability.
+- The native SQLite preference-table suite is skipped because its optional native runtime is not
+  available in this workspace; the reactivation/order regression is included for CI hosts with
+  that runtime.
+- The full `projectService.test.ts` file has two existing Windows-only failures: its default
+  workspace assertions expect `/mock/...`, while Node resolves the mocked path as `C:\mock\...`.
+  The failures do not execute the changed renderer code or the added selection-order contracts.

--- a/docs/features/sidebar-workspace-registration/tasks.md
+++ b/docs/features/sidebar-workspace-registration/tasks.md
@@ -62,6 +62,17 @@
 - [x] Cover single-row availability, successful lifecycle projection, and failure retention.
 - [x] Run focused and repository validation.
 
+## Stability Hardening
+
+- [x] Return the archive mutation version and keep confirmation open until that snapshot commits.
+- [x] Make Project-store snapshot readiness authoritative and include Chat workspace identity in
+  the snapshot.
+- [x] Clear manually selected New Thread paths when lifecycle state becomes archived or removed.
+- [x] Preserve POSIX and Windows drive roots in workspace grouping identity.
+- [x] Roll group-mode failures back to the latest persisted mode and propagate coalesced failures.
+- [x] Replace directory-selection projection scans with one transactional database activation.
+- [x] Add focused regression coverage for every hardening contract.
+
 ## Validation
 
 - [x] Run focused main and renderer Vitest suites.
@@ -73,13 +84,13 @@
 
 ## Validation Notes
 
-- Renderer validation passes: Project store 13/13, full Session store 80/80 (with an 8 GB Node
-  heap because the default 4 GB runner exhausts memory), sidebar 62/62, and New Thread 43/43.
-- Focused Project service validation for environment projection and directory selection passes 9/9,
-  including new/reactivated top insertion and duplicate active order stability.
+- Renderer validation passes: Project store 15/15, full Session store 83/83, sidebar 64/64, both
+  New Thread suites 42/42, and Project client coverage 43/43. The Session suite requires an 8 GB
+  worker heap because the default 4 GB runner exhausts memory.
+- Focused main validation passes 139 tests across Project service, route contracts/dispatch, and
+  shared filesystem utilities.
 - The native SQLite preference-table suite is skipped because its optional native runtime is not
-  available in this workspace; the reactivation/order regression is included for CI hosts with
-  that runtime.
-- The full `projectService.test.ts` file has two existing Windows-only failures: its default
-  workspace assertions expect `/mock/...`, while Node resolves the mocked path as `C:\mock\...`.
-  The failures do not execute the changed renderer code or the added selection-order contracts.
+  available in this workspace. Its five regression tests remain enabled for CI hosts with that
+  runtime, and the exact activation SQL was exercised successfully with the system SQLite runtime.
+- Formatting, i18n validation, lint, node/web typecheck, and the renderer architecture baseline
+  check pass.

--- a/src/main/project/data/tables/newEnvironmentPreferences.ts
+++ b/src/main/project/data/tables/newEnvironmentPreferences.ts
@@ -68,6 +68,48 @@ export class NewEnvironmentPreferencesTable extends BaseTable {
     this.setStatus(environmentPath, 'active')
   }
 
+  activateAtTop(environmentPath: string): void {
+    const normalizedPath = this.normalizePath(environmentPath)
+    if (!normalizedPath) {
+      return
+    }
+
+    const now = Date.now()
+    this.db
+      .prepare(
+        `INSERT INTO new_environment_preferences (
+          path,
+          status,
+          sort_order,
+          archived_at,
+          removed_at,
+          updated_at
+        ) VALUES (
+          ?,
+          'active',
+          COALESCE((
+            SELECT MIN(sort_order) - 1
+            FROM new_environment_preferences
+            WHERE status = 'active' AND sort_order < ${DEFAULT_ENVIRONMENT_SORT_ORDER}
+          ), 0),
+          NULL,
+          NULL,
+          ?
+        )
+        ON CONFLICT(path) DO UPDATE SET
+          status = 'active',
+          sort_order = CASE
+            WHEN new_environment_preferences.status = 'active'
+              THEN new_environment_preferences.sort_order
+            ELSE excluded.sort_order
+          END,
+          archived_at = NULL,
+          removed_at = NULL,
+          updated_at = excluded.updated_at`
+      )
+      .run(normalizedPath, now)
+  }
+
   markArchived(environmentPath: string): void {
     this.setStatus(environmentPath, 'archived')
   }

--- a/src/main/project/index.ts
+++ b/src/main/project/index.ts
@@ -250,9 +250,19 @@ export class ProjectService {
 
     const dirPath = result.filePaths[0]
     const dirName = path.basename(dirPath)
+    const activeEnvironmentPaths = (await this.getEnvironments()).map(
+      (environment) => environment.path
+    )
+    const wasActive = activeEnvironmentPaths.includes(dirPath)
 
     this.sqlitePresenter.newProjectsTable.upsert(dirPath, dirName)
     this.sqlitePresenter.newEnvironmentPreferencesTable.markActive(dirPath)
+    if (!wasActive) {
+      this.sqlitePresenter.newEnvironmentPreferencesTable.reorderActive([
+        dirPath,
+        ...activeEnvironmentPaths
+      ])
+    }
     this.bumpSnapshotVersion()
     return dirPath
   }

--- a/src/main/project/index.ts
+++ b/src/main/project/index.ts
@@ -109,6 +109,7 @@ export class ProjectService {
     archivedEnvironments: EnvironmentSummary[]
     removedEnvironments: EnvironmentSummary[]
     defaultProjectPath: string | null
+    defaultChatWorkspacePath: string | null
   }> {
     // All reads are synchronous SQLite/settings reads in this process. Keep them in
     // one uninterrupted turn and stamp the resulting projection with its version.
@@ -150,7 +151,8 @@ export class ProjectService {
       environments: byStatus('active'),
       archivedEnvironments: byStatus('archived'),
       removedEnvironments: byStatus('removed'),
-      defaultProjectPath: this.getDefaultProjectPath()
+      defaultProjectPath: this.getDefaultProjectPath(),
+      defaultChatWorkspacePath: this.getDefaultChatWorkspacePath()
     }
   }
 
@@ -166,18 +168,17 @@ export class ProjectService {
     this.bumpSnapshotVersion()
   }
 
-  async archiveEnvironment(environmentPath: string): Promise<void> {
+  async archiveEnvironment(environmentPath: string): Promise<number> {
     const normalizedPath = this.normalizeEnvironmentPath(environmentPath)
     if (!normalizedPath) {
-      return
+      return this.snapshotVersion
     }
 
     this.sqlitePresenter.newEnvironmentPreferencesTable.markArchived(normalizedPath)
     if (this.getDefaultProjectPath() === normalizedPath) {
-      this.setDefaultProjectPath(null)
-      return
+      return this.setDefaultProjectPath(null)
     }
-    this.bumpSnapshotVersion()
+    return this.bumpSnapshotVersion()
   }
 
   async restoreEnvironment(environmentPath: string): Promise<void> {
@@ -244,27 +245,24 @@ export class ProjectService {
     return version
   }
 
-  async selectDirectory(): Promise<string | null> {
+  async selectDirectory(): Promise<{ path: string | null; version: number }> {
     const result = await this.deviceService.selectDirectory()
-    if (result.canceled || result.filePaths.length === 0) return null
-
-    const dirPath = result.filePaths[0]
-    const dirName = path.basename(dirPath)
-    const activeEnvironmentPaths = (await this.getEnvironments()).map(
-      (environment) => environment.path
-    )
-    const wasActive = activeEnvironmentPaths.includes(dirPath)
-
-    this.sqlitePresenter.newProjectsTable.upsert(dirPath, dirName)
-    this.sqlitePresenter.newEnvironmentPreferencesTable.markActive(dirPath)
-    if (!wasActive) {
-      this.sqlitePresenter.newEnvironmentPreferencesTable.reorderActive([
-        dirPath,
-        ...activeEnvironmentPaths
-      ])
+    if (result.canceled || result.filePaths.length === 0) {
+      return { path: null, version: this.snapshotVersion }
     }
-    this.bumpSnapshotVersion()
-    return dirPath
+
+    const dirPath = this.normalizeEnvironmentPath(result.filePaths[0])
+    if (!dirPath) {
+      return { path: null, version: this.snapshotVersion }
+    }
+
+    const dirName = path.basename(dirPath) || dirPath
+    this.sqlitePresenter.getDatabase().transaction(() => {
+      this.sqlitePresenter.newProjectsTable.upsert(dirPath, dirName)
+      this.sqlitePresenter.newEnvironmentPreferencesTable.activateAtTop(dirPath)
+    })()
+    const version = this.bumpSnapshotVersion()
+    return { path: dirPath, version }
   }
 
   async ensureDefaultWorkspace(): Promise<string | null> {
@@ -304,6 +302,17 @@ export class ProjectService {
   getDefaultProjectPath(): string | null {
     const projectPath = this.settings.get<string | null>('defaultProjectPath')
     return projectPath?.trim() || null
+  }
+
+  getDefaultChatWorkspacePath(): string | null {
+    const projectPath = this.getDefaultProjectPath()
+    if (!projectPath) {
+      return null
+    }
+
+    return this.isDefaultWorkspaceCandidate(projectPath, this.getDefaultWorkspaceCandidates())
+      ? projectPath
+      : null
   }
 
   setDefaultProjectPath(projectPath: string | null): number {

--- a/src/main/project/routes.ts
+++ b/src/main/project/routes.ts
@@ -99,9 +99,9 @@ export function createProjectRoutes(deps: {
       projectArchiveEnvironmentRoute.name,
       async (rawInput) => {
         const input = projectArchiveEnvironmentRoute.input.parse(rawInput)
-        await projectService.archiveEnvironment(input.path)
-        publishEnvironmentsChanged('archive', input.path, projectService.getSnapshotVersion())
-        return projectArchiveEnvironmentRoute.output.parse({ updated: true })
+        const version = await projectService.archiveEnvironment(input.path)
+        publishEnvironmentsChanged('archive', input.path, version)
+        return projectArchiveEnvironmentRoute.output.parse({ updated: true, version })
       }
     ],
     [
@@ -145,11 +145,11 @@ export function createProjectRoutes(deps: {
       projectSelectDirectoryRoute.name,
       async (rawInput) => {
         projectSelectDirectoryRoute.input.parse(rawInput)
-        const path = await projectService.selectDirectory()
-        if (path) {
-          publishEnvironmentsChanged('select', path, projectService.getSnapshotVersion())
+        const result = await projectService.selectDirectory()
+        if (result.path) {
+          publishEnvironmentsChanged('select', result.path, result.version)
         }
-        return projectSelectDirectoryRoute.output.parse({ path })
+        return projectSelectDirectoryRoute.output.parse(result)
       }
     ]
   ])

--- a/src/renderer/api/ProjectClient.ts
+++ b/src/renderer/api/ProjectClient.ts
@@ -55,8 +55,12 @@ export function createProjectClient(bridge: DeepchatBridge = getDeepchatBridge()
     return result.exists
   }
 
+  async function selectDirectoryWithVersion() {
+    return await bridge.invoke(projectSelectDirectoryRoute.name, {})
+  }
+
   async function selectDirectory() {
-    const result = await bridge.invoke(projectSelectDirectoryRoute.name, {})
+    const result = await selectDirectoryWithVersion()
     return result.path
   }
 
@@ -80,6 +84,7 @@ export function createProjectClient(bridge: DeepchatBridge = getDeepchatBridge()
     removeEnvironment,
     openDirectory,
     pathExists,
+    selectDirectoryWithVersion,
     selectDirectory,
     onEnvironmentsChanged
   }

--- a/src/renderer/src/components/WindowSideBar.vue
+++ b/src/renderer/src/components/WindowSideBar.vue
@@ -431,26 +431,30 @@
                     <span
                       v-if="isTrueEmptyWorkspaceGroup(group)"
                       data-testid="window-sidebar-empty-workspace-label"
-                      class="ml-auto shrink-0 text-[10px] font-normal text-muted-foreground/70"
+                      class="ms-auto shrink-0 text-[10px] font-normal text-muted-foreground/70"
                     >
                       {{ t('chat.sidebar.emptyWorkspace') }}
                     </span>
-                    <Icon
+                    <span
                       v-if="isWorkspaceUnavailable(group)"
-                      icon="lucide:circle-alert"
-                      data-testid="window-sidebar-workspace-unavailable"
-                      aria-hidden="true"
-                      class="ml-auto size-3.5 shrink-0 text-amber-500"
+                      class="ms-auto flex shrink-0 items-center"
                       :title="
                         t('chat.input.workspaceUnavailableTooltip', {
-                          path: getGroupIdentifier(group)
+                          path: getWorkspacePath(group)
                         })
                       "
-                    />
+                    >
+                      <Icon
+                        icon="lucide:circle-alert"
+                        data-testid="window-sidebar-workspace-unavailable"
+                        aria-hidden="true"
+                        class="size-3.5 text-amber-500"
+                      />
+                    </span>
                     <span v-if="isWorkspaceUnavailable(group)" class="sr-only">
                       {{
                         t('chat.input.workspaceUnavailableTooltip', {
-                          path: getGroupIdentifier(group)
+                          path: getWorkspacePath(group)
                         })
                       }}
                     </span>
@@ -471,13 +475,12 @@
                         ? 'opacity-100'
                         : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100'
                     "
-                    @click.stop="handleNewChatForProject(group.id)"
+                    @click.stop="handleNewChatForProject(getWorkspacePath(group))"
                   />
 
                   <DropdownMenu v-if="isActiveProjectDirectoryGroup(group)">
                     <DropdownMenuTrigger as-child>
                       <DcButton
-                        v-if="isProjectDirectoryGroup(group)"
                         type="button"
                         size="icon-sm"
                         icon="lucide:ellipsis"
@@ -687,6 +690,7 @@ import { useSpotlightStore } from '@/stores/ui/spotlight'
 import { usePluginCatalogStore } from '@/stores/pluginCatalog'
 import type { EnvironmentSummary } from '@shared/types/agent-interface'
 import type { RemoteChannel, RemoteRuntimeState } from '@shared/types/remote'
+import { normalizeWorkspacePath } from '@shared/utils/filesystem'
 import AgentAvatar from './icons/AgentAvatar.vue'
 import WindowSideBarSessionItem from './WindowSideBarSessionItem.vue'
 import { useI18n } from 'vue-i18n'
@@ -904,7 +908,6 @@ const matchesSessionSearch = (session: UISession) => {
 }
 const isProjectGroupDragging = ref(false)
 const projectGroupDragScrollTop = ref<number | null>(null)
-const projectEnvironmentMetadataReady = ref(false)
 const pinnedSessions = computed(() =>
   sessionStore.getPinnedSessions(sidebarSelectedAgentId.value).filter(matchesSessionSearch)
 )
@@ -919,30 +922,40 @@ const baseFilteredGroups = computed(() =>
     }))
     .filter((group) => group.sessions.length > 0)
 )
-const normalizeProjectPath = (projectPath: string | null | undefined) =>
-  projectPath?.trim().replace(/[\\/]+$/, '') ?? ''
 const defaultChatWorkspacePath = computed(() =>
-  normalizeProjectPath(projectStore.defaultChatWorkspacePath)
+  normalizeWorkspacePath(projectStore.defaultChatWorkspacePath)
 )
 const projectOrderIndex = computed(
-  () => new Map(projectStore.environments.map((environment, index) => [environment.path, index]))
+  () =>
+    new Map(
+      projectStore.environments.map((environment, index) => [
+        normalizeWorkspacePath(environment.path),
+        index
+      ])
+    )
 )
 const activeProjectEnvironmentByPath = computed(
-  () => new Map(projectStore.environments.map((environment) => [environment.path, environment]))
+  () =>
+    new Map(
+      projectStore.environments.map((environment) => [
+        normalizeWorkspacePath(environment.path),
+        environment
+      ])
+    )
 )
 const historicalProjectEnvironmentByPath = computed(
   () =>
     new Map(
       [...projectStore.archivedEnvironments, ...projectStore.removedEnvironments].map(
-        (environment) => [environment.path, environment]
+        (environment) => [normalizeWorkspacePath(environment.path), environment]
       )
     )
 )
 const selectableProjectPathSet = computed(
-  () => new Set(projectStore.projects.map((project) => project.path))
+  () => new Set(projectStore.projects.map((project) => normalizeWorkspacePath(project.path)))
 )
 const isChatSession = (session: UISession) => {
-  const projectPath = normalizeProjectPath(session.projectDir)
+  const projectPath = normalizeWorkspacePath(session.projectDir)
   return (
     projectPath.length === 0 ||
     (defaultChatWorkspacePath.value.length > 0 && projectPath === defaultChatWorkspacePath.value)
@@ -951,7 +964,7 @@ const isChatSession = (session: UISession) => {
 const isChatProjectGroup = (group: SessionGroup) =>
   group.id === NO_PROJECT_GROUP_ID ||
   (defaultChatWorkspacePath.value.length > 0 &&
-    normalizeProjectPath(group.id) === defaultChatWorkspacePath.value)
+    normalizeWorkspacePath(group.id) === defaultChatWorkspacePath.value)
 const isProjectDirectoryGroup = (group: SessionGroup) =>
   sessionStore.groupMode === 'project' &&
   group.id !== NO_PROJECT_GROUP_ID &&
@@ -973,19 +986,18 @@ const isTrueEmptyWorkspaceGroup = (group: SessionGroup) => {
     group.sessions.length === 0
   )
 }
-const getProjectGroupRank = (group: SessionGroup) => {
-  return isActiveProjectDirectoryGroup(group) ? 0 : 1
-}
 const compareProjectGroups = (left: SessionGroup, right: SessionGroup) => {
-  const leftRank = getProjectGroupRank(left)
-  const rightRank = getProjectGroupRank(right)
+  const leftRank = isActiveProjectDirectoryGroup(left) ? 0 : 1
+  const rightRank = isActiveProjectDirectoryGroup(right) ? 0 : 1
 
   if (leftRank !== rightRank) {
     return leftRank - rightRank
   }
 
-  const leftOrder = projectOrderIndex.value.get(left.id) ?? Number.MAX_SAFE_INTEGER
-  const rightOrder = projectOrderIndex.value.get(right.id) ?? Number.MAX_SAFE_INTEGER
+  const leftOrder =
+    projectOrderIndex.value.get(normalizeWorkspacePath(left.id)) ?? Number.MAX_SAFE_INTEGER
+  const rightOrder =
+    projectOrderIndex.value.get(normalizeWorkspacePath(right.id)) ?? Number.MAX_SAFE_INTEGER
   if (leftOrder !== rightOrder) {
     return leftOrder - rightOrder
   }
@@ -1000,36 +1012,35 @@ const decorateWorkspaceGroup = (
   ...(environment ? { environment } : {})
 })
 const sortProjectGroups = (groups: SidebarWorkspaceGroup[]) =>
-  groups
-    .map((group, index) => ({ group, index }))
-    .sort(
-      (left, right) => compareProjectGroups(left.group, right.group) || left.index - right.index
-    )
-    .map(({ group }) => group)
+  [...groups].sort(compareProjectGroups)
 const mergeProjectWorkspaceGroups = (sessionGroups: SessionGroup[]) => {
   const decoratedSessionGroups = sessionGroups.map((group) => {
+    const pathIdentity = normalizeWorkspacePath(group.id)
     const environment =
-      activeProjectEnvironmentByPath.value.get(group.id) ??
-      historicalProjectEnvironmentByPath.value.get(group.id)
+      activeProjectEnvironmentByPath.value.get(pathIdentity) ??
+      historicalProjectEnvironmentByPath.value.get(pathIdentity)
     return decorateWorkspaceGroup(group, environment)
   })
 
-  if (!projectEnvironmentMetadataReady.value || normalizedSessionSearchQuery.value.length > 0) {
+  if (!projectStore.snapshotReady || normalizedSessionSearchQuery.value.length > 0) {
     return sortProjectGroups(decoratedSessionGroups)
   }
 
-  const sessionGroupByPath = new Map(decoratedSessionGroups.map((group) => [group.id, group]))
+  const sessionGroupByPath = new Map(
+    decoratedSessionGroups.map((group) => [normalizeWorkspacePath(group.id), group])
+  )
   const activeGroups = projectStore.environments
     .filter(
       (environment) =>
-        normalizeProjectPath(environment.path) !== defaultChatWorkspacePath.value &&
+        normalizeWorkspacePath(environment.path) !== defaultChatWorkspacePath.value &&
         (!environment.isTemp ||
-          selectableProjectPathSet.value.has(environment.path) ||
-          sessionGroupByPath.has(environment.path))
+          selectableProjectPathSet.value.has(normalizeWorkspacePath(environment.path)) ||
+          sessionGroupByPath.has(normalizeWorkspacePath(environment.path)))
     )
     .map((environment): SidebarWorkspaceGroup => {
-      const sessionGroup = sessionGroupByPath.get(environment.path)
-      sessionGroupByPath.delete(environment.path)
+      const pathIdentity = normalizeWorkspacePath(environment.path)
+      const sessionGroup = sessionGroupByPath.get(pathIdentity)
+      sessionGroupByPath.delete(pathIdentity)
       return {
         id: environment.path,
         label: sessionGroup?.label ?? environment.name,
@@ -1039,7 +1050,7 @@ const mergeProjectWorkspaceGroups = (sessionGroups: SessionGroup[]) => {
       }
     })
   const historicalGroups = decoratedSessionGroups.filter((group) =>
-    sessionGroupByPath.has(group.id)
+    sessionGroupByPath.has(normalizeWorkspacePath(group.id))
   )
 
   return [...activeGroups, ...historicalGroups]
@@ -1143,7 +1154,7 @@ const canReorderProjectGroups = computed(
     sessionStore.groupMode === 'project' &&
     normalizedSessionSearchQuery.value.length === 0 &&
     !pinFlightSessionId.value &&
-    projectEnvironmentMetadataReady.value &&
+    projectStore.snapshotReady &&
     sessionStore.hasLoadedInitialPage &&
     !sessionStore.loading &&
     projectReorderableGroups.value.length > 1
@@ -1173,7 +1184,8 @@ const archiveWorkspaceDialogOpen = computed({
   }
 })
 
-const getGroupIdentifier = (group: SessionGroup) => group.id
+const getGroupIdentifier = (group: SessionGroup) => normalizeWorkspacePath(group.id)
+const getWorkspacePath = (group: SessionGroup) => getWorkspaceEnvironment(group)?.path ?? group.id
 
 const getGroupLabel = (group: SessionGroup) => (group.labelKey ? t(group.labelKey) : group.label)
 const getGroupIcon = (group: SessionGroup) =>
@@ -1274,7 +1286,7 @@ const toggleGroup = (group: SessionGroup) => {
 
 const handleWorkspaceGroupClick = (group: SessionGroup) => {
   if (isTrueEmptyWorkspaceGroup(group)) {
-    void handleNewChatForProject(group.id)
+    void handleNewChatForProject(getWorkspacePath(group))
     return
   }
 
@@ -1287,12 +1299,12 @@ const getCurrentProjectOrderPaths = () => {
   const environmentPaths = projectStore.environments.map((environment) => environment.path)
   return environmentPaths.length > 0
     ? environmentPaths
-    : projectReorderableGroups.value.map((group) => group.id)
+    : projectReorderableGroups.value.map(getWorkspacePath)
 }
 
 const commitVisibleProjectGroupOrder = async (nextVisiblePaths: string[]) => {
   const currentOrder = getCurrentProjectOrderPaths()
-  const previousVisiblePaths = projectReorderableGroups.value.map((group) => group.id)
+  const previousVisiblePaths = projectReorderableGroups.value.map(getWorkspacePath)
   const previousVisiblePathSet = new Set(previousVisiblePaths)
   const nextOrder = [...currentOrder]
   let nextVisibleIndex = 0
@@ -1323,7 +1335,7 @@ const handleProjectGroupModelUpdate = (nextGroups: SessionGroup[]) => {
     return
   }
 
-  const nextVisiblePaths = nextGroups.filter(isActiveProjectDirectoryGroup).map((group) => group.id)
+  const nextVisiblePaths = nextGroups.filter(isActiveProjectDirectoryGroup).map(getWorkspacePath)
   void commitVisibleProjectGroupOrder(nextVisiblePaths).catch((error) => {
     console.warn('[WindowSideBar] Failed to reorder project groups:', error)
   })
@@ -1335,7 +1347,9 @@ const canMoveProjectGroup = (group: SessionGroup, delta: -1 | 1) => {
   }
 
   const groups = projectReorderableGroups.value
-  const index = groups.findIndex((candidate) => candidate.id === group.id)
+  const index = groups.findIndex(
+    (candidate) => getGroupIdentifier(candidate) === getGroupIdentifier(group)
+  )
   if (index < 0) {
     return false
   }
@@ -1348,8 +1362,8 @@ const handleMoveProjectGroup = (group: SessionGroup, target: ProjectGroupMoveTar
     return
   }
 
-  const paths = projectReorderableGroups.value.map((candidate) => candidate.id)
-  const currentIndex = paths.indexOf(group.id)
+  const paths = projectReorderableGroups.value.map(getWorkspacePath)
+  const currentIndex = paths.indexOf(getWorkspacePath(group))
   if (currentIndex < 0) {
     return
   }
@@ -1544,22 +1558,11 @@ const refreshRemoteControlStatus = async (): Promise<boolean> => {
   }
 }
 
-const refreshProjectEnvironmentMetadata = async () => {
-  try {
-    await projectStore.fetchEnvironments()
-    if (projectStore.error) {
-      throw new Error(projectStore.error)
-    }
-    projectEnvironmentMetadataReady.value = true
-  } catch (error) {
-    console.warn('[WindowSideBar] Failed to refresh project environment metadata:', error)
-  }
-}
-
 const revealWorkspaceGroup = async (projectPath: string) => {
   await nextTick()
-  const isChatWorkspace = normalizeProjectPath(projectPath) === defaultChatWorkspacePath.value
-  const groupId = isChatWorkspace ? CHAT_SECTION_GROUP_ID : projectPath
+  const pathIdentity = normalizeWorkspacePath(projectPath)
+  const isChatWorkspace = pathIdentity === defaultChatWorkspacePath.value
+  const groupId = isChatWorkspace ? CHAT_SECTION_GROUP_ID : pathIdentity
   const groupTarget = Array.from(
     sessionListRef.value?.querySelectorAll<HTMLElement>('[data-group-id]') ?? []
   ).find((element) => element.dataset.groupId === groupId)
@@ -1597,7 +1600,6 @@ const handleAddWorkspace = async () => {
       return
     }
 
-    projectEnvironmentMetadataReady.value = true
     sessionSearchQuery.value = ''
     await sessionStore.setGroupMode('project')
     await revealWorkspaceGroup(selectedPath)
@@ -2282,7 +2284,7 @@ const handleDeleteConfirm = async () => {
 
 onMounted(() => {
   remoteControlStatusUnmounted = false
-  void refreshProjectEnvironmentMetadata()
+  void projectStore.fetchEnvironments()
   void loadShortcutPlatform()
   window.addEventListener('keydown', handleWindowShortcutKeydown)
   window.addEventListener('keyup', handleWindowShortcutKeyup)

--- a/src/renderer/src/components/WindowSideBar.vue
+++ b/src/renderer/src/components/WindowSideBar.vue
@@ -287,6 +287,11 @@
           <div v-if="chatSectionGroup" class="pt-4">
             <div
               class="group flex w-full items-center gap-1 rounded-md pr-1 text-xs font-semibold text-muted-foreground transition-colors duration-150 hover:bg-accent/40 hover:text-foreground focus-within:bg-accent/40 focus-within:text-foreground"
+              :class="
+                revealedWorkspaceGroupId === CHAT_SECTION_GROUP_ID
+                  ? 'bg-accent/70 ring-1 ring-primary/20'
+                  : ''
+              "
             >
               <button
                 type="button"
@@ -342,24 +347,38 @@
             <div class="min-w-0 truncate text-xs font-semibold text-muted-foreground">
               {{ t('chat.sidebar.workspace') }}
             </div>
-            <DcButton
-              size="icon-sm"
-              icon="lucide:folder-kanban"
-              icon-size="4"
-              :tooltip="
-                sessionStore.groupMode === 'project'
-                  ? t('chat.sidebar.groupByDate')
-                  : t('chat.sidebar.groupByProject')
-              "
-              variant="ghost"
-              class="flex items-center justify-center rounded-md transition-all duration-150"
-              :class="
-                sessionStore.groupMode === 'project'
-                  ? 'bg-accent/80 text-foreground'
-                  : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
-              "
-              @click="sessionStore.toggleGroupMode()"
-            />
+            <div class="flex items-center gap-0.5">
+              <DcButton
+                size="icon-sm"
+                icon="lucide:folder-plus"
+                icon-size="4"
+                data-testid="window-sidebar-add-workspace-button"
+                :tooltip="t('chat.sidebar.addWorkspace')"
+                :aria-label="t('chat.sidebar.addWorkspace')"
+                :disabled="isAddingWorkspace"
+                variant="ghost"
+                class="flex items-center justify-center rounded-md text-muted-foreground transition-all duration-150 hover:bg-accent/50 hover:text-foreground"
+                @click="handleAddWorkspace"
+              />
+              <DcButton
+                size="icon-sm"
+                icon="lucide:folder-kanban"
+                icon-size="4"
+                :tooltip="
+                  sessionStore.groupMode === 'project'
+                    ? t('chat.sidebar.groupByDate')
+                    : t('chat.sidebar.groupByProject')
+                "
+                variant="ghost"
+                class="flex items-center justify-center rounded-md transition-all duration-150"
+                :class="
+                  sessionStore.groupMode === 'project'
+                    ? 'bg-accent/80 text-foreground'
+                    : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                "
+                @click="sessionStore.toggleGroupMode()"
+              />
+            </div>
           </div>
 
           <draggable
@@ -379,7 +398,12 @@
               <div>
                 <div
                   class="group mt-2 flex w-full items-center gap-1 rounded-md pr-1 text-xs font-medium text-muted-foreground transition-colors duration-150 hover:bg-accent/40 hover:text-foreground focus-within:bg-accent/40 focus-within:text-foreground"
-                  :class="isProjectGroupDragging ? 'pointer-events-none' : ''"
+                  :class="[
+                    isProjectGroupDragging ? 'pointer-events-none' : '',
+                    revealedWorkspaceGroupId === getGroupIdentifier(group)
+                      ? 'bg-accent/70 ring-1 ring-primary/20'
+                      : ''
+                  ]"
                 >
                   <button
                     type="button"
@@ -390,8 +414,8 @@
                         : ''
                     "
                     :data-group-id="getGroupIdentifier(group)"
-                    :aria-expanded="!isGroupCollapsed(group)"
-                    @click="toggleGroup(group)"
+                    :aria-expanded="getWorkspaceGroupAriaExpanded(group)"
+                    @click="handleWorkspaceGroupClick(group)"
                   >
                     <span class="shrink-0 size-6 flex items-center justify-center">
                       <Icon
@@ -404,10 +428,36 @@
                     <span class="truncate">
                       {{ getGroupLabel(group) }}
                     </span>
+                    <span
+                      v-if="isTrueEmptyWorkspaceGroup(group)"
+                      data-testid="window-sidebar-empty-workspace-label"
+                      class="ml-auto shrink-0 text-[10px] font-normal text-muted-foreground/70"
+                    >
+                      {{ t('chat.sidebar.emptyWorkspace') }}
+                    </span>
+                    <Icon
+                      v-if="isWorkspaceUnavailable(group)"
+                      icon="lucide:circle-alert"
+                      data-testid="window-sidebar-workspace-unavailable"
+                      aria-hidden="true"
+                      class="ml-auto size-3.5 shrink-0 text-amber-500"
+                      :title="
+                        t('chat.input.workspaceUnavailableTooltip', {
+                          path: getGroupIdentifier(group)
+                        })
+                      "
+                    />
+                    <span v-if="isWorkspaceUnavailable(group)" class="sr-only">
+                      {{
+                        t('chat.input.workspaceUnavailableTooltip', {
+                          path: getGroupIdentifier(group)
+                        })
+                      }}
+                    </span>
                   </button>
 
                   <DcButton
-                    v-if="isProjectDirectoryGroup(group)"
+                    v-if="canStartConversationInProjectGroup(group)"
                     type="button"
                     data-testid="window-sidebar-project-new-button"
                     size="icon-sm"
@@ -415,13 +465,16 @@
                     icon-size="3.5"
                     variant="ghost"
                     :tooltip="t('common.newChat')"
-                    class="flex items-center justify-center rounded-md text-muted-foreground opacity-0 transition-all duration-150 hover:bg-accent/60 hover:text-foreground group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
+                    class="flex items-center justify-center rounded-md text-muted-foreground transition-all duration-150 hover:bg-accent/60 hover:text-foreground focus-visible:opacity-100"
+                    :class="
+                      isTrueEmptyWorkspaceGroup(group)
+                        ? 'opacity-100'
+                        : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100'
+                    "
                     @click.stop="handleNewChatForProject(group.id)"
                   />
 
-                  <DropdownMenu
-                    v-if="isProjectGroupReorderTarget(group) && canReorderProjectGroups"
-                  >
+                  <DropdownMenu v-if="isActiveProjectDirectoryGroup(group)">
                     <DropdownMenuTrigger as-child>
                       <DcButton
                         v-if="isProjectDirectoryGroup(group)"
@@ -458,6 +511,14 @@
                         @select="handleMoveProjectGroup(group, 'bottom')"
                       >
                         {{ t('chat.sidebar.moveProjectGroupBottom') }}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        data-testid="window-sidebar-archive-workspace-menu-item"
+                        :disabled="isArchivingWorkspace"
+                        @select="requestWorkspaceArchive(group)"
+                      >
+                        {{ t('settings.environments.actions.archive') }}
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
@@ -543,6 +604,45 @@
       </DialogFooter>
     </DialogContent>
   </Dialog>
+
+  <Dialog v-model:open="archiveWorkspaceDialogOpen">
+    <DialogContent data-testid="window-sidebar-archive-workspace-dialog">
+      <DialogHeader>
+        <DialogTitle>
+          {{
+            t('settings.environments.confirm.archiveTitle', {
+              name: archiveTargetWorkspace?.name ?? ''
+            })
+          }}
+        </DialogTitle>
+        <DialogDescription>
+          {{ t('settings.environments.confirm.archiveDescription') }}
+        </DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <DcButton
+          data-testid="window-sidebar-archive-workspace-cancel"
+          variant="outline"
+          :disabled="isArchivingWorkspace"
+          @click="archiveWorkspaceDialogOpen = false"
+        >
+          {{ t('common.cancel') }}
+        </DcButton>
+        <DcButton
+          data-testid="window-sidebar-archive-workspace-confirm"
+          :disabled="isArchivingWorkspace"
+          @click="handleArchiveWorkspaceConfirm"
+        >
+          <Icon
+            v-if="isArchivingWorkspace"
+            icon="lucide:loader-circle"
+            class="mr-2 size-4 animate-spin"
+          />
+          {{ t('settings.environments.actions.archive') }}
+        </DcButton>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
 </template>
 
 <script setup lang="ts">
@@ -568,11 +668,13 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@shadcn/components/ui/dropdown-menu'
 import { createSettingsClient } from '@api/SettingsClient'
 import { createRemoteControlClient } from '@api/RemoteControlClient'
 import { createDeviceClient } from '@api/DeviceClient'
+import { notifyRenderer } from '@renderer-notifications/rendererNotificationPort'
 import { useAgentStore } from '@/stores/ui/agent'
 import { useProjectStore } from '@/stores/ui/project'
 import {
@@ -583,6 +685,7 @@ import {
 } from '@/stores/ui/session'
 import { useSpotlightStore } from '@/stores/ui/spotlight'
 import { usePluginCatalogStore } from '@/stores/pluginCatalog'
+import type { EnvironmentSummary } from '@shared/types/agent-interface'
 import type { RemoteChannel, RemoteRuntimeState } from '@shared/types/remote'
 import AgentAvatar from './icons/AgentAvatar.vue'
 import WindowSideBarSessionItem from './WindowSideBarSessionItem.vue'
@@ -609,6 +712,10 @@ const getPinFeedbackMode = (nextPinned: boolean): PinFeedbackMode =>
 type SessionItemRegion = 'pinned' | 'grouped'
 type ShortcutPlatform = 'mac' | 'other'
 type ProjectGroupMoveTarget = 'top' | 'up' | 'down' | 'bottom'
+type WorkspaceArchiveTarget = Pick<EnvironmentSummary, 'path' | 'name'>
+type SidebarWorkspaceGroup = SessionGroup & {
+  environment?: EnvironmentSummary
+}
 type SessionItemRect = {
   left: number
   top: number
@@ -672,6 +779,7 @@ let sessionListScrollFrame: number | null = null
 let sessionListFillFrame: number | null = null
 let sessionListResizeObserver: ResizeObserver | null = null
 let shortcutBadgeTimer: number | null = null
+let workspaceRevealTimer: number | null = null
 const shortcutPlatform = ref<ShortcutPlatform>(
   navigator.platform.toLowerCase().includes('mac') ? 'mac' : 'other'
 )
@@ -811,16 +919,27 @@ const baseFilteredGroups = computed(() =>
     }))
     .filter((group) => group.sessions.length > 0)
 )
-const projectOrderIndex = computed(
-  () => new Map(projectStore.environments.map((environment, index) => [environment.path, index]))
-)
-const archivedProjectPathSet = computed(
-  () => new Set(projectStore.archivedEnvironments.map((environment) => environment.path))
-)
 const normalizeProjectPath = (projectPath: string | null | undefined) =>
   projectPath?.trim().replace(/[\\/]+$/, '') ?? ''
 const defaultChatWorkspacePath = computed(() =>
   normalizeProjectPath(projectStore.defaultChatWorkspacePath)
+)
+const projectOrderIndex = computed(
+  () => new Map(projectStore.environments.map((environment, index) => [environment.path, index]))
+)
+const activeProjectEnvironmentByPath = computed(
+  () => new Map(projectStore.environments.map((environment) => [environment.path, environment]))
+)
+const historicalProjectEnvironmentByPath = computed(
+  () =>
+    new Map(
+      [...projectStore.archivedEnvironments, ...projectStore.removedEnvironments].map(
+        (environment) => [environment.path, environment]
+      )
+    )
+)
+const selectableProjectPathSet = computed(
+  () => new Set(projectStore.projects.map((project) => project.path))
 )
 const isChatSession = (session: UISession) => {
   const projectPath = normalizeProjectPath(session.projectDir)
@@ -838,14 +957,24 @@ const isProjectDirectoryGroup = (group: SessionGroup) =>
   group.id !== NO_PROJECT_GROUP_ID &&
   !group.labelKey &&
   !isChatProjectGroup(group)
+const getWorkspaceEnvironment = (group: SessionGroup) =>
+  (group as SidebarWorkspaceGroup).environment
 const isActiveProjectDirectoryGroup = (group: SessionGroup) =>
-  isProjectDirectoryGroup(group) && !archivedProjectPathSet.value.has(group.id)
+  isProjectDirectoryGroup(group) && getWorkspaceEnvironment(group)?.status === 'active'
+const isWorkspaceUnavailable = (group: SessionGroup) =>
+  isActiveProjectDirectoryGroup(group) && getWorkspaceEnvironment(group)?.exists === false
+const canStartConversationInProjectGroup = (group: SessionGroup) =>
+  isActiveProjectDirectoryGroup(group) && !isWorkspaceUnavailable(group)
+const isTrueEmptyWorkspaceGroup = (group: SessionGroup) => {
+  const environment = getWorkspaceEnvironment(group)
+  return (
+    canStartConversationInProjectGroup(group) &&
+    environment?.sessionCount === 0 &&
+    group.sessions.length === 0
+  )
+}
 const getProjectGroupRank = (group: SessionGroup) => {
-  if (!isProjectDirectoryGroup(group)) {
-    return 2
-  }
-
-  return archivedProjectPathSet.value.has(group.id) ? 1 : 0
+  return isActiveProjectDirectoryGroup(group) ? 0 : 1
 }
 const compareProjectGroups = (left: SessionGroup, right: SessionGroup) => {
   const leftRank = getProjectGroupRank(left)
@@ -853,10 +982,6 @@ const compareProjectGroups = (left: SessionGroup, right: SessionGroup) => {
 
   if (leftRank !== rightRank) {
     return leftRank - rightRank
-  }
-
-  if (leftRank !== 0) {
-    return 0
   }
 
   const leftOrder = projectOrderIndex.value.get(left.id) ?? Number.MAX_SAFE_INTEGER
@@ -867,18 +992,67 @@ const compareProjectGroups = (left: SessionGroup, right: SessionGroup) => {
 
   return 0
 }
-const orderedFilteredGroups = computed(() => {
-  const groups = baseFilteredGroups.value
-  if (sessionStore.groupMode !== 'project') {
-    return groups
-  }
-
-  return groups
+const decorateWorkspaceGroup = (
+  group: SessionGroup,
+  environment: EnvironmentSummary | undefined
+): SidebarWorkspaceGroup => ({
+  ...group,
+  ...(environment ? { environment } : {})
+})
+const sortProjectGroups = (groups: SidebarWorkspaceGroup[]) =>
+  groups
     .map((group, index) => ({ group, index }))
     .sort(
       (left, right) => compareProjectGroups(left.group, right.group) || left.index - right.index
     )
     .map(({ group }) => group)
+const mergeProjectWorkspaceGroups = (sessionGroups: SessionGroup[]) => {
+  const decoratedSessionGroups = sessionGroups.map((group) => {
+    const environment =
+      activeProjectEnvironmentByPath.value.get(group.id) ??
+      historicalProjectEnvironmentByPath.value.get(group.id)
+    return decorateWorkspaceGroup(group, environment)
+  })
+
+  if (!projectEnvironmentMetadataReady.value || normalizedSessionSearchQuery.value.length > 0) {
+    return sortProjectGroups(decoratedSessionGroups)
+  }
+
+  const sessionGroupByPath = new Map(decoratedSessionGroups.map((group) => [group.id, group]))
+  const activeGroups = projectStore.environments
+    .filter(
+      (environment) =>
+        normalizeProjectPath(environment.path) !== defaultChatWorkspacePath.value &&
+        (!environment.isTemp ||
+          selectableProjectPathSet.value.has(environment.path) ||
+          sessionGroupByPath.has(environment.path))
+    )
+    .map((environment): SidebarWorkspaceGroup => {
+      const sessionGroup = sessionGroupByPath.get(environment.path)
+      sessionGroupByPath.delete(environment.path)
+      return {
+        id: environment.path,
+        label: sessionGroup?.label ?? environment.name,
+        labelKey: sessionGroup?.labelKey,
+        sessions: sessionGroup?.sessions ?? [],
+        environment
+      }
+    })
+  const historicalGroups = decoratedSessionGroups.filter((group) =>
+    sessionGroupByPath.has(group.id)
+  )
+
+  return [...activeGroups, ...historicalGroups]
+}
+const orderedFilteredGroups = computed<SidebarWorkspaceGroup[]>(() => {
+  const groups = baseFilteredGroups.value
+  if (sessionStore.groupMode !== 'project') {
+    return groups
+  }
+
+  const chatGroups = groups.filter(isChatProjectGroup)
+  const workspaceSessionGroups = groups.filter(isProjectDirectoryGroup)
+  return [...chatGroups, ...mergeProjectWorkspaceGroups(workspaceSessionGroups)]
 })
 const compareSidebarSessions = (left: UISession, right: UISession) => {
   const leftUpdatedAt = Number.isFinite(left.updatedAt) ? left.updatedAt : 0
@@ -974,8 +1148,12 @@ const canReorderProjectGroups = computed(
     !sessionStore.loading &&
     projectReorderableGroups.value.length > 1
 )
+const isAddingWorkspace = ref(false)
+const revealedWorkspaceGroupId = ref<string | null>(null)
 const sessionListRef = ref<HTMLElement | null>(null)
 const deleteTargetSession = ref<UISession | null>(null)
+const archiveTargetWorkspace = ref<WorkspaceArchiveTarget | null>(null)
+const isArchivingWorkspace = ref(false)
 
 const deleteDialogOpen = computed({
   get: () => deleteTargetSession.value !== null,
@@ -986,14 +1164,29 @@ const deleteDialogOpen = computed({
   }
 })
 
+const archiveWorkspaceDialogOpen = computed({
+  get: () => archiveTargetWorkspace.value !== null,
+  set: (open: boolean) => {
+    if (!open && !isArchivingWorkspace.value) {
+      archiveTargetWorkspace.value = null
+    }
+  }
+})
+
 const getGroupIdentifier = (group: SessionGroup) => group.id
 
 const getGroupLabel = (group: SessionGroup) => (group.labelKey ? t(group.labelKey) : group.label)
 const getGroupIcon = (group: SessionGroup) =>
-  isGroupCollapsed(group) ? 'lucide:folder-closed' : 'lucide:folder-open'
+  isTrueEmptyWorkspaceGroup(group)
+    ? 'lucide:folder'
+    : isGroupCollapsed(group)
+      ? 'lucide:folder-closed'
+      : 'lucide:folder-open'
 
 const isGroupCollapsed = (group: SessionGroup) =>
   collapsedGroupIds.value.has(getGroupIdentifier(group))
+const getWorkspaceGroupAriaExpanded = (group: SessionGroup) =>
+  isTrueEmptyWorkspaceGroup(group) ? undefined : !isGroupCollapsed(group)
 
 const canAutoFillSessionList = computed(
   () =>
@@ -1077,6 +1270,15 @@ const toggleGroup = (group: SessionGroup) => {
 
   collapsedGroupIds.value = nextCollapsedGroupIds
   scheduleSessionListFillCheck()
+}
+
+const handleWorkspaceGroupClick = (group: SessionGroup) => {
+  if (isTrueEmptyWorkspaceGroup(group)) {
+    void handleNewChatForProject(group.id)
+    return
+  }
+
+  toggleGroup(group)
 }
 
 const isProjectGroupReorderTarget = (group: SessionGroup) => isActiveProjectDirectoryGroup(group)
@@ -1168,6 +1370,40 @@ const handleMoveProjectGroup = (group: SessionGroup, target: ProjectGroupMoveTar
   })
 }
 
+const requestWorkspaceArchive = (group: SessionGroup) => {
+  const environment = getWorkspaceEnvironment(group)
+  if (environment?.status !== 'active' || isArchivingWorkspace.value) {
+    return
+  }
+
+  archiveTargetWorkspace.value = {
+    path: environment.path,
+    name: environment.name
+  }
+}
+
+const handleArchiveWorkspaceConfirm = async () => {
+  const target = archiveTargetWorkspace.value
+  if (!target || isArchivingWorkspace.value) {
+    return
+  }
+
+  isArchivingWorkspace.value = true
+  try {
+    await projectStore.archiveEnvironment(target.path)
+    archiveTargetWorkspace.value = null
+  } catch (error) {
+    console.warn('[WindowSideBar] Failed to archive workspace:', error)
+    notifyRenderer({
+      kind: 'error',
+      code: 'chat.workspace.archive.failed',
+      title: t('settings.environments.errors.archiveTitle')
+    })
+  } finally {
+    isArchivingWorkspace.value = false
+  }
+}
+
 const handleProjectGroupDragStart = () => {
   isProjectGroupDragging.value = true
   projectGroupDragScrollTop.value = sessionListRef.value?.scrollTop ?? null
@@ -1205,7 +1441,9 @@ watch(
       return
     }
 
-    const validGroupIds = new Set(groups.map(getGroupIdentifier))
+    const validGroupIds = new Set(
+      groups.filter((group) => !isTrueEmptyWorkspaceGroup(group)).map(getGroupIdentifier)
+    )
     const nextCollapsedGroupIds = new Set(
       [...collapsedGroupIds.value].filter((groupId) => validGroupIds.has(groupId))
     )
@@ -1309,9 +1547,70 @@ const refreshRemoteControlStatus = async (): Promise<boolean> => {
 const refreshProjectEnvironmentMetadata = async () => {
   try {
     await projectStore.fetchEnvironments()
+    if (projectStore.error) {
+      throw new Error(projectStore.error)
+    }
     projectEnvironmentMetadataReady.value = true
   } catch (error) {
     console.warn('[WindowSideBar] Failed to refresh project environment metadata:', error)
+  }
+}
+
+const revealWorkspaceGroup = async (projectPath: string) => {
+  await nextTick()
+  const isChatWorkspace = normalizeProjectPath(projectPath) === defaultChatWorkspacePath.value
+  const groupId = isChatWorkspace ? CHAT_SECTION_GROUP_ID : projectPath
+  const groupTarget = Array.from(
+    sessionListRef.value?.querySelectorAll<HTMLElement>('[data-group-id]') ?? []
+  ).find((element) => element.dataset.groupId === groupId)
+  const target =
+    groupTarget ??
+    (isChatWorkspace
+      ? sessionListRef.value
+          ?.closest<HTMLElement>('[data-testid="window-sidebar"]')
+          ?.querySelector<HTMLElement>('[data-testid="app-new-chat-button"]')
+      : null)
+
+  target?.scrollIntoView?.({ block: 'nearest' })
+  target?.focus()
+  if (target && !prefersReducedMotion()) {
+    if (workspaceRevealTimer !== null) {
+      window.clearTimeout(workspaceRevealTimer)
+    }
+    revealedWorkspaceGroupId.value = groupId
+    workspaceRevealTimer = window.setTimeout(() => {
+      revealedWorkspaceGroupId.value = null
+      workspaceRevealTimer = null
+    }, 900)
+  }
+}
+
+const handleAddWorkspace = async () => {
+  if (isAddingWorkspace.value) {
+    return
+  }
+
+  isAddingWorkspace.value = true
+  try {
+    const selectedPath = await projectStore.openFolderPicker({ select: false })
+    if (!selectedPath) {
+      return
+    }
+
+    projectEnvironmentMetadataReady.value = true
+    sessionSearchQuery.value = ''
+    await sessionStore.setGroupMode('project')
+    await revealWorkspaceGroup(selectedPath)
+  } catch (error) {
+    console.warn('[WindowSideBar] Failed to add workspace:', error)
+    notifyRenderer({
+      kind: 'error',
+      code: 'chat.workspace.registrationFailed',
+      title: t('common.error.operationFailed'),
+      description: t('chat.sidebar.addWorkspaceFailed')
+    })
+  } finally {
+    isAddingWorkspace.value = false
   }
 }
 
@@ -2021,6 +2320,12 @@ onUnmounted(() => {
     window.cancelAnimationFrame(sessionListFillFrame)
     sessionListFillFrame = null
   }
+
+  if (workspaceRevealTimer !== null) {
+    window.clearTimeout(workspaceRevealTimer)
+    workspaceRevealTimer = null
+  }
+  revealedWorkspaceGroupId.value = null
 
   if (sessionListResizeObserver) {
     sessionListResizeObserver.disconnect()

--- a/src/renderer/src/i18n/da-DK/chat.json
+++ b/src/renderer/src/i18n/da-DK/chat.json
@@ -350,6 +350,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Tilføj arbejdsområde",
+    "emptyWorkspace": "Tom",
+    "addWorkspaceFailed": "Arbejdsområdet kunne ikke tilføjes",
     "searchLoadedRangeDescription": "Viser resultater fra indlæste samtaler. Rul for at indlæse mere historik."
   },
   "floatingWidget": {

--- a/src/renderer/src/i18n/de-DE/chat.json
+++ b/src/renderer/src/i18n/de-DE/chat.json
@@ -366,6 +366,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Arbeitsbereich hinzufügen",
+    "emptyWorkspace": "Leer",
+    "addWorkspaceFailed": "Arbeitsbereich konnte nicht hinzugefügt werden",
     "searchLoadedRangeDescription": "Es werden Treffer aus geladenen Unterhaltungen angezeigt. Scrolle, um weiteren Verlauf zu laden."
   },
   "spotlight": {

--- a/src/renderer/src/i18n/en-US/chat.json
+++ b/src/renderer/src/i18n/en-US/chat.json
@@ -427,6 +427,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Add workspace",
+    "emptyWorkspace": "Empty",
+    "addWorkspaceFailed": "Failed to add workspace",
     "remoteControlDisabled": "Disabled",
     "remoteControlStatus": {
       "disabled": "Remote control disabled",

--- a/src/renderer/src/i18n/es-ES/chat.json
+++ b/src/renderer/src/i18n/es-ES/chat.json
@@ -366,6 +366,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Añadir espacio de trabajo",
+    "emptyWorkspace": "Vacío",
+    "addWorkspaceFailed": "No se pudo añadir el espacio de trabajo",
     "searchLoadedRangeDescription": "Mostrando coincidencias de conversaciones cargadas. Desplázate para cargar más historial."
   },
   "spotlight": {

--- a/src/renderer/src/i18n/fa-IR/chat.json
+++ b/src/renderer/src/i18n/fa-IR/chat.json
@@ -350,6 +350,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "افزودن فضای کاری",
+    "emptyWorkspace": "خالی",
+    "addWorkspaceFailed": "افزودن فضای کاری ناموفق بود",
     "searchLoadedRangeDescription": "نتایج گفت‌وگوهای بارگذاری‌شده نمایش داده می‌شوند. برای بارگذاری تاریخچه بیشتر پیمایش کنید."
   },
   "floatingWidget": {

--- a/src/renderer/src/i18n/fr-FR/chat.json
+++ b/src/renderer/src/i18n/fr-FR/chat.json
@@ -350,6 +350,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Ajouter un espace de travail",
+    "emptyWorkspace": "Vide",
+    "addWorkspaceFailed": "Échec de l’ajout de l’espace de travail",
     "searchLoadedRangeDescription": "Affichage des résultats des conversations chargées. Faites défiler pour charger plus d’historique."
   },
   "floatingWidget": {

--- a/src/renderer/src/i18n/he-IL/chat.json
+++ b/src/renderer/src/i18n/he-IL/chat.json
@@ -350,6 +350,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "הוספת סביבת עבודה",
+    "emptyWorkspace": "ריק",
+    "addWorkspaceFailed": "הוספת סביבת העבודה נכשלה",
     "searchLoadedRangeDescription": "מוצגות התאמות משיחות שנטענו. גלול כדי לטעון היסטוריה נוספת."
   },
   "floatingWidget": {

--- a/src/renderer/src/i18n/id-ID/chat.json
+++ b/src/renderer/src/i18n/id-ID/chat.json
@@ -366,6 +366,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Tambah ruang kerja",
+    "emptyWorkspace": "Kosong",
+    "addWorkspaceFailed": "Gagal menambahkan ruang kerja",
     "searchLoadedRangeDescription": "Menampilkan kecocokan dari percakapan yang dimuat. Gulir untuk memuat riwayat lainnya."
   },
   "spotlight": {

--- a/src/renderer/src/i18n/it-IT/chat.json
+++ b/src/renderer/src/i18n/it-IT/chat.json
@@ -366,6 +366,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Aggiungi area di lavoro",
+    "emptyWorkspace": "Vuoto",
+    "addWorkspaceFailed": "Impossibile aggiungere l’area di lavoro",
     "searchLoadedRangeDescription": "Visualizzazione delle corrispondenze dalle conversazioni caricate. Scorri per caricare altra cronologia."
   },
   "spotlight": {

--- a/src/renderer/src/i18n/ja-JP/chat.json
+++ b/src/renderer/src/i18n/ja-JP/chat.json
@@ -350,6 +350,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "ワークスペースを追加",
+    "emptyWorkspace": "空",
+    "addWorkspaceFailed": "ワークスペースを追加できませんでした",
     "searchLoadedRangeDescription": "読み込み済みの会話から一致する項目を表示しています。スクロールして履歴をさらに読み込めます。"
   },
   "floatingWidget": {

--- a/src/renderer/src/i18n/ko-KR/chat.json
+++ b/src/renderer/src/i18n/ko-KR/chat.json
@@ -350,6 +350,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "작업 공간 추가",
+    "emptyWorkspace": "비어 있음",
+    "addWorkspaceFailed": "작업 공간을 추가하지 못했습니다",
     "searchLoadedRangeDescription": "불러온 대화의 일치 항목을 표시하고 있습니다. 스크롤하여 이전 기록을 더 불러오세요."
   },
   "floatingWidget": {

--- a/src/renderer/src/i18n/ms-MY/chat.json
+++ b/src/renderer/src/i18n/ms-MY/chat.json
@@ -366,6 +366,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Tambah ruang kerja",
+    "emptyWorkspace": "Kosong",
+    "addWorkspaceFailed": "Gagal menambah ruang kerja",
     "searchLoadedRangeDescription": "Memaparkan padanan daripada perbualan yang dimuatkan. Tatal untuk memuatkan lebih banyak sejarah."
   },
   "spotlight": {

--- a/src/renderer/src/i18n/pl-PL/chat.json
+++ b/src/renderer/src/i18n/pl-PL/chat.json
@@ -366,6 +366,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Dodaj obszar roboczy",
+    "emptyWorkspace": "Pusty",
+    "addWorkspaceFailed": "Nie udało się dodać obszaru roboczego",
     "searchLoadedRangeDescription": "Wyświetlanie wyników z załadowanych rozmów. Przewiń, aby załadować więcej historii."
   },
   "spotlight": {

--- a/src/renderer/src/i18n/pt-BR/chat.json
+++ b/src/renderer/src/i18n/pt-BR/chat.json
@@ -350,6 +350,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Adicionar espaço de trabalho",
+    "emptyWorkspace": "Vazio",
+    "addWorkspaceFailed": "Falha ao adicionar espaço de trabalho",
     "searchLoadedRangeDescription": "Mostrando resultados das conversas carregadas. Role para carregar mais histórico."
   },
   "floatingWidget": {

--- a/src/renderer/src/i18n/ru-RU/chat.json
+++ b/src/renderer/src/i18n/ru-RU/chat.json
@@ -350,6 +350,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Добавить рабочее пространство",
+    "emptyWorkspace": "Пусто",
+    "addWorkspaceFailed": "Не удалось добавить рабочее пространство",
     "searchLoadedRangeDescription": "Показаны совпадения из загруженных бесед. Прокрутите, чтобы загрузить больше истории."
   },
   "floatingWidget": {

--- a/src/renderer/src/i18n/tr-TR/chat.json
+++ b/src/renderer/src/i18n/tr-TR/chat.json
@@ -366,6 +366,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Çalışma alanı ekle",
+    "emptyWorkspace": "Boş",
+    "addWorkspaceFailed": "Çalışma alanı eklenemedi",
     "searchLoadedRangeDescription": "Yüklenen konuşmalardaki eşleşmeler gösteriliyor. Daha fazla geçmiş yüklemek için kaydırın."
   },
   "spotlight": {

--- a/src/renderer/src/i18n/vi-VN/chat.json
+++ b/src/renderer/src/i18n/vi-VN/chat.json
@@ -366,6 +366,9 @@
     "searchCommand": "Search",
     "chatSection": "Chat",
     "workspace": "Workspace",
+    "addWorkspace": "Thêm không gian làm việc",
+    "emptyWorkspace": "Trống",
+    "addWorkspaceFailed": "Không thể thêm không gian làm việc",
     "searchLoadedRangeDescription": "Đang hiển thị kết quả khớp từ các cuộc trò chuyện đã tải. Cuộn để tải thêm lịch sử."
   },
   "spotlight": {

--- a/src/renderer/src/i18n/zh-CN/chat.json
+++ b/src/renderer/src/i18n/zh-CN/chat.json
@@ -427,6 +427,9 @@
     "searchCommand": "搜索",
     "chatSection": "Chat",
     "workspace": "工作区",
+    "addWorkspace": "添加工作区",
+    "emptyWorkspace": "空",
+    "addWorkspaceFailed": "添加工作区失败",
     "remoteControlDisabled": "未启用",
     "remoteControlStatus": {
       "disabled": "远程控制已禁用",

--- a/src/renderer/src/i18n/zh-HK/chat.json
+++ b/src/renderer/src/i18n/zh-HK/chat.json
@@ -350,6 +350,9 @@
     "searchCommand": "搜尋",
     "chatSection": "Chat",
     "workspace": "工作區",
+    "addWorkspace": "新增工作區",
+    "emptyWorkspace": "空白",
+    "addWorkspaceFailed": "新增工作區失敗",
     "searchLoadedRangeDescription": "正在顯示已載入對話中的相符結果。向下捲動以載入更多記錄。"
   },
   "floatingWidget": {

--- a/src/renderer/src/i18n/zh-TW/chat.json
+++ b/src/renderer/src/i18n/zh-TW/chat.json
@@ -350,6 +350,9 @@
     "searchCommand": "搜尋",
     "chatSection": "Chat",
     "workspace": "工作區",
+    "addWorkspace": "新增工作區",
+    "emptyWorkspace": "空白",
+    "addWorkspaceFailed": "新增工作區失敗",
     "searchLoadedRangeDescription": "正在顯示已載入對話中的相符結果。向下捲動以載入更多歷史記錄。"
   },
   "floatingWidget": {

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -89,7 +89,7 @@
               icon="lucide:folder-open"
               :label="t('common.project.openFolder')"
               class="text-xs py-1.5 px-2"
-              @select="projectStore.openFolderPicker()"
+              @select="handleOpenFolderPicker"
             />
           </DropdownMenuContent>
         </DropdownMenu>
@@ -1315,6 +1315,20 @@ function onPendingSkillsChange(skills: string[]) {
 
 function clearSelectedProject() {
   projectStore.selectProject(null, 'manual')
+}
+
+async function handleOpenFolderPicker() {
+  try {
+    await projectStore.openFolderPicker()
+  } catch (error) {
+    console.warn('[NewThreadPage] Failed to open folder picker:', error)
+    notifyRenderer({
+      kind: 'error',
+      code: 'chat.workspace.selectFailed',
+      title: t('common.error.operationFailed'),
+      description: t('common.error.requestFailed')
+    })
+  }
 }
 
 const ensureAcpDraftSession = async (agentId: string, projectPath: string) => {

--- a/src/renderer/src/pages/NewThreadPage.vue
+++ b/src/renderer/src/pages/NewThreadPage.vue
@@ -224,6 +224,7 @@ import { isManualCompactionCommand } from '@/components/chat/mentions/utils'
 import { filterUnsupportedAudioAttachments } from '@/lib/audioInputSupport'
 import { isAbortError } from '@/lib/errors'
 import { isAttachmentPreparationCandidate } from '@shared/utils/attachmentRepresentation'
+import { normalizeWorkspacePath } from '@shared/utils/filesystem'
 import { useSpeechRecognition } from '@/components/chat/composables/useSpeechRecognition'
 import { cancelChatInputHeroFlight, prepareChatInputHeroFlight } from '@/lib/chatInputHero'
 
@@ -404,11 +405,9 @@ const normalizeProjectPath = (value: string | null | undefined) => {
   const normalized = value?.trim()
   return normalized ? normalized : null
 }
-const normalizeComparableProjectPath = (value: string | null | undefined) =>
-  normalizeProjectPath(value)?.replace(/[\\/]+$/, '') ?? null
 const isDefaultChatWorkspaceProject = (path: string | null | undefined) => {
-  const chatWorkspacePath = normalizeComparableProjectPath(projectStore.defaultChatWorkspacePath)
-  return Boolean(chatWorkspacePath) && normalizeComparableProjectPath(path) === chatWorkspacePath
+  const chatWorkspacePath = normalizeWorkspacePath(projectStore.defaultChatWorkspacePath)
+  return Boolean(chatWorkspacePath) && normalizeWorkspacePath(path) === chatWorkspacePath
 }
 const selectedProjectPath = computed(() => normalizeProjectPath(projectStore.selectedProject?.path))
 const archivedProjectPaths = computed(

--- a/src/renderer/src/stores/ui/project.ts
+++ b/src/renderer/src/stores/ui/project.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 import { createProjectClient } from '@api/ProjectClient'
 import { createConfigClient } from '../../../api/ConfigClient'
 import type { EnvironmentSummary, Project } from '@shared/types/agent-interface'
+import { normalizeWorkspacePath } from '@shared/utils/filesystem'
 
 export interface UIProject {
   name: string
@@ -25,6 +26,7 @@ type ProjectSnapshot = {
   archivedEnvironments: EnvironmentSummary[]
   removedEnvironments: EnvironmentSummary[]
   defaultProjectPath: string | null
+  defaultChatWorkspacePath: string | null
 }
 
 export const useProjectStore = defineStore('project', () => {
@@ -37,6 +39,7 @@ export const useProjectStore = defineStore('project', () => {
   const selectedProjectPath = ref<string | null>(null)
   const defaultProjectPath = ref<string | null>(null)
   const defaultChatWorkspacePath = ref<string | null>(null)
+  const snapshotReady = ref(false)
   const selectionSource = ref<ProjectSelectionSource>('none')
   const error = ref<string | null>(null)
   let listenersRegistered = false
@@ -50,7 +53,7 @@ export const useProjectStore = defineStore('project', () => {
 
   const normalizePath = (path: string | null | undefined): string | null => path?.trim() || null
   const createSyntheticProject = (projectPath: string): UIProject => ({
-    name: projectPath.split(/[/\\]/).pop() ?? projectPath,
+    name: projectPath.split(/[/\\]/).pop() || projectPath,
     path: projectPath,
     icon: null,
     exists: true,
@@ -95,6 +98,22 @@ export const useProjectStore = defineStore('project', () => {
     if (snapshot.version < committedSnapshotVersion) return false
     committedSnapshotVersion = snapshot.version
     defaultProjectPath.value = normalizePath(snapshot.defaultProjectPath)
+    defaultChatWorkspacePath.value = normalizePath(snapshot.defaultChatWorkspacePath)
+    environments.value = snapshot.environments
+    archivedEnvironments.value = snapshot.archivedEnvironments
+    removedEnvironments.value = snapshot.removedEnvironments
+    if (
+      selectedProjectPath.value &&
+      selectionSource.value === 'manual' &&
+      [...archivedEnvironments.value, ...removedEnvironments.value].some(
+        (environment) =>
+          normalizeWorkspacePath(environment.path) ===
+          normalizeWorkspacePath(selectedProjectPath.value)
+      )
+    ) {
+      selectedProjectPath.value = null
+      selectionSource.value = 'none'
+    }
     projects.value = reconcileProjects(
       snapshot.projects.map((project) => ({
         name: project.name,
@@ -103,9 +122,6 @@ export const useProjectStore = defineStore('project', () => {
         exists: project.exists
       }))
     )
-    environments.value = snapshot.environments
-    archivedEnvironments.value = snapshot.archivedEnvironments
-    removedEnvironments.value = snapshot.removedEnvironments
     if (
       selectedProjectPath.value &&
       selectionSource.value !== 'manual' &&
@@ -115,44 +131,57 @@ export const useProjectStore = defineStore('project', () => {
       selectionSource.value = 'none'
     }
     applyDefaultSelection()
+    snapshotReady.value = true
     error.value = null
     return true
   }
 
-  async function refreshProjectSnapshot(minVersion = 0): Promise<void> {
+  async function refreshProjectSnapshot(minVersion = 0): Promise<boolean> {
     requestedSnapshotVersion = Math.max(requestedSnapshotVersion, minVersion)
-    if (refreshPromise) {
-      return refreshPromise
-    }
-
-    refreshPromise = (async () => {
-      do {
-        const targetVersion = requestedSnapshotVersion
-        try {
-          const snapshot = (await projectClient.getSnapshot()) as ProjectSnapshot
-          if (snapshot.version >= targetVersion && snapshot.version >= committedSnapshotVersion) {
-            applySnapshot(snapshot)
-          } else {
-            // Events can become visible before their corresponding snapshot
-            // projection. Do not spin on a successful but incomplete read;
-            // leave the last committed state intact until a later refresh.
+    if (!refreshPromise) {
+      refreshPromise = (async () => {
+        do {
+          const targetVersion = requestedSnapshotVersion
+          try {
+            const snapshot = (await projectClient.getSnapshot()) as ProjectSnapshot
+            if (snapshot.version >= targetVersion && snapshot.version >= committedSnapshotVersion) {
+              applySnapshot(snapshot)
+            } else {
+              if (requestedSnapshotVersion > targetVersion) {
+                continue
+              }
+              // Events can become visible before their corresponding snapshot
+              // projection. Do not spin on a successful but incomplete read;
+              // leave the last committed state intact until a later refresh.
+              return
+            }
+          } catch (cause) {
+            // A versioned notification may arrive while the older read fails. In
+            // that case this single refresh owner must consume the newer target
+            // instead of publishing a stale failure that strands the store.
+            if (requestedSnapshotVersion > targetVersion) {
+              continue
+            }
+            error.value = `Failed to load project snapshot: ${cause}`
             return
           }
-        } catch (cause) {
-          // A versioned notification may arrive while the older read fails. In
-          // that case this single refresh owner must consume the newer target
-          // instead of publishing a stale failure that strands the store.
-          if (requestedSnapshotVersion > targetVersion) {
-            continue
-          }
-          error.value = `Failed to load project snapshot: ${cause}`
-          return
-        }
-      } while (committedSnapshotVersion < requestedSnapshotVersion)
-    })().finally(() => {
-      refreshPromise = null
-    })
-    return refreshPromise
+        } while (committedSnapshotVersion < requestedSnapshotVersion)
+      })().finally(() => {
+        refreshPromise = null
+      })
+    }
+
+    await refreshPromise
+    return committedSnapshotVersion >= minVersion && error.value === null
+  }
+
+  async function requireProjectSnapshot(minVersion = 0): Promise<void> {
+    const committed = await refreshProjectSnapshot(minVersion)
+    if (!committed || error.value) {
+      const message = error.value ?? `Project snapshot version ${minVersion} was not committed`
+      error.value = message
+      throw new Error(message)
+    }
   }
 
   function ensureListenersRegistered(): void {
@@ -185,14 +214,12 @@ export const useProjectStore = defineStore('project', () => {
     path: string | null | undefined,
     chatWorkspacePath?: string | null
   ): void {
-    // The workspace hint is bootstrap-only, while defaultProjectPath belongs to
-    // the versioned project snapshot. A delayed bootstrap response therefore
-    // must not roll back an already committed snapshot.
-    defaultChatWorkspacePath.value = normalizePath(chatWorkspacePath)
     if (committedSnapshotVersion >= 0) {
       return
     }
 
+    // A delayed bootstrap response must not roll back a committed Project snapshot.
+    defaultChatWorkspacePath.value = normalizePath(chatWorkspacePath)
     defaultProjectPath.value = normalizePath(path)
     projects.value = reconcileProjects(projects.value)
     applyDefaultSelection()
@@ -201,7 +228,7 @@ export const useProjectStore = defineStore('project', () => {
   async function setDefaultProject(path: string | null): Promise<void> {
     try {
       await configClient.setDefaultProjectPath(normalizePath(path))
-      await refreshProjectSnapshot()
+      await requireProjectSnapshot()
     } catch (cause) {
       error.value = `Failed to update default project path: ${cause}`
       throw cause
@@ -218,7 +245,7 @@ export const useProjectStore = defineStore('project', () => {
     if (orderedPaths.length === 0) return
     try {
       await projectClient.reorderEnvironments(orderedPaths)
-      await refreshProjectSnapshot()
+      await requireProjectSnapshot()
     } catch (cause) {
       error.value = `Failed to reorder environments: ${cause}`
       await refreshProjectSnapshot()
@@ -228,8 +255,19 @@ export const useProjectStore = defineStore('project', () => {
 
   async function archiveEnvironment(path: string): Promise<void> {
     try {
-      await projectClient.archiveEnvironment(path)
-      await refreshProjectSnapshot()
+      const result = await projectClient.archiveEnvironment(path)
+      await requireProjectSnapshot(result.version)
+      const pathIdentity = normalizeWorkspacePath(path)
+      if (
+        environments.value.some(
+          (environment) => normalizeWorkspacePath(environment.path) === pathIdentity
+        ) ||
+        !archivedEnvironments.value.some(
+          (environment) => normalizeWorkspacePath(environment.path) === pathIdentity
+        )
+      ) {
+        throw new Error('Archived environment is missing from the committed project snapshot')
+      }
     } catch (cause) {
       error.value = `Failed to archive environment: ${cause}`
       throw cause
@@ -239,7 +277,7 @@ export const useProjectStore = defineStore('project', () => {
   async function restoreEnvironment(path: string): Promise<void> {
     try {
       await projectClient.restoreEnvironment(path)
-      await refreshProjectSnapshot()
+      await requireProjectSnapshot()
     } catch (cause) {
       error.value = `Failed to restore environment: ${cause}`
       throw cause
@@ -249,7 +287,7 @@ export const useProjectStore = defineStore('project', () => {
   async function removeEnvironment(path: string): Promise<{ clearedSessionIds: string[] }> {
     try {
       const result = await projectClient.removeEnvironment(path)
-      await refreshProjectSnapshot()
+      await requireProjectSnapshot()
       return result
     } catch (cause) {
       error.value = `Failed to remove environment: ${cause}`
@@ -267,26 +305,44 @@ export const useProjectStore = defineStore('project', () => {
   }
 
   async function openFolderPicker(options: OpenFolderPickerOptions = {}): Promise<string | null> {
+    let selection: Awaited<ReturnType<typeof projectClient.selectDirectoryWithVersion>>
     try {
-      const selectedPath = await projectClient.selectDirectory()
-      if (!selectedPath) {
-        return null
-      }
+      selection = await projectClient.selectDirectoryWithVersion()
+    } catch (cause) {
+      error.value = `Failed to open folder picker: ${cause}`
+      throw cause
+    }
 
-      if (options.select !== false) {
-        selectProject(selectedPath, 'manual')
-      }
+    const selectedPath = selection.path
+    if (!selectedPath) {
+      return null
+    }
 
-      await refreshProjectSnapshot()
-      if (error.value) {
+    const shouldSelect = options.select !== false
+    const previousSelectedProjectPath = selectedProjectPath.value
+    const previousSelectionSource = selectionSource.value
+    if (shouldSelect) {
+      selectProject(selectedPath, 'manual')
+    }
+
+    try {
+      await requireProjectSnapshot(selection.version)
+      const selectedPathIdentity = normalizeWorkspacePath(selectedPath)
+      if (
+        !environments.value.some(
+          (environment) => normalizeWorkspacePath(environment.path) === selectedPathIdentity
+        )
+      ) {
+        error.value = 'Selected workspace is missing from the project snapshot'
         throw new Error(error.value)
-      }
-      if (!environments.value.some((environment) => environment.path === selectedPath)) {
-        throw new Error('Selected workspace is missing from the project snapshot')
       }
       return selectedPath
     } catch (cause) {
-      error.value = `Failed to open folder picker: ${cause}`
+      if (shouldSelect) {
+        selectedProjectPath.value = previousSelectedProjectPath
+        selectionSource.value = previousSelectionSource
+        projects.value = reconcileProjects(projects.value)
+      }
       throw cause
     }
   }
@@ -305,6 +361,7 @@ export const useProjectStore = defineStore('project', () => {
     selectedProjectPath,
     defaultProjectPath,
     defaultChatWorkspacePath,
+    snapshotReady,
     selectionSource,
     error,
     selectedProject,

--- a/src/renderer/src/stores/ui/project.ts
+++ b/src/renderer/src/stores/ui/project.ts
@@ -14,6 +14,10 @@ export interface UIProject {
 
 type ProjectSelectionSource = 'none' | 'manual' | 'default'
 
+type OpenFolderPickerOptions = {
+  select?: boolean
+}
+
 type ProjectSnapshot = {
   version: number
   projects: Project[]
@@ -262,15 +266,28 @@ export const useProjectStore = defineStore('project', () => {
     }
   }
 
-  async function openFolderPicker(): Promise<void> {
+  async function openFolderPicker(options: OpenFolderPickerOptions = {}): Promise<string | null> {
     try {
       const selectedPath = await projectClient.selectDirectory()
-      if (selectedPath) {
-        selectProject(selectedPath, 'manual')
-        await refreshProjectSnapshot()
+      if (!selectedPath) {
+        return null
       }
+
+      if (options.select !== false) {
+        selectProject(selectedPath, 'manual')
+      }
+
+      await refreshProjectSnapshot()
+      if (error.value) {
+        throw new Error(error.value)
+      }
+      if (!environments.value.some((environment) => environment.path === selectedPath)) {
+        throw new Error('Selected workspace is missing from the project snapshot')
+      }
+      return selectedPath
     } catch (cause) {
       error.value = `Failed to open folder picker: ${cause}`
+      throw cause
     }
   }
 

--- a/src/renderer/src/stores/ui/session.ts
+++ b/src/renderer/src/stores/ui/session.ts
@@ -1289,14 +1289,22 @@ export const useSessionStore = defineStore('session', () => {
     }
   }
 
-  async function toggleGroupMode(): Promise<void> {
+  async function setGroupMode(mode: GroupMode): Promise<void> {
+    if (!hasLoadedGroupMode) {
+      await ensureGroupModeLoaded()
+    }
     const previousMode = groupMode.value
-    groupMode.value = previousMode === 'time' ? 'project' : 'time'
+    if (previousMode === mode) {
+      await groupModeWritePromise
+      return
+    }
+
+    groupMode.value = mode
     const localVersion = ++groupModeUpdateVersion
 
-    groupModeWritePromise = groupModeWritePromise.then(async () => {
+    const writePromise = groupModeWritePromise.then(async () => {
       try {
-        await configClient.setSetting(SIDEBAR_GROUP_MODE_KEY, groupMode.value)
+        await configClient.setSetting(SIDEBAR_GROUP_MODE_KEY, mode)
         if (localVersion !== groupModeUpdateVersion) {
           return
         }
@@ -1305,10 +1313,23 @@ export const useSessionStore = defineStore('session', () => {
           groupMode.value = previousMode
         }
         console.warn('[sessionStore] Failed to persist sidebar group mode:', persistError)
+        throw persistError
       }
     })
 
-    await groupModeWritePromise
+    groupModeWritePromise = writePromise.catch(() => undefined)
+    await writePromise
+  }
+
+  async function toggleGroupMode(): Promise<void> {
+    try {
+      if (!hasLoadedGroupMode) {
+        await ensureGroupModeLoaded()
+      }
+      await setGroupMode(groupMode.value === 'time' ? 'project' : 'time')
+    } catch {
+      // setGroupMode already restores the visible state and records the failure.
+    }
   }
 
   function getPinnedSessions(agentId: string | null): UISession[] {
@@ -1412,6 +1433,7 @@ export const useSessionStore = defineStore('session', () => {
     deleteSession,
     setSessionProjectDir,
     moveSessionToAgent,
+    setGroupMode,
     toggleGroupMode,
     getPinnedSessions,
     getFilteredGroups

--- a/src/renderer/src/stores/ui/session.ts
+++ b/src/renderer/src/stores/ui/session.ts
@@ -33,6 +33,7 @@ import { useAttachmentPreparationStore } from './attachmentPreparation'
 import { useLiveDelegationStore } from './liveDelegation'
 import { isAbortError } from '@/lib/errors'
 import { bindSessionStoreIpc } from './sessionIpc'
+import { normalizeWorkspacePath } from '@shared/utils/filesystem'
 
 export type UISessionStatus = 'completed' | 'working' | 'error' | 'none'
 
@@ -189,7 +190,7 @@ function groupByTime(sessions: UISession[]): SessionGroup[] {
 }
 
 function normalizeProjectGroupId(projectDir: string): string {
-  const normalizedDir = projectDir.trim().replace(/[\\/]+$/, '')
+  const normalizedDir = normalizeWorkspacePath(projectDir)
   return normalizedDir || NO_PROJECT_GROUP_ID
 }
 
@@ -201,7 +202,7 @@ function getProjectGroupLabel(projectGroupId: string): { label: string; labelKey
     }
   }
 
-  const label = projectGroupId.split(/[\\/]/).pop() ?? projectGroupId
+  const label = projectGroupId.split(/[\\/]/).pop() || projectGroupId
   return { label }
 }
 
@@ -321,9 +322,11 @@ export const useSessionStore = defineStore('session', () => {
   const liveDelegationStore = useLiveDelegationStore()
   const myWebContentsId = ref<number | null>(null)
   let groupModeLoadPromise: Promise<void> | null = null
-  let groupModeWritePromise: Promise<void> = Promise.resolve()
+  let groupModeWriteQueue: Promise<void> = Promise.resolve()
+  let latestGroupModeWrite: Promise<void> = Promise.resolve()
   let hasLoadedGroupMode = false
-  let groupModeUpdateVersion = 0
+  let persistedGroupMode: GroupMode = DEFAULT_GROUP_MODE
+  let requestedGroupMode: GroupMode = DEFAULT_GROUP_MODE
   let initialPageRequestId = 0
   let nextPageRequestId = 0
   // A list epoch protects the first-page/pagination cursor chain. Targeted updates
@@ -399,19 +402,15 @@ export const useSessionStore = defineStore('session', () => {
     value === 'time' || value === 'project' ? value : DEFAULT_GROUP_MODE
 
   const loadGroupModePreference = async (): Promise<void> => {
-    const loadVersion = groupModeUpdateVersion
-
     try {
       const savedGroupMode = await configClient.getSetting(SIDEBAR_GROUP_MODE_KEY)
-      if (groupModeUpdateVersion === loadVersion) {
-        groupMode.value = normalizeGroupMode(savedGroupMode)
-      }
+      persistedGroupMode = normalizeGroupMode(savedGroupMode)
     } catch (loadError) {
-      if (groupModeUpdateVersion === loadVersion) {
-        groupMode.value = DEFAULT_GROUP_MODE
-      }
+      persistedGroupMode = DEFAULT_GROUP_MODE
       console.warn('[sessionStore] Failed to load sidebar group mode:', loadError)
     } finally {
+      requestedGroupMode = persistedGroupMode
+      groupMode.value = persistedGroupMode
       hasLoadedGroupMode = true
     }
   }
@@ -1293,31 +1292,29 @@ export const useSessionStore = defineStore('session', () => {
     if (!hasLoadedGroupMode) {
       await ensureGroupModeLoaded()
     }
-    const previousMode = groupMode.value
-    if (previousMode === mode) {
-      await groupModeWritePromise
+    if (requestedGroupMode === mode) {
+      await latestGroupModeWrite
       return
     }
 
+    requestedGroupMode = mode
     groupMode.value = mode
-    const localVersion = ++groupModeUpdateVersion
-
-    const writePromise = groupModeWritePromise.then(async () => {
+    const writePromise = groupModeWriteQueue.then(async () => {
       try {
         await configClient.setSetting(SIDEBAR_GROUP_MODE_KEY, mode)
-        if (localVersion !== groupModeUpdateVersion) {
-          return
-        }
+        persistedGroupMode = mode
       } catch (persistError) {
-        if (localVersion === groupModeUpdateVersion) {
-          groupMode.value = previousMode
+        if (requestedGroupMode === mode) {
+          requestedGroupMode = persistedGroupMode
+          groupMode.value = persistedGroupMode
         }
         console.warn('[sessionStore] Failed to persist sidebar group mode:', persistError)
         throw persistError
       }
     })
 
-    groupModeWritePromise = writePromise.catch(() => undefined)
+    latestGroupModeWrite = writePromise
+    groupModeWriteQueue = writePromise.catch(() => undefined)
     await writePromise
   }
 

--- a/src/shared/contracts/routes/project.routes.ts
+++ b/src/shared/contracts/routes/project.routes.ts
@@ -10,7 +10,8 @@ export const ProjectSnapshotSchema = z.object({
   environments: z.array(EnvironmentSummarySchema),
   archivedEnvironments: z.array(EnvironmentSummarySchema),
   removedEnvironments: z.array(EnvironmentSummarySchema),
-  defaultProjectPath: z.string().nullable()
+  defaultProjectPath: z.string().nullable(),
+  defaultChatWorkspacePath: z.string().nullable()
 })
 
 export const projectGetSnapshotRoute = defineRouteContract({
@@ -57,7 +58,8 @@ export const projectArchiveEnvironmentRoute = defineRouteContract({
     path: z.string().trim().min(1)
   }),
   output: z.object({
-    updated: z.boolean()
+    updated: z.boolean(),
+    version: RevisionSchema
   })
 })
 
@@ -105,6 +107,7 @@ export const projectSelectDirectoryRoute = defineRouteContract({
   name: 'project.selectDirectory',
   input: z.object({}).default({}),
   output: z.object({
-    path: z.string().nullable()
+    path: z.string().nullable(),
+    version: RevisionSchema
   })
 })

--- a/src/shared/utils/filesystem.ts
+++ b/src/shared/utils/filesystem.ts
@@ -9,6 +9,22 @@ const HARDLINK_UNAVAILABLE_CODES = new Set([
   'EXDEV'
 ])
 
+export function normalizeWorkspacePath(value: string | null | undefined): string {
+  const trimmed = value?.trim() ?? ''
+  if (!trimmed) return ''
+
+  if (/^[\\/]+$/.test(trimmed)) {
+    return trimmed[0]
+  }
+
+  const driveRoot = /^([A-Za-z]:)([\\/]+)$/.exec(trimmed)
+  if (driveRoot) {
+    return `${driveRoot[1]}${driveRoot[2][0]}`
+  }
+
+  return trimmed.replace(/[\\/]+$/, '')
+}
+
 export function isHardlinkUnavailableError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false
   const code = (error as NodeJS.ErrnoException).code

--- a/test/main/project/data/tables/newEnvironmentPreferencesTable.test.ts
+++ b/test/main/project/data/tables/newEnvironmentPreferencesTable.test.ts
@@ -118,4 +118,32 @@ describeIfSqlite('NewEnvironmentPreferencesTable', () => {
       removed_at: null
     })
   })
+
+  it('assigns unique top positions without moving an active duplicate', () => {
+    table.reorderActive(['/work/a', '/work/b'])
+
+    table.activateAtTop('/work/new')
+    expect(table.get('/work/new')).toMatchObject({ status: 'active', sort_order: -1 })
+
+    table.activateAtTop('/work/newer')
+    expect(table.get('/work/newer')).toMatchObject({ status: 'active', sort_order: -2 })
+
+    table.activateAtTop('/work/b')
+    expect(table.get('/work/b')).toMatchObject({ status: 'active', sort_order: 1 })
+
+    table.markArchived('/work/a')
+    table.activateAtTop('/work/a')
+    expect(table.get('/work/a')).toMatchObject({
+      status: 'active',
+      sort_order: -3,
+      archived_at: null,
+      removed_at: null
+    })
+    expect(
+      table
+        .list()
+        .filter((row) => row.status === 'active')
+        .map((row) => row.sort_order)
+    ).toEqual(expect.arrayContaining([-3, -2, -1, 1]))
+  })
 })

--- a/test/main/project/data/tables/newEnvironmentPreferencesTable.test.ts
+++ b/test/main/project/data/tables/newEnvironmentPreferencesTable.test.ts
@@ -94,4 +94,28 @@ describeIfSqlite('NewEnvironmentPreferencesTable', () => {
     })
     expect(table.get('/work/remove')?.removed_at).toEqual(expect.any(Number))
   })
+
+  it('reactivates one existing path without resetting its explicit order', () => {
+    table.reorderActive(['/work/a', '/work/b'])
+    table.markArchived('/work/a')
+    table.markRemoved('/work/b')
+
+    table.markActive('/work/a')
+    table.markActive('/work/b')
+    table.markActive('/work/a')
+
+    expect(table.list()).toHaveLength(2)
+    expect(table.get('/work/a')).toMatchObject({
+      status: 'active',
+      sort_order: 0,
+      archived_at: null,
+      removed_at: null
+    })
+    expect(table.get('/work/b')).toMatchObject({
+      status: 'active',
+      sort_order: 1,
+      archived_at: null,
+      removed_at: null
+    })
+  })
 })

--- a/test/main/project/projectService.test.ts
+++ b/test/main/project/projectService.test.ts
@@ -422,6 +422,34 @@ describe('ProjectService', () => {
   })
 
   describe('getEnvironments', () => {
+    it('includes an active preference before the workspace has any sessions', async () => {
+      sqlitePresenter.newEnvironmentPreferencesTable.list.mockReturnValue([
+        {
+          path: '/work/new',
+          status: 'active',
+          sort_order: 0,
+          archived_at: null,
+          removed_at: null,
+          updated_at: 1000
+        }
+      ])
+
+      await expect(presenter.getEnvironments()).resolves.toEqual([
+        {
+          path: '/work/new',
+          name: 'new',
+          sessionCount: 0,
+          lastUsedAt: 1000,
+          isTemp: false,
+          exists: true,
+          status: 'active',
+          sortOrder: 0,
+          archivedAt: null,
+          removedAt: null
+        }
+      ])
+    })
+
     it('maps environment rows with temp and exists metadata', async () => {
       sqlitePresenter.newEnvironmentsTable.list.mockReturnValue([
         {
@@ -665,7 +693,25 @@ describe('ProjectService', () => {
       expect(result).toBeNull()
     })
 
-    it('upserts project and returns path on selection', async () => {
+    it('registers a new directory at the top of the active order', async () => {
+      sqlitePresenter.newEnvironmentPreferencesTable.list.mockReturnValue([
+        {
+          path: '/work/alpha',
+          status: 'active',
+          sort_order: 0,
+          archived_at: null,
+          removed_at: null,
+          updated_at: 100
+        },
+        {
+          path: '/work/beta',
+          status: 'active',
+          sort_order: 1,
+          archived_at: null,
+          removed_at: null,
+          updated_at: 200
+        }
+      ])
       deviceService.selectDirectory.mockResolvedValue({
         canceled: false,
         filePaths: ['/Users/test/my-project']
@@ -681,6 +727,75 @@ describe('ProjectService', () => {
       expect(sqlitePresenter.newEnvironmentPreferencesTable.markActive).toHaveBeenCalledWith(
         '/Users/test/my-project'
       )
+      expect(sqlitePresenter.newEnvironmentPreferencesTable.reorderActive).toHaveBeenCalledWith([
+        '/Users/test/my-project',
+        '/work/alpha',
+        '/work/beta'
+      ])
+    })
+
+    it('keeps the persisted order when selecting an already active directory', async () => {
+      sqlitePresenter.newEnvironmentPreferencesTable.list.mockReturnValue([
+        {
+          path: '/work/alpha',
+          status: 'active',
+          sort_order: 0,
+          archived_at: null,
+          removed_at: null,
+          updated_at: 100
+        },
+        {
+          path: '/work/existing',
+          status: 'active',
+          sort_order: 1,
+          archived_at: null,
+          removed_at: null,
+          updated_at: 200
+        }
+      ])
+      deviceService.selectDirectory.mockResolvedValue({
+        canceled: false,
+        filePaths: ['/work/existing']
+      })
+
+      await presenter.selectDirectory()
+
+      expect(sqlitePresenter.newEnvironmentPreferencesTable.markActive).toHaveBeenCalledWith(
+        '/work/existing'
+      )
+      expect(sqlitePresenter.newEnvironmentPreferencesTable.reorderActive).not.toHaveBeenCalled()
+    })
+
+    it('reactivates an archived directory at the top of the active order', async () => {
+      sqlitePresenter.newEnvironmentPreferencesTable.list.mockReturnValue([
+        {
+          path: '/work/alpha',
+          status: 'active',
+          sort_order: 0,
+          archived_at: null,
+          removed_at: null,
+          updated_at: 100
+        },
+        {
+          path: '/work/archived',
+          status: 'archived',
+          sort_order: 1,
+          archived_at: 200,
+          removed_at: null,
+          updated_at: 200
+        }
+      ])
+      deviceService.selectDirectory.mockResolvedValue({
+        canceled: false,
+        filePaths: ['/work/archived']
+      })
+
+      await presenter.selectDirectory()
+
+      expect(sqlitePresenter.newEnvironmentPreferencesTable.reorderActive).toHaveBeenCalledWith([
+        '/work/archived',
+        '/work/alpha'
+      ])
     })
   })
 })

--- a/test/main/project/projectService.test.ts
+++ b/test/main/project/projectService.test.ts
@@ -51,6 +51,7 @@ function createMockSqlitePresenter() {
     newEnvironmentPreferencesTable: {
       list: vi.fn().mockReturnValue([]),
       get: vi.fn(),
+      activateAtTop: vi.fn(),
       reorderActive: vi.fn(),
       markActive: vi.fn(),
       markArchived: vi.fn(),
@@ -143,6 +144,7 @@ describe('ProjectService', () => {
       expect(initial.archivedEnvironments.map((item) => item.path)).toEqual(['/work/archived'])
       expect(initial.removedEnvironments.map((item) => item.path)).toEqual(['/work/removed'])
       expect(initial.defaultProjectPath).toBe('/work/default')
+      expect(initial.defaultChatWorkspacePath).toBeNull()
       expect(updated.version).toBe(1)
     })
 
@@ -595,8 +597,9 @@ describe('ProjectService', () => {
     })
 
     it('archives an environment through environment preferences', async () => {
-      await presenter.archiveEnvironment('/work/app')
+      const version = await presenter.archiveEnvironment('/work/app')
 
+      expect(version).toBe(1)
       expect(sqlitePresenter.newEnvironmentPreferencesTable.markArchived).toHaveBeenCalledWith(
         '/work/app'
       )
@@ -682,7 +685,7 @@ describe('ProjectService', () => {
 
       const result = await presenter.selectDirectory()
 
-      expect(result).toBeNull()
+      expect(result).toEqual({ path: null, version: 0 })
     })
 
     it('returns null when no path selected', async () => {
@@ -690,28 +693,10 @@ describe('ProjectService', () => {
 
       const result = await presenter.selectDirectory()
 
-      expect(result).toBeNull()
+      expect(result).toEqual({ path: null, version: 0 })
     })
 
     it('registers a new directory at the top of the active order', async () => {
-      sqlitePresenter.newEnvironmentPreferencesTable.list.mockReturnValue([
-        {
-          path: '/work/alpha',
-          status: 'active',
-          sort_order: 0,
-          archived_at: null,
-          removed_at: null,
-          updated_at: 100
-        },
-        {
-          path: '/work/beta',
-          status: 'active',
-          sort_order: 1,
-          archived_at: null,
-          removed_at: null,
-          updated_at: 200
-        }
-      ])
       deviceService.selectDirectory.mockResolvedValue({
         canceled: false,
         filePaths: ['/Users/test/my-project']
@@ -719,40 +704,19 @@ describe('ProjectService', () => {
 
       const result = await presenter.selectDirectory()
 
-      expect(result).toBe('/Users/test/my-project')
+      expect(result).toEqual({ path: '/Users/test/my-project', version: 1 })
       expect(sqlitePresenter.newProjectsTable.upsert).toHaveBeenCalledWith(
         '/Users/test/my-project',
         'my-project'
       )
-      expect(sqlitePresenter.newEnvironmentPreferencesTable.markActive).toHaveBeenCalledWith(
+      expect(sqlitePresenter.newEnvironmentPreferencesTable.activateAtTop).toHaveBeenCalledWith(
         '/Users/test/my-project'
       )
-      expect(sqlitePresenter.newEnvironmentPreferencesTable.reorderActive).toHaveBeenCalledWith([
-        '/Users/test/my-project',
-        '/work/alpha',
-        '/work/beta'
-      ])
+      expect(sqlitePresenter.getDatabase).toHaveBeenCalledTimes(1)
+      expect(existsSyncMock).not.toHaveBeenCalled()
     })
 
     it('keeps the persisted order when selecting an already active directory', async () => {
-      sqlitePresenter.newEnvironmentPreferencesTable.list.mockReturnValue([
-        {
-          path: '/work/alpha',
-          status: 'active',
-          sort_order: 0,
-          archived_at: null,
-          removed_at: null,
-          updated_at: 100
-        },
-        {
-          path: '/work/existing',
-          status: 'active',
-          sort_order: 1,
-          archived_at: null,
-          removed_at: null,
-          updated_at: 200
-        }
-      ])
       deviceService.selectDirectory.mockResolvedValue({
         canceled: false,
         filePaths: ['/work/existing']
@@ -760,31 +724,12 @@ describe('ProjectService', () => {
 
       await presenter.selectDirectory()
 
-      expect(sqlitePresenter.newEnvironmentPreferencesTable.markActive).toHaveBeenCalledWith(
+      expect(sqlitePresenter.newEnvironmentPreferencesTable.activateAtTop).toHaveBeenCalledWith(
         '/work/existing'
       )
-      expect(sqlitePresenter.newEnvironmentPreferencesTable.reorderActive).not.toHaveBeenCalled()
     })
 
     it('reactivates an archived directory at the top of the active order', async () => {
-      sqlitePresenter.newEnvironmentPreferencesTable.list.mockReturnValue([
-        {
-          path: '/work/alpha',
-          status: 'active',
-          sort_order: 0,
-          archived_at: null,
-          removed_at: null,
-          updated_at: 100
-        },
-        {
-          path: '/work/archived',
-          status: 'archived',
-          sort_order: 1,
-          archived_at: 200,
-          removed_at: null,
-          updated_at: 200
-        }
-      ])
       deviceService.selectDirectory.mockResolvedValue({
         canceled: false,
         filePaths: ['/work/archived']
@@ -792,10 +737,27 @@ describe('ProjectService', () => {
 
       await presenter.selectDirectory()
 
-      expect(sqlitePresenter.newEnvironmentPreferencesTable.reorderActive).toHaveBeenCalledWith([
-        '/work/archived',
-        '/work/alpha'
+      expect(sqlitePresenter.newEnvironmentPreferencesTable.activateAtTop).toHaveBeenCalledWith(
+        '/work/archived'
+      )
+    })
+
+    it('keeps concurrent selections on distinct snapshot versions', async () => {
+      deviceService.selectDirectory
+        .mockResolvedValueOnce({ canceled: false, filePaths: ['/work/first'] })
+        .mockResolvedValueOnce({ canceled: false, filePaths: ['/work/second'] })
+
+      const results = await Promise.all([presenter.selectDirectory(), presenter.selectDirectory()])
+
+      expect(results).toEqual([
+        { path: '/work/first', version: 1 },
+        { path: '/work/second', version: 2 }
       ])
+      expect(
+        sqlitePresenter.newEnvironmentPreferencesTable.activateAtTop.mock.calls.map(
+          ([environmentPath]) => environmentPath
+        )
+      ).toEqual(['/work/first', '/work/second'])
     })
   })
 })

--- a/test/main/routes/contracts.test.ts
+++ b/test/main/routes/contracts.test.ts
@@ -362,6 +362,30 @@ describe('main kernel contracts', () => {
         version: -1
       })
     ).toThrow()
+    expect(
+      DEEPCHAT_ROUTE_CATALOG['project.archiveEnvironment'].output.parse({
+        updated: true,
+        version: 7
+      })
+    ).toEqual({ updated: true, version: 7 })
+    expect(() =>
+      DEEPCHAT_ROUTE_CATALOG['project.archiveEnvironment'].output.parse({
+        updated: true,
+        version: -1
+      })
+    ).toThrow()
+    expect(
+      DEEPCHAT_ROUTE_CATALOG['project.selectDirectory'].output.parse({
+        path: '/workspace',
+        version: 7
+      })
+    ).toEqual({ path: '/workspace', version: 7 })
+    expect(() =>
+      DEEPCHAT_ROUTE_CATALOG['project.selectDirectory'].output.parse({
+        path: '/workspace',
+        version: -1
+      })
+    ).toThrow()
 
     expect(
       configLanguageChangedEvent.payload.parse({

--- a/test/main/routes/dispatcher.test.ts
+++ b/test/main/routes/dispatcher.test.ts
@@ -1017,7 +1017,8 @@ function createRuntime() {
       environments: [],
       archivedEnvironments: [],
       removedEnvironments: [],
-      defaultProjectPath: null
+      defaultProjectPath: null,
+      defaultChatWorkspacePath: null
     }),
     getRecentProjects: vi.fn().mockResolvedValue([
       {
@@ -1043,12 +1044,15 @@ function createRuntime() {
       }
     ]),
     reorderEnvironments: vi.fn().mockResolvedValue(undefined),
-    archiveEnvironment: vi.fn().mockResolvedValue(undefined),
+    archiveEnvironment: vi.fn().mockResolvedValue(1),
     restoreEnvironment: vi.fn().mockResolvedValue(undefined),
     removeEnvironment: vi.fn().mockResolvedValue({ clearedSessionIds: ['session-1'] }),
     openDirectory: vi.fn().mockResolvedValue(undefined),
     pathExists: vi.fn().mockResolvedValue(true),
-    selectDirectory: vi.fn().mockResolvedValue('C:/selected-workspace')
+    selectDirectory: vi.fn().mockResolvedValue({
+      path: 'C:/selected-workspace',
+      version: 1
+    })
   }
 
   const fileService = {
@@ -5610,7 +5614,7 @@ describe('dispatchDeepchatRoute', () => {
     expect(projectPresenter.reorderEnvironments).toHaveBeenCalledWith(['C:/workspace', 'C:/other'])
     expect(reorderEnvironmentsResult).toEqual({ updated: true })
     expect(projectPresenter.archiveEnvironment).toHaveBeenCalledWith('C:/workspace')
-    expect(archiveEnvironmentResult).toEqual({ updated: true })
+    expect(archiveEnvironmentResult).toEqual({ updated: true, version: 1 })
     expect(projectPresenter.restoreEnvironment).toHaveBeenCalledWith('C:/workspace')
     expect(restoreEnvironmentResult).toEqual({ updated: true })
     expect(projectPresenter.removeEnvironment).toHaveBeenCalledWith('C:/workspace')
@@ -5619,7 +5623,7 @@ describe('dispatchDeepchatRoute', () => {
     expect(openDirectoryResult).toEqual({ opened: true })
     expect(projectPresenter.pathExists).toHaveBeenCalledWith('C:/workspace')
     expect(pathExistsResult).toEqual({ exists: true })
-    expect(selectedDirectory).toEqual({ path: 'C:/selected-workspace' })
+    expect(selectedDirectory).toEqual({ path: 'C:/selected-workspace', version: 1 })
 
     expect(fileService.getMimeType).toHaveBeenCalledWith('/workspace/demo.txt')
     expect(mimeType).toEqual({ mimeType: 'text/plain' })

--- a/test/main/shared/filesystem.test.ts
+++ b/test/main/shared/filesystem.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isHardlinkUnavailableError } from '@shared/utils/filesystem'
+import { isHardlinkUnavailableError, normalizeWorkspacePath } from '@shared/utils/filesystem'
 
 describe('filesystem utilities', () => {
   it('recognizes hardlink capability errors without assuming an Error object', () => {
@@ -13,5 +13,15 @@ describe('filesystem utilities', () => {
     expect(
       isHardlinkUnavailableError(Object.assign(new Error('missing'), { code: 'ENOENT' }))
     ).toBe(false)
+  })
+
+  it('normalizes trailing separators without collapsing filesystem roots', () => {
+    expect(normalizeWorkspacePath('/workspace/')).toBe('/workspace')
+    expect(normalizeWorkspacePath('C:\\workspace\\')).toBe('C:\\workspace')
+    expect(normalizeWorkspacePath('/')).toBe('/')
+    expect(normalizeWorkspacePath('///')).toBe('/')
+    expect(normalizeWorkspacePath('C:\\')).toBe('C:\\')
+    expect(normalizeWorkspacePath('C:////')).toBe('C:/')
+    expect(normalizeWorkspacePath('  ')).toBe('')
   })
 })

--- a/test/renderer/api/clients.test.ts
+++ b/test/renderer/api/clients.test.ts
@@ -947,15 +947,16 @@ describe('renderer api clients', () => {
             case 'project.listEnvironments':
               return { environments: [] }
             case 'project.reorderEnvironments':
-            case 'project.archiveEnvironment':
             case 'project.restoreEnvironment':
               return { updated: true }
+            case 'project.archiveEnvironment':
+              return { updated: true, version: 1 }
             case 'project.removeEnvironment':
               return { clearedSessionIds: [] }
             case 'project.pathExists':
               return { exists: true }
             case 'project.selectDirectory':
-              return { path: '/workspace' }
+              return { path: '/workspace', version: 1 }
             case 'tools.listDefinitions':
               return { tools: [] }
             case 'memory.add':
@@ -2878,11 +2879,12 @@ describe('renderer api clients', () => {
     await projectClient.listRecent(8)
     await projectClient.listEnvironments('archived')
     await projectClient.reorderEnvironments(['/workspace', '/other'])
-    await projectClient.archiveEnvironment('/workspace')
+    const archiveResult = await projectClient.archiveEnvironment('/workspace')
     await projectClient.restoreEnvironment('/workspace')
     await projectClient.removeEnvironment('/workspace')
     await projectClient.pathExists('/workspace')
-    await projectClient.selectDirectory()
+    const selectedPath = await projectClient.selectDirectory()
+    const selectResult = await projectClient.selectDirectoryWithVersion()
     const unsubscribe = projectClient.onEnvironmentsChanged(() => undefined)
     await toolClient.getConfigurableAgentToolDefinitions({ chatMode: 'agent' })
 
@@ -2904,6 +2906,7 @@ describe('renderer api clients', () => {
     expect(bridge.invoke).toHaveBeenNthCalledWith(6, 'project.archiveEnvironment', {
       path: '/workspace'
     })
+    expect(archiveResult).toEqual({ updated: true, version: 1 })
     expect(bridge.invoke).toHaveBeenNthCalledWith(7, 'project.restoreEnvironment', {
       path: '/workspace'
     })
@@ -2914,9 +2917,12 @@ describe('renderer api clients', () => {
       path: '/workspace'
     })
     expect(bridge.invoke).toHaveBeenNthCalledWith(10, 'project.selectDirectory', {})
+    expect(selectedPath).toBe('/workspace')
+    expect(bridge.invoke).toHaveBeenNthCalledWith(11, 'project.selectDirectory', {})
+    expect(selectResult).toEqual({ path: '/workspace', version: 1 })
     expect(bridge.on).toHaveBeenCalledWith('project:environments-changed', expect.any(Function))
     expect(unsubscribe).toEqual(expect.any(Function))
-    expect(bridge.invoke).toHaveBeenNthCalledWith(11, 'tools.listDefinitions', {
+    expect(bridge.invoke).toHaveBeenNthCalledWith(12, 'tools.listDefinitions', {
       chatMode: 'agent'
     })
   })

--- a/test/renderer/components/WindowSideBar.test.ts
+++ b/test/renderer/components/WindowSideBar.test.ts
@@ -54,24 +54,38 @@ type SetupOptions = {
   openFolderPickerError?: Error
   setGroupModeError?: Error
   defaultChatWorkspacePath?: string | null
+  projectSnapshotReady?: boolean
   currentRouteName?: string
 }
 
 const createEnvironment = (
   environment: Partial<EnvironmentSummary> & Pick<EnvironmentSummary, 'path'>,
   fallbackStatus: EnvironmentSummary['status'] = 'active'
-): EnvironmentSummary => ({
-  path: environment.path,
-  name: environment.name ?? environment.path.split(/[\\/]/).pop() ?? environment.path,
-  sessionCount: environment.sessionCount ?? 1,
-  lastUsedAt: environment.lastUsedAt ?? 0,
-  isTemp: environment.isTemp ?? false,
-  exists: environment.exists ?? true,
-  status: environment.status ?? fallbackStatus,
-  sortOrder: environment.sortOrder ?? 0,
-  archivedAt: environment.archivedAt ?? null,
-  removedAt: environment.removedAt ?? null
-})
+): EnvironmentSummary => {
+  const status = environment.status ?? fallbackStatus
+  return {
+    path: environment.path,
+    name: environment.name ?? environment.path.split(/[\\/]/).pop() ?? environment.path,
+    sessionCount: environment.sessionCount ?? 1,
+    lastUsedAt: environment.lastUsedAt ?? 0,
+    isTemp: environment.isTemp ?? false,
+    exists: environment.exists ?? true,
+    status,
+    sortOrder: environment.sortOrder ?? 0,
+    archivedAt:
+      environment.archivedAt !== undefined
+        ? environment.archivedAt
+        : status === 'archived'
+          ? 100
+          : null,
+    removedAt:
+      environment.removedAt !== undefined
+        ? environment.removedAt
+        : status === 'removed'
+          ? 100
+          : null
+  }
+}
 
 const TEST_TIMEOUT_MS = 20000
 
@@ -280,6 +294,7 @@ const setup = async (options: SetupOptions = {}) => {
     ),
     error: null as string | null,
     defaultChatWorkspacePath: options.defaultChatWorkspacePath ?? null,
+    snapshotReady: options.projectSnapshotReady ?? true,
     fetchEnvironments: vi.fn().mockResolvedValue(undefined),
     reorderEnvironments: vi.fn().mockResolvedValue(undefined),
     archiveEnvironment: vi.fn().mockResolvedValue(undefined),
@@ -986,6 +1001,53 @@ describe('WindowSideBar agent switch', () => {
     expect(wrapper.text()).toContain('Session First')
   })
 
+  it('uses Project-store readiness and recovers after a later snapshot commit', async () => {
+    const { wrapper, projectStore } = await setup({
+      groupMode: 'project',
+      projectSnapshotReady: false,
+      projectEnvironments: [{ path: '/work/recovered', sessionCount: 0 }]
+    })
+
+    expect(wrapper.find('[data-group-id="/work/recovered"]').exists()).toBe(false)
+
+    projectStore.snapshotReady = true
+    await flushPromises()
+
+    expect(wrapper.find('[data-group-id="/work/recovered"]').exists()).toBe(true)
+  })
+
+  it('merges trailing-separator identities while preserving the managed action path', async () => {
+    const { wrapper, projectStore, sessionStore } = await setup({
+      groupMode: 'project',
+      projectEnvironments: [{ path: '/work/design/', sessionCount: 1 }],
+      groups: [
+        {
+          id: '/work/design',
+          label: 'design',
+          sessions: [
+            {
+              id: 'design-session',
+              title: 'Design Session',
+              status: 'none',
+              projectDir: '/work/design'
+            }
+          ]
+        }
+      ]
+    })
+
+    expect(wrapper.findAll('[data-group-id="/work/design"]')).toHaveLength(1)
+
+    await wrapper.get('[data-testid="window-sidebar-project-new-button"]').trigger('click')
+    await flushPromises()
+
+    expect(projectStore.selectProject).toHaveBeenCalledWith('/work/design/', 'manual')
+    expect(sessionStore.startNewConversation).toHaveBeenCalledWith({
+      refresh: true,
+      projectDir: '/work/design/'
+    })
+  })
+
   it('uses durable counts for empty semantics and hides synthesized rows during search', async () => {
     const { wrapper, sessionStore } = await setup({
       groupMode: 'project',
@@ -1045,7 +1107,7 @@ describe('WindowSideBar agent switch', () => {
       expect(
         wrapper.findAll('[data-group-id]').map((group) => group.attributes('data-group-id'))
       ).toEqual(['/work/new', '/work/existing'])
-      expect(focusSpy).toHaveBeenCalled()
+      expect(focusSpy.mock.instances).toContain(wrapper.get('[data-group-id="/work/new"]').element)
     },
     TEST_TIMEOUT_MS
   )
@@ -1067,7 +1129,9 @@ describe('WindowSideBar agent switch', () => {
     expect(projectStore.selectProject).not.toHaveBeenCalled()
     expect(wrapper.find(`[data-group-id="${chatWorkspacePath}"]`).exists()).toBe(false)
     expect(wrapper.find('[data-testid="app-new-chat-button"]').exists()).toBe(true)
-    expect(focusSpy).toHaveBeenCalled()
+    expect(focusSpy.mock.instances).toContain(
+      wrapper.get('[data-testid="app-new-chat-button"]').element
+    )
   })
 
   it('keeps cancellation side-effect free and guards concurrent folder pickers', async () => {
@@ -1081,9 +1145,9 @@ describe('WindowSideBar agent switch', () => {
         })
     )
 
-    const firstRequest = (wrapper.vm as any).handleAddWorkspace()
-    const secondRequest = (wrapper.vm as any).handleAddWorkspace()
-    await nextTick()
+    const addWorkspaceButton = wrapper.get('[data-testid="window-sidebar-add-workspace-button"]')
+    await addWorkspaceButton.trigger('click')
+    await addWorkspaceButton.trigger('click')
 
     expect(projectStore.openFolderPicker).toHaveBeenCalledTimes(1)
     expect(
@@ -1094,7 +1158,6 @@ describe('WindowSideBar agent switch', () => {
     ).toBe(true)
 
     finishPicker(null)
-    await Promise.all([firstRequest, secondRequest])
     await flushPromises()
 
     expect(sessionStore.setGroupMode).not.toHaveBeenCalled()
@@ -1136,7 +1199,11 @@ describe('WindowSideBar agent switch', () => {
       ]
     })
 
-    expect(wrapper.find('[data-testid="window-sidebar-workspace-unavailable"]').exists()).toBe(true)
+    const unavailableIcon = wrapper.get('[data-testid="window-sidebar-workspace-unavailable"]')
+    expect(unavailableIcon.element.parentElement?.getAttribute('title')).toBe(
+      'chat.input.workspaceUnavailableTooltip'
+    )
+    expect(unavailableIcon.element.parentElement?.classList.contains('ms-auto')).toBe(true)
     expect(wrapper.find('[data-testid="window-sidebar-project-new-button"]').exists()).toBe(false)
 
     await wrapper.get('[data-group-id="/work/missing"]').trigger('click')

--- a/test/renderer/components/WindowSideBar.test.ts
+++ b/test/renderer/components/WindowSideBar.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createPinia } from 'pinia'
 import { defineComponent, nextTick, reactive, ref } from 'vue'
 import { flushPromises, mount } from '@vue/test-utils'
+import type { EnvironmentSummary } from '../../../src/shared/types/agent-interface'
 
 vi.mock('pinia', async () => vi.importActual<typeof import('pinia')>('pinia'))
 
@@ -43,11 +44,34 @@ type SetupOptions = {
   }
   collapsed?: boolean
   platform?: 'darwin' | 'win32' | 'linux'
-  projectEnvironments?: Array<{ path: string }>
-  archivedProjectEnvironments?: Array<{ path: string }>
+  projectEnvironments?: Array<Partial<EnvironmentSummary> & Pick<EnvironmentSummary, 'path'>>
+  projects?: Array<{ path: string }>
+  archivedProjectEnvironments?: Array<
+    Partial<EnvironmentSummary> & Pick<EnvironmentSummary, 'path'>
+  >
+  removedProjectEnvironments?: Array<Partial<EnvironmentSummary> & Pick<EnvironmentSummary, 'path'>>
+  openFolderPickerResult?: string | null
+  openFolderPickerError?: Error
+  setGroupModeError?: Error
   defaultChatWorkspacePath?: string | null
   currentRouteName?: string
 }
+
+const createEnvironment = (
+  environment: Partial<EnvironmentSummary> & Pick<EnvironmentSummary, 'path'>,
+  fallbackStatus: EnvironmentSummary['status'] = 'active'
+): EnvironmentSummary => ({
+  path: environment.path,
+  name: environment.name ?? environment.path.split(/[\\/]/).pop() ?? environment.path,
+  sessionCount: environment.sessionCount ?? 1,
+  lastUsedAt: environment.lastUsedAt ?? 0,
+  isTemp: environment.isTemp ?? false,
+  exists: environment.exists ?? true,
+  status: environment.status ?? fallbackStatus,
+  sortOrder: environment.sortOrder ?? 0,
+  archivedAt: environment.archivedAt ?? null,
+  removedAt: environment.removedAt ?? null
+})
 
 const TEST_TIMEOUT_MS = 20000
 
@@ -142,6 +166,7 @@ const trackMountedWrapper = <T extends { unmount: () => void }>(wrapper: T): T =
 
 afterEach(() => {
   mountedWrappers.splice(0).forEach((wrapper) => wrapper.unmount())
+  vi.restoreAllMocks()
   vi.clearAllTimers()
   vi.useRealTimers()
   vi.unstubAllGlobals()
@@ -152,6 +177,7 @@ const setup = async (options: SetupOptions = {}) => {
   vi.useFakeTimers()
 
   const operations: string[] = []
+  const filteredGroups = reactive(options.groups ?? [])
   const remoteStatus = options.remoteStatus ?? {
     enabled: false,
     state: 'disabled' as const
@@ -215,9 +241,15 @@ const setup = async (options: SetupOptions = {}) => {
     toggleSessionPinned: vi.fn(async (id: string, pinned: boolean) => {
       operations.push(`pin:${id}:${pinned}`)
     }),
+    setGroupMode: vi.fn(async (mode: 'time' | 'project') => {
+      if (options.setGroupModeError) {
+        throw options.setGroupModeError
+      }
+      sessionStore.groupMode = mode
+    }),
     toggleGroupMode: vi.fn(),
     getPinnedSessions: vi.fn(() => options.pinnedSessions ?? []),
-    getFilteredGroups: vi.fn(() => options.groups ?? [])
+    getFilteredGroups: vi.fn(() => filteredGroups)
   })
 
   const themeStore = reactive({
@@ -236,11 +268,27 @@ const setup = async (options: SetupOptions = {}) => {
     goToNewThread: vi.fn()
   })
   const projectStore = reactive({
-    environments: options.projectEnvironments ?? [],
-    archivedEnvironments: options.archivedProjectEnvironments ?? [],
+    projects: options.projects ?? [],
+    environments: (options.projectEnvironments ?? []).map((environment) =>
+      createEnvironment(environment)
+    ),
+    archivedEnvironments: (options.archivedProjectEnvironments ?? []).map((environment) =>
+      createEnvironment(environment, 'archived')
+    ),
+    removedEnvironments: (options.removedProjectEnvironments ?? []).map((environment) =>
+      createEnvironment(environment, 'removed')
+    ),
+    error: null as string | null,
     defaultChatWorkspacePath: options.defaultChatWorkspacePath ?? null,
     fetchEnvironments: vi.fn().mockResolvedValue(undefined),
     reorderEnvironments: vi.fn().mockResolvedValue(undefined),
+    archiveEnvironment: vi.fn().mockResolvedValue(undefined),
+    openFolderPicker: vi.fn(async () => {
+      if (options.openFolderPickerError) {
+        throw options.openFolderPickerError
+      }
+      return options.openFolderPickerResult ?? null
+    }),
     selectProject: vi.fn((path: string | null, source?: string) => {
       operations.push(`project:${path ?? 'none'}:${source ?? 'default'}`)
     })
@@ -411,6 +459,10 @@ const setup = async (options: SetupOptions = {}) => {
   vi.doMock('@api/RemoteControlClient', () => ({
     createRemoteControlClient: vi.fn(() => remoteControlClient)
   }))
+  const notifyRenderer = vi.fn()
+  vi.doMock('@renderer-notifications/rendererNotificationPort', () => ({
+    notifyRenderer
+  }))
   vi.doMock('vue-i18n', () => ({
     useI18n: () => ({
       t: (key: string) => key
@@ -499,7 +551,8 @@ const setup = async (options: SetupOptions = {}) => {
     DropdownMenu: passthrough,
     DropdownMenuTrigger: passthrough,
     DropdownMenuContent: passthrough,
-    DropdownMenuItem: dropdownMenuItemStub
+    DropdownMenuItem: dropdownMenuItemStub,
+    DropdownMenuSeparator: passthrough
   }))
 
   const WindowSideBar = (await import('@/components/WindowSideBar.vue')).default
@@ -548,7 +601,9 @@ const setup = async (options: SetupOptions = {}) => {
     router,
     pageRouterStore,
     sidebarStore,
-    projectStore
+    projectStore,
+    notifyRenderer,
+    filteredGroups
   }
 }
 
@@ -770,6 +825,7 @@ describe('WindowSideBar agent switch', () => {
       const { wrapper, projectStore, router, sessionStore } = await setup({
         currentRouteName: 'plugins',
         groupMode: 'project',
+        projectEnvironments: [{ path: '/work/design' }],
         groups: [
           {
             id: '/work/design',
@@ -824,6 +880,270 @@ describe('WindowSideBar agent switch', () => {
     },
     TEST_TIMEOUT_MS
   )
+
+  it(
+    'renders and activates a registered workspace before its first session exists',
+    async () => {
+      const { wrapper, projectStore, sessionStore } = await setup({
+        groupMode: 'project',
+        projectEnvironments: [
+          {
+            path: '/work/new',
+            name: 'new',
+            sessionCount: 0
+          }
+        ]
+      })
+
+      const group = wrapper.get('[data-group-id="/work/new"]')
+      expect(group.attributes('aria-expanded')).toBeUndefined()
+      expect(wrapper.text()).toContain('chat.sidebar.emptyWorkspace')
+      expect(wrapper.get('[data-testid="window-sidebar-project-new-button"]').classes()).toContain(
+        'opacity-100'
+      )
+
+      await group.trigger('click')
+      await flushPromises()
+
+      expect(projectStore.selectProject).toHaveBeenCalledWith('/work/new', 'manual')
+      expect(sessionStore.startNewConversation).toHaveBeenCalledWith({
+        refresh: true,
+        projectDir: '/work/new'
+      })
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it('converts an empty workspace into one populated path-keyed row', async () => {
+    const { wrapper, projectStore, filteredGroups } = await setup({
+      groupMode: 'project',
+      projectEnvironments: [
+        {
+          path: '/work/new',
+          name: 'new',
+          sessionCount: 0
+        }
+      ]
+    })
+    const initialGroupElement = wrapper.get('[data-group-id="/work/new"]').element
+
+    filteredGroups.push({
+      id: '/work/new',
+      label: 'new',
+      sessions: [
+        {
+          id: 'new-session',
+          title: 'First Session',
+          status: 'none',
+          projectDir: '/work/new',
+          updatedAt: 100
+        }
+      ]
+    })
+    await flushPromises()
+
+    expect(wrapper.findAll('[data-group-id="/work/new"]')).toHaveLength(1)
+    expect(wrapper.get('[data-group-id="/work/new"]').element).toBe(initialGroupElement)
+    expect(wrapper.find('[data-testid="window-sidebar-empty-workspace-label"]').exists()).toBe(
+      false
+    )
+    expect(wrapper.text()).toContain('First Session')
+
+    projectStore.environments[0].sessionCount = 1
+    await flushPromises()
+
+    expect(wrapper.findAll('[data-group-id="/work/new"]')).toHaveLength(1)
+  })
+
+  it('merges a project snapshot into an earlier session-derived row without duplication', async () => {
+    const { wrapper, projectStore } = await setup({
+      groupMode: 'project',
+      groups: [
+        {
+          id: '/work/session-first',
+          label: 'session-first',
+          sessions: [
+            {
+              id: 'session-first',
+              title: 'Session First',
+              status: 'none',
+              projectDir: '/work/session-first',
+              updatedAt: 100
+            }
+          ]
+        }
+      ]
+    })
+    const initialGroupElement = wrapper.get('[data-group-id="/work/session-first"]').element
+
+    projectStore.environments.push(
+      createEnvironment({ path: '/work/session-first', sessionCount: 1 })
+    )
+    await flushPromises()
+
+    expect(wrapper.findAll('[data-group-id="/work/session-first"]')).toHaveLength(1)
+    expect(wrapper.get('[data-group-id="/work/session-first"]').element).toBe(initialGroupElement)
+    expect(wrapper.text()).toContain('Session First')
+  })
+
+  it('uses durable counts for empty semantics and hides synthesized rows during search', async () => {
+    const { wrapper, sessionStore } = await setup({
+      groupMode: 'project',
+      projects: [{ path: '/tmp/selected' }],
+      projectEnvironments: [
+        { path: '/work/empty', sessionCount: 0 },
+        { path: '/work/filtered', sessionCount: 3 },
+        { path: '/tmp/internal', sessionCount: 0, isTemp: true },
+        { path: '/tmp/selected', sessionCount: 0, isTemp: true }
+      ]
+    })
+
+    expect(wrapper.find('[data-group-id="/work/empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-group-id="/work/filtered"]').exists()).toBe(true)
+    expect(wrapper.find('[data-group-id="/tmp/internal"]').exists()).toBe(false)
+    expect(wrapper.find('[data-group-id="/tmp/selected"]').exists()).toBe(true)
+    expect(wrapper.findAll('[data-testid="window-sidebar-empty-workspace-label"]')).toHaveLength(2)
+
+    await wrapper.get('[data-group-id="/work/filtered"]').trigger('click')
+    await flushPromises()
+    expect(sessionStore.startNewConversation).not.toHaveBeenCalled()
+
+    ;(wrapper.vm as any).sessionSearchQuery = 'no matching session'
+    await flushPromises()
+
+    expect(wrapper.find('[data-group-id="/work/empty"]').exists()).toBe(false)
+    expect(wrapper.find('[data-group-id="/work/filtered"]').exists()).toBe(false)
+    expect(wrapper.find('[data-group-id="/tmp/selected"]').exists()).toBe(false)
+  })
+
+  it(
+    'adds a workspace first from date grouping, clears search, and focuses the registered row',
+    async () => {
+      const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+      const { wrapper, projectStore, sessionStore } = await setup({
+        groupMode: 'time',
+        openFolderPickerResult: '/work/new',
+        projectEnvironments: [{ path: '/work/existing', sessionCount: 0 }]
+      })
+      ;(wrapper.vm as any).sessionSearchQuery = 'filtered title'
+      projectStore.openFolderPicker.mockImplementation(async () => {
+        projectStore.environments.unshift(
+          createEnvironment({ path: '/work/new', name: 'new', sessionCount: 0 })
+        )
+        return '/work/new'
+      })
+
+      await wrapper.get('[data-testid="window-sidebar-add-workspace-button"]').trigger('click')
+      await flushPromises()
+
+      expect(projectStore.openFolderPicker).toHaveBeenCalledWith({ select: false })
+      expect(projectStore.selectProject).not.toHaveBeenCalled()
+      expect(sessionStore.setGroupMode).toHaveBeenCalledWith('project')
+      expect(sessionStore.groupMode).toBe('project')
+      expect((wrapper.vm as any).sessionSearchQuery).toBe('')
+      expect(wrapper.find('[data-group-id="/work/new"]').exists()).toBe(true)
+      expect(
+        wrapper.findAll('[data-group-id]').map((group) => group.attributes('data-group-id'))
+      ).toEqual(['/work/new', '/work/existing'])
+      expect(focusSpy).toHaveBeenCalled()
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it('reveals the built-in Chat action without duplicating it as a workspace', async () => {
+    const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+    const chatWorkspacePath = '/Users/test/Documents/DeepChat'
+    const { wrapper, projectStore, sessionStore } = await setup({
+      groupMode: 'time',
+      defaultChatWorkspacePath: chatWorkspacePath,
+      openFolderPickerResult: chatWorkspacePath,
+      projectEnvironments: [{ path: chatWorkspacePath, sessionCount: 0 }]
+    })
+
+    await wrapper.get('[data-testid="window-sidebar-add-workspace-button"]').trigger('click')
+    await flushPromises()
+
+    expect(sessionStore.setGroupMode).toHaveBeenCalledWith('project')
+    expect(projectStore.selectProject).not.toHaveBeenCalled()
+    expect(wrapper.find(`[data-group-id="${chatWorkspacePath}"]`).exists()).toBe(false)
+    expect(wrapper.find('[data-testid="app-new-chat-button"]').exists()).toBe(true)
+    expect(focusSpy).toHaveBeenCalled()
+  })
+
+  it('keeps cancellation side-effect free and guards concurrent folder pickers', async () => {
+    const { wrapper, projectStore, sessionStore } = await setup({ groupMode: 'time' })
+    ;(wrapper.vm as any).sessionSearchQuery = 'keep me'
+    let finishPicker!: (path: string | null) => void
+    projectStore.openFolderPicker.mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          finishPicker = resolve
+        })
+    )
+
+    const firstRequest = (wrapper.vm as any).handleAddWorkspace()
+    const secondRequest = (wrapper.vm as any).handleAddWorkspace()
+    await nextTick()
+
+    expect(projectStore.openFolderPicker).toHaveBeenCalledTimes(1)
+    expect(
+      (
+        wrapper.get('[data-testid="window-sidebar-add-workspace-button"]')
+          .element as HTMLButtonElement
+      ).disabled
+    ).toBe(true)
+
+    finishPicker(null)
+    await Promise.all([firstRequest, secondRequest])
+    await flushPromises()
+
+    expect(sessionStore.setGroupMode).not.toHaveBeenCalled()
+    expect(sessionStore.groupMode).toBe('time')
+    expect((wrapper.vm as any).sessionSearchQuery).toBe('keep me')
+  })
+
+  it('reports registration failures without fabricating a workspace row', async () => {
+    const { wrapper, notifyRenderer, sessionStore } = await setup({
+      groupMode: 'time',
+      openFolderPickerError: new Error('picker failed')
+    })
+
+    await wrapper.get('[data-testid="window-sidebar-add-workspace-button"]').trigger('click')
+    await flushPromises()
+
+    expect(notifyRenderer).toHaveBeenCalledWith({
+      kind: 'error',
+      code: 'chat.workspace.registrationFailed',
+      title: 'common.error.operationFailed',
+      description: 'chat.sidebar.addWorkspaceFailed'
+    })
+    expect(sessionStore.setGroupMode).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="window-sidebar-empty-workspace-label"]').exists()).toBe(
+      false
+    )
+  })
+
+  it('shows missing active workspaces without a new-conversation action', async () => {
+    const { wrapper, sessionStore } = await setup({
+      groupMode: 'project',
+      projectEnvironments: [
+        {
+          path: '/work/missing',
+          name: 'missing',
+          sessionCount: 0,
+          exists: false
+        }
+      ]
+    })
+
+    expect(wrapper.find('[data-testid="window-sidebar-workspace-unavailable"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="window-sidebar-project-new-button"]').exists()).toBe(false)
+
+    await wrapper.get('[data-group-id="/work/missing"]').trigger('click')
+    await flushPromises()
+
+    expect(sessionStore.startNewConversation).not.toHaveBeenCalled()
+  })
 
   it(
     'toggles pinned state from a session item action',
@@ -1459,7 +1779,7 @@ describe('WindowSideBar agent switch', () => {
   )
 
   it(
-    'reorders project groups while preserving hidden environment positions',
+    'reorders every registered project group, including groups without visible sessions',
     async () => {
       const alphaGroup = {
         id: '/work/alpha',
@@ -1483,18 +1803,6 @@ describe('WindowSideBar agent switch', () => {
           }
         ]
       }
-      const unassignedGroup = {
-        id: '__no_project__',
-        label: 'No Project',
-        labelKey: 'chat.sidebar.noProject',
-        sessions: [
-          {
-            id: 'project-none',
-            title: 'No Project Session',
-            status: 'none'
-          }
-        ]
-      }
       const { wrapper, projectStore } = await setup({
         groupMode: 'project',
         projectEnvironments: [
@@ -1502,24 +1810,127 @@ describe('WindowSideBar agent switch', () => {
           { path: '/work/hidden' },
           { path: '/work/beta' }
         ],
-        groups: [alphaGroup, betaGroup, unassignedGroup]
+        groups: [alphaGroup, betaGroup]
       })
 
       await wrapper.vm.$nextTick()
       const draggable = wrapper.getComponent({ name: 'draggable' })
       expect(draggable.attributes('data-disabled')).toBe('false')
+      const renderedGroups = draggable.props('modelValue') as Array<{ id: string }>
+      expect(renderedGroups.map((group) => group.id)).toEqual([
+        '/work/alpha',
+        '/work/hidden',
+        '/work/beta'
+      ])
 
-      draggable.vm.$emit('update:modelValue', [betaGroup, alphaGroup, unassignedGroup])
+      draggable.vm.$emit('update:modelValue', [
+        renderedGroups[2],
+        renderedGroups[0],
+        renderedGroups[1]
+      ])
       await flushPromises()
 
       expect(projectStore.reorderEnvironments).toHaveBeenCalledWith([
         '/work/beta',
-        '/work/hidden',
-        '/work/alpha'
+        '/work/alpha',
+        '/work/hidden'
       ])
     },
     TEST_TIMEOUT_MS
   )
+
+  it(
+    'archives the only active workspace after confirmation while move actions stay disabled',
+    async () => {
+      const { wrapper, projectStore } = await setup({
+        groupMode: 'project',
+        projectEnvironments: [{ path: '/work/only', name: 'only', sessionCount: 0 }]
+      })
+      let resolveArchive!: () => void
+      projectStore.archiveEnvironment.mockImplementation(async (projectPath: string) => {
+        await new Promise<void>((resolve) => {
+          resolveArchive = resolve
+        })
+        const index = projectStore.environments.findIndex(
+          (environment) => environment.path === projectPath
+        )
+        const [environment] = projectStore.environments.splice(index, 1)
+        projectStore.archivedEnvironments.push({
+          ...environment,
+          status: 'archived',
+          archivedAt: 100
+        })
+      })
+
+      expect(wrapper.findAll('[aria-label="chat.sidebar.projectGroupActions"]')).toHaveLength(1)
+      const moveActions = wrapper
+        .findAll('button')
+        .filter((button) => button.text().startsWith('chat.sidebar.moveProjectGroup'))
+      expect(moveActions).toHaveLength(4)
+      expect(moveActions.every((button) => button.attributes('disabled') !== undefined)).toBe(true)
+
+      await wrapper
+        .get('[data-testid="window-sidebar-archive-workspace-menu-item"]')
+        .trigger('click')
+      await flushPromises()
+
+      expect(
+        wrapper.find('[data-testid="window-sidebar-archive-workspace-confirm"]').exists()
+      ).toBe(true)
+
+      await wrapper.get('[data-testid="window-sidebar-archive-workspace-confirm"]').trigger('click')
+
+      expect(projectStore.archiveEnvironment).toHaveBeenCalledTimes(1)
+      expect(
+        wrapper
+          .get('[data-testid="window-sidebar-archive-workspace-confirm"]')
+          .attributes('disabled')
+      ).toBeDefined()
+      expect(
+        wrapper
+          .get('[data-testid="window-sidebar-archive-workspace-cancel"]')
+          .attributes('disabled')
+      ).toBeDefined()
+
+      await wrapper.get('[data-testid="window-sidebar-archive-workspace-confirm"]').trigger('click')
+      expect(projectStore.archiveEnvironment).toHaveBeenCalledTimes(1)
+
+      resolveArchive()
+      await flushPromises()
+
+      expect(projectStore.archiveEnvironment).toHaveBeenCalledWith('/work/only')
+      expect(wrapper.find('[data-group-id="/work/only"]').exists()).toBe(false)
+      expect(
+        wrapper.find('[data-testid="window-sidebar-archive-workspace-confirm"]').exists()
+      ).toBe(false)
+    },
+    TEST_TIMEOUT_MS
+  )
+
+  it('keeps the workspace and confirmation visible when archive fails', async () => {
+    const { wrapper, projectStore, notifyRenderer } = await setup({
+      groupMode: 'project',
+      projectEnvironments: [{ path: '/work/active', name: 'active', sessionCount: 0 }]
+    })
+    projectStore.archiveEnvironment.mockRejectedValueOnce(new Error('/private/project.db'))
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    await wrapper.get('[data-testid="window-sidebar-archive-workspace-menu-item"]').trigger('click')
+    await wrapper.get('[data-testid="window-sidebar-archive-workspace-confirm"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-group-id="/work/active"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="window-sidebar-archive-workspace-confirm"]').exists()).toBe(
+      true
+    )
+    expect(notifyRenderer).toHaveBeenCalledWith({
+      kind: 'error',
+      code: 'chat.workspace.archive.failed',
+      title: 'settings.environments.errors.archiveTitle'
+    })
+    expect(wrapper.text()).not.toContain('/private/project.db')
+    consoleWarn.mockRestore()
+  })
 
   it(
     'labels the built-in chat workspace separately from reorderable project groups',
@@ -1586,9 +1997,9 @@ describe('WindowSideBar agent switch', () => {
       ).toEqual(['__pinned__', '__chat__', '/work/alpha', '/work/beta'])
       expect(wrapper.findAll('[aria-label="chat.sidebar.projectGroupActions"]')).toHaveLength(2)
 
-      wrapper
-        .getComponent({ name: 'draggable' })
-        .vm.$emit('update:modelValue', [betaGroup, alphaGroup])
+      const draggable = wrapper.getComponent({ name: 'draggable' })
+      const renderedGroups = draggable.props('modelValue') as Array<{ id: string }>
+      draggable.vm.$emit('update:modelValue', [...renderedGroups].reverse())
       await flushPromises()
 
       expect(projectStore.reorderEnvironments).toHaveBeenCalledWith([
@@ -1652,9 +2063,9 @@ describe('WindowSideBar agent switch', () => {
       expect(wrapper.find('[data-group-id="__chat__"]').exists()).toBe(true)
       expect(wrapper.findAll('[aria-label="chat.sidebar.projectGroupActions"]')).toHaveLength(2)
 
-      wrapper
-        .getComponent({ name: 'draggable' })
-        .vm.$emit('update:modelValue', [betaGroup, alphaGroup])
+      const draggable = wrapper.getComponent({ name: 'draggable' })
+      const renderedGroups = draggable.props('modelValue') as Array<{ id: string }>
+      draggable.vm.$emit('update:modelValue', [...renderedGroups].reverse())
       await flushPromises()
 
       expect(projectStore.reorderEnvironments).toHaveBeenCalledWith(['/work/beta', '/work/alpha'])
@@ -1860,7 +2271,7 @@ describe('WindowSideBar agent switch', () => {
   })
 
   it(
-    'disables project group reordering while the sidebar search is active',
+    'disables project group reordering but keeps archive available during search',
     async () => {
       const alphaGroup = {
         id: '/work/alpha',
@@ -1895,7 +2306,16 @@ describe('WindowSideBar agent switch', () => {
 
       const draggable = wrapper.getComponent({ name: 'draggable' })
       expect(draggable.attributes('data-disabled')).toBe('true')
-      expect(wrapper.find('[aria-label="chat.sidebar.projectGroupActions"]').exists()).toBe(false)
+      expect(wrapper.findAll('[aria-label="chat.sidebar.projectGroupActions"]')).toHaveLength(2)
+      expect(
+        wrapper
+          .findAll('button')
+          .filter((button) => button.text().startsWith('chat.sidebar.moveProjectGroup'))
+          .every((button) => button.attributes('disabled') !== undefined)
+      ).toBe(true)
+      expect(
+        wrapper.findAll('[data-testid="window-sidebar-archive-workspace-menu-item"]')
+      ).toHaveLength(2)
 
       draggable.vm.$emit('update:modelValue', [betaGroup, alphaGroup])
       await flushPromises()
@@ -1906,7 +2326,7 @@ describe('WindowSideBar agent switch', () => {
   )
 
   it(
-    'keeps archived project groups visible but outside active reordering',
+    'keeps archived and removed project groups visible without active affordances',
     async () => {
       const activeGroup = {
         id: '/work/active',
@@ -1930,22 +2350,45 @@ describe('WindowSideBar agent switch', () => {
           }
         ]
       }
+      const removedGroup = {
+        id: '/work/removed',
+        label: 'removed',
+        sessions: [
+          {
+            id: 'project-removed',
+            title: 'Removed Session',
+            status: 'none'
+          }
+        ]
+      }
       const { wrapper, projectStore } = await setup({
         groupMode: 'project',
         projectEnvironments: [{ path: '/work/active' }],
         archivedProjectEnvironments: [{ path: '/work/archived' }],
-        groups: [archivedGroup, activeGroup]
+        removedProjectEnvironments: [{ path: '/work/removed' }],
+        groups: [archivedGroup, removedGroup, activeGroup]
       })
 
       await wrapper.vm.$nextTick()
 
       expect(wrapper.text()).toContain('Active Session')
       expect(wrapper.text()).toContain('Archived Session')
-      expect(wrapper.findAll('[aria-label="chat.sidebar.projectGroupActions"]')).toHaveLength(0)
+      expect(wrapper.text()).toContain('Removed Session')
+      expect(wrapper.findAll('[aria-label="chat.sidebar.projectGroupActions"]')).toHaveLength(1)
+      expect(
+        wrapper
+          .get('[data-group-id="/work/archived"]')
+          .element.parentElement?.querySelector('[data-testid="window-sidebar-project-new-button"]')
+      ).toBeNull()
+      expect(
+        wrapper
+          .get('[data-group-id="/work/removed"]')
+          .element.parentElement?.querySelector('[data-testid="window-sidebar-project-new-button"]')
+      ).toBeNull()
 
       wrapper
         .getComponent({ name: 'draggable' })
-        .vm.$emit('update:modelValue', [archivedGroup, activeGroup])
+        .vm.$emit('update:modelValue', [removedGroup, archivedGroup, activeGroup])
       await flushPromises()
 
       expect(projectStore.reorderEnvironments).not.toHaveBeenCalled()

--- a/test/renderer/stores/projectStore.test.ts
+++ b/test/renderer/stores/projectStore.test.ts
@@ -227,4 +227,58 @@ describe('projectStore snapshot ownership', () => {
     expect(projectClient.getSnapshot).toHaveBeenCalledTimes(3)
     expect(store.projects.value.map((project) => project.path)).toEqual(['/work/after-event'])
   })
+
+  it('treats folder picker cancellation as a no-op', async () => {
+    const { store, projectClient } = await setupStore()
+
+    await expect(store.openFolderPicker()).resolves.toBeNull()
+
+    expect(projectClient.getSnapshot).not.toHaveBeenCalled()
+    expect(store.selectedProjectPath.value).toBeNull()
+    expect(store.selectionSource.value).toBe('none')
+  })
+
+  it('returns and selects a picked workspace by default', async () => {
+    const { store, projectClient } = await setupStore()
+    projectClient.selectDirectory.mockResolvedValue('/work/new')
+    projectClient.getSnapshot.mockResolvedValue(snapshot(2, ['/work/new']))
+
+    await expect(store.openFolderPicker()).resolves.toBe('/work/new')
+
+    expect(store.selectedProjectPath.value).toBe('/work/new')
+    expect(store.selectionSource.value).toBe('manual')
+    expect(store.environments.value.map((item) => item.path)).toEqual(['/work/new'])
+  })
+
+  it('registers a picked workspace without replacing the current selection', async () => {
+    const { store, projectClient } = await setupStore()
+    store.selectProject('/work/current', 'manual')
+    projectClient.selectDirectory.mockResolvedValue('/work/new')
+    projectClient.getSnapshot.mockResolvedValue(snapshot(2, ['/work/new', '/work/current']))
+
+    await expect(store.openFolderPicker({ select: false })).resolves.toBe('/work/new')
+
+    expect(store.selectedProjectPath.value).toBe('/work/current')
+    expect(store.selectionSource.value).toBe('manual')
+    expect(store.environments.value.map((item) => item.path)).toEqual([
+      '/work/new',
+      '/work/current'
+    ])
+  })
+
+  it('rejects picker and uncommitted snapshot failures', async () => {
+    const { store, projectClient } = await setupStore()
+    const pickerFailure = new Error('picker failed')
+    projectClient.selectDirectory.mockRejectedValueOnce(pickerFailure)
+
+    await expect(store.openFolderPicker()).rejects.toBe(pickerFailure)
+
+    projectClient.selectDirectory.mockResolvedValueOnce('/work/uncommitted')
+    projectClient.getSnapshot.mockRejectedValueOnce(new Error('snapshot failed'))
+
+    await expect(store.openFolderPicker({ select: false })).rejects.toThrow(
+      'Failed to load project snapshot'
+    )
+    expect(store.environments.value).toEqual([])
+  })
 })

--- a/test/renderer/stores/projectStore.test.ts
+++ b/test/renderer/stores/projectStore.test.ts
@@ -19,7 +19,8 @@ const snapshot = (version: number, paths: string[] = ['/work/recent']) => ({
   environments: paths.map((path) => environment(path)),
   archivedEnvironments: [],
   removedEnvironments: [],
-  defaultProjectPath: null
+  defaultProjectPath: null,
+  defaultChatWorkspacePath: null
 })
 
 const deferred = <T>() => {
@@ -45,11 +46,11 @@ async function setupStore() {
   const projectClient = {
     getSnapshot: vi.fn().mockResolvedValue(snapshot(1)),
     reorderEnvironments: vi.fn().mockResolvedValue({ updated: true }),
-    archiveEnvironment: vi.fn().mockResolvedValue({ updated: true }),
+    archiveEnvironment: vi.fn().mockResolvedValue({ updated: true, version: 1 }),
     restoreEnvironment: vi.fn().mockResolvedValue({ updated: true }),
     removeEnvironment: vi.fn().mockResolvedValue({ clearedSessionIds: ['s1'] }),
     openDirectory: vi.fn().mockResolvedValue(undefined),
-    selectDirectory: vi.fn().mockResolvedValue(null),
+    selectDirectoryWithVersion: vi.fn().mockResolvedValue({ path: null, version: 1 }),
     onEnvironmentsChanged: vi.fn((listener) => {
       environmentListeners.push(listener)
       return () => undefined
@@ -98,12 +99,15 @@ describe('projectStore snapshot ownership', () => {
       environments: [environment('/work/active')],
       archivedEnvironments: [environment('/work/archived', 'archived')],
       removedEnvironments: [environment('/work/removed', 'removed')],
-      defaultProjectPath: '/work/default'
+      defaultProjectPath: '/work/default',
+      defaultChatWorkspacePath: '/work/chat'
     })
 
     await store.refreshProjectSnapshot()
 
     expect(store.defaultProjectPath.value).toBe('/work/default')
+    expect(store.defaultChatWorkspacePath.value).toBe('/work/chat')
+    expect(store.snapshotReady.value).toBe(true)
     expect(store.projects.value.map((project) => project.path)).toEqual([
       '/work/default',
       '/work/recent'
@@ -186,14 +190,15 @@ describe('projectStore snapshot ownership', () => {
     const { store, projectClient } = await setupStore()
     projectClient.getSnapshot.mockResolvedValue({
       ...snapshot(2, ['/work/current']),
-      defaultProjectPath: '/work/current'
+      defaultProjectPath: '/work/current',
+      defaultChatWorkspacePath: '/work/current-chat'
     })
 
     await store.refreshProjectSnapshot()
     store.applyBootstrapDefaultProjectPath('/work/stale-bootstrap', '/work/bootstrap-workspace')
 
     expect(store.defaultProjectPath.value).toBe('/work/current')
-    expect(store.defaultChatWorkspacePath.value).toBe('/work/bootstrap-workspace')
+    expect(store.defaultChatWorkspacePath.value).toBe('/work/current-chat')
     expect(store.projects.value.map((project) => project.path)).toEqual(['/work/current'])
   })
 
@@ -206,6 +211,43 @@ describe('projectStore snapshot ownership', () => {
 
     await expect(store.removeEnvironment('/work/a')).resolves.toEqual({ clearedSessionIds: ['s1'] })
     expect(store.projects.value.map((project) => project.path)).toEqual(['/work/b'])
+  })
+
+  it('keeps archive pending until its exact snapshot version commits', async () => {
+    const { store, projectClient } = await setupStore()
+    projectClient.getSnapshot.mockResolvedValue(snapshot(1, ['/work/a']))
+    await store.refreshProjectSnapshot()
+    store.selectProject('/work/a', 'manual')
+
+    projectClient.archiveEnvironment.mockResolvedValue({ updated: true, version: 3 })
+    projectClient.getSnapshot.mockResolvedValue({
+      ...snapshot(2, []),
+      archivedEnvironments: [environment('/work/a', 'archived')]
+    })
+
+    await expect(store.archiveEnvironment('/work/a')).rejects.toThrow(
+      'Project snapshot version 3 was not committed'
+    )
+    expect(store.environments.value.map((item) => item.path)).toEqual(['/work/a'])
+    expect(store.selectedProjectPath.value).toBe('/work/a')
+  })
+
+  it('clears a manually selected workspace after archive commits', async () => {
+    const { store, projectClient } = await setupStore()
+    projectClient.getSnapshot.mockResolvedValue(snapshot(1, ['/work/a']))
+    await store.refreshProjectSnapshot()
+    store.selectProject('/work/a', 'manual')
+
+    projectClient.archiveEnvironment.mockResolvedValue({ updated: true, version: 2 })
+    projectClient.getSnapshot.mockResolvedValue({
+      ...snapshot(2, []),
+      archivedEnvironments: [environment('/work/a', 'archived')]
+    })
+
+    await expect(store.archiveEnvironment('/work/a')).resolves.toBeUndefined()
+    expect(store.selectedProjectPath.value).toBeNull()
+    expect(store.selectionSource.value).toBe('none')
+    expect(store.projects.value).toEqual([])
   })
 
   it('does not commit a mutation refresh ahead of a newer environment event', async () => {
@@ -240,7 +282,7 @@ describe('projectStore snapshot ownership', () => {
 
   it('returns and selects a picked workspace by default', async () => {
     const { store, projectClient } = await setupStore()
-    projectClient.selectDirectory.mockResolvedValue('/work/new')
+    projectClient.selectDirectoryWithVersion.mockResolvedValue({ path: '/work/new', version: 2 })
     projectClient.getSnapshot.mockResolvedValue(snapshot(2, ['/work/new']))
 
     await expect(store.openFolderPicker()).resolves.toBe('/work/new')
@@ -253,7 +295,7 @@ describe('projectStore snapshot ownership', () => {
   it('registers a picked workspace without replacing the current selection', async () => {
     const { store, projectClient } = await setupStore()
     store.selectProject('/work/current', 'manual')
-    projectClient.selectDirectory.mockResolvedValue('/work/new')
+    projectClient.selectDirectoryWithVersion.mockResolvedValue({ path: '/work/new', version: 2 })
     projectClient.getSnapshot.mockResolvedValue(snapshot(2, ['/work/new', '/work/current']))
 
     await expect(store.openFolderPicker({ select: false })).resolves.toBe('/work/new')
@@ -266,19 +308,46 @@ describe('projectStore snapshot ownership', () => {
     ])
   })
 
-  it('rejects picker and uncommitted snapshot failures', async () => {
+  it('reports picker failures', async () => {
     const { store, projectClient } = await setupStore()
     const pickerFailure = new Error('picker failed')
-    projectClient.selectDirectory.mockRejectedValueOnce(pickerFailure)
+    projectClient.selectDirectoryWithVersion.mockRejectedValueOnce(pickerFailure)
 
     await expect(store.openFolderPicker()).rejects.toBe(pickerFailure)
+    expect(store.error.value).toBe('Failed to open folder picker: Error: picker failed')
+  })
 
-    projectClient.selectDirectory.mockResolvedValueOnce('/work/uncommitted')
+  it('requires the selected version and restores the previous selection on failure', async () => {
+    const { store, projectClient } = await setupStore()
+    projectClient.getSnapshot.mockResolvedValue(snapshot(1, ['/work/current']))
+    await store.refreshProjectSnapshot()
+    store.selectProject('/work/current', 'manual')
+
+    projectClient.selectDirectoryWithVersion.mockResolvedValue({ path: '/work/new', version: 3 })
+    projectClient.getSnapshot.mockResolvedValue(snapshot(2, ['/work/new', '/work/current']))
+
+    await expect(store.openFolderPicker()).rejects.toThrow(
+      'Project snapshot version 3 was not committed'
+    )
+    expect(store.error.value).toBe('Project snapshot version 3 was not committed')
+    expect(store.selectedProjectPath.value).toBe('/work/current')
+    expect(store.selectionSource.value).toBe('manual')
+    expect(store.environments.value.map((item) => item.path)).toEqual(['/work/current'])
+  })
+
+  it('preserves snapshot errors without rewrapping them as picker failures', async () => {
+    const { store, projectClient } = await setupStore()
+
+    projectClient.selectDirectoryWithVersion.mockResolvedValueOnce({
+      path: '/work/uncommitted',
+      version: 2
+    })
     projectClient.getSnapshot.mockRejectedValueOnce(new Error('snapshot failed'))
 
     await expect(store.openFolderPicker({ select: false })).rejects.toThrow(
       'Failed to load project snapshot'
     )
+    expect(store.error.value).toBe('Failed to load project snapshot: Error: snapshot failed')
     expect(store.environments.value).toEqual([])
   })
 })

--- a/test/renderer/stores/sessionStore.test.ts
+++ b/test/renderer/stores/sessionStore.test.ts
@@ -16,6 +16,7 @@ type SetupStoreOptions = {
   initialSettings?: Record<string, unknown>
   failGetSetting?: boolean
   failSetSetting?: boolean
+  getSettingPromise?: Promise<unknown>
   selectedAgentId?: string | null
   enabledAgents?: Array<{ id: string; name?: string; type?: 'deepchat' | 'acp'; enabled?: boolean }>
   onboardingCurrentStepId?:
@@ -273,6 +274,9 @@ const setupStore = async (options: SetupStoreOptions = {}) => {
     getSetting: vi.fn(async <T>(key: string) => {
       if (options.failGetSetting) {
         throw new Error('failed to read setting')
+      }
+      if (options.getSettingPromise) {
+        return (await options.getSettingPromise) as T
       }
       return settings[key] as T | undefined
     }),
@@ -778,11 +782,29 @@ describe('sessionStore group mode preferences', () => {
     const { store, settings, configClient } = await setupStore()
 
     await store.fetchSessions()
+    await store.setGroupMode('project')
+
+    expect(configClient.setSetting).not.toHaveBeenCalled()
+
     await store.toggleGroupMode()
 
     expect(store.groupMode.value).toBe('time')
     expect(configClient.setSetting).toHaveBeenCalledWith(SIDEBAR_GROUP_MODE_KEY, 'time')
     expect(settings[SIDEBAR_GROUP_MODE_KEY]).toBe('time')
+  })
+
+  it('does not let a delayed saved preference overwrite an explicit project-mode request', async () => {
+    const savedPreference = createDeferred<unknown>()
+    const { store, configClient } = await setupStore({
+      getSettingPromise: savedPreference.promise
+    })
+
+    const request = store.setGroupMode('project')
+    savedPreference.resolve('time')
+    await request
+
+    expect(store.groupMode.value).toBe('project')
+    expect(configClient.setSetting).toHaveBeenCalledWith(SIDEBAR_GROUP_MODE_KEY, 'project')
   })
 
   it('rolls back the group mode when persistence fails', async () => {
@@ -791,7 +813,7 @@ describe('sessionStore group mode preferences', () => {
     })
 
     await store.fetchSessions()
-    await store.toggleGroupMode()
+    await expect(store.setGroupMode('time')).rejects.toThrow('failed to write setting')
 
     expect(store.groupMode.value).toBe('project')
     expect(configClient.setSetting).toHaveBeenCalledWith(SIDEBAR_GROUP_MODE_KEY, 'time')

--- a/test/renderer/stores/sessionStore.test.ts
+++ b/test/renderer/stores/sessionStore.test.ts
@@ -566,6 +566,44 @@ describe('sessionStore.getFilteredGroups', () => {
     ])
   })
 
+  it('preserves filesystem roots while merging ordinary trailing separators', async () => {
+    const { store } = await setupStore()
+    const now = Date.now()
+    const createSession = (id: string, projectDir: string) => ({
+      id,
+      title: id,
+      agentId: 'deepchat',
+      status: 'none' as const,
+      projectDir,
+      providerId: 'openai',
+      modelId: 'gpt-4',
+      isPinned: false,
+      isDraft: false,
+      createdAt: now,
+      updatedAt: now
+    })
+
+    await store.fetchSessions()
+    store.sessions.value = [
+      createSession('posix-root', '/'),
+      createSession('windows-root', 'C:\\'),
+      createSession('trailing-a', '/work/a/'),
+      createSession('trailing-b', '/work/a')
+    ]
+
+    const groups = store.getFilteredGroups(null)
+
+    expect(groups.map((group: SessionListTestItem) => group.id)).toHaveLength(3)
+    expect(groups.map((group: SessionListTestItem) => group.id)).toEqual(
+      expect.arrayContaining(['/', 'C:\\', '/work/a'])
+    )
+    expect(groups.find((group: SessionListTestItem) => group.id === '/')?.label).toBe('/')
+    expect(groups.find((group: SessionListTestItem) => group.id === 'C:\\')?.label).toBe('C:\\')
+    expect(
+      groups.find((group: SessionListTestItem) => group.id === '/work/a')?.sessions
+    ).toHaveLength(2)
+  })
+
   it('sorts sessions inside project groups by most recent update', async () => {
     const { store } = await setupStore()
     const now = Date.now()
@@ -817,6 +855,37 @@ describe('sessionStore group mode preferences', () => {
 
     expect(store.groupMode.value).toBe('project')
     expect(configClient.setSetting).toHaveBeenCalledWith(SIDEBAR_GROUP_MODE_KEY, 'time')
+  })
+
+  it('rolls consecutive failed writes back to the last persisted mode', async () => {
+    const { store, configClient } = await setupStore()
+
+    await store.fetchSessions()
+    configClient.setSetting.mockRejectedValue(new Error('failed to write setting'))
+
+    const firstWrite = store.setGroupMode('time')
+    const secondWrite = store.setGroupMode('project')
+
+    await expect(firstWrite).rejects.toThrow('failed to write setting')
+    await expect(secondWrite).rejects.toThrow('failed to write setting')
+    expect(store.groupMode.value).toBe('project')
+  })
+
+  it('propagates an in-flight write failure to same-target callers', async () => {
+    const { store, configClient } = await setupStore()
+    const write = createDeferred<void>()
+
+    await store.fetchSessions()
+    configClient.setSetting.mockReturnValueOnce(write.promise)
+
+    const firstWrite = store.setGroupMode('time')
+    const secondWrite = store.setGroupMode('time')
+    write.reject(new Error('failed to write setting'))
+
+    await expect(firstWrite).rejects.toThrow('failed to write setting')
+    await expect(secondWrite).rejects.toThrow('failed to write setting')
+    expect(configClient.setSetting).toHaveBeenCalledTimes(1)
+    expect(store.groupMode.value).toBe('project')
   })
 
   it('serializes concurrent group mode writes and persists the last toggle', async () => {


### PR DESCRIPTION
## Problem

The sidebar treated Session groups as the source of workspace existence. Selecting a directory could persist a valid active environment, but a zero-Session workspace was filtered out and appeared not to have been added.

The same projection caused several related UX problems:

- users could not add a workspace from the Workspace header;
- a newly active directory could land behind explicitly ordered workspaces;
- empty, filtered, paginated, missing, and historical workspaces were conflated;
- the workspace ellipsis menu was coupled to reorder availability, so it disappeared for a single workspace or during search and offered only movement actions.

## UX

### Before

```text
Workspace                                      [Group]
  project-a                                      [+] [...]
    Session A
  project-b                                      [+] [...]
    Session B
```

A selected directory with no Session did not appear.

### After

```text
Workspace                               [Add] [Group]
  new-project                         Empty      [+] [...]
  project-a                                      [+] [...]
    Session A
  project-b                                      [+] [...]
    Session B

  [...]
    Move to Top
    Move Up
    Move Down
    Move to Bottom
    ----------------
    Archive
```

`Archive` reuses the existing reversible environment-hide flow. It does not introduce a new lifecycle, delete Sessions, delete messages, or touch the real folder.

## Solution

- Add an accessible, guarded **Add workspace** action to the sidebar header.
- Project active environments into the sidebar independently of loaded Session groups.
- Render zero-Session workspaces as `Empty` and start the first correctly scoped draft through the existing one-shot project intent.
- Keep Project as the owner of identity, lifecycle, durable counts, and ordering; keep Session as the owner of visible children.
- Persist newly selected or reactivated directories at the top while leaving duplicate active selection order-stable.
- Preserve search, agent filters, pinning, pagination, path-keyed collapse state, missing paths, historical groups, and the built-in Chat section.
- Keep the ellipsis menu available for every active workspace. Movement actions retain their existing gates; Archive calls the existing `projectStore.archiveEnvironment(path)` action behind confirmation and failure feedback.
- Document the UX, business rules, implementation boundary, rollback, and validation in SDD artifacts.

## Business behavior

- Adding a workspace registers it without replacing the current New Thread project selection or automatically creating a draft.
- A committed Project snapshot is required before a workspace row appears.
- New or reactivated workspaces are persisted first; selecting an already-active workspace does not move it.
- Empty workspace activation starts a draft with the exact `projectDir`.
- Archived zero-Session workspaces disappear from the active list. Existing Session history remains navigable as a historical group without active affordances.
- Missing, archived, and removed workspaces cannot start new conversations.
- The built-in Chat workspace is never duplicated under Workspace.

## Validation

- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- Sidebar component: 62/62 passed
- Project store: 13/13 passed
- Session store: 80/80 passed with an 8 GB Node heap
- New Thread suites: 43/43 passed
- Focused Project service environment/selection tests: 9/9 passed

## Validation notes

- Native Windows and POSIX manual validation remains pending while this PR is Draft.
- The optional native SQLite preference-table suite is unavailable in this workspace; its focused regression remains committed for CI.
- The full Project service suite has two pre-existing Windows path expectation failures (`/mock/...` versus resolved `C:\mock\...`); the focused changed contracts pass.
- Local Node is 24.15.0 while the repository requests Node 24.18 or newer.

Closes #2115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add and manage workspaces directly from the sidebar.
  * View empty, unavailable, archived, and historical workspaces clearly.
  * Start a new chat from an empty workspace.
  * Reorder active workspaces while preserving existing selections.
  * Archive workspaces with confirmation and accessible keyboard/menu actions.
  * Restore archived workspaces through Settings.

* **Bug Fixes**
  * Improved folder-picker error handling and workspace registration.
  * Preserved workspace visibility when refreshes fail.
  * Prevented duplicate activation and preserved workspace ordering.
  * Cleared stale selections after workspace removal or archival.

* **Localization**
  * Added sidebar workspace translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->