### PR TITLE
test(renderer): reduce suite memory

### DIFF
--- a/docs/features/sidebar-workspace-registration/tasks.md
+++ b/docs/features/sidebar-workspace-registration/tasks.md
@@ -84,9 +84,8 @@
 
 ## Validation Notes
 
-- Renderer validation passes: Project store 15/15, full Session store 83/83, sidebar 64/64, both
-  New Thread suites 42/42, and Project client coverage 43/43. The Session suite requires an 8 GB
-  worker heap because the default 4 GB runner exhausts memory.
+- Renderer validation passes: the full renderer suite passes 2099/2099, including Session store
+  80/80 and sidebar 64/64, with the default Node worker heap.
 - Focused main validation passes 139 tests across Project service, route contracts/dispatch, and
   shared filesystem utilities.
 - The native SQLite preference-table suite is skipped because its optional native runtime is not

--- a/test/renderer/stores/sessionStore.test.ts
+++ b/test/renderer/stores/sessionStore.test.ts
@@ -15,7 +15,6 @@ type SessionListTestItem = {
 type SetupStoreOptions = {
   initialSettings?: Record<string, unknown>
   failGetSetting?: boolean
-  failSetSetting?: boolean
   getSettingPromise?: Promise<unknown>
   selectedAgentId?: string | null
   enabledAgents?: Array<{ id: string; name?: string; type?: 'deepchat' | 'acp'; enabled?: boolean }>
@@ -281,9 +280,6 @@ const setupStore = async (options: SetupStoreOptions = {}) => {
       return settings[key] as T | undefined
     }),
     setSetting: vi.fn(async <T>(key: string, value: T) => {
-      if (options.failSetSetting) {
-        throw new Error('failed to write setting')
-      }
       settings[key] = value
     })
   }
@@ -519,89 +515,44 @@ describe('sessionStore.getFilteredGroups', () => {
     expect(groups[0]?.label).toBe('workspace')
   })
 
-  it('keeps a stable unique id for project groups with the same folder name', async () => {
+  it('preserves normalized project path identities', async () => {
     const { store } = await setupStore()
     const now = Date.now()
 
     await store.fetchSessions()
     store.sessions.value = [
-      {
+      createSession({
         id: 'project-1',
         title: 'Workspace A',
-        agentId: 'deepchat',
-        status: 'none',
         projectDir: '/tmp/company-a/deepchat',
-        providerId: 'openai',
-        modelId: 'gpt-4',
-        isPinned: false,
-        isDraft: false,
-        createdAt: now,
         updatedAt: now
-      },
-      {
+      }),
+      createSession({
         id: 'project-2',
         title: 'Workspace B',
-        agentId: 'deepchat',
-        status: 'none',
         projectDir: '/tmp/company-b/deepchat',
-        providerId: 'openai',
-        modelId: 'gpt-4',
-        isPinned: false,
-        isDraft: false,
-        createdAt: now - 1,
         updatedAt: now - 1
-      }
+      }),
+      createSession({ id: 'posix-root', projectDir: '/' }),
+      createSession({ id: 'windows-root', projectDir: 'C:\\' }),
+      createSession({ id: 'trailing-a', projectDir: '/work/a/' }),
+      createSession({ id: 'trailing-b', projectDir: '/work/a' })
     ]
 
     const groups = store.getFilteredGroups(null)
-
-    expect(groups).toHaveLength(2)
-    expect(groups.map((group: SessionListTestItem) => group.id)).toEqual([
-      '/tmp/company-a/deepchat',
-      '/tmp/company-b/deepchat'
-    ])
-    expect(groups.map((group: SessionListTestItem) => group.label)).toEqual([
-      'deepchat',
-      'deepchat'
-    ])
-  })
-
-  it('preserves filesystem roots while merging ordinary trailing separators', async () => {
-    const { store } = await setupStore()
-    const now = Date.now()
-    const createSession = (id: string, projectDir: string) => ({
-      id,
-      title: id,
-      agentId: 'deepchat',
-      status: 'none' as const,
-      projectDir,
-      providerId: 'openai',
-      modelId: 'gpt-4',
-      isPinned: false,
-      isDraft: false,
-      createdAt: now,
-      updatedAt: now
-    })
-
-    await store.fetchSessions()
-    store.sessions.value = [
-      createSession('posix-root', '/'),
-      createSession('windows-root', 'C:\\'),
-      createSession('trailing-a', '/work/a/'),
-      createSession('trailing-b', '/work/a')
-    ]
-
-    const groups = store.getFilteredGroups(null)
-
-    expect(groups.map((group: SessionListTestItem) => group.id)).toHaveLength(3)
-    expect(groups.map((group: SessionListTestItem) => group.id)).toEqual(
-      expect.arrayContaining(['/', 'C:\\', '/work/a'])
+    const groupById = new Map(
+      groups.map((group: SessionListTestItem) => [group.id, group] as const)
     )
-    expect(groups.find((group: SessionListTestItem) => group.id === '/')?.label).toBe('/')
-    expect(groups.find((group: SessionListTestItem) => group.id === 'C:\\')?.label).toBe('C:\\')
+
+    expect(groups).toHaveLength(5)
     expect(
-      groups.find((group: SessionListTestItem) => group.id === '/work/a')?.sessions
-    ).toHaveLength(2)
+      groups
+        .filter((group: SessionListTestItem) => group.label === 'deepchat')
+        .map((group: SessionListTestItem) => group.id)
+    ).toEqual(['/tmp/company-a/deepchat', '/tmp/company-b/deepchat'])
+    expect(groupById.get('/')?.label).toBe('/')
+    expect(groupById.get('C:\\')?.label).toBe('C:\\')
+    expect(groupById.get('/work/a')?.sessions).toHaveLength(2)
   })
 
   it('sorts sessions inside project groups by most recent update', async () => {
@@ -845,33 +796,7 @@ describe('sessionStore group mode preferences', () => {
     expect(configClient.setSetting).toHaveBeenCalledWith(SIDEBAR_GROUP_MODE_KEY, 'project')
   })
 
-  it('rolls back the group mode when persistence fails', async () => {
-    const { store, configClient } = await setupStore({
-      failSetSetting: true
-    })
-
-    await store.fetchSessions()
-    await expect(store.setGroupMode('time')).rejects.toThrow('failed to write setting')
-
-    expect(store.groupMode.value).toBe('project')
-    expect(configClient.setSetting).toHaveBeenCalledWith(SIDEBAR_GROUP_MODE_KEY, 'time')
-  })
-
-  it('rolls consecutive failed writes back to the last persisted mode', async () => {
-    const { store, configClient } = await setupStore()
-
-    await store.fetchSessions()
-    configClient.setSetting.mockRejectedValue(new Error('failed to write setting'))
-
-    const firstWrite = store.setGroupMode('time')
-    const secondWrite = store.setGroupMode('project')
-
-    await expect(firstWrite).rejects.toThrow('failed to write setting')
-    await expect(secondWrite).rejects.toThrow('failed to write setting')
-    expect(store.groupMode.value).toBe('project')
-  })
-
-  it('propagates an in-flight write failure to same-target callers', async () => {
+  it('rolls failed writes back and propagates failures to queued callers', async () => {
     const { store, configClient } = await setupStore()
     const write = createDeferred<void>()
 
@@ -885,6 +810,17 @@ describe('sessionStore group mode preferences', () => {
     await expect(firstWrite).rejects.toThrow('failed to write setting')
     await expect(secondWrite).rejects.toThrow('failed to write setting')
     expect(configClient.setSetting).toHaveBeenCalledTimes(1)
+    expect(store.groupMode.value).toBe('project')
+
+    configClient.setSetting.mockReset()
+    configClient.setSetting.mockRejectedValue(new Error('failed to write setting'))
+
+    const queuedTimeWrite = store.setGroupMode('time')
+    const queuedProjectWrite = store.setGroupMode('project')
+
+    await expect(queuedTimeWrite).rejects.toThrow('failed to write setting')
+    await expect(queuedProjectWrite).rejects.toThrow('failed to write setting')
+    expect(configClient.setSetting).toHaveBeenCalledTimes(2)
     expect(store.groupMode.value).toBe('project')
   })
 


### PR DESCRIPTION
## Summary

- merge duplicate Session-store setup while preserving path identity and persistence failure contracts
- restore the Session-store suite from 83 to 80 heavyweight module initializations
- document that the renderer suite now passes with the default Node worker heap

## Root cause

PR #2138 added three isolated Session-store regression scenarios. Each scenario reloads the renderer store module graph, which pushed one Vitest worker past the default 4 GB heap during the full renderer job.

## Validation

- `pnpm run test:renderer` (253 files, 2099 tests)
- `pnpm exec vitest run --config vitest.config.renderer.ts test/renderer/stores/sessionStore.test.ts` (80 tests)
- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for session store project-group identity handling, including same-name directories, filesystem roots, and trailing separators.
  * Expanded persistence failure coverage to verify queued operations fail consistently and state rolls back correctly.
* **Documentation**
  * Updated renderer validation notes to reflect the current passing test totals and standard memory configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->