### PR TITLE
docs(sdd): adopt implementation-first flow

### DIFF
--- a/.agents/skills/add-provider/SKILL.md
+++ b/.agents/skills/add-provider/SKILL.md
@@ -79,7 +79,8 @@ Typical files:
 ## Workflow
 
 1. Read `docs/features/provider-runtime/spec.md` when the provider work touches the provider runtime
-   scope. Also read `plan.md` and `tasks.md` if they exist for an active provider-runtime goal.
+   scope. Also read `plan.md` if it exists for an active provider-runtime goal. Treat any legacy
+   `tasks.md` as migration input rather than another execution tracker.
 2. Inspect the current provider files before editing:
    - `src/main/provider/defaults.ts`
    - `src/main/provider/providerId.ts`
@@ -89,8 +90,11 @@ Typical files:
    - `src/renderer/settings/components/ProviderApiConfig.vue`
 3. Classify the request into one supported path.
 4. Add the smallest explicit source changes for that path.
-5. Add or update tests that prove provider creation, auth handling, and model discovery behavior.
-6. Update the active SDD `tasks.md` entries as the work lands, when an active tasks file exists.
+5. After implementation, assess provider creation, auth handling, and model discovery for durable
+   regression coverage; add only the smallest contract-level tests warranted.
+6. Update an active SDD `plan.md` as coherent implementation slices land, when one exists. When a
+   legacy `tasks.md` exists for the active goal, merge its remaining work into the plan instead of
+   updating or recreating the task file.
 7. Run:
 
 ```bash

--- a/.agents/skills/add-provider/SKILL.md
+++ b/.agents/skills/add-provider/SKILL.md
@@ -92,15 +92,17 @@ Typical files:
 4. Add the smallest explicit source changes for that path.
 5. After implementation, assess provider creation, auth handling, and model discovery for durable
    regression coverage; add only the smallest contract-level tests warranted.
-6. Update an active SDD `plan.md` as coherent implementation slices land, when one exists. When a
-   legacy `tasks.md` exists for the active goal, merge its remaining work into the plan instead of
-   updating or recreating the task file.
+6. Update an active SDD `plan.md` as coherent implementation slices land, when one exists. For a
+   legacy `tasks.md`, merge remaining work into the existing plan; without one, keep a single-slice
+   complex bug checklist in `spec.md` and create `plan.md` for feature, architecture, or multi-slice
+   bug work. Do not update or recreate the task file.
 7. Run:
 
 ```bash
 pnpm run format
 pnpm run i18n
 pnpm run lint
+pnpm run typecheck
 ```
 
 Run focused main/renderer tests for any touched provider code.

--- a/.agents/skills/deepchat-sdd-cleanup/SKILL.md
+++ b/.agents/skills/deepchat-sdd-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepchat-sdd-cleanup
-description: Use only when a developer explicitly asks to clean, prune, tidy, or organize DeepChat SDD documentation after implementation and validation. Scans docs/features, docs/issues, and docs/architecture; prefers multi-agent review when available; removes completed issue docs tied to closed GitHub issues, drops stale plan/tasks files from completed feature or architecture goals, and deletes obsolete feature or architecture docs.
+description: Use only when a developer explicitly asks to clean, prune, tidy, or organize DeepChat SDD documentation after implementation and validation. Scans docs/features, docs/issues, and docs/architecture; prefers multi-agent review when available; removes completed issue docs tied to closed GitHub issues, drops stale plans and legacy task files from completed feature or architecture goals, and deletes obsolete feature or architecture docs.
 ---
 
 # DeepChat SDD Cleanup
@@ -25,11 +25,11 @@ feature, bug, architecture, or release work.
 
 ## Cleanup Rules
 
-- Completed feature or architecture goal: delete `plan.md` and `tasks.md`; keep `spec.md` only when
-  it still defines a maintained contract, regression guard, platform policy, or architecture
-  decision.
-- Completed issue goal: delete the issue folder when a linked GitHub issue is closed or the local
-  code and tests prove the bug no longer exists.
+- Completed feature or architecture goal: delete `plan.md` and any legacy `tasks.md`; keep `spec.md`
+  only when it still defines a maintained contract, regression guard, platform policy, or
+  architecture decision.
+- Completed issue goal: delete the issue folder when a linked GitHub issue is closed or the
+  implementation and validation evidence prove the bug no longer exists.
 - Removed feature: delete its folder when the product/code path is gone and the spec has no reusable
   decision record.
 - Obsolete architecture: delete its folder when the module was fully replaced and the doc no longer
@@ -45,7 +45,7 @@ solely because a GitHub link looks old.
 
 ## Never Delete
 
-- Active work with unchecked tasks.
+- Active work with unchecked `plan.md` steps or legacy tasks.
 - Any document containing unresolved `[NEEDS CLARIFICATION]`.
 - A document referenced by `docs/README.md`, `docs/ARCHITECTURE.md`, `docs/FLOWS.md`, or AGENTS
   instructions unless the reference is updated in the same change.

--- a/.agents/skills/deepchat-sdd-cleanup/SKILL.md
+++ b/.agents/skills/deepchat-sdd-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepchat-sdd-cleanup
-description: Use only when a developer explicitly asks to clean, prune, tidy, or organize DeepChat SDD documentation after implementation and validation. Scans docs/features, docs/issues, and docs/architecture; prefers multi-agent review when available; removes completed issue docs tied to closed GitHub issues, drops stale plans and legacy task files from completed feature or architecture goals, and deletes obsolete feature or architecture docs.
+description: Use only when a developer explicitly asks to clean, prune, tidy, or organize DeepChat SDD documentation after implementation and validation. Scans docs/features, docs/issues, and docs/architecture; prefers multi-agent review when available; removes completed issue docs when a linked GitHub issue is closed or implementation and validation evidence proves the bug no longer exists, drops stale plans and legacy task files from completed feature or architecture goals, and deletes obsolete feature or architecture docs.
 ---
 
 # DeepChat SDD Cleanup

--- a/.agents/skills/deepchat-sdd/SKILL.md
+++ b/.agents/skills/deepchat-sdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepchat-sdd
-description: Use before substantial DeepChat code, configuration, documentation, test, build, feature, issue, refactor, or architecture changes that need a durable spec. Skip trivial style fixes, small localized logic changes, routine docs edits, and simple bugs unless the developer asks for SDD. Classify substantial work into feature SDD, complex-bug issue spec, or architecture SDD; ask before optional GitHub issue sync unless the developer explicitly requested sync.
+description: Use before substantial DeepChat code, configuration, documentation, test, build, feature, issue, refactor, or architecture changes that need a durable RFC and an explicit execution path. Skip trivial style fixes, small localized logic changes, routine docs edits, and simple bugs unless the developer asks for SDD. Use plan.md as the only separate tracker when needed, default to implementation-first validation, and ask before optional GitHub issue sync unless the developer explicitly requested sync.
 ---
 
 # DeepChat SDD
@@ -43,19 +43,36 @@ cross-module redesign, classify the work as feature or architecture instead.
 
 ## Required Artifacts
 
-Feature and architecture goals use the full SDD set:
+Feature and architecture goals use two artifacts:
 
-- `spec.md`: user need, goal, acceptance criteria, constraints, non-goals, open questions
-- `plan.md`: implementation approach, affected interfaces, data flow, compatibility, test strategy
-- `tasks.md`: ordered tasks that can map to commits or review slices
+- `spec.md`: the normative RFC covering context, goals, non-goals, design, ownership, interfaces,
+  data flow, invariants, compatibility, acceptance criteria, and open questions
+- `plan.md`: ordered implementation steps and live completion state, followed by whole-change
+  review, validation selection, cleanup, and quality gates
 
-Complex bug goals use one file only:
+Do not create `tasks.md`. The plan is the only execution tracker.
 
-- `spec.md`: issue description, impact, root cause or suspected location, fix plan, task checklist,
-  validation, and linked GitHub issue if one exists
+Complex bug goals normally use one file:
+
+- `spec.md`: issue description, impact, root cause or suspected location, fix design, concise
+  implementation checklist, validation outcome, and linked GitHub issue if one exists
+
+Add `plan.md` only when a complex bug has multiple independently trackable implementation slices.
+Never add `tasks.md`.
 
 Resolve every `[NEEDS CLARIFICATION]` marker before implementation. If the requested change is tiny,
 prefer skipping SDD over creating a token artifact.
+
+## Artifact Boundaries
+
+Write `spec.md` as an RFC. It must explain enough implementation direction to constrain local code
+decisions without becoming a file-by-file task list. Acceptance criteria describe observable
+outcomes or independently verifiable contracts, not a test inventory.
+
+Use `plan.md` as both plan and task tracker. Organize it into ordered checkbox sections whose steps
+are coherent, reviewable implementation slices. Include the objective, ownership boundary,
+essential guidance, dependencies when any, and completion condition. Reference the spec instead of
+repeating its design.
 
 ## GitHub Issue Sync
 
@@ -91,25 +108,57 @@ automatically after merge.
 1. Inspect the current code and docs first.
 2. Decide whether the work is substantial enough for SDD; skip artifacts for trivial/local changes.
 3. Pick the target folder from the classification rules when SDD is needed.
-4. Create or update the required artifact set for that classification.
-5. Keep the implementation aligned with existing DeepChat patterns:
+4. Write or update the RFC and resolve every question that could change the implementation.
+5. For feature, architecture, or multi-slice bug work, write one ordered implementation plan
+   without a separate task list or upfront test matrix.
+6. Keep the implementation aligned with existing DeepChat patterns:
    - main process Presenter boundaries
    - typed `shared/contracts/*`
    - renderer `api/*Client`
    - Vue 3 Composition API and i18n for UI strings
-6. For architecture work that changes or replaces a historical feature, update that feature's
+7. For architecture work that changes or replaces a historical feature, update that feature's
    retained `spec.md` if it is still a maintained contract.
-7. Implement the change after the SDD artifacts are complete.
-8. Update `tasks.md` or the issue spec checklist as work lands.
-9. Ask whether to sync an eligible GitHub issue only after the docs or implementation clarify the
+8. Complete the planned implementation before deciding whether to author new test code. Existing
+   checks may run at any time.
+9. Review the whole change against the spec for hidden side effects, compatibility, failure
+   behavior, performance, security, naming, and maintenance cost.
+10. Select the smallest useful validation, remove temporary verification, and add durable tests
+    only for qualifying behavior or contracts.
+11. Update `plan.md` or the complex-bug spec checklist as coherent implementation slices land.
+12. Ask whether to sync an eligible GitHub issue only after the docs or implementation clarify the
    scope, unless the developer already requested issue sync.
-10. Run `pnpm run format`, `pnpm run i18n`, and `pnpm run lint` before handoff when app code,
-    tests, i18n, or project docs changed.
+13. Run `pnpm run format`, `pnpm run i18n`, `pnpm run lint`, and `pnpm run typecheck` before handoff
+    when app code, tests, i18n, or project docs changed.
+
+## Implementation-First Validation
+
+Implementation-first means finishing the planned implementation before deciding whether to author
+new tests. It does not prohibit running existing tests, type checking, linting, builds, or manual
+checks during development.
+
+New test code before implementation is exceptional. Use it only when the developer requests TDD, a
+minimal executable reproduction is required to understand a complex failure, or migration,
+concurrency, recovery, or protocol compatibility needs characterization of current behavior. Record
+the reason in one sentence in `plan.md` or the complex-bug spec.
+
+After implementation, choose among:
+
+- existing tests and static or build checks;
+- temporary probes, scripts, or tests that must be removed before handoff; and
+- the smallest durable regression tests for user-visible behavior, documented cross-module
+  contracts, persistence or migration, lifecycle or concurrency, recovery, security boundaries, or
+  proven regressions.
+
+Do not retain tests that mirror private control flow, assert incidental call order, duplicate the
+implementation through mocks, or exist only to increase coverage. Prefer no new test to a
+low-value implementation-coupled test.
 
 ## Documentation Hygiene
 
 - Do not perform broad SDD cleanup during ordinary feature, bug, or architecture work.
 - Use the separate `deepchat-sdd-cleanup` skill only when the developer explicitly asks to clean or
   organize SDD documentation.
+- Treat existing `tasks.md` files as legacy. Merge remaining work into `plan.md` only when that goal
+  is actively updated; do not perform a repository-wide migration during unrelated work.
 - During the current goal, update directly affected historical specs when they remain active
   contracts.

--- a/.agents/skills/deepchat-sdd/SKILL.md
+++ b/.agents/skills/deepchat-sdd/SKILL.md
@@ -158,7 +158,9 @@ low-value implementation-coupled test.
 - Do not perform broad SDD cleanup during ordinary feature, bug, or architecture work.
 - Use the separate `deepchat-sdd-cleanup` skill only when the developer explicitly asks to clean or
   organize SDD documentation.
-- Treat existing `tasks.md` files as legacy. Merge remaining work into `plan.md` only when that goal
-  is actively updated; do not perform a repository-wide migration during unrelated work.
+- Treat existing `tasks.md` files as legacy and migrate them only when that goal is actively
+  updated. Merge remaining work into an existing `plan.md`; without one, keep a single-slice complex
+  bug checklist in `spec.md` and create `plan.md` for feature, architecture, or multi-slice bug work.
+  Do not perform a repository-wide migration during unrelated work.
 - During the current goal, update directly affected historical specs when they remain active
   contracts.

--- a/.agents/skills/deepchat-sdd/agents/openai.yaml
+++ b/.agents/skills/deepchat-sdd/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "DeepChat SDD"
-  short_description: "Spec substantial DeepChat changes only"
-  default_prompt: "Use $deepchat-sdd for substantial DeepChat changes that need SDD; skip trivial fixes and ask before GitHub issue sync."
+  short_description: "RFC, one tracker, implementation-first validation"
+  default_prompt: "Use $deepchat-sdd for substantial DeepChat changes: write an RFC-style spec, use plan.md as the only separate tracker when needed, implement before deciding on new tests, skip trivial fixes, and ask before GitHub issue sync."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@
 - Preserve unrelated worktree changes; avoid destructive Git unless explicitly requested.
 - Use pnpm only; require Node >=20.19 and pnpm >=10.11.
 - Core code: `src/main`, `src/preload`, `src/renderer`, `src/shared`; stack: Electron/Vue 3/TS.
-- Tests: `test/main`, `test/renderer`, `test/e2e`; use Vitest and the smallest relevant suite.
+- Tests: use Vitest in `test/main`, Vitest with Vue Test Utils in `test/renderer`, and Playwright in
+  `test/e2e`; run the smallest relevant suite.
 - Default to implementation-first development: inspect and design, complete the planned code change,
   then decide what new verification is needed. Do not default to TDD unless explicitly requested or
   a minimal executable reproduction is required to understand a complex failure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,18 @@
 - Use pnpm only; require Node >=20.19 and pnpm >=10.11.
 - Core code: `src/main`, `src/preload`, `src/renderer`, `src/shared`; stack: Electron/Vue 3/TS.
 - Tests: `test/main`, `test/renderer`, `test/e2e`; use Vitest and the smallest relevant suite.
-- Keep committed tests lean and focused on project reliability, stability, and observable contracts;
-  remove temporary checks that only prove an individual function's internals before handoff.
+- Default to implementation-first development: inspect and design, complete the planned code change,
+  then decide what new verification is needed. Do not default to TDD unless explicitly requested or
+  a minimal executable reproduction is required to understand a complex failure.
+- Existing checks may run at any time. Treat new tests as regression protection, not implementation
+  scaffolding; remove temporary probes and tests before handoff.
+- Commit only the smallest durable tests for user-visible behavior, documented contracts,
+  persistence or migration, lifecycle or concurrency, recovery, security boundaries, or proven
+  regressions. Prefer no new test to implementation-coupled coverage.
 - Keep native capabilities behind typed preload/IPC boundaries with context isolation enabled.
 - Use vue-i18n for user copy; prefer existing shadcn-vue primitives and VueUse utilities.
 - Follow Oxfmt: single quotes, no semicolons, 100 columns.
 - Before editing, inspect ownership, callers, tests, and nearby patterns; fix the root cause.
-- Add the smallest regression test for user-visible behavior or a documented contract.
 - Before handoff run format, i18n, lint, typecheck, and relevant test suites.
 - Keep provider and ACP registry refreshes produced by normal builds.
 - Use Conventional Commits (`type(scope): subject`, <=50 chars); never add AI co-authors.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # DeepChat 文档索引
 
-本文档反映 `2026-08-05` 的当前代码。历史实施过程、已完成 issue 和一次性 SDD 通过 Git
+本文档反映 `2026-08-12` 的当前代码。历史实施过程、已完成 issue 和一次性 SDD 通过 Git
 历史查询，不再长期留在 `docs/`。
 
 ## 当前必读
@@ -23,7 +23,9 @@
 
 ## 进行中的目标
 
-未完成的实施保留 `plan.md` / `tasks.md`；仅剩外部验证的目标只保留精简的 `tasks.md`。
+新建或继续维护的 feature / architecture 以 `plan.md` 作为唯一执行清单；有界复杂 bug 可在
+`spec.md` 中保留简短清单。历史 `tasks.md` 在对应目标下次更新时并入 `plan.md`，不为规范迁移
+单独批量改写。
 
 | 文档 | 状态 |
 | --- | --- |
@@ -64,8 +66,9 @@
 ## 文档保留规则
 
 - 当前事实写入核心 architecture、flow 或 guide，不再保留重复的 implemented SDD。
-- 完成的 feature / architecture 删除 `plan.md` 和 `tasks.md`；只有维护合同需要时保留压缩后的
-  `spec.md`。
-- 已修复 issue 直接删除；历史和验证证据由 Git 与测试保存。
-- active goal、未完成 task 和 `[NEEDS CLARIFICATION]` 不得在 cleanup 中删除。
+- 完成的 feature / architecture 删除 `plan.md` 和遗留 `tasks.md`；只有维护合同需要时保留
+  压缩后的 `spec.md`。
+- 已修复 issue 直接删除；历史由 Git 保存，必要的持久化回归由测试保护。
+- active goal、`plan.md` 中的未完成步骤、遗留未完成 task 和 `[NEEDS CLARIFICATION]` 不得在
+  cleanup 中删除。
 - 文档引用的路径必须存在；旧实现只通过 `git log` / `git show` 查询。

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,8 @@
 ## 进行中的目标
 
 新建或继续维护的 feature / architecture 以 `plan.md` 作为唯一执行清单；有界复杂 bug 可在
-`spec.md` 中保留简短清单。历史 `tasks.md` 在对应目标下次更新时并入 `plan.md`，不为规范迁移
+`spec.md` 中保留简短清单。历史 `tasks.md` 仅在对应目标下次更新时迁移：优先并入已有
+`plan.md`；没有 plan 的单阶段复杂 bug 并入 `spec.md`，其他目标创建 `plan.md`。不为规范迁移
 单独批量改写。
 
 | 文档 | 状态 |

--- a/docs/spec-driven-dev.md
+++ b/docs/spec-driven-dev.md
@@ -2,11 +2,16 @@
 
 ## Core Philosophy
 
-Specification-Driven Development (SDD) eliminates the gap between requirements and implementation by making specifications the primary artifact. Specifications don't serve code—code serves specifications. When implementing features in DeepChat, start with clear specifications that define WHAT users need and WHY, before deciding HOW to implement.
+Specification-Driven Development (SDD) makes the specification the primary artifact. Specifications
+do not serve code; code serves specifications. For substantial DeepChat work, the specification is
+an RFC that defines the problem, required behavior, design decisions, invariants, and implementation
+constraints before execution begins.
 
-In practice, SDD works best when the spec is concrete enough to drive design decisions, tests, and
-PR review. Use it for substantial work that needs shared context or a durable decision record, not
-for every small edit. Prefer small, reviewable increments that keep spec → plan → code traceability.
+The spec is the durable source of truth. The plan is the single live execution tracker. Tests are
+one validation mechanism and a form of regression protection; they do not drive implementation by
+default. Use SDD for substantial work that needs shared context or a durable decision record, not
+for every small edit. Keep spec → plan → code traceability without duplicating the same design or
+status across files.
 
 ## Required Artifacts
 
@@ -29,16 +34,23 @@ Pure release metadata work is exempt from SDD. Version bumps, `CHANGELOG.md` upd
 management, tags, and release PR preparation should follow `docs/release-flow.md` without creating a
 release-specific SDD folder.
 
-Feature and architecture goals use the full SDD set:
+Feature and architecture goals use two artifacts:
 
-- `spec.md` - user stories, acceptance criteria, non-goals, constraints, open questions
-- `plan.md` - architecture decisions, event flow, data model, compatibility, test strategy
-- `tasks.md` - small, ordered tasks that map to commits/PRs
+- `spec.md` - the RFC: context, goals, non-goals, design, invariants, interfaces, compatibility,
+  acceptance criteria, and open questions
+- `plan.md` - the ordered implementation steps and their live completion state, including final
+  review, validation decisions, cleanup, and quality gates
 
-Complex bug goals use one file:
+Do not create `tasks.md`. The plan is the only execution tracker.
 
-- `spec.md` - issue description, impact, root cause or suspected location, fix plan, task checklist,
-  validation, and linked GitHub issue if one exists
+Complex bug goals normally use one file:
+
+- `spec.md` - issue description, impact, root cause or suspected location, fix design, a concise
+  implementation checklist, validation outcome, and linked GitHub issue if one exists
+
+Add `plan.md` to a complex bug only when the implementation has multiple independently trackable
+slices. Use the same artifact boundaries as feature and architecture work, and never add
+`tasks.md`.
 
 A bug is SDD-worthy only when the root cause, blast radius, or fix path is complex enough that
 future developers benefit from the written record. For simple style defects or obvious local logic
@@ -48,6 +60,38 @@ If a bug fix introduces a new user-visible capability, data migration, public co
 cross-module redesign, classify the work as feature or architecture instead.
 
 If a change is tiny, prefer skipping SDD over creating a token artifact.
+
+## Artifact Responsibilities
+
+### Specification
+
+Write `spec.md` as the normative RFC. It should explain enough of the implementation direction that
+a capable developer can make local coding decisions without inventing architecture. Include only
+sections that carry real information, chosen from:
+
+- context and problem
+- goals and non-goals
+- current and proposed design
+- ownership, dependency direction, interfaces, and data flow
+- invariants, failure behavior, compatibility, and migration
+- security, privacy, and performance constraints
+- acceptance criteria, open questions, and rejected alternatives
+
+Acceptance criteria describe observable outcomes or independently verifiable contracts. They are
+not a test-case inventory. Keep file-by-file work, status checkboxes, and command transcripts out of
+the spec.
+
+### Implementation Plan
+
+Use `plan.md` as both the implementation plan and task tracker. Organize it into ordered checkbox
+sections. Each step should be a coherent, reviewable implementation slice with its objective,
+ownership boundary, essential implementation guidance, dependencies when any, and completion
+condition.
+
+Reference the spec instead of repeating its design. Do not split individual functions, files, or
+tests into bookkeeping tasks unless they are independently meaningful deliverables. End the plan
+with whole-change review, validation selection, temporary-verification cleanup, and required
+quality gates.
 
 ## GitHub Issue Sync
 
@@ -82,13 +126,52 @@ after merge.
 
 1. **Classification** - Decide whether SDD is needed, then choose feature, complex bug, or
    architecture.
-2. **Specification** - Write the required artifact set for that classification when SDD is needed.
-3. **Implementation & Validation** - TDD (pragmatic), Presenter patterns, UI consistency, quality
-   gates.
-4. **GitHub Sync** - Ask whether to sync an eligible GitHub issue only after the docs or
+2. **Specification** - Write the RFC, settle ownership and design, and resolve every open question
+   that would change the implementation.
+3. **Planning** - For feature, architecture, or multi-slice bug work, write one ordered
+   implementation plan; do not create a separate task list or an upfront test matrix.
+4. **Implementation** - Complete the planned code change while following existing DeepChat
+   boundaries. Existing checks may run whenever they provide useful feedback.
+5. **Review** - Review the complete change against the spec for hidden side effects, compatibility,
+   failure behavior, performance, security, naming, and maintenance cost.
+6. **Validation** - Decide which existing checks, temporary verification, and durable regression
+   tests are warranted. Remove temporary verification before handoff.
+7. **GitHub Sync** - Ask whether to sync an eligible GitHub issue only after the docs or
    implementation clarify the scope, unless the developer already requested issue sync.
 
-Before implementation, inspect existing docs and code, choose the correct SDD folder, and resolve every `[NEEDS CLARIFICATION]` marker. For architecture work that changes or replaces a historical feature, update that feature's retained `spec.md` if it is still a maintained contract.
+Before implementation, inspect existing docs, code, callers, ownership, and nearby tests; choose the
+correct SDD folder; and resolve every `[NEEDS CLARIFICATION]` marker. For architecture work that
+changes or replaces a historical feature, update that feature's retained `spec.md` if it is still a
+maintained contract.
+
+### Implementation-First Validation
+
+Implementation-first means finishing the planned implementation before deciding whether to author
+new test code. It does not prohibit running existing tests, type checking, linting, builds, or
+manual checks during development.
+
+New test code before implementation is exceptional. Use it only when:
+
+- the developer explicitly requests TDD;
+- a minimal executable reproduction is required to understand a complex failure; or
+- migration, concurrency, recovery, or protocol compatibility cannot be designed safely without
+  characterization of existing behavior.
+
+Record the exception and its reason in one sentence in `plan.md` or the complex-bug spec. Keep the
+reproduction narrow; it may become a durable regression only if it protects a qualifying contract.
+
+After implementation, classify validation as follows:
+
+- **Existing validation**: run the smallest relevant existing tests and static or build checks.
+- **Temporary verification**: add a probe, script, or test only to investigate implementation
+  behavior, then remove it before handoff.
+- **Durable regression protection**: commit the smallest test that protects user-visible behavior,
+  a documented cross-module contract, persistence or migration, lifecycle or concurrency,
+  recovery, a security boundary, or a proven regression.
+
+Do not retain tests that merely mirror private control flow, assert incidental call order, duplicate
+the implementation through mocks, or exist only to increase coverage. Prefer no new test to a
+low-value implementation-coupled test.
 
 Cleanup policy:
 
@@ -96,28 +179,33 @@ Cleanup policy:
 - Use the `deepchat-sdd-cleanup` skill only when a developer explicitly asks to clean, prune, or
   organize SDD docs.
 - Completed feature/architecture SDD content should become current documentation in `README.md`,
-  `ARCHITECTURE.md`, `FLOWS.md`, `architecture/*.md`, or `guides/*.md`; keep a spec-only folder
-  when the acceptance criteria still define a useful maintained contract.
-- Completed issue folders may be deleted when a linked GitHub issue is closed or the local code and
-  tests prove the bug no longer exists.
+  `ARCHITECTURE.md`, `FLOWS.md`, `architecture/*.md`, or `guides/*.md`; remove `plan.md` and keep a
+  spec-only folder when the RFC still defines a useful maintained contract.
+- Completed issue folders may be deleted when a linked GitHub issue is closed or the implementation
+  and validation evidence prove the bug no longer exists.
 - Long-term history should be recovered from git history, not accumulated under `docs/archives/`.
 
 ## Six Core Principles
 
 ### 1. Specification-First Development
 
-Write clear requirements with measurable acceptance criteria before writing code. Mark any ambiguities with `[NEEDS CLARIFICATION]` and resolve them before implementation. Focus on user needs and business value, avoiding premature technical decisions.
+Write clear requirements, design decisions, invariants, and independently verifiable acceptance
+criteria before writing code. Mark ambiguities with `[NEEDS CLARIFICATION]` and resolve them before
+implementation. Include the architectural guidance needed to constrain the implementation, but
+leave file-level sequencing and status tracking to the plan.
 
 ### 2. Architectural Consistency
 
 Follow DeepChat's existing architectural patterns:
+
 - **明确模块职责**: 把行为放到负责该能力的 main 模块，不新增通用 Presenter 总入口
 - **Typed Event Communication**: main → renderer 状态通知使用
   `shared/contracts/events.ts` + `publishDeepchatEvent()`；main 内部操作使用直接调用
 - **Secure IPC**: Prefer typed IPC via `src/preload/` (contextIsolation on); avoid ad-hoc channels
 - **Type Definitions**: Shared types live in `src/shared/`
 
-Every feature should integrate seamlessly with existing Presenters and use the established event flow patterns.
+Every feature should integrate seamlessly with existing Presenters and use the established event
+flow patterns.
 
 renderer-main 能力使用 typed route / typed event + `renderer/api/*Client`。
 `useLegacyPresenter()` 和 legacy presenter transport 已删除，不存在可复用的兼容路径。
@@ -125,12 +213,14 @@ renderer-main 能力使用 typed route / typed event + `renderer/api/*Client`。
 ### 3. Minimal Complexity
 
 Start simple. Add complexity only when proven necessary. Avoid:
+
 - Future-proofing (build for now, not hypothetical future needs)
 - Unnecessary abstraction layers
 - Over-generalization
 - Premature optimization
 
-Use framework features directly. Prefer a small “first increment” (e.g. Presenter method + critical test + minimal UI); if a change touches many files, explain why in the plan.
+Use framework features directly. Prefer a small coherent implementation slice that proves the
+end-to-end design. If a change touches many files, explain why in the plan.
 
 ### 4. Compatibility & Migration
 
@@ -143,39 +233,52 @@ Prefer forward-looking designs, but treat stored user data, config, and external
 ### 5. UI Consistency
 
 Maintain consistency across the codebase:
+
 - **Vue 3 Composition API** for all components
 - **i18n** for all user-facing strings in `src/renderer/src/i18n/`
 - **Tailwind CSS** following existing utility patterns
 - Follow existing component conventions (props, emits, composition patterns)
 
-### 6. Test-Driven Approach (Pragmatic)
+### 6. Implementation-First, Risk-Based Validation
 
-Use Vitest + Vue Test Utils for testing. Test files mirror source structure under `/test/main/` and `/test/renderer/`. Write tests for critical paths and high-impact code. Not exhaustive: focus on value, not coverage.
+Put the primary reasoning budget into design and implementation. After the implementation is
+coherent, choose the cheapest validation that can reveal meaningful failures. Use Vitest + Vue Test
+Utils when durable regression coverage is warranted; test files mirror source structure under
+`/test/main/` and `/test/renderer/`. Optimize for protected contracts and project stability, not
+test count or coverage percentage.
 
 ## Development Checklist
 
 ### Specification Phase
-- [ ] User stories clearly defined
-- [ ] Acceptance criteria testable and measurable
+
+- [ ] Problem, goals, and affected users or systems are clear
+- [ ] Acceptance criteria are observable or independently verifiable
 - [ ] Non-goals and constraints stated
+- [ ] Ownership, interfaces, data flow, and required invariants defined
+- [ ] Compatibility, migration, failure, security, and performance implications addressed
 - [ ] Key UX states covered (loading/empty/error)
 - [ ] No `[NEEDS CLARIFICATION]` markers remain
-- [ ] Business value articulated
-- [ ] GitHub issue linked or sync decision recorded for eligible feature and complex bug work
 
 ### Planning Phase
+
 - [ ] Identify all involved owning modules and narrow ports
 - [ ] Design event flow (if cross-process communication required)
 - [ ] Define/verify IPC surface (`src/preload/`) and types (`src/shared/`)
 - [ ] Define shared types in `src/shared/`
-- [ ] Plan test coverage for critical paths
+- [ ] Express the implementation as ordered, coherent slices in `plan.md`, or in the bounded
+  complex-bug spec when no separate plan is needed
+- [ ] Keep whole-change review and validation selection after implementation
 - [ ] Identify risks (security/privacy/perf) and mitigations
 
 ### Implementation Phase
-- [ ] Create/update test file
+
 - [ ] Implement owning module and typed route/client changes
 - [ ] Implement UI component (if needed)
 - [ ] Add i18n keys (if user-facing)
+- [ ] Review the complete implementation against the spec and affected boundaries
+- [ ] Run existing validation and add temporary verification only where uncertainty remains
+- [ ] Add the smallest durable regression tests only for qualifying behavior or contracts
+- [ ] Remove temporary probes, scripts, and tests
 - [ ] Run: `pnpm run format && pnpm run i18n && pnpm run lint && pnpm run typecheck`
 
 ## Common Patterns
@@ -223,8 +326,12 @@ Compatibility note:
 
 A change is “done” when:
 
-- The acceptance criteria are met (and ideally covered by tests)
-- Lint/typecheck/tests pass locally
+- The acceptance criteria and documented invariants are met
+- The complete implementation has been reviewed against affected boundaries and failure modes
+- Relevant existing tests and required quality gates pass locally, or environment limits are
+  reported precisely
+- Any warranted durable regression tests are focused on qualifying behavior or contracts
+- Temporary verification code has been removed
 - User-facing strings use i18n keys
 - Any migrations or breaking changes are documented
 - Linked GitHub issues, when any, are referenced from the PR with `Closes #NNN`

--- a/docs/spec-driven-dev.md
+++ b/docs/spec-driven-dev.md
@@ -242,10 +242,10 @@ Maintain consistency across the codebase:
 ### 6. Implementation-First, Risk-Based Validation
 
 Put the primary reasoning budget into design and implementation. After the implementation is
-coherent, choose the cheapest validation that can reveal meaningful failures. Use Vitest + Vue Test
-Utils when durable regression coverage is warranted; test files mirror source structure under
-`/test/main/` and `/test/renderer/`. Optimize for protected contracts and project stability, not
-test count or coverage percentage.
+coherent, choose the cheapest validation that can reveal meaningful failures. When durable
+regression coverage is warranted, use Vitest in `test/main`, Vitest with Vue Test Utils in
+`test/renderer`, and Playwright in `test/e2e`. Optimize for protected contracts and project
+stability, not test count or coverage percentage.
 
 ## Development Checklist
 


### PR DESCRIPTION
## Summary

- Make repository and SDD guidance implementation-first by default.
- Treat spec.md as the RFC and plan.md as the single execution tracker; stop creating tasks.md.
- Separate existing checks, temporary verification, and durable regression protection.
- Align the SDD prompt, documentation index, cleanup workflow, and provider workflow.

##  核心改动

修改 Agents 和 sdd 的skill的目的是修改一下整个项目的开发流程。主要变化是
1、 原来的 spec 升级成类似 rfc 一样的文档，讲清楚这是干啥的，架构是什么，为什么要这么做
2、task 和 plan 合并到一起，这个作为统一的实施指导
3、从测试优先改为实现优先，模型和agent越来越聪明的时候，其实让更多的上下文给实施是更合适的，等到实施完成后统一进行思考和分析，在怀疑的地方用临时测试验证加固，在涉及到整体架构的地方添加能保护整体架构设计和约束的自动化测试
4、临时开发过程中允许跑已有的测试，也允许写临时测试代码来保障开发正确性，这部分需要合理使用并自动清理

## Validation

- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Standardized RFC-based specifications and `plan.md` as the development workflow.
  - Clarified migration and cleanup of legacy task documentation.
  - Improved guidance for implementation review, validation, durable regression testing, and removing temporary checks.
  - Expanded provider development guidance to cover creation, authentication, and model discovery testing.
  - Clarified planning, handoff, issue synchronization, and quality-gate expectations across project documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->