### PR TITLE
Fix workspace prepend order and parallelize read tools

### DIFF
--- a/docs/features/sidebar-workspace-registration/plan.md
+++ b/docs/features/sidebar-workspace-registration/plan.md
@@ -162,8 +162,8 @@ Session route is required.
 
 A small main-process ordering change is required:
 
-- `NewEnvironmentPreferencesTable.activateAtTop()` uses one upsert to preserve an already-active
-  path's order or assign a newly active path before the current minimum explicit order.
+- `NewEnvironmentPreferencesTable.activateAtTop()` uses a transaction to preserve an already-active
+  path's order or shift existing explicit orders before assigning a newly active path order zero.
 - `ProjectService.selectDirectory()` wraps recent-project upsert and preference activation in one
   database transaction. It does not call `getEnvironments()` or synchronously check unrelated
   filesystem paths.

--- a/src/main/project/data/tables/newEnvironmentPreferences.ts
+++ b/src/main/project/data/tables/newEnvironmentPreferences.ts
@@ -75,9 +75,16 @@ export class NewEnvironmentPreferencesTable extends BaseTable {
     }
 
     const now = Date.now()
-    this.db
-      .prepare(
-        `INSERT INTO new_environment_preferences (
+    const getStatus = this.db.prepare(
+      'SELECT status FROM new_environment_preferences WHERE path = ?'
+    )
+    const shiftActiveOrder = this.db.prepare(
+      `UPDATE new_environment_preferences
+       SET sort_order = sort_order + 1
+       WHERE status = 'active' AND sort_order < ${DEFAULT_ENVIRONMENT_SORT_ORDER}`
+    )
+    const activate = this.db.prepare(
+      `INSERT INTO new_environment_preferences (
           path,
           status,
           sort_order,
@@ -87,27 +94,30 @@ export class NewEnvironmentPreferencesTable extends BaseTable {
         ) VALUES (
           ?,
           'active',
-          COALESCE((
-            SELECT MIN(sort_order) - 1
-            FROM new_environment_preferences
-            WHERE status = 'active' AND sort_order < ${DEFAULT_ENVIRONMENT_SORT_ORDER}
-          ), 0),
+          0,
           NULL,
           NULL,
           ?
         )
         ON CONFLICT(path) DO UPDATE SET
           status = 'active',
-          sort_order = CASE
-            WHEN new_environment_preferences.status = 'active'
-              THEN new_environment_preferences.sort_order
-            ELSE excluded.sort_order
-          END,
+          sort_order = excluded.sort_order,
           archived_at = NULL,
           removed_at = NULL,
           updated_at = excluded.updated_at`
-      )
-      .run(normalizedPath, now)
+    )
+
+    this.db.transaction(() => {
+      const existing = getStatus.get(normalizedPath) as
+        | Pick<NewEnvironmentPreferenceRow, 'status'>
+        | undefined
+      if (existing?.status === 'active') {
+        return
+      }
+
+      shiftActiveOrder.run()
+      activate.run(normalizedPath, now)
+    })()
   }
 
   markArchived(environmentPath: string): void {

--- a/src/main/tool/agentTools/agentTapeTools.ts
+++ b/src/main/tool/agentTools/agentTapeTools.ts
@@ -123,7 +123,7 @@ function buildToolDefinition(
   schema: z.ZodTypeAny
 ): MCPToolDefinition {
   return {
-    execution: TOOL_EXECUTION.read.sequential,
+    execution: TOOL_EXECUTION.read.parallel,
     type: 'function',
     function: {
       name,

--- a/src/main/tool/agentTools/agentToolManager.ts
+++ b/src/main/tool/agentTools/agentToolManager.ts
@@ -949,7 +949,7 @@ export class AgentToolManager {
         }
       },
       {
-        execution: TOOL_EXECUTION.read.sequential,
+        execution: TOOL_EXECUTION.read.parallel,
         type: 'function',
         function: {
           name: GLOB_TOOL_NAME,
@@ -968,7 +968,7 @@ export class AgentToolManager {
         }
       },
       {
-        execution: TOOL_EXECUTION.read.sequential,
+        execution: TOOL_EXECUTION.read.parallel,
         type: 'function',
         function: {
           name: GREP_TOOL_NAME,
@@ -2243,7 +2243,7 @@ export class AgentToolManager {
     const schemas = this.skillSchemas
     return [
       {
-        execution: TOOL_EXECUTION.read.sequential,
+        execution: TOOL_EXECUTION.read.parallel,
         type: 'function',
         function: {
           name: 'skill_list',

--- a/src/main/tool/browser/definitions.ts
+++ b/src/main/tool/browser/definitions.ts
@@ -71,7 +71,7 @@ export function getYoBrowserToolDefinitions(): MCPToolDefinition[] {
       'get_browser_status',
       'Get the current session browser status',
       yoBrowserSchemas.get_browser_status,
-      TOOL_EXECUTION.read.sequential
+      TOOL_EXECUTION.read.parallel
     ),
     toDefinition(
       'load_url',

--- a/test/main/project/data/tables/newEnvironmentPreferencesTable.test.ts
+++ b/test/main/project/data/tables/newEnvironmentPreferencesTable.test.ts
@@ -119,23 +119,29 @@ describeIfSqlite('NewEnvironmentPreferencesTable', () => {
     })
   })
 
-  it('assigns unique top positions without moving an active duplicate', () => {
+  it('atomically prepends newly active paths without moving an active duplicate', () => {
     table.reorderActive(['/work/a', '/work/b'])
 
     table.activateAtTop('/work/new')
-    expect(table.get('/work/new')).toMatchObject({ status: 'active', sort_order: -1 })
+    expect(table.get('/work/new')).toMatchObject({ status: 'active', sort_order: 0 })
+    expect(table.get('/work/a')).toMatchObject({ status: 'active', sort_order: 1 })
+    expect(table.get('/work/b')).toMatchObject({ status: 'active', sort_order: 2 })
 
     table.activateAtTop('/work/newer')
-    expect(table.get('/work/newer')).toMatchObject({ status: 'active', sort_order: -2 })
+    expect(table.get('/work/newer')).toMatchObject({ status: 'active', sort_order: 0 })
+    expect(table.get('/work/new')).toMatchObject({ status: 'active', sort_order: 1 })
+    expect(table.get('/work/a')).toMatchObject({ status: 'active', sort_order: 2 })
+    expect(table.get('/work/b')).toMatchObject({ status: 'active', sort_order: 3 })
 
     table.activateAtTop('/work/b')
-    expect(table.get('/work/b')).toMatchObject({ status: 'active', sort_order: 1 })
+    expect(table.get('/work/b')).toMatchObject({ status: 'active', sort_order: 3 })
+    expect(table.get('/work/newer')).toMatchObject({ status: 'active', sort_order: 0 })
 
     table.markArchived('/work/a')
     table.activateAtTop('/work/a')
     expect(table.get('/work/a')).toMatchObject({
       status: 'active',
-      sort_order: -3,
+      sort_order: 0,
       archived_at: null,
       removed_at: null
     })
@@ -143,7 +149,31 @@ describeIfSqlite('NewEnvironmentPreferencesTable', () => {
       table
         .list()
         .filter((row) => row.status === 'active')
-        .map((row) => row.sort_order)
-    ).toEqual(expect.arrayContaining([-3, -2, -1, 1]))
+        .sort((left, right) => left.sort_order - right.sort_order)
+        .map((row) => row.path)
+    ).toEqual(['/work/a', '/work/newer', '/work/new', '/work/b'])
+  })
+
+  it('rolls back order shifts when prepending fails', () => {
+    table.reorderActive(['/work/a', '/work/b'])
+    db!.exec(`
+      CREATE TRIGGER fail_environment_prepend
+      BEFORE INSERT ON new_environment_preferences
+      WHEN NEW.path = '/work/fail'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected prepend failure');
+      END;
+    `)
+
+    expect(() => table.activateAtTop('/work/fail')).toThrow('injected prepend failure')
+    expect(
+      table
+        .list()
+        .sort((left, right) => left.sort_order - right.sort_order)
+        .map((row) => ({ path: row.path, sort_order: row.sort_order }))
+    ).toEqual([
+      { path: '/work/a', sort_order: 0 },
+      { path: '/work/b', sort_order: 1 }
+    ])
   })
 })


### PR DESCRIPTION
## Summary

- Fix workspace registration so newly added workspaces are prepended consistently.
- Allow independent read-only agent tools, Tape queries, skill listing, and browser status reads to participate in parallel tool batches.
- Refresh the generated ACP registry entries.

## Validation

- `git diff --cached --check` passed before commit.
- Tests, formatting, and typecheck were not run per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace path activation so newly activated paths consistently appear at the top.
  - Preserved existing path order when reactivating an already active path.
  - Ensured archived paths are correctly restored and ordering remains consistent if an update fails.

- **Performance Improvements**
  - Enabled compatible search, filesystem, skill, and browser status operations to run in parallel, improving responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->