### PR TITLE
perf(agent): parallelize safe read tools

### DIFF
--- a/src/main/agent/deepchat/runtime/runLifecycleCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/runLifecycleCoordinator.ts
@@ -394,12 +394,7 @@ export class RunLifecycleCoordinator {
   }
 
   schedulePendingInputDrain(sessionId: string, reason: PendingInputWakeReason): void {
-    void this.requestPendingInputDrain(sessionId, reason).catch((error) => {
-      logger.error(
-        `[DeepChatAgent] drainPendingQueueIfPossible error session=${sessionId} reason=${reason}`,
-        redactRuntimeErrorForLog(error)
-      )
-    })
+    void this.requestPendingInputDrain(sessionId, reason).catch(() => undefined)
   }
 
   private canSettleAbortedRun(scope: SessionRuntimeScope, runId?: string): boolean {

--- a/src/main/tool/agentTools/agentTapeTools.ts
+++ b/src/main/tool/agentTools/agentTapeTools.ts
@@ -123,7 +123,7 @@ function buildToolDefinition(
   schema: z.ZodTypeAny
 ): MCPToolDefinition {
   return {
-    execution: TOOL_EXECUTION.read.sequential,
+    execution: TOOL_EXECUTION.read.parallel,
     type: 'function',
     function: {
       name,

--- a/src/main/tool/agentTools/agentToolManager.ts
+++ b/src/main/tool/agentTools/agentToolManager.ts
@@ -949,7 +949,7 @@ export class AgentToolManager {
         }
       },
       {
-        execution: TOOL_EXECUTION.read.sequential,
+        execution: TOOL_EXECUTION.read.parallel,
         type: 'function',
         function: {
           name: GLOB_TOOL_NAME,
@@ -968,7 +968,7 @@ export class AgentToolManager {
         }
       },
       {
-        execution: TOOL_EXECUTION.read.sequential,
+        execution: TOOL_EXECUTION.read.parallel,
         type: 'function',
         function: {
           name: GREP_TOOL_NAME,
@@ -2243,7 +2243,7 @@ export class AgentToolManager {
     const schemas = this.skillSchemas
     return [
       {
-        execution: TOOL_EXECUTION.read.sequential,
+        execution: TOOL_EXECUTION.read.parallel,
         type: 'function',
         function: {
           name: 'skill_list',

--- a/src/main/tool/browser/definitions.ts
+++ b/src/main/tool/browser/definitions.ts
@@ -71,7 +71,7 @@ export function getYoBrowserToolDefinitions(): MCPToolDefinition[] {
       'get_browser_status',
       'Get the current session browser status',
       yoBrowserSchemas.get_browser_status,
-      TOOL_EXECUTION.read.sequential
+      TOOL_EXECUTION.read.parallel
     ),
     toDefinition(
       'load_url',

--- a/test/main/agent/deepchat/runtime/runLifecycleCoordinator.test.ts
+++ b/test/main/agent/deepchat/runtime/runLifecycleCoordinator.test.ts
@@ -414,7 +414,7 @@ describe('RunLifecycleCoordinator', () => {
     )
   })
 
-  it('isolates scheduled queue wake failures from lifecycle callers', async () => {
+  it('isolates scheduled queue wake failures without duplicate lifecycle logging', async () => {
     const { coordinator, pendingInputWakeup } = createHarness()
     const error = new Error('queue unavailable')
     vi.mocked(pendingInputWakeup.drain).mockRejectedValueOnce(error)
@@ -423,9 +423,6 @@ describe('RunLifecycleCoordinator', () => {
     coordinator.schedulePendingInputDrain(SESSION_ID, 'completed')
     await flushPromises()
 
-    expect(logError).toHaveBeenCalledWith(
-      '[DeepChatAgent] drainPendingQueueIfPossible error session=session reason=completed',
-      expect.anything()
-    )
+    expect(logError).not.toHaveBeenCalled()
   })
 })

--- a/test/main/agent/deepchat/runtime/toolExecutionPolicy.test.ts
+++ b/test/main/agent/deepchat/runtime/toolExecutionPolicy.test.ts
@@ -51,9 +51,18 @@ describe('selectToolBatchExecutionMode', () => {
   })
 
   it('selects parallel for a multi-call batch of explicitly parallel reads', () => {
-    const definitions = [makeDefinition('inspect', TOOL_EXECUTION.read.parallel)]
+    const definitions = [
+      ...['glob', 'grep', 'skill_list', 'tape_search', 'tape_context', 'get_browser_status'].map(
+        (name) => makeDefinition(name, TOOL_EXECUTION.read.parallel)
+      )
+    ]
 
-    expect(selectMode(['inspect', 'inspect'], definitions)).toBe('parallel')
+    expect(
+      selectMode(
+        ['glob', 'grep', 'skill_list', 'tape_search', 'tape_context', 'get_browser_status'],
+        definitions
+      )
+    ).toBe('parallel')
   })
 
   it.each<PermissionMode>(['default', 'auto_approve'])(

--- a/test/main/agent/deepchat/runtime/toolExecutionPolicy.test.ts
+++ b/test/main/agent/deepchat/runtime/toolExecutionPolicy.test.ts
@@ -51,18 +51,9 @@ describe('selectToolBatchExecutionMode', () => {
   })
 
   it('selects parallel for a multi-call batch of explicitly parallel reads', () => {
-    const definitions = [
-      ...['glob', 'grep', 'skill_list', 'tape_search', 'tape_context', 'get_browser_status'].map(
-        (name) => makeDefinition(name, TOOL_EXECUTION.read.parallel)
-      )
-    ]
+    const definitions = [makeDefinition('inspect', TOOL_EXECUTION.read.parallel)]
 
-    expect(
-      selectMode(
-        ['glob', 'grep', 'skill_list', 'tape_search', 'tape_context', 'get_browser_status'],
-        definitions
-      )
-    ).toBe('parallel')
+    expect(selectMode(['inspect', 'inspect'], definitions)).toBe('parallel')
   })
 
   it.each<PermissionMode>(['default', 'auto_approve'])(

--- a/test/main/tool/agentTools/agentToolManagerRead.test.ts
+++ b/test/main/tool/agentTools/agentToolManagerRead.test.ts
@@ -10,6 +10,8 @@ import { backgroundExecSessionManager } from '@/agent/shared/process/backgroundE
 import * as sessionVisionResolverModule from '@/agent/vision/sessionVisionResolver'
 import { createAgentToolDependencies } from './agentToolDependencies'
 import { CommandPermissionService } from '@/tool/permission'
+import { getYoBrowserToolDefinitions } from '@/tool/browser/definitions'
+import { selectToolBatchExecutionMode } from '@/agent/deepchat/runtime/toolExecutionPolicy'
 
 vi.mock('fs', async (importOriginal) => {
   const actual = (await importOriginal()) as typeof import('fs')
@@ -75,6 +77,7 @@ describe('AgentToolManager read routing', () => {
     resolveConversationWorkdir = vi.fn().mockResolvedValue(workspaceDir)
     resolveConversationSessionInfo = vi.fn().mockResolvedValue({
       agentId: 'deepchat',
+      agentType: 'deepchat',
       providerId: 'openai',
       modelId: 'gpt-4'
     })
@@ -178,7 +181,8 @@ describe('AgentToolManager read routing', () => {
       chatMode: 'agent',
       supportsVision: false,
       agentWorkspacePath: workspaceDir,
-      conversationId: 'conv1'
+      conversationId: 'conv1',
+      skillsEnabled: true
     })
     const filesystemContracts = Object.fromEntries(
       definitions
@@ -190,11 +194,48 @@ describe('AgentToolManager read routing', () => {
       read: { effect: 'read', mode: 'parallel' },
       write: { effect: 'write', mode: 'sequential' },
       edit: { effect: 'write', mode: 'sequential' },
-      glob: { effect: 'read', mode: 'sequential' },
-      grep: { effect: 'read', mode: 'sequential' },
+      glob: { effect: 'read', mode: 'parallel' },
+      grep: { effect: 'read', mode: 'parallel' },
       exec: { effect: 'write', mode: 'sequential' },
       process: { effect: 'write', mode: 'sequential' }
     })
+  })
+
+  it('selects parallel for the production read tool definitions', async () => {
+    const definitions = [
+      ...(await manager.getAllToolDefinitions({
+        chatMode: 'agent',
+        supportsVision: false,
+        agentWorkspacePath: workspaceDir,
+        conversationId: 'conv1',
+        skillsEnabled: true
+      })),
+      ...getYoBrowserToolDefinitions()
+    ]
+    const names = [
+      'glob',
+      'grep',
+      'skill_list',
+      'tape_search',
+      'tape_context',
+      'get_browser_status'
+    ]
+    const selectedDefinitions = definitions.filter((definition) =>
+      names.includes(definition.function.name)
+    )
+
+    expect(
+      Object.fromEntries(
+        selectedDefinitions.map(({ function: { name }, execution }) => [name, execution])
+      )
+    ).toEqual(Object.fromEntries(names.map((name) => [name, { effect: 'read', mode: 'parallel' }])))
+    expect(
+      selectToolBatchExecutionMode({
+        permissionMode: 'full_access',
+        toolCalls: names.map((name) => ({ name })),
+        toolDefinitions: selectedDefinitions
+      })
+    ).toBe('parallel')
   })
 
   it('commits process mutations after local validation and before the utility target', async () => {


### PR DESCRIPTION
## Summary
- remove duplicate pending-input drain logging from the lifecycle coordinator while preserving rejection isolation
- mark filesystem glob/grep, skill_list, Tape search/context, and browser status as parallel-safe reads
- extend execution policy regression coverage to the real built-in read tool names

## Validation
- `pnpm exec oxfmt --check ...`
- `pnpm run typecheck:node`
- `pnpm lint`
- focused Vitest suites for tool execution policy, pending input pump, lifecycle coordination, FFF search, and YoBrowser definitions

Node 26 emitted the repository's existing engine-range warning; typecheck and lint passed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate lifecycle error logging when pending input processing fails.

* **Performance Improvements**
  * Enabled parallel execution for read-only search, filesystem, skills, tape, and browser tools, improving efficiency during agent operations.

* **Tests**
  * Updated coverage to verify parallel read execution and prevent duplicate lifecycle logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->