### PR TITLE
fix(provider): omit MiniMax-M3 temperature

### DIFF
--- a/src/main/provider/aiSdk/providerOptionsMapper.ts
+++ b/src/main/provider/aiSdk/providerOptionsMapper.ts
@@ -1,7 +1,11 @@
 import type { MCPToolDefinition } from '@shared/types/mcp'
 import type { ModelConfig } from '@shared/types/provider'
 import type { ModelMessage } from 'ai'
-import { applyRequestParameterPolicy, type ModelRequestPolicy } from '@shared/modelRequestPolicy'
+import {
+  applyRequestParameterPolicy,
+  isMiniMaxM3AdaptiveThinkingModel,
+  type ModelRequestPolicy
+} from '@shared/modelRequestPolicy'
 import {
   getReasoningEffectiveEnabledForProvider,
   hasAnthropicReasoningToggle,
@@ -158,20 +162,14 @@ function supportsGrokReasoningEffort(modelId: string): boolean {
   return unqualifiedModelId === 'grok-3-mini' || unqualifiedModelId.startsWith('grok-3-mini-')
 }
 
-function normalizeMiniMaxModelId(modelId: string): string {
-  const normalized = modelId.trim().toLowerCase()
-  return normalized.includes('/') ? normalized.slice(normalized.lastIndexOf('/') + 1) : normalized
-}
-
 function supportsMiniMaxAdaptiveThinking(
   providerId: string,
   capabilityProviderId: string,
   modelId: string
 ): boolean {
-  const providerIds = [providerId, capabilityProviderId].map((id) => id.trim().toLowerCase())
   return (
-    providerIds.some((id) => id === 'minimax' || id === 'minimax-cn') &&
-    normalizeMiniMaxModelId(modelId) === 'minimax-m3'
+    isMiniMaxM3AdaptiveThinkingModel(providerId, modelId) ||
+    isMiniMaxM3AdaptiveThinkingModel(capabilityProviderId, modelId)
   )
 }
 

--- a/src/main/provider/settings.ts
+++ b/src/main/provider/settings.ts
@@ -64,7 +64,10 @@ import type {
   ResolvedCapabilityIdentity,
   ResolvedModelCapabilitySnapshot
 } from '@shared/types/model-capabilities'
-import { getMoonshotKimiTemperaturePolicy } from '@shared/modelRequestPolicy'
+import {
+  getMoonshotKimiTemperaturePolicy,
+  isMiniMaxM3AdaptiveThinkingModel
+} from '@shared/modelRequestPolicy'
 import { resolveDeepSeekResponsesRoute } from './deepseekResponsesAdapter'
 
 // Create interface for model storage
@@ -556,14 +559,13 @@ export class ProviderSettings implements ProviderSettingsPort {
       input.routeOverride,
       resolvedModelConfig
     )
-    const fixedTemperaturePolicy = getMoonshotKimiTemperaturePolicy(
-      identity.providerId,
-      identity.requestModelId
-    )
+    const reasoningDependentPolicy =
+      getMoonshotKimiTemperaturePolicy(identity.providerId, identity.requestModelId) ||
+      isMiniMaxM3AdaptiveThinkingModel(identity.providerId, identity.requestModelId)
     const reasoningEnabled =
       input.reasoningEnabled ??
       resolvedModelConfig?.reasoning ??
-      (fixedTemperaturePolicy
+      (reasoningDependentPolicy
         ? this.getModelConfig(modelId, providerId, identity).reasoning
         : undefined)
 

--- a/src/shared/modelRequestPolicy.ts
+++ b/src/shared/modelRequestPolicy.ts
@@ -1,6 +1,7 @@
-import { normalizeCanonicalModelId, normalizeModelIdText } from './modelId'
+import { getUnqualifiedModelId, normalizeCanonicalModelId, normalizeModelIdText } from './modelId'
 
 const THINKING_SUFFIX = ':thinking'
+const MINIMAX_ADAPTIVE_THINKING_PROVIDER_IDS = new Set(['minimax', 'minimax-cn', 'minimax-global'])
 const FIXED_TEMPERATURE_MODELS = new Set([
   'kimi-k2.5',
   'kimi-k2.6',
@@ -68,6 +69,18 @@ export const isKimiK3ModelId = (modelId: string | null | undefined): boolean => 
   return /^(?:coding-)?kimi-k3(?:-free)?$/.test(canonicalModelId)
 }
 
+export const isMiniMaxM3AdaptiveThinkingModel = (
+  providerId: string | null | undefined,
+  modelId: string | null | undefined
+): boolean => {
+  const normalizedProviderId = providerId?.trim().toLowerCase()
+  if (!normalizedProviderId || !MINIMAX_ADAPTIVE_THINKING_PROVIDER_IDS.has(normalizedProviderId)) {
+    return false
+  }
+
+  return getUnqualifiedModelId(modelId) === 'minimax-m3'
+}
+
 export const getMoonshotKimiTemperaturePolicy = (
   _providerId: string | null | undefined,
   modelId: string | null | undefined
@@ -129,6 +142,15 @@ export const resolveModelRequestPolicy = (
       topP: { mode: 'omit' },
       reasoning: { mode: 'fixed', value: true },
       legacyThinking: { mode: 'omit' }
+    }
+  }
+
+  if (isMiniMaxM3AdaptiveThinkingModel(providerId, modelId) && reasoningEnabled === true) {
+    return {
+      temperature: { mode: 'omit' },
+      topP: passthrough(),
+      reasoning: passthrough(),
+      legacyThinking: passthrough()
     }
   }
 

--- a/test/main/provider/aiSdkProviderOptionsMapper.test.ts
+++ b/test/main/provider/aiSdkProviderOptionsMapper.test.ts
@@ -568,32 +568,40 @@ describe('AI SDK provider options', () => {
     expect(result.providerOptions?.anthropic).not.toHaveProperty('effort')
   })
 
-  it('maps MiniMax-M3 reasoning to Anthropic-compatible adaptive thinking', () => {
-    mockGetReasoningPortrait.mockReturnValue({
-      supported: true,
-      defaultEnabled: true
-    })
+  it.each([
+    ['minimax', 'minimax', 'MiniMax-M3'],
+    ['minimax-cn', 'minimax-cn', 'MiniMax-M3'],
+    ['minimax-global', 'minimax', 'minimax-m3'],
+    ['minimax', 'minimax', 'MiniMaxAI/MiniMax-M3']
+  ])(
+    'maps MiniMax-M3 reasoning to Anthropic-compatible adaptive thinking for %s/%s/%s',
+    (providerId, capabilityProviderId, modelId) => {
+      mockGetReasoningPortrait.mockReturnValue({
+        supported: true,
+        defaultEnabled: true
+      })
 
-    const result = buildProviderOptions({
-      providerId: 'minimax',
-      capabilityProviderId: 'minimax',
-      providerOptionsKey: 'anthropic',
-      apiType: 'anthropic',
-      modelId: 'MiniMax-M3',
-      modelConfig: {
-        reasoning: true
-      } as any,
-      tools: [],
-      messages: []
-    })
+      const result = buildProviderOptions({
+        providerId,
+        capabilityProviderId,
+        providerOptionsKey: 'anthropic',
+        apiType: 'anthropic',
+        modelId,
+        modelConfig: {
+          reasoning: true
+        } as any,
+        tools: [],
+        messages: []
+      })
 
-    expect(result.providerOptions?.anthropic).toEqual({
-      toolStreaming: false,
-      thinking: {
-        type: 'adaptive'
-      }
-    })
-  })
+      expect(result.providerOptions?.anthropic).toEqual({
+        toolStreaming: false,
+        thinking: {
+          type: 'adaptive'
+        }
+      })
+    }
+  )
 
   it('does not send MiniMax-M3 adaptive thinking when reasoning is disabled', () => {
     mockGetReasoningPortrait.mockReturnValue({

--- a/test/main/provider/aiSdkRuntime.test.ts
+++ b/test/main/provider/aiSdkRuntime.test.ts
@@ -2354,6 +2354,126 @@ describe('AI SDK runtime', () => {
     expect(events).toEqual([])
   })
 
+  it('omits MiniMax-M3 temperature from non-streaming requests and traces when thinking is enabled', async () => {
+    mockCreateAiSdkProviderContext.mockReturnValue({
+      providerOptionsKey: 'anthropic',
+      apiType: 'anthropic',
+      model: {},
+      endpoint: 'https://api.minimaxi.com/anthropic'
+    })
+    const stored = {
+      apiEndpoint: 'chat',
+      reasoning: true,
+      temperature: 0.6
+    }
+    const tracePayloads: Array<{
+      modelConfig: Record<string, unknown>
+      body?: Record<string, unknown>
+    }> = []
+    const context = {
+      providerKind: 'anthropic',
+      provider: {
+        id: 'minimax',
+        apiType: 'anthropic'
+      },
+      providerSettings: createProviderSettings(),
+      defaultHeaders: {},
+      emitRequestTrace: vi.fn(async (modelConfig, payload) => {
+        tracePayloads.push({ modelConfig, ...payload })
+      })
+    } as any
+
+    await runAiSdkGenerateText(context, [], 'MiniMax-M3', stored as any, 0.6, 1024)
+
+    const request = mockGenerateText.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(request).not.toHaveProperty('temperature')
+    expect(tracePayloads[0]?.body).not.toHaveProperty('temperature')
+    expect(stored.temperature).toBe(0.6)
+  })
+
+  it('omits MiniMax-M3 temperature from streaming requests and traces when thinking is enabled', async () => {
+    mockCreateAiSdkProviderContext.mockReturnValue({
+      providerOptionsKey: 'anthropic',
+      apiType: 'anthropic',
+      model: {},
+      endpoint: 'https://api.minimaxi.com/anthropic'
+    })
+    const tracePayloads: Array<{ body?: Record<string, unknown> }> = []
+    const context = {
+      providerKind: 'anthropic',
+      provider: {
+        id: 'minimax-cn',
+        apiType: 'anthropic'
+      },
+      providerSettings: createProviderSettings(),
+      defaultHeaders: {},
+      emitRequestTrace: vi.fn(async (_modelConfig, payload) => {
+        tracePayloads.push(payload)
+      })
+    } as any
+
+    const events = []
+    for await (const event of runAiSdkCoreStream(
+      context,
+      [],
+      'MiniMaxAI/MiniMax-M3',
+      {
+        apiEndpoint: 'chat',
+        reasoning: true,
+        temperature: 0.4,
+        functionCall: false
+      } as any,
+      0.4,
+      2048,
+      []
+    )) {
+      events.push(event)
+    }
+
+    const request = mockStreamText.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(request).not.toHaveProperty('temperature')
+    expect(tracePayloads[0]?.body).not.toHaveProperty('temperature')
+    expect(events).toEqual([])
+  })
+
+  it('keeps MiniMax-M3 temperature when thinking is disabled', async () => {
+    mockCreateAiSdkProviderContext.mockReturnValue({
+      providerOptionsKey: 'anthropic',
+      apiType: 'anthropic',
+      model: {},
+      endpoint: 'https://api.minimaxi.com/anthropic'
+    })
+    const tracePayloads: Array<{ body?: Record<string, unknown> }> = []
+    const context = {
+      providerKind: 'anthropic',
+      provider: {
+        id: 'minimax',
+        apiType: 'anthropic'
+      },
+      providerSettings: createProviderSettings(),
+      defaultHeaders: {},
+      emitRequestTrace: vi.fn(async (_modelConfig, payload) => {
+        tracePayloads.push(payload)
+      })
+    } as any
+
+    await runAiSdkGenerateText(
+      context,
+      [],
+      'MiniMax-M3',
+      {
+        apiEndpoint: 'chat',
+        reasoning: false
+      } as any,
+      0.6,
+      1024
+    )
+
+    const request = mockGenerateText.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(request).toHaveProperty('temperature', 0.6)
+    expect(tracePayloads[0]?.body).toHaveProperty('temperature', 0.6)
+  })
+
   it('passes cache intent through OpenAI-compatible Zenmux conversation routes', async () => {
     mockCreateAiSdkProviderContext.mockReturnValue({
       providerOptionsKey: 'zenmux',

--- a/test/main/provider/capabilityIdentity.test.ts
+++ b/test/main/provider/capabilityIdentity.test.ts
@@ -139,6 +139,11 @@ const state = vi.hoisted(() => ({
             id: 'MiniMax-M2',
             temperature: true,
             reasoning: { supported: true, default: true }
+          },
+          {
+            id: 'MiniMax-M3',
+            temperature: true,
+            reasoning: { supported: true, default: true }
           }
         ]
       },
@@ -541,6 +546,67 @@ describe('capability identity resolution', () => {
       endpointType: 'openai',
       reasoning: false
     })
+    expect(getModelConfig).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits MiniMax-M3 temperature when thinking is enabled without rewriting catalog support', () => {
+    const identity = resolveCapabilityIdentity({
+      providerId: 'minimax',
+      modelId: 'MiniMax-M3'
+    })
+
+    expect(identity).toEqual({
+      providerId: 'minimax',
+      requestModelId: 'MiniMax-M3',
+      catalogMatched: true,
+      catalogModelId: 'minimax-m3'
+    })
+    expect(buildResolvedCapabilitySnapshot(identity, { reasoningEnabled: true })).toMatchObject({
+      temperatureCapability: true,
+      requestPolicy: {
+        temperature: { mode: 'omit' },
+        topP: { mode: 'passthrough' }
+      }
+    })
+    expect(buildResolvedCapabilitySnapshot(identity, { reasoningEnabled: false })).toMatchObject({
+      temperatureCapability: true,
+      requestPolicy: {
+        temperature: { mode: 'passthrough' }
+      }
+    })
+  })
+
+  it('uses stored MiniMax-M3 reasoning for temperature omit unless a draft overrides it', () => {
+    const providerSettings = Object.create(ProviderSettings.prototype) as ProviderSettings
+    const identity = {
+      providerId: 'minimax',
+      requestModelId: 'MiniMax-M3',
+      catalogMatched: true as const,
+      catalogModelId: 'minimax-m3'
+    }
+    const resolveIdentity = vi.fn(() => identity)
+    const getModelConfig = vi.fn(() => ({ reasoning: true, temperature: 0.6 }))
+
+    Object.assign(providerSettings as object, {
+      resolveCapabilityIdentityForModel: resolveIdentity,
+      getModelConfig
+    })
+
+    expect(
+      providerSettings.getCapabilitySnapshot({
+        providerId: 'minimax',
+        modelId: 'MiniMax-M3'
+      }).requestPolicy.temperature
+    ).toEqual({ mode: 'omit' })
+    expect(getModelConfig).toHaveBeenCalledWith('MiniMax-M3', 'minimax', identity)
+
+    expect(
+      providerSettings.getCapabilitySnapshot({
+        providerId: 'minimax',
+        modelId: 'MiniMax-M3',
+        reasoningEnabled: false
+      }).requestPolicy.temperature
+    ).toEqual({ mode: 'passthrough' })
     expect(getModelConfig).toHaveBeenCalledTimes(1)
   })
 

--- a/test/main/shared/modelRequestPolicy.test.ts
+++ b/test/main/shared/modelRequestPolicy.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   applyModelRequestPolicy,
   isKimiK3ModelId,
+  isMiniMaxM3AdaptiveThinkingModel,
   resolveCapabilityAwareRequestParameterPolicy,
   resolveModelRequestPolicy
 } from '../../../src/shared/modelRequestPolicy'
@@ -129,6 +130,82 @@ describe('moonshot Kimi temperature policy', () => {
     expect(resolveCapabilityAwareRequestParameterPolicy(fixed, false)).toEqual({
       mode: 'fixed',
       value: 1
+    })
+
+    const miniMaxOmit = resolveModelRequestPolicy('minimax', 'MiniMax-M3', true).temperature
+    expect(resolveCapabilityAwareRequestParameterPolicy(miniMaxOmit, true)).toEqual({
+      mode: 'omit'
+    })
+  })
+})
+
+describe('MiniMax-M3 thinking temperature policy', () => {
+  const omitTemperaturePolicy = {
+    temperature: { mode: 'omit' },
+    topP: { mode: 'passthrough' },
+    reasoning: { mode: 'passthrough' },
+    legacyThinking: { mode: 'passthrough' }
+  }
+  const passthroughPolicy = {
+    temperature: { mode: 'passthrough' },
+    topP: { mode: 'passthrough' },
+    reasoning: { mode: 'passthrough' },
+    legacyThinking: { mode: 'passthrough' }
+  }
+
+  it.each([
+    ['minimax', 'MiniMax-M3'],
+    ['minimax', 'minimax-m3'],
+    ['minimax', 'MiniMaxAI/MiniMax-M3'],
+    ['minimax-cn', 'MiniMax-M3'],
+    ['minimax-global', 'minimax-m3']
+  ])('omits temperature for %s/%s when thinking is enabled', (providerId, modelId) => {
+    expect(isMiniMaxM3AdaptiveThinkingModel(providerId, modelId)).toBe(true)
+    expect(resolveModelRequestPolicy(providerId, modelId, true)).toEqual(omitTemperaturePolicy)
+  })
+
+  it.each([
+    ['minimax', 'MiniMax-M3'],
+    ['minimax-cn', 'minimax-m3'],
+    ['minimax-global', 'MiniMaxAI/MiniMax-M3']
+  ])('keeps temperature for %s/%s when thinking is disabled', (providerId, modelId) => {
+    expect(resolveModelRequestPolicy(providerId, modelId, false)).toEqual(passthroughPolicy)
+    expect(resolveModelRequestPolicy(providerId, modelId, undefined)).toEqual(passthroughPolicy)
+  })
+
+  it.each([
+    ['minimax', 'MiniMax-M2.5'],
+    ['minimax', 'minimax-m2.7'],
+    ['minimax', 'minimax-m3-free'],
+    ['minimax', 'minimax-m3:thinking'],
+    ['openrouter', 'minimax/minimax-m3'],
+    ['openai', 'MiniMax-M3'],
+    ['anthropic', 'claude-opus-4-7']
+  ])('does not apply MiniMax-M3 thinking policy to %s/%s', (providerId, modelId) => {
+    expect(isMiniMaxM3AdaptiveThinkingModel(providerId, modelId)).toBe(false)
+    expect(resolveModelRequestPolicy(providerId, modelId, true)).toEqual(passthroughPolicy)
+  })
+
+  it('applies MiniMax-M3 omit without mutating stored generation settings', () => {
+    const stored = {
+      reasoning: true,
+      temperature: 0.6,
+      topP: 0.8
+    }
+    const effective = applyModelRequestPolicy(
+      stored,
+      resolveModelRequestPolicy('minimax', 'MiniMax-M3', stored.reasoning)
+    )
+
+    expect(effective).toEqual({
+      reasoning: true,
+      temperature: undefined,
+      topP: 0.8
+    })
+    expect(stored).toEqual({
+      reasoning: true,
+      temperature: 0.6,
+      topP: 0.8
     })
   })
 })


### PR DESCRIPTION
Closes #2119

## Summary

MiniMax-M3 uses Anthropic adaptive thinking, which does not accept `temperature`. The request policy now omits temperature from both AI SDK calls and request traces when thinking is on. Turning thinking off restores the stored temperature.

The model check covers `minimax`, `minimax-cn`, `minimax-global`, and qualified MiniMax-M3 IDs. The renderer uses the resolved policy to disable its temperature control without deleting the saved value.

## Validation

- focused provider-policy tests: 163 passed
- `pnpm run test:main`: 7,863 passed, 432 skipped
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`

Local Node was 24.12.0, below the repository requirement of 24.18.0 or newer. All commands above passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for MiniMax M3 adaptive thinking across supported provider variants.
  - Reasoning-enabled requests now omit temperature while preserving other generation settings.
  - Added support for MiniMax, MiniMax China, and MiniMax Global identifiers.

- **Bug Fixes**
  - Improved temperature handling for streaming and non-streaming MiniMax M3 requests.
  - Explicit reasoning settings now correctly take precedence over stored configuration.

- **Tests**
  - Expanded coverage for provider aliases, reasoning behavior, temperature handling, and capability detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->