### PR TITLE
fix(chat): restore parent session navigation

### DIFF
--- a/src/renderer/src/components/chat/ChatTopBar.vue
+++ b/src/renderer/src/components/chat/ChatTopBar.vue
@@ -27,7 +27,7 @@
         variant="ghost"
         size="sm"
         icon="lucide:corner-up-left"
-        class="h-7 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+        class="no-drag h-7 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
         :title="t('chat.topbar.backToParent')"
         @click="handleBackToParent"
       >


### PR DESCRIPTION
## Summary

- mark the subagent parent-session button as an explicit non-draggable control
- preserve the existing parent-session selection flow

## Root cause

The button is rendered inside the draggable chat top bar. After it moved to `DcButton`, it no longer reliably inherited the scoped `button` no-drag rule, so Electron treated the pointer interaction as window dragging instead of dispatching the click.

## UI

```text
BEFORE  [Back to Parent] -> window drag region
AFTER   [Back to Parent] -> select parent session
```

## Verification

- `pnpm format:check`
- `pnpm i18n`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec vitest run --config vitest.config.renderer.ts test/renderer/components/chat/ChatTopBar.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the back-to-parent button so it remains clickable and does not interfere with window dragging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->