### PR TITLE
chore(renderer): upgrade markstream-vue 2

### DIFF
--- a/docs/architecture/chat-markstream-rendering-pipeline/plan.md
+++ b/docs/architecture/chat-markstream-rendering-pipeline/plan.md
@@ -24,11 +24,11 @@ guard no-op，不新增 timer cleanup 或第二份派生状态。
 - `shouldVirtualizeNodes = virtualizeNodes && !isStreaming`：只决定 Markdown node DOM window；
 - `shouldUseViewportPriority = virtualizeNodes`：继续决定 heavy node 是否接近视口后才启动。
 
-保持 `codeRenderer="monaco"` 贯穿同一个 `NodeRenderer`，不要以 phase key 重建它。当前 Markstream 将
-该兼容名称映射到由 `stream-diffs` 支持的 `CodeBlockNode`：流式期间它保留自身的 `<pre>` fallback，代码块
-完成且可见后再把同一宿主原子升级为单一 File/FileDiff surface。`deferNodesUntilVisible` 与
-`viewportPriority` 继续使用第二个值，保留既有 Mermaid/KaTeX 等重节点的调度策略。搜索/截图传入
-`virtualizeNodes=false` 时，所有内容仍立即可用。
+保持同一个 `NodeRenderer`，不要以 phase key 重建它。Markstream 2.0 在安装 `stream-diffs` 后默认使用
+增强 `CodeBlockNode`：流式期间它保留自身的 `<pre>` fallback，代码块完成且可见后再把同一宿主原子
+升级为单一 File/FileDiff surface。不要设置只用于普通输出的 `renderCodeBlocksAsPre`。
+`deferNodesUntilVisible` 与 `viewportPriority` 继续使用第二个值，保留既有 Mermaid/KaTeX 等重节点的
+调度策略。搜索/截图传入 `virtualizeNodes=false` 时，所有内容仍立即可用。
 
 `MessageBlockContent` 只在搜索、截图等完整 DOM 消费者出现时传 `virtualizeNodes=false`。streaming 的
 node window 仍由 `MarkdownRenderer` 内部的 `virtualizeNodes && !isStreaming` 负责关闭。
@@ -38,10 +38,17 @@ eligibility，但不使用 precise 模式每次提交的 Range/getClientRects �
 
 ## 3. 使用 Markstream 内建 code renderer
 
-- 增加 `stream-diffs` direct dependency，使 Markstream 的动态 runtime import 可解析；
-- live chat 与 completed/static 均显式传 `codeRenderer="monaco"`；live 传 `codeBlockStream=true`，完成时传 false 并同步更新 `final=true`。不重建 NodeRenderer，也不直接调用 `stream-diffs`；
+- 精确锁定 `markstream-vue@2.0.0-beta.2` 并保留 `stream-diffs@0.0.2` direct dependency，使
+  Markstream 的动态 runtime import 可解析；DeepChat 独立编辑器继续保留 `stream-monaco`；
+- live chat 与 completed/static 均不传已删除的 `codeRenderer`；live 传 `codeBlockStream=true`，
+  完成时传 false 并同步更新 `final=true`。不重建 NodeRenderer，也不直接调用 `stream-diffs`；
 - 删除 generic `code_block` custom mapping，恢复 `CodeBlockNode` 的内建 `<pre>` fallback 与增强 surface handoff；
-- 通过 `codeBlockProps` 传 themes 和工具栏选项，通过 `codeBlockMonacoOptions` 传字体/换行，通过 `@handle-artifact-click` 接收预览；
+- 通过顶层 `themes` 加载主题，通过 `codeBlockOptions` 传字体与 `overflow='wrap'`，通过
+  `@handle-artifact-click` 接收 preview payload；
+- 脱离 NodeRenderer 直接挂载 `CodeBlockNode` 或 `MermaidBlockNode` 时，外层保留
+  `class="markstream-vue"`，使 2.0 的作用域样式与变量生效；
+- `ThinkContent` 的 scoped override 直接挂载 2.0 导出的 `PreCodeNode` 组件，不再读取已移除的
+  `PreCodeNode.vue` 动态属性；
 - 保留 Mermaid strict props、`break-words` prose root 和可收缩的 flex host，但不覆盖 `stream-diffs` gutter/content 内部几何。
 
 ## 4. 消息顺序与流式窗口
@@ -95,7 +102,7 @@ pending placeholder -> real stream message -> persisted final message
 - MarkdownRenderer component test：
   - 后续 streaming snapshot 同步转交，不只覆盖首 chunk；
   - final transition 同步带上最终 content，且旧 timer 不能回写；
-  - streaming 到 final 始终选择同一个 enhanced renderer，并把 `codeBlockStream` 从 true 切到 false；
+  - streaming 到 final 始终使用默认 enhanced renderer，并把 `codeBlockStream` 从 true 切到 false；
   - explicit `virtualizeNodes=false` 同时关闭三类延迟；
   - `stream-diffs` handoff、无 generic override、preview 和 Mermaid strict 保持。
 - useDisplayMessages：
@@ -128,7 +135,8 @@ pnpm run build
 | final 与 content 同 patch 时顺序不确定 | 同时 watch 两个 source，并用 previous streaming 状态同步提交 |
 | streaming heavy node 延迟后高度变化影响滚动 | 使用 Markstream 自带 lifecycle/ResizeObserver，外层继续按 PR #2000 批量测量 |
 | 搜索或截图拿不到离屏 DOM | `virtualizeNodes=false` 同时关闭 node window 与 viewport deferral |
-| stream-diffs optional peer 缺失 | direct dependency + Markstream 内建 pre fallback + production build 验证 |
+| stream-diffs optional peer 缺失 | 精确 direct dependency + Markstream 内建 pre fallback + production build 验证 |
+| 独立节点组件丢失 2.0 作用域样式 | direct component host 显式使用 `.markstream-vue` |
 | 旧静态 debounce 晚到覆盖 stream | 每次同步旁路递增同一个 revision，使旧 callback no-op |
 | 事件委托误拦截普通节点 | 只处理 closest anchor / `.reference-node`，其他 click/mouse event 原样忽略 |
 | 中间 stream 被错误追加到尾部 | 仅以排序后的 `messageIds` 最后一个 id 精确匹配，其他情况返回 null |

--- a/docs/architecture/chat-markstream-rendering-pipeline/spec.md
+++ b/docs/architecture/chat-markstream-rendering-pipeline/spec.md
@@ -4,7 +4,8 @@
 
 PR #2000 已把高频流式消息从稳定历史列表中拆出，并为消息窗口增加 append-only tail
 快路径、批量测量和显式行级 streaming 状态。与此同时，聊天正文仍经过 DeepChat 自己的
-内容防抖，再交给当前 `markstream-vue@1.0.7-beta.4` 的 smooth streaming、解析合并、节点批量挂载和重节点延迟机制。增强代码块使用其 `stream-diffs@0.0.2` peer。
+内容防抖，再交给当前精确锁定的 `markstream-vue@2.0.0-beta.2` 的 smooth streaming、解析合并、
+节点批量挂载和重节点延迟机制。增强代码块使用其 `stream-diffs@0.0.2` peer。
 
 当前端到端链路如下：
 
@@ -21,7 +22,7 @@ provider token events
   -> MarkdownRenderer stream handoff
   -> Markstream smooth streaming (up to 20 commits/s)
   -> incremental Markdown parse + node batching
-  -> Monaco / Mermaid / KaTeX viewport deferral
+  -> stream-diffs / Mermaid / KaTeX viewport deferral
   -> DOM measurement -> outer message window / scroll follow
 ```
 
@@ -32,10 +33,11 @@ provider token events
 
 1. 聊天流内容在进入 Markstream 前再经过 32 ms 或 96 ms 防抖。它不能减少 main snapshot
    数量，却增加首段之外每个 snapshot 的延迟，并可能让 `final` 先于最新防抖内容生效。
-2. 旧集成曾把 `codeRenderer="monaco"` 误当作流式期间即时创建 Monaco 的开关，并因此尝试在
-   应用层把 renderer 从 `pre` 重建为 `monaco`。当前 Markstream 的该兼容名称实际选择由
-   `stream-diffs` 驱动的增强 `CodeBlockNode`：它在 block streaming 时保留内建 `<pre>`，仅在
-   block 完成且可见后才升级同一宿主。因此外部 remount 会破坏受支持的 handoff，并可能造成完成闪烁或瞬时几何。
+2. 旧集成曾把 1.x 的 `codeRenderer="monaco"` 兼容名称误当作流式期间即时创建 Monaco 的开关，
+   并因此尝试在应用层把 renderer 从 `pre` 重建为 `monaco`。Markstream 2.0 已删除该 selector，
+   安装 `stream-diffs` 后默认使用增强 `CodeBlockNode`：它在 block streaming 时保留内建 `<pre>`，
+   仅在 block 完成且可见后才升级同一宿主。因此外部 remount 或显式选择 renderer 都会破坏受
+   支持的 handoff，并可能造成完成闪烁或瞬时几何。
 3. generic `code_block` 自定义映射会绕过 Markstream 内建的 renderer selection、异步 fallback 和
    viewport-deferred `stream-diffs` 路径。仅安装 optional peer 或直接导入其 controller 都不能替代该路径。
 4. 该阶段曾为尾部 inline stream 引入 stable/tail layout segments；后续
@@ -53,7 +55,9 @@ provider token events
 
 1. 让 main 进程负责 snapshot 合帧，Markstream 负责文本 pacing；聊天集成层同步转交流式内容。
 2. 从 streaming 到 final 的同一消息、MarkdownRenderer、NodeRenderer 与内建 CodeBlockNode 都保持身份稳定；最终内容不会被旧的防抖回调覆盖。
-3. 整个生命周期保持 Markstream `codeRenderer="monaco"`，并仅以 `codeBlockStream` / `final` 表达流式状态；内建 `CodeBlockNode` 在 streaming 时呈现 `<pre>`，完成且可见后才挂载 `stream-diffs` 表面。内层 node virtualization 继续在 streaming 阶段关闭，避免 typewriter 尾部被节点窗口裁掉。
+3. 整个生命周期不设置 `renderCodeBlocksAsPre`，仅以 `codeBlockStream` / `final` 表达流式状态；
+   内建 `CodeBlockNode` 在 streaming 时呈现 `<pre>`，完成且可见后才挂载 `stream-diffs` 表面。
+   内层 node virtualization 继续在 streaming 阶段关闭，避免 typewriter 尾部被节点窗口裁掉。
 4. completed 历史消息继续使用 Markstream node virtualization 及可见性延迟；聊天搜索、截图和其他要求
    完整 DOM 的路径仍可通过 `virtualizeNodes=false` 同时关闭虚拟化与视口延迟。
 5. ordinary fenced code 使用 Markstream 内建 `stream-diffs` 路径；streaming 时先显示轻量 fallback，
@@ -85,10 +89,16 @@ provider token events
 2. streaming -> final 时，NodeRenderer 同步收到最终 content 和 `final=true`；任何较早的静态防抖
    任务都不能回写旧内容。
 3. 非流式内容更新继续走已有 fast/slow debounce；现有 docs/artifact 行为不变。
-4. 正常 streaming chat 配置为 `nodeVirtual=false`、`maxLiveNodes=0`、`codeRenderer="monaco"`、`codeBlockStream=true`；完成态在同一 NodeRenderer 上设为 `final=true` 与 `codeBlockStream=false`。Markstream 在流式阶段展示内建 `<pre>`，完成且可见后才升级 `stream-diffs` surface。`viewportPriority` 与 `deferNodesUntilVisible` 仍仅由 `virtualizeNodes` 控制。
+4. 正常 streaming chat 配置为 `nodeVirtual=false`、`maxLiveNodes=0`、`codeBlockStream=true`，且不设置
+   `renderCodeBlocksAsPre`；完成态在同一 NodeRenderer 上设为 `final=true` 与
+   `codeBlockStream=false`。Markstream 在流式阶段展示内建 `<pre>`，完成且可见后才升级
+   `stream-diffs` surface。`viewportPriority` 与 `deferNodesUntilVisible` 仍仅由
+   `virtualizeNodes` 控制。
 5. `virtualizeNodes=false` 时，node virtualization、viewport priority 和 visible deferral 均关闭，
    保证搜索、截图和完整 DOM 消费者可用。
-6. NodeRenderer 在 live chat 和 completed/static 内容均保持 `codeRenderer="monaco"`，只通过 `codeBlockStream` 与 `final` 交给 Markstream 管理单一代码块 handoff；preview event 与 strict Mermaid 仍可用。
+6. NodeRenderer 在 live chat 和 completed/static 内容均使用 Markstream 默认增强代码块路径，只通过
+   `codeBlockStream` 与 `final` 交给 Markstream 管理单一代码块 handoff；preview event 与 strict
+   Mermaid 仍可用。
 7. MarkdownRenderer 不写入 Markstream 全局 custom component registry；内建 link/reference 事件经
    根级委托保持 DeepChat 导航和引用交互，同消息多个 text part 互不覆盖。
 8. inline stream 在完整 display-list 中保持 `messageIds` 顺序；未变化记录的转换缓存、单行
@@ -103,7 +113,7 @@ provider token events
 - 单个 stream snapshot 的 display-message 转换复用未变化记录；外层 geometry 仍以完整 display-list
   计算，并由虚拟窗口限制实际挂载的行数。
 - 已校验 blocks 不得在 renderer 同步热路径再次 JSON.parse。
-- 重节点在接近视口前不得启动 Monaco/Mermaid/KaTeX 重工作；完成态的 fallback 到 enhanced
+- 重节点在接近视口前不得启动 stream-diffs/Mermaid/KaTeX 重工作；完成态的 fallback 到 enhanced
   切换不得替换外层 message row。
 - 沿用 chat scroll ownership 的每帧最多一次 scroll write、1 px anchor 误差和无新增 >50 ms
   long task 预算；jsdom 测试覆盖可自动化的调度和 handoff 回归。

--- a/docs/issues/markstream-code-block-rendering/spec.md
+++ b/docs/issues/markstream-code-block-rendering/spec.md
@@ -4,8 +4,8 @@
 
 DeepChat's Markstream-backed code blocks can show gutter/content overlap or an incorrectly measured
 code surface after an assistant message changes from streaming to final. The integration must use the
-current enhanced code-block runtime: `markstream-vue@1.0.7-beta.4` with its `stream-diffs@0.0.2`
-peer.
+current enhanced code-block runtime: the exact `markstream-vue@2.0.0-beta.2` beta with its
+`stream-diffs@0.0.2` peer.
 
 ## Impact
 
@@ -22,13 +22,14 @@ had been pinned away from the current release line. That runtime is not the one 
 integration, and its application-managed continuous Monaco lifecycle is not the documented behavior
 of the current `stream-diffs` adapter.
 
-For current Markstream, `codeRenderer="monaco"` remains the compatibility name for the enhanced
-`CodeBlockNode`, but it does **not** create a live Monaco instance for every streaming code update.
-The component owns a stable handoff:
+In Markstream 1.x, `codeRenderer="monaco"` was the compatibility name for the enhanced
+`CodeBlockNode`; it did **not** create a live Monaco instance for every streaming code update.
+Markstream 2.0 removes that selector and uses the enhanced path by default when `stream-diffs` is
+installed. The component still owns the same stable handoff:
 
 ```text
 MarkdownRenderer
-  -> NodeRenderer (content grows, final=false, codeRenderer="monaco", codeBlockStream=true)
+  -> NodeRenderer (content grows, final=false, codeBlockStream=true)
     -> CodeBlockNode renders its built-in PreCodeNode while the fence is streaming
 
 same NodeRenderer / same CodeBlockNode
@@ -36,43 +37,51 @@ same NodeRenderer / same CodeBlockNode
     -> CodeBlockNode dynamically imports stream-diffs and mounts one File/FileDiff surface
 ```
 
-Replacing the renderer at the application boundary (`pre` → `monaco`) or calling private runtime APIs
-would bypass that lifecycle and reintroduce a completion flash or geometry race. The app-level prose
-root also applies `break-all`; enhanced code hosts must opt out of that inherited text-breaking rule,
-and their flex parent must be allowed to shrink, without targeting runtime gutter internals.
+Selecting or replacing the renderer at the application boundary, setting `renderCodeBlocksAsPre`, or
+calling private runtime APIs would bypass that lifecycle and reintroduce a completion flash or
+geometry race. The app-level prose root also applies text-breaking rules; enhanced code hosts must
+retain `break-words`, and their flex parent must be allowed to shrink, without targeting runtime
+gutter internals.
 
 ## Fix Plan
 
-1. Restore current direct dependencies: `markstream-vue@1.0.7-beta.4` and `stream-diffs@0.0.2`.
+1. Pin direct dependencies to `markstream-vue@2.0.0-beta.2` and `stream-diffs@0.0.2`.
    Keep `stream-monaco` because DeepChat's independent artifact/editor surfaces still import it.
-2. Keep one stable `NodeRenderer` with `codeRenderer="monaco"` for both streaming and final states.
-   Pass `codeBlockStream=true` only while the message is live and set `final=true` with the last
-   content snapshot when it completes.
+2. Keep one stable `NodeRenderer` on Markstream's default enhanced path for both streaming and final
+   states. Pass `codeBlockStream=true` only while the message is live and set `final=true` with the
+   last content snapshot when it completes.
 3. Do not set `renderCodeBlocksAsPre`, register a generic `code_block` override, remount the renderer,
    import `stream-diffs` directly from DeepChat, or call private adapter methods.
 4. Continue using Markstream's documented `handle-artifact-click` event and supported
-   `codeBlockProps` / `codeBlockMonacoOptions` props.
+   top-level `themes` / `codeBlockOptions` props. Map the old `wordWrap: 'on'` behavior to
+   `overflow: 'wrap'`.
 5. Replace DeepChat-only Markdown fence labels such as `desktop-local-file` with `plaintext` before
    passing content to Markstream. `stream-diffs` delegates final highlighting to Shiki and rejects
    unsupported identifiers; valid standard fence languages remain unchanged.
 6. Use `break-words` instead of the prose root's `break-all`, and retain `min-w-0` on the assistant
    content flex item. Neither change overrides runtime gutter/content geometry.
 7. Update DOM-contract tests to cover both unlabeled and TypeScript fallback/final handoff.
+8. Wrap direct `CodeBlockNode` and `MermaidBlockNode` hosts in `.markstream-vue`, because 2.0 scopes
+   component variables and fallback styles under that container.
+9. Render the exported `PreCodeNode` component directly in `ThinkContent`; beta.2 no longer exposes
+   the 1.x `PreCodeNode.vue` runtime property.
 
 ## Validation
 
-- [x] Package lock resolves `markstream-vue@1.0.7-beta.4` with `stream-diffs@0.0.2`.
-- [x] Focused MarkdownRenderer tests confirm one enhanced renderer configuration through streaming and
-  final completion, with the final snapshot committed synchronously.
-- [x] Markstream DOM-contract test proves the built-in streaming `<pre>` fallback and post-completion
+- [x] Package lock resolves `markstream-vue@2.0.0-beta.2` with `stream-diffs@0.0.2`, while preserving
+  DeepChat's direct `stream-monaco` dependency.
+- [x] Focused MarkdownRenderer tests confirm renderer-neutral options and one enhanced renderer
+  configuration through streaming and final completion.
+- [x] Markstream DOM-contract tests prove the built-in streaming `<pre>` fallback and post-completion
   enhanced `stream-diffs` handoff for unlabeled and TypeScript fences.
-- [x] Message layout test verifies the code host's flex ancestor can shrink.
-- [x] Focused renderer tests (54), format, i18n, lint, typecheck, and direct `electron-vite build`
-  passed. The full renderer suite remains a host-capacity follow-up: its parallel run produced 32
-  unrelated 10-second test timeouts, while all Markstream-related suites passed. The standard
-  `pnpm run build` command also needs a `pnpm` Corepack shim in this host's child-script PATH; its
-  prebuild refresh completed and direct production bundling passed.
+- [x] Direct node hosts retain the `.markstream-vue` CSS scope, and `ThinkContent` uses the direct
+  `PreCodeNode` export.
+- [x] Format, i18n, lint, typecheck, 72 focused renderer tests, and the production Electron Vite
+  build pass.
 
+The full renderer suite was also attempted, but a Vitest worker exceeded its 4 GB Node heap before
+the suite completed. This was a host-capacity failure rather than a useful migration verdict; all
+Markstream integration, worker, CSS-source, and direct-host suites passed independently.
 
 ## GitHub Issue
 

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "electron-vite": "5.0.0",
     "jsdom": "^26.1.0",
     "katex": "^0.16.47",
-    "markstream-vue": "1.0.7-beta.4",
+    "markstream-vue": "2.0.0-beta.2",
     "mermaid": "^11.16.1",
     "minimatch": "^10.2.5",
     "monaco-editor": "^0.55.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,8 +315,8 @@ importers:
         specifier: ^0.16.47
         version: 0.16.47
       markstream-vue:
-        specifier: 1.0.7-beta.4
-        version: 1.0.7-beta.4(@antv/infographic@0.2.19)(katex@0.16.47)(mermaid@11.16.1)(stream-diffs@0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2)))(stream-monaco@0.0.49(monaco-editor@0.55.1))(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2))
+        specifier: 2.0.0-beta.2
+        version: 2.0.0-beta.2(@antv/infographic@0.2.19)(katex@0.16.47)(mermaid@11.16.1)(stream-diffs@0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2)))(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2))
       mermaid:
         specifier: ^11.16.1
         version: 11.16.1
@@ -5209,6 +5209,9 @@ packages:
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
+  linkify-it@6.1.0:
+    resolution: {integrity: sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==}
+
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
@@ -5304,18 +5307,15 @@ packages:
   markdown-it-mark@4.0.0:
     resolution: {integrity: sha512-YLhzaOsU9THO/cal0lUjfMjrqSMPjjyjChYM7oyj4DnyaXEzA8gnW6cVJeyCrCVeyesrY2PlEdUYJSPFYL4Nkg==}
 
-  markdown-it-sub@2.0.0:
-    resolution: {integrity: sha512-iCBKgwCkfQBRg2vApy9vx1C1Tu6D8XYo8NvevI3OlwzBRmiMtsJ2sXupBgEA7PPxiDwNni3qIUkhZ6j5wofDUA==}
-
   markdown-it-sup@2.0.0:
     resolution: {integrity: sha512-5VgmdKlkBd8sgXuoDoxMpiU+BiEt3I49GItBzzw7Mxq9CxvnhE/k09HFli09zgfFDRixDQDfDxi0mgBCXtaTvA==}
 
   markdown-it-task-checkbox@1.0.6:
     resolution: {integrity: sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw==}
 
-  markdown-it-ts@1.0.4:
-    resolution: {integrity: sha512-FmCjj7D0C54EhWNn6WdSIBoyEbEoLeqE/Orgzik+CHSIz3aQJW3/U3uc8BEOMdGl/SE4O+s4BjwKhtO7LPOwWA==}
-    engines: {node: '>=18'}
+  markdown-it-ts@1.0.10:
+    resolution: {integrity: sha512-8FIKgiTAewMr67TMwikpwMj2u3dVSBLMJ9RZOG4HdqjE0Q+g0o3wDT1LFOXSddQr+RAr6ZT4PFiICU4kRX1l5Q==}
+    engines: {node: '>=20.19'}
 
   markdown-it@14.3.0:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
@@ -5331,19 +5331,17 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  markstream-core@1.0.3:
-    resolution: {integrity: sha512-QXn+yERo1q+RD6YlGDW61zc/af65uhkQEH3K8YvEKkprHbgRJ/JIeBeEQjELCTyBnPoxqtKQ7I565rylY+PePg==}
+  markstream-core@1.1.0-beta.2:
+    resolution: {integrity: sha512-aylQdwVOT9DP5zhl5+YfO4ZDaflaZaPUIwbxAYNuFNHcqTDiGJ9c9anqD5y6JU/bj8P7SWbxLBfshSH/0hH8/w==}
 
-  markstream-vue@1.0.7-beta.4:
-    resolution: {integrity: sha512-i1WtxzZ0XB+z3Dmb5E8oKd+ec30FgtXMDHXuTMu6SUlFuzqxWeCSm7QBbFomK05ucQk9g9a2nG4ae1X9j40U/Q==}
+  markstream-vue@2.0.0-beta.2:
+    resolution: {integrity: sha512-Hc65EsJUiuZfAIxGRGYYB6wWzLQwb7Jur807WHeHWa7T8Q0fu8ZIyS8MuL6CWisIae/mXV3LRC+kqRSG4DieLQ==}
     peerDependencies:
       '@antv/infographic': ^0.2.3
       '@terrastruct/d2': '>=0.1.33'
       katex: '>=0.16.22'
       mermaid: '>=11'
       stream-diffs: '>=0.0.2'
-      stream-markdown: '>=0.0.16'
-      stream-monaco: '>=0.0.48'
       vue: '>=3.0.0'
       vue-i18n: '>=9'
     peerDependenciesMeta:
@@ -5356,10 +5354,6 @@ packages:
       mermaid:
         optional: true
       stream-diffs:
-        optional: true
-      stream-markdown:
-        optional: true
-      stream-monaco:
         optional: true
       vue-i18n:
         optional: true
@@ -6389,8 +6383,8 @@ packages:
       vue:
         optional: true
 
-  stream-markdown-parser@1.1.3:
-    resolution: {integrity: sha512-tge6aKbOGU36vBLeeroHGBAJ7qiNcsTYyvmgqevVN0+5kMiLOjAyeDmv3PQkniTMbgOsswVHN9izmgmSw5bsBQ==}
+  stream-markdown-parser@1.2.6-beta.1:
+    resolution: {integrity: sha512-ist3dgeqxFAtxD83N2/i42F8U6Z7pZOuVuQ44oLasN1Me0ju5SyJRpptP1B32x/bo7GyJEMe8jgquExjhSIoww==}
 
   stream-monaco@0.0.49:
     resolution: {integrity: sha512-ksZYJXw45NralnpgWqcptqrgDdbGZaTyYmvATvhlK8eY0tyeTxs0iuQzMTF4cpGf5OlIgkNJOfbFh4M97OozSw==}
@@ -6659,6 +6653,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  uc.micro@3.0.0:
+    resolution: {integrity: sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -12069,6 +12066,10 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  linkify-it@6.1.0:
+    dependencies:
+      uc.micro: 3.0.0
+
   locate-path@3.0.0:
     dependencies:
       p-locate: 3.0.0
@@ -12181,21 +12182,16 @@ snapshots:
 
   markdown-it-mark@4.0.0: {}
 
-  markdown-it-sub@2.0.0: {}
-
   markdown-it-sup@2.0.0: {}
 
   markdown-it-task-checkbox@1.0.6: {}
 
-  markdown-it-ts@1.0.4:
+  markdown-it-ts@1.0.10:
     dependencies:
-      '@types/linkify-it': 5.0.0
-      '@types/mdurl': 2.0.0
-      entities: 4.5.0
-      linkify-it: 5.0.2
+      entities: 8.0.0
+      linkify-it: 6.1.0
       mdurl: 2.1.0
       punycode.js: 2.3.1
-      uc.micro: 2.1.0
 
   markdown-it@14.3.0:
     dependencies:
@@ -12210,21 +12206,20 @@ snapshots:
 
   marked@16.4.2: {}
 
-  markstream-core@1.0.3: {}
+  markstream-core@1.1.0-beta.2: {}
 
-  markstream-vue@1.0.7-beta.4(@antv/infographic@0.2.19)(katex@0.16.47)(mermaid@11.16.1)(stream-diffs@0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2)))(stream-monaco@0.0.49(monaco-editor@0.55.1))(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2)):
+  markstream-vue@2.0.0-beta.2(@antv/infographic@0.2.19)(katex@0.16.47)(mermaid@11.16.1)(stream-diffs@0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2)))(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2)):
     dependencies:
       '@chenglou/pretext': 0.0.8
       '@floating-ui/dom': 1.8.0
-      markstream-core: 1.0.3
-      stream-markdown-parser: 1.1.3
+      markstream-core: 1.1.0-beta.2
+      stream-markdown-parser: 1.2.6-beta.1
       vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2)
     optionalDependencies:
       '@antv/infographic': 0.2.19
       katex: 0.16.47
       mermaid: 11.16.1
       stream-diffs: 0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2))
-      stream-monaco: 0.0.49(monaco-editor@0.55.1)
       vue-i18n: 11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.7.tsgo.7.0.2))
 
   matcher@3.0.0:
@@ -13388,16 +13383,15 @@ snapshots:
       - react
       - react-dom
 
-  stream-markdown-parser@1.1.3:
+  stream-markdown-parser@1.2.6-beta.1:
     dependencies:
       markdown-it-container: 4.0.0
       markdown-it-footnote: 4.0.0
       markdown-it-ins: 4.0.0
       markdown-it-mark: 4.0.0
-      markdown-it-sub: 2.0.0
       markdown-it-sup: 2.0.0
       markdown-it-task-checkbox: 1.0.6
-      markdown-it-ts: 1.0.4
+      markdown-it-ts: 1.0.10
 
   stream-monaco@0.0.49(monaco-editor@0.55.1):
     dependencies:
@@ -13672,6 +13666,8 @@ snapshots:
       '@typescript-native-bridge/win32-x64': 6.0.3-bridge.7.tsgo.7.0.2
 
   uc.micro@2.1.0: {}
+
+  uc.micro@3.0.0: {}
 
   ufo@1.6.4: {}
 

--- a/src/renderer/settings/components/AboutUsSettings.vue
+++ b/src/renderer/settings/components/AboutUsSettings.vue
@@ -86,6 +86,7 @@
             :isDark="themeStore.isDark"
             :content="upgrade.updateInfo.releaseNotes"
             :typewriter="false"
+            :final="true"
             :codeBlockStream="false"
           ></NodeRenderer>
         </div>
@@ -195,6 +196,7 @@
             :isDark="themeStore.isDark"
             :content="t('searchDisclaimer')"
             :typewriter="false"
+            :final="true"
             :codeBlockStream="false"
           ></NodeRenderer>
         </DialogDescription>

--- a/src/renderer/src/components/artifacts/CodeArtifact.vue
+++ b/src/renderer/src/components/artifacts/CodeArtifact.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="isMermaid" class="markstream-vue">
-    <MermaidBlockNode :node="mermaidNode" />
+    <MermaidBlockNode :node="mermaidNode" :is-dark="themeStore.isDark" :loading="false" />
   </div>
   <div v-else class="m-4 rounded-lg border border-border overflow-hidden shadow-sm">
     <div class="flex justify-between items-center p-2 bg-muted text-xs">
@@ -47,6 +47,7 @@ import { Icon } from '@iconify/vue'
 import { MermaidBlockNode } from 'markstream-vue'
 import { DcCopyButton } from '@dc-ui/components'
 import { useArtifactStore } from '@/stores/artifact'
+import { useThemeStore } from '@/stores/theme'
 import { useUiSettingsStore } from '@/stores/uiSettingsStore'
 import { getLanguageIcon } from 'markstream-vue'
 import { detectLanguage, useMonaco } from 'stream-monaco'
@@ -67,6 +68,7 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
+const themeStore = useThemeStore()
 const uiSettingsStore = useUiSettingsStore()
 const { createEditor, updateCode, getEditorView } = useMonaco({
   wordWrap: 'on',

--- a/src/renderer/src/components/artifacts/CodeArtifact.vue
+++ b/src/renderer/src/components/artifacts/CodeArtifact.vue
@@ -1,5 +1,7 @@
 <template>
-  <MermaidBlockNode v-if="isMermaid" :node="mermaidNode" />
+  <div v-if="isMermaid" class="markstream-vue">
+    <MermaidBlockNode :node="mermaidNode" />
+  </div>
   <div v-else class="m-4 rounded-lg border border-border overflow-hidden shadow-sm">
     <div class="flex justify-between items-center p-2 bg-muted text-xs">
       <span class="flex items-center space-x-2">

--- a/src/renderer/src/components/markdown/MarkdownRenderer.vue
+++ b/src/renderer/src/components/markdown/MarkdownRenderer.vue
@@ -12,8 +12,8 @@
       :smooth-streaming="resolvedSmoothStreaming"
       :typewriter="resolvedTypewriter"
       :code-block-stream="isStreaming"
-      :code-renderer="codeRenderer"
-      :codeBlockProps="codeBlockProps"
+      :themes="codeBlockThemes"
+      :code-block-options="codeBlockOptions"
       :mermaid-props="mermaidProps"
       :fade="false"
       :batch-rendering="true"
@@ -30,9 +30,6 @@
       :node-virtual="resolvedNodeVirtual"
       :max-live-nodes="maxLiveNodes"
       :live-node-buffer="liveNodeBuffer"
-      :codeBlockDarkTheme="codeBlockDarkTheme"
-      :codeBlockLightTheme="codeBlockLightTheme"
-      :codeBlockMonacoOptions="codeBlockMonacoOption"
       @copy="$emit('copy', $event)"
       @handle-artifact-click="handleArtifactClick"
       @click="handleRendererClick"
@@ -129,14 +126,9 @@ const customRendererId = computed(() =>
   ].join('::')
 )
 const codeBlockThemes = ['vitesse-dark', 'vitesse-light'] as const
-const codeBlockDarkTheme = codeBlockThemes[0]
-const codeBlockLightTheme = codeBlockThemes[1]
-const codeBlockMonacoOption = computed(() => ({
+const codeBlockOptions = computed(() => ({
   fontFamily: uiSettingsStore.formattedCodeFontFamily,
-  wordWrap: 'on' as const
-}))
-const codeBlockProps = computed(() => ({
-  themes: [...codeBlockThemes]
+  overflow: 'wrap' as const
 }))
 const mermaidProps = { isStrict: true } as const
 const NESTED_NODE_ARRAY_KEYS = ['children', 'items', 'rows', 'cells', 'term', 'definition'] as const
@@ -222,9 +214,6 @@ const resolvedSmoothStreaming = computed(() => {
   return 'auto' as const
 })
 const resolvedTypewriter = computed(() => (isStreaming.value ? ('simple' as const) : false))
-// In current Markstream, `monaco` is the compatibility name for the enhanced stream-diffs
-// CodeBlockNode. Keep it stable: Markstream owns the streaming <pre> -> final surface handoff.
-const codeRenderer = 'monaco' as const
 const STREAM_INITIAL_RENDER_BATCH_SIZE = 10
 const STREAM_RENDER_BATCH_SIZE = 14
 const STREAM_RENDER_BATCH_DELAY_MS = 8

--- a/src/renderer/src/components/markdown/MarkdownRenderer.vue
+++ b/src/renderer/src/components/markdown/MarkdownRenderer.vue
@@ -56,6 +56,7 @@ import { useUiSettingsStore } from '@/stores/uiSettingsStore'
 import { useMarkdownLinkNavigation } from './useMarkdownLinkNavigation'
 import type { MarkdownLinkContext } from './linkTypes'
 import { ensureMarkdownWorkers } from '@/lib/markdownWorkerLifecycle'
+import { normalizeMarkstreamCodeFenceLanguages } from '@/lib/markstreamLanguage'
 
 const props = withDefaults(
   defineProps<{
@@ -82,22 +83,11 @@ const props = withDefaults(
 const themeStore = useThemeStore()
 const uiSettingsStore = useUiSettingsStore()
 const artifactStore = useArtifactStore()
-const UNSUPPORTED_CODE_FENCE_LANGUAGES = new Set(['desktop-local-file'])
 const fallbackMessageId = `artifact-msg-${nanoid()}`
 const fallbackThreadId = `artifact-thread-${nanoid()}`
 const referenceStore = useReferenceStore()
 const sessionClient = createSessionClient()
-const normalizeCodeFenceLanguages = (content: string): string =>
-  content.replace(/(^|\n)(`{3,}|~{3,})([^\r\n]*)/g, (fence, lineStart, delimiter, info) => {
-    const [language, ...meta] = info.trim().split(/\s+/)
-    if (!UNSUPPORTED_CODE_FENCE_LANGUAGES.has(language?.toLowerCase())) {
-      return fence
-    }
-
-    return `${lineStart}${delimiter}plaintext${meta.length ? ` ${meta.join(' ')}` : ''}`
-  })
-
-const renderContent = ref(normalizeCodeFenceLanguages(props.content))
+const renderContent = ref(normalizeMarkstreamCodeFenceLanguages(props.content))
 let searchResultsPromise: ReturnType<typeof sessionClient.getSearchResults> | null = null
 let activeReferenceElement: HTMLElement | null = null
 let rendererContextRevision = 0
@@ -389,7 +379,7 @@ const updateContentSlow = useDebounceFn(
 
 const updateContent = (value: string, commitImmediately: boolean) => {
   const revision = ++contentRevision
-  const normalizedValue = normalizeCodeFenceLanguages(value)
+  const normalizedValue = normalizeMarkstreamCodeFenceLanguages(value)
 
   // Main already coalesces renderer snapshots and Markstream owns visible pacing.
   // Stream updates, including the final handoff, must not pass through a third timer.

--- a/src/renderer/src/components/message/MessageBlockToolCall.vue
+++ b/src/renderer/src/components/message/MessageBlockToolCall.vue
@@ -196,7 +196,7 @@
                 />
               </div>
               <template v-if="diffData">
-                <div class="dc-overscroll-contain min-h-0 overflow-auto">
+                <div class="markstream-vue dc-overscroll-contain min-h-0 overflow-auto">
                   <CodeBlockNode
                     :node="{
                       type: 'code_block',

--- a/src/renderer/src/components/message/MessageBlockToolCall.vue
+++ b/src/renderer/src/components/message/MessageBlockToolCall.vue
@@ -261,7 +261,7 @@ import { CodeBlockNode } from 'markstream-vue'
 import { summarizeToolCallPreview } from '@shared/lib/toolCallSummary'
 import { useThemeStore } from '@/stores/theme'
 import { useSessionStore } from '@/stores/ui/session'
-import { getLanguageFromFilename } from '@shared/utils/codeLanguage'
+import { getMarkstreamLanguageFromFilename } from '@/lib/markstreamLanguage'
 import type { DisplayAssistantMessageBlock } from '@/features/chat-page/model/displayMessage'
 import { parseLiveDelegationSpawnBlock } from '@/lib/liveDelegationToolCall'
 import LiveDelegationToolCallCard from './LiveDelegationToolCallCard.vue'
@@ -574,7 +574,6 @@ const diffData = computed(() => {
       success?: boolean
       originalCode?: unknown
       updatedCode?: unknown
-      language?: unknown
       replacements?: unknown
     }
     if (
@@ -585,7 +584,6 @@ const diffData = computed(() => {
       return {
         originalCode: parsed.originalCode,
         updatedCode: parsed.updatedCode,
-        language: typeof parsed.language === 'string' ? parsed.language : undefined,
         replacements: typeof parsed.replacements === 'number' ? parsed.replacements : undefined
       }
     }
@@ -609,10 +607,7 @@ const paramsPath = computed(() => {
   return ''
 })
 
-const diffLanguage = computed(() => {
-  if (diffData.value?.language) return diffData.value.language
-  return getLanguageFromFilename(paramsPath.value)
-})
+const diffLanguage = computed(() => getMarkstreamLanguageFromFilename(paramsPath.value))
 
 const hasDiff = computed(() => Boolean(diffData.value))
 

--- a/src/renderer/src/components/message/MessageBlockToolCall.vue
+++ b/src/renderer/src/components/message/MessageBlockToolCall.vue
@@ -208,6 +208,8 @@
                       updatedCode: diffData.updatedCode
                     }"
                     :is-dark="themeStore.isDark"
+                    :loading="false"
+                    :stream="false"
                     :show-header="false"
                     class="rounded-md border bg-background text-xs p-2 h-full min-h-0"
                   />

--- a/src/renderer/src/components/think-content/ThinkContent.vue
+++ b/src/renderer/src/components/think-content/ThinkContent.vue
@@ -36,6 +36,10 @@
         :maxLiveNodes="120"
         :liveNodeBuffer="30"
         :customId="customId"
+        :final="!thinking"
+        :smooth-streaming="false"
+        :code-block-stream="thinking"
+        :code-block-props="thinkingCodeBlockProps"
       />
     </div>
 
@@ -51,7 +55,7 @@
 import { useThemeStore } from '@/stores/theme'
 import { Icon } from '@iconify/vue'
 import { h, computed, onMounted, watch } from 'vue'
-import NodeRenderer, { setCustomComponents, CodeBlockNode, PreCodeNode } from 'markstream-vue'
+import NodeRenderer, { setCustomComponents, PreCodeNode } from 'markstream-vue'
 import { ensureMarkdownWorkers } from '@/lib/markdownWorkerLifecycle'
 
 const props = defineProps<{
@@ -72,6 +76,13 @@ defineEmits<{
 }>()
 const customId = 'thinking-content'
 const themeStore = useThemeStore()
+const thinkingCodeBlockProps = {
+  isShowPreview: false,
+  showCopyButton: false,
+  showExpandButton: false,
+  showPreviewButton: false,
+  showFontSizeButtons: false
+} as const
 const propsWatchSource = () => [props.label, props.expanded, props.thinking, props.content] as const
 
 onMounted(() => {
@@ -82,27 +93,6 @@ onMounted(() => {
 
 watch(propsWatchSource, () => {}, { immediate: true })
 setCustomComponents(customId, {
-  code_block: (_props) => {
-    const isMermaid = _props.node.language === 'mermaid'
-    if (isMermaid) {
-      // Keep diagrams as readable source in the compact thinking surface.
-      return h(PreCodeNode, {
-        ..._props
-      })
-    }
-    return h(
-      CodeBlockNode,
-      {
-        ..._props,
-        isShowPreview: false,
-        showCopyButton: false,
-        showExpandButton: false,
-        showPreviewButton: false,
-        showFontSizeButtons: false
-      },
-      undefined
-    )
-  },
   mermaid: (_props) =>
     h(PreCodeNode, {
       ..._props

--- a/src/renderer/src/components/think-content/ThinkContent.vue
+++ b/src/renderer/src/components/think-content/ThinkContent.vue
@@ -85,8 +85,8 @@ setCustomComponents(customId, {
   code_block: (_props) => {
     const isMermaid = _props.node.language === 'mermaid'
     if (isMermaid) {
-      // 对于 Mermaid 代码块，直接返回 MermaidNode 组件
-      return h(PreCodeNode.vue, {
+      // Keep diagrams as readable source in the compact thinking surface.
+      return h(PreCodeNode, {
         ..._props
       })
     }
@@ -104,7 +104,7 @@ setCustomComponents(customId, {
     )
   },
   mermaid: (_props) =>
-    h(PreCodeNode.vue, {
+    h(PreCodeNode, {
       ..._props
     })
 })

--- a/src/renderer/src/lib/markstreamLanguage.ts
+++ b/src/renderer/src/lib/markstreamLanguage.ts
@@ -1,0 +1,29 @@
+import { getLanguageFromFilename } from '@shared/utils/codeLanguage'
+import { resolveLanguageId } from 'markstream-vue'
+
+// The shared filename map also serves Monaco and contains IDs that Shiki does not provide.
+const MARKSTREAM_LANGUAGE_REPLACEMENTS: Readonly<Record<string, string>> = {
+  apacheconf: 'apache',
+  configuration: 'ini',
+  'desktop-local-file': 'plaintext',
+  fortran: 'fortran-free-form',
+  gitignore: 'plaintext'
+}
+
+const replaceUnsupportedLanguage = (language: string): string =>
+  MARKSTREAM_LANGUAGE_REPLACEMENTS[language] ?? language
+
+export const getMarkstreamLanguageFromFilename = (filename?: string): string =>
+  replaceUnsupportedLanguage(resolveLanguageId(getLanguageFromFilename(filename)))
+
+export const normalizeMarkstreamCodeFenceLanguages = (content: string): string =>
+  content.replace(/(^|\n)(`{3,}|~{3,})([^\r\n]*)/g, (fence, lineStart, delimiter, info) => {
+    const [languageWithSuffix, ...meta] = info.trim().split(/\s+/)
+    const [language] = languageWithSuffix.split(':')
+    const suffix = languageWithSuffix.slice(language.length)
+    const resolvedLanguage = resolveLanguageId(language)
+    const replacement = replaceUnsupportedLanguage(resolvedLanguage)
+    if (replacement === resolvedLanguage) return fence
+
+    return `${lineStart}${delimiter}${replacement}${suffix}${meta.length ? ` ${meta.join(' ')}` : ''}`
+  })

--- a/test/renderer/components/MarkdownRenderer.test.ts
+++ b/test/renderer/components/MarkdownRenderer.test.ts
@@ -202,6 +202,7 @@ const setup = async (props: Record<string, unknown> = {}) => {
       default: NodeRenderer,
       NodeRenderer,
       removeCustomComponents: removeCustomComponentsMock,
+      resolveLanguageId: (language?: string) => language?.trim().toLowerCase() || 'plaintext',
       setCustomComponents: setCustomComponentsMock
     }
   })

--- a/test/renderer/components/MarkdownRenderer.test.ts
+++ b/test/renderer/components/MarkdownRenderer.test.ts
@@ -112,6 +112,14 @@ const setup = async (props: Record<string, unknown> = {}) => {
           type: Boolean,
           default: false
         },
+        codeBlockOptions: {
+          type: Object,
+          default: undefined
+        },
+        themes: {
+          type: Array,
+          default: undefined
+        },
         mermaidProps: {
           type: Object,
           default: undefined
@@ -138,6 +146,9 @@ const setup = async (props: Record<string, unknown> = {}) => {
               'data-testid': 'node-renderer',
               'data-final': String(props.final),
               'data-code-block-stream': String(props.codeBlockStream),
+              'data-code-block-overflow': props.codeBlockOptions?.overflow,
+              'data-code-block-font-family': props.codeBlockOptions?.fontFamily,
+              'data-code-block-themes': props.themes?.join(','),
               'data-mermaid-strict': String(props.mermaidProps?.isStrict),
               'data-custom-id': props.customId,
               'data-content': props.content
@@ -305,10 +316,19 @@ describe('MarkdownRenderer', () => {
     )
   })
 
-  it('leaves generic code blocks on Markstream’s built-in Monaco path', async () => {
+  it('leaves generic code blocks on Markstream’s built-in enhanced path', async () => {
     const { getCustomComponents } = await setup({ mode: 'chat' })
 
     expect(getCustomComponents().code_block).toBeUndefined()
+  })
+
+  it('passes renderer-neutral code block options and themes', async () => {
+    const { wrapper } = await setup()
+    const renderer = wrapper.get('[data-testid="node-renderer"]')
+
+    expect(renderer.attributes('data-code-block-overflow')).toBe('wrap')
+    expect(renderer.attributes('data-code-block-font-family')).toBe('monospace')
+    expect(renderer.attributes('data-code-block-themes')).toBe('vitesse-dark,vitesse-light')
   })
 
   it('uses the built-in strict Mermaid renderer without a global custom registry', async () => {

--- a/test/renderer/components/MarkstreamDomContract.test.ts
+++ b/test/renderer/components/MarkstreamDomContract.test.ts
@@ -55,7 +55,7 @@ async function mountMarkstream(content: string) {
       deferNodesUntilVisible: false,
       viewportPriority: false,
       nodeVirtual: false,
-      codeRenderer: 'pre'
+      renderCodeBlocksAsPre: true
     }
   })
   await settleRenderer()
@@ -78,7 +78,6 @@ describe('Markstream DOM contracts used by MarkdownRenderer delegation', () => {
           deferNodesUntilVisible: false,
           viewportPriority: false,
           nodeVirtual: false,
-          codeRenderer: 'monaco',
           codeBlockStream: true
         }
       })
@@ -110,7 +109,6 @@ describe('Markstream DOM contracts used by MarkdownRenderer delegation', () => {
         deferNodesUntilVisible: false,
         viewportPriority: false,
         nodeVirtual: false,
-        codeRenderer: 'monaco',
         codeBlockStream: true
       }
     })

--- a/test/renderer/components/MarkstreamDomContract.test.ts
+++ b/test/renderer/components/MarkstreamDomContract.test.ts
@@ -1,7 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils'
-import { nextTick } from 'vue'
+import { defineComponent, h, nextTick } from 'vue'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import NodeRenderer from 'markstream-vue'
+import NodeRenderer, { CodeBlockNode } from 'markstream-vue'
 
 const originalCssStyleSheet = globalThis.CSSStyleSheet
 const originalResizeObserver = globalThis.ResizeObserver
@@ -121,6 +121,34 @@ describe('Markstream DOM contracts used by MarkdownRenderer delegation', () => {
 
     expect(wrapper.get('[data-markstream-code-block="1"]').element).toBe(codeBlock)
     expect(wrapper.get('pre.code-pre-fallback').text()).toContain('const answer = 43')
+  })
+
+  it('settles a completed standalone diff node', async () => {
+    const StandaloneDiff = defineComponent({
+      setup: () => () =>
+        h('div', { class: 'markstream-vue' }, [
+          h(CodeBlockNode, {
+            node: {
+              type: 'code_block',
+              language: 'typescript',
+              code: 'const answer = 43',
+              raw: 'const answer = 43',
+              diff: true,
+              originalCode: 'const answer = 42',
+              updatedCode: 'const answer = 43'
+            },
+            loading: false,
+            stream: false
+          })
+        ])
+    })
+    const wrapper = mount(StandaloneDiff)
+
+    await settleRenderer()
+
+    const codeBlock = wrapper.get('[data-markstream-code-block="1"]')
+    expect(codeBlock.attributes('data-markstream-code-block-state')).toBe('settled')
+    expect(codeBlock.text()).toContain('const answer = 43')
   })
 
   it('marks both Markdown and normalized safe HTML links for delegation', async () => {

--- a/test/renderer/components/ThinkContent.test.ts
+++ b/test/renderer/components/ThinkContent.test.ts
@@ -2,8 +2,9 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent, h } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { ensureMarkdownWorkersMock } = vi.hoisted(() => ({
-  ensureMarkdownWorkersMock: vi.fn().mockResolvedValue(undefined)
+const { ensureMarkdownWorkersMock, setCustomComponentsMock } = vi.hoisted(() => ({
+  ensureMarkdownWorkersMock: vi.fn().mockResolvedValue(undefined),
+  setCustomComponentsMock: vi.fn()
 }))
 
 vi.mock('@/lib/markdownWorkerLifecycle', () => ({
@@ -45,25 +46,30 @@ vi.mock('markstream-vue', () => {
     }
   })
 
-  const PassthroughNode = defineComponent({
-    name: 'PassthroughNode',
+  const CodeBlockNode = defineComponent({
+    name: 'CodeBlockNode',
     render() {
       return h('div')
+    }
+  })
+  const PreCodeNode = defineComponent({
+    name: 'PreCodeNode',
+    render() {
+      return h('pre')
     }
   })
 
   return {
     default: NodeRenderer,
     NodeRenderer,
-    CodeBlockNode: PassthroughNode,
-    PreCodeNode: {
-      vue: PassthroughNode
-    },
-    setCustomComponents: vi.fn()
+    CodeBlockNode,
+    PreCodeNode,
+    setCustomComponents: setCustomComponentsMock
   }
 })
 
 const mountThinkContent = async () => {
+  vi.resetModules()
   const ThinkContent = (await import('@/components/think-content/ThinkContent.vue')).default
   const wrapper = mount(ThinkContent, {
     props: {
@@ -83,11 +89,34 @@ describe('ThinkContent', () => {
   beforeEach(() => {
     ensureMarkdownWorkersMock.mockReset()
     ensureMarkdownWorkersMock.mockResolvedValue(undefined)
+    setCustomComponentsMock.mockReset()
   })
 
   it('initializes markdown workers lazily when mounted', async () => {
     await mountThinkContent()
 
     expect(ensureMarkdownWorkersMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('registers the Markstream 2 code block components directly', async () => {
+    await mountThinkContent()
+
+    expect(setCustomComponentsMock).toHaveBeenCalledTimes(1)
+    const [customId, components] = setCustomComponentsMock.mock.calls[0]
+    const preCode = components.code_block({ node: { language: 'mermaid' } })
+    const codeBlock = components.code_block({ node: { language: 'typescript' } })
+    const mermaid = components.mermaid({ node: { language: 'mermaid' } })
+
+    expect(customId).toBe('thinking-content')
+    expect(preCode.type.name).toBe('PreCodeNode')
+    expect(mermaid.type.name).toBe('PreCodeNode')
+    expect(codeBlock.type.name).toBe('CodeBlockNode')
+    expect(codeBlock.props).toMatchObject({
+      isShowPreview: false,
+      showCopyButton: false,
+      showExpandButton: false,
+      showPreviewButton: false,
+      showFontSizeButtons: false
+    })
   })
 })

--- a/test/renderer/components/ThinkContent.test.ts
+++ b/test/renderer/components/ThinkContent.test.ts
@@ -39,6 +39,22 @@ vi.mock('markstream-vue', () => {
       content: {
         type: String,
         default: ''
+      },
+      final: {
+        type: Boolean,
+        default: false
+      },
+      smoothStreaming: {
+        type: Boolean,
+        default: true
+      },
+      codeBlockStream: {
+        type: Boolean,
+        default: true
+      },
+      codeBlockProps: {
+        type: Object,
+        default: undefined
       }
     },
     setup(props) {
@@ -46,12 +62,6 @@ vi.mock('markstream-vue', () => {
     }
   })
 
-  const CodeBlockNode = defineComponent({
-    name: 'CodeBlockNode',
-    render() {
-      return h('div')
-    }
-  })
   const PreCodeNode = defineComponent({
     name: 'PreCodeNode',
     render() {
@@ -62,20 +72,19 @@ vi.mock('markstream-vue', () => {
   return {
     default: NodeRenderer,
     NodeRenderer,
-    CodeBlockNode,
     PreCodeNode,
     setCustomComponents: setCustomComponentsMock
   }
 })
 
-const mountThinkContent = async () => {
+const mountThinkContent = async (thinking = false) => {
   vi.resetModules()
   const ThinkContent = (await import('@/components/think-content/ThinkContent.vue')).default
   const wrapper = mount(ThinkContent, {
     props: {
       label: 'Thinking',
       expanded: true,
-      thinking: false,
+      thinking,
       content: 'reasoning content'
     }
   })
@@ -98,25 +107,41 @@ describe('ThinkContent', () => {
     expect(ensureMarkdownWorkersMock).toHaveBeenCalledTimes(1)
   })
 
-  it('registers the Markstream 2 code block components directly', async () => {
+  it('uses Markstream lifecycle props for live and completed thinking', async () => {
+    const wrapper = await mountThinkContent()
+    const renderer = wrapper.getComponent({ name: 'NodeRenderer' })
+
+    expect(renderer.props()).toMatchObject({
+      final: true,
+      smoothStreaming: false,
+      codeBlockStream: false,
+      codeBlockProps: {
+        isShowPreview: false,
+        showCopyButton: false,
+        showExpandButton: false,
+        showPreviewButton: false,
+        showFontSizeButtons: false
+      }
+    })
+
+    await wrapper.setProps({ thinking: true })
+
+    expect(renderer.props()).toMatchObject({
+      final: false,
+      smoothStreaming: false,
+      codeBlockStream: true
+    })
+  })
+
+  it('keeps Mermaid source-only without overriding ordinary code blocks', async () => {
     await mountThinkContent()
 
     expect(setCustomComponentsMock).toHaveBeenCalledTimes(1)
     const [customId, components] = setCustomComponentsMock.mock.calls[0]
-    const preCode = components.code_block({ node: { language: 'mermaid' } })
-    const codeBlock = components.code_block({ node: { language: 'typescript' } })
     const mermaid = components.mermaid({ node: { language: 'mermaid' } })
 
     expect(customId).toBe('thinking-content')
-    expect(preCode.type.name).toBe('PreCodeNode')
+    expect(components.code_block).toBeUndefined()
     expect(mermaid.type.name).toBe('PreCodeNode')
-    expect(codeBlock.type.name).toBe('CodeBlockNode')
-    expect(codeBlock.props).toMatchObject({
-      isShowPreview: false,
-      showCopyButton: false,
-      showExpandButton: false,
-      showPreviewButton: false,
-      showFontSizeButtons: false
-    })
   })
 })

--- a/test/renderer/components/message/MessageBlockToolCall.test.ts
+++ b/test/renderer/components/message/MessageBlockToolCall.test.ts
@@ -101,7 +101,8 @@ vi.mock('markstream-vue', () => ({
       }
     },
     template: '<div class="code-block-stub"></div>'
-  })
+  }),
+  resolveLanguageId: (language?: string) => language?.trim().toLowerCase() || 'plaintext'
 }))
 
 const createBlock = (
@@ -344,7 +345,11 @@ describe('MessageBlockToolCall', () => {
     const wrapper = mount(MessageBlockToolCall, {
       props: {
         block: createBlock({
-          tool_call: { name: 'edit_text', response }
+          tool_call: {
+            name: 'edit_text',
+            params: '{"path":"/tmp/example.ts"}',
+            response
+          }
         })
       }
     })
@@ -362,6 +367,32 @@ describe('MessageBlockToolCall', () => {
     })
     expect(codeBlock.props('loading')).toBe(false)
     expect(codeBlock.props('stream')).toBe(false)
+  })
+
+  it('uses the file path instead of an unsupported response language for diffs', async () => {
+    const response = JSON.stringify({
+      success: true,
+      originalCode: 'key=before',
+      updatedCode: 'key=after',
+      language: 'unsupported-from-tool'
+    })
+    const wrapper = mount(MessageBlockToolCall, {
+      props: {
+        block: createBlock({
+          tool_call: {
+            name: 'edit_text',
+            params: '{"path":"/tmp/example.conf"}',
+            response
+          }
+        })
+      }
+    })
+
+    await wrapper.get('[data-testid="tool-call-trigger"]').trigger('click')
+
+    expect(wrapper.findComponent({ name: 'CodeBlockNode' }).props('node')).toMatchObject({
+      language: 'ini'
+    })
   })
 
   it('falls back to preformatted text for non-diff responses', async () => {

--- a/test/renderer/components/message/MessageBlockToolCall.test.ts
+++ b/test/renderer/components/message/MessageBlockToolCall.test.ts
@@ -90,6 +90,14 @@ vi.mock('markstream-vue', () => ({
       showHeader: {
         type: Boolean,
         default: true
+      },
+      loading: {
+        type: Boolean,
+        default: true
+      },
+      stream: {
+        type: Boolean,
+        default: true
       }
     },
     template: '<div class="code-block-stub"></div>'
@@ -352,6 +360,8 @@ describe('MessageBlockToolCall', () => {
       originalCode: 'alpha\nbeta',
       updatedCode: 'alpha\ngamma'
     })
+    expect(codeBlock.props('loading')).toBe(false)
+    expect(codeBlock.props('stream')).toBe(false)
   })
 
   it('falls back to preformatted text for non-diff responses', async () => {

--- a/test/renderer/components/message/MessageBlockToolCall.test.ts
+++ b/test/renderer/components/message/MessageBlockToolCall.test.ts
@@ -345,6 +345,7 @@ describe('MessageBlockToolCall', () => {
 
     const codeBlock = wrapper.findComponent({ name: 'CodeBlockNode' })
     expect(codeBlock.exists()).toBe(true)
+    expect(codeBlock.element.parentElement?.classList.contains('markstream-vue')).toBe(true)
     expect(codeBlock.props('node')).toMatchObject({
       diff: true,
       language: 'typescript',

--- a/test/renderer/lib/markstreamLanguage.test.ts
+++ b/test/renderer/lib/markstreamLanguage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getMarkstreamLanguageFromFilename,
+  normalizeMarkstreamCodeFenceLanguages
+} from '@/lib/markstreamLanguage'
+
+describe('Markstream language normalization', () => {
+  it.each([
+    ['/tmp/example.ts', 'typescript'],
+    ['/tmp/example.sh', 'zsh'],
+    ['/tmp/example.conf', 'ini'],
+    ['/tmp/example.f90', 'fortran-free-form'],
+    ['/tmp/.htaccess', 'apache'],
+    ['/tmp/.gitignore', 'plaintext'],
+    ['/tmp/unknown', 'plaintext']
+  ])('maps %s to a stream-diffs language', (filename, expected) => {
+    expect(getMarkstreamLanguageFromFilename(filename)).toBe(expected)
+  })
+
+  it('rewrites known unsupported fence languages without dropping metadata', () => {
+    expect(
+      normalizeMarkstreamCodeFenceLanguages(
+        '```configuration:app.conf title=config\nkey=value\n```\n\n```typescript\nconst value = 1\n```'
+      )
+    ).toBe('```ini:app.conf title=config\nkey=value\n```\n\n```typescript\nconst value = 1\n```')
+  })
+})


### PR DESCRIPTION
## Summary

- Pin `markstream-vue` to `2.0.0-beta.2`.
- Preserve `stream-diffs@0.0.2` and `stream-monaco`.
- Migrate `MarkdownRenderer` from the removed Monaco compatibility API to the Markstream 2 code-block API.
- Update themes, wrapping options, worker/CSS contracts, tests, and architecture documentation.
- Fix completed-state handling for tool-call diffs, thinking content, static Markdown, and standalone Mermaid nodes.
- Keep thinking Mermaid blocks source-only while allowing ordinary fences to use Markstream’s built-in deferred renderer.

## Before / After

```text
BEFORE
Streaming code ──▶ <pre> fallback
Completed secondary surfaces ──▶ could remain in streaming/loading state

AFTER
Streaming code ──▶ <pre> fallback
Completed code ──▶ settled stream-diffs surface
Thinking Mermaid ──▶ readable source
Standalone Mermaid ──▶ completed state with correct light/dark theme
```

## Implementation Notes

- Removed the deprecated `codeRenderer="monaco"` selector.
- Replaced `codeBlockMonacoOptions` with `codeBlockOptions`.
- Replaced `wordWrap: 'on'` with `overflow: 'wrap'`.
- Moved code themes to the top-level `themes` prop.
- Explicitly pass `loading=false` and `stream=false` to completed standalone diff blocks.
- Explicitly connect thinking state to `final` and `codeBlockStream`.
- Removed the generic thinking `code_block` override so ordinary fences use Markstream’s built-in viewport-deferred path.
- Retained `stream-monaco` because DeepChat’s artifact, workspace, trace, and ACP editors still use it directly.

## Validation

- `pnpm run format:check`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- 57 focused renderer tests
- Markstream 2 DOM contract coverage for streaming-to-final handoff and standalone completed diffs

## Risk

`markstream-vue` 2.0 is still in beta, so the dependency is pinned to the exact `2.0.0-beta.2` version instead of following `@next`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated Markdown rendering with enhanced built-in code block support.
  - Code blocks transition smoothly from streaming content to completed displays.
  - Added theme-aware Mermaid diagram rendering.
  - Improved code block styling, font handling, and wrapped overflow behavior.
  - Added more reliable language detection for code fences and files.
  - Updated release notes and disclaimer content to render in their final state.

- **Bug Fixes**
  - Improved rendering for completed streamed code updates and diff views.

- **Tests**
  - Expanded coverage for streaming states, themes, Mermaid content, and language handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->