### PR TITLE
fix(runtime): preserve paused runOutcome

### DIFF
--- a/src/main/agent/deepchat/runtime/interactionCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/interactionCoordinator.ts
@@ -39,7 +39,7 @@ import { MAX_TOOL_CALLS_SKIPPED_ERROR } from './process'
 import {
   buildUsageFromMetadata,
   incrementToolCallAccounting,
-  stampTerminalMetadata
+  stampInteractionResolution
 } from './runtimeMetadata'
 import type { DeferredToolExecutionResult, DeferredToolExecutor } from './deferredToolExecutor'
 import {
@@ -528,7 +528,7 @@ export class InteractionCoordinator {
             instance.advancePendingToolBatch({ invokedCallId: toolCall.id })
           }
           if (execution.terminalError) {
-            const terminalMetadata = stampTerminalMetadata(resumeAccounting, 'error', 'tool_error')
+            const terminalMetadata = stampInteractionResolution(resumeAccounting, 'error')
             instance.advancePendingToolBatch({ committedResultCallId: toolCall.id })
             hooks.emit({
               event: 'PostToolUseFailure',
@@ -647,16 +647,24 @@ export class InteractionCoordinator {
       const awaitsUserFollowUp = waitingForUserMessage || hasQuestionFollowUpIntent(blocks)
       const finishesForUserFollowUp = awaitsUserFollowUp && remainingPending.length === 0
       const persistedMetadata = finishesForUserFollowUp
-        ? stampTerminalMetadata(resumeAccounting, 'completed', 'user_follow_up')
+        ? stampInteractionResolution(resumeAccounting, 'follow_up')
         : resumeAccounting
       if (remainingPending.length === 0 && !awaitsUserFollowUp) {
         await resumeWaitingAdmission()
       }
-      this.ports.messageStore.updateAssistantContent(
-        messageId,
-        blocks,
-        finishesForUserFollowUp || accountingChanged ? JSON.stringify(persistedMetadata) : undefined
-      )
+      if (finishesForUserFollowUp) {
+        this.ports.messageStore.finalizeAssistantMessage(
+          messageId,
+          blocks,
+          JSON.stringify(persistedMetadata)
+        )
+      } else {
+        this.ports.messageStore.updateAssistantContent(
+          messageId,
+          blocks,
+          accountingChanged ? JSON.stringify(resumeAccounting) : undefined
+        )
+      }
       replacePendingInteractions(instance, remainingPending)
       this.ports.messageProjection.refresh(sessionId, messageId)
 
@@ -670,7 +678,6 @@ export class InteractionCoordinator {
 
       if (awaitsUserFollowUp) {
         emitResolvedToolHook?.()
-        this.ports.messageStore.updateMessageStatus(messageId, 'sent')
         this.ports.runLifecycle.observeTerminal(sessionId, {
           status: 'completed',
           stopReason: 'user_follow_up',
@@ -726,7 +733,7 @@ export class InteractionCoordinator {
           sessionId,
           messageId,
           undefined,
-          JSON.stringify(stampTerminalMetadata(accounting, 'aborted', 'user_stop'))
+          JSON.stringify(stampInteractionResolution(accounting, 'cancelled'))
         )
         this.ports.runLifecycle.schedulePendingInputDrain(sessionId, 'completed')
         return { resumed: false }

--- a/src/main/agent/deepchat/runtime/providerPermissionCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/providerPermissionCoordinator.ts
@@ -8,7 +8,7 @@ import {
   type ProviderPermissionProjection
 } from './interactionProjection'
 import { buildTerminalErrorBlocks, type SessionTranscript } from '@/session/data/transcript'
-import { buildUsageFromMetadata, stampTerminalMetadata } from './runtimeMetadata'
+import { buildUsageFromMetadata, stampInteractionResolution } from './runtimeMetadata'
 import type {
   DeepChatEventPublisher,
   PendingToolInteraction,
@@ -225,10 +225,9 @@ export class ProviderPermissionCoordinator {
     const blocks = parseAssistantBlocks(message.content)
     applyProviderPermissionProjection(blocks, input, { status: 'error', message: errorMessage })
     const terminalBlocks = buildTerminalErrorBlocks(blocks, errorMessage)
-    const terminalMetadata = stampTerminalMetadata(
+    const terminalMetadata = stampInteractionResolution(
       parseMessageMetadata(message.metadata),
-      'error',
-      'provider_error'
+      'error'
     )
     this.deps.messageStore.setMessageError(
       input.messageId,

--- a/src/main/agent/deepchat/runtime/runLifecycleCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/runLifecycleCoordinator.ts
@@ -23,7 +23,7 @@ import {
 } from './interactionProjection'
 import { resolveProviderPermissionSafely } from './providerPermissionResolution'
 import { redactRuntimeErrorForLog } from './runtimeErrorLogging'
-import { buildUsageFromMetadata, stampTerminalMetadata } from './runtimeMetadata'
+import { buildUsageFromMetadata, stampInteractionResolution } from './runtimeMetadata'
 import type { SessionStatusPublisher } from './sessionStatusPublisher'
 import type { MessageProjectionService } from './messageProjectionService'
 import { resolveStreamRequestId as resolveRegistryStreamRequestId } from './streamRequestId'
@@ -294,7 +294,7 @@ export class RunLifecycleCoordinator {
       )
       return {
         messageId,
-        terminalMetadata: stampTerminalMetadata(metadata, 'aborted', 'user_stop')
+        terminalMetadata: stampInteractionResolution(metadata, 'cancelled')
       }
     })
     for (const { messageId, terminalMetadata } of terminalMessages) {

--- a/src/main/agent/deepchat/runtime/runtimeMetadata.ts
+++ b/src/main/agent/deepchat/runtime/runtimeMetadata.ts
@@ -1,4 +1,4 @@
-import type { MessageMetadata } from '@shared/types/agent-interface'
+import type { InteractionResolution, MessageMetadata } from '@shared/types/agent-interface'
 
 export function incrementToolCallAccounting(metadata: MessageMetadata): MessageMetadata {
   const currentToolCalls =
@@ -17,6 +17,14 @@ export function stampTerminalMetadata(
   runId?: string
 ): MessageMetadata {
   return { ...metadata, ...(runId ? { runId } : {}), runOutcome, runStopReason }
+}
+
+/** Session-layer close of an already journaled Run. Never rewrites runOutcome. */
+export function stampInteractionResolution(
+  metadata: MessageMetadata,
+  interactionResolution: InteractionResolution
+): MessageMetadata {
+  return { ...metadata, interactionResolution }
 }
 
 export function buildUsageFromMetadata(

--- a/src/main/agent/deepchat/runtime/turnCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/turnCoordinator.ts
@@ -59,7 +59,11 @@ import {
 } from './interactionProjection'
 import { buildTerminalErrorBlocks, type SessionTranscript } from '@/session/data/transcript'
 import type { DeepChatEventPublisher, ProcessResult } from './types'
-import { buildUsageFromMetadata, stampTerminalMetadata } from './runtimeMetadata'
+import {
+  buildUsageFromMetadata,
+  stampInteractionResolution,
+  stampTerminalMetadata
+} from './runtimeMetadata'
 import type { SessionSettingsStore } from '@/session/data/settings'
 import type {
   TapeProviderAttemptReader,
@@ -1798,11 +1802,7 @@ export class TurnCoordinator {
           )
         } else if (resumeBudget?.kind === 'terminal_error') {
           updateToolCallResponse(initialBlocks, budgetToolCall.id, resumeBudget.message, true)
-          const terminalMetadata = stampTerminalMetadata(
-            resumeAccounting,
-            'error',
-            'context_window'
-          )
+          const terminalMetadata = stampInteractionResolution(resumeAccounting, 'error')
           this.ports.messageStore.setMessageError(
             messageId,
             initialBlocks,
@@ -1948,12 +1948,14 @@ export class TurnCoordinator {
             messageId,
             parseAssistantBlocks(message.content),
             JSON.stringify(
-              stampTerminalMetadata(
-                resumeAccounting,
-                'completed',
-                PENDING_INPUT_ABORT_REASON,
-                streamRunId
-              )
+              streamRunId
+                ? stampTerminalMetadata(
+                    resumeAccounting,
+                    'completed',
+                    PENDING_INPUT_ABORT_REASON,
+                    streamRunId
+                  )
+                : stampInteractionResolution(resumeAccounting, 'pending_input')
             )
           )
           this.ports.messageProjection.refresh(sessionId, messageId)
@@ -1985,7 +1987,9 @@ export class TurnCoordinator {
           messageId,
           streamRunId,
           JSON.stringify(
-            stampTerminalMetadata(resumeAccounting, 'aborted', 'user_stop', streamRunId)
+            streamRunId
+              ? stampTerminalMetadata(resumeAccounting, 'aborted', 'user_stop', streamRunId)
+              : stampInteractionResolution(resumeAccounting, 'cancelled')
           )
         )
         // Stop/steer: continue the queue automatically with the next item (steer items first).
@@ -1998,12 +2002,9 @@ export class TurnCoordinator {
       const stopReason =
         committedErrorTerminal?.stopReason ??
         (isContextWindowErrorLike(errorToProject) ? 'context_window' : 'pre_stream_error')
-      const terminalMetadata = stampTerminalMetadata(
-        resumeAccounting,
-        'error',
-        stopReason,
-        streamRunId
-      )
+      const terminalMetadata = streamRunId
+        ? stampTerminalMetadata(resumeAccounting, 'error', stopReason, streamRunId)
+        : stampInteractionResolution(resumeAccounting, 'error')
       const blocks = buildTerminalErrorBlocks(initialBlocks, errorMessage)
       this.ports.messageStore.setMessageError(messageId, blocks, JSON.stringify(terminalMetadata))
       this.ports.messageProjection.refresh(sessionId, messageId)

--- a/src/shared/types/agent-interface.d.ts
+++ b/src/shared/types/agent-interface.d.ts
@@ -416,10 +416,13 @@ export interface AgentNoProgressToolLoopMetadata {
   evidence: 'strong' | 'weak'
 }
 
+export type InteractionResolution = 'cancelled' | 'follow_up' | 'error' | 'pending_input'
+
 export interface MessageMetadata {
   runId?: string
   runOutcome?: 'completed' | 'paused' | 'aborted' | 'error'
   runStopReason?: string
+  interactionResolution?: InteractionResolution
   noProgressToolLoop?: AgentNoProgressToolLoopMetadata
   totalTokens?: number
   inputTokens?: number

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -16513,6 +16513,74 @@ describe('DeepChatAgentHarness', () => {
       expect(processStream).not.toHaveBeenCalled()
     })
 
+    it('keeps a paused runOutcome when resume is cancelled before a new run starts', async () => {
+      const fitStarted = deferred<AbortSignal>()
+      vi.spyOn(ToolOutputGuard.prototype, 'prepareToolOutput').mockResolvedValueOnce({
+        kind: 'ok',
+        content: 'prepared',
+        offloaded: true,
+        offloadPath: '/tmp/original-tool-output.offload'
+      })
+      vi.spyOn(ToolOutputGuard.prototype, 'fitExistingToolOutput').mockImplementationOnce(
+        async (params) => {
+          if (!params.signal) throw new Error('Missing resume fit signal')
+          fitStarted.resolve(params.signal)
+          return await new Promise<never>((_resolve, reject) => {
+            params.signal?.addEventListener('abort', () => reject(params.signal?.reason), {
+              once: true
+            })
+          })
+        }
+      )
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      const row = installPendingPermission({
+        toolName: 'write_file',
+        serverName: 'agent-filesystem',
+        shellProfile: 'posix',
+        paths: ['/workspace/file.txt']
+      })
+      row.metadata = JSON.stringify({
+        runId: 'paused-run',
+        runOutcome: 'paused',
+        runStopReason: 'interaction'
+      })
+      toolService.callTool.mockResolvedValueOnce({
+        content: 'done',
+        rawData: { content: 'done', isError: false }
+      })
+      toolService.getAllToolDefinitions.mockResolvedValueOnce([
+        {
+          type: 'function',
+          source: 'agent',
+          function: {
+            name: 'write_file',
+            description: 'write file',
+            parameters: { type: 'object', properties: {} }
+          },
+          server: { name: 'agent-filesystem', icons: '', description: '' }
+        }
+      ])
+
+      const resume = approvePendingTool()
+      await fitStarted.promise
+      agent.deepChatRuntime.getHydrated(toAppSessionId('s1'))?.getAbortController()?.abort()
+      await expect(resume).resolves.toEqual({ resumed: false })
+
+      const errorWrite =
+        sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls.find(
+          (call) => call[0] === 'm1' && call[2] === 'error'
+        )
+      expect(errorWrite).toBeDefined()
+      expect(JSON.parse(errorWrite?.[3] ?? '{}')).toMatchObject({
+        runId: 'paused-run',
+        runOutcome: 'paused',
+        runStopReason: 'interaction',
+        interactionResolution: 'cancelled'
+      })
+      expect(processStream).not.toHaveBeenCalled()
+    })
+
     it.each(['tool_error', 'terminal_error'] as const)(
       'does not clean a referenced offload when a stale fit returns %s',
       async (kind) => {

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -42,6 +42,7 @@ import type { MemoryRuntimePort } from '@/memory/injection'
 import { CompactionService } from '@/agent/deepchat/runtime/compactionService'
 import { reviewAutoApproveToolPermission } from '@/agent/deepchat/runtime/toolPermissionReviewer'
 import { normalizeToolResultContent } from '@/agent/deepchat/runtime/toolAdapters'
+import { PENDING_INPUT_ABORT_REASON } from '@/agent/deepchat/runtime/abortErrors'
 import {
   ToolOutputGuard,
   type ToolOutputGuardResult
@@ -10090,8 +10091,9 @@ describe('DeepChatAgentHarness', () => {
         )
         expect(JSON.parse(errorWrite?.[3] ?? '{}')).toMatchObject({
           ...accumulatedMetadata,
-          runOutcome: 'aborted',
-          runStopReason: 'user_stop'
+          runOutcome: 'paused',
+          runStopReason: 'interaction',
+          interactionResolution: 'cancelled'
         })
         expect(instance?.getPendingInteractions()).toEqual([])
         expect((await agent.getSessionState('s1'))?.status).toBe('idle')
@@ -15247,6 +15249,11 @@ describe('DeepChatAgentHarness', () => {
     it('handles question_other and waits for user message without resume', async () => {
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
       makeAssistantRow({
+        metadata: {
+          runId: 'paused-question-run',
+          runOutcome: 'paused',
+          runStopReason: 'interaction'
+        },
         blocks: [
           {
             type: 'tool_call',
@@ -15274,7 +15281,17 @@ describe('DeepChatAgentHarness', () => {
       })
 
       expect(result).toEqual({ resumed: false, waitingForUserMessage: true })
-      expect(sqlitePresenter.deepchatMessagesTable.updateStatus).toHaveBeenCalledWith('m1', 'sent')
+      const sentWrite =
+        sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls.find(
+          (call) => call[0] === 'm1' && call[2] === 'sent'
+        )
+      expect(sentWrite).toBeDefined()
+      expect(JSON.parse(sentWrite?.[3] ?? '{}')).toMatchObject({
+        runId: 'paused-question-run',
+        runOutcome: 'paused',
+        runStopReason: 'interaction',
+        interactionResolution: 'follow_up'
+      })
       expect(processStream).not.toHaveBeenCalled()
 
       const updatedBlocks = JSON.parse(
@@ -16303,6 +16320,199 @@ describe('DeepChatAgentHarness', () => {
       expect(processStream).not.toHaveBeenCalled()
     })
 
+    it('keeps a paused runOutcome when resume budget fitting hits a context-window terminal', async () => {
+      vi.spyOn(ToolOutputGuard.prototype, 'prepareToolOutput').mockResolvedValueOnce({
+        kind: 'ok',
+        content: 'prepared',
+        offloaded: true,
+        offloadPath: '/tmp/original-tool-output.offload'
+      })
+      vi.spyOn(ToolOutputGuard.prototype, 'fitExistingToolOutput').mockResolvedValueOnce({
+        kind: 'terminal_error',
+        message: 'context overflow'
+      } as ToolOutputGuardResult)
+      vi.spyOn(ToolOutputGuard.prototype, 'cleanupOffloadedOutput').mockResolvedValue()
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      const row = installPendingPermission({
+        toolName: 'write_file',
+        serverName: 'agent-filesystem',
+        shellProfile: 'posix',
+        paths: ['/workspace/file.txt']
+      })
+      row.metadata = JSON.stringify({
+        runId: 'paused-run',
+        runOutcome: 'paused',
+        runStopReason: 'interaction'
+      })
+      toolService.callTool.mockResolvedValueOnce({
+        content: 'done',
+        rawData: { content: 'done', isError: false }
+      })
+      toolService.getAllToolDefinitions.mockResolvedValueOnce([
+        {
+          type: 'function',
+          source: 'agent',
+          function: {
+            name: 'write_file',
+            description: 'write file',
+            parameters: { type: 'object', properties: {} }
+          },
+          server: { name: 'agent-filesystem', icons: '', description: '' }
+        }
+      ])
+
+      await expect(approvePendingTool()).resolves.toEqual({ resumed: false })
+
+      const errorWrite =
+        sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls.find(
+          (call) => call[0] === 'm1' && call[2] === 'error'
+        )
+      expect(errorWrite).toBeDefined()
+      expect(JSON.parse(errorWrite?.[3] ?? '{}')).toMatchObject({
+        runId: 'paused-run',
+        runOutcome: 'paused',
+        runStopReason: 'interaction',
+        interactionResolution: 'error'
+      })
+      expect(processStream).not.toHaveBeenCalled()
+    })
+
+    it('keeps a paused runOutcome when deferred execution reports a post-dispatch permission', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      const row = installPendingPermission({
+        toolName: 'write_file',
+        serverName: 'agent-filesystem',
+        shellProfile: 'posix',
+        paths: ['/workspace/file.txt']
+      })
+      row.metadata = JSON.stringify({
+        runId: 'paused-run',
+        runOutcome: 'paused',
+        runStopReason: 'interaction'
+      })
+      toolService.callTool.mockImplementationOnce(async (_request: unknown, options: any) => {
+        options?.commitDispatch?.({
+          toolName: 'write_file',
+          toolSource: 'agent',
+          normalizedArguments: { path: '/workspace/file.txt' },
+          target: { serverName: 'agent-filesystem', originalName: 'write_file' }
+        })
+        return {
+          content: 'approval required',
+          rawData: {
+            content: 'approval required',
+            isError: true,
+            requiresPermission: true,
+            permissionRequest: {
+              permissionType: 'write',
+              description: 'approval required',
+              toolName: 'write_file',
+              serverName: 'agent-filesystem'
+            }
+          }
+        }
+      })
+      toolService.getAllToolDefinitions.mockResolvedValueOnce([
+        {
+          type: 'function',
+          source: 'agent',
+          function: {
+            name: 'write_file',
+            description: 'write file',
+            parameters: { type: 'object', properties: {} }
+          },
+          server: { name: 'agent-filesystem', icons: '', description: '' }
+        }
+      ])
+
+      await expect(approvePendingTool()).resolves.toEqual({ resumed: false })
+
+      const errorWrite =
+        sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls.find(
+          (call) => call[0] === 'm1' && call[2] === 'error'
+        )
+      expect(errorWrite).toBeDefined()
+      expect(JSON.parse(errorWrite?.[3] ?? '{}')).toMatchObject({
+        runId: 'paused-run',
+        runOutcome: 'paused',
+        runStopReason: 'interaction',
+        interactionResolution: 'error'
+      })
+      expect(processStream).not.toHaveBeenCalled()
+    })
+
+    it('records pending_input resolution when resume is superseded before a new run starts', async () => {
+      const fitStarted = deferred<AbortSignal>()
+      vi.spyOn(ToolOutputGuard.prototype, 'prepareToolOutput').mockResolvedValueOnce({
+        kind: 'ok',
+        content: 'prepared',
+        offloaded: true,
+        offloadPath: '/tmp/original-tool-output.offload'
+      })
+      vi.spyOn(ToolOutputGuard.prototype, 'fitExistingToolOutput').mockImplementationOnce(
+        async (params) => {
+          if (!params.signal) throw new Error('Missing resume fit signal')
+          fitStarted.resolve(params.signal)
+          return await new Promise<never>((_resolve, reject) => {
+            params.signal?.addEventListener('abort', () => reject(params.signal?.reason), {
+              once: true
+            })
+          })
+        }
+      )
+
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      const row = installPendingPermission({
+        toolName: 'write_file',
+        serverName: 'agent-filesystem',
+        shellProfile: 'posix',
+        paths: ['/workspace/file.txt']
+      })
+      row.metadata = JSON.stringify({
+        runId: 'paused-run',
+        runOutcome: 'paused',
+        runStopReason: 'interaction'
+      })
+      toolService.callTool.mockResolvedValueOnce({
+        content: 'done',
+        rawData: { content: 'done', isError: false }
+      })
+      toolService.getAllToolDefinitions.mockResolvedValueOnce([
+        {
+          type: 'function',
+          source: 'agent',
+          function: {
+            name: 'write_file',
+            description: 'write file',
+            parameters: { type: 'object', properties: {} }
+          },
+          server: { name: 'agent-filesystem', icons: '', description: '' }
+        }
+      ])
+
+      const resume = approvePendingTool()
+      await fitStarted.promise
+      agent.deepChatRuntime
+        .getHydrated(toAppSessionId('s1'))
+        ?.getAbortController()
+        ?.abort(PENDING_INPUT_ABORT_REASON)
+      await expect(resume).resolves.toEqual({ resumed: false })
+
+      const sentWrite =
+        sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls.find(
+          (call) => call[0] === 'm1' && call[2] === 'sent'
+        )
+      expect(sentWrite).toBeDefined()
+      expect(JSON.parse(sentWrite?.[3] ?? '{}')).toMatchObject({
+        runId: 'paused-run',
+        runOutcome: 'paused',
+        runStopReason: 'interaction',
+        interactionResolution: 'pending_input'
+      })
+      expect(processStream).not.toHaveBeenCalled()
+    })
+
     it.each(['tool_error', 'terminal_error'] as const)(
       'does not clean a referenced offload when a stale fit returns %s',
       async (kind) => {
@@ -16819,8 +17029,9 @@ describe('DeepChatAgentHarness', () => {
       expect(JSON.parse(errorWrite?.[3] ?? '{}')).toEqual(
         expect.objectContaining({
           runId: 'old-run',
-          runOutcome: 'error',
-          runStopReason: 'provider_error',
+          runOutcome: 'paused',
+          runStopReason: 'interaction',
+          interactionResolution: 'error',
           totalTokens: 12
         })
       )
@@ -16910,8 +17121,9 @@ describe('DeepChatAgentHarness', () => {
       expect(JSON.parse(terminalWrites[0][3])).toEqual(
         expect.objectContaining({
           runId: 'orphan-run',
-          runOutcome: 'aborted',
-          runStopReason: 'user_stop',
+          runOutcome: 'paused',
+          runStopReason: 'interaction',
+          interactionResolution: 'cancelled',
           totalTokens: 7
         })
       )
@@ -16992,8 +17204,12 @@ describe('DeepChatAgentHarness', () => {
       expect(errorWrite).toBeDefined()
       expect(JSON.parse(errorWrite?.[3] ?? '{}')).toEqual(
         expect.objectContaining({
-          runOutcome: 'error',
-          runStopReason: 'provider_error'
+          interactionResolution: 'error'
+        })
+      )
+      expect(JSON.parse(errorWrite?.[3] ?? '{}')).not.toEqual(
+        expect.objectContaining({
+          runOutcome: 'error'
         })
       )
     })
@@ -17059,8 +17275,12 @@ describe('DeepChatAgentHarness', () => {
       expect(updatedBlocks[1].extra.needsUserAction).toBe(false)
       expect(JSON.parse(errorWrite?.[3] ?? '{}')).toEqual(
         expect.objectContaining({
-          runOutcome: 'error',
-          runStopReason: 'provider_error'
+          interactionResolution: 'error'
+        })
+      )
+      expect(JSON.parse(errorWrite?.[3] ?? '{}')).not.toEqual(
+        expect.objectContaining({
+          runOutcome: 'error'
         })
       )
       expect(getRuntimeState(agent, 's1').status).toBe('error')

--- a/test/main/agent/deepchat/runtime/runLifecycleCoordinator.test.ts
+++ b/test/main/agent/deepchat/runtime/runLifecycleCoordinator.test.ts
@@ -304,7 +304,7 @@ describe('RunLifecycleCoordinator', () => {
       'message-paused',
       [createPendingAction('tool-1')],
       1,
-      '{"runId":"run-1"}'
+      '{"runId":"run-1","runOutcome":"paused","runStopReason":"interaction"}'
     )
     const { coordinator, pendingInputWakeup, terminalObserver, transcript } = createHarness([
       message
@@ -318,6 +318,20 @@ describe('RunLifecycleCoordinator', () => {
     expect(scope.instance.getPendingInteractions()).toEqual([])
     expect(scope.state()?.status).toBe('idle')
     expect(transcript.setMessageError).toHaveBeenCalledOnce()
+    expect(transcript.setMessageError).toHaveBeenCalledWith(
+      'message-paused',
+      expect.any(Array),
+      expect.stringContaining('"interactionResolution":"cancelled"')
+    )
+    const canceledMetadata = JSON.parse(
+      vi.mocked(transcript.setMessageError).mock.calls[0][2] ?? '{}'
+    )
+    expect(canceledMetadata).toMatchObject({
+      runId: 'run-1',
+      runOutcome: 'paused',
+      runStopReason: 'interaction',
+      interactionResolution: 'cancelled'
+    })
     expect(terminalObserver.observeTerminal).toHaveBeenCalledOnce()
     expect(pendingInputWakeup.drain).toHaveBeenCalledWith(SESSION_ID, 'completed')
   })

--- a/test/main/agent/deepchat/runtime/runtimeMetadata.test.ts
+++ b/test/main/agent/deepchat/runtime/runtimeMetadata.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  stampInteractionResolution,
+  stampTerminalMetadata
+} from '@/agent/deepchat/runtime/runtimeMetadata'
+
+describe('runtimeMetadata stamps', () => {
+  const paused = {
+    runId: 'run-paused',
+    runOutcome: 'paused' as const,
+    runStopReason: 'interaction',
+    toolCalls: 2
+  }
+
+  it('writes a new physical run outcome without touching interactionResolution', () => {
+    expect(stampTerminalMetadata(paused, 'completed', 'complete', 'run-next')).toEqual({
+      ...paused,
+      runId: 'run-next',
+      runOutcome: 'completed',
+      runStopReason: 'complete'
+    })
+  })
+
+  it('records a session-layer resolution without rewriting the paused run outcome', () => {
+    expect(stampInteractionResolution(paused, 'cancelled')).toEqual({
+      ...paused,
+      interactionResolution: 'cancelled'
+    })
+    expect(stampInteractionResolution(paused, 'pending_input').runOutcome).toBe('paused')
+    expect(stampInteractionResolution(paused, 'follow_up').runStopReason).toBe('interaction')
+  })
+})

--- a/test/main/session/data/transcript.test.ts
+++ b/test/main/session/data/transcript.test.ts
@@ -1344,7 +1344,7 @@ describe('SessionTranscript', () => {
       expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).not.toHaveBeenCalled()
     })
 
-    it('does not keep a cancelled interaction in pending restart recovery', () => {
+    it('does not let interactionResolution drop a still-pending action', () => {
       sqlitePresenter.deepchatMessagesTable.getByStatus.mockReturnValue([
         {
           id: 'm1',
@@ -1356,6 +1356,35 @@ describe('SessionTranscript', () => {
             runOutcome: 'paused',
             runStopReason: 'interaction',
             interactionResolution: 'cancelled'
+          }),
+          content: JSON.stringify([
+            {
+              type: 'action',
+              action_type: 'tool_call_permission',
+              status: 'pending',
+              timestamp: 1,
+              tool_call: { id: 'tc1' },
+              extra: { needsUserAction: true }
+            }
+          ])
+        }
+      ])
+
+      expect(store.recoverPendingMessages()).toBe(0)
+      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).not.toHaveBeenCalled()
+    })
+
+    it('does not keep an interaction after its pending action is settled', () => {
+      sqlitePresenter.deepchatMessagesTable.getByStatus.mockReturnValue([
+        {
+          id: 'm1',
+          session_id: 's1',
+          role: 'assistant',
+          status: 'pending',
+          metadata: JSON.stringify({
+            runId: 'paused-run',
+            runOutcome: 'paused',
+            runStopReason: 'interaction'
           }),
           content: JSON.stringify([
             {

--- a/test/main/session/data/transcript.test.ts
+++ b/test/main/session/data/transcript.test.ts
@@ -1286,6 +1286,11 @@ describe('SessionTranscript', () => {
       ])
 
       expect(store.recoverPendingMessages()).toBe(1)
+      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).not.toHaveBeenCalledWith(
+        'm1',
+        expect.anything(),
+        expect.anything()
+      )
       expect(sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage).toHaveBeenCalledWith(
         'm2',
         expect.any(Array)
@@ -1308,6 +1313,69 @@ describe('SessionTranscript', () => {
           timestamp: expect.any(Number)
         }
       ])
+    })
+
+    it('keeps a paused pending interaction across restart so it can still be cancelled', () => {
+      sqlitePresenter.deepchatMessagesTable.getByStatus.mockReturnValue([
+        {
+          id: 'm1',
+          session_id: 's1',
+          role: 'assistant',
+          status: 'pending',
+          metadata: JSON.stringify({
+            runId: 'paused-run',
+            runOutcome: 'paused',
+            runStopReason: 'interaction'
+          }),
+          content: JSON.stringify([
+            {
+              type: 'action',
+              action_type: 'tool_call_permission',
+              status: 'pending',
+              timestamp: 1,
+              tool_call: { id: 'tc1' },
+              extra: { needsUserAction: true }
+            }
+          ])
+        }
+      ])
+
+      expect(store.recoverPendingMessages()).toBe(0)
+      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).not.toHaveBeenCalled()
+    })
+
+    it('does not keep a cancelled interaction in pending restart recovery', () => {
+      sqlitePresenter.deepchatMessagesTable.getByStatus.mockReturnValue([
+        {
+          id: 'm1',
+          session_id: 's1',
+          role: 'assistant',
+          status: 'pending',
+          metadata: JSON.stringify({
+            runId: 'paused-run',
+            runOutcome: 'paused',
+            runStopReason: 'interaction',
+            interactionResolution: 'cancelled'
+          }),
+          content: JSON.stringify([
+            {
+              type: 'action',
+              action_type: 'tool_call_permission',
+              status: 'error',
+              timestamp: 1,
+              tool_call: { id: 'tc1' },
+              extra: { needsUserAction: false }
+            }
+          ])
+        }
+      ])
+
+      expect(store.recoverPendingMessages()).toBe(1)
+      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).toHaveBeenCalledWith(
+        'm1',
+        expect.any(String),
+        'error'
+      )
     })
 
     it('recovers a pending interaction when Journal evidence parks its message', () => {


### PR DESCRIPTION
## Summary

After a physical run pauses for a permission or question, later session-layer closes (cancel, follow-up, resume abort, ACP orphan) were overwriting `runOutcome` on the same `runId`. Journal already had an immutable `execution/run_terminal` of `paused`, so diagnostics looked contradictory.

This change splits the two layers. The same `runId` writes `runOutcome` once. Closes that do not start a new run write
`interactionResolution` (`cancelled` | `follow_up` | `error` | `pending_input`) and leave `paused` in place. A new `runId` may replace both identity and outcome. `user_follow_up` now finalizes through `finalizeAssistantMessage` so Tape gets a message fact. Execution Journal v1 is unchanged.

## Test plan

- [x] cancel-after-pause keeps `paused` + `cancelled`
- [x] question follow-up keeps `paused` + `follow_up`, status `sent`
- [x] resume budget / deferred post-dispatch / ACP orphan write `error`
- [x] resume abort before `run_started`: `pending_input` vs `cancelled`
- [x] restart keeps a still-pending pause; cancelled interactions stay closed

Closes #2123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction state tracking for cancellations, follow-up requests, pending input, and errors.
  * Preserved paused interaction details when recording cancellation or failure outcomes.
  * Prevented pending interactions from being incorrectly recovered after restart.
  * Improved handling of permission failures and stale interaction states.
  * Ensured follow-up requests and pending interactions retain the correct status until resolved.

* **Tests**
  * Expanded coverage for interaction completion, cancellation, recovery, permission handling, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->