### PR TITLE
fix(renderer): make body portals no-drag

### DIFF
--- a/src/renderer/src/assets/style.css
+++ b/src/renderer/src/assets/style.css
@@ -1168,4 +1168,16 @@
   html.dark *::-webkit-scrollbar-thumb:hover {
     background: rgba(148, 163, 184, 0.7);
   }
+
+  /*
+   * Layers teleported to <body> (reka-ui portals: dialog overlays/contents,
+   * popper wrappers of dropdowns, selects, tooltips) can stack above areas
+   * declaring `-webkit-app-region: drag` (AppBar, sidebar, welcome pages).
+   * Electron resolves drag regions from plain element geometry, ignoring
+   * z-index, so such a layer would swallow every mouse click as a window
+   * drag while only keyboard events get through.
+   */
+  body > :not(#app) {
+    -webkit-app-region: no-drag;
+  }
 }


### PR DESCRIPTION
Fixes #2170

## Root cause

With no conversation selected (fresh launch), the main area shows `AgentWelcomePage`, whose root element declares `-webkit-app-region: drag` across the whole pane. Electron resolves drag regions **geometrically** — z-index is ignored — so the delete-confirmation dialog, teleported to `<body>` and centered over that pane, sits entirely inside the OS drag region. Every mouse click on it is consumed as a window-drag hit; only keyboard events (Esc) get through.

The scoped `button { -webkit-app-region: no-drag }` rules in `WindowSideBar.vue` never reach the dialog: its DOM is teleported to `<body>` and the `data-v-*` scope attribute is not inherited through the portal (verified at runtime: the dialog buttons' computed `-webkit-app-region` was `none`).

Every overlay teleported to `<body>` (dialogs, dropdowns, selects, tooltips) has the same exposure — `SheetContent.vue` already carries an inline spot-fix for exactly this on its close button.

## Fix

One global rule in `style.css`: direct children of `<body>` other than `#app` (i.e. all portal layers — every renderer entry mounts at `#app`) are declared `no-drag`. Floating layers must never act as window drag handles. Chromium subtracts each no-drag element's rect from the drag region, so descendants need no extra declarations.

## BEFORE

```
+--------------------------------------------------+
| AppBar ==================================== drag |
|+---------+ +------------------------------------+|
|| sidebar | | AgentWelcomePage ============= drag ||
|| [del]<--+-+--- clickable (scoped no-drag)      ||
||         | |   +---------------------------+    ||
||         | |   | Delete this conversation? |    ||
||         | |   |       [Cancel] [Delete]<--+----++--- dead: inside OS
||         | |   +---------------------------+    ||     drag region, mouse
|+---------+ +------------------------------------+|     never reaches page
+--------------------------------------------------+
```

## AFTER

```
+--------------------------------------------------+
| AppBar ==================================== drag |
|+---------+ +------------------------------------+|
|| sidebar | | AgentWelcomePage ============= drag ||
||         | |   +---------------------------+    ||
||         | |   | Delete this conversation? |    ||
||         | |   |       [Cancel] [Delete]<--+----++--- clickable: portal
||         | |   +---------------------------+    ||     rect subtracted
|+---------+ +------------------------------------+|     from drag region
+--------------------------------------------------+
```

## Verification

- Runtime-inspected via CDP on the dev build: before the fix, dialog buttons sat inside the drag rect with computed `-webkit-app-region: none`; after, the dialog content/overlay and dropdown popper wrappers all resolve to `no-drag`.
- Cancel flow regression-checked: dialog opens/closes cleanly, no overlay residue.
- `format`, `i18n`, `lint`, `typecheck` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction with controls and portal-rendered interface elements by preventing unintended window dragging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->