### PR TITLE
fix(agent): stop silent empty file reads

### DIFF
--- a/src/main/file/mime.ts
+++ b/src/main/file/mime.ts
@@ -139,3 +139,22 @@ export const getMimeTypeAdapterMap = (): Map<string, FileAdapterConstructor> => 
 
   return map
 }
+
+const DOCUMENT_READ_ADAPTERS: ReadonlySet<FileAdapterConstructor> = new Set([
+  PdfFileAdapter,
+  DocFileAdapter,
+  ExcelFileAdapter,
+  PptFileAdapter,
+  OpenDocumentFileAdapter,
+  RtfFileAdapter
+])
+
+export const DOCUMENT_READ_MIMES: ReadonlySet<string> = new Set(
+  [...getMimeTypeAdapterMap().entries()]
+    .filter(([key, adapter]) => DOCUMENT_READ_ADAPTERS.has(adapter) && !key.includes('*'))
+    .map(([key]) => key)
+)
+
+export function isDocumentReadMime(mimeType: string): boolean {
+  return DOCUMENT_READ_MIMES.has(mimeType)
+}

--- a/src/main/file/mime.ts
+++ b/src/main/file/mime.ts
@@ -149,7 +149,7 @@ const DOCUMENT_READ_ADAPTERS: ReadonlySet<FileAdapterConstructor> = new Set([
   RtfFileAdapter
 ])
 
-export const DOCUMENT_READ_MIMES: ReadonlySet<string> = new Set(
+const DOCUMENT_READ_MIMES: ReadonlySet<string> = new Set(
   [...getMimeTypeAdapterMap().entries()]
     .filter(([key, adapter]) => DOCUMENT_READ_ADAPTERS.has(adapter) && !key.includes('*'))
     .map(([key]) => key)

--- a/src/main/lib/binaryReadGuard.ts
+++ b/src/main/lib/binaryReadGuard.ts
@@ -1,5 +1,8 @@
 import path from 'path'
-import { detectMimeType, isLikelyTextFile } from '@/file/mime'
+import { detectMimeType, isDocumentReadMime, isLikelyTextFile } from '@/file/mime'
+import { DEFAULT_AGENT_OUTPUT_LIMITS } from '@shared/lib/agentOutputLimits'
+
+export { isDocumentReadMime }
 
 const TEXT_LIKE_MIMES = new Set([
   'application/json',
@@ -22,51 +25,9 @@ const ALWAYS_BINARY_MIMES = new Set([
 ])
 
 const NUL_SNIFF_BYTES = 8192
+const UTF16BE_DECODER = new TextDecoder('utf-16be')
 
-/**
- * Concrete document MIME keys whose adapters extract structured text for `read`.
- * Wildcard adapter keys are excluded because findAdapterForMimeType never selects them
- * as document extractors (`text/*` is a text adapter, not a document one).
- */
-export const DOCUMENT_READ_MIMES: ReadonlySet<string> = new Set([
-  'application/pdf',
-  'application/msword',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'application/vnd.ms-word.document.macroenabled.12',
-  'application/vnd.ms-word.document.macroEnabled.12',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
-  'application/vnd.ms-word.template.macroenabled.12',
-  'application/vnd.ms-word.template.macroEnabled.12',
-  'application/vnd.ms-excel',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  'application/vnd.ms-excel.sheet.macroenabled.12',
-  'application/vnd.ms-excel.sheet.macroEnabled.12',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
-  'application/vnd.ms-excel.template.macroenabled.12',
-  'application/vnd.ms-excel.template.macroEnabled.12',
-  'application/vnd.oasis.opendocument.spreadsheet',
-  'application/vnd.ms-excel.sheet.binary.macroEnabled.12',
-  'application/vnd.ms-excel.sheet.binary.macroenabled.12',
-  'application/vnd.ms-excel.addin.macroenabled.12',
-  'application/vnd.ms-excel.addin.macroEnabled.12',
-  'application/vnd.apple.numbers',
-  'application/vnd.ms-powerpoint',
-  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-  'application/vnd.ms-powerpoint.presentation.macroenabled.12',
-  'application/vnd.ms-powerpoint.presentation.macroEnabled.12',
-  'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
-  'application/vnd.ms-powerpoint.slideshow.macroenabled.12',
-  'application/vnd.ms-powerpoint.slideshow.macroEnabled.12',
-  'application/vnd.openxmlformats-officedocument.presentationml.template',
-  'application/vnd.ms-powerpoint.template.macroenabled.12',
-  'application/vnd.ms-powerpoint.template.macroEnabled.12',
-  'application/vnd.oasis.opendocument.text',
-  'application/vnd.oasis.opendocument.presentation',
-  'application/rtf',
-  'text/rtf',
-  'text/csv',
-  'text/tab-separated-values'
-])
+export const AGENT_RAW_READ_MAX_BYTES = 10 * 1024 * 1024
 
 export type AgentFileDecodeResult = { kind: 'text'; content: string } | { kind: 'binary' }
 
@@ -104,30 +65,72 @@ export function shouldRejectAgentBinaryRead(mimeType: string): boolean {
   )
 }
 
-export function isDocumentReadMime(mimeType: string): boolean {
-  return DOCUMENT_READ_MIMES.has(mimeType)
-}
-
-export function decodeAgentFileBytes(bytes: Uint8Array): AgentFileDecodeResult {
+export function decodeAgentFileBytes(bytes: Buffer): AgentFileDecodeResult {
   if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe) {
-    return { kind: 'text', content: toBuffer(bytes.subarray(2)).toString('utf16le') }
+    // Node Buffer has utf16le but no utf16be.
+    return { kind: 'text', content: bytes.subarray(2).toString('utf16le') }
   }
   if (bytes.length >= 2 && bytes[0] === 0xfe && bytes[1] === 0xff) {
-    return { kind: 'text', content: new TextDecoder('utf-16be').decode(bytes.subarray(2)) }
+    return { kind: 'text', content: UTF16BE_DECODER.decode(bytes.subarray(2)) }
   }
-  if (bytes.subarray(0, Math.min(bytes.length, NUL_SNIFF_BYTES)).includes(0)) {
+  if (bytes.subarray(0, NUL_SNIFF_BYTES).includes(0)) {
     return { kind: 'binary' }
   }
-  return {
-    kind: 'text',
-    content: toBuffer(bytes)
-      .toString('utf8')
-      .replace(/^\uFEFF/, '')
-  }
+  return { kind: 'text', content: bytes.toString('utf8').replace(/^\uFEFF/, '') }
 }
 
-function toBuffer(bytes: Uint8Array): Buffer {
-  return Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes)
+export function paginateReadContent(
+  pathLabel: string,
+  fullContent: string,
+  offset?: number,
+  limit?: number,
+  autoTruncateChars = DEFAULT_AGENT_OUTPUT_LIMITS.readFileAutoTruncateChars
+): string {
+  const start = Math.max(0, offset ?? 0)
+  const totalLength = fullContent.length
+
+  let effectiveLimit = limit
+  let autoTruncated = false
+  if (effectiveLimit === undefined && totalLength - start > autoTruncateChars) {
+    effectiveLimit = autoTruncateChars
+    autoTruncated = true
+  }
+
+  const content =
+    effectiveLimit !== undefined
+      ? fullContent.slice(start, start + effectiveLimit)
+      : fullContent.slice(start)
+  const endOffset = start + content.length
+
+  if (start > 0 || limit !== undefined || autoTruncated) {
+    let header = `${pathLabel} [chars ${start}-${endOffset} of ${totalLength}]`
+    if (autoTruncated) {
+      header += ' (auto-truncated, use offset/limit to read more)'
+    }
+    return `${header}:\n${content}\n`
+  }
+
+  return `${pathLabel}:\n${content}\n`
+}
+
+export function buildOversizedReadGuidance(
+  filePath: string,
+  fileSize: number,
+  limitBytes: number
+): string {
+  return `File too large: "${path.basename(filePath)}" is ${fileSize} bytes (limit ${limitBytes}).`
+}
+
+export function buildEmptyDocumentReadGuidance(
+  filePath: string,
+  mimeType: string,
+  fileSize: number
+): string {
+  return [
+    `Cannot extract text from "${path.basename(filePath)}" (detected MIME: ${mimeType}).`,
+    'The file may exceed the 30MB document limit, be damaged, or contain no extractable text layer.',
+    `File size: ${fileSize} bytes.`
+  ].join(' ')
 }
 
 export function buildBinaryReadGuidance(
@@ -143,6 +146,13 @@ export function buildBinaryReadGuidance(
       shared,
       '`fs/read_text_file` only supports text files.',
       'Use OCR/image tooling for images, and convert or extract PDFs/binary formats before reading them as text.'
+    ].join(' ')
+  }
+
+  if (isTextLikeMime(mimeType)) {
+    return [
+      shared,
+      'The file contains NUL bytes and may be UTF-16 without a BOM. Convert it to UTF-8 and retry.'
     ].join(' ')
   }
 

--- a/src/main/lib/binaryReadGuard.ts
+++ b/src/main/lib/binaryReadGuard.ts
@@ -1,8 +1,5 @@
 import path from 'path'
-import { detectMimeType, isDocumentReadMime, isLikelyTextFile } from '@/file/mime'
-import { DEFAULT_AGENT_OUTPUT_LIMITS } from '@shared/lib/agentOutputLimits'
-
-export { isDocumentReadMime }
+import { detectMimeType, isLikelyTextFile } from '@/file/mime'
 
 const TEXT_LIKE_MIMES = new Set([
   'application/json',
@@ -12,6 +9,17 @@ const TEXT_LIKE_MIMES = new Set([
   'application/typescript',
   'application/x-typescript',
   'application/x-sh'
+])
+
+const AGENT_ENCODING_HINT_MIMES = new Set([
+  'application/toml',
+  'application/sql',
+  'application/rls-services+xml',
+  'application/x-httpd-php',
+  'application/node',
+  'application/x-ipynb+json',
+  'application/x-yaml',
+  'application/yaml'
 ])
 
 const ALWAYS_BINARY_MIMES = new Set([
@@ -28,11 +36,16 @@ const NUL_SNIFF_BYTES = 8192
 const UTF16BE_DECODER = new TextDecoder('utf-16be')
 
 export const AGENT_RAW_READ_MAX_BYTES = 10 * 1024 * 1024
+export const DEFAULT_DOCUMENT_READ_MAX_BYTES = 30 * 1024 * 1024
 
-export type AgentFileDecodeResult = { kind: 'text'; content: string } | { kind: 'binary' }
+type AgentFileDecodeResult = { kind: 'text'; content: string } | { kind: 'binary' }
 
-export function isTextLikeMime(mimeType: string): boolean {
+function isTextLikeMime(mimeType: string): boolean {
   return mimeType.startsWith('text/') || TEXT_LIKE_MIMES.has(mimeType)
+}
+
+function shouldHintUtf16WithoutBom(mimeType: string): boolean {
+  return isTextLikeMime(mimeType) || AGENT_ENCODING_HINT_MIMES.has(mimeType)
 }
 
 export async function shouldRejectAcpTextRead(filePath: string): Promise<{
@@ -82,9 +95,10 @@ export function decodeAgentFileBytes(bytes: Buffer): AgentFileDecodeResult {
 export function paginateReadContent(
   pathLabel: string,
   fullContent: string,
-  offset?: number,
-  limit?: number,
-  autoTruncateChars = DEFAULT_AGENT_OUTPUT_LIMITS.readFileAutoTruncateChars
+  offset: number | undefined,
+  limit: number | undefined,
+  autoTruncateChars: number,
+  byteWindow?: { readBytes: number; totalBytes: number }
 ): string {
   const start = Math.max(0, offset ?? 0)
   const totalLength = fullContent.length
@@ -101,16 +115,25 @@ export function paginateReadContent(
       ? fullContent.slice(start, start + effectiveLimit)
       : fullContent.slice(start)
   const endOffset = start + content.length
+  const truncatedByBytes = byteWindow !== undefined && byteWindow.readBytes < byteWindow.totalBytes
+  const needsHeader = start > 0 || limit !== undefined || autoTruncated || truncatedByBytes
 
-  if (start > 0 || limit !== undefined || autoTruncated) {
-    let header = `${pathLabel} [chars ${start}-${endOffset} of ${totalLength}]`
-    if (autoTruncated) {
-      header += ' (auto-truncated, use offset/limit to read more)'
-    }
-    return `${header}:\n${content}\n`
+  if (!needsHeader) {
+    return `${pathLabel}:\n${content}\n`
   }
 
-  return `${pathLabel}:\n${content}\n`
+  const parts: string[] = []
+  if (truncatedByBytes && byteWindow) {
+    parts.push(`first ${byteWindow.readBytes} of ${byteWindow.totalBytes} bytes`)
+  }
+  if (start > 0 || limit !== undefined || autoTruncated) {
+    parts.push(`chars ${start}-${endOffset} of ${totalLength}`)
+  }
+  let header = `${pathLabel} [${parts.join('; ')}]`
+  if (autoTruncated) {
+    header += ' (auto-truncated, use offset/limit to read more)'
+  }
+  return `${header}:\n${content}\n`
 }
 
 export function buildOversizedReadGuidance(
@@ -124,12 +147,13 @@ export function buildOversizedReadGuidance(
 export function buildEmptyDocumentReadGuidance(
   filePath: string,
   mimeType: string,
-  fileSize: number
+  fileSize: number,
+  maxFileSize: number
 ): string {
   return [
     `Cannot extract text from "${path.basename(filePath)}" (detected MIME: ${mimeType}).`,
-    'The file may exceed the 30MB document limit, be damaged, or contain no extractable text layer.',
-    `File size: ${fileSize} bytes.`
+    'The file may be damaged or contain no extractable text layer.',
+    `File size: ${fileSize} bytes (document limit ${maxFileSize} bytes).`
   ].join(' ')
 }
 
@@ -149,7 +173,7 @@ export function buildBinaryReadGuidance(
     ].join(' ')
   }
 
-  if (isTextLikeMime(mimeType)) {
+  if (shouldHintUtf16WithoutBom(mimeType)) {
     return [
       shared,
       'The file contains NUL bytes and may be UTF-16 without a BOM. Convert it to UTF-8 and retry.'

--- a/src/main/lib/binaryReadGuard.ts
+++ b/src/main/lib/binaryReadGuard.ts
@@ -21,6 +21,55 @@ const ALWAYS_BINARY_MIMES = new Set([
   'application/wasm'
 ])
 
+const NUL_SNIFF_BYTES = 8192
+
+/**
+ * Concrete document MIME keys whose adapters extract structured text for `read`.
+ * Wildcard adapter keys are excluded because findAdapterForMimeType never selects them
+ * as document extractors (`text/*` is a text adapter, not a document one).
+ */
+export const DOCUMENT_READ_MIMES: ReadonlySet<string> = new Set([
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-word.document.macroenabled.12',
+  'application/vnd.ms-word.document.macroEnabled.12',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
+  'application/vnd.ms-word.template.macroenabled.12',
+  'application/vnd.ms-word.template.macroEnabled.12',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel.sheet.macroenabled.12',
+  'application/vnd.ms-excel.sheet.macroEnabled.12',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
+  'application/vnd.ms-excel.template.macroenabled.12',
+  'application/vnd.ms-excel.template.macroEnabled.12',
+  'application/vnd.oasis.opendocument.spreadsheet',
+  'application/vnd.ms-excel.sheet.binary.macroEnabled.12',
+  'application/vnd.ms-excel.sheet.binary.macroenabled.12',
+  'application/vnd.ms-excel.addin.macroenabled.12',
+  'application/vnd.ms-excel.addin.macroEnabled.12',
+  'application/vnd.apple.numbers',
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/vnd.ms-powerpoint.presentation.macroenabled.12',
+  'application/vnd.ms-powerpoint.presentation.macroEnabled.12',
+  'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
+  'application/vnd.ms-powerpoint.slideshow.macroenabled.12',
+  'application/vnd.ms-powerpoint.slideshow.macroEnabled.12',
+  'application/vnd.openxmlformats-officedocument.presentationml.template',
+  'application/vnd.ms-powerpoint.template.macroenabled.12',
+  'application/vnd.ms-powerpoint.template.macroEnabled.12',
+  'application/vnd.oasis.opendocument.text',
+  'application/vnd.oasis.opendocument.presentation',
+  'application/rtf',
+  'text/rtf',
+  'text/csv',
+  'text/tab-separated-values'
+])
+
+export type AgentFileDecodeResult = { kind: 'text'; content: string } | { kind: 'binary' }
+
 export function isTextLikeMime(mimeType: string): boolean {
   return mimeType.startsWith('text/') || TEXT_LIKE_MIMES.has(mimeType)
 }
@@ -53,6 +102,32 @@ export function shouldRejectAgentBinaryRead(mimeType: string): boolean {
     mimeType.startsWith('audio/') ||
     mimeType.startsWith('video/')
   )
+}
+
+export function isDocumentReadMime(mimeType: string): boolean {
+  return DOCUMENT_READ_MIMES.has(mimeType)
+}
+
+export function decodeAgentFileBytes(bytes: Uint8Array): AgentFileDecodeResult {
+  if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe) {
+    return { kind: 'text', content: toBuffer(bytes.subarray(2)).toString('utf16le') }
+  }
+  if (bytes.length >= 2 && bytes[0] === 0xfe && bytes[1] === 0xff) {
+    return { kind: 'text', content: new TextDecoder('utf-16be').decode(bytes.subarray(2)) }
+  }
+  if (bytes.subarray(0, Math.min(bytes.length, NUL_SNIFF_BYTES)).includes(0)) {
+    return { kind: 'binary' }
+  }
+  return {
+    kind: 'text',
+    content: toBuffer(bytes)
+      .toString('utf8')
+      .replace(/^\uFEFF/, '')
+  }
+}
+
+function toBuffer(bytes: Uint8Array): Buffer {
+  return Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes)
 }
 
 export function buildBinaryReadGuidance(

--- a/src/main/tool/agentTools/agentFileSystemHandler.ts
+++ b/src/main/tool/agentTools/agentFileSystemHandler.ts
@@ -12,7 +12,13 @@ import { glob } from 'glob'
 import type { CommandShellPathStyle } from '@shared/commandShell'
 import { normalizeCommandShellFilePath } from '@/agent/shared/process/commandShellPath'
 import { DEFAULT_AGENT_OUTPUT_LIMITS } from '@shared/lib/agentOutputLimits'
-import { buildBinaryReadGuidance, decodeAgentFileBytes } from '@/lib/binaryReadGuard'
+import {
+  AGENT_RAW_READ_MAX_BYTES,
+  buildBinaryReadGuidance,
+  buildOversizedReadGuidance,
+  decodeAgentFileBytes,
+  paginateReadContent
+} from '@/lib/binaryReadGuard'
 
 const ReadFileArgsSchema = z.object({
   paths: z.array(z.string()).min(1).describe('Array of file paths to read'),
@@ -125,7 +131,9 @@ interface FileMutationOptions {
 }
 
 interface FileReadOptions {
-  binaryMimeType?: string
+  mimeType: string
+  autoTruncateChars?: number
+  maxReadBytes?: number
 }
 
 interface GrepMatch {
@@ -845,8 +853,8 @@ export class AgentFileSystemHandler {
 
   async readFile(
     args: unknown,
-    baseDirectory?: string,
-    options: FileReadOptions = {}
+    baseDirectory: string | undefined,
+    options: FileReadOptions
   ): Promise<string> {
     const parsed = ReadFileArgsSchema.safeParse(args)
     if (!parsed.success) {
@@ -862,46 +870,23 @@ export class AgentFileSystemHandler {
             enforceAllowed: false,
             accessType: 'read'
           })
+          const stats = await fs.stat(validPath)
+          const maxReadBytes = options.maxReadBytes ?? AGENT_RAW_READ_MAX_BYTES
+          if (stats.size > maxReadBytes) {
+            return buildOversizedReadGuidance(filePath, stats.size, maxReadBytes)
+          }
           const bytes = await fs.readFile(validPath)
           const decoded = decodeAgentFileBytes(bytes)
           if (decoded.kind === 'binary') {
-            return buildBinaryReadGuidance(
-              filePath,
-              options.binaryMimeType ?? 'application/octet-stream',
-              'agent'
-            )
+            return buildBinaryReadGuidance(filePath, options.mimeType, 'agent')
           }
-          const fullContent = decoded.content
-          const totalLength = fullContent.length
-
-          // Determine effective limit
-          let effectiveLimit = limit
-          let autoTruncated = false
-
-          // Auto-truncate large files when no explicit limit specified
-          if (limit === undefined && totalLength - offset > this.readFileAutoTruncateChars) {
-            effectiveLimit = this.readFileAutoTruncateChars
-            autoTruncated = true
-          }
-
-          // Apply offset and limit
-          const content =
-            effectiveLimit !== undefined
-              ? fullContent.slice(offset, offset + effectiveLimit)
-              : fullContent.slice(offset)
-
-          const endOffset = offset + content.length
-
-          // Build result with metadata when pagination is active or auto-truncated
-          if (offset > 0 || limit !== undefined || autoTruncated) {
-            let header = `${filePath} [chars ${offset}-${endOffset} of ${totalLength}]`
-            if (autoTruncated) {
-              header += ` (auto-truncated, use offset/limit to read more)`
-            }
-            return `${header}:\n${content}\n`
-          }
-
-          return `${filePath}:\n${content}\n`
+          return paginateReadContent(
+            filePath,
+            decoded.content,
+            offset,
+            limit,
+            options.autoTruncateChars ?? this.readFileAutoTruncateChars
+          )
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error)
           return `${filePath}: Error - ${errorMessage}`

--- a/src/main/tool/agentTools/agentFileSystemHandler.ts
+++ b/src/main/tool/agentTools/agentFileSystemHandler.ts
@@ -12,6 +12,7 @@ import { glob } from 'glob'
 import type { CommandShellPathStyle } from '@shared/commandShell'
 import { normalizeCommandShellFilePath } from '@/agent/shared/process/commandShellPath'
 import { DEFAULT_AGENT_OUTPUT_LIMITS } from '@shared/lib/agentOutputLimits'
+import { buildBinaryReadGuidance, decodeAgentFileBytes } from '@/lib/binaryReadGuard'
 
 const ReadFileArgsSchema = z.object({
   paths: z.array(z.string()).min(1).describe('Array of file paths to read'),
@@ -121,6 +122,10 @@ const GetFileInfoArgsSchema = z.object({
 
 interface FileMutationOptions {
   beforeMutation?: () => void
+}
+
+interface FileReadOptions {
+  binaryMimeType?: string
 }
 
 interface GrepMatch {
@@ -838,7 +843,11 @@ export class AgentFileSystemHandler {
     }
   }
 
-  async readFile(args: unknown, baseDirectory?: string): Promise<string> {
+  async readFile(
+    args: unknown,
+    baseDirectory?: string,
+    options: FileReadOptions = {}
+  ): Promise<string> {
     const parsed = ReadFileArgsSchema.safeParse(args)
     if (!parsed.success) {
       throw new Error(`Invalid arguments: ${parsed.error}`)
@@ -854,14 +863,15 @@ export class AgentFileSystemHandler {
             accessType: 'read'
           })
           const bytes = await fs.readFile(validPath)
-          let fullContent: string
-          if (bytes[0] === 0xff && bytes[1] === 0xfe) {
-            fullContent = bytes.subarray(2).toString('utf16le')
-          } else if (bytes[0] === 0xfe && bytes[1] === 0xff) {
-            fullContent = new TextDecoder('utf-16be').decode(bytes.subarray(2))
-          } else {
-            fullContent = bytes.toString('utf8').replace(/^\uFEFF/, '')
+          const decoded = decodeAgentFileBytes(bytes)
+          if (decoded.kind === 'binary') {
+            return buildBinaryReadGuidance(
+              filePath,
+              options.binaryMimeType ?? 'application/octet-stream',
+              'agent'
+            )
           }
+          const fullContent = decoded.content
           const totalLength = fullContent.length
 
           // Determine effective limit

--- a/src/main/tool/agentTools/agentFileSystemHandler.ts
+++ b/src/main/tool/agentTools/agentFileSystemHandler.ts
@@ -134,24 +134,7 @@ interface FileReadOptions {
   maxReadBytes?: number
 }
 
-async function readFully(
-  handle: Awaited<ReturnType<typeof fs.open>>,
-  targetBytes: number
-): Promise<Buffer> {
-  if (targetBytes <= 0) {
-    return Buffer.alloc(0)
-  }
-  const bytes = Buffer.alloc(targetBytes)
-  let offset = 0
-  while (offset < targetBytes) {
-    const { bytesRead } = await handle.read(bytes, offset, targetBytes - offset, offset)
-    if (bytesRead === 0) {
-      return bytes.subarray(0, offset)
-    }
-    offset += bytesRead
-  }
-  return bytes
-}
+const READ_CHUNK_BYTES = 64 * 1024
 
 async function readFileWindow(
   filePath: string,
@@ -160,11 +143,29 @@ async function readFileWindow(
   const handle = await fs.open(filePath, 'r')
   try {
     const { size } = await handle.stat()
-    const target = size > 0 ? Math.min(size, maxReadBytes) : maxReadBytes
-    const bytes = await readFully(handle, target)
-    // Size-0 files can still have content. A full window then means more remains.
-    const totalBytes =
-      size > 0 ? size : bytes.length === maxReadBytes ? bytes.length + 1 : bytes.length
+    const chunks: Buffer[] = []
+    let offset = 0
+    while (offset < maxReadBytes) {
+      const want = Math.min(READ_CHUNK_BYTES, maxReadBytes - offset)
+      const chunk = Buffer.alloc(want)
+      const { bytesRead } = await handle.read(chunk, 0, want, offset)
+      if (bytesRead === 0) {
+        break
+      }
+      chunks.push(bytesRead === want ? chunk : chunk.subarray(0, bytesRead))
+      offset += bytesRead
+      if (bytesRead < want) {
+        break
+      }
+    }
+    const bytes = Buffer.concat(chunks, offset)
+    let truncated = false
+    if (offset === maxReadBytes) {
+      const peek = Buffer.alloc(1)
+      const { bytesRead } = await handle.read(peek, 0, 1, offset)
+      truncated = bytesRead > 0
+    }
+    const totalBytes = truncated ? Math.max(size, bytes.length + 1) : bytes.length
     return { bytes, totalBytes }
   } finally {
     await handle.close()

--- a/src/main/tool/agentTools/agentFileSystemHandler.ts
+++ b/src/main/tool/agentTools/agentFileSystemHandler.ts
@@ -132,18 +132,40 @@ interface FileReadOptions {
   mimeType: string
   autoTruncateChars: number
   maxReadBytes?: number
-  fileSize?: number
 }
 
-async function readFileWindow(filePath: string, windowSize: number): Promise<Buffer> {
-  if (windowSize <= 0) {
+async function readFully(
+  handle: Awaited<ReturnType<typeof fs.open>>,
+  targetBytes: number
+): Promise<Buffer> {
+  if (targetBytes <= 0) {
     return Buffer.alloc(0)
   }
+  const bytes = Buffer.alloc(targetBytes)
+  let offset = 0
+  while (offset < targetBytes) {
+    const { bytesRead } = await handle.read(bytes, offset, targetBytes - offset, offset)
+    if (bytesRead === 0) {
+      return bytes.subarray(0, offset)
+    }
+    offset += bytesRead
+  }
+  return bytes
+}
+
+async function readFileWindow(
+  filePath: string,
+  maxReadBytes: number
+): Promise<{ bytes: Buffer; totalBytes: number }> {
   const handle = await fs.open(filePath, 'r')
   try {
-    const bytes = Buffer.alloc(windowSize)
-    const { bytesRead } = await handle.read(bytes, 0, windowSize, 0)
-    return bytesRead === windowSize ? bytes : bytes.subarray(0, bytesRead)
+    const { size } = await handle.stat()
+    const target = size > 0 ? Math.min(size, maxReadBytes) : maxReadBytes
+    const bytes = await readFully(handle, target)
+    // Size-0 files can still have content. A full window then means more remains.
+    const totalBytes =
+      size > 0 ? size : bytes.length === maxReadBytes ? bytes.length + 1 : bytes.length
+    return { bytes, totalBytes }
   } finally {
     await handle.close()
   }
@@ -879,10 +901,8 @@ export class AgentFileSystemHandler {
             enforceAllowed: false,
             accessType: 'read'
           })
-          const fileSize = options.fileSize ?? (await fs.stat(validPath)).size
           const maxReadBytes = options.maxReadBytes ?? AGENT_RAW_READ_MAX_BYTES
-          const windowSize = Math.min(fileSize, maxReadBytes)
-          const bytes = await readFileWindow(validPath, windowSize)
+          const { bytes, totalBytes } = await readFileWindow(validPath, maxReadBytes)
           const decoded = decodeAgentFileBytes(bytes)
           if (decoded.kind === 'binary') {
             return buildBinaryReadGuidance(filePath, options.mimeType, 'agent')
@@ -893,7 +913,7 @@ export class AgentFileSystemHandler {
             offset,
             limit,
             options.autoTruncateChars,
-            windowSize < fileSize ? { readBytes: bytes.length, totalBytes: fileSize } : undefined
+            bytes.length < totalBytes ? { readBytes: bytes.length, totalBytes } : undefined
           )
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error)

--- a/src/main/tool/agentTools/agentFileSystemHandler.ts
+++ b/src/main/tool/agentTools/agentFileSystemHandler.ts
@@ -11,11 +11,9 @@ import { getLanguageFromFilename } from '@shared/utils/codeLanguage'
 import { glob } from 'glob'
 import type { CommandShellPathStyle } from '@shared/commandShell'
 import { normalizeCommandShellFilePath } from '@/agent/shared/process/commandShellPath'
-import { DEFAULT_AGENT_OUTPUT_LIMITS } from '@shared/lib/agentOutputLimits'
 import {
   AGENT_RAW_READ_MAX_BYTES,
   buildBinaryReadGuidance,
-  buildOversizedReadGuidance,
   decodeAgentFileBytes,
   paginateReadContent
 } from '@/lib/binaryReadGuard'
@@ -132,8 +130,23 @@ interface FileMutationOptions {
 
 interface FileReadOptions {
   mimeType: string
-  autoTruncateChars?: number
+  autoTruncateChars: number
   maxReadBytes?: number
+  fileSize?: number
+}
+
+async function readFileWindow(filePath: string, windowSize: number): Promise<Buffer> {
+  if (windowSize <= 0) {
+    return Buffer.alloc(0)
+  }
+  const handle = await fs.open(filePath, 'r')
+  try {
+    const bytes = Buffer.alloc(windowSize)
+    const { bytesRead } = await handle.read(bytes, 0, windowSize, 0)
+    return bytesRead === windowSize ? bytes : bytes.subarray(0, bytesRead)
+  } finally {
+    await handle.close()
+  }
 }
 
 interface GrepMatch {
@@ -211,7 +224,6 @@ export class AgentFileSystemHandler {
   private readonly commandShellPathStyle: CommandShellPathStyle
   private readonly pathApi: path.PlatformPath
   private readonly caseInsensitivePathComparison: boolean
-  private readonly readFileAutoTruncateChars: number
   private readonly protectedDirectoryRules: Array<{
     roots: string[]
     allowedRoots: string[]
@@ -222,7 +234,6 @@ export class AgentFileSystemHandler {
     options: {
       conversationId?: string
       allowExternalAccess?: boolean
-      readFileAutoTruncateChars?: number
       protectedDirectoryRules?: ProtectedDirectoryRule[]
       commandShellPathStyle?: CommandShellPathStyle
     } = {}
@@ -253,8 +264,6 @@ export class AgentFileSystemHandler {
     this.conversationId = options.conversationId
     this.sessionsRoot = this.normalizePath(getSessionsRoot())
     this.allowExternalAccess = options.allowExternalAccess === true
-    this.readFileAutoTruncateChars =
-      options.readFileAutoTruncateChars ?? DEFAULT_AGENT_OUTPUT_LIMITS.readFileAutoTruncateChars
     this.protectedDirectoryRules = (options.protectedDirectoryRules ?? []).map((rule) => ({
       roots: this.resolveDirectoryRoots([rule.root]),
       allowedRoots: this.resolveDirectoryRoots(rule.allowedDirectories)
@@ -870,12 +879,10 @@ export class AgentFileSystemHandler {
             enforceAllowed: false,
             accessType: 'read'
           })
-          const stats = await fs.stat(validPath)
+          const fileSize = options.fileSize ?? (await fs.stat(validPath)).size
           const maxReadBytes = options.maxReadBytes ?? AGENT_RAW_READ_MAX_BYTES
-          if (stats.size > maxReadBytes) {
-            return buildOversizedReadGuidance(filePath, stats.size, maxReadBytes)
-          }
-          const bytes = await fs.readFile(validPath)
+          const windowSize = Math.min(fileSize, maxReadBytes)
+          const bytes = await readFileWindow(validPath, windowSize)
           const decoded = decodeAgentFileBytes(bytes)
           if (decoded.kind === 'binary') {
             return buildBinaryReadGuidance(filePath, options.mimeType, 'agent')
@@ -885,7 +892,8 @@ export class AgentFileSystemHandler {
             decoded.content,
             offset,
             limit,
-            options.autoTruncateChars ?? this.readFileAutoTruncateChars
+            options.autoTruncateChars,
+            windowSize < fileSize ? { readBytes: bytes.length, totalBytes: fileSize } : undefined
           )
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error)

--- a/src/main/tool/agentTools/agentToolManager.ts
+++ b/src/main/tool/agentTools/agentToolManager.ts
@@ -1090,8 +1090,16 @@ export class AgentToolManager {
         type: 'function',
         function: {
           name: 'read',
-          description:
-            "Read the contents of a file. Supports pagination via offset/limit for large files (auto-truncated using the Agent's configured output limit if not specified). Files larger than 10MB return only the first 10MB. Office and PDF files return extracted text, not the original binary. For image files, returns an English description of visible content instead of raw pixels. When invoked from a skill context with relative paths, provide base_directory as the skill's root directory.",
+          description: [
+            'Read the contents of a file.',
+            'Supports pagination via offset/limit for large files',
+            '(auto-truncated using the configured Agent output limit if not specified).',
+            'Raw text reads return only the first 10MB.',
+            'Office and PDF files return extracted text, not the original binary,',
+            'and follow the configured document size limit.',
+            'For image files, returns an English description of visible content instead of raw pixels.',
+            'When invoked from a skill context with relative paths, provide base_directory as the skill root directory.'
+          ].join(' '),
           parameters: toDeepChatJsonSchema(schemas.read) as {
             type: string
             properties: Record<string, unknown>

--- a/src/main/tool/agentTools/agentToolManager.ts
+++ b/src/main/tool/agentTools/agentToolManager.ts
@@ -1091,7 +1091,7 @@ export class AgentToolManager {
         function: {
           name: 'read',
           description:
-            "Read the contents of a file. Supports pagination via offset/limit for large files (auto-truncated using the Agent's configured output limit if not specified). For image files, returns an English description of visible content instead of raw pixels. When invoked from a skill context with relative paths, provide base_directory as the skill's root directory.",
+            "Read the contents of a file. Supports pagination via offset/limit for large files (auto-truncated using the Agent's configured output limit if not specified). Files larger than 10MB return only the first 10MB. Office and PDF files return extracted text, not the original binary. For image files, returns an English description of visible content instead of raw pixels. When invoked from a skill context with relative paths, provide base_directory as the skill's root directory.",
           parameters: toDeepChatJsonSchema(schemas.read) as {
             type: string
             properties: Record<string, unknown>
@@ -1698,8 +1698,7 @@ export class AgentToolManager {
               baseDirectory,
               {
                 mimeType,
-                autoTruncateChars: readOutputLimits.readFileAutoTruncateChars,
-                fileSize
+                autoTruncateChars: readOutputLimits.readFileAutoTruncateChars
               }
             )
           }

--- a/src/main/tool/agentTools/agentToolManager.ts
+++ b/src/main/tool/agentTools/agentToolManager.ts
@@ -27,10 +27,12 @@ import {
   SKILL_RUNTIME_VIEW_RESULT_MAX_BYTES,
   type SkillManageResult
 } from '@shared/types/skill'
+import { isDocumentReadMime } from '@/file/mime'
 import {
   buildBinaryReadGuidance,
   buildEmptyDocumentReadGuidance,
-  isDocumentReadMime,
+  buildOversizedReadGuidance,
+  DEFAULT_DOCUMENT_READ_MAX_BYTES,
   paginateReadContent,
   shouldRejectAgentBinaryRead
 } from '@/lib/binaryReadGuard'
@@ -1624,7 +1626,7 @@ export class AgentToolManager {
             offset?: number
             limit?: number
           }
-          const validPath = await this.resolveValidatedReadPath(
+          const { path: validPath, size: fileSize } = await this.resolveValidatedReadPath(
             fileSystemHandler,
             readArgs.path,
             baseDirectory,
@@ -1658,6 +1660,12 @@ export class AgentToolManager {
           const readOutputLimits = await this.resolveOutputLimitsForConversation(conversationId)
 
           if (isDocumentReadMime(mimeType)) {
+            const maxFileSize = this.resolveDocumentMaxFileSize()
+            if (fileSize > maxFileSize) {
+              return {
+                content: buildOversizedReadGuidance(validPath, fileSize, maxFileSize)
+              }
+            }
             const prepared = await this.getFileService().prepareFileCompletely(
               validPath,
               mimeType,
@@ -1665,9 +1673,8 @@ export class AgentToolManager {
             )
             const extracted = prepared.content ?? ''
             if (extracted.trim().length === 0) {
-              const fileSize = (await fs.promises.stat(validPath)).size
               return {
-                content: buildEmptyDocumentReadGuidance(validPath, mimeType, fileSize)
+                content: buildEmptyDocumentReadGuidance(validPath, mimeType, fileSize, maxFileSize)
               }
             }
             return {
@@ -1691,7 +1698,8 @@ export class AgentToolManager {
               baseDirectory,
               {
                 mimeType,
-                autoTruncateChars: readOutputLimits.readFileAutoTruncateChars
+                autoTruncateChars: readOutputLimits.readFileAutoTruncateChars,
+                fileSize
               }
             )
           }
@@ -2386,7 +2394,7 @@ export class AgentToolManager {
     requestedPath: string,
     baseDirectory?: string,
     allowExternalFileAccess = false
-  ): Promise<string> {
+  ): Promise<{ path: string; size: number }> {
     const resolvedPath = fileSystemHandler.resolvePath(requestedPath, baseDirectory)
     fileSystemHandler.assertReadAllowedAbsolute(resolvedPath)
     if (!allowExternalFileAccess && !fileSystemHandler.isPathAllowedAbsolute(resolvedPath)) {
@@ -2414,7 +2422,11 @@ export class AgentToolManager {
       throw new Error(`Path is not a file: ${requestedPath}`)
     }
 
-    return pathForRead
+    return { path: pathForRead, size: stats.size }
+  }
+
+  private resolveDocumentMaxFileSize(): number {
+    return this.settings.get<number>('maxFileSize') ?? DEFAULT_DOCUMENT_READ_MAX_BYTES
   }
 
   private isImageMimeType(mimeType: string): boolean {

--- a/src/main/tool/agentTools/agentToolManager.ts
+++ b/src/main/tool/agentTools/agentToolManager.ts
@@ -27,7 +27,11 @@ import {
   SKILL_RUNTIME_VIEW_RESULT_MAX_BYTES,
   type SkillManageResult
 } from '@shared/types/skill'
-import { buildBinaryReadGuidance, shouldRejectAgentBinaryRead } from '@/lib/binaryReadGuard'
+import {
+  buildBinaryReadGuidance,
+  isDocumentReadMime,
+  shouldRejectAgentBinaryRead
+} from '@/lib/binaryReadGuard'
 import { AgentFileSystemHandler, type ProtectedDirectoryRule } from './agentFileSystemHandler'
 import { AgentBashHandler, type AgentCommandEnvironmentPort } from './agentBashHandler'
 import {
@@ -1650,6 +1654,30 @@ export class AgentToolManager {
           }
 
           const readOutputLimits = await this.resolveOutputLimitsForConversation(conversationId)
+
+          if (isDocumentReadMime(mimeType)) {
+            const prepared = await this.getFileService().prepareFileCompletely(
+              validPath,
+              mimeType,
+              'llm-friendly'
+            )
+            const extracted = prepared.content ?? ''
+            if (extracted.trim().length === 0) {
+              return {
+                content: `No extractable text in "${path.basename(validPath)}" (detected MIME: ${mimeType}).`
+              }
+            }
+            return {
+              content: this.paginateReadContent(
+                readArgs.path,
+                extracted,
+                readArgs.offset,
+                readArgs.limit,
+                readOutputLimits.readFileAutoTruncateChars
+              )
+            }
+          }
+
           const readFileSystemHandler = new AgentFileSystemHandler(allowedDirectories, {
             conversationId,
             allowExternalAccess: allowExternalFileAccess,
@@ -1658,31 +1686,15 @@ export class AgentToolManager {
             commandShellPathStyle: options.commandShell.pathStyle
           })
 
-          if (this.shouldUseRawTextRead(mimeType)) {
-            return {
-              content: await readFileSystemHandler.readFile(
-                {
-                  paths: [readArgs.path],
-                  offset: readArgs.offset,
-                  limit: readArgs.limit
-                },
-                baseDirectory
-              )
-            }
-          }
-
-          const prepared = await this.getFileService().prepareFileCompletely(
-            validPath,
-            mimeType,
-            'llm-friendly'
-          )
           return {
-            content: this.paginateReadContent(
-              readArgs.path,
-              prepared.content || '',
-              readArgs.offset,
-              readArgs.limit,
-              readOutputLimits.readFileAutoTruncateChars
+            content: await readFileSystemHandler.readFile(
+              {
+                paths: [readArgs.path],
+                offset: readArgs.offset,
+                limit: readArgs.limit
+              },
+              baseDirectory,
+              { binaryMimeType: mimeType }
             )
           }
         }
@@ -2409,25 +2421,6 @@ export class AgentToolManager {
 
   private isImageMimeType(mimeType: string): boolean {
     return mimeType.startsWith('image/')
-  }
-
-  private shouldUseRawTextRead(mimeType: string): boolean {
-    if (mimeType === 'text/csv') {
-      return false
-    }
-    if (mimeType.startsWith('text/') || mimeType === 'application/octet-stream') {
-      return true
-    }
-
-    const codeLikeMimes = new Set([
-      'application/json',
-      'application/xml',
-      'application/javascript',
-      'application/x-javascript',
-      'application/typescript',
-      'application/x-typescript'
-    ])
-    return codeLikeMimes.has(mimeType)
   }
 
   private paginateReadContent(

--- a/src/main/tool/agentTools/agentToolManager.ts
+++ b/src/main/tool/agentTools/agentToolManager.ts
@@ -29,7 +29,9 @@ import {
 } from '@shared/types/skill'
 import {
   buildBinaryReadGuidance,
+  buildEmptyDocumentReadGuidance,
   isDocumentReadMime,
+  paginateReadContent,
   shouldRejectAgentBinaryRead
 } from '@/lib/binaryReadGuard'
 import { AgentFileSystemHandler, type ProtectedDirectoryRule } from './agentFileSystemHandler'
@@ -1663,12 +1665,13 @@ export class AgentToolManager {
             )
             const extracted = prepared.content ?? ''
             if (extracted.trim().length === 0) {
+              const fileSize = (await fs.promises.stat(validPath)).size
               return {
-                content: `No extractable text in "${path.basename(validPath)}" (detected MIME: ${mimeType}).`
+                content: buildEmptyDocumentReadGuidance(validPath, mimeType, fileSize)
               }
             }
             return {
-              content: this.paginateReadContent(
+              content: paginateReadContent(
                 readArgs.path,
                 extracted,
                 readArgs.offset,
@@ -1678,23 +1681,18 @@ export class AgentToolManager {
             }
           }
 
-          const readFileSystemHandler = new AgentFileSystemHandler(allowedDirectories, {
-            conversationId,
-            allowExternalAccess: allowExternalFileAccess,
-            readFileAutoTruncateChars: readOutputLimits.readFileAutoTruncateChars,
-            protectedDirectoryRules,
-            commandShellPathStyle: options.commandShell.pathStyle
-          })
-
           return {
-            content: await readFileSystemHandler.readFile(
+            content: await fileSystemHandler.readFile(
               {
                 paths: [readArgs.path],
                 offset: readArgs.offset,
                 limit: readArgs.limit
               },
               baseDirectory,
-              { binaryMimeType: mimeType }
+              {
+                mimeType,
+                autoTruncateChars: readOutputLimits.readFileAutoTruncateChars
+              }
             )
           }
         }
@@ -2421,40 +2419,6 @@ export class AgentToolManager {
 
   private isImageMimeType(mimeType: string): boolean {
     return mimeType.startsWith('image/')
-  }
-
-  private paginateReadContent(
-    pathLabel: string,
-    fullContent: string,
-    offset?: number,
-    limit?: number,
-    autoTruncateChars = resolveAgentOutputLimits().readFileAutoTruncateChars
-  ): string {
-    const start = Math.max(0, offset ?? 0)
-    const totalLength = fullContent.length
-
-    let effectiveLimit = limit
-    let autoTruncated = false
-    if (effectiveLimit === undefined && totalLength - start > autoTruncateChars) {
-      effectiveLimit = autoTruncateChars
-      autoTruncated = true
-    }
-
-    const content =
-      effectiveLimit !== undefined
-        ? fullContent.slice(start, start + effectiveLimit)
-        : fullContent.slice(start)
-    const endOffset = start + content.length
-
-    if (start > 0 || limit !== undefined || autoTruncated) {
-      let header = `${pathLabel} [chars ${start}-${endOffset} of ${totalLength}]`
-      if (autoTruncated) {
-        header += ' (auto-truncated, use offset/limit to read more)'
-      }
-      return `${header}:\n${content}\n`
-    }
-
-    return `${pathLabel}:\n${content}\n`
   }
 
   private buildImageMetadataBlock(filePath: string, mimeType: string, fileSize: number): string {

--- a/test/main/lib/binaryReadGuard.test.ts
+++ b/test/main/lib/binaryReadGuard.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from 'vitest'
-import { shouldRejectAgentBinaryRead } from '../../../src/main/lib/binaryReadGuard'
+import {
+  decodeAgentFileBytes,
+  DOCUMENT_READ_MIMES,
+  isDocumentReadMime,
+  shouldRejectAgentBinaryRead
+} from '../../../src/main/lib/binaryReadGuard'
+import { CsvFileAdapter } from '../../../src/main/file/adapters/CsvFileAdapter'
+import { DocFileAdapter } from '../../../src/main/file/adapters/DocFileAdapter'
+import { ExcelFileAdapter } from '../../../src/main/file/adapters/ExcelFileAdapter'
+import { OpenDocumentFileAdapter } from '../../../src/main/file/adapters/OpenDocumentFileAdapter'
+import { PdfFileAdapter } from '../../../src/main/file/adapters/PdfFileAdapter'
+import { PptFileAdapter } from '../../../src/main/file/adapters/PptFileAdapter'
+import { RtfFileAdapter } from '../../../src/main/file/adapters/RtfFileAdapter'
+import { getMimeTypeAdapterMap } from '../../../src/main/file/mime'
+
+const DOCUMENT_ADAPTERS = new Set([
+  CsvFileAdapter,
+  DocFileAdapter,
+  ExcelFileAdapter,
+  OpenDocumentFileAdapter,
+  PdfFileAdapter,
+  PptFileAdapter,
+  RtfFileAdapter
+])
 
 describe('binaryReadGuard', () => {
   it('allows application/octet-stream without binary sniffing', () => {
@@ -15,5 +38,69 @@ describe('binaryReadGuard', () => {
 
   it('keeps images available for vision reads', () => {
     expect(shouldRejectAgentBinaryRead('image/png')).toBe(false)
+  })
+
+  it('matches concrete document adapter MIME keys and ignores wildcards', () => {
+    const expected = [...getMimeTypeAdapterMap().entries()]
+      .filter(([key, adapter]) => DOCUMENT_ADAPTERS.has(adapter) && !key.includes('*'))
+      .map(([key]) => key)
+      .sort()
+
+    expect([...DOCUMENT_READ_MIMES].sort()).toEqual(expected)
+    expect(expected).toHaveLength(37)
+    expect(isDocumentReadMime('application/toml')).toBe(false)
+    expect(isDocumentReadMime('text/*')).toBe(false)
+    expect(isDocumentReadMime('application/vnd.oasis.opendocument.text')).toBe(true)
+    expect(isDocumentReadMime('text/tab-separated-values')).toBe(true)
+  })
+
+  it.each([
+    [
+      'UTF-16LE BOM',
+      Buffer.from('\uFEFFdiff --git a/file.ts b/file.ts\n+const value = 1\n', 'utf16le'),
+      'diff --git a/file.ts b/file.ts'
+    ],
+    [
+      'UTF-16BE BOM',
+      Buffer.from('\uFEFFdiff --git a/file.ts b/file.ts\n+const value = 1\n', 'utf16le').swap16(),
+      'diff --git a/file.ts b/file.ts'
+    ],
+    [
+      'UTF-8 BOM',
+      Buffer.concat([
+        Buffer.from([0xef, 0xbb, 0xbf]),
+        Buffer.from('diff --git a/file.ts b/file.ts\n+const value = 1\n', 'utf8')
+      ]),
+      'diff --git a/file.ts b/file.ts'
+    ]
+  ])('decodes %s as text without a BOM mark', (_label, bytes, snippet) => {
+    const decoded = decodeAgentFileBytes(bytes)
+    expect(decoded).toEqual({ kind: 'text', content: expect.stringContaining(snippet) })
+    if (decoded.kind === 'text') {
+      expect(decoded.content).not.toContain('\uFEFF')
+      expect(decoded.content).not.toContain('\u0000')
+    }
+  })
+
+  it('treats a NUL in the first 8KB without a BOM as binary', () => {
+    expect(decodeAgentFileBytes(Buffer.from([0x68, 0x69, 0x00, 0x21]))).toEqual({ kind: 'binary' })
+  })
+
+  it('ignores a NUL past the 8KB sniff window', () => {
+    const bytes = Buffer.alloc(8193, 0x61)
+    bytes[8192] = 0
+    expect(decodeAgentFileBytes(bytes)).toEqual({
+      kind: 'text',
+      content: 'a'.repeat(8192) + '\u0000'
+    })
+  })
+
+  it('keeps GBK-like bytes as relaxed UTF-8 text', () => {
+    const decoded = decodeAgentFileBytes(Buffer.from([0xc4, 0xe3, 0xba, 0xc3]))
+    expect(decoded.kind).toBe('text')
+  })
+
+  it('decodes an empty buffer as empty text', () => {
+    expect(decodeAgentFileBytes(Buffer.alloc(0))).toEqual({ kind: 'text', content: '' })
   })
 })

--- a/test/main/lib/binaryReadGuard.test.ts
+++ b/test/main/lib/binaryReadGuard.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   buildBinaryReadGuidance,
   decodeAgentFileBytes,
-  isDocumentReadMime,
   shouldRejectAgentBinaryRead
 } from '../../../src/main/lib/binaryReadGuard'
+import { isDocumentReadMime } from '../../../src/main/file/mime'
 
 describe('binaryReadGuard', () => {
   it('allows application/octet-stream without binary sniffing', () => {
@@ -32,8 +32,11 @@ describe('binaryReadGuard', () => {
     expect(isDocumentReadMime('text/*')).toBe(false)
   })
 
-  it('guides NUL hits on text MIME as an encoding problem', () => {
+  it('guides NUL hits on source and config MIME as an encoding problem', () => {
     expect(buildBinaryReadGuidance('app.log', 'text/plain', 'agent')).toContain(
+      'UTF-16 without a BOM'
+    )
+    expect(buildBinaryReadGuidance('Cargo.toml', 'application/toml', 'agent')).toContain(
       'UTF-16 without a BOM'
     )
     expect(buildBinaryReadGuidance('payload.tar', 'application/x-tar', 'agent')).toContain(

--- a/test/main/lib/binaryReadGuard.test.ts
+++ b/test/main/lib/binaryReadGuard.test.ts
@@ -1,28 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildBinaryReadGuidance,
   decodeAgentFileBytes,
-  DOCUMENT_READ_MIMES,
   isDocumentReadMime,
   shouldRejectAgentBinaryRead
 } from '../../../src/main/lib/binaryReadGuard'
-import { CsvFileAdapter } from '../../../src/main/file/adapters/CsvFileAdapter'
-import { DocFileAdapter } from '../../../src/main/file/adapters/DocFileAdapter'
-import { ExcelFileAdapter } from '../../../src/main/file/adapters/ExcelFileAdapter'
-import { OpenDocumentFileAdapter } from '../../../src/main/file/adapters/OpenDocumentFileAdapter'
-import { PdfFileAdapter } from '../../../src/main/file/adapters/PdfFileAdapter'
-import { PptFileAdapter } from '../../../src/main/file/adapters/PptFileAdapter'
-import { RtfFileAdapter } from '../../../src/main/file/adapters/RtfFileAdapter'
-import { getMimeTypeAdapterMap } from '../../../src/main/file/mime'
-
-const DOCUMENT_ADAPTERS = new Set([
-  CsvFileAdapter,
-  DocFileAdapter,
-  ExcelFileAdapter,
-  OpenDocumentFileAdapter,
-  PdfFileAdapter,
-  PptFileAdapter,
-  RtfFileAdapter
-])
 
 describe('binaryReadGuard', () => {
   it('allows application/octet-stream without binary sniffing', () => {
@@ -40,18 +22,23 @@ describe('binaryReadGuard', () => {
     expect(shouldRejectAgentBinaryRead('image/png')).toBe(false)
   })
 
-  it('matches concrete document adapter MIME keys and ignores wildcards', () => {
-    const expected = [...getMimeTypeAdapterMap().entries()]
-      .filter(([key, adapter]) => DOCUMENT_ADAPTERS.has(adapter) && !key.includes('*'))
-      .map(([key]) => key)
-      .sort()
-
-    expect([...DOCUMENT_READ_MIMES].sort()).toEqual(expected)
-    expect(expected).toHaveLength(37)
-    expect(isDocumentReadMime('application/toml')).toBe(false)
-    expect(isDocumentReadMime('text/*')).toBe(false)
+  it('treats office documents as extracted reads and leaves csv on the text path', () => {
+    expect(isDocumentReadMime('application/pdf')).toBe(true)
     expect(isDocumentReadMime('application/vnd.oasis.opendocument.text')).toBe(true)
-    expect(isDocumentReadMime('text/tab-separated-values')).toBe(true)
+    expect(isDocumentReadMime('text/rtf')).toBe(true)
+    expect(isDocumentReadMime('application/toml')).toBe(false)
+    expect(isDocumentReadMime('text/csv')).toBe(false)
+    expect(isDocumentReadMime('text/tab-separated-values')).toBe(false)
+    expect(isDocumentReadMime('text/*')).toBe(false)
+  })
+
+  it('guides NUL hits on text MIME as an encoding problem', () => {
+    expect(buildBinaryReadGuidance('app.log', 'text/plain', 'agent')).toContain(
+      'UTF-16 without a BOM'
+    )
+    expect(buildBinaryReadGuidance('payload.tar', 'application/x-tar', 'agent')).toContain(
+      'conversion/extraction tool'
+    )
   })
 
   it.each([

--- a/test/main/tool/agentTools/agentFileSystemHandler.test.ts
+++ b/test/main/tool/agentTools/agentFileSystemHandler.test.ts
@@ -295,11 +295,32 @@ describe('AgentFileSystemHandler read batch isolation', () => {
       await fs.writeFile(binaryPath, Buffer.from([0x00, 0x01, 0x02]))
 
       const content = await handler.readFile({ paths: [textPath, binaryPath] }, undefined, {
-        binaryMimeType: 'application/octet-stream'
+        mimeType: 'application/x-tar'
       })
 
       expect(content).toContain('keep me')
       expect(content).toContain('Cannot read "bad.bin" as plain text')
+      expect(content).toContain('application/x-tar')
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses to buffer a file above the raw read size cap', async () => {
+    const testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-fs-read-cap-'))
+    try {
+      const handler = new AgentFileSystemHandler([testDir])
+      const filePath = path.join(testDir, 'huge.bin')
+      await fs.writeFile(filePath, Buffer.alloc(32, 0x41))
+
+      const content = await handler.readFile({ paths: [filePath] }, undefined, {
+        mimeType: 'application/x-iso9660-image',
+        maxReadBytes: 16
+      })
+
+      expect(content).toContain('File too large')
+      expect(content).toContain('32 bytes')
+      expect(content).toContain('limit 16')
     } finally {
       await fs.rm(testDir, { recursive: true, force: true })
     }

--- a/test/main/tool/agentTools/agentFileSystemHandler.test.ts
+++ b/test/main/tool/agentTools/agentFileSystemHandler.test.ts
@@ -328,4 +328,23 @@ describe('AgentFileSystemHandler read batch isolation', () => {
       await fs.rm(testDir, { recursive: true, force: true })
     }
   })
+
+  it('reads an empty regular file without a byte-window header', async () => {
+    const testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-fs-read-empty-'))
+    try {
+      const handler = new AgentFileSystemHandler([testDir])
+      const filePath = path.join(testDir, 'empty.txt')
+      await fs.writeFile(filePath, '', 'utf-8')
+
+      const content = await handler.readFile({ paths: [filePath] }, undefined, {
+        mimeType: 'text/plain',
+        autoTruncateChars: 4_500
+      })
+
+      expect(content).toBe(`${filePath}:\n\n`)
+      expect(content).not.toContain('first ')
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/test/main/tool/agentTools/agentFileSystemHandler.test.ts
+++ b/test/main/tool/agentTools/agentFileSystemHandler.test.ts
@@ -283,3 +283,25 @@ describe('AgentFileSystemHandler path authorization', () => {
     }
   )
 })
+
+describe('AgentFileSystemHandler read batch isolation', () => {
+  it('keeps a binary sibling from replacing other files in the same batch', async () => {
+    const testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-fs-read-'))
+    try {
+      const handler = new AgentFileSystemHandler([testDir])
+      const textPath = path.join(testDir, 'ok.txt')
+      const binaryPath = path.join(testDir, 'bad.bin')
+      await fs.writeFile(textPath, 'keep me\n', 'utf-8')
+      await fs.writeFile(binaryPath, Buffer.from([0x00, 0x01, 0x02]))
+
+      const content = await handler.readFile({ paths: [textPath, binaryPath] }, undefined, {
+        binaryMimeType: 'application/octet-stream'
+      })
+
+      expect(content).toContain('keep me')
+      expect(content).toContain('Cannot read "bad.bin" as plain text')
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/main/tool/agentTools/agentFileSystemHandler.test.ts
+++ b/test/main/tool/agentTools/agentFileSystemHandler.test.ts
@@ -329,6 +329,52 @@ describe('AgentFileSystemHandler read batch isolation', () => {
     }
   })
 
+  it('reads a file larger than one chunk without a byte-window header', async () => {
+    const testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-fs-read-chunk-'))
+    try {
+      const handler = new AgentFileSystemHandler([testDir])
+      const filePath = path.join(testDir, 'chunked.txt')
+      const body = 'B'.repeat(80 * 1024)
+      await fs.writeFile(filePath, body, 'utf-8')
+
+      const content = await handler.readFile({ paths: [filePath] }, undefined, {
+        mimeType: 'text/plain',
+        autoTruncateChars: 200_000
+      })
+
+      expect(content).toContain(body)
+      expect(content).not.toContain('first ')
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true })
+    }
+  })
+
+  it('reads a batch of empty files without allocating a full window each', async () => {
+    const testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-fs-read-empty-batch-'))
+    try {
+      const handler = new AgentFileSystemHandler([testDir])
+      const paths = await Promise.all(
+        Array.from({ length: 8 }, async (_, index) => {
+          const filePath = path.join(testDir, `empty-${index}.txt`)
+          await fs.writeFile(filePath, '', 'utf-8')
+          return filePath
+        })
+      )
+
+      const content = await handler.readFile({ paths }, undefined, {
+        mimeType: 'text/plain',
+        autoTruncateChars: 4_500
+      })
+
+      for (const filePath of paths) {
+        expect(content).toContain(`${filePath}:\n\n`)
+      }
+      expect(content).not.toContain('first ')
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true })
+    }
+  })
+
   it('reads an empty regular file without a byte-window header', async () => {
     const testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-fs-read-empty-'))
     try {

--- a/test/main/tool/agentTools/agentFileSystemHandler.test.ts
+++ b/test/main/tool/agentTools/agentFileSystemHandler.test.ts
@@ -295,7 +295,8 @@ describe('AgentFileSystemHandler read batch isolation', () => {
       await fs.writeFile(binaryPath, Buffer.from([0x00, 0x01, 0x02]))
 
       const content = await handler.readFile({ paths: [textPath, binaryPath] }, undefined, {
-        mimeType: 'application/x-tar'
+        mimeType: 'application/x-tar',
+        autoTruncateChars: 4_500
       })
 
       expect(content).toContain('keep me')
@@ -306,21 +307,23 @@ describe('AgentFileSystemHandler read batch isolation', () => {
     }
   })
 
-  it('refuses to buffer a file above the raw read size cap', async () => {
+  it('reads only the first window of a file above the raw byte cap', async () => {
     const testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-fs-read-cap-'))
     try {
       const handler = new AgentFileSystemHandler([testDir])
-      const filePath = path.join(testDir, 'huge.bin')
-      await fs.writeFile(filePath, Buffer.alloc(32, 0x41))
+      const filePath = path.join(testDir, 'huge.log')
+      await fs.writeFile(filePath, 'A'.repeat(32), 'utf-8')
 
       const content = await handler.readFile({ paths: [filePath] }, undefined, {
-        mimeType: 'application/x-iso9660-image',
+        mimeType: 'text/plain',
+        autoTruncateChars: 4_500,
         maxReadBytes: 16
       })
 
-      expect(content).toContain('File too large')
-      expect(content).toContain('32 bytes')
-      expect(content).toContain('limit 16')
+      expect(content).toContain('first 16 of 32 bytes')
+      expect(content).toContain('A'.repeat(16))
+      expect(content).not.toContain('A'.repeat(17))
+      expect(content).not.toContain('File too large')
     } finally {
       await fs.rm(testDir, { recursive: true, force: true })
     }

--- a/test/main/tool/agentTools/agentToolManagerRead.test.ts
+++ b/test/main/tool/agentTools/agentToolManagerRead.test.ts
@@ -317,61 +317,84 @@ describe('AgentToolManager read routing', () => {
     expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
   })
 
-  it('reads Cargo.toml reported as application/toml', async () => {
-    const filePath = path.join(workspaceDir, 'Cargo.toml')
-    await fs.writeFile(filePath, '[package]\nname = "server-status"\nversion = "0.1.0"\n', 'utf-8')
-    fileService.getMimeType.mockResolvedValue('application/toml')
+  it.each([
+    ['Cargo.toml', 'application/toml', '[package]\nname = "server-status"\n', '[package]'],
+    ['foo.rs', 'application/rls-services+xml', 'fn main() {}\n', 'fn main()'],
+    ['query.sql', 'application/sql', 'SELECT 1;\n', 'SELECT 1;']
+  ])('reads %s reported as %s as raw text', async (name, mimeType, source, snippet) => {
+    await fs.writeFile(path.join(workspaceDir, name), source, 'utf-8')
+    fileService.getMimeType.mockResolvedValue(mimeType)
 
-    const result = (await manager.callTool('read', { path: 'Cargo.toml' }, 'conv1')) as {
+    const result = (await manager.callTool('read', { path: name }, 'conv1')) as {
       content: string
     }
 
-    expect(result.content).toContain('[package]')
-    expect(result.content).toContain('server-status')
+    expect(result.content).toContain(snippet)
     expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
   })
 
-  it('reads Rust sources reported as application/rls-services+xml', async () => {
-    const filePath = path.join(workspaceDir, 'foo.rs')
-    await fs.writeFile(filePath, 'fn main() {}\n', 'utf-8')
-    fileService.getMimeType.mockResolvedValue('application/rls-services+xml')
+  it.each([
+    [
+      'rows.csv',
+      'text/csv',
+      ['h1,h2', ...Array.from({ length: 12 }, (_, index) => `r${index + 1},v${index + 1}`)].join(
+        '\n'
+      ),
+      'r12,v12'
+    ],
+    [
+      'rows.tsv',
+      'text/tab-separated-values',
+      ['h1\th2', ...Array.from({ length: 12 }, (_, index) => `r${index + 1}\tv${index + 1}`)].join(
+        '\n'
+      ),
+      'r12\tv12'
+    ]
+  ])(
+    'reads the full %s body instead of a ten-row preview',
+    async (name, mimeType, source, last) => {
+      await fs.writeFile(path.join(workspaceDir, name), source, 'utf-8')
+      fileService.getMimeType.mockResolvedValue(mimeType)
 
-    const result = (await manager.callTool('read', { path: 'foo.rs' }, 'conv1')) as {
-      content: string
+      const result = (await manager.callTool('read', { path: name }, 'conv1')) as {
+        content: string
+      }
+
+      expect(result.content).toContain(last)
+      expect(result.content).not.toContain('Data Preview')
+      expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
     }
+  )
 
-    expect(result.content).toContain('fn main()')
-    expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
-  })
-
-  it('reads application/sql as raw text', async () => {
-    const filePath = path.join(workspaceDir, 'query.sql')
-    await fs.writeFile(filePath, 'SELECT 1;\n', 'utf-8')
-    fileService.getMimeType.mockResolvedValue('application/sql')
-
-    const result = (await manager.callTool('read', { path: 'query.sql' }, 'conv1')) as {
-      content: string
-    }
-
-    expect(result.content).toContain('SELECT 1;')
-    expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
-  })
-
-  it('rejects a NUL-prefixed file on the default read path', async () => {
-    const filePath = path.join(workspaceDir, 'payload.bin')
+  it('rejects a NUL-prefixed archive on the default read path', async () => {
+    const filePath = path.join(workspaceDir, 'payload.tar')
     await fs.writeFile(filePath, Buffer.from([0x7b, 0x00, 0x7d]))
-    fileService.getMimeType.mockResolvedValue('application/octet-stream')
+    fileService.getMimeType.mockResolvedValue('application/x-tar')
 
-    const result = (await manager.callTool('read', { path: 'payload.bin' }, 'conv1')) as {
+    const result = (await manager.callTool('read', { path: 'payload.tar' }, 'conv1')) as {
       content: string
     }
 
-    expect(result.content).toContain('Cannot read "payload.bin" as plain text')
-    expect(result.content).not.toMatch(/^payload\.bin:\s*$/m)
+    expect(result.content).toContain('Cannot read "payload.tar" as plain text')
+    expect(result.content).toContain('application/x-tar')
+    expect(result.content).toContain('conversion/extraction tool')
     expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
   })
 
-  it('reports when a document adapter returns no extractable text', async () => {
+  it('guides NUL hits on text files toward an encoding conversion', async () => {
+    const filePath = path.join(workspaceDir, 'app.log')
+    await fs.writeFile(filePath, Buffer.from([0x61, 0x00, 0x62]))
+    fileService.getMimeType.mockResolvedValue('text/plain')
+
+    const result = (await manager.callTool('read', { path: 'app.log' }, 'conv1')) as {
+      content: string
+    }
+
+    expect(result.content).toContain('UTF-16 without a BOM')
+    expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
+  })
+
+  it('reports document extraction failures with the file size', async () => {
     const filePath = path.join(workspaceDir, 'blank.pdf')
     await fs.writeFile(filePath, 'pdf-binary', 'utf-8')
     fileService.getMimeType.mockResolvedValue('application/pdf')
@@ -381,23 +404,9 @@ describe('AgentToolManager read routing', () => {
       content: string
     }
 
-    expect(result.content).toContain('No extractable text')
-    expect(result.content).toContain('application/pdf')
-    expect(result.content).not.toMatch(/^blank\.pdf:\s*$/m)
-    expect(fileService.prepareFileCompletely).toHaveBeenCalled()
-  })
-
-  it('routes tab-separated values through the document adapter', async () => {
-    const filePath = path.join(workspaceDir, 'rows.tsv')
-    await fs.writeFile(filePath, 'a\tb\n', 'utf-8')
-    fileService.getMimeType.mockResolvedValue('text/tab-separated-values')
-    fileService.prepareFileCompletely.mockResolvedValue({ content: 'a | b' })
-
-    const result = (await manager.callTool('read', { path: 'rows.tsv' }, 'conv1')) as {
-      content: string
-    }
-
-    expect(result.content).toContain('a | b')
+    expect(result.content).toContain('Cannot extract text')
+    expect(result.content).toContain('30MB document limit')
+    expect(result.content).toContain(`File size: ${Buffer.byteLength('pdf-binary')} bytes`)
     expect(fileService.prepareFileCompletely).toHaveBeenCalled()
   })
 

--- a/test/main/tool/agentTools/agentToolManagerRead.test.ts
+++ b/test/main/tool/agentTools/agentToolManagerRead.test.ts
@@ -317,6 +317,90 @@ describe('AgentToolManager read routing', () => {
     expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
   })
 
+  it('reads Cargo.toml reported as application/toml', async () => {
+    const filePath = path.join(workspaceDir, 'Cargo.toml')
+    await fs.writeFile(filePath, '[package]\nname = "server-status"\nversion = "0.1.0"\n', 'utf-8')
+    fileService.getMimeType.mockResolvedValue('application/toml')
+
+    const result = (await manager.callTool('read', { path: 'Cargo.toml' }, 'conv1')) as {
+      content: string
+    }
+
+    expect(result.content).toContain('[package]')
+    expect(result.content).toContain('server-status')
+    expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
+  })
+
+  it('reads Rust sources reported as application/rls-services+xml', async () => {
+    const filePath = path.join(workspaceDir, 'foo.rs')
+    await fs.writeFile(filePath, 'fn main() {}\n', 'utf-8')
+    fileService.getMimeType.mockResolvedValue('application/rls-services+xml')
+
+    const result = (await manager.callTool('read', { path: 'foo.rs' }, 'conv1')) as {
+      content: string
+    }
+
+    expect(result.content).toContain('fn main()')
+    expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
+  })
+
+  it('reads application/sql as raw text', async () => {
+    const filePath = path.join(workspaceDir, 'query.sql')
+    await fs.writeFile(filePath, 'SELECT 1;\n', 'utf-8')
+    fileService.getMimeType.mockResolvedValue('application/sql')
+
+    const result = (await manager.callTool('read', { path: 'query.sql' }, 'conv1')) as {
+      content: string
+    }
+
+    expect(result.content).toContain('SELECT 1;')
+    expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
+  })
+
+  it('rejects a NUL-prefixed file on the default read path', async () => {
+    const filePath = path.join(workspaceDir, 'payload.bin')
+    await fs.writeFile(filePath, Buffer.from([0x7b, 0x00, 0x7d]))
+    fileService.getMimeType.mockResolvedValue('application/octet-stream')
+
+    const result = (await manager.callTool('read', { path: 'payload.bin' }, 'conv1')) as {
+      content: string
+    }
+
+    expect(result.content).toContain('Cannot read "payload.bin" as plain text')
+    expect(result.content).not.toMatch(/^payload\.bin:\s*$/m)
+    expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
+  })
+
+  it('reports when a document adapter returns no extractable text', async () => {
+    const filePath = path.join(workspaceDir, 'blank.pdf')
+    await fs.writeFile(filePath, 'pdf-binary', 'utf-8')
+    fileService.getMimeType.mockResolvedValue('application/pdf')
+    fileService.prepareFileCompletely.mockResolvedValue({ content: '   ' })
+
+    const result = (await manager.callTool('read', { path: 'blank.pdf' }, 'conv1')) as {
+      content: string
+    }
+
+    expect(result.content).toContain('No extractable text')
+    expect(result.content).toContain('application/pdf')
+    expect(result.content).not.toMatch(/^blank\.pdf:\s*$/m)
+    expect(fileService.prepareFileCompletely).toHaveBeenCalled()
+  })
+
+  it('routes tab-separated values through the document adapter', async () => {
+    const filePath = path.join(workspaceDir, 'rows.tsv')
+    await fs.writeFile(filePath, 'a\tb\n', 'utf-8')
+    fileService.getMimeType.mockResolvedValue('text/tab-separated-values')
+    fileService.prepareFileCompletely.mockResolvedValue({ content: 'a | b' })
+
+    const result = (await manager.callTool('read', { path: 'rows.tsv' }, 'conv1')) as {
+      content: string
+    }
+
+    expect(result.content).toContain('a | b')
+    expect(fileService.prepareFileCompletely).toHaveBeenCalled()
+  })
+
   it.each([
     [
       'UTF-16LE',

--- a/test/main/tool/agentTools/agentToolManagerRead.test.ts
+++ b/test/main/tool/agentTools/agentToolManagerRead.test.ts
@@ -59,6 +59,7 @@ describe('AgentToolManager read routing', () => {
   }
   let resolveConversationWorkdir: ReturnType<typeof vi.fn>
   let resolveConversationSessionInfo: ReturnType<typeof vi.fn>
+  let settingsGet: ReturnType<typeof vi.fn>
   let callToolWithoutCommandShell: AgentToolManager['callTool']
   let preCheckWithoutCommandShell: AgentToolManager['preCheckToolPermission']
 
@@ -90,9 +91,10 @@ describe('AgentToolManager read routing', () => {
       }),
       resolveDeepChatAgentConfig: vi.fn().mockResolvedValue({})
     }
+    settingsGet = vi.fn()
     manager = new AgentToolManager({
       skillSettings: { isEnabled: () => false } as any,
-      settings: { get: vi.fn() },
+      settings: { get: settingsGet },
       commandPermissionHandler: new CommandPermissionService(),
       agentWorkspacePath: workspaceDir,
       providerSettings,
@@ -381,12 +383,12 @@ describe('AgentToolManager read routing', () => {
     expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
   })
 
-  it('guides NUL hits on text files toward an encoding conversion', async () => {
-    const filePath = path.join(workspaceDir, 'app.log')
+  it('guides NUL hits on toml files toward an encoding conversion', async () => {
+    const filePath = path.join(workspaceDir, 'Cargo.toml')
     await fs.writeFile(filePath, Buffer.from([0x61, 0x00, 0x62]))
-    fileService.getMimeType.mockResolvedValue('text/plain')
+    fileService.getMimeType.mockResolvedValue('application/toml')
 
-    const result = (await manager.callTool('read', { path: 'app.log' }, 'conv1')) as {
+    const result = (await manager.callTool('read', { path: 'Cargo.toml' }, 'conv1')) as {
       content: string
     }
 
@@ -394,20 +396,41 @@ describe('AgentToolManager read routing', () => {
     expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
   })
 
-  it('reports document extraction failures with the file size', async () => {
+  it('reports document extraction failures with the configured size limit', async () => {
     const filePath = path.join(workspaceDir, 'blank.pdf')
     await fs.writeFile(filePath, 'pdf-binary', 'utf-8')
     fileService.getMimeType.mockResolvedValue('application/pdf')
     fileService.prepareFileCompletely.mockResolvedValue({ content: '   ' })
+    settingsGet.mockImplementation((key: string) =>
+      key === 'maxFileSize' ? 50 * 1024 * 1024 : undefined
+    )
 
     const result = (await manager.callTool('read', { path: 'blank.pdf' }, 'conv1')) as {
       content: string
     }
 
     expect(result.content).toContain('Cannot extract text')
-    expect(result.content).toContain('30MB document limit')
-    expect(result.content).toContain(`File size: ${Buffer.byteLength('pdf-binary')} bytes`)
+    expect(result.content).toContain('damaged or contain no extractable text layer')
+    expect(result.content).toContain(
+      `File size: ${Buffer.byteLength('pdf-binary')} bytes (document limit ${50 * 1024 * 1024} bytes)`
+    )
     expect(fileService.prepareFileCompletely).toHaveBeenCalled()
+  })
+
+  it('skips document adapters when the file exceeds the configured size limit', async () => {
+    const filePath = path.join(workspaceDir, 'huge.pdf')
+    await fs.writeFile(filePath, 'x'.repeat(32), 'utf-8')
+    fileService.getMimeType.mockResolvedValue('application/pdf')
+    settingsGet.mockImplementation((key: string) => (key === 'maxFileSize' ? 16 : undefined))
+
+    const result = (await manager.callTool('read', { path: 'huge.pdf' }, 'conv1')) as {
+      content: string
+    }
+
+    expect(result.content).toContain('File too large')
+    expect(result.content).toContain('32 bytes')
+    expect(result.content).toContain('limit 16')
+    expect(fileService.prepareFileCompletely).not.toHaveBeenCalled()
   })
 
   it.each([


### PR DESCRIPTION
## Summary

`read` returned an empty `path:\n\n` body for workspace files such as `Cargo.toml` and `.rs`. The chat-box citation was a red herring: attachments already omit content and tell the model to `read`. The split was MIME type, not citation.

PR #1319 routed any MIME outside a small text allowlist through `prepareFileCompletely`. Unknown `application/*` types (`application/toml`, `application/rls-services+xml`, `application/sql`, …) hit `UnsupportFileAdapter` and collapsed to `''`.

`read` now treats text as the default. Images, office/PDF/RTF extraction, and known binaries stay special-cased. Failures return an explicit message.

Closes #2173

## Behavior

- Raw-read source and config files that mime-db maps to `application/*` (toml, Rust, SQL, PHP, …).
- Keep CSV/TSV on the raw path so `read` returns the full file, not a 10-row preview.
- Office/PDF/RTF still go through document adapters. Files above `maxFileSize` are rejected before extraction. Empty extraction reports the real file size and configured limit.
- Raw reads load at most the first 10MB from the same open fd (loop until the window is full or EOF). Larger files keep a `[first N of M bytes]` header so the model can continue.
- NUL-only files get an explicit binary or encoding hint instead of an empty body.

## Test plan

- [x] `vitest` `binaryReadGuard` / `agentToolManagerRead` / `agentFileSystemHandler`
- [x] `pnpm run typecheck:node`
- [x] `oxlint` on the touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved reading of documents, source files, and configuration files.
  * Added support for BOM-less UTF-16 content and more reliable text detection.
  * Large files are read in bounded sections with pagination and truncation guidance.
  * Document reads enforce configurable size limits and provide clearer guidance for oversized or empty files.

* **Bug Fixes**
  * Binary file errors no longer affect other files in the same read operation.
  * Improved handling of empty files, archives, and files containing embedded null characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->