### PR TITLE
fix: repair usage stats and MCP startup

### DIFF
--- a/docs/architecture/mcp-v2-protocol/spec.md
+++ b/docs/architecture/mcp-v2-protocol/spec.md
@@ -318,9 +318,10 @@ details surface shows declared origins; packaged malicious fixtures prove blocke
 | DeepChat host | Built-in/in-memory pair | legacy | Create both transport halves from the same v2 package |
 | ACP agent | Agent-declared transport | agent-owned | Do not migrate, probe, wrap, or reinterpret |
 
-The modern probe timeout must be below DeepChat's existing 45-second soft startup timeout. Start at
-8 seconds and change it only from measured evidence. A failed disposable stdio probe must not leave
-a child process running.
+The HTTP modern probe uses a 20-second timeout with one retry so a transiently slow remote router can
+recover while repeated timeouts still fail within DeepChat's existing 45-second soft startup
+budget. Stdio keeps its eight-second probe without a retry. A failed disposable stdio probe must not
+leave a child process running.
 
 ## Package Boundary
 

--- a/docs/issues/mcp-startup-lifecycle/spec.md
+++ b/docs/issues/mcp-startup-lifecycle/spec.md
@@ -1,0 +1,65 @@
+# MCP Startup Lifecycle Stabilization
+
+Status: Implemented
+
+## Issue
+
+An enabled remote MCP server can appear stopped or failed during application startup and work after
+a manual restart. A direct connection with the same configuration succeeds, and startup logs can
+show a successful connection while the settings page still projects only a stale boolean status.
+
+## Root Cause
+
+Proxy initialization is fire-and-forget, so MCP startup has no explicit readiness dependency on the
+network configuration it consumes. The main process already publishes a detailed MCP lifecycle,
+but the renderer client narrows the event to `isRunning`, and initial settings hydration queries only
+that boolean. Failed clients are removed immediately, so diagnostics opened after the event also
+lose the terminal lifecycle and its error.
+
+Remote HTTP negotiation also used an eight-second probe with zero timeout retries. A transiently
+slow router therefore turned a short `server/discover` timeout into a terminal failure even when the
+same legacy endpoint responded normally later. One retry alone was still insufficient while each
+attempt retained the same short timeout.
+
+## Required Behavior
+
+- Start MCP initialization only after the current proxy resolution attempt settles.
+- Keep MCP initialization behind the main-window startup path; proxy resolution must not block
+  window creation.
+- Preserve failed inactive clients until an explicit restart or stop so diagnostics retain their
+  terminal state.
+- Expose lifecycle status and the bounded last error through MCP diagnostics.
+- Hydrate renderer server state from diagnostics and consume the complete lifecycle event.
+- Render `connecting`, `timeout`, and `retrying` as starting; render `failed` as error.
+- Preserve existing authentication precedence and manual toggle behavior.
+- Give HTTP negotiation 20 seconds per probe and retry one timeout before failing the connection.
+
+## Non-Goals
+
+- Arbitrary fixed startup sleeps.
+- Unbounded automatic retries.
+- Treating an HTTP timeout as proof that a server is legacy.
+- Retrying authentication or invalid configuration failures.
+- Changing general MCP request, startup-soft, hard-connection, or transport timeouts.
+
+## Tasks
+
+- [x] Add an awaitable proxy readiness snapshot and use it before MCP initialization.
+- [x] Preserve terminal MCP client diagnostics after startup failure.
+- [x] Extend diagnostics and renderer state with lifecycle/error data.
+- [x] Allow one bounded SDK negotiation retry for transient HTTP probe timeouts.
+- [x] Add focused main-process, store, and component regressions.
+- [x] Run renderer, MCP, architecture, and static checks.
+
+## Validation
+
+- MCP initialization waits for the proxy resolution already started during main-process bootstrap.
+- A settings page mounted during connection shows starting instead of stopped.
+- A settings page mounted after failure shows error and the retained failure message.
+- A later successful manual restart replaces the failed client and clears the error.
+- An HTTP probe gets up to two 20-second attempts within the existing startup budget; repeated
+  timeouts still fail.
+
+Focused MCP, startup-boundary, proxy, renderer-store, and component suites passed. Formatting,
+i18n validation, lint, and node type checking passed. Web type checking remains blocked by the
+pre-existing readonly Monaco theme tuple mismatch in `MarkdownRenderer.vue`.

--- a/docs/issues/usage-stats-v68-migration/spec.md
+++ b/docs/issues/usage-stats-v68-migration/spec.md
@@ -1,0 +1,48 @@
+# Usage Stats V68 Migration Recovery
+
+Status: Implemented
+
+## Issue
+
+Some databases already record schema version 68 while `deepchat_usage_stats` still uses the legacy
+`message_id` primary key. The settings usage dashboard then attempts to write `usage_id` and fails
+with `table deepchat_usage_stats has no column named usage_id`.
+
+## Root Cause
+
+Schema versions are a global monotonic high-water mark. The category-aware usage migration was
+assigned to version 68 after affected databases had already recorded version 68, so startup never
+evaluates that migration for those profiles. Generic schema repair cannot fix the primary-key shape
+with `ALTER TABLE ADD COLUMN`.
+
+## Required Behavior
+
+- Allocate a new schema version for the compatibility migration.
+- Rebuild only legacy or partially repaired usage tables.
+- Preserve every legacy row and map its `message_id` to `usage_id` with category `chat`.
+- Leave already-correct category-aware tables unchanged, including compaction rows whose
+  `message_id` is null.
+- Restore all usage indexes after a rebuild.
+
+## Non-Goals
+
+- Adding `usage_id` without replacing the legacy primary key.
+- Changing usage aggregation or dashboard presentation.
+- Editing user database files outside normal application migration.
+
+## Tasks
+
+- [x] Add a compatibility migration after version 68.
+- [x] Cover an already-version-68 legacy table with preserved data.
+- [x] Cover an already-correct version-68 table with compaction data.
+- [x] Run focused database migration validation and static checks.
+
+## Validation
+
+- A version-68 legacy database opens without manual schema repair and records version 69.
+- The migrated table has `usage_id` as its primary key and `message_id` as a nullable non-key.
+- Existing chat rows and already-correct compaction rows remain unchanged.
+
+Validated with the Electron-native SQLite runtime against both regression fixtures and a temporary
+copy of the affected release profile. The profile migrated from version 68 to 69 with all 916 usage
+rows preserved. The temporary copy was removed after verification.

--- a/src/main/app/composition.ts
+++ b/src/main/app/composition.ts
@@ -2478,6 +2478,7 @@ export async function createMainProcessControl(dependencies: {
     }
 
     try {
+      await proxyConfig.whenReady()
       await mcpService.initialize()
     } catch (error) {
       reportMainStartupComponentFailure(dependencies.startupRunId, 'mcp', 'unknown')

--- a/src/main/mcp/index.ts
+++ b/src/main/mcp/index.ts
@@ -1112,8 +1112,12 @@ export class McpService implements McpServicePort {
     const { name: serverName, config } = await this.requireServerById(serverId)
     const auth = this.mcpOAuthManager.getStatus(serverName, config)
     const client = this.serverManager.getClient(serverName)
+    const lastError = this.serverManager.getServerLastError(serverName)?.slice(0, 2048)
     if (client) {
-      return client.getDiagnostics(auth)
+      return {
+        ...client.getDiagnostics(auth),
+        ...(lastError ? { lastError } : {})
+      }
     }
 
     let authorizationExtensions: string[] = []
@@ -1127,7 +1131,9 @@ export class McpService implements McpServicePort {
       serverName,
       owner: config.ownerPluginId ? 'plugin' : 'deepchat',
       transport: config.type,
-      connectionState: 'stopped',
+      connectionState: lastError ? 'error' : 'stopped',
+      lifecycleStatus: lastError ? 'failed' : 'stopped',
+      ...(lastError ? { lastError } : {}),
       era: 'unknown',
       probe: { outcome: 'not-run' },
       extensions: [],

--- a/src/main/mcp/mcpClient.ts
+++ b/src/main/mcp/mcpClient.ts
@@ -82,7 +82,8 @@ const ALLOWED_SAMPLING_IMAGE_MIME_TYPES = new Set([
 
 const MCP_STARTUP_SOFT_TIMEOUT_MS = 45 * 1000
 const MCP_CONNECT_HARD_TIMEOUT_MS = 5 * 60 * 1000
-const MCP_NEGOTIATION_PROBE_TIMEOUT_MS = 8 * 1000
+const MCP_STDIO_NEGOTIATION_PROBE_TIMEOUT_MS = 8 * 1000
+const MCP_HTTP_NEGOTIATION_PROBE_TIMEOUT_MS = 20 * 1000
 const MCP_STDIO_MAX_BUFFER_BYTES = 10 * 1024 * 1024
 const MCP_INPUT_REQUIRED_MAX_ROUNDS = 10
 const MCP_DEFAULT_CACHE_TTL_MS = 0
@@ -691,8 +692,11 @@ export class McpClient {
             ? {
                 mode: 'auto',
                 probe: {
-                  timeoutMs: MCP_NEGOTIATION_PROBE_TIMEOUT_MS,
-                  maxRetries: 0
+                  timeoutMs:
+                    transportType === 'http'
+                      ? MCP_HTTP_NEGOTIATION_PROBE_TIMEOUT_MS
+                      : MCP_STDIO_NEGOTIATION_PROBE_TIMEOUT_MS,
+                  maxRetries: transportType === 'http' ? 1 : 0
                 }
               }
             : { mode: 'legacy' },
@@ -1858,6 +1862,7 @@ export class McpClient {
       owner: this.serverConfig.ownerPluginId ? 'plugin' : 'deepchat',
       transport,
       connectionState,
+      lifecycleStatus: this.lifecycleStatus,
       era: client?.getProtocolEra() ?? 'unknown',
       protocolVersion: client?.getNegotiatedProtocolVersion(),
       serverImplementation: serverVersion

--- a/src/main/mcp/serverManager.ts
+++ b/src/main/mcp/serverManager.ts
@@ -306,6 +306,7 @@ export class ServerManager {
         this.clients.set(name, client)
       }
 
+      this.clearServerLastError(name)
       const connectTask = client.connect({
         phase: 'startup',
         waitForConnection: options.waitForConnection
@@ -336,10 +337,8 @@ export class ServerManager {
 
       console.error(`Failed to start MCP server ${name}:`, error)
 
-      // Remove client reference
-      if (client && this.clients.get(name) === client) {
-        this.clients.delete(name)
-      }
+      // Retain the inactive client so diagnostics can report the terminal lifecycle until the
+      // user restarts or stops it. A later start replaces this client through the normal path.
       this.setServerLastError(name, error)
       const authHandled =
         this.mcpOAuthManager?.handleConnectionError(name, serverConfig, error) ?? false
@@ -386,7 +385,6 @@ export class ServerManager {
           return
         }
 
-        this.clients.delete(name)
         this.setServerLastError(name, error)
         const authHandled =
           this.mcpOAuthManager?.handleConnectionError(name, serverConfig, error) ?? false

--- a/src/main/platform/proxy.ts
+++ b/src/main/platform/proxy.ts
@@ -34,8 +34,19 @@ export class ProxyConfig {
   private proxyUrl: string | null = null
   private mode: ProxyMode = ProxyMode.SYSTEM
   private customProxyUrl: string = ''
+  private resolutionPromise: Promise<boolean> = Promise.resolve(true)
 
-  async resolveProxy(): Promise<boolean> {
+  resolveProxy(): Promise<boolean> {
+    const resolution = this.resolveProxyNow()
+    this.resolutionPromise = resolution
+    return resolution
+  }
+
+  whenReady(): Promise<boolean> {
+    return this.resolutionPromise
+  }
+
+  private async resolveProxyNow(): Promise<boolean> {
     try {
       // 根据不同的代理模式设置
       if (this.mode === ProxyMode.NONE) {

--- a/src/main/platform/proxy.ts
+++ b/src/main/platform/proxy.ts
@@ -37,7 +37,9 @@ export class ProxyConfig {
   private resolutionPromise: Promise<boolean> = Promise.resolve(true)
 
   resolveProxy(): Promise<boolean> {
-    const resolution = this.resolveProxyNow()
+    const mode = this.mode
+    const customProxyUrl = this.customProxyUrl
+    const resolution = this.resolutionPromise.then(() => this.resolveProxyNow(mode, customProxyUrl))
     this.resolutionPromise = resolution
     return resolution
   }
@@ -46,21 +48,21 @@ export class ProxyConfig {
     return this.resolutionPromise
   }
 
-  private async resolveProxyNow(): Promise<boolean> {
+  private async resolveProxyNow(mode: ProxyMode, customProxyUrl: string): Promise<boolean> {
     try {
       // 根据不同的代理模式设置
-      if (this.mode === ProxyMode.NONE) {
-        this.clearProxy()
+      if (mode === ProxyMode.NONE) {
+        await this.clearProxy()
         logger.info('clear proxy')
         return false
-      } else if (this.mode === ProxyMode.CUSTOM && this.customProxyUrl) {
-        logger.info('proxy url', this.customProxyUrl)
-        this.setCustomProxy(this.customProxyUrl)
+      } else if (mode === ProxyMode.CUSTOM && customProxyUrl) {
+        logger.info('proxy url', customProxyUrl)
+        await this.setCustomProxy(customProxyUrl)
         return false
       }
 
       // 系统代理模式
-      session.defaultSession.setProxy({ mode: 'system' })
+      await session.defaultSession.setProxy({ mode: 'system' })
       const proxyString = await session.defaultSession.resolveProxy('https://www.google.com')
       const [protocol, address] = proxyString.split(';')[0].split(' ')
       logger.info('proxy url', protocol, address)
@@ -91,7 +93,8 @@ export class ProxyConfig {
     }
   }
 
-  private clearProxy(): void {
+  private async clearProxy(): Promise<void> {
+    await session.defaultSession.setProxy({ mode: 'direct' })
     this.proxyUrl = null
     delete process.env.http_proxy
     delete process.env.https_proxy
@@ -101,11 +104,11 @@ export class ProxyConfig {
     delete process.env.grpc_proxy
     delete process.env.no_proxy
     delete process.env.NO_PROXY
-    session.defaultSession.setProxy({ mode: 'direct' })
     setGlobalDispatcher(new Agent())
   }
 
-  private setCustomProxy(proxyUrl: string): void {
+  private async setCustomProxy(proxyUrl: string): Promise<void> {
+    await session.defaultSession.setProxy({ proxyRules: proxyUrl })
     this.proxyUrl = proxyUrl
     process.env.http_proxy = proxyUrl
     process.env.https_proxy = proxyUrl
@@ -116,7 +119,6 @@ export class ProxyConfig {
     const mergedNoProxy = mergeNoProxy(NO_PROXY)
     process.env.no_proxy = mergedNoProxy
     process.env.NO_PROXY = mergedNoProxy
-    session.defaultSession.setProxy({ proxyRules: proxyUrl })
     setGlobalDispatcher(
       new EnvHttpProxyAgent({
         httpProxy: proxyUrl,

--- a/src/main/session/data/tables/deepchatUsageStats.ts
+++ b/src/main/session/data/tables/deepchatUsageStats.ts
@@ -77,6 +77,7 @@ export interface DeepChatUsageStatsCategoryRow {
 }
 
 export const USAGE_STATS_CATEGORY_SCHEMA_VERSION = 68
+export const USAGE_STATS_CATEGORY_RECOVERY_SCHEMA_VERSION = 69
 
 function normalizeAggregate(row: AggregateRow | undefined): DeepChatUsageStatsSummary {
   return {
@@ -125,6 +126,95 @@ export class DeepChatUsageStatsTable extends BaseTable {
         ON deepchat_usage_stats(session_id, compaction_attempt_id, provider_call_id)
         WHERE usage_category = 'compaction';
     `
+  }
+
+  private getCategoryMigrationSQL(targetTable: string): string {
+    return `
+      CREATE TABLE ${targetTable} (
+        usage_id TEXT PRIMARY KEY,
+        message_id TEXT,
+        usage_category TEXT NOT NULL CHECK (usage_category IN ('chat', 'compaction')),
+        compaction_attempt_id TEXT,
+        provider_call_id TEXT,
+        provider_call_seq INTEGER,
+        session_id TEXT NOT NULL,
+        usage_date TEXT NOT NULL,
+        provider_id TEXT NOT NULL,
+        model_id TEXT NOT NULL,
+        input_tokens INTEGER,
+        output_tokens INTEGER,
+        total_tokens INTEGER,
+        cached_input_tokens INTEGER,
+        cache_write_input_tokens INTEGER,
+        source TEXT NOT NULL DEFAULT 'live',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO ${targetTable} (
+        usage_id,
+        message_id,
+        usage_category,
+        compaction_attempt_id,
+        provider_call_id,
+        provider_call_seq,
+        session_id,
+        usage_date,
+        provider_id,
+        model_id,
+        input_tokens,
+        output_tokens,
+        total_tokens,
+        cached_input_tokens,
+        cache_write_input_tokens,
+        source,
+        created_at,
+        updated_at
+      )
+      SELECT
+        message_id,
+        message_id,
+        'chat',
+        NULL,
+        NULL,
+        NULL,
+        session_id,
+        usage_date,
+        provider_id,
+        model_id,
+        input_tokens,
+        output_tokens,
+        total_tokens,
+        cached_input_tokens,
+        cache_write_input_tokens,
+        source,
+        created_at,
+        updated_at
+      FROM deepchat_usage_stats;
+      DROP TABLE deepchat_usage_stats;
+      ALTER TABLE ${targetTable} RENAME TO deepchat_usage_stats;
+      CREATE INDEX idx_deepchat_usage_stats_date ON deepchat_usage_stats(usage_date);
+      CREATE INDEX idx_deepchat_usage_stats_provider_date ON deepchat_usage_stats(provider_id, usage_date);
+      CREATE INDEX idx_deepchat_usage_stats_model_date ON deepchat_usage_stats(model_id, usage_date);
+      CREATE INDEX idx_deepchat_usage_stats_category_date ON deepchat_usage_stats(usage_category, usage_date);
+      CREATE UNIQUE INDEX idx_deepchat_usage_stats_compaction_call
+        ON deepchat_usage_stats(session_id, compaction_attempt_id, provider_call_id)
+        WHERE usage_category = 'compaction';
+    `
+  }
+
+  private hasCategoryAwarePrimaryKey(): boolean {
+    const columns = this.db.prepare('PRAGMA table_info(deepchat_usage_stats)').all() as Array<{
+      name: string
+      pk: number
+    }>
+    const usageId = columns.find((column) => column.name === 'usage_id')
+    const messageId = columns.find((column) => column.name === 'message_id')
+
+    return (
+      usageId?.pk === 1 &&
+      messageId?.pk === 0 &&
+      columns.some((column) => column.name === 'usage_category')
+    )
   }
 
   getMigrationSQL(version: number): string | null {
@@ -189,83 +279,25 @@ export class DeepChatUsageStatsTable extends BaseTable {
       `
     }
     if (version === USAGE_STATS_CATEGORY_SCHEMA_VERSION) {
-      return `
-        CREATE TABLE deepchat_usage_stats_v68 (
-          usage_id TEXT PRIMARY KEY,
-          message_id TEXT,
-          usage_category TEXT NOT NULL CHECK (usage_category IN ('chat', 'compaction')),
-          compaction_attempt_id TEXT,
-          provider_call_id TEXT,
-          provider_call_seq INTEGER,
-          session_id TEXT NOT NULL,
-          usage_date TEXT NOT NULL,
-          provider_id TEXT NOT NULL,
-          model_id TEXT NOT NULL,
-          input_tokens INTEGER,
-          output_tokens INTEGER,
-          total_tokens INTEGER,
-          cached_input_tokens INTEGER,
-          cache_write_input_tokens INTEGER,
-          source TEXT NOT NULL DEFAULT 'live',
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL
-        );
-        INSERT INTO deepchat_usage_stats_v68 (
-          usage_id,
-          message_id,
-          usage_category,
-          compaction_attempt_id,
-          provider_call_id,
-          provider_call_seq,
-          session_id,
-          usage_date,
-          provider_id,
-          model_id,
-          input_tokens,
-          output_tokens,
-          total_tokens,
-          cached_input_tokens,
-          cache_write_input_tokens,
-          source,
-          created_at,
-          updated_at
-        )
-        SELECT
-          message_id,
-          message_id,
-          'chat',
-          NULL,
-          NULL,
-          NULL,
-          session_id,
-          usage_date,
-          provider_id,
-          model_id,
-          input_tokens,
-          output_tokens,
-          total_tokens,
-          cached_input_tokens,
-          cache_write_input_tokens,
-          source,
-          created_at,
-          updated_at
-        FROM deepchat_usage_stats;
-        DROP TABLE deepchat_usage_stats;
-        ALTER TABLE deepchat_usage_stats_v68 RENAME TO deepchat_usage_stats;
-        CREATE INDEX idx_deepchat_usage_stats_date ON deepchat_usage_stats(usage_date);
-        CREATE INDEX idx_deepchat_usage_stats_provider_date ON deepchat_usage_stats(provider_id, usage_date);
-        CREATE INDEX idx_deepchat_usage_stats_model_date ON deepchat_usage_stats(model_id, usage_date);
-        CREATE INDEX idx_deepchat_usage_stats_category_date ON deepchat_usage_stats(usage_category, usage_date);
-        CREATE UNIQUE INDEX idx_deepchat_usage_stats_compaction_call
-          ON deepchat_usage_stats(session_id, compaction_attempt_id, provider_call_id)
-          WHERE usage_category = 'compaction';
-      `
+      return this.getCategoryMigrationSQL('deepchat_usage_stats_v68')
+    }
+    if (version === USAGE_STATS_CATEGORY_RECOVERY_SCHEMA_VERSION) {
+      return 'SELECT 1 /* recover usage stats schemas that already recorded version 68 */;'
     }
     return null
   }
 
   getLatestVersion(): number {
-    return USAGE_STATS_CATEGORY_SCHEMA_VERSION
+    return USAGE_STATS_CATEGORY_RECOVERY_SCHEMA_VERSION
+  }
+
+  finalizeMigration(version: number): void {
+    if (
+      version === USAGE_STATS_CATEGORY_RECOVERY_SCHEMA_VERSION &&
+      !this.hasCategoryAwarePrimaryKey()
+    ) {
+      this.db.exec(this.getCategoryMigrationSQL('deepchat_usage_stats_v69'))
+    }
   }
 
   upsert(row: UsageStatsRecordInput): void {

--- a/src/renderer/api/McpClient.ts
+++ b/src/renderer/api/McpClient.ts
@@ -1,5 +1,6 @@
 import type { DeepchatBridge } from '@shared/contracts/bridge'
 import type { MCPContentItem } from '@shared/types/mcp'
+import type { McpServerStatusChangedPayload } from '@shared/types/core/mcp'
 import {
   mcpAppConsentRequestEvent,
   mcpConfigChangedEvent,
@@ -189,9 +190,9 @@ export function createMcpClient(bridge: DeepchatBridge = getDeepchatBridge()) {
     return result.status
   }
 
-  async function getServerDiagnostics(serverName: string) {
+  async function getServerDiagnostics(serverName: string, serverId?: string) {
     const result = await bridge.invoke(mcpGetServerDiagnosticsRoute.name, {
-      serverId: await resolveServerId(serverName)
+      serverId: serverId || (await resolveServerId(serverName))
     })
     return result.diagnostics
   }
@@ -456,9 +457,7 @@ export function createMcpClient(bridge: DeepchatBridge = getDeepchatBridge()) {
     return bridge.on(mcpConfigChangedEvent.name, listener)
   }
 
-  function onServerStatusChanged(
-    listener: (payload: { serverName: string; isRunning: boolean; version: number }) => void
-  ) {
+  function onServerStatusChanged(listener: (payload: McpServerStatusChangedPayload) => void) {
     return bridge.on(mcpServerStatusChangedEvent.name, listener)
   }
 

--- a/src/renderer/src/components/mcp-config/components/McpServerCard.vue
+++ b/src/renderer/src/components/mcp-config/components/McpServerCard.vue
@@ -16,6 +16,7 @@ import { computed, ref, nextTick, onMounted, watch } from 'vue'
 import { Separator } from '@shadcn/components/ui/separator'
 import { Spinner } from '@shadcn/components/ui/spinner'
 import type { McpServerAuthStatus } from '@shared/types/mcp'
+import type { McpServerLifecycleStatus } from '@shared/types/core/mcp'
 
 interface ServerInfo {
   name: string
@@ -25,6 +26,7 @@ interface ServerInfo {
   args: string[]
   enabled: boolean
   isRunning: boolean
+  lifecycleStatus?: McpServerLifecycleStatus
   type?: string
   baseUrl?: string
   errorMessage?: string
@@ -79,8 +81,11 @@ const serverStatus = computed(() => {
   if (props.server.authStatus?.state === 'authenticating') return 'loading'
   if (props.server.authStatus?.state === 'required') return 'auth-required'
   if (props.server.authStatus?.state === 'error') return 'auth-error'
-  if (props.server.errorMessage) return 'error'
-  if (props.server.isRunning) return 'running'
+  if (['connecting', 'timeout', 'retrying'].includes(props.server.lifecycleStatus ?? '')) {
+    return 'loading'
+  }
+  if (props.server.lifecycleStatus === 'failed' || props.server.errorMessage) return 'error'
+  if (props.server.lifecycleStatus === 'connected' || props.server.isRunning) return 'running'
   return 'stopped'
 })
 

--- a/src/renderer/src/stores/mcp.ts
+++ b/src/renderer/src/stores/mcp.ts
@@ -53,6 +53,17 @@ export const useMcpStore = defineStore('mcp', () => {
   const serverAuthStatuses = ref<Record<string, McpServerAuthStatus>>({})
   const serverLoadingStates = ref<Record<string, boolean>>({})
   const configLoading = ref(false)
+  const serverLifecycleRevisions = new Map<string, number>()
+  let nextServerLifecycleRevision = 0
+
+  const advanceServerLifecycleRevision = (serverName: string): number => {
+    const revision = ++nextServerLifecycleRevision
+    serverLifecycleRevisions.set(serverName, revision)
+    return revision
+  }
+
+  const isCurrentServerLifecycleRevision = (serverName: string, revision: number): boolean =>
+    serverLifecycleRevisions.get(serverName) === revision
 
   // 工具相关状态
   const toolLoadingStates = ref<Record<string, boolean>>({})
@@ -441,7 +452,8 @@ export const useMcpStore = defineStore('mcp', () => {
     serverName: string,
     lifecycleStatus: McpServerLifecycleStatus,
     message?: string
-  ) => {
+  ): number => {
+    const revision = advanceServerLifecycleRevision(serverName)
     serverLifecycleStatuses.value[serverName] = lifecycleStatus
     serverStatuses.value[serverName] = lifecycleStatus === 'connected'
 
@@ -450,6 +462,8 @@ export const useMcpStore = defineStore('mcp', () => {
     } else if (lifecycleStatus !== 'failed') {
       delete serverStatusMessages.value[serverName]
     }
+
+    return revision
   }
 
   const applyServerStatusEvent = (payload: McpServerStatusChangedPayload) => {
@@ -662,6 +676,7 @@ export const useMcpStore = defineStore('mcp', () => {
 
   // 更新单个服务器状态
   const updateServerStatus = async (serverName: string, noRefresh: boolean = false) => {
+    let revision = advanceServerLifecycleRevision(serverName)
     try {
       const serverConfig = config.value.mcpServers[serverName]
       if (!config.value.mcpEnabled && !isPluginOwnedServerConfig(serverConfig)) {
@@ -670,10 +685,20 @@ export const useMcpStore = defineStore('mcp', () => {
       }
 
       const diagnostics = await mcpClient.getServerDiagnostics(serverName, serverConfig?.serverId)
-      applyServerLifecycle(serverName, diagnostics.lifecycleStatus, diagnostics.lastError)
+      if (!isCurrentServerLifecycleRevision(serverName, revision)) {
+        return
+      }
+      revision = applyServerLifecycle(
+        serverName,
+        diagnostics.lifecycleStatus,
+        diagnostics.lastError
+      )
       if (!noRefresh) {
         // Refresh tools and clients when server status changes
         await Promise.all([loadTools({ force: true }), loadClients({ force: true })])
+        if (!isCurrentServerLifecycleRevision(serverName, revision)) {
+          return
+        }
       }
       // 根据服务器的状态，关闭或者开启该服务器的所有工具
       const isRunning = serverStatuses.value[serverName] || false
@@ -698,11 +723,20 @@ export const useMcpStore = defineStore('mcp', () => {
         await setEnabledToolNames(filteredTools)
       }
     } catch (error) {
+      if (!isCurrentServerLifecycleRevision(serverName, revision)) {
+        return
+      }
       console.error(t('mcp.errors.getServerStatusFailed', { serverName }), error)
       try {
         const isRunning = await mcpClient.isServerRunning(serverName)
+        if (!isCurrentServerLifecycleRevision(serverName, revision)) {
+          return
+        }
         applyServerLifecycle(serverName, isRunning ? 'connected' : 'stopped')
       } catch {
+        if (!isCurrentServerLifecycleRevision(serverName, revision)) {
+          return
+        }
         applyServerLifecycle(serverName, 'stopped')
       }
     }
@@ -760,6 +794,7 @@ export const useMcpStore = defineStore('mcp', () => {
       delete serverStatusMessages.value[serverName]
       delete serverAuthStatuses.value[serverName]
       delete serverLoadingStates.value[serverName]
+      serverLifecycleRevisions.delete(serverName)
       void refreshServerMutationQueries()
       return true
     } catch (error) {

--- a/src/renderer/src/stores/mcp.ts
+++ b/src/renderer/src/stores/mcp.ts
@@ -18,6 +18,10 @@ import type {
   Resource,
   ResourceListEntry
 } from '@shared/types/mcp'
+import type {
+  McpServerLifecycleStatus,
+  McpServerStatusChangedPayload
+} from '@shared/types/core/mcp'
 
 const ENABLED_MCP_TOOLS_KEY = 'input_enabledMcpTools'
 
@@ -44,6 +48,8 @@ export const useMcpStore = defineStore('mcp', () => {
 
   // 服务器状态
   const serverStatuses = ref<Record<string, boolean>>({})
+  const serverLifecycleStatuses = ref<Record<string, McpServerLifecycleStatus>>({})
+  const serverStatusMessages = ref<Record<string, string>>({})
   const serverAuthStatuses = ref<Record<string, McpServerAuthStatus>>({})
   const serverLoadingStates = ref<Record<string, boolean>>({})
   const configLoading = ref(false)
@@ -352,6 +358,8 @@ export const useMcpStore = defineStore('mcp', () => {
       } else {
         // MCP disabled: clear state and refresh queries to get empty results
         serverStatuses.value = {}
+        serverLifecycleStatuses.value = {}
+        serverStatusMessages.value = {}
         toolInputs.value = {}
         toolResults.value = {}
         Promise.all([
@@ -429,12 +437,35 @@ export const useMcpStore = defineStore('mcp', () => {
     }
   )
   // ==================== 计算属性 ====================
+  const applyServerLifecycle = (
+    serverName: string,
+    lifecycleStatus: McpServerLifecycleStatus,
+    message?: string
+  ) => {
+    serverLifecycleStatuses.value[serverName] = lifecycleStatus
+    serverStatuses.value[serverName] = lifecycleStatus === 'connected'
+
+    if (lifecycleStatus === 'failed' && message) {
+      serverStatusMessages.value[serverName] = message
+    } else if (lifecycleStatus !== 'failed') {
+      delete serverStatusMessages.value[serverName]
+    }
+  }
+
+  const applyServerStatusEvent = (payload: McpServerStatusChangedPayload) => {
+    applyServerLifecycle(payload.serverName, payload.lifecycleStatus, payload.message)
+  }
+
   // 服务器列表
   const allServerList = computed(() => {
     const servers = Object.entries(config.value.mcpServers ?? {}).map(([name, serverConfig]) => ({
       name,
       ...serverConfig,
       isRunning: serverStatuses.value[name] || false,
+      lifecycleStatus:
+        serverLifecycleStatuses.value[name] ??
+        (serverStatuses.value[name] ? 'connected' : 'stopped'),
+      errorMessage: serverStatusMessages.value[name],
       authStatus: serverAuthStatuses.value[name],
       isLoading: serverLoadingStates.value[name] || false
     }))
@@ -588,6 +619,16 @@ export const useMcpStore = defineStore('mcp', () => {
             isPluginOwnedServerName(serverName)
           )
         )
+        serverLifecycleStatuses.value = Object.fromEntries(
+          Object.entries(serverLifecycleStatuses.value).filter(([serverName]) =>
+            isPluginOwnedServerName(serverName)
+          )
+        )
+        serverStatusMessages.value = Object.fromEntries(
+          Object.entries(serverStatusMessages.value).filter(([serverName]) =>
+            isPluginOwnedServerName(serverName)
+          )
+        )
         toolInputs.value = {}
         toolResults.value = {}
         // Force refresh queries to get empty results
@@ -624,11 +665,12 @@ export const useMcpStore = defineStore('mcp', () => {
     try {
       const serverConfig = config.value.mcpServers[serverName]
       if (!config.value.mcpEnabled && !isPluginOwnedServerConfig(serverConfig)) {
-        serverStatuses.value[serverName] = false
+        applyServerLifecycle(serverName, 'stopped')
         return
       }
 
-      serverStatuses.value[serverName] = await mcpClient.isServerRunning(serverName)
+      const diagnostics = await mcpClient.getServerDiagnostics(serverName, serverConfig?.serverId)
+      applyServerLifecycle(serverName, diagnostics.lifecycleStatus, diagnostics.lastError)
       if (!noRefresh) {
         // Refresh tools and clients when server status changes
         await Promise.all([loadTools({ force: true }), loadClients({ force: true })])
@@ -657,7 +699,12 @@ export const useMcpStore = defineStore('mcp', () => {
       }
     } catch (error) {
       console.error(t('mcp.errors.getServerStatusFailed', { serverName }), error)
-      serverStatuses.value[serverName] = false
+      try {
+        const isRunning = await mcpClient.isServerRunning(serverName)
+        applyServerLifecycle(serverName, isRunning ? 'connected' : 'stopped')
+      } catch {
+        applyServerLifecycle(serverName, 'stopped')
+      }
     }
   }
 
@@ -709,6 +756,8 @@ export const useMcpStore = defineStore('mcp', () => {
       delete nextServers[serverName]
       config.value.mcpServers = nextServers
       delete serverStatuses.value[serverName]
+      delete serverLifecycleStatuses.value[serverName]
+      delete serverStatusMessages.value[serverName]
       delete serverAuthStatuses.value[serverName]
       delete serverLoadingStates.value[serverName]
       void refreshServerMutationQueries()
@@ -747,7 +796,7 @@ export const useMcpStore = defineStore('mcp', () => {
       if (nextEnabled) {
         await updateServerAuthStatus(serverName)
         if (isAuthWaitingStatus(serverAuthStatuses.value[serverName])) {
-          serverStatuses.value[serverName] = false
+          applyServerLifecycle(serverName, 'stopped')
           return true
         }
       }
@@ -1056,9 +1105,9 @@ export const useMcpStore = defineStore('mcp', () => {
       })
     })
 
-    mcpClient.onServerStatusChanged(({ serverName, isRunning }) => {
-      console.log(`MCP server ${serverName} status changed: ${isRunning}`)
-      serverStatuses.value[serverName] = isRunning
+    mcpClient.onServerStatusChanged((payload) => {
+      console.log(`MCP server ${payload.serverName} lifecycle changed: ${payload.lifecycleStatus}`)
+      applyServerStatusEvent(payload)
     })
 
     mcpClient.onServerAuthChanged(({ serverName, status }) => {
@@ -1153,6 +1202,8 @@ export const useMcpStore = defineStore('mcp', () => {
     // 状态
     config,
     serverStatuses,
+    serverLifecycleStatuses,
+    serverStatusMessages,
     serverAuthStatuses,
     serverLoadingStates,
     configLoading,

--- a/src/shared/contracts/routes/mcp.routes.ts
+++ b/src/shared/contracts/routes/mcp.routes.ts
@@ -827,6 +827,8 @@ const McpServerDiagnosticsSchema: z.ZodType<McpServerDiagnostics> = z.object({
   owner: z.enum(['deepchat', 'plugin']),
   transport: z.enum(['sse', 'stdio', 'inmemory', 'http']),
   connectionState: z.enum(['stopped', 'starting', 'running', 'error']),
+  lifecycleStatus: z.enum(['connecting', 'connected', 'timeout', 'retrying', 'failed', 'stopped']),
+  lastError: z.string().max(2048).optional(),
   era: z.enum(['modern', 'legacy', 'unknown']),
   protocolVersion: z.string().max(64).optional(),
   serverImplementation: z

--- a/src/shared/types/mcp.ts
+++ b/src/shared/types/mcp.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { FileItem } from './file'
 import type {
+  McpServerLifecycleStatus,
   MCPToolDefinition as CoreMCPToolDefinition,
   ToolDispatchCommit,
   ToolOutcomeProjectionRegistrar
@@ -492,6 +493,8 @@ export interface McpServerDiagnostics {
   owner: 'deepchat' | 'plugin'
   transport: MCPServerConfig['type']
   connectionState: 'stopped' | 'starting' | 'running' | 'error'
+  lifecycleStatus: McpServerLifecycleStatus
+  lastError?: string
   era: McpProtocolEra
   protocolVersion?: string
   serverImplementation?: {

--- a/test/main/app/compositionBoundaries.test.ts
+++ b/test/main/app/compositionBoundaries.test.ts
@@ -365,6 +365,9 @@ describe('session boundary composition', () => {
     expect(mcpSource.indexOf('await initializePlugins()')).toBeLessThan(
       mcpSource.indexOf('await mcpService.initialize()')
     )
+    expect(mcpSource.indexOf('await proxyConfig.whenReady()')).toBeLessThan(
+      mcpSource.indexOf('await mcpService.initialize()')
+    )
   })
 
   it('routes restart requests through App shutdown', async () => {

--- a/test/main/data/mainDatabase.test.ts
+++ b/test/main/data/mainDatabase.test.ts
@@ -1226,6 +1226,128 @@ describeIfSqlite('MainDatabase legacy schema bootstrap', () => {
     checkDb.close()
   })
 
+  it('recovers a legacy usage table after schema version 68 was already recorded', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-sqlite-presenter-'))
+    tempDirs.push(tempDir)
+
+    const dbPath = path.join(tempDir, 'agent.db')
+    const initialDatabase = new MainDatabaseCtor(dbPath)
+    initialDatabase.close()
+    const bootstrapDb = new DatabaseCtor(dbPath)
+    bootstrapDb.exec(`
+      DELETE FROM schema_versions;
+      INSERT INTO schema_versions (version, applied_at) VALUES (68, ${Date.now()});
+      DROP TABLE deepchat_usage_stats;
+      CREATE TABLE deepchat_usage_stats (
+        message_id TEXT PRIMARY KEY,
+        usage_category TEXT NOT NULL DEFAULT 'chat',
+        compaction_attempt_id TEXT,
+        provider_call_id TEXT,
+        provider_call_seq INTEGER,
+        session_id TEXT NOT NULL,
+        usage_date TEXT NOT NULL,
+        provider_id TEXT NOT NULL,
+        model_id TEXT NOT NULL,
+        input_tokens INTEGER,
+        output_tokens INTEGER,
+        total_tokens INTEGER,
+        cached_input_tokens INTEGER,
+        cache_write_input_tokens INTEGER,
+        source TEXT NOT NULL DEFAULT 'live',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO deepchat_usage_stats (
+        message_id, session_id, usage_date, provider_id, model_id, input_tokens, output_tokens,
+        total_tokens, cached_input_tokens, cache_write_input_tokens, source, created_at, updated_at
+      ) VALUES (
+        'message-v68', 'session-1', '2026-08-17', 'minimax', 'MiniMax-M3', 120, 30, 150,
+        20, 5, 'live', 1000, 2000
+      );
+    `)
+    bootstrapDb.close()
+
+    const presenter = new MainDatabaseCtor(dbPath)
+    presenter.close()
+
+    const checkDb = new DatabaseCtor(dbPath)
+    const columns = checkDb.prepare('PRAGMA table_info(deepchat_usage_stats)').all() as Array<{
+      name: string
+      pk: number
+    }>
+    const row = checkDb
+      .prepare(
+        `SELECT usage_id, message_id, usage_category, input_tokens, total_tokens
+         FROM deepchat_usage_stats
+         WHERE usage_id = ?`
+      )
+      .get('message-v68')
+    const versions = checkDb
+      .prepare('SELECT version FROM schema_versions ORDER BY version ASC')
+      .all() as Array<{ version: number }>
+
+    expect(columns.find((column) => column.name === 'usage_id')?.pk).toBe(1)
+    expect(columns.find((column) => column.name === 'message_id')?.pk).toBe(0)
+    expect(row).toEqual({
+      usage_id: 'message-v68',
+      message_id: 'message-v68',
+      usage_category: 'chat',
+      input_tokens: 120,
+      total_tokens: 150
+    })
+    expect(versions.map((entry) => entry.version)).toContain(69)
+    checkDb.close()
+  })
+
+  it('leaves an already-correct version 68 usage table unchanged', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-sqlite-presenter-'))
+    tempDirs.push(tempDir)
+
+    const dbPath = path.join(tempDir, 'agent.db')
+    const initialDatabase = new MainDatabaseCtor(dbPath)
+    initialDatabase.close()
+    const bootstrapDb = new DatabaseCtor(dbPath)
+    bootstrapDb.exec(`
+      DELETE FROM schema_versions;
+      INSERT INTO schema_versions (version, applied_at) VALUES (68, ${Date.now()});
+      INSERT INTO deepchat_usage_stats (
+        usage_id, message_id, usage_category, compaction_attempt_id, provider_call_id,
+        provider_call_seq, session_id, usage_date, provider_id, model_id, input_tokens,
+        output_tokens, total_tokens, cached_input_tokens, cache_write_input_tokens, source,
+        created_at, updated_at
+      ) VALUES (
+        'compaction-1', NULL, 'compaction', 'attempt-1', 'call-1', 1, 'session-1',
+        '2026-08-17', 'minimax', 'MiniMax-M3', 1000, 40, 1040, 900, 0, 'live', 1000, 2000
+      );
+    `)
+    bootstrapDb.close()
+
+    const presenter = new MainDatabaseCtor(dbPath)
+    presenter.close()
+
+    const checkDb = new DatabaseCtor(dbPath)
+    const row = checkDb
+      .prepare(
+        `SELECT usage_id, message_id, usage_category, compaction_attempt_id, provider_call_id
+         FROM deepchat_usage_stats
+         WHERE usage_id = ?`
+      )
+      .get('compaction-1')
+    const versions = checkDb
+      .prepare('SELECT version FROM schema_versions ORDER BY version ASC')
+      .all() as Array<{ version: number }>
+
+    expect(row).toEqual({
+      usage_id: 'compaction-1',
+      message_id: null,
+      usage_category: 'compaction',
+      compaction_attempt_id: 'attempt-1',
+      provider_call_id: 'call-1'
+    })
+    expect(versions.map((entry) => entry.version)).toContain(69)
+    checkDb.close()
+  })
+
   it('repairs a missing agent_memory category column', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deepchat-sqlite-presenter-'))
     tempDirs.push(tempDir)

--- a/test/main/mcp/mcpClient.test.ts
+++ b/test/main/mcp/mcpClient.test.ts
@@ -575,6 +575,26 @@ describe('McpClient Runtime Command Processing Tests', () => {
     })
   })
 
+  describe('Version negotiation', () => {
+    it('retries one timed-out HTTP version negotiation probe', async () => {
+      const client = createMcpClient('remote-server', {
+        type: 'http',
+        baseUrl: 'https://example.com/mcp'
+      })
+
+      await client.connect()
+
+      const clientOptions = vi.mocked(Client).mock.calls.at(-1)?.[1]
+      expect(clientOptions?.versionNegotiation).toEqual({
+        mode: 'auto',
+        probe: {
+          timeoutMs: 20_000,
+          maxRetries: 1
+        }
+      })
+    })
+  })
+
   describe('Unsupported MCP capabilities', () => {
     it('does not call list methods for capabilities the server did not advertise', async () => {
       const sdkClient = {

--- a/test/main/mcp/mcpService.test.ts
+++ b/test/main/mcp/mcpService.test.ts
@@ -4,6 +4,8 @@ const serverManagerMocks = vi.hoisted(() => ({
   startServer: vi.fn(),
   stopServer: vi.fn(),
   isServerRunning: vi.fn(),
+  getClient: vi.fn(),
+  getServerLastError: vi.fn(),
   getRunningClients: vi.fn().mockResolvedValue([]),
   getActiveClients: vi.fn().mockResolvedValue([]),
   testNpmRegistrySpeed: vi.fn().mockResolvedValue('https://registry.npmjs.org/'),
@@ -33,6 +35,8 @@ vi.mock('../../../src/main/mcp/serverManager', () => ({
     startServer: serverManagerMocks.startServer,
     stopServer: serverManagerMocks.stopServer,
     isServerRunning: serverManagerMocks.isServerRunning,
+    getClient: serverManagerMocks.getClient,
+    getServerLastError: serverManagerMocks.getServerLastError,
     getRunningClients: serverManagerMocks.getRunningClients,
     getActiveClients: serverManagerMocks.getActiveClients,
     testNpmRegistrySpeed: serverManagerMocks.testNpmRegistrySpeed,
@@ -118,6 +122,8 @@ describe('McpService', () => {
     serverManagerMocks.startServer.mockResolvedValue(undefined)
     serverManagerMocks.stopServer.mockResolvedValue(undefined)
     serverManagerMocks.isServerRunning.mockReturnValue(false)
+    serverManagerMocks.getClient.mockReturnValue(undefined)
+    serverManagerMocks.getServerLastError.mockReturnValue(undefined)
     serverManagerMocks.getRunningClients.mockResolvedValue([])
     serverManagerMocks.getActiveClients.mockResolvedValue([])
     serverManagerMocks.testNpmRegistrySpeed.mockResolvedValue('https://registry.npmjs.org/')
@@ -573,6 +579,37 @@ describe('McpService', () => {
       expect.objectContaining({ onBackgroundConnected: expect.any(Function) })
     )
     expect(serverManagerMocks.startServer).toHaveBeenCalledTimes(1)
+  })
+
+  it('retains terminal startup diagnostics after a failed client becomes inactive', async () => {
+    const serverId = '11111111-1111-4111-8111-111111111111'
+    const providerSettings = createProviderSettings(true, false, {
+      remote: {
+        serverId,
+        configGeneration: 1,
+        bindingHash: 'remote-binding',
+        type: 'http',
+        baseUrl: 'https://mcp.example.com',
+        command: '',
+        args: [],
+        env: {},
+        enabled: true
+      }
+    })
+    const presenter = createMcpService(providerSettings)
+    ;(presenter as any).serverManager = {
+      getClient: serverManagerMocks.getClient,
+      getServerLastError: serverManagerMocks.getServerLastError
+    }
+    serverManagerMocks.getServerLastError.mockReturnValue('connect failed')
+
+    await expect(presenter.getServerDiagnostics(serverId)).resolves.toMatchObject({
+      serverId,
+      serverName: 'remote',
+      connectionState: 'error',
+      lifecycleStatus: 'failed',
+      lastError: 'connect failed'
+    })
   })
 
   it('reports a swallowed initialization failure once without exposing the error', async () => {

--- a/test/main/mcp/serverManager.test.ts
+++ b/test/main/mcp/serverManager.test.ts
@@ -121,6 +121,7 @@ describe('ServerManager notifications and plugin isolation', () => {
     await expect(manager.startServer('regular')).rejects.toThrow('connect failed')
 
     expect(manager.getServerLastError('regular')).toBe('connect failed')
+    expect(manager.getClient('regular')).toBeDefined()
     expect(semanticNotificationsMock.occur).toHaveBeenCalledWith({
       code: 'mcp.connectionFailed',
       serverName: 'regular'
@@ -145,6 +146,27 @@ describe('ServerManager notifications and plugin isolation', () => {
       code: 'mcp.connectionFailed',
       serverName: 'regular'
     })
+  })
+
+  it('replaces retained failed clients on a later manual start', async () => {
+    const providerSettings = createProviderSettings({
+      regular: {
+        command: 'regular-command',
+        args: [],
+        env: {},
+        type: 'stdio'
+      }
+    })
+    const manager = createManager(providerSettings)
+    clientMocks.isServerRunning.mockReturnValue(false)
+    clientMocks.connect.mockRejectedValueOnce(new Error('connect failed'))
+
+    await expect(manager.startServer('regular')).rejects.toThrow('connect failed')
+    await expect(manager.startServer('regular')).resolves.toBe('connected')
+
+    expect(clientMocks.disconnect).toHaveBeenCalledOnce()
+    expect(McpClient).toHaveBeenCalledTimes(2)
+    expect(manager.getServerLastError('regular')).toBeUndefined()
   })
 
   it('recovers the connection episode only after a successful stop', async () => {

--- a/test/main/platform/proxy.test.ts
+++ b/test/main/platform/proxy.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronMocks = vi.hoisted(() => ({
+  setProxy: vi.fn(),
+  resolveProxy: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  session: {
+    defaultSession: {
+      setProxy: electronMocks.setProxy,
+      resolveProxy: electronMocks.resolveProxy
+    }
+  }
+}))
+
+vi.mock('undici', () => ({
+  Agent: class Agent {},
+  EnvHttpProxyAgent: class EnvHttpProxyAgent {},
+  setGlobalDispatcher: vi.fn()
+}))
+
+import { ProxyConfig, ProxyMode } from '@/platform/proxy'
+
+describe('ProxyConfig readiness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    electronMocks.setProxy.mockResolvedValue(undefined)
+  })
+
+  it('exposes the active system proxy resolution as a startup barrier', async () => {
+    let finishResolution!: (value: string) => void
+    electronMocks.resolveProxy.mockReturnValue(
+      new Promise<string>((resolve) => {
+        finishResolution = resolve
+      })
+    )
+    const config = new ProxyConfig()
+
+    config.initFromConfig(ProxyMode.SYSTEM, '')
+    let settled = false
+    void config.whenReady().then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+
+    expect(settled).toBe(false)
+    finishResolution('DIRECT')
+    await expect(config.whenReady()).resolves.toBe(true)
+    expect(electronMocks.resolveProxy).toHaveBeenCalledWith('https://www.google.com')
+  })
+})

--- a/test/main/platform/proxy.test.ts
+++ b/test/main/platform/proxy.test.ts
@@ -49,4 +49,30 @@ describe('ProxyConfig readiness', () => {
     await expect(config.whenReady()).resolves.toBe(true)
     expect(electronMocks.resolveProxy).toHaveBeenCalledWith('https://www.google.com')
   })
+
+  it('keeps the latest proxy mode when an earlier system resolution finishes late', async () => {
+    let finishResolution!: (value: string) => void
+    electronMocks.resolveProxy.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        finishResolution = resolve
+      })
+    )
+    const config = new ProxyConfig()
+
+    config.setProxyMode(ProxyMode.SYSTEM)
+    const systemResolution = config.resolveProxy()
+    await vi.waitFor(() => {
+      expect(electronMocks.resolveProxy).toHaveBeenCalledTimes(1)
+    })
+
+    config.setProxyMode(ProxyMode.NONE)
+    const directResolution = config.resolveProxy()
+    expect(electronMocks.setProxy).not.toHaveBeenCalledWith({ mode: 'direct' })
+
+    finishResolution('PROXY stale.example:8080')
+    await Promise.all([systemResolution, directResolution])
+
+    expect(config.getProxyUrl()).toBeNull()
+    expect(electronMocks.setProxy).toHaveBeenLastCalledWith({ mode: 'direct' })
+  })
 })

--- a/test/renderer/components/McpServerCard.test.ts
+++ b/test/renderer/components/McpServerCard.test.ts
@@ -127,4 +127,21 @@ describe('McpServerCard', () => {
     expect(wrapper.text()).toContain('settings.mcp.authFailed')
     expect(wrapper.text()).not.toContain('settings.mcp.authRequired')
   })
+
+  it('renders startup lifecycle separately from stopped and failed states', async () => {
+    const { wrapper } = mountCard(vi.fn(), { lifecycleStatus: 'connecting' })
+
+    expect(wrapper.text()).toContain('settings.mcp.starting')
+    expect(wrapper.text()).not.toContain('settings.mcp.stopped')
+
+    await wrapper.setProps({
+      server: {
+        ...server,
+        lifecycleStatus: 'failed',
+        errorMessage: 'connection failed'
+      }
+    })
+
+    expect(wrapper.text()).toContain('settings.mcp.error')
+  })
 })

--- a/test/renderer/components/McpServers.test.ts
+++ b/test/renderer/components/McpServers.test.ts
@@ -98,6 +98,7 @@ const createDiagnostics = (serverId: string) => ({
   owner: 'deepchat' as const,
   transport: 'http' as const,
   connectionState: 'running' as const,
+  lifecycleStatus: 'connected' as const,
   era: 'modern' as const,
   protocolVersion: '2025-06-18',
   probe: {

--- a/test/renderer/stores/mcpStore.test.ts
+++ b/test/renderer/stores/mcpStore.test.ts
@@ -5,6 +5,7 @@ const addMcpServerMutate = vi.hoisted(() => vi.fn())
 const updateMcpServerMutate = vi.hoisted(() => vi.fn())
 const removeMcpServerMutate = vi.hoisted(() => vi.fn())
 const configRefetch = vi.hoisted(() => vi.fn())
+const mountedCallbacks = vi.hoisted(() => [] as Array<() => Promise<void>>)
 
 const mcpClientMock = vi.hoisted(() => ({
   getMcpServers: vi.fn().mockResolvedValue({}),
@@ -24,7 +25,13 @@ const mcpClientMock = vi.hoisted(() => ({
   }),
   getAllToolDefinitions: vi.fn().mockResolvedValue([]),
   getMcpClients: vi.fn().mockResolvedValue([]),
-  getAllResources: vi.fn().mockResolvedValue([])
+  getAllResources: vi.fn().mockResolvedValue([]),
+  onServerStarted: vi.fn(() => vi.fn()),
+  onServerStopped: vi.fn(() => vi.fn()),
+  onConfigChanged: vi.fn(() => vi.fn()),
+  onServerStatusChanged: vi.fn(() => vi.fn()),
+  onServerAuthChanged: vi.fn(() => vi.fn()),
+  onToolCallResult: vi.fn(() => vi.fn())
 }))
 
 const configServiceMock = vi.hoisted(() => ({
@@ -48,7 +55,9 @@ vi.mock('vue', async () => {
   const actual = await vi.importActual<typeof import('vue')>('vue')
   return {
     ...actual,
-    onMounted: vi.fn()
+    onMounted: vi.fn((callback: () => Promise<void>) => {
+      mountedCallbacks.push(callback)
+    })
   }
 })
 
@@ -105,6 +114,7 @@ const setupStore = async () => {
 describe('useMcpStore', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mountedCallbacks.length = 0
     setMcpServerEnabledMutate.mockReset()
     addMcpServerMutate.mockReset()
     updateMcpServerMutate.mockReset()
@@ -283,6 +293,53 @@ describe('useMcpStore', () => {
       lifecycleStatus: 'failed',
       errorMessage: 'connection failed'
     })
+  })
+
+  it('keeps a newer lifecycle event over stale diagnostics', async () => {
+    let finishDiagnostics!: (value: {
+      lifecycleStatus: 'connected'
+      connectionState: 'connected'
+    }) => void
+    mcpClientMock.getServerDiagnostics.mockReturnValueOnce(
+      new Promise((resolve) => {
+        finishDiagnostics = resolve
+      })
+    )
+    const store = await setupStore()
+    await mountedCallbacks[0]()
+    store.config = {
+      mcpServers: {
+        demo: {
+          command: 'demo-command',
+          args: [],
+          env: {},
+          descriptions: 'Demo server',
+          icons: 'D',
+          disable: false,
+          type: 'stdio',
+          enabled: true
+        }
+      },
+      mcpEnabled: true,
+      ready: true
+    }
+
+    const pendingStatus = store.updateServerStatus('demo', true)
+    await vi.waitFor(() => {
+      expect(mcpClientMock.getServerDiagnostics).toHaveBeenCalledWith('demo', undefined)
+    })
+    const statusListener = mcpClientMock.onServerStatusChanged.mock.calls[0][0]
+    statusListener({
+      serverName: 'demo',
+      lifecycleStatus: 'failed',
+      message: 'startup failed'
+    })
+    finishDiagnostics({ lifecycleStatus: 'connected', connectionState: 'connected' })
+    await pendingStatus
+
+    expect(store.serverStatuses.demo).toBe(false)
+    expect(store.serverLifecycleStatuses.demo).toBe('failed')
+    expect(store.serverStatusMessages.demo).toBe('startup failed')
   })
 
   it('hides plugin-owned servers from MCP UI lists', async () => {

--- a/test/renderer/stores/mcpStore.test.ts
+++ b/test/renderer/stores/mcpStore.test.ts
@@ -13,6 +13,10 @@ const mcpClientMock = vi.hoisted(() => ({
   startServer: vi.fn().mockResolvedValue(undefined),
   stopServer: vi.fn().mockResolvedValue(undefined),
   isServerRunning: vi.fn().mockResolvedValue(false),
+  getServerDiagnostics: vi.fn().mockResolvedValue({
+    lifecycleStatus: 'stopped',
+    connectionState: 'stopped'
+  }),
   getServerAuthStatus: vi.fn().mockResolvedValue({
     serverName: 'demo',
     state: 'none',
@@ -109,6 +113,11 @@ describe('useMcpStore', () => {
     configRefetch.mockResolvedValue({ status: 'success', data: undefined })
     mcpClientMock.startServer.mockClear()
     mcpClientMock.stopServer.mockClear()
+    mcpClientMock.getServerDiagnostics.mockReset()
+    mcpClientMock.getServerDiagnostics.mockResolvedValue({
+      lifecycleStatus: 'stopped',
+      connectionState: 'stopped'
+    })
     mcpClientMock.getServerAuthStatus.mockReset()
     mcpClientMock.getServerAuthStatus.mockResolvedValue({
       serverName: 'demo',
@@ -226,6 +235,54 @@ describe('useMcpStore', () => {
     expect(store.enabledServers).toEqual([])
     expect(store.enabledPluginServers.map((server) => server.name)).toEqual(['cua-driver'])
     expect(store.enabledServerCount).toBe(0)
+  })
+
+  it('hydrates startup and failure lifecycle from main-process diagnostics', async () => {
+    const store = await setupStore()
+
+    store.config = {
+      mcpServers: {
+        demo: {
+          command: 'https://mcp.example.com',
+          args: [],
+          env: {},
+          descriptions: 'Demo server',
+          icons: 'D',
+          disable: false,
+          type: 'http',
+          enabled: true
+        }
+      },
+      mcpEnabled: true,
+      ready: true
+    }
+    mcpClientMock.getServerDiagnostics.mockResolvedValueOnce({
+      lifecycleStatus: 'connecting',
+      connectionState: 'starting'
+    })
+
+    await store.updateServerStatus('demo', true)
+
+    expect(store.serverStatuses.demo).toBe(false)
+    expect(store.serverLifecycleStatuses.demo).toBe('connecting')
+    expect(store.serverList[0]).toMatchObject({
+      isRunning: false,
+      lifecycleStatus: 'connecting',
+      errorMessage: undefined
+    })
+
+    mcpClientMock.getServerDiagnostics.mockResolvedValueOnce({
+      lifecycleStatus: 'failed',
+      connectionState: 'error',
+      lastError: 'connection failed'
+    })
+    await store.updateServerStatus('demo', true)
+
+    expect(store.serverLifecycleStatuses.demo).toBe('failed')
+    expect(store.serverList[0]).toMatchObject({
+      lifecycleStatus: 'failed',
+      errorMessage: 'connection failed'
+    })
   })
 
   it('hides plugin-owned servers from MCP UI lists', async () => {


### PR DESCRIPTION
## Summary

- recover legacy `deepchat_usage_stats` tables even when schema version 68 was already recorded, preserving existing usage rows through a shape-aware version 69 migration
- wait for proxy readiness before MCP startup, retain terminal diagnostics, and project the full lifecycle into renderer state
- allow Streamable HTTP negotiation two 20-second attempts while keeping stdio negotiation at one 8-second attempt

## UI

```text
BEFORE                              AFTER
┌─ minimax ───────────────┐         ┌─ minimax ───────────────┐
│ Stopped          [ ON ] │         │ Starting…        [ ON ] │
└─────────────────────────┘         └─────────────────────────┘
                                      ↓ terminal failure
                                    ┌─ minimax ───────────────┐
                                    │ Error  ⚠        [ ON ] │
                                    │ bounded failure detail  │
                                    └─────────────────────────┘
```

## Validation

- `pnpm run format`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck:node`
- focused main MCP/startup suites: 123 passed
- focused renderer MCP suites: 31 passed
- native SQLite migration regressions passed
- a copied release database retained all 916 usage rows and migrated from schema 68 to 69
- the current MiniMax endpoint completed a real authenticated handshake as legacy protocol `2025-03-26`

`pnpm run typecheck:web` remains blocked by the pre-existing readonly Monaco theme tuple mismatch in `src/renderer/src/components/markdown/MarkdownRenderer.vue`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP server cards now show startup, connected, stopped, and error states.
  - Server diagnostics include lifecycle status and recent error details.
  - Failed MCP connections remain available for troubleshooting and can recover on restart.

- **Bug Fixes**
  - HTTP MCP negotiation now uses a 20-second timeout and one retry.
  - MCP startup waits for proxy initialization to complete.
  - Usage-statistics migration preserves legacy data and repairs affected schemas.

- **Tests**
  - Added coverage for lifecycle reporting, proxy readiness, connection recovery, and database migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->