### PR TITLE
fix(ai-sdk): honor model timeout instead of undici 300s headersTimeout

### DIFF
--- a/src/main/platform/proxy.ts
+++ b/src/main/platform/proxy.ts
@@ -12,6 +12,29 @@ export const NO_PROXY =
   'localhost, 127.0.0.1, ::1, 192.168.*.*, 10.*.*.*, *.local, host.docker.internal'
 // const NO_PROXY = ''
 
+// undici's default Agent uses headersTimeout 300s. 0 disables it so slow first-token
+// providers (local Ollama) are bounded by the model timeout instead.
+export const FETCH_DISPATCHER_TIMEOUTS = {
+  headersTimeout: 0,
+  bodyTimeout: 0
+} as const
+
+export function createGlobalFetchDispatcher(proxy?: {
+  httpProxy: string
+  httpsProxy: string
+  noProxy: string
+}): Agent | EnvHttpProxyAgent {
+  if (proxy) {
+    return new EnvHttpProxyAgent({
+      httpProxy: proxy.httpProxy,
+      httpsProxy: proxy.httpsProxy,
+      noProxy: proxy.noProxy,
+      ...FETCH_DISPATCHER_TIMEOUTS
+    })
+  }
+  return new Agent(FETCH_DISPATCHER_TIMEOUTS)
+}
+
 // 合并系统和自定义的 no_proxy 设置
 function mergeNoProxy(defaultNoProxy: string): string {
   const systemNoProxy = process.env.no_proxy || process.env.NO_PROXY || ''
@@ -79,12 +102,14 @@ export class ProxyConfig {
         process.env.no_proxy = mergedNoProxy
         process.env.NO_PROXY = mergedNoProxy
         setGlobalDispatcher(
-          new EnvHttpProxyAgent({
+          createGlobalFetchDispatcher({
             httpProxy: this.proxyUrl,
             httpsProxy: this.proxyUrl,
             noProxy: mergedNoProxy
           })
         )
+      } else {
+        setGlobalDispatcher(createGlobalFetchDispatcher())
       }
       return true
     } catch (error) {
@@ -104,7 +129,7 @@ export class ProxyConfig {
     delete process.env.grpc_proxy
     delete process.env.no_proxy
     delete process.env.NO_PROXY
-    setGlobalDispatcher(new Agent())
+    setGlobalDispatcher(createGlobalFetchDispatcher())
   }
 
   private async setCustomProxy(proxyUrl: string): Promise<void> {
@@ -120,7 +145,7 @@ export class ProxyConfig {
     process.env.no_proxy = mergedNoProxy
     process.env.NO_PROXY = mergedNoProxy
     setGlobalDispatcher(
-      new EnvHttpProxyAgent({
+      createGlobalFetchDispatcher({
         httpProxy: proxyUrl,
         httpsProxy: proxyUrl,
         noProxy: mergedNoProxy

--- a/src/main/provider/aiSdk/providerFactory.ts
+++ b/src/main/provider/aiSdk/providerFactory.ts
@@ -9,7 +9,7 @@ import { createVertex } from '@ai-sdk/google-vertex'
 import { createOpenAI } from '@ai-sdk/openai'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers'
-import { ProxyAgent } from 'undici'
+import { Agent, ProxyAgent } from 'undici'
 import { proxyConfig } from '../../platform/proxy'
 import { createReasoningMiddleware } from './middlewares/reasoningMiddleware'
 import {
@@ -363,22 +363,29 @@ function shouldUseGeminiApiKeyHeader(provider: LLM_PROVIDER): boolean {
   return provider.apiType === 'gemini'
 }
 
+const PROVIDER_FETCH_TIMEOUTS = {
+  headersTimeout: 0,
+  bodyTimeout: 0
+} as const
+
+export function createProviderFetchDispatcher(proxyUrl: string | null): Agent | ProxyAgent {
+  return proxyUrl
+    ? new ProxyAgent({ uri: proxyUrl, ...PROVIDER_FETCH_TIMEOUTS })
+    : new Agent(PROVIDER_FETCH_TIMEOUTS)
+}
+
 function createFetchMiddleware(
   provider: LLM_PROVIDER,
   defaultHeaders: Record<string, string>,
   cleanHeaders = false
 ) {
-  const proxyUrl = proxyConfig.getProxyUrl()
-  const dispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined
+  const dispatcher = createProviderFetchDispatcher(proxyConfig.getProxyUrl())
 
   return async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const requestUrl = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
-    const nextInit: RequestInit & { dispatcher?: ProxyAgent } = {
-      ...init
-    }
-
-    if (dispatcher) {
-      nextInit.dispatcher = dispatcher
+    const nextInit: RequestInit & { dispatcher?: Agent | ProxyAgent } = {
+      ...init,
+      dispatcher
     }
 
     const headers = new Headers(init?.headers ?? {})

--- a/src/main/provider/aiSdk/providerFactory.ts
+++ b/src/main/provider/aiSdk/providerFactory.ts
@@ -9,8 +9,6 @@ import { createVertex } from '@ai-sdk/google-vertex'
 import { createOpenAI } from '@ai-sdk/openai'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers'
-import { Agent, ProxyAgent } from 'undici'
-import { proxyConfig } from '../../platform/proxy'
 import { createReasoningMiddleware } from './middlewares/reasoningMiddleware'
 import {
   buildOpenAICodexResponsesEndpoint,
@@ -363,29 +361,15 @@ function shouldUseGeminiApiKeyHeader(provider: LLM_PROVIDER): boolean {
   return provider.apiType === 'gemini'
 }
 
-const PROVIDER_FETCH_TIMEOUTS = {
-  headersTimeout: 0,
-  bodyTimeout: 0
-} as const
-
-export function createProviderFetchDispatcher(proxyUrl: string | null): Agent | ProxyAgent {
-  return proxyUrl
-    ? new ProxyAgent({ uri: proxyUrl, ...PROVIDER_FETCH_TIMEOUTS })
-    : new Agent(PROVIDER_FETCH_TIMEOUTS)
-}
-
 function createFetchMiddleware(
   provider: LLM_PROVIDER,
   defaultHeaders: Record<string, string>,
   cleanHeaders = false
 ) {
-  const dispatcher = createProviderFetchDispatcher(proxyConfig.getProxyUrl())
-
   return async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const requestUrl = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
-    const nextInit: RequestInit & { dispatcher?: Agent | ProxyAgent } = {
-      ...init,
-      dispatcher
+    const nextInit: RequestInit = {
+      ...init
     }
 
     const headers = new Headers(init?.headers ?? {})

--- a/test/main/platform/proxy.test.ts
+++ b/test/main/platform/proxy.test.ts
@@ -1,8 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const electronMocks = vi.hoisted(() => ({
   setProxy: vi.fn(),
   resolveProxy: vi.fn()
+}))
+
+const { Agent, EnvHttpProxyAgent, setGlobalDispatcher } = vi.hoisted(() => ({
+  Agent: vi.fn(function Agent() {
+    return {}
+  }),
+  EnvHttpProxyAgent: vi.fn(function EnvHttpProxyAgent() {
+    return {}
+  }),
+  setGlobalDispatcher: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -15,12 +25,17 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('undici', () => ({
-  Agent: class Agent {},
-  EnvHttpProxyAgent: class EnvHttpProxyAgent {},
-  setGlobalDispatcher: vi.fn()
+  Agent,
+  EnvHttpProxyAgent,
+  setGlobalDispatcher
 }))
 
-import { ProxyConfig, ProxyMode } from '@/platform/proxy'
+import {
+  FETCH_DISPATCHER_TIMEOUTS,
+  ProxyConfig,
+  ProxyMode,
+  createGlobalFetchDispatcher
+} from '@/platform/proxy'
 
 describe('ProxyConfig readiness', () => {
   beforeEach(() => {
@@ -74,5 +89,105 @@ describe('ProxyConfig readiness', () => {
 
     expect(config.getProxyUrl()).toBeNull()
     expect(electronMocks.setProxy).toHaveBeenLastCalledWith({ mode: 'direct' })
+  })
+})
+
+const PROXY_ENV_KEYS = [
+  'http_proxy',
+  'https_proxy',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'GRPC_PROXY',
+  'grpc_proxy',
+  'no_proxy',
+  'NO_PROXY'
+] as const
+
+describe('process-wide fetch dispatcher', () => {
+  const previousEnv: Partial<Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>> = {}
+
+  beforeEach(() => {
+    for (const key of PROXY_ENV_KEYS) {
+      previousEnv[key] = process.env[key]
+    }
+    vi.clearAllMocks()
+    electronMocks.setProxy.mockResolvedValue(undefined)
+    electronMocks.resolveProxy.mockResolvedValue('DIRECT')
+  })
+
+  afterEach(() => {
+    for (const key of PROXY_ENV_KEYS) {
+      if (previousEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = previousEnv[key]
+      }
+    }
+  })
+
+  it('disables undici 300s headersTimeout and bodyTimeout', () => {
+    expect(FETCH_DISPATCHER_TIMEOUTS).toEqual({
+      headersTimeout: 0,
+      bodyTimeout: 0
+    })
+
+    createGlobalFetchDispatcher()
+    expect(Agent).toHaveBeenCalledWith({
+      headersTimeout: 0,
+      bodyTimeout: 0
+    })
+
+    createGlobalFetchDispatcher({
+      httpProxy: 'http://127.0.0.1:7890',
+      httpsProxy: 'http://127.0.0.1:7890',
+      noProxy: 'localhost, 127.0.0.1'
+    })
+    expect(EnvHttpProxyAgent).toHaveBeenCalledWith({
+      httpProxy: 'http://127.0.0.1:7890',
+      httpsProxy: 'http://127.0.0.1:7890',
+      noProxy: 'localhost, 127.0.0.1',
+      headersTimeout: 0,
+      bodyTimeout: 0
+    })
+  })
+
+  it('installs a no-proxy Agent with those timeouts when SYSTEM mode has no proxy', async () => {
+    const config = new ProxyConfig()
+    await config.resolveProxy()
+
+    expect(Agent).toHaveBeenCalledWith({
+      headersTimeout: 0,
+      bodyTimeout: 0
+    })
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
+    expect(EnvHttpProxyAgent).not.toHaveBeenCalled()
+  })
+
+  it('installs a no-proxy Agent with those timeouts when proxy mode is NONE', async () => {
+    const config = new ProxyConfig()
+    config.setProxyMode(ProxyMode.NONE)
+    await config.resolveProxy()
+
+    expect(Agent).toHaveBeenCalledWith({
+      headersTimeout: 0,
+      bodyTimeout: 0
+    })
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('installs EnvHttpProxyAgent with those timeouts when a proxy is set', async () => {
+    electronMocks.resolveProxy.mockResolvedValue('PROXY 127.0.0.1:7890')
+    const config = new ProxyConfig()
+    await config.resolveProxy()
+
+    expect(EnvHttpProxyAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpProxy: 'http://127.0.0.1:7890',
+        httpsProxy: 'http://127.0.0.1:7890',
+        headersTimeout: 0,
+        bodyTimeout: 0
+      })
+    )
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/main/provider/aiSdkProviderFactory.test.ts
+++ b/test/main/provider/aiSdkProviderFactory.test.ts
@@ -598,7 +598,7 @@ describe('AI SDK provider factory', () => {
     expect(headers.has('authorization')).toBe(false)
   })
 
-  it('invokes openai-compatible fetch with a dispatcher that disables undici 300s headersTimeout', async () => {
+  it('does not attach a private dispatcher for no-proxy openai-compatible fetch', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -657,43 +657,6 @@ describe('AI SDK provider factory', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const init = fetchMock.mock.calls[0]?.[1] as (RequestInit & { dispatcher?: object }) | undefined
-    const dispatcher = init?.dispatcher
-    expect(dispatcher).toBeDefined()
-
-    const { headersTimeout } = getUndiciDispatcherTimeouts(dispatcher)
-    const defaultUndiciHeadersTimeout = 300_000
-    const oneHourMs = 3_600_000
-    expect(headersTimeout).not.toBe(defaultUndiciHeadersTimeout)
-    expect(
-      headersTimeout === 0 || (typeof headersTimeout === 'number' && headersTimeout >= oneHourMs)
-    ).toBe(true)
+    expect(init?.dispatcher).toBeUndefined()
   })
 })
-
-function getUndiciDispatcherTimeouts(dispatcher: object | undefined): {
-  headersTimeout?: number
-  bodyTimeout?: number
-} {
-  if (!dispatcher) {
-    return {}
-  }
-
-  for (const symbol of Object.getOwnPropertySymbols(dispatcher)) {
-    const value = (dispatcher as Record<symbol, unknown>)[symbol]
-    if (!value || typeof value !== 'object') {
-      continue
-    }
-
-    const record = value as Record<string, unknown>
-    if (!('headersTimeout' in record) && !('bodyTimeout' in record) && !('maxOrigins' in record)) {
-      continue
-    }
-
-    return {
-      headersTimeout: typeof record.headersTimeout === 'number' ? record.headersTimeout : undefined,
-      bodyTimeout: typeof record.bodyTimeout === 'number' ? record.bodyTimeout : undefined
-    }
-  }
-
-  return {}
-}

--- a/test/main/provider/aiSdkProviderFactory.test.ts
+++ b/test/main/provider/aiSdkProviderFactory.test.ts
@@ -597,4 +597,103 @@ describe('AI SDK provider factory', () => {
     expect(headers.get('x-goog-api-key')).toBe('test-key-1234')
     expect(headers.has('authorization')).toBe(false)
   })
+
+  it('invokes openai-compatible fetch with a dispatcher that disables undici 300s headersTimeout', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'chatcmpl-headers-timeout',
+          object: 'chat.completion',
+          created: 1,
+          model: 'llama3',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'ok'
+              },
+              finish_reason: 'stop'
+            }
+          ],
+          usage: {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2
+          }
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json'
+          }
+        }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const context = createAiSdkProviderContext({
+      providerKind: 'openai-compatible',
+      provider: {
+        id: 'ollama',
+        name: 'Ollama',
+        apiType: 'ollama',
+        apiKey: '',
+        baseUrl: 'http://127.0.0.1:11434',
+        enable: true
+      } as any,
+      providerSettings: {
+        getAzureApiVersion: () => undefined
+      } as any,
+      defaultHeaders: {},
+      modelId: 'llama3',
+      wrapThinkReasoning: false
+    })
+
+    await generateText({
+      model: context.model,
+      messages: [{ role: 'user', content: 'Hello' }]
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const init = fetchMock.mock.calls[0]?.[1] as (RequestInit & { dispatcher?: object }) | undefined
+    const dispatcher = init?.dispatcher
+    expect(dispatcher).toBeDefined()
+
+    const { headersTimeout } = getUndiciDispatcherTimeouts(dispatcher)
+    const defaultUndiciHeadersTimeout = 300_000
+    const oneHourMs = 3_600_000
+    expect(headersTimeout).not.toBe(defaultUndiciHeadersTimeout)
+    expect(
+      headersTimeout === 0 || (typeof headersTimeout === 'number' && headersTimeout >= oneHourMs)
+    ).toBe(true)
+  })
 })
+
+function getUndiciDispatcherTimeouts(dispatcher: object | undefined): {
+  headersTimeout?: number
+  bodyTimeout?: number
+} {
+  if (!dispatcher) {
+    return {}
+  }
+
+  for (const symbol of Object.getOwnPropertySymbols(dispatcher)) {
+    const value = (dispatcher as Record<symbol, unknown>)[symbol]
+    if (!value || typeof value !== 'object') {
+      continue
+    }
+
+    const record = value as Record<string, unknown>
+    if (!('headersTimeout' in record) && !('bodyTimeout' in record) && !('maxOrigins' in record)) {
+      continue
+    }
+
+    return {
+      headersTimeout: typeof record.headersTimeout === 'number' ? record.headersTimeout : undefined,
+      bodyTimeout: typeof record.bodyTimeout === 'number' ? record.bodyTimeout : undefined
+    }
+  }
+
+  return {}
+}


### PR DESCRIPTION
Local Ollama (and any other slow first-token provider) was dying at about five minutes with `UND_ERR_HEADERS_TIMEOUT` / `AI_APICallError: Headers Timeout Error`, even when the model timeout was set to one hour.

Node's default undici Agent uses `headersTimeout` 300s, independent of the `AbortSignal` from `combineRequestSignal`. `src/main/platform/proxy.ts` only called `setGlobalDispatcher` when a proxy URL was set, so SYSTEM mode with no proxy (typical local Ollama) kept that 300s default.

This installs the process-wide dispatcher with `headersTimeout: 0` and `bodyTimeout: 0` in `clearProxy`, custom/system proxy setup, and SYSTEM mode with no detected proxy. `EnvHttpProxyAgent` still gets the global `NO_PROXY` list. The AI SDK factory no longer attaches a per-request Agent/ProxyAgent, so fetch uses that dispatcher. Retry policy is unchanged.

Credit: @jianpuwuwei

Fixes #2180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for AI provider requests by preventing premature timeout failures.
  * Improved network routing across direct connections, system proxy settings, and custom proxy configurations.
  * Prevented unnecessary routing configuration from being applied to direct provider requests.
* **Tests**
  * Added coverage for timeout behavior, proxy selection, and direct provider requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->