### PR TITLE
fix(proxy): inherit global fetch timeouts on remaining fetches

### DIFF
--- a/src/main/platform/proxy.ts
+++ b/src/main/platform/proxy.ts
@@ -105,6 +105,7 @@ export class ProxyConfig {
       } else {
         setGlobalDispatcher(createGlobalFetchDispatcher())
         this.proxyUrl = null
+        this.clearProxyEnv()
       }
       return true
     } catch (error) {
@@ -135,9 +136,7 @@ export class ProxyConfig {
     }
   }
 
-  private async clearProxy(): Promise<void> {
-    await session.defaultSession.setProxy({ mode: 'direct' })
-    this.proxyUrl = null
+  private clearProxyEnv(): void {
     delete process.env.http_proxy
     delete process.env.https_proxy
     delete process.env.HTTP_PROXY
@@ -146,6 +145,12 @@ export class ProxyConfig {
     delete process.env.grpc_proxy
     delete process.env.no_proxy
     delete process.env.NO_PROXY
+  }
+
+  private async clearProxy(): Promise<void> {
+    await session.defaultSession.setProxy({ mode: 'direct' })
+    this.proxyUrl = null
+    this.clearProxyEnv()
     setGlobalDispatcher(createGlobalFetchDispatcher())
   }
 

--- a/src/main/platform/proxy.ts
+++ b/src/main/platform/proxy.ts
@@ -35,20 +35,19 @@ export function createGlobalFetchDispatcher(proxy?: {
   return new Agent(FETCH_DISPATCHER_TIMEOUTS)
 }
 
-// 合并系统和自定义的 no_proxy 设置
-function mergeNoProxy(defaultNoProxy: string): string {
-  const systemNoProxy = process.env.no_proxy || process.env.NO_PROXY || ''
-  logger.info('systemNoProxy', systemNoProxy)
-  if (!systemNoProxy) {
+// Merge app defaults with the process inherited no_proxy snapshot, not live env.
+// resolve can write NO_PROXY then later clear it; live env would lose the original.
+function mergeNoProxy(defaultNoProxy: string, inheritedNoProxy: string): string {
+  logger.info('systemNoProxy', inheritedNoProxy)
+  if (!inheritedNoProxy) {
     return defaultNoProxy
   }
-  // 将两个 no_proxy 字符串分割成数组，去重，然后重新组合
   const noProxySet = new Set(
     [
       ...defaultNoProxy.split(',').map((item) => item.trim()),
-      ...systemNoProxy.split(',').map((item) => item.trim())
+      ...inheritedNoProxy.split(',').map((item) => item.trim())
     ].filter(Boolean)
-  ) // 过滤掉空字符串
+  )
 
   return Array.from(noProxySet).join(', ')
 }
@@ -58,13 +57,26 @@ export class ProxyConfig {
   private mode: ProxyMode = ProxyMode.SYSTEM
   private customProxyUrl: string = ''
   private resolutionPromise: Promise<boolean> = Promise.resolve(true)
+  private dispatcherInstalled = false
+  private readonly inheritedNoProxy = process.env.no_proxy || process.env.NO_PROXY || ''
 
   resolveProxy(): Promise<boolean> {
     const mode = this.mode
     const customProxyUrl = this.customProxyUrl
-    const resolution = this.resolutionPromise.then(() => this.resolveProxyNow(mode, customProxyUrl))
+    const resolution = this.resolutionPromise.then(
+      () => this.resolveProxyNow(mode, customProxyUrl),
+      () => this.resolveProxyNow(mode, customProxyUrl)
+    )
     this.resolutionPromise = resolution
     return resolution
+  }
+
+  private ensureTimeoutDispatcher(): void {
+    if (this.dispatcherInstalled) {
+      return
+    }
+    setGlobalDispatcher(createGlobalFetchDispatcher())
+    this.dispatcherInstalled = true
   }
 
   whenReady(): Promise<boolean> {
@@ -73,6 +85,7 @@ export class ProxyConfig {
 
   private async resolveProxyNow(mode: ProxyMode, customProxyUrl: string): Promise<boolean> {
     try {
+      this.ensureTimeoutDispatcher()
       // 根据不同的代理模式设置
       if (mode === ProxyMode.NONE) {
         await this.clearProxy()
@@ -93,7 +106,7 @@ export class ProxyConfig {
         protocol === 'PROXY' && address?.trim() ? `http://${address.trim()}` : null
 
       if (resolvedProxyUrl) {
-        const mergedNoProxy = mergeNoProxy(NO_PROXY)
+        const mergedNoProxy = mergeNoProxy(NO_PROXY, this.inheritedNoProxy)
         setGlobalDispatcher(
           createGlobalFetchDispatcher({
             httpProxy: resolvedProxyUrl,
@@ -110,28 +123,8 @@ export class ProxyConfig {
       return true
     } catch (error) {
       console.error('Failed to resolve proxy:', error)
-      // Never throw: a rejected resolutionPromise skips every later resolve.
-      // Reuse the last installed proxy URL so a later failure does not drop it.
-      try {
-        if (this.proxyUrl) {
-          setGlobalDispatcher(
-            createGlobalFetchDispatcher({
-              httpProxy: this.proxyUrl,
-              httpsProxy: this.proxyUrl,
-              noProxy: mergeNoProxy(NO_PROXY)
-            })
-          )
-        } else {
-          setGlobalDispatcher(createGlobalFetchDispatcher())
-        }
-      } catch (dispatcherError) {
-        console.error('Failed to install fetch dispatcher:', dispatcherError)
-        try {
-          setGlobalDispatcher(createGlobalFetchDispatcher())
-        } catch (fallbackError) {
-          console.error('Failed to install no-proxy fetch dispatcher:', fallbackError)
-        }
-      }
+      // Leave the last good dispatcher in place. Recreating it here leaks the
+      // previous pool and can drop a working proxy after a later resolve fails.
       return false
     }
   }
@@ -168,7 +161,7 @@ export class ProxyConfig {
 
   private async setCustomProxy(proxyUrl: string): Promise<void> {
     await session.defaultSession.setProxy({ proxyRules: proxyUrl })
-    const mergedNoProxy = mergeNoProxy(NO_PROXY)
+    const mergedNoProxy = mergeNoProxy(NO_PROXY, this.inheritedNoProxy)
     setGlobalDispatcher(
       createGlobalFetchDispatcher({
         httpProxy: proxyUrl,
@@ -253,6 +246,7 @@ export class ProxyConfig {
         this.mode = ProxyMode.SYSTEM
       }
     }
+    this.ensureTimeoutDispatcher()
     void this.resolveProxy()
   }
 }

--- a/src/main/platform/proxy.ts
+++ b/src/main/platform/proxy.ts
@@ -114,6 +114,19 @@ export class ProxyConfig {
       return true
     } catch (error) {
       console.error('Failed to resolve proxy:', error)
+      // Timeouts must still be disabled. Reuse a known proxy URL so a later
+      // resolve failure does not drop an already-working proxy.
+      if (this.proxyUrl) {
+        setGlobalDispatcher(
+          createGlobalFetchDispatcher({
+            httpProxy: this.proxyUrl,
+            httpsProxy: this.proxyUrl,
+            noProxy: mergeNoProxy(NO_PROXY)
+          })
+        )
+      } else {
+        setGlobalDispatcher(createGlobalFetchDispatcher())
+      }
       return false
     }
   }

--- a/src/main/platform/proxy.ts
+++ b/src/main/platform/proxy.ts
@@ -89,43 +89,47 @@ export class ProxyConfig {
       const proxyString = await session.defaultSession.resolveProxy('https://www.google.com')
       const [protocol, address] = proxyString.split(';')[0].split(' ')
       logger.info('proxy url', protocol, address)
-      this.proxyUrl = protocol === 'PROXY' ? `http://${address}` : null
+      const resolvedProxyUrl =
+        protocol === 'PROXY' && address?.trim() ? `http://${address.trim()}` : null
 
-      if (this.proxyUrl) {
-        process.env.http_proxy = this.proxyUrl
-        process.env.https_proxy = this.proxyUrl
-        process.env.HTTP_PROXY = this.proxyUrl
-        process.env.HTTPS_PROXY = this.proxyUrl
-        process.env.GRPC_PROXY = this.proxyUrl
-        process.env.grpc_proxy = this.proxyUrl
+      if (resolvedProxyUrl) {
         const mergedNoProxy = mergeNoProxy(NO_PROXY)
-        process.env.no_proxy = mergedNoProxy
-        process.env.NO_PROXY = mergedNoProxy
         setGlobalDispatcher(
           createGlobalFetchDispatcher({
-            httpProxy: this.proxyUrl,
-            httpsProxy: this.proxyUrl,
+            httpProxy: resolvedProxyUrl,
+            httpsProxy: resolvedProxyUrl,
             noProxy: mergedNoProxy
           })
         )
+        this.commitResolvedProxy(resolvedProxyUrl, mergedNoProxy)
       } else {
         setGlobalDispatcher(createGlobalFetchDispatcher())
+        this.proxyUrl = null
       }
       return true
     } catch (error) {
       console.error('Failed to resolve proxy:', error)
-      // Timeouts must still be disabled. Reuse a known proxy URL so a later
-      // resolve failure does not drop an already-working proxy.
-      if (this.proxyUrl) {
-        setGlobalDispatcher(
-          createGlobalFetchDispatcher({
-            httpProxy: this.proxyUrl,
-            httpsProxy: this.proxyUrl,
-            noProxy: mergeNoProxy(NO_PROXY)
-          })
-        )
-      } else {
-        setGlobalDispatcher(createGlobalFetchDispatcher())
+      // Never throw: a rejected resolutionPromise skips every later resolve.
+      // Reuse the last installed proxy URL so a later failure does not drop it.
+      try {
+        if (this.proxyUrl) {
+          setGlobalDispatcher(
+            createGlobalFetchDispatcher({
+              httpProxy: this.proxyUrl,
+              httpsProxy: this.proxyUrl,
+              noProxy: mergeNoProxy(NO_PROXY)
+            })
+          )
+        } else {
+          setGlobalDispatcher(createGlobalFetchDispatcher())
+        }
+      } catch (dispatcherError) {
+        console.error('Failed to install fetch dispatcher:', dispatcherError)
+        try {
+          setGlobalDispatcher(createGlobalFetchDispatcher())
+        } catch (fallbackError) {
+          console.error('Failed to install no-proxy fetch dispatcher:', fallbackError)
+        }
       }
       return false
     }
@@ -145,8 +149,7 @@ export class ProxyConfig {
     setGlobalDispatcher(createGlobalFetchDispatcher())
   }
 
-  private async setCustomProxy(proxyUrl: string): Promise<void> {
-    await session.defaultSession.setProxy({ proxyRules: proxyUrl })
+  private commitResolvedProxy(proxyUrl: string, mergedNoProxy: string): void {
     this.proxyUrl = proxyUrl
     process.env.http_proxy = proxyUrl
     process.env.https_proxy = proxyUrl
@@ -154,9 +157,13 @@ export class ProxyConfig {
     process.env.HTTPS_PROXY = proxyUrl
     process.env.GRPC_PROXY = proxyUrl
     process.env.grpc_proxy = proxyUrl
-    const mergedNoProxy = mergeNoProxy(NO_PROXY)
     process.env.no_proxy = mergedNoProxy
     process.env.NO_PROXY = mergedNoProxy
+  }
+
+  private async setCustomProxy(proxyUrl: string): Promise<void> {
+    await session.defaultSession.setProxy({ proxyRules: proxyUrl })
+    const mergedNoProxy = mergeNoProxy(NO_PROXY)
     setGlobalDispatcher(
       createGlobalFetchDispatcher({
         httpProxy: proxyUrl,
@@ -164,6 +171,7 @@ export class ProxyConfig {
         noProxy: mergedNoProxy
       })
     )
+    this.commitResolvedProxy(proxyUrl, mergedNoProxy)
   }
 
   /**

--- a/src/main/provider/aiSdk/runtime.ts
+++ b/src/main/provider/aiSdk/runtime.ts
@@ -47,8 +47,6 @@ import type { LLMCoreStreamEvent } from '@shared/types/core/llm-events'
 import { mcpToolsToAISDKTools } from './toolMapper'
 import { mapMessagesToModelMessages } from './messageMapper'
 import { buildProviderOptions } from './providerOptionsMapper'
-import { ProxyAgent } from 'undici'
-import { proxyConfig } from '../../platform/proxy'
 import {
   type AiSdkProviderKind,
   createAiSdkProviderContext,
@@ -468,9 +466,7 @@ async function executeTtsPatternA(
   const disposeCallerAbort = relayAbortSignal(signal, controller)
 
   try {
-    const proxyUrl = proxyConfig.getProxyUrl()
-    const dispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined
-    const fetchInit: RequestInit & { dispatcher?: ProxyAgent } = {
+    const fetchInit: RequestInit = {
       method: 'POST',
       headers: {
         ...defaultHeaders,
@@ -480,7 +476,6 @@ async function executeTtsPatternA(
       body: JSON.stringify(body),
       signal: controller.signal
     }
-    if (dispatcher) fetchInit.dispatcher = dispatcher
     const response = await fetch(url, fetchInit)
 
     if (!response.ok) {
@@ -533,9 +528,7 @@ async function executeTtsPatternB(
   const disposeCallerAbort = relayAbortSignal(signal, controller)
 
   try {
-    const proxyUrl = proxyConfig.getProxyUrl()
-    const dispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined
-    const fetchInit: RequestInit & { dispatcher?: ProxyAgent } = {
+    const fetchInit: RequestInit = {
       method: 'POST',
       headers: {
         ...defaultHeaders,
@@ -545,7 +538,6 @@ async function executeTtsPatternB(
       body: JSON.stringify(body),
       signal: controller.signal
     }
-    if (dispatcher) fetchInit.dispatcher = dispatcher
     const response = await fetch(url, fetchInit)
 
     if (!response.ok) {
@@ -617,9 +609,7 @@ async function executeTtsPatternC(
   const disposeCallerAbort = relayAbortSignal(signal, controller)
 
   try {
-    const proxyUrl = proxyConfig.getProxyUrl()
-    const dispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined
-    const fetchInit: RequestInit & { dispatcher?: ProxyAgent } = {
+    const fetchInit: RequestInit = {
       method: 'POST',
       headers: {
         ...defaultHeaders,
@@ -629,7 +619,6 @@ async function executeTtsPatternC(
       body: JSON.stringify(body),
       signal: controller.signal
     }
-    if (dispatcher) fetchInit.dispatcher = dispatcher
     const response = await fetch(url, fetchInit)
 
     if (!response.ok) {
@@ -1088,11 +1077,8 @@ async function executeOpenAICompatibleVideoGeneration(
   const disposeCallerAbort = relayAbortSignal(signal, controller)
 
   try {
-    const proxyUrl = proxyConfig.getProxyUrl()
-    const dispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined
-
     const fetchJson = async <T>(url: string, init: RequestInit): Promise<T> => {
-      const fetchInit: RequestInit & { dispatcher?: ProxyAgent } = {
+      const fetchInit: RequestInit = {
         ...init,
         headers: {
           ...defaultHeaders,
@@ -1101,7 +1087,6 @@ async function executeOpenAICompatibleVideoGeneration(
         },
         signal: controller.signal
       }
-      if (dispatcher) fetchInit.dispatcher = dispatcher
 
       const response = await fetch(url, fetchInit)
       if (!response.ok) {
@@ -1113,7 +1098,7 @@ async function executeOpenAICompatibleVideoGeneration(
     }
 
     const fetchBinary = async (url: string): Promise<{ buffer: ArrayBuffer; mimeType: string }> => {
-      const fetchInit: RequestInit & { dispatcher?: ProxyAgent } = {
+      const fetchInit: RequestInit = {
         method: 'GET',
         headers: {
           ...defaultHeaders,
@@ -1121,7 +1106,6 @@ async function executeOpenAICompatibleVideoGeneration(
         },
         signal: controller.signal
       }
-      if (dispatcher) fetchInit.dispatcher = dispatcher
 
       const response = await fetch(url, fetchInit)
       if (!response.ok) {

--- a/src/main/provider/openaiCodexAdapter.ts
+++ b/src/main/provider/openaiCodexAdapter.ts
@@ -1,14 +1,8 @@
-import { ProxyAgent } from 'undici'
-import { proxyConfig } from '../platform/proxy'
 import {
   OPENAI_CODEX_API_BASE_URL,
   isOpenAICodexDisabled
 } from '../provider/auth/openaiCodex/constants'
 import { getGlobalOpenAICodexAuth, type OpenAICodexBackendAuth } from '../provider/auth/openaiCodex'
-
-type FetchInitWithDispatcher = RequestInit & {
-  dispatcher?: ProxyAgent
-}
 
 const OPENAI_CODEX_PRODUCT_SKU = 'codex'
 const OPENAI_CODEX_ORIGINATOR = 'codex_cli_rs'
@@ -185,49 +179,17 @@ function applyCodexHeaders(
 }
 
 export function createOpenAICodexFetch(defaultHeaders: Record<string, string>) {
-  let currentProxyUrl: string | null = null
-  let proxyAgent: ProxyAgent | undefined
-
-  const closeProxyAgent = () => {
-    if (proxyAgent) {
-      void proxyAgent.close().catch(() => undefined)
-    }
-    proxyAgent = undefined
-    currentProxyUrl = null
-  }
-
-  const getDispatcher = () => {
-    const proxyUrl = proxyConfig.getProxyUrl()
-    if (!proxyUrl) {
-      closeProxyAgent()
-      return undefined
-    }
-
-    if (currentProxyUrl !== proxyUrl || !proxyAgent) {
-      closeProxyAgent()
-      proxyAgent = new ProxyAgent(proxyUrl)
-      currentProxyUrl = proxyUrl
-    }
-
-    return proxyAgent
-  }
-
   return async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
     if (isOpenAICodexDisabled()) {
       throw new Error('OpenAI Codex provider is disabled by environment')
     }
 
-    const dispatcher = getDispatcher()
     const auth = getGlobalOpenAICodexAuth()
     const backendAuth = await auth.getBackendAuth()
-    const nextInit: FetchInitWithDispatcher = {
+    const nextInit: RequestInit = {
       ...init,
       body: normalizeOpenAICodexRequestBody(init?.body),
       headers: applyCodexHeaders(init?.headers, defaultHeaders, backendAuth)
-    }
-
-    if (dispatcher) {
-      nextInit.dispatcher = dispatcher
     }
 
     let response = await fetch(url, nextInit)

--- a/src/main/provider/providers/aiSdkProvider.ts
+++ b/src/main/provider/providers/aiSdkProvider.ts
@@ -27,7 +27,6 @@ import type {
 } from '@shared/types/provider'
 import { BedrockClient, ListFoundationModelsCommand } from '@aws-sdk/client-bedrock'
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers'
-import { ProxyAgent } from 'undici'
 import {
   BaseLLMProvider,
   SUMMARY_TITLES_PROMPT,
@@ -46,7 +45,6 @@ import { normalizeAzureBaseUrl, normalizeGeminiBaseUrl } from '../aiSdk/provider
 import { shouldUseXaiGrokOAuthFetch } from '../xaiGrokAuthAdapter'
 import { getGlobalXaiGrokAuth } from '../../provider/auth/xaiGrok'
 import { isTrustedXaiApiEndpoint } from '../../provider/auth/xaiGrok/constants'
-import { proxyConfig } from '../../platform/proxy'
 import {
   type AiSdkBehaviorPreset,
   type AiSdkCredentialStrategy,
@@ -655,11 +653,6 @@ export class AiSdkProvider extends BaseLLMProvider {
     return this.getModelFetchTimeout()
   }
 
-  private getFetchDispatcher(): ProxyAgent | undefined {
-    const proxyUrl = proxyConfig.getProxyUrl()
-    return proxyUrl ? new ProxyAgent(proxyUrl) : undefined
-  }
-
   private isAzureOpenAI(decision: RouteDecision, runtimeProvider: LLM_PROVIDER): boolean {
     return decision.providerKind === 'azure' || runtimeProvider.id === 'azure-openai'
   }
@@ -873,7 +866,6 @@ export class AiSdkProvider extends BaseLLMProvider {
       const requestRuntimeProvider = useGrokOAuth
         ? refreshedRuntimeProvider
         : { ...refreshedRuntimeProvider, oauthToken: undefined }
-      const dispatcher = this.getFetchDispatcher()
       const response = await fetch(url, {
         ...init,
         headers: {
@@ -885,9 +877,8 @@ export class AiSdkProvider extends BaseLLMProvider {
           ),
           ...(init.headers as Record<string, string> | undefined)
         },
-        signal: controller.signal,
-        ...(dispatcher ? ({ dispatcher } as Record<string, unknown>) : {})
-      } as RequestInit)
+        signal: controller.signal
+      })
 
       if (!response.ok) {
         const errorText = await response.text()
@@ -1412,7 +1403,6 @@ export class AiSdkProvider extends BaseLLMProvider {
     const { signal, dispose } = this.createModelRequestSignal(null)
 
     try {
-      const dispatcher = this.getFetchDispatcher()
       const response = await fetch(modelsUrl, {
         method: 'GET',
         headers: {
@@ -1422,8 +1412,7 @@ export class AiSdkProvider extends BaseLLMProvider {
           ...this.defaultHeaders,
           ...this.definition.defaultHeadersPatch
         },
-        signal,
-        ...(dispatcher ? ({ dispatcher } as Record<string, unknown>) : {})
+        signal
       })
 
       if (!response.ok) {
@@ -1470,7 +1459,6 @@ export class AiSdkProvider extends BaseLLMProvider {
     const { signal, dispose } = this.createModelRequestSignal(null)
 
     try {
-      const dispatcher = this.getFetchDispatcher()
       const response = await fetch(modelsUrl, {
         method: 'GET',
         headers: {
@@ -1479,8 +1467,7 @@ export class AiSdkProvider extends BaseLLMProvider {
           ...this.defaultHeaders,
           ...this.definition.defaultHeadersPatch
         },
-        signal,
-        ...(dispatcher ? ({ dispatcher } as Record<string, unknown>) : {})
+        signal
       })
 
       if (!response.ok) {

--- a/src/main/provider/providers/aiSdkProvider.ts
+++ b/src/main/provider/providers/aiSdkProvider.ts
@@ -1400,7 +1400,9 @@ export class AiSdkProvider extends BaseLLMProvider {
     const modelsUrl = /\/v1$/i.test(normalizedBaseUrl)
       ? `${normalizedBaseUrl}/models`
       : `${normalizedBaseUrl}/v1/models`
-    const { signal, dispose } = this.createModelRequestSignal(null)
+    const { signal, dispose } = this.createModelRequestSignal({
+      timeout: this.getModelFetchTimeout()
+    })
 
     try {
       const response = await fetch(modelsUrl, {
@@ -1456,7 +1458,9 @@ export class AiSdkProvider extends BaseLLMProvider {
     }
 
     const modelsUrl = `${normalizeGeminiBaseUrl(this.provider.baseUrl || undefined).replace(/\/+$/, '')}/models`
-    const { signal, dispose } = this.createModelRequestSignal(null)
+    const { signal, dispose } = this.createModelRequestSignal({
+      timeout: this.getModelFetchTimeout()
+    })
 
     try {
       const response = await fetch(modelsUrl, {

--- a/src/main/provider/providers/voiceAIProvider.ts
+++ b/src/main/provider/providers/voiceAIProvider.ts
@@ -16,8 +16,6 @@ import {
   extractProviderFailureMetadata
 } from '../providerFailure'
 import type { ProviderLocalePort } from '../ports'
-import { proxyConfig } from '../../platform/proxy'
-import { ProxyAgent } from 'undici'
 
 const DEFAULT_BASE_URL = 'https://dev.voice.ai'
 const DEFAULT_AUDIO_FORMAT = 'mp3'
@@ -61,9 +59,6 @@ type VoiceAITtsConfig = {
 }
 
 export class VoiceAIProvider extends BaseLLMProvider {
-  private proxyAgent?: ProxyAgent
-  private proxyUrl?: string
-
   constructor(
     provider: LLM_PROVIDER,
     providerSettings: ProviderSettingsPort,
@@ -73,16 +68,7 @@ export class VoiceAIProvider extends BaseLLMProvider {
     this.init()
   }
 
-  public onProxyResolved(): void {
-    this.proxyAgent = undefined
-    this.proxyUrl = undefined
-  }
-
-  public override updateConfig(provider: LLM_PROVIDER): void {
-    super.updateConfig(provider)
-    this.proxyAgent = undefined
-    this.proxyUrl = undefined
-  }
+  public onProxyResolved(): void {}
 
   public async check(): Promise<{ isOk: boolean; errorMsg: string | null }> {
     if (!this.provider.apiKey) {
@@ -241,16 +227,6 @@ export class VoiceAIProvider extends BaseLLMProvider {
     }
   }
 
-  private getFetchOptions(): { dispatcher?: ProxyAgent } {
-    const proxyUrl = proxyConfig.getProxyUrl()
-    if (!proxyUrl) return {}
-    if (this.proxyUrl !== proxyUrl || !this.proxyAgent) {
-      this.proxyAgent = new ProxyAgent(proxyUrl)
-      this.proxyUrl = proxyUrl
-    }
-    return { dispatcher: this.proxyAgent }
-  }
-
   private getBaseUrl(): string {
     const raw = this.provider.baseUrl?.trim()
     if (raw && raw.length > 0) {
@@ -341,8 +317,7 @@ export class VoiceAIProvider extends BaseLLMProvider {
     const response = await fetch(url, {
       method: 'GET',
       headers,
-      ...(signal ? { signal } : {}),
-      ...this.getFetchOptions()
+      ...(signal ? { signal } : {})
     })
 
     if (!response.ok) {
@@ -416,8 +391,7 @@ export class VoiceAIProvider extends BaseLLMProvider {
   private async listVoices(): Promise<VoiceStatusResponse[]> {
     const response = await fetch(this.buildUrl('/api/v1/tts/voices'), {
       method: 'GET',
-      headers: this.getAuthHeaders(),
-      ...this.getFetchOptions()
+      headers: this.getAuthHeaders()
     })
 
     if (!response.ok) {
@@ -478,8 +452,7 @@ export class VoiceAIProvider extends BaseLLMProvider {
         method: 'POST',
         headers,
         body: JSON.stringify(requestBody),
-        ...(signal ? { signal } : {}),
-        ...this.getFetchOptions()
+        ...(signal ? { signal } : {})
       })
 
       if (!response.ok) {

--- a/src/main/provider/providers/voiceAIProvider.ts
+++ b/src/main/provider/providers/voiceAIProvider.ts
@@ -389,22 +389,30 @@ export class VoiceAIProvider extends BaseLLMProvider {
   }
 
   private async listVoices(): Promise<VoiceStatusResponse[]> {
-    const response = await fetch(this.buildUrl('/api/v1/tts/voices'), {
-      method: 'GET',
-      headers: this.getAuthHeaders()
+    const { signal, dispose } = this.createModelRequestSignal({
+      timeout: this.getModelFetchTimeout()
     })
+    try {
+      const response = await fetch(this.buildUrl('/api/v1/tts/voices'), {
+        method: 'GET',
+        headers: this.getAuthHeaders(),
+        ...(signal ? { signal } : {})
+      })
 
-    if (!response.ok) {
-      throw createProviderHttpErrorFromResponse(
-        `Voice.ai list voices failed: ${response.status} ${response.statusText}`,
-        response,
-        'voiceai_voices_http_error'
-      )
+      if (!response.ok) {
+        throw createProviderHttpErrorFromResponse(
+          `Voice.ai list voices failed: ${response.status} ${response.statusText}`,
+          response,
+          'voiceai_voices_http_error'
+        )
+      }
+
+      const data = await response.json()
+      if (!Array.isArray(data)) return []
+      return data as VoiceStatusResponse[]
+    } finally {
+      dispose()
     }
-
-    const data = await response.json()
-    if (!Array.isArray(data)) return []
-    return data as VoiceStatusResponse[]
   }
 
   private async generateSpeech(

--- a/src/main/provider/xaiGrokAuthAdapter.ts
+++ b/src/main/provider/xaiGrokAuthAdapter.ts
@@ -1,5 +1,3 @@
-import { ProxyAgent } from 'undici'
-import { proxyConfig } from '../platform/proxy'
 import { getGlobalXaiGrokAuth } from '../provider/auth/xaiGrok'
 import {
   XAI_GROK_API_BASE_URL,
@@ -7,8 +5,6 @@ import {
   isTrustedXaiApiEndpoint
 } from '../provider/auth/xaiGrok/constants'
 import type { LLM_PROVIDER } from '@shared/types/provider'
-
-type FetchInitWithDispatcher = RequestInit & { dispatcher?: ProxyAgent }
 
 function applyBearerHeaders(
   headersInit: HeadersInit | undefined,
@@ -30,33 +26,7 @@ export function createXaiGrokFetch(
   defaultHeaders: Record<string, string>,
   baseFetch?: (url: string | URL | Request, init?: RequestInit) => Promise<Response>
 ) {
-  let currentProxyUrl: string | null = null
-  let proxyAgent: ProxyAgent | undefined
   const underlyingFetch = baseFetch ?? fetch
-
-  const closeProxyAgent = () => {
-    if (proxyAgent) {
-      void proxyAgent.close().catch(() => undefined)
-    }
-    proxyAgent = undefined
-    currentProxyUrl = null
-  }
-
-  const getDispatcher = () => {
-    const proxyUrl = proxyConfig.getProxyUrl()
-    if (!proxyUrl) {
-      closeProxyAgent()
-      return undefined
-    }
-
-    if (currentProxyUrl !== proxyUrl || !proxyAgent) {
-      closeProxyAgent()
-      proxyAgent = new ProxyAgent(proxyUrl)
-      currentProxyUrl = proxyUrl
-    }
-
-    return proxyAgent
-  }
 
   return async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const requestUrl = url instanceof Request ? url.url : url.toString()
@@ -71,14 +41,9 @@ export function createXaiGrokFetch(
       throw new Error('Grok requires xAI OAuth sign-in or an API key')
     }
 
-    const dispatcher = getDispatcher()
-    const nextInit: FetchInitWithDispatcher = {
+    const nextInit: RequestInit = {
       ...init,
       headers: applyBearerHeaders(init?.headers, defaultHeaders, accessToken)
-    }
-
-    if (dispatcher) {
-      nextInit.dispatcher = dispatcher
     }
 
     let response = await underlyingFetch(url, nextInit)

--- a/test/main/platform/proxy.test.ts
+++ b/test/main/platform/proxy.test.ts
@@ -190,4 +190,60 @@ describe('process-wide fetch dispatcher', () => {
     )
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
   })
+
+  it('merges process NO_PROXY into the system proxy dispatcher', async () => {
+    process.env.NO_PROXY = 'example.test, .internal'
+    electronMocks.resolveProxy.mockResolvedValue('PROXY 127.0.0.1:7890')
+    const config = new ProxyConfig()
+    await config.resolveProxy()
+
+    expect(EnvHttpProxyAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        noProxy: expect.stringMatching(/localhost/),
+        headersTimeout: 0,
+        bodyTimeout: 0
+      })
+    )
+    const noProxy = (EnvHttpProxyAgent.mock.calls[0]?.[0] as { noProxy?: string } | undefined)
+      ?.noProxy
+    expect(noProxy).toContain('example.test')
+    expect(noProxy).toContain('.internal')
+  })
+
+  it('installs a no-proxy Agent with those timeouts when resolveProxy fails', async () => {
+    electronMocks.resolveProxy.mockRejectedValue(new Error('resolve failed'))
+    const config = new ProxyConfig()
+
+    await expect(config.resolveProxy()).resolves.toBe(false)
+
+    expect(Agent).toHaveBeenCalledWith({
+      headersTimeout: 0,
+      bodyTimeout: 0
+    })
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
+    expect(EnvHttpProxyAgent).not.toHaveBeenCalled()
+  })
+
+  it('keeps the known proxy dispatcher when a later resolve fails', async () => {
+    electronMocks.resolveProxy
+      .mockResolvedValueOnce('PROXY 127.0.0.1:7890')
+      .mockRejectedValueOnce(new Error('resolve failed'))
+    const config = new ProxyConfig()
+    await config.resolveProxy()
+    vi.clearAllMocks()
+    electronMocks.setProxy.mockResolvedValue(undefined)
+
+    await expect(config.resolveProxy()).resolves.toBe(false)
+
+    expect(EnvHttpProxyAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpProxy: 'http://127.0.0.1:7890',
+        httpsProxy: 'http://127.0.0.1:7890',
+        headersTimeout: 0,
+        bodyTimeout: 0
+      })
+    )
+    expect(Agent).not.toHaveBeenCalled()
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
+  })
 })

--- a/test/main/platform/proxy.test.ts
+++ b/test/main/platform/proxy.test.ts
@@ -247,6 +247,31 @@ describe('process-wide fetch dispatcher', () => {
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
   })
 
+  it('clears committed proxy env when system resolution becomes DIRECT', async () => {
+    electronMocks.resolveProxy
+      .mockResolvedValueOnce('PROXY 127.0.0.1:7890')
+      .mockResolvedValueOnce('DIRECT')
+    const config = new ProxyConfig()
+    await config.resolveProxy()
+    expect(process.env.HTTP_PROXY).toBe('http://127.0.0.1:7890')
+    expect(process.env.GRPC_PROXY).toBe('http://127.0.0.1:7890')
+
+    await expect(config.resolveProxy()).resolves.toBe(true)
+    expect(config.getProxyUrl()).toBeNull()
+    expect(process.env.http_proxy).toBeUndefined()
+    expect(process.env.https_proxy).toBeUndefined()
+    expect(process.env.HTTP_PROXY).toBeUndefined()
+    expect(process.env.HTTPS_PROXY).toBeUndefined()
+    expect(process.env.GRPC_PROXY).toBeUndefined()
+    expect(process.env.grpc_proxy).toBeUndefined()
+    expect(process.env.no_proxy).toBeUndefined()
+    expect(process.env.NO_PROXY).toBeUndefined()
+    expect(Agent).toHaveBeenLastCalledWith({
+      headersTimeout: 0,
+      bodyTimeout: 0
+    })
+  })
+
   it('treats a PROXY result without an address as a no-proxy dispatcher', async () => {
     electronMocks.resolveProxy.mockResolvedValue('PROXY')
     const config = new ProxyConfig()

--- a/test/main/platform/proxy.test.ts
+++ b/test/main/platform/proxy.test.ts
@@ -159,7 +159,7 @@ describe('process-wide fetch dispatcher', () => {
       headersTimeout: 0,
       bodyTimeout: 0
     })
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2)
     expect(EnvHttpProxyAgent).not.toHaveBeenCalled()
   })
 
@@ -172,7 +172,7 @@ describe('process-wide fetch dispatcher', () => {
       headersTimeout: 0,
       bodyTimeout: 0
     })
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2)
   })
 
   it('installs EnvHttpProxyAgent with those timeouts when a proxy is set', async () => {
@@ -188,7 +188,7 @@ describe('process-wide fetch dispatcher', () => {
         bodyTimeout: 0
       })
     )
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2)
   })
 
   it('merges process NO_PROXY into the system proxy dispatcher', async () => {
@@ -235,16 +235,26 @@ describe('process-wide fetch dispatcher', () => {
 
     await expect(config.resolveProxy()).resolves.toBe(false)
 
-    expect(EnvHttpProxyAgent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        httpProxy: 'http://127.0.0.1:7890',
-        httpsProxy: 'http://127.0.0.1:7890',
-        headersTimeout: 0,
-        bodyTimeout: 0
-      })
-    )
+    expect(EnvHttpProxyAgent).not.toHaveBeenCalled()
     expect(Agent).not.toHaveBeenCalled()
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
+    expect(setGlobalDispatcher).not.toHaveBeenCalled()
+    expect(config.getProxyUrl()).toBe('http://127.0.0.1:7890')
+  })
+
+  it('preserves inherited NO_PROXY after a DIRECT to proxy transition', async () => {
+    process.env.NO_PROXY = 'corp.internal'
+    electronMocks.resolveProxy
+      .mockResolvedValueOnce('DIRECT')
+      .mockResolvedValueOnce('PROXY 127.0.0.1:7890')
+    const config = new ProxyConfig()
+    await config.resolveProxy()
+    expect(process.env.NO_PROXY).toBeUndefined()
+
+    await expect(config.resolveProxy()).resolves.toBe(true)
+    const noProxy = (EnvHttpProxyAgent.mock.calls.at(-1)?.[0] as { noProxy?: string } | undefined)
+      ?.noProxy
+    expect(noProxy).toContain('corp.internal')
+    expect(noProxy).toContain('localhost')
   })
 
   it('clears committed proxy env when system resolution becomes DIRECT', async () => {

--- a/test/main/platform/proxy.test.ts
+++ b/test/main/platform/proxy.test.ts
@@ -246,4 +246,36 @@ describe('process-wide fetch dispatcher', () => {
     expect(Agent).not.toHaveBeenCalled()
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1)
   })
+
+  it('treats a PROXY result without an address as a no-proxy dispatcher', async () => {
+    electronMocks.resolveProxy.mockResolvedValue('PROXY')
+    const config = new ProxyConfig()
+
+    await expect(config.resolveProxy()).resolves.toBe(true)
+    expect(config.getProxyUrl()).toBeNull()
+    expect(Agent).toHaveBeenCalledWith({
+      headersTimeout: 0,
+      bodyTimeout: 0
+    })
+    expect(EnvHttpProxyAgent).not.toHaveBeenCalled()
+  })
+
+  it('does not stall later resolves when dispatcher setup fails', async () => {
+    electronMocks.resolveProxy
+      .mockResolvedValueOnce('PROXY 127.0.0.1:7890')
+      .mockResolvedValueOnce('PROXY 127.0.0.1:9999')
+      .mockResolvedValueOnce('PROXY 127.0.0.1:7891')
+    const config = new ProxyConfig()
+    await config.resolveProxy()
+    expect(config.getProxyUrl()).toBe('http://127.0.0.1:7890')
+
+    EnvHttpProxyAgent.mockImplementationOnce(() => {
+      throw new Error('invalid proxy')
+    })
+    await expect(config.resolveProxy()).resolves.toBe(false)
+    expect(config.getProxyUrl()).toBe('http://127.0.0.1:7890')
+
+    await expect(config.resolveProxy()).resolves.toBe(true)
+    expect(config.getProxyUrl()).toBe('http://127.0.0.1:7891')
+  })
 })

--- a/test/main/provider/openaiCodexAdapter.test.ts
+++ b/test/main/provider/openaiCodexAdapter.test.ts
@@ -7,18 +7,8 @@ const authState = vi.hoisted(() => ({
   forceRefreshBackendAuth: vi.fn()
 }))
 
-const proxyState = vi.hoisted(() => ({
-  getProxyUrl: vi.fn()
-}))
-
 vi.mock('../../../src/main/provider/auth/openaiCodex', () => ({
   getGlobalOpenAICodexAuth: () => authState
-}))
-
-vi.mock('../../../src/main/platform/proxy', () => ({
-  proxyConfig: {
-    getProxyUrl: proxyState.getProxyUrl
-  }
 }))
 
 describe('OpenAI Codex adapter', () => {
@@ -27,8 +17,6 @@ describe('OpenAI Codex adapter', () => {
     authState.forceRefreshAccessToken.mockReset()
     authState.getBackendAuth.mockReset()
     authState.forceRefreshBackendAuth.mockReset()
-    proxyState.getProxyUrl.mockReset()
-    proxyState.getProxyUrl.mockReturnValue(null)
   })
 
   afterEach(() => {
@@ -95,36 +83,21 @@ describe('OpenAI Codex adapter', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
-  it('reuses the proxy dispatcher until the proxy URL changes', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi
-        .fn()
-        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
-        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
-        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
-    )
+  it('does not attach a private dispatcher', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })))
     authState.getBackendAuth.mockResolvedValue({
       accessToken: 'token'
     })
-    proxyState.getProxyUrl.mockReturnValue('http://127.0.0.1:1080')
 
     const { createOpenAICodexFetch } = await import('../../../src/main/provider/openaiCodexAdapter')
     const fetcher = createOpenAICodexFetch({})
 
     await fetcher('https://chatgpt.com/backend-api/codex/responses')
-    await fetcher('https://chatgpt.com/backend-api/codex/responses')
-    proxyState.getProxyUrl.mockReturnValue('http://127.0.0.1:1081')
-    await fetcher('https://chatgpt.com/backend-api/codex/responses')
 
-    const fetchMock = vi.mocked(fetch)
-    const firstDispatcher = (fetchMock.mock.calls[0][1] as { dispatcher?: unknown }).dispatcher
-    const secondDispatcher = (fetchMock.mock.calls[1][1] as { dispatcher?: unknown }).dispatcher
-    const thirdDispatcher = (fetchMock.mock.calls[2][1] as { dispatcher?: unknown }).dispatcher
-
-    expect(firstDispatcher).toBeDefined()
-    expect(secondDispatcher).toBe(firstDispatcher)
-    expect(thirdDispatcher).not.toBe(firstDispatcher)
+    const init = vi.mocked(fetch).mock.calls[0]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined
+    expect(init?.dispatcher).toBeUndefined()
   })
 
   it('normalizes Codex Responses request bodies for backend compatibility', async () => {

--- a/test/main/provider/voiceAIProvider.test.ts
+++ b/test/main/provider/voiceAIProvider.test.ts
@@ -2,12 +2,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { VoiceAIProvider } from '@/provider/providers/voiceAIProvider'
 
-vi.mock('@/platform/proxy', () => ({
-  proxyConfig: {
-    getProxyUrl: vi.fn().mockReturnValue(null)
-  }
-}))
-
 describe('VoiceAIProvider text cancellation', () => {
   afterEach(() => {
     vi.useRealTimers()

--- a/test/main/provider/voiceAIProvider.test.ts
+++ b/test/main/provider/voiceAIProvider.test.ts
@@ -142,6 +142,43 @@ describe('VoiceAIProvider text cancellation', () => {
     ).rejects.toBe(reason)
   })
 
+  it('aborts a hung voice list after the model fetch timeout', async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi.fn().mockImplementation((_url: string, options?: RequestInit) => {
+      return new Promise((_, reject) => {
+        const signal = options?.signal as AbortSignal | undefined
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = Object.create(VoiceAIProvider.prototype) as VoiceAIProvider & {
+      provider: { id: string; name: string; apiKey: string; baseUrl: string }
+      defaultHeaders: Record<string, string>
+      getModelFetchTimeout: () => number
+    }
+    provider.provider = {
+      id: 'voiceai',
+      name: 'VoiceAI',
+      apiKey: 'test-key',
+      baseUrl: 'https://voice.example.com'
+    }
+    provider.defaultHeaders = {}
+    provider.getModelFetchTimeout = () => 25
+
+    const checking = provider.check()
+    await Promise.resolve()
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://voice.example.com/api/v1/tts/voices',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+    await vi.advanceTimersByTimeAsync(25)
+    await expect(checking).resolves.toEqual({
+      isOk: false,
+      errorMsg: 'Request timed out after 25ms'
+    })
+  })
+
   it('emits allowlisted HTTP failure metadata without the response body', async () => {
     vi.stubGlobal(
       'fetch',


### PR DESCRIPTION
## Summary
- Follow-up to #2182. Remaining provider fetches still created a private `ProxyAgent`, which overrode the process dispatcher and restored undici's 300s `headersTimeout` / `bodyTimeout` when a proxy was set.
- Codex, Grok, TTS, video generation, model listing, and VoiceAI now use the global dispatcher so they share `headersTimeout: 0`, `bodyTimeout: 0`, and `NO_PROXY`.
- `resolveProxy()` failures also install that dispatcher. If dispatcher setup throws, the serialized resolve queue still settles and later proxy updates keep running; a previously working proxy URL is not dropped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system proxy handling, including `NO_PROXY` support and recovery when proxy resolution fails.
  * Invalid or unavailable proxy addresses now fall back safely to direct connections.
  * Preserved working proxy connections when later resolution attempts fail.
  * Voice availability checks now time out reliably when requests hang.

* **Changes**
  * AI, voice, video, and Codex requests now use standard network connections without provider-specific proxy dispatchers.

* **Tests**
  * Added coverage for proxy fallback, recovery, environment merging, timeouts, and direct request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->