### PR TITLE
fix(acp): allow uninstall while disabled

### DIFF
--- a/src/main/session/assignment.ts
+++ b/src/main/session/assignment.ts
@@ -500,7 +500,8 @@ export class SessionAssignment implements SessionAgentAssignmentPort, SessionAss
     const { handle, facet } = this.dependencies.runtime.resolveTransferSource(
       toAppSessionId(session.id)
     )
-    const state = await handle.snapshot({ lightweight: true })
+    const state =
+      handle.kind === 'acp' ? await handle.snapshot({ lightweight: true }) : await handle.snapshot()
     const status = state?.status ?? 'idle'
     let hasMessages = true
     try {
@@ -578,10 +579,9 @@ export class SessionAssignment implements SessionAgentAssignmentPort, SessionAss
       session.projectDir
     )
     const source = this.dependencies.runtime.resolveTransferSource(toAppSessionId(sessionId))
-    const sourceState = await source.handle.snapshot({ lightweight: true })
     const previousDirectAcp = source.handle.kind === 'acp'
     const previousCompatibilityAcp =
-      source.handle.kind === 'deepchat' && sourceState?.providerId === 'acp'
+      source.handle.kind === 'deepchat' && (await source.handle.snapshot())?.providerId === 'acp'
     const { facet: transferTarget } = this.dependencies.runtime.resolveDeepChatTransferTarget(
       target.agentId
     )

--- a/src/main/session/assignment.ts
+++ b/src/main/session/assignment.ts
@@ -500,7 +500,7 @@ export class SessionAssignment implements SessionAgentAssignmentPort, SessionAss
     const { handle, facet } = this.dependencies.runtime.resolveTransferSource(
       toAppSessionId(session.id)
     )
-    const state = await handle.snapshot()
+    const state = await handle.snapshot({ lightweight: true })
     const status = state?.status ?? 'idle'
     let hasMessages = true
     try {
@@ -578,7 +578,7 @@ export class SessionAssignment implements SessionAgentAssignmentPort, SessionAss
       session.projectDir
     )
     const source = this.dependencies.runtime.resolveTransferSource(toAppSessionId(sessionId))
-    const sourceState = await source.handle.snapshot()
+    const sourceState = await source.handle.snapshot({ lightweight: true })
     const previousDirectAcp = source.handle.kind === 'acp'
     const previousCompatibilityAcp =
       source.handle.kind === 'deepchat' && sourceState?.providerId === 'acp'

--- a/src/main/session/assignment.ts
+++ b/src/main/session/assignment.ts
@@ -495,6 +495,7 @@ export class SessionAssignment implements SessionAgentAssignmentPort, SessionAss
   private async assessTransferSession(session: SessionRecord): Promise<{
     status: SessionWithState['status']
     isEmptyDraft: boolean
+    queuedInputIds: string[]
     blockReason?: AgentTransferBlockReason
   }> {
     const { handle, facet } = this.dependencies.runtime.resolveTransferSource(
@@ -513,15 +514,18 @@ export class SessionAssignment implements SessionAgentAssignmentPort, SessionAss
       )
     }
 
-    let hasPendingInput = false
+    let queuedInputIds: string[] = []
+    let pendingInputInspectionFailed = false
     try {
-      hasPendingInput = (await facet.listPendingInputs(toAppSessionId(session.id))).length > 0
+      queuedInputIds = (await facet.listPendingInputs(toAppSessionId(session.id)))
+        .filter((input) => input.mode === 'queue')
+        .map((input) => input.id)
     } catch (error) {
       console.warn(
         `[SessionAssignment] Failed to inspect pending input for session=${session.id}:`,
         error
       )
-      hasPendingInput = true
+      pendingInputInspectionFailed = true
     }
 
     const hasSubagentChildren =
@@ -532,9 +536,24 @@ export class SessionAssignment implements SessionAgentAssignmentPort, SessionAss
       }).length > 0
     const isEmptyDraft = Boolean(session.isDraft) && !hasMessages && !hasSubagentChildren
 
-    if (status === 'generating') return { status, isEmptyDraft, blockReason: 'active' }
-    if (hasPendingInput) return { status, isEmptyDraft, blockReason: 'pending-input' }
-    return { status, isEmptyDraft }
+    if (pendingInputInspectionFailed) {
+      return { status, isEmptyDraft, queuedInputIds, blockReason: 'pending-input' }
+    }
+    return { status, isEmptyDraft, queuedInputIds }
+  }
+
+  private async prepareSessionForTransfer(
+    sessionId: string,
+    status: SessionWithState['status'],
+    queuedInputIds: string[]
+  ): Promise<void> {
+    if (status !== 'generating' && queuedInputIds.length === 0) return
+
+    const { handle } = this.dependencies.runtime.resolveTransferSource(toAppSessionId(sessionId))
+    if (status === 'generating') await handle.cancel()
+    for (const itemId of queuedInputIds) {
+      await handle.pending.delete(itemId)
+    }
   }
 
   private async moveSessionToAgentInternal(
@@ -578,6 +597,7 @@ export class SessionAssignment implements SessionAgentAssignmentPort, SessionAss
       targetAgentId,
       session.projectDir
     )
+    await this.prepareSessionForTransfer(sessionId, assessment.status, assessment.queuedInputIds)
     const source = this.dependencies.runtime.resolveTransferSource(toAppSessionId(sessionId))
     const previousDirectAcp = source.handle.kind === 'acp'
     const previousCompatibilityAcp =

--- a/src/main/session/assignment.ts
+++ b/src/main/session/assignment.ts
@@ -30,6 +30,10 @@ import {
   type OrchestrationPolicy
 } from '@shared/orchestration/policy'
 import { normalizeToolModeOverride, type ToolModeOverride } from '@shared/toolMode'
+import { setTimeout as delay } from 'node:timers/promises'
+
+const TRANSFER_STOP_TIMEOUT_MS = 10_000
+const TRANSFER_STOP_POLL_MS = 50
 
 export interface SessionAgentAssignmentDependencies {
   sessions: SessionAssignmentStorePort
@@ -550,9 +554,21 @@ export class SessionAssignment implements SessionAgentAssignmentPort, SessionAss
     if (status !== 'generating' && queuedInputIds.length === 0) return
 
     const { handle } = this.dependencies.runtime.resolveTransferSource(toAppSessionId(sessionId))
-    if (status === 'generating') await handle.cancel()
     for (const itemId of queuedInputIds) {
       await handle.pending.delete(itemId)
+    }
+    if (status === 'generating') {
+      await handle.cancel()
+      const deadline = Date.now() + TRANSFER_STOP_TIMEOUT_MS
+      while (
+        (await handle.snapshot(handle.kind === 'acp' ? { lightweight: true } : undefined))
+          ?.status === 'generating'
+      ) {
+        if (Date.now() >= deadline) {
+          throw new Error(`Session ${sessionId} did not stop before transfer.`)
+        }
+        await delay(TRANSFER_STOP_POLL_MS)
+      }
     }
   }
 

--- a/test/main/session/assignment.test.ts
+++ b/test/main/session/assignment.test.ts
@@ -312,8 +312,14 @@ describe('SessionAssignment', () => {
     })
   })
 
-  it('uses the required deletion port for bulk deletion and publishes once', async () => {
+  it('deletes active Agent sessions and ignores their queued input', async () => {
     const harness = createHarness([createSession({ id: 'parent' })])
+    harness.deepchatHandle.snapshot.mockResolvedValue({
+      status: 'generating',
+      providerId: 'openai',
+      modelId: 'gpt-4'
+    })
+    harness.pendingInputs.set('parent', [{ id: 'queued-1', mode: 'queue' }])
     harness.deletion.deleteSessionTree.mockResolvedValue(['child', 'parent'])
 
     await expect(harness.coordinator.deleteAgentSessions('source')).resolves.toEqual([

--- a/test/main/session/assignment.test.ts
+++ b/test/main/session/assignment.test.ts
@@ -333,19 +333,28 @@ describe('SessionAssignment', () => {
     })
   })
 
-  it('uses lightweight snapshots to transfer unavailable ACP sessions', async () => {
+  it('uses lightweight snapshots to stop and transfer unavailable ACP sessions', async () => {
     const harness = createHarness([createSession({ agentId: 'codex-acp' })])
+    let cancelled = false
+    const cancel = vi.fn(async () => {
+      cancelled = true
+    })
     const snapshot = vi.fn(async (options?: { lightweight?: boolean }) => {
       if (!options?.lightweight) throw new Error('Agent "codex-acp" is unavailable: invalid-config')
       return {
-        status: 'idle' as const,
+        status: cancelled ? ('idle' as const) : ('generating' as const),
         providerId: 'acp',
         modelId: 'codex-acp'
       }
     })
     harness.runtime.resolveTransferSource.mockReturnValue({
       descriptor: { id: 'codex-acp', kind: 'acp', source: 'registry' },
-      handle: { ...harness.acpHandle, snapshot },
+      handle: {
+        ...harness.acpHandle,
+        snapshot,
+        cancel,
+        pending: { delete: vi.fn().mockResolvedValue(undefined) }
+      },
       facet: {
         hasMessages: vi.fn().mockResolvedValue(true),
         listPendingInputs: vi.fn().mockResolvedValue([])
@@ -364,6 +373,7 @@ describe('SessionAssignment', () => {
     })
     expect(snapshot).toHaveBeenCalled()
     expect(snapshot.mock.calls.every(([options]) => options?.lightweight)).toBe(true)
+    expect(cancel).toHaveBeenCalledOnce()
   })
 
   it('preserves the non-transactional project update order', async () => {

--- a/test/main/session/assignment.test.ts
+++ b/test/main/session/assignment.test.ts
@@ -327,6 +327,39 @@ describe('SessionAssignment', () => {
     })
   })
 
+  it('uses lightweight snapshots to transfer unavailable ACP sessions', async () => {
+    const harness = createHarness([createSession({ agentId: 'codex-acp' })])
+    const snapshot = vi.fn(async (options?: { lightweight?: boolean }) => {
+      if (!options?.lightweight) throw new Error('Agent "codex-acp" is unavailable: invalid-config')
+      return {
+        status: 'idle' as const,
+        providerId: 'acp',
+        modelId: 'codex-acp'
+      }
+    })
+    harness.runtime.resolveTransferSource.mockReturnValue({
+      descriptor: { id: 'codex-acp', kind: 'acp', source: 'registry' },
+      handle: { ...harness.acpHandle, snapshot },
+      facet: {
+        hasMessages: vi.fn().mockResolvedValue(true),
+        listPendingInputs: vi.fn().mockResolvedValue([])
+      },
+      closeRuntime: harness.acpFacet.closeRuntime
+    })
+
+    await expect(harness.coordinator.getAgentTransferImpact('codex-acp')).resolves.toMatchObject({
+      totalSessions: 1,
+      movableSessions: 1,
+      blockedSessions: 0
+    })
+    await expect(harness.coordinator.moveAgentSessions('codex-acp', 'target')).resolves.toEqual({
+      movedSessionIds: ['s1'],
+      deletedSessionIds: []
+    })
+    expect(snapshot).toHaveBeenCalled()
+    expect(snapshot.mock.calls.every(([options]) => options?.lightweight)).toBe(true)
+  })
+
   it('preserves the non-transactional project update order', async () => {
     const harness = createHarness([createSession({ agentId: 'claude-acp' })])
     const order: string[] = []

--- a/test/main/session/session.integration.test.ts
+++ b/test/main/session/session.integration.test.ts
@@ -4169,6 +4169,16 @@ describe('Session application coordinators', () => {
         defaultModelPreset: { providerId: 'openai', modelId: 'gpt-4.1' }
       })
       deepChatAgent.hasMessages.mockResolvedValue(true)
+      let activeStatus: 'generating' | 'idle' = 'generating'
+      let activeCancelRequested = false
+      deepChatAgent.cancelGeneration.mockImplementation(async (sessionId: string) => {
+        if (sessionId === 's-active') activeCancelRequested = true
+      })
+      deepChatAgent.setSessionAgentContext.mockImplementation(async (sessionId: string) => {
+        if (sessionId === 's-active' && activeStatus === 'generating') {
+          throw new Error('Cannot move session while it is generating.')
+        }
+      })
       deepChatAgent.listPendingInputs.mockImplementation(async (sessionId: string) =>
         sessionId === 's-active'
           ? [
@@ -4188,12 +4198,15 @@ describe('Session application coordinators', () => {
             ]
           : []
       )
-      deepChatAgent.getSessionState.mockImplementation(async (sessionId: string) => ({
-        status: sessionId === 's-active' ? 'generating' : 'idle',
-        providerId: 'openai',
-        modelId: 'gpt-4.1',
-        permissionMode: 'full_access'
-      }))
+      deepChatAgent.getSessionState.mockImplementation(async (sessionId: string) => {
+        if (sessionId === 's-active' && activeCancelRequested) activeStatus = 'idle'
+        return {
+          status: sessionId === 's-active' ? activeStatus : 'idle',
+          providerId: 'openai',
+          modelId: 'gpt-4.1',
+          permissionMode: 'full_access'
+        }
+      })
 
       await expect(
         assignment.moveAgentSessions('deepchat-writer', 'deepchat-coder')
@@ -4207,10 +4220,10 @@ describe('Session application coordinators', () => {
         's-active',
         'queued-1'
       )
-      expect(deepChatAgent.cancelGeneration.mock.invocationCallOrder[0]).toBeLessThan(
-        deepChatAgent.deletePendingInput.mock.invocationCallOrder[0]
-      )
       expect(deepChatAgent.deletePendingInput.mock.invocationCallOrder[0]).toBeLessThan(
+        deepChatAgent.cancelGeneration.mock.invocationCallOrder[0]
+      )
+      expect(deepChatAgent.cancelGeneration.mock.invocationCallOrder[0]).toBeLessThan(
         deepChatAgent.setSessionAgentContext.mock.invocationCallOrder[1]
       )
       expect(sqlitePresenter.newSessionsTable.updateAgentId).toHaveBeenCalledWith(

--- a/test/main/session/session.integration.test.ts
+++ b/test/main/session/session.integration.test.ts
@@ -4128,7 +4128,7 @@ describe('Session application coordinators', () => {
       expectSessionsUpdated({ reason: 'updated', sessionIds: ['s1'] })
     })
 
-    it('validates every batch session before applying the first mutation', async () => {
+    it('stops active sessions and discards queued input before batch transfer', async () => {
       const rows = [
         {
           id: 's-ready',
@@ -4169,6 +4169,25 @@ describe('Session application coordinators', () => {
         defaultModelPreset: { providerId: 'openai', modelId: 'gpt-4.1' }
       })
       deepChatAgent.hasMessages.mockResolvedValue(true)
+      deepChatAgent.listPendingInputs.mockImplementation(async (sessionId: string) =>
+        sessionId === 's-active'
+          ? [
+              {
+                id: 'queued-1',
+                sessionId,
+                mode: 'queue',
+                state: 'pending',
+                payload: { text: 'Ignore me', files: [] },
+                blocking: null,
+                queueOrder: 1,
+                claimedAt: null,
+                consumedAt: null,
+                createdAt: 1000,
+                updatedAt: 1000
+              }
+            ]
+          : []
+      )
       deepChatAgent.getSessionState.mockImplementation(async (sessionId: string) => ({
         status: sessionId === 's-active' ? 'generating' : 'idle',
         providerId: 'openai',
@@ -4178,13 +4197,27 @@ describe('Session application coordinators', () => {
 
       await expect(
         assignment.moveAgentSessions('deepchat-writer', 'deepchat-coder')
-      ).rejects.toThrow('Session s-active cannot be moved: active')
+      ).resolves.toEqual({
+        movedSessionIds: ['s-ready', 's-active'],
+        deletedSessionIds: []
+      })
 
-      expect(deepChatAgent.setSessionAgentContext).not.toHaveBeenCalled()
-      expect(sqlitePresenter.newSessionsTable.updateAgentId).not.toHaveBeenCalled()
-      expect(sqlitePresenter.newSessionsTable.update).not.toHaveBeenCalled()
+      expect(deepChatAgent.cancelGeneration).toHaveBeenCalledExactlyOnceWith('s-active')
+      expect(deepChatAgent.deletePendingInput).toHaveBeenCalledExactlyOnceWith(
+        's-active',
+        'queued-1'
+      )
+      expect(deepChatAgent.cancelGeneration.mock.invocationCallOrder[0]).toBeLessThan(
+        deepChatAgent.deletePendingInput.mock.invocationCallOrder[0]
+      )
+      expect(deepChatAgent.deletePendingInput.mock.invocationCallOrder[0]).toBeLessThan(
+        deepChatAgent.setSessionAgentContext.mock.invocationCallOrder[1]
+      )
+      expect(sqlitePresenter.newSessionsTable.updateAgentId).toHaveBeenCalledWith(
+        's-active',
+        'deepchat-coder'
+      )
       expect(sqlitePresenter.newSessionsTable.delete).not.toHaveBeenCalled()
-      expect(publishDeepchatEvent).not.toHaveBeenCalled()
     })
 
     it('moves a direct ACP conversation to DeepChat without entering compatibility cleanup', async () => {


### PR DESCRIPTION
## Summary

- use lightweight session snapshots only for direct ACP transfer assessment
- discard queued input, stop running sessions, and wait for cancellation to settle before transfer
- allow active or queued sessions to be deleted through the existing runtime cleanup path
- preserve conservative blocking when pending-input inspection itself fails
- add regression coverage for unavailable ACP, active transfer, queued input, and deletion

## Root cause

Disabling a registry ACP Agent removes it from the executable ACP configuration list. The uninstall flow queried related sessions with a full runtime snapshot, which tried to resolve that disabled Agent and failed with `AgentUnavailableError: invalid-config`.

The transfer flow also treated running sessions and queued input as hard blockers. Agent removal should instead discard queue-only input and stop active work before ownership changes. Cancellation is asynchronous, so transfer now waits until the runtime leaves `generating` (with a bounded timeout) before changing the Agent context. Session deletion already performs runtime cleanup before removing durable data.

## Behavior

```text
BEFORE                              AFTER
[Agent has related sessions]        [Agent has related sessions]
             |                                   |
     [Running / queued?]                  [Running / queued?]
             |                                   |
       [Block removal]                [Discard queue + stop run]
                                                 |
                                         [Wait until settled]
                                                 |
                                        [Move or delete sessions]
                                                 |
                                           [Remove Agent]
```

## Validation

- `pnpm run format:check`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck:node`
- `pnpm exec vitest run test/main/session/assignment.test.ts test/main/session/session.integration.test.ts` (156 passed)
- `pnpm run test:main` (8149 passed, 457 skipped)
- PR Check: static, test-main, test-renderer, test-native-memory, build, and pr-required passed
- Package Check: package-impact and package-required passed
- CodeRabbit passed

Local `pnpm run typecheck` is blocked by the unchanged `MarkdownRenderer.vue` readonly theme tuple error; the clean CI `static` job, including typecheck, passed on the current revision.

Closes #2186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session transfer assessments with lightweight ACP snapshots.
  * Active sessions can now be transferred safely; ongoing generation is canceled and queued inputs are removed first.
  * Transfers are blocked when pending-input checks cannot be completed.
  * Improved compatibility handling for agent migrations and unavailable ACP sessions.

* **Tests**
  * Added coverage for active-session transfers, queued-input cleanup, unavailable sessions, and successful batch transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->