### PR TITLE
fix(readme): restore broken star history chart

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -482,7 +482,7 @@ DeepChatはアクティブなオープンソースコミュニティプロジェ
 
 ## ⭐ スター履歴
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ThinkInAIXYZ/deepchat&type=Timeline)](https://www.star-history.com/#ThinkInAIXYZ/deepchat&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ThinkInAIXYZ/deepchat&type=Timeline)](https://star-history.dera.page/#ThinkInAIXYZ/deepchat&Timeline)
 
 ## 👨‍💻 貢献者
 

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ Check the [Contribution Guidelines](./CONTRIBUTING.md) to learn more about ways 
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ThinkInAIXYZ/deepchat&type=Timeline)](https://www.star-history.com/#ThinkInAIXYZ/deepchat&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ThinkInAIXYZ/deepchat&type=Timeline)](https://star-history.dera.page/#ThinkInAIXYZ/deepchat&Timeline)
 
 ## 👨‍💻 Contributors
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -482,7 +482,7 @@ DeepChat是一个活跃的开源社区项目，我们欢迎各种形式的贡献
 
 ## ⭐ Star历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ThinkInAIXYZ/deepchat&type=Timeline)](https://www.star-history.com/#ThinkInAIXYZ/deepchat&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ThinkInAIXYZ/deepchat&type=Timeline)](https://star-history.dera.page/#ThinkInAIXYZ/deepchat&Timeline)
 
 ## 👨‍💻 贡献者
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders, which is unfortunate for a project like DeepChat that wants to showcase its growth.

This change points the chart image and its linking text to a working star history service, restoring the chart in all three README variants (English, Chinese, and Japanese).

No badges or other elements are touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History chart images and links in the English, Japanese, and Chinese README files to use the new `star-history.dera.page` address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->