### PR TITLE
perf(markdown): gentle prefix batching + fix(retry): keep user message on retry

### DIFF
--- a/src/main/agent/deepchat/runtime/compactionService.ts
+++ b/src/main/agent/deepchat/runtime/compactionService.ts
@@ -409,6 +409,7 @@ export class CompactionService {
     preserveInterleavedReasoning: boolean
     preserveEmptyInterleavedReasoning?: boolean
     newUserContent: SendMessageInput
+    newUserContentInHistory?: boolean
     forceContextPressure?: boolean
     historyRecords?: ChatMessageRecord[]
     signal?: AbortSignal
@@ -440,13 +441,20 @@ export class CompactionService {
       pinnedFirstUser,
       minimumRetainedTurnCount: settings.retainRecentPairs,
       triggerThreshold: settings.triggerThreshold,
-      projectedMessages: [
-        createUserChatMessage(
-          params.newUserContent,
-          params.supportsVision,
-          params.supportsAudioInput === true
-        )
-      ],
+      // When retry reuses an existing user prompt that is already part of the
+      // history (newUserContentInHistory), do not project it a second time:
+      // counting it in both historyRecords and projectedMessages inflates the
+      // context estimate and can prematurely trigger compaction.
+      projectedMessages:
+        params.newUserContentInHistory === true
+          ? []
+          : [
+              createUserChatMessage(
+                params.newUserContent,
+                params.supportsVision,
+                params.supportsAudioInput === true
+              )
+            ],
       force: params.forceContextPressure === true,
       anchorName: params.forceContextPressure
         ? 'auto_handoff/context_overflow'

--- a/src/main/agent/deepchat/runtime/contextBuilder.ts
+++ b/src/main/agent/deepchat/runtime/contextBuilder.ts
@@ -1842,7 +1842,15 @@ export function buildCacheAwareContextWithMetadata(
           undefined,
           options.runPinnedFirstUser
         )
-    : null
+      : null
+  // When the reused retried prompt is itself the pinned first user, drop it from
+  // the leading pinned message: the live newUserMessage already carries it, so
+  // pinning it again would send the prompt twice.
+  const emittedPinnedFirstUser =
+    options.newUserContentMessageId != null &&
+    pinnedFirstUser?.record.id === options.newUserContentMessageId
+      ? null
+      : pinnedFirstUser
   const historyRecords = filterRecordsFromCursor(contextCandidateRecords, cursor)
     .filter((record) => record.id !== pinnedFirstUser?.record.id)
     .filter((record) => record.id !== options.newUserContentMessageId)
@@ -1855,7 +1863,11 @@ export function buildCacheAwareContextWithMetadata(
     undefined,
     options.providerReplayProjector
   )
-  const leadingMessages = buildCacheAwareLeadingMessages(systemPrompt, context, pinnedFirstUser)
+  const leadingMessages = buildCacheAwareLeadingMessages(
+    systemPrompt,
+    context,
+    emittedPinnedFirstUser
+  )
   const inputBudget = resolveFiniteInputBudget(
     contextLength,
     reserveTokens,
@@ -1940,7 +1952,7 @@ export function buildCacheAwareContextWithMetadata(
       emittedTurns: historyTurns,
       cursor,
       context,
-      pinnedFirstUser,
+      pinnedFirstUser: emittedPinnedFirstUser,
       includesSystemPrompt: Boolean(systemPrompt)
     })
   }

--- a/src/main/agent/deepchat/runtime/contextBuilder.ts
+++ b/src/main/agent/deepchat/runtime/contextBuilder.ts
@@ -102,6 +102,11 @@ export type ContextBuildOptions = {
   extraReserveTokens?: number
   supportsAudioInput?: boolean
   providerReplayProjector?: ChatMessageProviderReplayProjector
+  // When retry reuses an existing user prompt that is already part of the
+  // history, the context build must not include it both in the history turns
+  // and as the new user message.
+  newUserContentInHistory?: boolean
+  newUserContentMessageId?: string
 }
 
 export type CacheAwareContextBuildOptions = ContextBuildOptions & {
@@ -1838,9 +1843,9 @@ export function buildCacheAwareContextWithMetadata(
           options.runPinnedFirstUser
         )
     : null
-  const historyRecords = filterRecordsFromCursor(contextCandidateRecords, cursor).filter(
-    (record) => record.id !== pinnedFirstUser?.record.id
-  )
+  const historyRecords = filterRecordsFromCursor(contextCandidateRecords, cursor)
+    .filter((record) => record.id !== pinnedFirstUser?.record.id)
+    .filter((record) => record.id !== options.newUserContentMessageId)
   const historyTurns = buildHistoryTurns(
     historyRecords,
     supportsVision,

--- a/src/main/agent/deepchat/runtime/turnCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/turnCoordinator.ts
@@ -800,6 +800,13 @@ export class TurnCoordinator {
             state.providerId,
             state.modelId
           )
+        // A retried user prompt that is anchored and kept in the transcript is
+        // already part of the history, so compaction must not project it a second
+        // time (avoids inflating the context estimate).
+        const anchorMessageId = instance.getPreStreamTranscriptAnchorId()
+        const newUserContentInHistory = Boolean(
+          anchorMessageId && historyRecords.some((record) => record.id === anchorMessageId)
+        )
         return await this.runPreStreamStep(
           {
             sessionId,
@@ -822,6 +829,7 @@ export class TurnCoordinator {
               preserveEmptyInterleavedReasoning:
                 interleavedReasoning.preserveEmptyReasoningContent === true,
               newUserContent: content,
+              newUserContentInHistory,
               ...(pendingContextPressure ? { forceContextPressure: true } : {}),
               historyRecords,
               signal: preStreamAbortSignal

--- a/src/main/agent/deepchat/runtime/turnCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/turnCoordinator.ts
@@ -148,6 +148,7 @@ export interface TurnStartContext {
   maxProviderRounds?: number
   preserveResolvedRepresentations?: boolean
   beforeHistoryPreparation?: () => void
+  preStreamAnchorMessageId?: string
 }
 
 export interface TurnExecutionContext extends TurnStartContext {
@@ -495,7 +496,9 @@ export class TurnCoordinator {
       if (!instance) throw new Error(`Session ${sessionId} not found`)
       instance.clearPreStreamTranscriptAnchor()
       const reservedTranscriptAnchor =
-        reservedSteerAssistantMessageId ?? linkedSteerMessageIds.at(-1)
+        context?.preStreamAnchorMessageId ??
+        reservedSteerAssistantMessageId ??
+        linkedSteerMessageIds.at(-1)
       if (reservedTranscriptAnchor) {
         instance.setPreStreamTranscriptAnchorId(reservedTranscriptAnchor)
       }

--- a/src/main/agent/deepchat/runtime/turnCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/turnCoordinator.ts
@@ -1003,6 +1003,14 @@ export class TurnCoordinator {
         >
       ) => {
         const contextBuildStartedAt = Date.now()
+        // A retried user prompt that is anchored and kept in the transcript is
+        // already carried by historyRecords; exclude it from the history turns so
+        // the newUserMessage (which holds the live turn and memory injection)
+        // does not duplicate it.
+        const anchorMessageId = instance.getPreStreamTranscriptAnchorId()
+        const newUserContentInHistory = Boolean(
+          anchorMessageId && historyRecords.some((record) => record.id === anchorMessageId)
+        )
         const contextBuild = buildTapeChatView({
           sessionId,
           newUserContent: content,
@@ -1020,7 +1028,9 @@ export class TurnCoordinator {
             preserveInterleavedReasoning: interleavedReasoning.preserveReasoningContent,
             preserveEmptyInterleavedReasoning:
               interleavedReasoning.preserveEmptyReasoningContent === true,
-            providerReplayProjector
+            providerReplayProjector,
+            newUserContentInHistory,
+            newUserContentMessageId: newUserContentInHistory ? anchorMessageId : undefined
           }
         })
         logSlowPreStreamStep(sessionId, 'context-build', contextBuildStartedAt)

--- a/src/main/session/data/contracts.ts
+++ b/src/main/session/data/contracts.ts
@@ -72,8 +72,14 @@ export interface SessionTranscriptMutationPort {
   prepareRetryMessage(
     sessionId: string,
     messageId: string
-  ): Promise<{ content: SendMessageInput; projectDir: string | null; sourceOrderSeq: number }>
-  commitRetryMessage(sessionId: string, sourceOrderSeq: number): void
+  ): Promise<{
+    content: SendMessageInput
+    projectDir: string | null
+    sourceOrderSeq: number
+    retryFromOrderSeq: number
+    sourceMessageId: string | null
+  }>
+  commitRetryMessage(sessionId: string, orderSeq: number): void
   deleteMessage(sessionId: string, messageId: string): Promise<void>
   editUserMessage(sessionId: string, messageId: string, text: string): Promise<ChatMessageRecord>
   forkSessionFromMessage(

--- a/src/main/session/transcriptMutations.ts
+++ b/src/main/session/transcriptMutations.ts
@@ -43,7 +43,13 @@ export class SessionTranscriptMutations {
   async prepareRetryMessage(
     sessionId: string,
     messageId: string
-  ): Promise<{ content: SendMessageInput; projectDir: string | null; sourceOrderSeq: number }> {
+  ): Promise<{
+    content: SendMessageInput
+    projectDir: string | null
+    sourceOrderSeq: number
+    retryFromOrderSeq: number
+    sourceMessageId: string | null
+  }> {
     const target = this.requireMessage(sessionId, messageId)
     const sourceUserMessage =
       target.role === 'user'
@@ -62,14 +68,25 @@ export class SessionTranscriptMutations {
       throw new Error('Cannot retry an empty user message.')
     }
 
-    return { content, projectDir, sourceOrderSeq: sourceUserMessage.orderSeq }
+    return {
+      content,
+      projectDir,
+      sourceOrderSeq: sourceUserMessage.orderSeq,
+      // Truncate from the retried message (not the source user message) so the
+      // user prompt survives and only the assistant reply is regenerated. When
+      // the retried message IS the user prompt, keep it too and truncate from
+      // the next order sequence, anchoring it so the same record is re-sent
+      // instead of a fresh duplicate.
+      retryFromOrderSeq: target.role === 'user' ? target.orderSeq + 1 : target.orderSeq,
+      sourceMessageId: sourceUserMessage.id
+    }
   }
 
-  commitRetryMessage(sessionId: string, sourceOrderSeq: number): void {
+  commitRetryMessage(sessionId: string, orderSeq: number): void {
     this.dependencies.runInTransaction(() => {
-      this.dependencies.transcript.deleteFromOrderSeq(sessionId, sourceOrderSeq)
+      this.dependencies.transcript.deleteFromOrderSeq(sessionId, orderSeq)
     })
-    this.dependencies.runtime.invalidateTranscriptFrom(sessionId, sourceOrderSeq)
+    this.dependencies.runtime.invalidateTranscriptFrom(sessionId, orderSeq)
   }
 
   async deleteMessage(sessionId: string, messageId: string): Promise<void> {

--- a/src/main/session/transcriptMutations.ts
+++ b/src/main/session/transcriptMutations.ts
@@ -68,6 +68,14 @@ export class SessionTranscriptMutations {
       throw new Error('Cannot retry an empty user message.')
     }
 
+    // The retried user prompt is kept in the transcript and reused as the
+    // pre-stream anchor. A failed/error row (e.g. a failed Steer prompt) must be
+    // restored to 'sent' so context history filtering keeps it; otherwise the
+    // prompt silently drops out of future turns.
+    if (sourceUserMessage.status !== 'sent') {
+      this.dependencies.transcript.updateMessageStatus(sourceUserMessage.id, 'sent')
+    }
+
     return {
       content,
       projectDir,

--- a/src/main/session/turn.ts
+++ b/src/main/session/turn.ts
@@ -352,6 +352,8 @@ export class SessionTurn implements SessionTurnPort, SessionInitialTurnPort {
     const runtime = this.dependencies.runtime.resolveSession(toAppSessionId(sessionId))
     const prepared = await this.dependencies.transcript.prepareRetryMessage(sessionId, messageId)
     if (runtime.kind === 'acp') {
+      // ACP re-creates the user message on send, so truncate from the source
+      // user message (inclusive) to avoid a stale duplicate.
       this.dependencies.transcript.commitRetryMessage(sessionId, prepared.sourceOrderSeq)
       return await runtime.send({
         content: prepared.content,
@@ -370,8 +372,11 @@ export class SessionTurn implements SessionTurnPort, SessionInitialTurnPort {
         projectDir: prepared.projectDir,
         emitRefreshBeforeStream: true,
         preserveResolvedRepresentations: true,
+        ...(prepared.sourceMessageId
+          ? { preStreamAnchorMessageId: prepared.sourceMessageId }
+          : {}),
         beforeHistoryPreparation: () =>
-          this.dependencies.transcript.commitRetryMessage(sessionId, prepared.sourceOrderSeq)
+          this.dependencies.transcript.commitRetryMessage(sessionId, prepared.retryFromOrderSeq)
       }
     })
   }

--- a/src/main/session/turn.ts
+++ b/src/main/session/turn.ts
@@ -372,9 +372,7 @@ export class SessionTurn implements SessionTurnPort, SessionInitialTurnPort {
         projectDir: prepared.projectDir,
         emitRefreshBeforeStream: true,
         preserveResolvedRepresentations: true,
-        ...(prepared.sourceMessageId
-          ? { preStreamAnchorMessageId: prepared.sourceMessageId }
-          : {}),
+        ...(prepared.sourceMessageId ? { preStreamAnchorMessageId: prepared.sourceMessageId } : {}),
         beforeHistoryPreparation: () =>
           this.dependencies.transcript.commitRetryMessage(sessionId, prepared.retryFromOrderSeq)
       }

--- a/src/renderer/src/components/markdown/MarkdownRenderer.vue
+++ b/src/renderer/src/components/markdown/MarkdownRenderer.vue
@@ -422,8 +422,11 @@ const renderSegments = computed<RenderSegment[]>(() => {
       smoothStreaming: false,
       typewriter: false,
       nodeVirtual: 'auto',
-      maxLiveNodes: STATIC_MAX_LIVE_NODES,
-      liveNodeBuffer: STATIC_LIVE_NODE_BUFFER,
+      // Incremental batching only takes effect when virtual live-node limiting is
+      // off (markstream-vue gates batching on `maxLiveNodes <= 0`), so the prefix
+      // must not pin live nodes or the gentle raster spreading never happens.
+      maxLiveNodes: 0,
+      liveNodeBuffer: 0,
       initialBatch: PREFIX_INITIAL_RENDER_BATCH_SIZE,
       batchSize: PREFIX_RENDER_BATCH_SIZE,
       batchDelay: PREFIX_RENDER_BATCH_DELAY_MS,

--- a/src/renderer/src/components/markdown/MarkdownRenderer.vue
+++ b/src/renderer/src/components/markdown/MarkdownRenderer.vue
@@ -244,6 +244,15 @@ const STATIC_RENDER_BATCH_IDLE_TIMEOUT_MS = 16
 const STATIC_PARSE_COALESCE_MS = 0
 const STATIC_MAX_LIVE_NODES = 260
 const STATIC_LIVE_NODE_BUFFER = 80
+// The committed prefix advances in ~6 KB chunks. Mounting a whole chunk at once
+// queued a burst of GPU rasterization (0.2-1 s stalls in profiles), so the
+// prefix renders with gentle, budget-capped batching that spreads the mount and
+// raster work across frames.
+const PREFIX_INITIAL_RENDER_BATCH_SIZE = 12
+const PREFIX_RENDER_BATCH_SIZE = 8
+const PREFIX_RENDER_BATCH_DELAY_MS = 12
+const PREFIX_RENDER_BATCH_BUDGET_MS = 4
+const PREFIX_RENDER_BATCH_IDLE_TIMEOUT_MS = 40
 
 const shouldVirtualizeNodes = computed(() => props.virtualizeNodes && !isStreaming.value)
 const resolvedNodeVirtual = computed(() =>
@@ -415,11 +424,11 @@ const renderSegments = computed<RenderSegment[]>(() => {
       nodeVirtual: 'auto',
       maxLiveNodes: STATIC_MAX_LIVE_NODES,
       liveNodeBuffer: STATIC_LIVE_NODE_BUFFER,
-      initialBatch: STATIC_INITIAL_RENDER_BATCH_SIZE,
-      batchSize: STATIC_RENDER_BATCH_SIZE,
-      batchDelay: STATIC_RENDER_BATCH_DELAY_MS,
-      batchBudget: STATIC_RENDER_BATCH_BUDGET_MS,
-      batchIdle: STATIC_RENDER_BATCH_IDLE_TIMEOUT_MS,
+      initialBatch: PREFIX_INITIAL_RENDER_BATCH_SIZE,
+      batchSize: PREFIX_RENDER_BATCH_SIZE,
+      batchDelay: PREFIX_RENDER_BATCH_DELAY_MS,
+      batchBudget: PREFIX_RENDER_BATCH_BUDGET_MS,
+      batchIdle: PREFIX_RENDER_BATCH_IDLE_TIMEOUT_MS,
       parseCoalesce: STATIC_PARSE_COALESCE_MS,
       customId: `${customRendererId.value}::prefix`
     },

--- a/src/renderer/src/features/chat-page/composables/useMessageActions.ts
+++ b/src/renderer/src/features/chat-page/composables/useMessageActions.ts
@@ -84,6 +84,19 @@ export function useMessageActions(options: UseMessageActionsOptions) {
     try {
       activeRetrySessionIds.add(sessionId)
       options.messageStore.clearStreamingState()
+      // The main process truncates from the retried message onward (the user
+      // prompt survives) and re-streams with fresh ids. Mirror that in the UI
+      // BEFORE the IPC: the main starts streaming before the retry IPC resolves,
+      // so an after-await truncation would leave the stale rows visible under
+      // the new stream. When the retried message IS the user prompt, keep it in
+      // place and truncate from the next order sequence instead. The blocked/
+      // failure paths below restore via a reload.
+      const target = options.messageStore.messageCache.get(messageId)
+      if (target) {
+        const fromOrderSeq = target.role === 'user' ? target.orderSeq + 1 : target.orderSeq
+        options.messageStore.truncateMessagesFromOrderSeq(sessionId, fromOrderSeq)
+      }
+
       const result = attachmentFallbackPolicy
         ? await options.sessionClient.retryMessage(sessionId, messageId, {
             attachmentFallbackPolicy
@@ -94,6 +107,9 @@ export function useMessageActions(options: UseMessageActionsOptions) {
           blockedRetryAttempt.value = { sessionId, messageId }
           retryAttachmentPreparationSummary.value =
             result.attachmentPreparation ?? fallbackPreparationSummary()
+          // A blocked retry did not delete anything; bring the optimistically
+          // removed rows back.
+          await options.loadMessagesForSession(sessionId)
         }
         return
       }

--- a/src/renderer/src/features/chat-page/composables/useMessageActions.ts
+++ b/src/renderer/src/features/chat-page/composables/useMessageActions.ts
@@ -41,7 +41,7 @@ type UseMessageActionsOptions = {
   chatClient: ChatClientLike
   beginPlanTurn: (sessionId: string) => void
   clearPlanSnapshotForDeletedMessage: (sessionId: string, messageId: string) => void
-  loadMessagesForSession: (sessionId: string) => Promise<unknown>
+  loadMessagesForSession: (sessionId: string, count?: number) => Promise<unknown>
   applyRestoredSessionSummary: (session: unknown) => void
   currentRestoreRequestId: () => number
   canWriteSessionView: (sessionId: string, requestId: number) => boolean
@@ -92,6 +92,9 @@ export function useMessageActions(options: UseMessageActionsOptions) {
       // place and truncate from the next order sequence instead. The blocked/
       // failure paths below restore via a reload.
       const target = options.messageStore.messageCache.get(messageId)
+      // Optimistic truncation shortens messageIds; remember the pre-truncation
+      // window so a blocked retry can restore the full loaded view.
+      const priorMessageCount = options.messageStore.messageIds.length
       if (target) {
         const fromOrderSeq = target.role === 'user' ? target.orderSeq + 1 : target.orderSeq
         options.messageStore.truncateMessagesFromOrderSeq(sessionId, fromOrderSeq)
@@ -108,8 +111,8 @@ export function useMessageActions(options: UseMessageActionsOptions) {
           retryAttachmentPreparationSummary.value =
             result.attachmentPreparation ?? fallbackPreparationSummary()
           // A blocked retry did not delete anything; bring the optimistically
-          // removed rows back.
-          await options.loadMessagesForSession(sessionId)
+          // removed rows back with the same window that was visible before.
+          await options.loadMessagesForSession(sessionId, priorMessageCount)
         }
         return
       }

--- a/src/renderer/src/stores/ui/message.ts
+++ b/src/renderer/src/stores/ui/message.ts
@@ -863,6 +863,30 @@ export const useMessageStore = defineStore('message', () => {
     parsedMessageCache.delete(id)
   }
 
+  /**
+   * Removes every record with orderSeq >= fromOrderSeq (inclusive), mirroring the
+   * main-process `deleteFromOrderSeq` used by retry. Retry truncates the
+   * transcript and re-streams with fresh ids, so without this the stale rows stay
+   * mounted until the stream completes and the full reload lands (visible as the
+   * old message lingering below the new one).
+   */
+  function truncateMessagesFromOrderSeq(sessionId: string, fromOrderSeq: number): void {
+    if (committedSessionId.value !== sessionId) return
+    const removedIds = messageIds.value.filter((id) => {
+      const record = messageCache.value.get(id)
+      return Boolean(record && record.orderSeq >= fromOrderSeq)
+    })
+    if (removedIds.length === 0) return
+
+    markLiveMessageViewMutation(sessionId)
+    for (const id of removedIds) {
+      messageCache.value.delete(id)
+      parsedMessageCache.delete(id)
+    }
+    messageIds.value = messageIds.value.filter((id) => !removedIds.includes(id))
+    lastPersistedRevision.value += 1
+  }
+
   function applyPersistedMessageRecords(records: ChatMessageRecord[]): void {
     const sessionId = records[0]?.sessionId
     if (
@@ -1076,6 +1100,7 @@ export const useMessageStore = defineStore('message', () => {
     getMessage,
     addOptimisticUserMessage,
     removeOptimisticMessage,
+    truncateMessagesFromOrderSeq,
     applyPersistedMessageRecords,
     clearStreamingState,
     clearStreamingStateForOtherSession,

--- a/src/renderer/src/stores/ui/message.ts
+++ b/src/renderer/src/stores/ui/message.ts
@@ -872,18 +872,20 @@ export const useMessageStore = defineStore('message', () => {
    */
   function truncateMessagesFromOrderSeq(sessionId: string, fromOrderSeq: number): void {
     if (committedSessionId.value !== sessionId) return
-    const removedIds = messageIds.value.filter((id) => {
-      const record = messageCache.value.get(id)
-      return Boolean(record && record.orderSeq >= fromOrderSeq)
-    })
-    if (removedIds.length === 0) return
+    const removedIds = new Set(
+      messageIds.value.filter((id) => {
+        const record = messageCache.value.get(id)
+        return Boolean(record && record.orderSeq >= fromOrderSeq)
+      })
+    )
+    if (removedIds.size === 0) return
 
     markLiveMessageViewMutation(sessionId)
     for (const id of removedIds) {
       messageCache.value.delete(id)
       parsedMessageCache.delete(id)
     }
-    messageIds.value = messageIds.value.filter((id) => !removedIds.includes(id))
+    messageIds.value = messageIds.value.filter((id) => !removedIds.has(id))
     lastPersistedRevision.value += 1
   }
 

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -14204,6 +14204,25 @@ describe('DeepChatAgentHarness', () => {
       // live turn, so it must appear exactly once in the assembled request.
       expect(retriedPromptCount).toBe(1)
     })
+
+    it('does not duplicate a pinned first user prompt on retry', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      installSessionRows([
+        makeDeepchatUserRow(1, 'pinned retry me', 'retry-user'),
+        makeDeepchatAssistantRow(2, 'failed reply', 'retry-assistant', 'error')
+      ])
+
+      await retryMessage('s1', 'retry-user')
+
+      const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const runMessages = (callArgs as { run: { messages: ChatMessage[] } }).run.messages
+      const retriedPromptCount = runMessages.filter(
+        (message) => message.role === 'user' && String(message.content).includes('pinned retry me')
+      ).length
+      // The retried prompt is also the pinned first user; it must still appear
+      // exactly once (as the live turn, not also as the pinned leading message).
+      expect(retriedPromptCount).toBe(1)
+    })
   })
 
   describe('respondToolInteraction', () => {

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -14121,11 +14121,15 @@ describe('DeepChatAgentHarness', () => {
         estimateToolReserveTokens(providerTools) +
         providerMaxTokens
 
-      expect(llmProvider.generateText).toHaveBeenCalled()
+      // Retry kept the user prompt in the transcript, so the pre-stream
+      // compaction already fit the request below the budget and no further
+      // runtime compaction is needed. The durable signal is the conversation
+      // checkpoint that the compaction added to the assembled request.
+      const runMessages = (callArgs as { run: { messages: ChatMessage[] } }).run.messages
       expect(providerCoreStream).toHaveBeenCalledTimes(1)
       expect(providerMessages[0].content).toBe(baseSystemPrompt)
       expect(
-        providerMessages.some(
+        runMessages.some(
           (message: any) =>
             message.role === 'user' && String(message.content).includes('Persisted Rolling Summary')
         )

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -1280,9 +1280,7 @@ describe('DeepChatAgentHarness', () => {
       projectDir: prepared.projectDir,
       emitRefreshBeforeStream: true,
       preserveResolvedRepresentations: true,
-      ...(prepared.sourceMessageId
-        ? { preStreamAnchorMessageId: prepared.sourceMessageId }
-        : {}),
+      ...(prepared.sourceMessageId ? { preStreamAnchorMessageId: prepared.sourceMessageId } : {}),
       beforeHistoryPreparation: () =>
         transcriptMutations.commitRetryMessage(sessionId, prepared.retryFromOrderSeq)
     })

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -1280,8 +1280,11 @@ describe('DeepChatAgentHarness', () => {
       projectDir: prepared.projectDir,
       emitRefreshBeforeStream: true,
       preserveResolvedRepresentations: true,
+      ...(prepared.sourceMessageId
+        ? { preStreamAnchorMessageId: prepared.sourceMessageId }
+        : {}),
       beforeHistoryPreparation: () =>
-        transcriptMutations.commitRetryMessage(sessionId, prepared.sourceOrderSeq)
+        transcriptMutations.commitRetryMessage(sessionId, prepared.retryFromOrderSeq)
     })
   }
 
@@ -11690,9 +11693,11 @@ describe('DeepChatAgentHarness', () => {
       sqlitePresenter.deepchatSessionsTable.rewindMemoryCursorOrderSeq.mockClear()
       await retryMessage('s1', 'retry-assistant')
 
+      // Retry keeps the user prompt in place and truncates from the retried
+      // assistant message, so the memory cursor only rewinds to just before it.
       expect(sqlitePresenter.deepchatSessionsTable.rewindMemoryCursorOrderSeq).toHaveBeenCalledWith(
         's1',
-        4
+        5
       )
     })
 

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -14183,6 +14183,27 @@ describe('DeepChatAgentHarness', () => {
         error: expect.stringContaining('Request was not sent')
       })
     })
+
+    it('does not duplicate a retried user prompt in the assembled request', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      installSessionRows([
+        makeDeepchatUserRow(1, 'hello one', 'user-1'),
+        makeDeepchatAssistantRow(2, 'reply one', 'assistant-1'),
+        makeDeepchatUserRow(3, 'retry me now', 'retry-user'),
+        makeDeepchatAssistantRow(4, 'failed reply', 'retry-assistant', 'error')
+      ])
+
+      await retryMessage('s1', 'retry-user')
+
+      const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const runMessages = (callArgs as { run: { messages: ChatMessage[] } }).run.messages
+      const retriedPromptCount = runMessages.filter(
+        (message) => message.role === 'user' && String(message.content).includes('retry me now')
+      ).length
+      // The retried user prompt stays in the transcript and is re-sent as the
+      // live turn, so it must appear exactly once in the assembled request.
+      expect(retriedPromptCount).toBe(1)
+    })
   })
 
   describe('respondToolInteraction', () => {

--- a/test/main/session/assignment.test.ts
+++ b/test/main/session/assignment.test.ts
@@ -660,7 +660,10 @@ describe('SessionAssignment', () => {
       const send = vi.fn().mockResolvedValue({ requestId: 'request-1', messageId: 'message-1' })
       const prepareRetryMessage = vi.fn().mockResolvedValue({
         content: { text: 'Retry', files: [] },
-        projectDir: '/source'
+        projectDir: '/source',
+        sourceOrderSeq: 1,
+        retryFromOrderSeq: 2,
+        sourceMessageId: 'user-1'
       })
       const resolveSession = vi.fn(() => {
         observedAgentIds.push(harness.records.get('s1')?.agentId ?? 'missing')

--- a/test/main/session/session.integration.test.ts
+++ b/test/main/session/session.integration.test.ts
@@ -148,7 +148,9 @@ function createMockDeepChatAgent() {
     prepareRetryMessage: vi.fn().mockResolvedValue({
       content: { text: 'retry', files: [] },
       projectDir: null,
-      sourceOrderSeq: 1
+      sourceOrderSeq: 1,
+      retryFromOrderSeq: 2,
+      sourceMessageId: 'user-1'
     }),
     commitRetryMessage: vi.fn(),
     retryMessage: vi.fn().mockResolvedValue(undefined),
@@ -2474,7 +2476,9 @@ describe('Session application coordinators', () => {
       deepChatAgent.prepareRetryMessage.mockResolvedValueOnce({
         content: { text: 'Retry body', files: [] },
         projectDir: '/retry/project',
-        sourceOrderSeq: 3
+        sourceOrderSeq: 3,
+        retryFromOrderSeq: 4,
+        sourceMessageId: 'user-1'
       })
 
       await turn.retryMessage('s1', 'message-1')
@@ -2487,12 +2491,13 @@ describe('Session application coordinators', () => {
           projectDir: '/retry/project',
           emitRefreshBeforeStream: true,
           preserveResolvedRepresentations: true,
+          preStreamAnchorMessageId: 'user-1',
           beforeHistoryPreparation: expect.any(Function)
         }
       )
       const retryContext = deepChatAgent.processMessage.mock.calls[0][2]
       retryContext.beforeHistoryPreparation()
-      expect(deepChatAgent.commitRetryMessage).toHaveBeenCalledWith('s1', 3)
+      expect(deepChatAgent.commitRetryMessage).toHaveBeenCalledWith('s1', 4)
       expect(deepChatAgent.prepareRetryMessage.mock.invocationCallOrder[0]).toBeLessThan(
         deepChatAgent.processMessage.mock.invocationCallOrder[0]
       )

--- a/test/main/session/transcriptMutations.test.ts
+++ b/test/main/session/transcriptMutations.test.ts
@@ -23,10 +23,44 @@ describe('SessionTranscriptMutations', () => {
     await expect(mutations.prepareRetryMessage('s1', 'steer-1')).resolves.toEqual({
       content: { text: 'Retry steer', files: [], search: false },
       projectDir: '/repo',
-      sourceOrderSeq: 3
+      sourceOrderSeq: 3,
+      retryFromOrderSeq: 4,
+      sourceMessageId: 'steer-1'
     })
     expect(runtime.prepareRetry).toHaveBeenCalledWith('s1', {
       allowRestartHeldQueue: true
+    })
+  })
+
+  it('keeps the user prompt in place when retrying a user message directly', async () => {
+    const message = {
+      id: 'user-1',
+      sessionId: 's1',
+      orderSeq: 3,
+      role: 'user',
+      content: JSON.stringify({ text: 'Retry prompt', files: [] }),
+      status: 'sent',
+      metadata: '{}'
+    }
+    const runtime = {
+      prepareRetry: vi.fn().mockResolvedValue({ projectDir: '/repo' })
+    }
+    const mutations = new SessionTranscriptMutations({
+      transcript: { getMessage: vi.fn(() => message) },
+      runtime
+    } as any)
+
+    await expect(mutations.prepareRetryMessage('s1', 'user-1')).resolves.toEqual({
+      content: { text: 'Retry prompt', files: [], search: false },
+      projectDir: '/repo',
+      sourceOrderSeq: 3,
+      // Truncate from the message after the prompt so the prompt survives, and
+      // anchor it so the same record is re-sent instead of a fresh duplicate.
+      retryFromOrderSeq: 4,
+      sourceMessageId: 'user-1'
+    })
+    expect(runtime.prepareRetry).toHaveBeenCalledWith('s1', {
+      allowRestartHeldQueue: false
     })
   })
 

--- a/test/main/session/transcriptMutations.test.ts
+++ b/test/main/session/transcriptMutations.test.ts
@@ -15,8 +15,12 @@ describe('SessionTranscriptMutations', () => {
     const runtime = {
       prepareRetry: vi.fn().mockResolvedValue({ projectDir: '/repo' })
     }
+    const transcript = {
+      getMessage: vi.fn(() => message),
+      updateMessageStatus: vi.fn()
+    }
     const mutations = new SessionTranscriptMutations({
-      transcript: { getMessage: vi.fn(() => message) },
+      transcript,
       runtime
     } as any)
 
@@ -30,6 +34,9 @@ describe('SessionTranscriptMutations', () => {
     expect(runtime.prepareRetry).toHaveBeenCalledWith('s1', {
       allowRestartHeldQueue: true
     })
+    // The failed Steer prompt is kept as the pre-stream anchor, so it must be
+    // restored to 'sent' to remain visible to context history filtering.
+    expect(transcript.updateMessageStatus).toHaveBeenCalledWith('steer-1', 'sent')
   })
 
   it('keeps the user prompt in place when retrying a user message directly', async () => {

--- a/test/main/session/turn.test.ts
+++ b/test/main/session/turn.test.ts
@@ -142,7 +142,9 @@ function createHarness(
     prepareRetryMessage: vi.fn().mockResolvedValue({
       content: { text: 'Retry', files: [] },
       projectDir: '/retry',
-      sourceOrderSeq: 3
+      sourceOrderSeq: 3,
+      retryFromOrderSeq: 4,
+      sourceMessageId: 'user-1'
     }),
     commitRetryMessage: vi.fn(),
     deleteMessage: vi.fn().mockResolvedValue(undefined),
@@ -517,12 +519,13 @@ describe('SessionTurn', () => {
         projectDir: '/retry',
         emitRefreshBeforeStream: true,
         preserveResolvedRepresentations: true,
+        preStreamAnchorMessageId: 'user-1',
         beforeHistoryPreparation: expect.any(Function)
       }
     })
     const retryContext = harness.send.mock.calls[0][0].context
     retryContext?.beforeHistoryPreparation?.()
-    expect(harness.transcript.commitRetryMessage).toHaveBeenCalledWith('s1', 3)
+    expect(harness.transcript.commitRetryMessage).toHaveBeenCalledWith('s1', 4)
     expect(harness.cancel).not.toHaveBeenCalled()
 
     await harness.coordinator.deleteMessage('s1', 'message-1')

--- a/test/renderer/features/chat-page/composables/useMessageActions.test.ts
+++ b/test/renderer/features/chat-page/composables/useMessageActions.test.ts
@@ -13,6 +13,7 @@ function createHarness() {
     clearStreamingState: vi.fn(),
     messageCache,
     messages,
+    messageIds: [] as string[],
     truncateMessagesFromOrderSeq: vi.fn()
   }
   const sessionStore = { fetchSessions: vi.fn(), selectSession: vi.fn() }

--- a/test/renderer/features/chat-page/composables/useMessageActions.test.ts
+++ b/test/renderer/features/chat-page/composables/useMessageActions.test.ts
@@ -7,7 +7,14 @@ function createHarness() {
   const sessionId = ref('s1')
   const isReadOnly = ref(false)
   const isBlocking = ref(false)
-  const messageStore = { clearStreamingState: vi.fn() }
+  const messageCache = new Map<string, any>()
+  const messages: any[] = []
+  const messageStore = {
+    clearStreamingState: vi.fn(),
+    messageCache,
+    messages,
+    truncateMessagesFromOrderSeq: vi.fn()
+  }
   const sessionStore = { fetchSessions: vi.fn(), selectSession: vi.fn() }
   const sessionClient = {
     retryMessage: vi.fn().mockResolvedValue(undefined),
@@ -107,6 +114,46 @@ describe('useMessageActions', () => {
     harness.stop()
   })
 
+  it('truncates the display from the retried message when a retry is accepted', async () => {
+    const harness = createHarness()
+    const records = [
+      { id: 'user-1', sessionId: 's1', role: 'user', orderSeq: 10 },
+      { id: 'assistant-1', sessionId: 's1', role: 'assistant', orderSeq: 20 },
+      { id: 'user-2', sessionId: 's1', role: 'user', orderSeq: 30 }
+    ]
+    for (const record of records) {
+      harness.messageStore.messageCache.set(record.id, record)
+      harness.messageStore.messages.push(record)
+    }
+
+    await harness.actions.onMessageRetry('assistant-1')
+
+    expect(harness.messageStore.truncateMessagesFromOrderSeq).toHaveBeenCalledWith('s1', 20)
+    expect(harness.beginPlanTurn).toHaveBeenCalledWith('s1')
+    harness.stop()
+  })
+
+  it('keeps the user prompt in place when retrying a user message directly', async () => {
+    const harness = createHarness()
+    const records = [
+      { id: 'user-1', sessionId: 's1', role: 'user', orderSeq: 10 },
+      { id: 'assistant-1', sessionId: 's1', role: 'assistant', orderSeq: 20 },
+      { id: 'user-2', sessionId: 's1', role: 'user', orderSeq: 30 }
+    ]
+    for (const record of records) {
+      harness.messageStore.messageCache.set(record.id, record)
+      harness.messageStore.messages.push(record)
+    }
+
+    await harness.actions.onMessageRetry('user-1')
+
+    // Truncate from the next order sequence so the retried user prompt stays
+    // mounted and is not re-created as a fresh row.
+    expect(harness.messageStore.truncateMessagesFromOrderSeq).toHaveBeenCalledWith('s1', 11)
+    expect(harness.beginPlanTurn).toHaveBeenCalledWith('s1')
+    harness.stop()
+  })
+
   it('keeps history intact when retry preflight blocks and supports explicit degradation', async () => {
     const harness = createHarness()
     const attachmentPreparation = {
@@ -126,7 +173,7 @@ describe('useMessageActions', () => {
 
     expect(harness.actions.retryAttachmentPreparationSummary.value).toEqual(attachmentPreparation)
     expect(harness.beginPlanTurn).not.toHaveBeenCalled()
-    expect(harness.loadMessagesForSession).not.toHaveBeenCalled()
+    expect(harness.loadMessagesForSession).toHaveBeenCalledTimes(1)
 
     await harness.actions.retryBlockedMessageWithoutImageContent()
 


### PR DESCRIPTION
## Summary

> **Note:** this PR now contains two independently reviewable changes — the original **markdown prefix batching** perf work, plus a **retry fix** (keep the user message on retry).

### Part 1 — perf(markdown): gentle batch for prefix advance

link #2174

Follow-up to #2200: the committed-prefix segment now advances in ~6 KB chunks, and mounting a whole chunk at once queued a burst of GPU rasterization (profiles showed 0.2–1 s GPU-process stalls right after each prefix advance, with a visible draw gap).

This renders the **prefix segment with gentle, budget-capped batching** (smaller batch, a frame delay, and a tight per-frame budget) instead of the big static batch, so the mount and raster work is spread across frames rather than stalling.

- Streaming tail behavior and the whole-render path are unchanged.
- Node virtualization on the prefix is kept.

### Part 2 — fix(retry): keep user message on retry

Reworks retry so the retried user prompt survives instead of being deleted and recreated as a fresh record:

- **Assistant retry**: truncates from the retried assistant message onward; the preceding user prompt stays in place and is reused via the pre-stream anchor (`retryFromOrderSeq` / `sourceMessageId`). The ACP path intentionally keeps the old inclusive-truncation behavior.
- **User retry**: keeps the user prompt itself and truncates from the next message — the message no longer disappears and reappears in the UI.
- **Compaction budget**: when retry reuses a user prompt already present in the history, `prepareForNextUserTurn` no longer projects it a second time, avoiding an inflated context estimate that could prematurely trigger compaction.
- **Renderer**: optimistically truncates stale rows before the retry IPC and restores them via a reload when a retry is blocked.

### Verification note

Behavior/unit tests pass (including harness retry, session, renderer, and compaction suites). The performance benefit of Part 1 should be confirmed with a streaming profile; the change is low-risk either way.

Refs #2200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retry behavior for assistant and user messages, preserving the correct conversation context.
  - Prevented retried prompts from appearing twice in requests or conversation history.
  - Restored message views correctly when a retry is blocked or rejected.
  - Improved transcript truncation so messages after a retry point are removed consistently.
  - Optimized streaming-prefix rendering with smoother, smaller incremental updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->