### PR TITLE
feat(provider): support Codex image generation

### DIFF
--- a/docs/features/openai-codex-image-generation/plan.md
+++ b/docs/features/openai-codex-image-generation/plan.md
@@ -1,0 +1,43 @@
+# OpenAI Codex Image Generation Plan
+
+Objective: make `gpt-image-2` available through the existing `openai-codex` provider and DeepChat
+image-generation flow without adding a provider, dependency, credential path, or renderer-specific
+branch.
+
+## 1. Contract and catalog
+
+- [x] Confirm the official model, endpoint, usage, and active-provider auth behavior.
+- [x] Define the provider, transport, metadata, security, and compatibility contract in `spec.md`.
+- [x] Add `gpt-image-2` to the curated Codex model catalog and maintained provider runtime contract.
+
+Completion condition: model refresh can surface the provider-db-backed image model without changing
+fallback behavior.
+
+## 2. Runtime support
+
+- [x] Create the Codex image model and trace endpoint in the existing AI SDK provider context.
+- [x] Keep Responses-only body and Accept normalization away from image requests.
+- [x] Preserve OAuth injection, refresh, abort, and normalized error behavior for both endpoints.
+
+Completion condition: the existing image runtime can call the Codex image endpoint with the current
+credential store and no renderer-owned provider logic.
+
+## 3. Whole-change review and validation
+
+- [x] Review model typing, image settings compatibility, credential boundaries, traces, error paths,
+  and text-request compatibility against `spec.md`.
+- [x] Select and add only durable provider contract tests needed to protect the new route.
+- [x] Run focused provider tests.
+- [x] Run format, i18n, lint, and typecheck quality gates.
+- [x] Remove temporary probes and record the final validation outcome.
+
+Completion condition: all acceptance criteria are covered by code inspection or durable checks, and
+the repository quality gates pass.
+
+## Validation outcome
+
+- `pnpm run format`: passed.
+- `pnpm run i18n`: passed.
+- `pnpm run lint`: passed.
+- `pnpm run typecheck`: passed.
+- Focused main and renderer provider tests: 5 files and 91 tests passed.

--- a/docs/features/openai-codex-image-generation/plan.md
+++ b/docs/features/openai-codex-image-generation/plan.md
@@ -18,6 +18,7 @@ fallback behavior.
 - [x] Create the Codex image model and trace endpoint in the existing AI SDK provider context.
 - [x] Keep Responses-only body and Accept normalization away from image requests.
 - [x] Preserve OAuth injection, refresh, abort, and normalized error behavior for both endpoints.
+- [x] Preserve shared model/session image settings and disable unsupported reference-image input.
 
 Completion condition: the existing image runtime can call the Codex image endpoint with the current
 credential store and no renderer-owned provider logic.
@@ -40,4 +41,4 @@ the repository quality gates pass.
 - `pnpm run i18n`: passed.
 - `pnpm run lint`: passed.
 - `pnpm run typecheck`: passed.
-- Focused main and renderer provider tests: 5 files and 91 tests passed.
+- Focused main and renderer provider tests: 7 files and 261 tests passed.

--- a/docs/features/openai-codex-image-generation/spec.md
+++ b/docs/features/openai-codex-image-generation/spec.md
@@ -1,0 +1,144 @@
+# OpenAI Codex Image Generation
+
+Status: implemented.
+
+## Context
+
+DeepChat already treats `openai-codex` as a dedicated runtime that uses ChatGPT OAuth credentials
+against `https://chatgpt.com/backend-api/codex`. Its curated model catalog currently exposes only
+text-output Codex models, and its AI SDK context only creates a Responses language model.
+
+OpenAI documents that Codex built-in image generation uses `gpt-image-2` and counts against general
+Codex usage limits. The model supports text input and image output through
+`/images/generations`. The Codex client implementation sends that image request through the active
+model provider and auth context, so ChatGPT OAuth uses the same Codex backend base URL with the
+image endpoint appended.
+
+References:
+
+- <https://learn.chatgpt.com/docs/image-generation>
+- <https://developers.openai.com/api/docs/models/gpt-image-2>
+- <https://github.com/openai/codex/blob/rust-v0.142.3/codex-rs/ext/image-generation/src/tool.rs>
+- <https://github.com/openai/codex/blob/rust-v0.142.3/codex-rs/ext/image-generation/src/backend.rs>
+
+## Goals
+
+- Expose `gpt-image-2` in the curated OpenAI Codex model list when its OpenAI provider-db record is
+  available.
+- Route generation through `POST /images/generations` with the existing OpenAI Codex OAuth token
+  and account header.
+- Reuse DeepChat's existing image-generation conversation flow, image cache, model type detection,
+  and OpenAI image settings.
+- Preserve the current text-model connection check so enabling or refreshing the provider does not
+  consume image-generation quota.
+
+## Non-goals
+
+- Add a second OpenAI or Codex provider.
+- Store OAuth credentials in provider API-key fields or expose them to the renderer.
+- Add image editing or reference-image input to DeepChat's standalone image-generation flow.
+- Reproduce the Codex `imagegen` skill, prompt rewriting, or artifact filesystem conventions.
+- Add settings that `gpt-image-2` does not support, including transparent backgrounds.
+
+## Design
+
+### Provider catalog
+
+`openai-codex` continues to use the OpenAI provider database as its capability identity and model
+metadata source. `gpt-image-2` joins the explicit curated model ID list. If provider-db does not
+contain that ID, it is omitted in the same way as every other curated Codex model.
+
+The provider-db record owns the `imageGeneration` type and text/image modalities. Renderer code
+does not add a Codex-specific type rule.
+
+### Runtime transport
+
+The existing `openai-codex` AI SDK factory branch creates both:
+
+- a Responses language model for `/responses`; and
+- an image model for `/images/generations`.
+
+Both models use the same Codex-specific fetch adapter. The adapter refreshes OAuth once after a
+`401`, preserves abort signals, includes `ChatGPT-Account-ID` when present, and normalizes provider
+errors without exposing credentials.
+
+Request handling is endpoint-aware:
+
+- `/responses` keeps `store: false`, removes unsupported `max_output_tokens`, and defaults
+  `Accept` to `text/event-stream`;
+- image endpoints keep the AI SDK image body unchanged and default `Accept` to
+  `application/json`.
+
+This separation prevents Responses-only compatibility fields from reaching the image API.
+
+### Data flow
+
+```text
+user selects GPT Image 2
+          |
+          v
+existing image-generation chat route
+          |
+          v
+AI SDK OpenAI image model
+          |
+          v
+Codex OAuth fetch adapter -- refresh on 401 --> encrypted credential store
+          |
+          v
+POST /backend-api/codex/images/generations
+          |
+          v
+base64 image -> existing DeepChat image cache and message preview
+```
+
+### User-visible layout
+
+```text
+BEFORE                              AFTER
+OpenAI Codex                        OpenAI Codex
+  GPT-5.6 Luna       [chat]           GPT-5.6 Luna       [chat]
+  GPT-5.6 Sol        [chat]           GPT-5.6 Sol        [chat]
+  ...                                   ...
+                                      GPT Image 2        [imageGeneration]
+```
+
+Selecting `GPT Image 2` uses the existing image settings panel and image result rendering; no new
+screen, control, or copy is introduced.
+
+## Ownership and security
+
+- Provider ID: `openai-codex`.
+- Runtime/API type: dedicated `openai-codex` transport over OpenAI-compatible image JSON.
+- Default base URL: `https://chatgpt.com/backend-api/codex`.
+- Auth: ChatGPT OAuth; tokens remain in the existing OpenAI Codex credential store in the main
+  process.
+- Model metadata: built-in provider-db, source provider `openai`.
+- Connection check: `generate-text` with `gpt-5.6-luna` and prompt `Hello`.
+- Image generation model: `gpt-image-2`.
+
+The renderer receives only model metadata and auth status. Raw access tokens, refresh tokens, and
+account identifiers never cross the preload boundary or appear in request traces.
+
+## Compatibility and failure behavior
+
+- Existing OpenAI Codex text requests retain their wire shape and streaming behavior.
+- Existing API-key OpenAI image generation is unchanged.
+- Accounts without image entitlement receive the existing normalized Codex permission error.
+- Missing provider-db metadata omits `gpt-image-2` instead of synthesizing incomplete capability
+  data.
+- The default provider connection check remains a text request and does not prove image entitlement;
+  image-specific errors surface on the first generation request.
+
+## Acceptance criteria
+
+- Refreshing OpenAI Codex models includes `gpt-image-2` when bundled provider-db includes it.
+- DeepChat identifies that model as image generation and shows the existing image settings UI.
+- A generation request targets `/backend-api/codex/images/generations` with OAuth/account headers,
+  a JSON accept header, and no Responses-only `store` field.
+- Returned base64 image data follows the existing image cache and preview path.
+- Text generation, OAuth refresh, error normalization, and provider checks remain unchanged.
+
+## Open questions
+
+None.

--- a/docs/features/openai-codex-image-generation/spec.md
+++ b/docs/features/openai-codex-image-generation/spec.md
@@ -48,8 +48,9 @@ References:
 metadata source. `gpt-image-2` joins the explicit curated model ID list. If provider-db does not
 contain that ID, it is omitted in the same way as every other curated Codex model.
 
-The provider-db record owns the `imageGeneration` type and text/image modalities. Renderer code
-does not add a Codex-specific type rule.
+The provider-db record owns the `imageGeneration` type and image-output modality. The Codex
+image-generation projection disables vision input because the current standalone route sends only a
+text prompt to `/images/generations`; renderer code does not add a Codex-specific type rule.
 
 ### Runtime transport
 
@@ -104,7 +105,7 @@ OpenAI Codex                        OpenAI Codex
 ```
 
 Selecting `GPT Image 2` uses the existing image settings panel and image result rendering; no new
-screen, control, or copy is introduced.
+screen, control, or copy is introduced. Reference-image attachments remain disabled for this route.
 
 ## Ownership and security
 
@@ -124,6 +125,8 @@ account identifiers never cross the preload boundary or appear in request traces
 
 - Existing OpenAI Codex text requests retain their wire shape and streaming behavior.
 - Existing API-key OpenAI image generation is unchanged.
+- Codex image generation does not advertise vision input, keeping reference images out of the
+  supported attachment flow.
 - Accounts without image entitlement receive the existing normalized Codex permission error.
 - Missing provider-db metadata omits `gpt-image-2` instead of synthesizing incomplete capability
   data.
@@ -134,6 +137,8 @@ account identifiers never cross the preload boundary or appear in request traces
 
 - Refreshing OpenAI Codex models includes `gpt-image-2` when bundled provider-db includes it.
 - DeepChat identifies that model as an image-generation model and shows the existing image settings UI.
+- Model and session image-generation options survive capability normalization, while reference-image
+  attachments remain unavailable.
 - A generation request targets `/backend-api/codex/images/generations` with OAuth/account headers,
   a JSON accept header, and no Responses-only `store` field.
 - Returned base64 image data follows the existing image cache and preview path.

--- a/docs/features/openai-codex-image-generation/spec.md
+++ b/docs/features/openai-codex-image-generation/spec.md
@@ -133,7 +133,7 @@ account identifiers never cross the preload boundary or appear in request traces
 ## Acceptance criteria
 
 - Refreshing OpenAI Codex models includes `gpt-image-2` when bundled provider-db includes it.
-- DeepChat identifies that model as image generation and shows the existing image settings UI.
+- DeepChat identifies that model as an image-generation model and shows the existing image settings UI.
 - A generation request targets `/backend-api/codex/images/generations` with OAuth/account headers,
   a JSON accept header, and no Responses-only `store` field.
 - Returned base64 image data follows the existing image cache and preview path.

--- a/docs/features/provider-runtime/spec.md
+++ b/docs/features/provider-runtime/spec.md
@@ -77,12 +77,14 @@ passing through unless an explicit model request policy requires a different wir
 
 `openai-codex` is separate from standard `openai`: distinct provider ID, runtime kind, credential store,
 routes and request adapter. Current recommended catalog includes `gpt-5.5`, `gpt-5.6-sol`,
-`gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.4`, `gpt-5.4-mini` and `gpt-5.3-codex-spark` when provider-db
-metadata contains them; connection check uses `gpt-5.6-luna`.
+`gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark` and `gpt-image-2`
+when provider-db metadata contains them; connection check uses `gpt-5.6-luna`.
 
 Codex requests include required instructions and backend routing headers, preserve streaming/tool/reasoning
-behavior, and surface entitlement failure without logging token or account identifiers. Background
-provider-db refresh skips its dedicated runtime catalog; manual refresh remains available.
+behavior, and surface entitlement failure without logging token or account identifiers. Image generation
+uses the same OAuth credential path with `/images/generations`; Responses-only body normalization does not
+apply to image requests. Background provider-db refresh skips its dedicated runtime catalog; manual refresh
+remains available.
 
 ## Validation
 

--- a/docs/features/provider-runtime/spec.md
+++ b/docs/features/provider-runtime/spec.md
@@ -83,8 +83,9 @@ when provider-db metadata contains them; connection check uses `gpt-5.6-luna`.
 Codex requests include required instructions and backend routing headers, preserve streaming/tool/reasoning
 behavior, and surface entitlement failure without logging token or account identifiers. Image generation
 uses the same OAuth credential path with `/images/generations`; Responses-only body normalization does not
-apply to image requests. Background provider-db refresh skips its dedicated runtime catalog; manual refresh
-remains available.
+apply to image requests. The image-generation projection preserves shared OpenAI image settings but disables
+vision input because the standalone route accepts only text prompts. Background provider-db refresh skips
+its dedicated runtime catalog; manual refresh remains available.
 
 ## Validation
 

--- a/src/main/provider/aiSdk/providerFactory.ts
+++ b/src/main/provider/aiSdk/providerFactory.ts
@@ -593,7 +593,9 @@ export function createAiSdkProviderContext(
         providerOptionsKey: 'openai',
         apiType: 'openai_responses',
         model: maybeWrapModel(provider.responses(params.modelId) as any),
-        endpoint: buildOpenAICodexResponsesEndpoint(codexBaseUrl)
+        imageModel: provider.image(params.modelId),
+        endpoint: buildOpenAICodexResponsesEndpoint(codexBaseUrl),
+        imageEndpoint: buildOpenAIEndpoint(codexBaseUrl, '/images/generations')
       }
     }
 

--- a/src/main/provider/modelConfig.ts
+++ b/src/main/provider/modelConfig.ts
@@ -155,6 +155,15 @@ export class ModelConfigHelper {
 
     const policyConfig = applyMoonshotKimiReasoningTemperaturePolicy(providerId, modelId, config)
 
+    if (
+      normalizeProviderKind(providerId) === 'openai-codex' &&
+      (policyConfig.type === ModelType.ImageGeneration ||
+        policyConfig.apiEndpoint === ApiEndpointType.Image ||
+        policyConfig.endpointType === 'image-generation')
+    ) {
+      return { ...policyConfig, vision: false }
+    }
+
     if (!isMiniMaxM3Model(providerId, modelId)) {
       return policyConfig
     }

--- a/src/main/provider/openaiCodexAdapter.ts
+++ b/src/main/provider/openaiCodexAdapter.ts
@@ -13,6 +13,16 @@ function stripResponsesSuffix(pathname: string): string {
   return pathname.replace(/\/responses\/?$/i, '') || '/'
 }
 
+function isResponsesRequest(input: string | URL | Request): boolean {
+  const requestUrl =
+    typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+  try {
+    return /\/responses\/?$/i.test(new URL(requestUrl).pathname)
+  } catch {
+    return /\/responses\/?(?:\?|$)/i.test(requestUrl)
+  }
+}
+
 export function normalizeOpenAICodexBaseUrl(baseUrl: string | undefined): string {
   const normalized = (baseUrl || '').trim().replace(/\/+$/, '')
   if (!normalized) {
@@ -154,7 +164,8 @@ function normalizeOpenAICodexRequestBody(
 function applyCodexHeaders(
   inputHeaders: HeadersInit | undefined,
   defaultHeaders: Record<string, string>,
-  auth: OpenAICodexBackendAuth
+  auth: OpenAICodexBackendAuth,
+  accept: string
 ): Headers {
   const headers = new Headers(inputHeaders ?? {})
   Object.entries(defaultHeaders).forEach(([key, value]) => headers.set(key, value))
@@ -170,7 +181,7 @@ function applyCodexHeaders(
   headers.set('Version', OPENAI_CODEX_CLIENT_VERSION)
   headers.set('User-Agent', OPENAI_CODEX_USER_AGENT)
   if (!headers.has('Accept')) {
-    headers.set('Accept', 'text/event-stream')
+    headers.set('Accept', accept)
   }
   if (!headers.has('Content-Type')) {
     headers.set('Content-Type', 'application/json')
@@ -186,10 +197,12 @@ export function createOpenAICodexFetch(defaultHeaders: Record<string, string>) {
 
     const auth = getGlobalOpenAICodexAuth()
     const backendAuth = await auth.getBackendAuth()
+    const responsesRequest = isResponsesRequest(url)
+    const accept = responsesRequest ? 'text/event-stream' : 'application/json'
     const nextInit: RequestInit = {
       ...init,
-      body: normalizeOpenAICodexRequestBody(init?.body),
-      headers: applyCodexHeaders(init?.headers, defaultHeaders, backendAuth)
+      body: responsesRequest ? normalizeOpenAICodexRequestBody(init?.body) : init?.body,
+      headers: applyCodexHeaders(init?.headers, defaultHeaders, backendAuth, accept)
     }
 
     let response = await fetch(url, nextInit)
@@ -200,7 +213,7 @@ export function createOpenAICodexFetch(defaultHeaders: Record<string, string>) {
     const refreshedAuth = await auth.forceRefreshBackendAuth()
     response = await fetch(url, {
       ...nextInit,
-      headers: applyCodexHeaders(init?.headers, defaultHeaders, refreshedAuth)
+      headers: applyCodexHeaders(init?.headers, defaultHeaders, refreshedAuth, accept)
     })
     return normalizeOpenAICodexErrorResponse(response)
   }

--- a/src/main/provider/providers/aiSdkProvider.ts
+++ b/src/main/provider/providers/aiSdkProvider.ts
@@ -79,7 +79,8 @@ const OPENAI_CODEX_RECOMMENDED_MODEL_IDS = [
   'gpt-5.6-luna',
   'gpt-5.4',
   'gpt-5.4-mini',
-  'gpt-5.3-codex-spark'
+  'gpt-5.3-codex-spark',
+  'gpt-image-2'
 ]
 const GREENPT_RECOMMENDED_MODEL_IDS = [
   'glm-5.2',

--- a/src/shared/imageGenerationSettings.ts
+++ b/src/shared/imageGenerationSettings.ts
@@ -99,7 +99,11 @@ const isOpenAICompatibleProvider = (target: OpenAIImageGenerationSettingsTarget)
     return false
   }
 
-  if (providerKind === 'openai-responses' || providerKind === 'openai-compatible') {
+  if (
+    providerKind === 'openai-codex' ||
+    providerKind === 'openai-responses' ||
+    providerKind === 'openai-compatible'
+  ) {
     return true
   }
 
@@ -107,12 +111,18 @@ const isOpenAICompatibleProvider = (target: OpenAIImageGenerationSettingsTarget)
     return true
   }
 
-  if (providerId === 'openai' || providerId === 'openai-responses' || providerId === 'new-api') {
+  if (
+    providerId === 'openai' ||
+    providerId === 'openai-codex' ||
+    providerId === 'openai-responses' ||
+    providerId === 'new-api'
+  ) {
     return true
   }
 
   if (
     providerApiType === 'openai' ||
+    providerApiType === 'openai-codex' ||
     providerApiType === 'openai-responses' ||
     providerApiType === 'openai-compatible' ||
     providerApiType === 'openai-completions' ||

--- a/test/main/agent/deepchat/runtime/generationSettings.test.ts
+++ b/test/main/agent/deepchat/runtime/generationSettings.test.ts
@@ -2,6 +2,7 @@ import type { ProviderSettingsPort } from '@/provider/settings'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { SessionGenerationSettings } from '@shared/types/agent-interface'
+import { ApiEndpointType, ModelType } from '@shared/model'
 import {
   buildPersistedGenerationSettingsPatch,
   mapPersistedGenerationPatch,
@@ -284,5 +285,36 @@ describe('generation settings policy', () => {
       imageGeneration: { size: '1024x1024', quality: 'high' },
       videoGeneration: { duration: 8, generateAudio: true }
     })
+  })
+
+  it('preserves OpenAI Codex image options during session sanitization', async () => {
+    const providerSettings = createProviderSettings()
+    vi.mocked(providerSettings.getProviderById).mockReturnValue({
+      id: 'openai-codex',
+      name: 'OpenAI Codex',
+      apiType: 'openai-codex',
+      apiKey: '',
+      baseUrl: 'https://chatgpt.com/backend-api/codex',
+      enable: true
+    })
+    vi.mocked(providerSettings.getModelConfig).mockReturnValue({
+      contextLength: 8_192,
+      maxTokens: 8_192,
+      temperature: 0.7,
+      timeout: 60_000,
+      type: ModelType.ImageGeneration,
+      apiEndpoint: ApiEndpointType.Image,
+      imageGeneration: { size: '1024x1024', quality: 'high' }
+    })
+
+    const result = await sanitizeGenerationSettings(
+      providerSettings,
+      { getDefaultSystemPrompt: vi.fn().mockResolvedValue('default prompt') },
+      'openai-codex',
+      'gpt-image-2',
+      { imageGeneration: { size: '1536x1024', quality: 'medium' } }
+    )
+
+    expect(result.imageGeneration).toEqual({ size: '1536x1024', quality: 'medium' })
   })
 })

--- a/test/main/provider/aiSdkProviderFactory.test.ts
+++ b/test/main/provider/aiSdkProviderFactory.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { generateText, streamText } from 'ai'
+import { generateImage, generateText, streamText } from 'ai'
+
+const codexAuthState = vi.hoisted(() => ({
+  getBackendAuth: vi.fn(),
+  forceRefreshBackendAuth: vi.fn()
+}))
 
 vi.mock('../../../src/main/platform/proxy', () => ({
   proxyConfig: {
     getProxyUrl: vi.fn().mockReturnValue(null)
   }
+}))
+
+vi.mock('../../../src/main/provider/auth/openaiCodex', () => ({
+  getGlobalOpenAICodexAuth: () => codexAuthState
 }))
 
 import {
@@ -241,7 +250,27 @@ describe('AI SDK provider factory', () => {
     expect(context.resolvedModelId).toBe('my-gpt-4.1-deployment')
   })
 
-  it('creates an image model for the OpenAI Codex image endpoint', () => {
+  it('generates images through the OpenAI Codex image endpoint', async () => {
+    const imageBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          created: 1,
+          data: [{ b64_json: imageBase64 }]
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    codexAuthState.getBackendAuth.mockResolvedValueOnce({
+      accessToken: 'codex-token',
+      accountId: 'acct-1'
+    })
+
     const context = createAiSdkProviderContext({
       providerKind: 'openai-codex',
       provider: {
@@ -261,6 +290,23 @@ describe('AI SDK provider factory', () => {
     expect(context.imageModel).toBeDefined()
     expect(context.endpoint).toBe('https://chatgpt.com/backend-api/codex/responses')
     expect(context.imageEndpoint).toBe('https://chatgpt.com/backend-api/codex/images/generations')
+
+    const result = await generateImage({
+      model: context.imageModel,
+      prompt: 'A red fox in a field',
+      size: '1024x1024'
+    })
+
+    expect(result.image.base64).toBe(imageBase64)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(requestUrl).toBe('https://chatgpt.com/backend-api/codex/images/generations')
+    expect(JSON.parse(String(requestInit.body))).toEqual({
+      model: 'gpt-image-2',
+      prompt: 'A red fox in a field',
+      n: 1,
+      size: '1024x1024'
+    })
   })
 
   it('uses deployment ids from azure deployment-scoped urls', () => {

--- a/test/main/provider/aiSdkProviderFactory.test.ts
+++ b/test/main/provider/aiSdkProviderFactory.test.ts
@@ -241,6 +241,28 @@ describe('AI SDK provider factory', () => {
     expect(context.resolvedModelId).toBe('my-gpt-4.1-deployment')
   })
 
+  it('creates an image model for the OpenAI Codex image endpoint', () => {
+    const context = createAiSdkProviderContext({
+      providerKind: 'openai-codex',
+      provider: {
+        id: 'openai-codex',
+        name: 'OpenAI Codex',
+        apiType: 'openai-codex',
+        apiKey: '',
+        baseUrl: 'https://chatgpt.com/backend-api/codex',
+        enable: true
+      } as any,
+      providerSettings: {} as any,
+      defaultHeaders: {},
+      modelId: 'gpt-image-2',
+      wrapThinkReasoning: false
+    })
+
+    expect(context.imageModel).toBeDefined()
+    expect(context.endpoint).toBe('https://chatgpt.com/backend-api/codex/responses')
+    expect(context.imageEndpoint).toBe('https://chatgpt.com/backend-api/codex/images/generations')
+  })
+
   it('uses deployment ids from azure deployment-scoped urls', () => {
     const context = createAiSdkProviderContext({
       providerKind: 'azure',

--- a/test/main/provider/openaiCodexAdapter.test.ts
+++ b/test/main/provider/openaiCodexAdapter.test.ts
@@ -129,6 +129,36 @@ describe('OpenAI Codex adapter', () => {
     expect(body).not.toHaveProperty('max_output_tokens')
   })
 
+  it('preserves image request bodies and asks the Codex backend for JSON', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(new Response('{}', { status: 200 })))
+    authState.getBackendAuth.mockResolvedValueOnce({
+      accessToken: 'token',
+      accountId: 'acct-1'
+    })
+
+    const { createOpenAICodexFetch } = await import('../../../src/main/provider/openaiCodexAdapter')
+    const fetcher = createOpenAICodexFetch({})
+    const imageBody = JSON.stringify({
+      model: 'gpt-image-2',
+      prompt: 'A red fox in a field',
+      quality: 'medium',
+      size: '1024x1024'
+    })
+
+    await fetcher('https://chatgpt.com/backend-api/codex/images/generations', {
+      method: 'POST',
+      body: imageBody
+    })
+
+    const requestInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+    const headers = requestInit.headers as Headers
+    expect(requestInit.body).toBe(imageBody)
+    expect(headers.get('Accept')).toBe('application/json')
+    expect(headers.get('Content-Type')).toBe('application/json')
+    expect(headers.get('Authorization')).toBe('Bearer token')
+    expect(headers.get('ChatGPT-Account-ID')).toBe('acct-1')
+  })
+
   it('preserves streaming responses and abort signals', async () => {
     const streamBody = 'data: {"type":"response.output_text.delta","delta":"hello"}\n\n'
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(new Response(streamBody, { status: 200 })))

--- a/test/main/provider/openaiCodexProvider.test.ts
+++ b/test/main/provider/openaiCodexProvider.test.ts
@@ -7,7 +7,13 @@ import { AiSdkProvider } from '../../../src/main/provider/providers/aiSdkProvide
 import { resolveAiSdkProviderDefinition } from '../../../src/main/provider/providerRegistry'
 import type { LLM_PROVIDER } from '@shared/types/provider'
 
-const CODEX_5_6_RESOURCE_MODEL_IDS = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra']
+const CODEX_RESOURCE_MODEL_IDS = [
+  'gpt-5.6',
+  'gpt-5.6-sol',
+  'gpt-5.6-luna',
+  'gpt-5.6-terra',
+  'gpt-image-2'
+]
 
 describe('OpenAI Codex provider registration', () => {
   it('keeps OpenAI Codex separate from the OpenAI API-key provider', () => {
@@ -39,14 +45,14 @@ describe('OpenAI Codex provider registration', () => {
     expect(definition?.checkModelId).toBe('gpt-5.6-luna')
   })
 
-  it('has Codex 5.6 models in the bundled OpenAI provider database', async () => {
+  it('has curated Codex models in the bundled OpenAI provider database', async () => {
     const fs = await vi.importActual<typeof import('fs')>('fs')
     const providerDbPath = path.join(process.cwd(), 'resources', 'model-db', 'providers.json')
     const db = JSON.parse(fs.readFileSync(providerDbPath, 'utf-8'))
     const openaiProvider = db.providers.openai
     const modelIds = new Set(openaiProvider.models.map((model: { id: string }) => model.id))
 
-    for (const modelId of CODEX_5_6_RESOURCE_MODEL_IDS) {
+    for (const modelId of CODEX_RESOURCE_MODEL_IDS) {
       expect(modelIds.has(modelId)).toBe(true)
     }
   })
@@ -140,6 +146,15 @@ describe('OpenAI Codex provider registration', () => {
           limit: { context: 1050000, output: 128000 },
           tool_call: true,
           reasoning: { supported: true }
+        },
+        {
+          id: 'gpt-image-2',
+          display_name: 'GPT Image 2',
+          modalities: { input: ['text', 'image'], output: ['image'] },
+          limit: { context: 8192, output: 8192 },
+          type: 'imageGeneration',
+          tool_call: false,
+          reasoning: { supported: false }
         }
       ]
     } as any)
@@ -155,7 +170,8 @@ describe('OpenAI Codex provider registration', () => {
       'gpt-5.6-luna',
       'gpt-5.4',
       'gpt-5.4-mini',
-      'gpt-5.3-codex-spark'
+      'gpt-5.3-codex-spark',
+      'gpt-image-2'
     ])
     expect(models.some((model) => model.id === 'gpt-5.6')).toBe(false)
     expect(models.every((model) => model.group === 'Codex')).toBe(true)

--- a/test/main/provider/providerDbModelConfig.test.ts
+++ b/test/main/provider/providerDbModelConfig.test.ts
@@ -73,6 +73,13 @@ describe('Provider DB strict matching and user overrides', () => {
               tool_call: true
             },
             {
+              id: 'gpt-image-2',
+              type: 'imageGeneration',
+              limit: { context: 8192, output: 8192 },
+              modalities: { input: ['text', 'image'], output: ['image'] },
+              tool_call: false
+            },
+            {
               id: 'opaque-renderer',
               type: 'imageGeneration',
               limit: { context: 65_536, output: 8_192 },
@@ -304,6 +311,19 @@ describe('Provider DB strict matching and user overrides', () => {
       contextLength: 1_050_000,
       maxTokens: 32_000,
       reasoning: true
+    })
+  })
+
+  it('resolves the OpenAI Codex image model through the OpenAI catalog identity', () => {
+    const helper = new ModelConfigHelper()
+
+    const config = helper.getModelConfig('gpt-image-2', 'openai-codex')
+
+    expect(config).toMatchObject({
+      type: ModelType.ImageGeneration,
+      apiEndpoint: ApiEndpointType.Image,
+      vision: true,
+      functionCall: false
     })
   })
 

--- a/test/main/provider/providerDbModelConfig.test.ts
+++ b/test/main/provider/providerDbModelConfig.test.ts
@@ -322,9 +322,11 @@ describe('Provider DB strict matching and user overrides', () => {
     expect(config).toMatchObject({
       type: ModelType.ImageGeneration,
       apiEndpoint: ApiEndpointType.Image,
-      vision: true,
+      vision: false,
       functionCall: false
     })
+
+    expect(helper.getModelConfig('gpt-image-2', 'openai').vision).toBe(true)
   })
 
   it('applies partial fallbacks when limit fields are missing', () => {

--- a/test/renderer/components/ChatStatusBar.test.ts
+++ b/test/renderer/components/ChatStatusBar.test.ts
@@ -1758,17 +1758,24 @@ describe('ChatStatusBar model and session panels', () => {
     expect((wrapper.vm as any).localSettings.thinkingBudget).toBe(512)
   })
 
-  it('uses the dedicated image settings panel for gpt-image-2', async () => {
+  it.each([
+    { providerId: 'openai', providerName: 'OpenAI', apiType: 'openai' },
+    {
+      providerId: 'openai-codex',
+      providerName: 'OpenAI Codex',
+      apiType: 'openai-codex'
+    }
+  ])('uses the dedicated image settings panel for gpt-image-2 on $providerId', async (provider) => {
     const { wrapper } = await setup({
       agentId: 'deepchat',
       hasActiveSession: false,
-      preferredModel: { providerId: 'openai', modelId: 'gpt-image-2' },
-      defaultModel: { providerId: 'openai', modelId: 'gpt-image-2' },
+      preferredModel: { providerId: provider.providerId, modelId: 'gpt-image-2' },
+      defaultModel: { providerId: provider.providerId, modelId: 'gpt-image-2' },
       extraModelGroups: [
         {
-          providerId: 'openai',
-          providerName: 'OpenAI',
-          apiType: 'openai',
+          providerId: provider.providerId,
+          providerName: provider.providerName,
+          apiType: provider.apiType,
           models: [{ id: 'gpt-image-2', name: 'GPT Image 2', type: 'imageGeneration' }]
         }
       ],
@@ -1780,7 +1787,7 @@ describe('ChatStatusBar model and session panels', () => {
       }
     })
 
-    await (wrapper.vm as any).selectModel('openai', 'gpt-image-2')
+    await (wrapper.vm as any).selectModel(provider.providerId, 'gpt-image-2')
     await flushPromises()
 
     expect((wrapper.vm as any).showOpenAIImageGenerationSettings).toBe(true)

--- a/test/renderer/components/ModelConfigDialog.test.ts
+++ b/test/renderer/components/ModelConfigDialog.test.ts
@@ -999,12 +999,15 @@ describe('ModelConfigDialog reasoning portraits', () => {
 })
 
 describe('ModelConfigDialog OpenAI image generation settings', () => {
-  it('uses the image settings form for gpt-image-2', async () => {
+  it.each([
+    { providerId: 'openai', providerApiType: 'openai' },
+    { providerId: 'openai-codex', providerApiType: 'openai-codex' }
+  ])('uses the image settings form for gpt-image-2 on $providerId', async (provider) => {
     const { wrapper } = await setup({
-      providerId: 'openai',
+      providerId: provider.providerId,
       modelId: 'gpt-image-2',
       modelName: 'GPT Image 2',
-      providerApiType: 'openai',
+      providerApiType: provider.providerApiType,
       modelConfig: {
         imageGeneration: {
           size: '1024x1024'
@@ -1039,12 +1042,15 @@ describe('ModelConfigDialog OpenAI image generation settings', () => {
     expect(wrapper.text()).toContain('settings.model.modelConfig.maxTokens.label')
   })
 
-  it('saves normalized image settings for gpt-image-2', async () => {
+  it.each([
+    { providerId: 'openai', providerApiType: 'openai' },
+    { providerId: 'openai-codex', providerApiType: 'openai-codex' }
+  ])('saves normalized image settings for gpt-image-2 on $providerId', async (provider) => {
     const { wrapper, modelConfigStore } = await setup({
-      providerId: 'openai',
+      providerId: provider.providerId,
       modelId: 'gpt-image-2',
       modelName: 'GPT Image 2',
-      providerApiType: 'openai',
+      providerApiType: provider.providerApiType,
       modelConfig: {
         topP: 0.4
       }
@@ -1062,7 +1068,7 @@ describe('ModelConfigDialog OpenAI image generation settings', () => {
 
     expect(modelConfigStore.setModelConfig).toHaveBeenCalledWith(
       'gpt-image-2',
-      'openai',
+      provider.providerId,
       expect.objectContaining({
         topP: 0.4,
         imageGeneration: {


### PR DESCRIPTION
## Summary

- expose gpt-image-2 in the curated OpenAI Codex model catalog
- route image generation through the Codex /images/generations endpoint with existing ChatGPT OAuth credentials
- keep Responses-only request normalization away from image requests
- reuse the existing image settings, cache, and message preview flow

## Provider contract

- Provider ID: openai-codex
- Runtime: dedicated OpenAI Codex transport
- Credential storage: existing main-process Codex OAuth credential store
- Model metadata: bundled OpenAI provider database
- Connection check: gpt-5.6-luna text generation
- Image model: gpt-image-2

## User experience

```text
BEFORE                              AFTER
OpenAI Codex                        OpenAI Codex
  GPT-5.6 Luna       [chat]           GPT-5.6 Luna       [chat]
  GPT-5.6 Sol        [chat]           GPT-5.6 Sol        [chat]
  ...                                   ...
                                      GPT Image 2        [imageGeneration]
```

Selecting GPT Image 2 uses the existing image-generation settings and result preview. No new screen or control is introduced.

## Validation

- pnpm run format
- pnpm run i18n
- pnpm run lint
- pnpm run typecheck
- focused main and renderer provider tests: 5 files, 91 tests passed

## References

- https://learn.chatgpt.com/docs/image-generation
- https://developers.openai.com/api/docs/models/gpt-image-2
- https://github.com/openai/codex/blob/rust-v0.142.3/codex-rs/ext/image-generation/src/tool.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating images with `gpt-image-2` through OpenAI Codex.
  * Integrated Codex image generation with existing image settings and display behavior.
  * Added appropriate endpoint routing, authentication, and session refresh handling.
  * Disabled unsupported vision input and reference-image attachments for Codex image generation.
  * Preserved text connection checks and credential isolation.

* **Documentation**
  * Documented setup, compatibility, security, request handling, and acceptance criteria.

* **Tests**
  * Expanded coverage for model discovery, request formatting, authentication, endpoint behavior, and image responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->