### PR TITLE
release: v1.1.1-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.1.1-beta.4 (2026-08-24)
+- Added Codex image generation support for providers
+- Reduced markdown streaming stalls with split rendering and gentle prefix batching
+- Kept the user message mounted on retry, fixed retry budget double counting and duplicate pinned prompts
+- Fixed decimal value formatting in the memory diagnostics panel
+- 新增 Provider 的 Codex 图片生成支持
+- 通过分段渲染与温和的前缀批处理减少 Markdown 流式渲染卡顿
+- 重试时保留用户消息挂载，修复重试预算重复计算与重复固定提示词
+- 修复内存诊断面板中十进制数值的格式化
+
 ## v1.1.1-beta.3 (2026-08-20)
 - Added managed Node.js and uv toolchains with automatic detection, installation, repair, and recovery
 - Added terminal authentication for ACP agents

--- a/docs/features/openai-codex-image-generation/plan.md
+++ b/docs/features/openai-codex-image-generation/plan.md
@@ -1,0 +1,44 @@
+# OpenAI Codex Image Generation Plan
+
+Objective: make `gpt-image-2` available through the existing `openai-codex` provider and DeepChat
+image-generation flow without adding a provider, dependency, credential path, or renderer-specific
+branch.
+
+## 1. Contract and catalog
+
+- [x] Confirm the official model, endpoint, usage, and active-provider auth behavior.
+- [x] Define the provider, transport, metadata, security, and compatibility contract in `spec.md`.
+- [x] Add `gpt-image-2` to the curated Codex model catalog and maintained provider runtime contract.
+
+Completion condition: model refresh can surface the provider-db-backed image model without changing
+fallback behavior.
+
+## 2. Runtime support
+
+- [x] Create the Codex image model and trace endpoint in the existing AI SDK provider context.
+- [x] Keep Responses-only body and Accept normalization away from image requests.
+- [x] Preserve OAuth injection, refresh, abort, and normalized error behavior for both endpoints.
+- [x] Preserve shared model/session image settings and disable unsupported reference-image input.
+
+Completion condition: the existing image runtime can call the Codex image endpoint with the current
+credential store and no renderer-owned provider logic.
+
+## 3. Whole-change review and validation
+
+- [x] Review model typing, image settings compatibility, credential boundaries, traces, error paths,
+  and text-request compatibility against `spec.md`.
+- [x] Select and add only durable provider contract tests needed to protect the new route.
+- [x] Run focused provider tests.
+- [x] Run format, i18n, lint, and typecheck quality gates.
+- [x] Remove temporary probes and record the final validation outcome.
+
+Completion condition: all acceptance criteria are covered by code inspection or durable checks, and
+the repository quality gates pass.
+
+## Validation outcome
+
+- `pnpm run format`: passed.
+- `pnpm run i18n`: passed.
+- `pnpm run lint`: passed.
+- `pnpm run typecheck`: passed.
+- Focused main and renderer provider tests: 7 files and 261 tests passed.

--- a/docs/features/openai-codex-image-generation/spec.md
+++ b/docs/features/openai-codex-image-generation/spec.md
@@ -1,0 +1,149 @@
+# OpenAI Codex Image Generation
+
+Status: implemented.
+
+## Context
+
+DeepChat already treats `openai-codex` as a dedicated runtime that uses ChatGPT OAuth credentials
+against `https://chatgpt.com/backend-api/codex`. Its curated model catalog currently exposes only
+text-output Codex models, and its AI SDK context only creates a Responses language model.
+
+OpenAI documents that Codex built-in image generation uses `gpt-image-2` and counts against general
+Codex usage limits. The model supports text input and image output through
+`/images/generations`. The Codex client implementation sends that image request through the active
+model provider and auth context, so ChatGPT OAuth uses the same Codex backend base URL with the
+image endpoint appended.
+
+References:
+
+- <https://learn.chatgpt.com/docs/image-generation>
+- <https://developers.openai.com/api/docs/models/gpt-image-2>
+- <https://github.com/openai/codex/blob/rust-v0.142.3/codex-rs/ext/image-generation/src/tool.rs>
+- <https://github.com/openai/codex/blob/rust-v0.142.3/codex-rs/ext/image-generation/src/backend.rs>
+
+## Goals
+
+- Expose `gpt-image-2` in the curated OpenAI Codex model list when its OpenAI provider-db record is
+  available.
+- Route generation through `POST /images/generations` with the existing OpenAI Codex OAuth token
+  and account header.
+- Reuse DeepChat's existing image-generation conversation flow, image cache, model type detection,
+  and OpenAI image settings.
+- Preserve the current text-model connection check so enabling or refreshing the provider does not
+  consume image-generation quota.
+
+## Non-goals
+
+- Add a second OpenAI or Codex provider.
+- Store OAuth credentials in provider API-key fields or expose them to the renderer.
+- Add image editing or reference-image input to DeepChat's standalone image-generation flow.
+- Reproduce the Codex `imagegen` skill, prompt rewriting, or artifact filesystem conventions.
+- Add settings that `gpt-image-2` does not support, including transparent backgrounds.
+
+## Design
+
+### Provider catalog
+
+`openai-codex` continues to use the OpenAI provider database as its capability identity and model
+metadata source. `gpt-image-2` joins the explicit curated model ID list. If provider-db does not
+contain that ID, it is omitted in the same way as every other curated Codex model.
+
+The provider-db record owns the `imageGeneration` type and image-output modality. The Codex
+image-generation projection disables vision input because the current standalone route sends only a
+text prompt to `/images/generations`; renderer code does not add a Codex-specific type rule.
+
+### Runtime transport
+
+The existing `openai-codex` AI SDK factory branch creates both:
+
+- a Responses language model for `/responses`; and
+- an image model for `/images/generations`.
+
+Both models use the same Codex-specific fetch adapter. The adapter refreshes OAuth once after a
+`401`, preserves abort signals, includes `ChatGPT-Account-ID` when present, and normalizes provider
+errors without exposing credentials.
+
+Request handling is endpoint-aware:
+
+- `/responses` keeps `store: false`, removes unsupported `max_output_tokens`, and defaults
+  `Accept` to `text/event-stream`;
+- image endpoints keep the AI SDK image body unchanged and default `Accept` to
+  `application/json`.
+
+This separation prevents Responses-only compatibility fields from reaching the image API.
+
+### Data flow
+
+```text
+user selects GPT Image 2
+          |
+          v
+existing image-generation chat route
+          |
+          v
+AI SDK OpenAI image model
+          |
+          v
+Codex OAuth fetch adapter -- refresh on 401 --> encrypted credential store
+          |
+          v
+POST /backend-api/codex/images/generations
+          |
+          v
+base64 image -> existing DeepChat image cache and message preview
+```
+
+### User-visible layout
+
+```text
+BEFORE                              AFTER
+OpenAI Codex                        OpenAI Codex
+  GPT-5.6 Luna       [chat]           GPT-5.6 Luna       [chat]
+  GPT-5.6 Sol        [chat]           GPT-5.6 Sol        [chat]
+  ...                                   ...
+                                      GPT Image 2        [imageGeneration]
+```
+
+Selecting `GPT Image 2` uses the existing image settings panel and image result rendering; no new
+screen, control, or copy is introduced. Reference-image attachments remain disabled for this route.
+
+## Ownership and security
+
+- Provider ID: `openai-codex`.
+- Runtime/API type: dedicated `openai-codex` transport over OpenAI-compatible image JSON.
+- Default base URL: `https://chatgpt.com/backend-api/codex`.
+- Auth: ChatGPT OAuth; tokens remain in the existing OpenAI Codex credential store in the main
+  process.
+- Model metadata: built-in provider-db, source provider `openai`.
+- Connection check: `generate-text` with `gpt-5.6-luna` and prompt `Hello`.
+- Image generation model: `gpt-image-2`.
+
+The renderer receives only model metadata and auth status. Raw access tokens, refresh tokens, and
+account identifiers never cross the preload boundary or appear in request traces.
+
+## Compatibility and failure behavior
+
+- Existing OpenAI Codex text requests retain their wire shape and streaming behavior.
+- Existing API-key OpenAI image generation is unchanged.
+- Codex image generation does not advertise vision input, keeping reference images out of the
+  supported attachment flow.
+- Accounts without image entitlement receive the existing normalized Codex permission error.
+- Missing provider-db metadata omits `gpt-image-2` instead of synthesizing incomplete capability
+  data.
+- The default provider connection check remains a text request and does not prove image entitlement;
+  image-specific errors surface on the first generation request.
+
+## Acceptance criteria
+
+- Refreshing OpenAI Codex models includes `gpt-image-2` when bundled provider-db includes it.
+- DeepChat identifies that model as an image-generation model and shows the existing image settings UI.
+- Model and session image-generation options survive capability normalization, while reference-image
+  attachments remain unavailable.
+- A generation request targets `/backend-api/codex/images/generations` with OAuth/account headers,
+  a JSON accept header, and no Responses-only `store` field.
+- Returned base64 image data follows the existing image cache and preview path.
+- Text generation, OAuth refresh, error normalization, and provider checks remain unchanged.
+
+## Open questions
+
+None.

--- a/docs/features/provider-runtime/spec.md
+++ b/docs/features/provider-runtime/spec.md
@@ -77,12 +77,15 @@ passing through unless an explicit model request policy requires a different wir
 
 `openai-codex` is separate from standard `openai`: distinct provider ID, runtime kind, credential store,
 routes and request adapter. Current recommended catalog includes `gpt-5.5`, `gpt-5.6-sol`,
-`gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.4`, `gpt-5.4-mini` and `gpt-5.3-codex-spark` when provider-db
-metadata contains them; connection check uses `gpt-5.6-luna`.
+`gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark` and `gpt-image-2`
+when provider-db metadata contains them; connection check uses `gpt-5.6-luna`.
 
 Codex requests include required instructions and backend routing headers, preserve streaming/tool/reasoning
-behavior, and surface entitlement failure without logging token or account identifiers. Background
-provider-db refresh skips its dedicated runtime catalog; manual refresh remains available.
+behavior, and surface entitlement failure without logging token or account identifiers. Image generation
+uses the same OAuth credential path with `/images/generations`; Responses-only body normalization does not
+apply to image requests. The image-generation projection preserves shared OpenAI image settings but disables
+vision input because the standalone route accepts only text prompts. Background provider-db refresh skips
+its dedicated runtime catalog; manual refresh remains available.
 
 ## Validation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DeepChat",
-  "version": "1.1.1-beta.3",
+  "version": "1.1.1-beta.4",
   "description": "DeepChat，一个简单易用的 Agent 客户端",
   "main": "./out/main/index.js",
   "author": "ThinkInAIXYZ",

--- a/src/main/agent/deepchat/runtime/compactionService.ts
+++ b/src/main/agent/deepchat/runtime/compactionService.ts
@@ -409,6 +409,7 @@ export class CompactionService {
     preserveInterleavedReasoning: boolean
     preserveEmptyInterleavedReasoning?: boolean
     newUserContent: SendMessageInput
+    newUserContentInHistory?: boolean
     forceContextPressure?: boolean
     historyRecords?: ChatMessageRecord[]
     signal?: AbortSignal
@@ -440,13 +441,20 @@ export class CompactionService {
       pinnedFirstUser,
       minimumRetainedTurnCount: settings.retainRecentPairs,
       triggerThreshold: settings.triggerThreshold,
-      projectedMessages: [
-        createUserChatMessage(
-          params.newUserContent,
-          params.supportsVision,
-          params.supportsAudioInput === true
-        )
-      ],
+      // When retry reuses an existing user prompt that is already part of the
+      // history (newUserContentInHistory), do not project it a second time:
+      // counting it in both historyRecords and projectedMessages inflates the
+      // context estimate and can prematurely trigger compaction.
+      projectedMessages:
+        params.newUserContentInHistory === true
+          ? []
+          : [
+              createUserChatMessage(
+                params.newUserContent,
+                params.supportsVision,
+                params.supportsAudioInput === true
+              )
+            ],
       force: params.forceContextPressure === true,
       anchorName: params.forceContextPressure
         ? 'auto_handoff/context_overflow'

--- a/src/main/agent/deepchat/runtime/contextBuilder.ts
+++ b/src/main/agent/deepchat/runtime/contextBuilder.ts
@@ -102,6 +102,11 @@ export type ContextBuildOptions = {
   extraReserveTokens?: number
   supportsAudioInput?: boolean
   providerReplayProjector?: ChatMessageProviderReplayProjector
+  // When retry reuses an existing user prompt that is already part of the
+  // history, the context build must not include it both in the history turns
+  // and as the new user message.
+  newUserContentInHistory?: boolean
+  newUserContentMessageId?: string
 }
 
 export type CacheAwareContextBuildOptions = ContextBuildOptions & {
@@ -1837,10 +1842,18 @@ export function buildCacheAwareContextWithMetadata(
           undefined,
           options.runPinnedFirstUser
         )
-    : null
-  const historyRecords = filterRecordsFromCursor(contextCandidateRecords, cursor).filter(
-    (record) => record.id !== pinnedFirstUser?.record.id
-  )
+      : null
+  // When the reused retried prompt is itself the pinned first user, drop it from
+  // the leading pinned message: the live newUserMessage already carries it, so
+  // pinning it again would send the prompt twice.
+  const emittedPinnedFirstUser =
+    options.newUserContentMessageId != null &&
+    pinnedFirstUser?.record.id === options.newUserContentMessageId
+      ? null
+      : pinnedFirstUser
+  const historyRecords = filterRecordsFromCursor(contextCandidateRecords, cursor)
+    .filter((record) => record.id !== pinnedFirstUser?.record.id)
+    .filter((record) => record.id !== options.newUserContentMessageId)
   const historyTurns = buildHistoryTurns(
     historyRecords,
     supportsVision,
@@ -1850,7 +1863,11 @@ export function buildCacheAwareContextWithMetadata(
     undefined,
     options.providerReplayProjector
   )
-  const leadingMessages = buildCacheAwareLeadingMessages(systemPrompt, context, pinnedFirstUser)
+  const leadingMessages = buildCacheAwareLeadingMessages(
+    systemPrompt,
+    context,
+    emittedPinnedFirstUser
+  )
   const inputBudget = resolveFiniteInputBudget(
     contextLength,
     reserveTokens,
@@ -1935,7 +1952,7 @@ export function buildCacheAwareContextWithMetadata(
       emittedTurns: historyTurns,
       cursor,
       context,
-      pinnedFirstUser,
+      pinnedFirstUser: emittedPinnedFirstUser,
       includesSystemPrompt: Boolean(systemPrompt)
     })
   }

--- a/src/main/agent/deepchat/runtime/turnCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/turnCoordinator.ts
@@ -148,6 +148,7 @@ export interface TurnStartContext {
   maxProviderRounds?: number
   preserveResolvedRepresentations?: boolean
   beforeHistoryPreparation?: () => void
+  preStreamAnchorMessageId?: string
 }
 
 export interface TurnExecutionContext extends TurnStartContext {
@@ -495,7 +496,9 @@ export class TurnCoordinator {
       if (!instance) throw new Error(`Session ${sessionId} not found`)
       instance.clearPreStreamTranscriptAnchor()
       const reservedTranscriptAnchor =
-        reservedSteerAssistantMessageId ?? linkedSteerMessageIds.at(-1)
+        context?.preStreamAnchorMessageId ??
+        reservedSteerAssistantMessageId ??
+        linkedSteerMessageIds.at(-1)
       if (reservedTranscriptAnchor) {
         instance.setPreStreamTranscriptAnchorId(reservedTranscriptAnchor)
       }
@@ -797,6 +800,13 @@ export class TurnCoordinator {
             state.providerId,
             state.modelId
           )
+        // A retried user prompt that is anchored and kept in the transcript is
+        // already part of the history, so compaction must not project it a second
+        // time (avoids inflating the context estimate).
+        const anchorMessageId = instance.getPreStreamTranscriptAnchorId()
+        const newUserContentInHistory = Boolean(
+          anchorMessageId && historyRecords.some((record) => record.id === anchorMessageId)
+        )
         return await this.runPreStreamStep(
           {
             sessionId,
@@ -819,6 +829,7 @@ export class TurnCoordinator {
               preserveEmptyInterleavedReasoning:
                 interleavedReasoning.preserveEmptyReasoningContent === true,
               newUserContent: content,
+              newUserContentInHistory,
               ...(pendingContextPressure ? { forceContextPressure: true } : {}),
               historyRecords,
               signal: preStreamAbortSignal
@@ -992,6 +1003,14 @@ export class TurnCoordinator {
         >
       ) => {
         const contextBuildStartedAt = Date.now()
+        // A retried user prompt that is anchored and kept in the transcript is
+        // already carried by historyRecords; exclude it from the history turns so
+        // the newUserMessage (which holds the live turn and memory injection)
+        // does not duplicate it.
+        const anchorMessageId = instance.getPreStreamTranscriptAnchorId()
+        const newUserContentInHistory = Boolean(
+          anchorMessageId && historyRecords.some((record) => record.id === anchorMessageId)
+        )
         const contextBuild = buildTapeChatView({
           sessionId,
           newUserContent: content,
@@ -1009,7 +1028,9 @@ export class TurnCoordinator {
             preserveInterleavedReasoning: interleavedReasoning.preserveReasoningContent,
             preserveEmptyInterleavedReasoning:
               interleavedReasoning.preserveEmptyReasoningContent === true,
-            providerReplayProjector
+            providerReplayProjector,
+            newUserContentInHistory,
+            newUserContentMessageId: newUserContentInHistory ? anchorMessageId : undefined
           }
         })
         logSlowPreStreamStep(sessionId, 'context-build', contextBuildStartedAt)

--- a/src/main/provider/aiSdk/providerFactory.ts
+++ b/src/main/provider/aiSdk/providerFactory.ts
@@ -593,7 +593,9 @@ export function createAiSdkProviderContext(
         providerOptionsKey: 'openai',
         apiType: 'openai_responses',
         model: maybeWrapModel(provider.responses(params.modelId) as any),
-        endpoint: buildOpenAICodexResponsesEndpoint(codexBaseUrl)
+        imageModel: provider.image(params.modelId),
+        endpoint: buildOpenAICodexResponsesEndpoint(codexBaseUrl),
+        imageEndpoint: buildOpenAIEndpoint(codexBaseUrl, '/images/generations')
       }
     }
 

--- a/src/main/provider/modelConfig.ts
+++ b/src/main/provider/modelConfig.ts
@@ -155,6 +155,15 @@ export class ModelConfigHelper {
 
     const policyConfig = applyMoonshotKimiReasoningTemperaturePolicy(providerId, modelId, config)
 
+    if (
+      normalizeProviderKind(providerId) === 'openai-codex' &&
+      (policyConfig.type === ModelType.ImageGeneration ||
+        policyConfig.apiEndpoint === ApiEndpointType.Image ||
+        policyConfig.endpointType === 'image-generation')
+    ) {
+      return { ...policyConfig, vision: false }
+    }
+
     if (!isMiniMaxM3Model(providerId, modelId)) {
       return policyConfig
     }

--- a/src/main/provider/openaiCodexAdapter.ts
+++ b/src/main/provider/openaiCodexAdapter.ts
@@ -13,6 +13,16 @@ function stripResponsesSuffix(pathname: string): string {
   return pathname.replace(/\/responses\/?$/i, '') || '/'
 }
 
+function isResponsesRequest(input: string | URL | Request): boolean {
+  const requestUrl =
+    typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+  try {
+    return /\/responses\/?$/i.test(new URL(requestUrl).pathname)
+  } catch {
+    return /\/responses\/?(?:\?|$)/i.test(requestUrl)
+  }
+}
+
 export function normalizeOpenAICodexBaseUrl(baseUrl: string | undefined): string {
   const normalized = (baseUrl || '').trim().replace(/\/+$/, '')
   if (!normalized) {
@@ -154,7 +164,8 @@ function normalizeOpenAICodexRequestBody(
 function applyCodexHeaders(
   inputHeaders: HeadersInit | undefined,
   defaultHeaders: Record<string, string>,
-  auth: OpenAICodexBackendAuth
+  auth: OpenAICodexBackendAuth,
+  accept: string
 ): Headers {
   const headers = new Headers(inputHeaders ?? {})
   Object.entries(defaultHeaders).forEach(([key, value]) => headers.set(key, value))
@@ -170,7 +181,7 @@ function applyCodexHeaders(
   headers.set('Version', OPENAI_CODEX_CLIENT_VERSION)
   headers.set('User-Agent', OPENAI_CODEX_USER_AGENT)
   if (!headers.has('Accept')) {
-    headers.set('Accept', 'text/event-stream')
+    headers.set('Accept', accept)
   }
   if (!headers.has('Content-Type')) {
     headers.set('Content-Type', 'application/json')
@@ -186,10 +197,12 @@ export function createOpenAICodexFetch(defaultHeaders: Record<string, string>) {
 
     const auth = getGlobalOpenAICodexAuth()
     const backendAuth = await auth.getBackendAuth()
+    const responsesRequest = isResponsesRequest(url)
+    const accept = responsesRequest ? 'text/event-stream' : 'application/json'
     const nextInit: RequestInit = {
       ...init,
-      body: normalizeOpenAICodexRequestBody(init?.body),
-      headers: applyCodexHeaders(init?.headers, defaultHeaders, backendAuth)
+      body: responsesRequest ? normalizeOpenAICodexRequestBody(init?.body) : init?.body,
+      headers: applyCodexHeaders(init?.headers, defaultHeaders, backendAuth, accept)
     }
 
     let response = await fetch(url, nextInit)
@@ -200,7 +213,7 @@ export function createOpenAICodexFetch(defaultHeaders: Record<string, string>) {
     const refreshedAuth = await auth.forceRefreshBackendAuth()
     response = await fetch(url, {
       ...nextInit,
-      headers: applyCodexHeaders(init?.headers, defaultHeaders, refreshedAuth)
+      headers: applyCodexHeaders(init?.headers, defaultHeaders, refreshedAuth, accept)
     })
     return normalizeOpenAICodexErrorResponse(response)
   }

--- a/src/main/provider/providers/aiSdkProvider.ts
+++ b/src/main/provider/providers/aiSdkProvider.ts
@@ -79,7 +79,8 @@ const OPENAI_CODEX_RECOMMENDED_MODEL_IDS = [
   'gpt-5.6-luna',
   'gpt-5.4',
   'gpt-5.4-mini',
-  'gpt-5.3-codex-spark'
+  'gpt-5.3-codex-spark',
+  'gpt-image-2'
 ]
 const GREENPT_RECOMMENDED_MODEL_IDS = [
   'glm-5.2',

--- a/src/main/session/data/contracts.ts
+++ b/src/main/session/data/contracts.ts
@@ -72,8 +72,14 @@ export interface SessionTranscriptMutationPort {
   prepareRetryMessage(
     sessionId: string,
     messageId: string
-  ): Promise<{ content: SendMessageInput; projectDir: string | null; sourceOrderSeq: number }>
-  commitRetryMessage(sessionId: string, sourceOrderSeq: number): void
+  ): Promise<{
+    content: SendMessageInput
+    projectDir: string | null
+    sourceOrderSeq: number
+    retryFromOrderSeq: number
+    sourceMessageId: string | null
+  }>
+  commitRetryMessage(sessionId: string, orderSeq: number): void
   deleteMessage(sessionId: string, messageId: string): Promise<void>
   editUserMessage(sessionId: string, messageId: string, text: string): Promise<ChatMessageRecord>
   forkSessionFromMessage(

--- a/src/main/session/transcriptMutations.ts
+++ b/src/main/session/transcriptMutations.ts
@@ -43,7 +43,13 @@ export class SessionTranscriptMutations {
   async prepareRetryMessage(
     sessionId: string,
     messageId: string
-  ): Promise<{ content: SendMessageInput; projectDir: string | null; sourceOrderSeq: number }> {
+  ): Promise<{
+    content: SendMessageInput
+    projectDir: string | null
+    sourceOrderSeq: number
+    retryFromOrderSeq: number
+    sourceMessageId: string | null
+  }> {
     const target = this.requireMessage(sessionId, messageId)
     const sourceUserMessage =
       target.role === 'user'
@@ -62,14 +68,33 @@ export class SessionTranscriptMutations {
       throw new Error('Cannot retry an empty user message.')
     }
 
-    return { content, projectDir, sourceOrderSeq: sourceUserMessage.orderSeq }
+    // The retried user prompt is kept in the transcript and reused as the
+    // pre-stream anchor. A failed/error row (e.g. a failed Steer prompt) must be
+    // restored to 'sent' so context history filtering keeps it; otherwise the
+    // prompt silently drops out of future turns.
+    if (sourceUserMessage.status !== 'sent') {
+      this.dependencies.transcript.updateMessageStatus(sourceUserMessage.id, 'sent')
+    }
+
+    return {
+      content,
+      projectDir,
+      sourceOrderSeq: sourceUserMessage.orderSeq,
+      // Truncate from the retried message (not the source user message) so the
+      // user prompt survives and only the assistant reply is regenerated. When
+      // the retried message IS the user prompt, keep it too and truncate from
+      // the next order sequence, anchoring it so the same record is re-sent
+      // instead of a fresh duplicate.
+      retryFromOrderSeq: target.role === 'user' ? target.orderSeq + 1 : target.orderSeq,
+      sourceMessageId: sourceUserMessage.id
+    }
   }
 
-  commitRetryMessage(sessionId: string, sourceOrderSeq: number): void {
+  commitRetryMessage(sessionId: string, orderSeq: number): void {
     this.dependencies.runInTransaction(() => {
-      this.dependencies.transcript.deleteFromOrderSeq(sessionId, sourceOrderSeq)
+      this.dependencies.transcript.deleteFromOrderSeq(sessionId, orderSeq)
     })
-    this.dependencies.runtime.invalidateTranscriptFrom(sessionId, sourceOrderSeq)
+    this.dependencies.runtime.invalidateTranscriptFrom(sessionId, orderSeq)
   }
 
   async deleteMessage(sessionId: string, messageId: string): Promise<void> {

--- a/src/main/session/turn.ts
+++ b/src/main/session/turn.ts
@@ -352,6 +352,8 @@ export class SessionTurn implements SessionTurnPort, SessionInitialTurnPort {
     const runtime = this.dependencies.runtime.resolveSession(toAppSessionId(sessionId))
     const prepared = await this.dependencies.transcript.prepareRetryMessage(sessionId, messageId)
     if (runtime.kind === 'acp') {
+      // ACP re-creates the user message on send, so truncate from the source
+      // user message (inclusive) to avoid a stale duplicate.
       this.dependencies.transcript.commitRetryMessage(sessionId, prepared.sourceOrderSeq)
       return await runtime.send({
         content: prepared.content,
@@ -370,8 +372,9 @@ export class SessionTurn implements SessionTurnPort, SessionInitialTurnPort {
         projectDir: prepared.projectDir,
         emitRefreshBeforeStream: true,
         preserveResolvedRepresentations: true,
+        ...(prepared.sourceMessageId ? { preStreamAnchorMessageId: prepared.sourceMessageId } : {}),
         beforeHistoryPreparation: () =>
-          this.dependencies.transcript.commitRetryMessage(sessionId, prepared.sourceOrderSeq)
+          this.dependencies.transcript.commitRetryMessage(sessionId, prepared.retryFromOrderSeq)
       }
     })
   }

--- a/src/renderer/settings/components/MemoryDiagnosticsPanel.vue
+++ b/src/renderer/settings/components/MemoryDiagnosticsPanel.vue
@@ -164,6 +164,7 @@
         </DcSectionCard>
 
         <DcSectionCard
+          data-testid="archive-candidates"
           :title="t('settings.memory.redesign.archiveCandidatesTitle')"
           :description="t('settings.memory.redesign.archiveCandidatesDescription')"
         >
@@ -195,12 +196,12 @@
               <div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-muted-foreground">
                 <span>
                   {{ t('settings.deepchatAgents.memoryManager.health.archivePrediction.ageDays') }}:
-                  {{ formatNumber(lifecycle.forget.ageDays) }}
+                  {{ formatDays(lifecycle.forget.ageDays) }}
                 </span>
                 <span>
                   {{
                     t('settings.deepchatAgents.memoryManager.health.archivePrediction.decayScore')
-                  }}: {{ formatNumber(lifecycle.forget.decayScore) }}
+                  }}: {{ formatDecimal(lifecycle.forget.decayScore) }}
                 </span>
               </div>
             </li>
@@ -332,6 +333,7 @@ import type {
 import { auditSentenceKey, formatRelativeTime } from './memoryRedesignUtils'
 import MemoryInlineFeedback from './MemoryInlineFeedback.vue'
 import { useMemoryInlineFeedback } from '../lib/useMemoryInlineFeedback'
+import { useMemoryNumberFormatters } from '../lib/useMemoryNumberFormatters'
 
 const props = defineProps<{
   agentId: string
@@ -340,6 +342,8 @@ const props = defineProps<{
 }>()
 
 const { t, te, locale } = useI18n()
+const { formatDecimal, formatDays } = useMemoryNumberFormatters()
+
 const memoryClient = createMemoryClient()
 const panelFeedback = useMemoryInlineFeedback('MemoryDiagnosticsPanel')
 const feedback = panelFeedback.feedback
@@ -384,8 +388,12 @@ const reindexFailureReason = computed(() => {
   return t('settings.memory.redesign.reindexInternalReason')
 })
 const recallDiagnostics = computed(() => health.value?.runtime.agent.retrieval.recall)
-const recallLatencyP50 = computed(() => recallDiagnostics.value?.latencyMs.total.p50 ?? '—')
-const recallLatencyP95 = computed(() => recallDiagnostics.value?.latencyMs.total.p95 ?? '—')
+const recallLatencyP50 = computed(() =>
+  formatOptionalDecimal(recallDiagnostics.value?.latencyMs.total.p50)
+)
+const recallLatencyP95 = computed(() =>
+  formatOptionalDecimal(recallDiagnostics.value?.latencyMs.total.p95)
+)
 const fallbackCount = computed(() => {
   const counts = recallDiagnostics.value?.degradationCounts
   if (!counts) return 0
@@ -461,8 +469,8 @@ function shortId(id: string): string {
   return id.length > 10 ? `${id.slice(0, 4)}…${id.slice(-6)}` : id
 }
 
-function formatNumber(value: number): string {
-  return Number.isFinite(value) ? value.toFixed(value >= 10 ? 0 : 2) : String(value)
+function formatOptionalDecimal(value: number | null | undefined): string {
+  return value == null ? '—' : formatDecimal(value)
 }
 
 function eventLabel(eventType: string): string {

--- a/src/renderer/settings/components/MemoryLifecyclePanel.vue
+++ b/src/renderer/settings/components/MemoryLifecyclePanel.vue
@@ -151,6 +151,7 @@ import { useI18n } from 'vue-i18n'
 import { Icon } from '@iconify/vue'
 import { DcBadge } from '@dc-ui/components/badge'
 import type { MemoryLifecycle } from '@shared/contracts/routes'
+import { useMemoryNumberFormatters } from '../lib/useMemoryNumberFormatters'
 
 const props = defineProps<{
   lifecycle: MemoryLifecycle | null
@@ -159,21 +160,7 @@ const props = defineProps<{
 }>()
 
 const { t, locale } = useI18n()
-
-const decimalFormatter = computed(
-  () =>
-    new Intl.NumberFormat(locale.value || undefined, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 3
-    })
-)
-const dayFormatter = computed(
-  () =>
-    new Intl.NumberFormat(locale.value || undefined, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 1
-    })
-)
+const { formatDecimal: formatScore, formatDays } = useMemoryNumberFormatters()
 const dateFormatter = computed(
   () =>
     new Intl.DateTimeFormat(locale.value || undefined, {
@@ -254,18 +241,10 @@ const archiveConditions = computed(() => {
   ]
 })
 
-function formatScore(value: number): string {
-  return decimalFormatter.value.format(value)
-}
-
 function formatOptionalScore(value: number | null): string {
   return value === null
     ? t('settings.deepchatAgents.memoryManager.lifecycle.forget.notRefreshed')
     : formatScore(value)
-}
-
-function formatDays(value: number): string {
-  return dayFormatter.value.format(value)
 }
 
 function formatTime(value: number): string {

--- a/src/renderer/settings/lib/useMemoryNumberFormatters.ts
+++ b/src/renderer/settings/lib/useMemoryNumberFormatters.ts
@@ -1,0 +1,27 @@
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+export function useMemoryNumberFormatters() {
+  const { locale } = useI18n()
+  const decimalFormatter = computed(
+    () =>
+      new Intl.NumberFormat(locale.value || undefined, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 3
+      })
+  )
+  const dayFormatter = computed(
+    () =>
+      new Intl.NumberFormat(locale.value || undefined, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 1
+      })
+  )
+
+  const formatDecimal = (value: number): string =>
+    Number.isFinite(value) ? decimalFormatter.value.format(value) : String(value)
+  const formatDays = (value: number): string =>
+    Number.isFinite(value) ? dayFormatter.value.format(value) : String(value)
+
+  return { formatDecimal, formatDays }
+}

--- a/src/renderer/src/components/markdown/MarkdownRenderer.vue
+++ b/src/renderer/src/components/markdown/MarkdownRenderer.vue
@@ -244,6 +244,15 @@ const STATIC_RENDER_BATCH_IDLE_TIMEOUT_MS = 16
 const STATIC_PARSE_COALESCE_MS = 0
 const STATIC_MAX_LIVE_NODES = 260
 const STATIC_LIVE_NODE_BUFFER = 80
+// The committed prefix advances in ~6 KB chunks. Mounting a whole chunk at once
+// queued a burst of GPU rasterization (0.2-1 s stalls in profiles), so the
+// prefix renders with gentle, budget-capped batching that spreads the mount and
+// raster work across frames.
+const PREFIX_INITIAL_RENDER_BATCH_SIZE = 12
+const PREFIX_RENDER_BATCH_SIZE = 8
+const PREFIX_RENDER_BATCH_DELAY_MS = 12
+const PREFIX_RENDER_BATCH_BUDGET_MS = 4
+const PREFIX_RENDER_BATCH_IDLE_TIMEOUT_MS = 40
 
 const shouldVirtualizeNodes = computed(() => props.virtualizeNodes && !isStreaming.value)
 const resolvedNodeVirtual = computed(() =>
@@ -413,13 +422,16 @@ const renderSegments = computed<RenderSegment[]>(() => {
       smoothStreaming: false,
       typewriter: false,
       nodeVirtual: 'auto',
-      maxLiveNodes: STATIC_MAX_LIVE_NODES,
-      liveNodeBuffer: STATIC_LIVE_NODE_BUFFER,
-      initialBatch: STATIC_INITIAL_RENDER_BATCH_SIZE,
-      batchSize: STATIC_RENDER_BATCH_SIZE,
-      batchDelay: STATIC_RENDER_BATCH_DELAY_MS,
-      batchBudget: STATIC_RENDER_BATCH_BUDGET_MS,
-      batchIdle: STATIC_RENDER_BATCH_IDLE_TIMEOUT_MS,
+      // Incremental batching only takes effect when virtual live-node limiting is
+      // off (markstream-vue gates batching on `maxLiveNodes <= 0`), so the prefix
+      // must not pin live nodes or the gentle raster spreading never happens.
+      maxLiveNodes: 0,
+      liveNodeBuffer: 0,
+      initialBatch: PREFIX_INITIAL_RENDER_BATCH_SIZE,
+      batchSize: PREFIX_RENDER_BATCH_SIZE,
+      batchDelay: PREFIX_RENDER_BATCH_DELAY_MS,
+      batchBudget: PREFIX_RENDER_BATCH_BUDGET_MS,
+      batchIdle: PREFIX_RENDER_BATCH_IDLE_TIMEOUT_MS,
       parseCoalesce: STATIC_PARSE_COALESCE_MS,
       customId: `${customRendererId.value}::prefix`
     },

--- a/src/renderer/src/components/markdown/MarkdownRenderer.vue
+++ b/src/renderer/src/components/markdown/MarkdownRenderer.vue
@@ -4,32 +4,34 @@
     @keydown="handleRendererKeydown"
   >
     <NodeRenderer
-      :content="renderContent"
-      :custom-id="customRendererId"
+      v-for="segment in renderSegments"
+      :key="segment.key"
+      :content="segment.content"
+      :custom-id="segment.customId"
       :isDark="themeStore.isDark"
       :mode="props.mode"
-      :final="resolvedFinal"
-      :smooth-streaming="resolvedSmoothStreaming"
-      :typewriter="resolvedTypewriter"
-      :code-block-stream="isStreaming"
+      :final="segment.final"
+      :smooth-streaming="segment.smoothStreaming"
+      :typewriter="segment.typewriter"
+      :code-block-stream="segment.codeBlockStream"
       :themes="codeBlockThemes"
       :code-block-options="codeBlockOptions"
       :mermaid-props="mermaidProps"
       :fade="false"
       :batch-rendering="true"
-      :initial-render-batch-size="initialRenderBatchSize"
-      :render-batch-size="renderBatchSize"
-      :render-batch-delay="renderBatchDelay"
-      :render-batch-budget-ms="renderBatchBudgetMs"
-      :render-batch-idle-timeout-ms="renderBatchIdleTimeoutMs"
-      :parse-coalesce-ms="parseCoalesceMs"
+      :initial-render-batch-size="segment.initialBatch"
+      :render-batch-size="segment.batchSize"
+      :render-batch-delay="segment.batchDelay"
+      :render-batch-budget-ms="segment.batchBudget"
+      :render-batch-idle-timeout-ms="segment.batchIdle"
+      :parse-coalesce-ms="segment.parseCoalesce"
       :parse-options="parseOptions"
       html-policy="safe"
-      :defer-nodes-until-visible="shouldUseViewportPriority"
-      :viewport-priority="shouldUseViewportPriority"
-      :node-virtual="resolvedNodeVirtual"
-      :max-live-nodes="maxLiveNodes"
-      :live-node-buffer="liveNodeBuffer"
+      :defer-nodes-until-visible="props.virtualizeNodes"
+      :viewport-priority="props.virtualizeNodes"
+      :node-virtual="segment.nodeVirtual"
+      :max-live-nodes="segment.maxLiveNodes"
+      :live-node-buffer="segment.liveNodeBuffer"
       @copy="$emit('copy', $event)"
       @handle-artifact-click="handleArtifactClick"
       @click="handleRendererClick"
@@ -209,7 +211,31 @@ const STREAM_RENDER_BATCH_SIZE = 14
 const STREAM_RENDER_BATCH_DELAY_MS = 8
 const STREAM_RENDER_BATCH_BUDGET_MS = 3
 const STREAM_RENDER_BATCH_IDLE_TIMEOUT_MS = 24
-const STREAM_PARSE_COALESCE_MS = 12
+// Content-update coalescing scales with the accumulated document length.
+// Streaming updates bypass these debouncers entirely (they commit immediately
+// via commitImmediately: main already coalesces renderer snapshots and Markstream
+// owns visible pacing); the length-adaptive levels feed `parseCoalesceMs` during
+// streaming and keep the remaining content-update path debounced (profile:
+// 19-33fps, 1.8s main thread stalls on long streams).
+const CONTENT_UPDATE_COALESCE_LEVELS = [
+  { maxLength: 8_000, debounceMs: 32, maxWaitMs: 64, parseCoalesceMs: 12 },
+  { maxLength: 32_000, debounceMs: 64, maxWaitMs: 128, parseCoalesceMs: 28 },
+  {
+    maxLength: Number.POSITIVE_INFINITY,
+    debounceMs: 120,
+    maxWaitMs: 220,
+    parseCoalesceMs: 48
+  }
+] as const
+
+const contentUpdateCoalesceLevel = (length: number) =>
+  CONTENT_UPDATE_COALESCE_LEVELS.find((level) => length <= level.maxLength) ??
+  CONTENT_UPDATE_COALESCE_LEVELS[CONTENT_UPDATE_COALESCE_LEVELS.length - 1]
+// Streaming render is split into a static committed prefix + a small live tail
+// (see findSafeSplit / renderSegments below). The tail must stay small so each
+// token only re-renders a bounded chunk instead of the whole document.
+const STREAM_TAIL_CAP_CHARS = 6000
+const STREAM_MIN_TAIL_CHARS = 2000
 const STATIC_INITIAL_RENDER_BATCH_SIZE = 96
 const STATIC_RENDER_BATCH_SIZE = 80
 const STATIC_RENDER_BATCH_DELAY_MS = 0
@@ -220,7 +246,6 @@ const STATIC_MAX_LIVE_NODES = 260
 const STATIC_LIVE_NODE_BUFFER = 80
 
 const shouldVirtualizeNodes = computed(() => props.virtualizeNodes && !isStreaming.value)
-const shouldUseViewportPriority = computed(() => props.virtualizeNodes)
 const resolvedNodeVirtual = computed(() =>
   shouldVirtualizeNodes.value ? ('auto' as const) : false
 )
@@ -241,9 +266,184 @@ const renderBatchBudgetMs = computed(() =>
 const renderBatchIdleTimeoutMs = computed(() =>
   isStreaming.value ? STREAM_RENDER_BATCH_IDLE_TIMEOUT_MS : STATIC_RENDER_BATCH_IDLE_TIMEOUT_MS
 )
-const parseCoalesceMs = computed(() =>
-  isStreaming.value ? STREAM_PARSE_COALESCE_MS : STATIC_PARSE_COALESCE_MS
+const parseCoalesceMs = computed(() => {
+  if (!isStreaming.value) return STATIC_PARSE_COALESCE_MS
+  return contentUpdateCoalesceLevel(renderContent.value.length).parseCoalesceMs
+})
+
+// --- Streaming split-render (committed prefix + live tail) ---
+// Each token currently makes Markstream re-render the whole document, so long
+// streams stall the renderer. Instead, once the stream passes the tail cap we
+// render a static committed prefix (only re-rendered when the split advances,
+// with node virtualization limiting the cost) plus a small streaming tail that
+// is cheap to re-render per token. On completion everything re-renders once as
+// a single static document.
+const committedLength = ref(0)
+
+const fenceLineStarts = (s: string): { backtick: number[]; tilde: number[] } => {
+  const backtick: number[] = []
+  const tilde: number[] = []
+  const re = /^(`{3,}|~{3,})/gm
+  let match: RegExpExecArray | null
+  while ((match = re.exec(s)) !== null) {
+    if (match[1].startsWith('`')) {
+      backtick.push(match.index)
+    } else {
+      tilde.push(match.index)
+    }
+  }
+  return { backtick, tilde }
+}
+
+const findSafeSplit = (content: string, preferred: number, current: number): number => {
+  const minSplit = Math.max(0, content.length - STREAM_TAIL_CAP_CHARS)
+  const maxSplit = Math.min(content.length, Math.max(0, preferred))
+  // Prefer a blank-line boundary so blocks/paragraphs aren't chopped mid-way.
+  const blankLine = content.lastIndexOf('\n\n', maxSplit)
+  let split = blankLine >= minSplit ? Math.min(maxSplit, blankLine + 2) : maxSplit
+  // No blank-line boundary in the window: advancing would chop a long
+  // paragraph/list mid-way. Keep the current split (no advance) until a safe
+  // boundary appears instead of rendering a half-paragraph in the prefix.
+  if (blankLine < minSplit) return current
+  // Fences must be balanced per marker type (` vs ~): an odd count of either
+  // means the committed prefix ends inside an unclosed fence.
+  const fenceStarts = fenceLineStarts(content.slice(0, split))
+  const unbalanced =
+    fenceStarts.backtick.length % 2 === 1
+      ? fenceStarts.backtick
+      : fenceStarts.tilde.length % 2 === 1
+        ? fenceStarts.tilde
+        : null
+  if (unbalanced) {
+    const opener = unbalanced[unbalanced.length - 1]
+    const beforeFence = opener >= 0 ? content.lastIndexOf('\n\n', opener) : -1
+    // A single fenced block can be larger than the tail cap; committing a piece
+    // of it would leave an unterminated code block in the static prefix. Keep
+    // the current split (no advance) until the fence closes.
+    if (beforeFence < minSplit || beforeFence < 0) return current
+    split = Math.min(maxSplit, beforeFence + 2)
+  }
+  return split
+}
+
+// Split only once a committed prefix actually exists: a stream that cannot be
+// split safely (e.g. a single fenced block larger than the tail cap) keeps
+// `committedLength` at 0 and renders as a single streaming document.
+const usingSplitRender = computed(() => isStreaming.value && committedLength.value > 0)
+const committedContent = computed(() =>
+  usingSplitRender.value ? renderContent.value.slice(0, committedLength.value) : ''
 )
+const tailContent = computed(() =>
+  usingSplitRender.value ? renderContent.value.slice(committedLength.value) : renderContent.value
+)
+
+watch(
+  renderContent,
+  (content) => {
+    if (!isStreaming.value) return
+    // A regenerated/interrupted stream can shrink below an already-advanced
+    // split; reset so the split restarts from scratch instead of keeping a
+    // stale prefix (which would eat the whole content into the prefix).
+    if (content.length < committedLength.value) {
+      committedLength.value = 0
+    }
+    if (content.length - committedLength.value > STREAM_TAIL_CAP_CHARS) {
+      committedLength.value = findSafeSplit(
+        content,
+        content.length - STREAM_MIN_TAIL_CHARS,
+        committedLength.value
+      )
+    }
+  },
+  { immediate: true }
+)
+
+watch(isStreaming, (streaming, wasStreaming) => {
+  if (wasStreaming && !streaming) committedLength.value = 0
+})
+
+type RenderSegment = {
+  key: string
+  content: string
+  final: boolean
+  codeBlockStream: boolean
+  smoothStreaming: boolean | 'auto'
+  typewriter: boolean | 'simple'
+  nodeVirtual: boolean | 'auto'
+  maxLiveNodes: number
+  liveNodeBuffer: number
+  initialBatch: number
+  batchSize: number
+  batchDelay: number
+  batchBudget: number
+  batchIdle: number
+  parseCoalesce: number
+  customId: string
+}
+
+const renderSegments = computed<RenderSegment[]>(() => {
+  if (!usingSplitRender.value) {
+    return [
+      {
+        key: 'full',
+        content: renderContent.value,
+        final: resolvedFinal.value,
+        codeBlockStream: isStreaming.value,
+        smoothStreaming: resolvedSmoothStreaming.value,
+        typewriter: resolvedTypewriter.value,
+        nodeVirtual: resolvedNodeVirtual.value,
+        maxLiveNodes: maxLiveNodes.value,
+        liveNodeBuffer: liveNodeBuffer.value,
+        initialBatch: initialRenderBatchSize.value,
+        batchSize: renderBatchSize.value,
+        batchDelay: renderBatchDelay.value,
+        batchBudget: renderBatchBudgetMs.value,
+        batchIdle: renderBatchIdleTimeoutMs.value,
+        parseCoalesce: parseCoalesceMs.value,
+        customId: customRendererId.value
+      }
+    ]
+  }
+  return [
+    {
+      key: 'prefix',
+      content: committedContent.value,
+      final: true,
+      codeBlockStream: false,
+      smoothStreaming: false,
+      typewriter: false,
+      nodeVirtual: 'auto',
+      maxLiveNodes: STATIC_MAX_LIVE_NODES,
+      liveNodeBuffer: STATIC_LIVE_NODE_BUFFER,
+      initialBatch: STATIC_INITIAL_RENDER_BATCH_SIZE,
+      batchSize: STATIC_RENDER_BATCH_SIZE,
+      batchDelay: STATIC_RENDER_BATCH_DELAY_MS,
+      batchBudget: STATIC_RENDER_BATCH_BUDGET_MS,
+      batchIdle: STATIC_RENDER_BATCH_IDLE_TIMEOUT_MS,
+      parseCoalesce: STATIC_PARSE_COALESCE_MS,
+      customId: `${customRendererId.value}::prefix`
+    },
+    {
+      key: 'tail',
+      content: tailContent.value,
+      final: false,
+      codeBlockStream: true,
+      smoothStreaming: resolvedSmoothStreaming.value,
+      typewriter: resolvedTypewriter.value,
+      nodeVirtual: false,
+      maxLiveNodes: 0,
+      liveNodeBuffer: 0,
+      initialBatch: STREAM_INITIAL_RENDER_BATCH_SIZE,
+      batchSize: STREAM_RENDER_BATCH_SIZE,
+      batchDelay: STREAM_RENDER_BATCH_DELAY_MS,
+      batchBudget: STREAM_RENDER_BATCH_BUDGET_MS,
+      batchIdle: STREAM_RENDER_BATCH_IDLE_TIMEOUT_MS,
+      parseCoalesce: parseCoalesceMs.value,
+      customId: `${customRendererId.value}::tail`
+    }
+  ]
+})
+
 const { navigateLink } = useMarkdownLinkNavigation({
   linkContext: effectiveLinkContext
 })
@@ -358,23 +558,16 @@ function handleRendererMouseout(event: MouseEvent): void {
 // which would repaint stale markdown and reintroduce the completion flash.
 let contentRevision = 0
 
-const updateContentFast = useDebounceFn(
-  (revision: number, value: string) => {
-    if (revision === contentRevision) {
-      renderContent.value = value
-    }
-  },
-  32,
-  { maxWait: 64 }
-)
-const updateContentSlow = useDebounceFn(
-  (revision: number, value: string) => {
-    if (revision === contentRevision) {
-      renderContent.value = value
-    }
-  },
-  96,
-  { maxWait: 180 }
+const contentUpdateDebouncers = CONTENT_UPDATE_COALESCE_LEVELS.map((level) =>
+  useDebounceFn(
+    (revision: number, value: string) => {
+      if (revision === contentRevision) {
+        renderContent.value = value
+      }
+    },
+    level.debounceMs,
+    { maxWait: level.maxWaitMs }
+  )
 )
 
 const updateContent = (value: string, commitImmediately: boolean) => {
@@ -388,12 +581,10 @@ const updateContent = (value: string, commitImmediately: boolean) => {
     return
   }
 
-  if (props.smoothStreaming && value.length > 12_000) {
-    updateContentSlow(revision, normalizedValue)
-    return
-  }
-
-  updateContentFast(revision, normalizedValue)
+  const levelIndex = isStreaming.value
+    ? CONTENT_UPDATE_COALESCE_LEVELS.indexOf(contentUpdateCoalesceLevel(value.length))
+    : 0
+  contentUpdateDebouncers[levelIndex](revision, normalizedValue)
 }
 
 watch([() => props.content, isStreaming], ([value, streaming], [, wasStreaming]) => {

--- a/src/renderer/src/features/chat-page/composables/useMessageActions.ts
+++ b/src/renderer/src/features/chat-page/composables/useMessageActions.ts
@@ -41,7 +41,7 @@ type UseMessageActionsOptions = {
   chatClient: ChatClientLike
   beginPlanTurn: (sessionId: string) => void
   clearPlanSnapshotForDeletedMessage: (sessionId: string, messageId: string) => void
-  loadMessagesForSession: (sessionId: string) => Promise<unknown>
+  loadMessagesForSession: (sessionId: string, count?: number) => Promise<unknown>
   applyRestoredSessionSummary: (session: unknown) => void
   currentRestoreRequestId: () => number
   canWriteSessionView: (sessionId: string, requestId: number) => boolean
@@ -84,6 +84,22 @@ export function useMessageActions(options: UseMessageActionsOptions) {
     try {
       activeRetrySessionIds.add(sessionId)
       options.messageStore.clearStreamingState()
+      // The main process truncates from the retried message onward (the user
+      // prompt survives) and re-streams with fresh ids. Mirror that in the UI
+      // BEFORE the IPC: the main starts streaming before the retry IPC resolves,
+      // so an after-await truncation would leave the stale rows visible under
+      // the new stream. When the retried message IS the user prompt, keep it in
+      // place and truncate from the next order sequence instead. The blocked/
+      // failure paths below restore via a reload.
+      const target = options.messageStore.messageCache.get(messageId)
+      // Optimistic truncation shortens messageIds; remember the pre-truncation
+      // window so a blocked retry can restore the full loaded view.
+      const priorMessageCount = options.messageStore.messageIds.length
+      if (target) {
+        const fromOrderSeq = target.role === 'user' ? target.orderSeq + 1 : target.orderSeq
+        options.messageStore.truncateMessagesFromOrderSeq(sessionId, fromOrderSeq)
+      }
+
       const result = attachmentFallbackPolicy
         ? await options.sessionClient.retryMessage(sessionId, messageId, {
             attachmentFallbackPolicy
@@ -94,6 +110,9 @@ export function useMessageActions(options: UseMessageActionsOptions) {
           blockedRetryAttempt.value = { sessionId, messageId }
           retryAttachmentPreparationSummary.value =
             result.attachmentPreparation ?? fallbackPreparationSummary()
+          // A blocked retry did not delete anything; bring the optimistically
+          // removed rows back with the same window that was visible before.
+          await options.loadMessagesForSession(sessionId, priorMessageCount)
         }
         return
       }

--- a/src/renderer/src/stores/ui/message.ts
+++ b/src/renderer/src/stores/ui/message.ts
@@ -863,6 +863,32 @@ export const useMessageStore = defineStore('message', () => {
     parsedMessageCache.delete(id)
   }
 
+  /**
+   * Removes every record with orderSeq >= fromOrderSeq (inclusive), mirroring the
+   * main-process `deleteFromOrderSeq` used by retry. Retry truncates the
+   * transcript and re-streams with fresh ids, so without this the stale rows stay
+   * mounted until the stream completes and the full reload lands (visible as the
+   * old message lingering below the new one).
+   */
+  function truncateMessagesFromOrderSeq(sessionId: string, fromOrderSeq: number): void {
+    if (committedSessionId.value !== sessionId) return
+    const removedIds = new Set(
+      messageIds.value.filter((id) => {
+        const record = messageCache.value.get(id)
+        return Boolean(record && record.orderSeq >= fromOrderSeq)
+      })
+    )
+    if (removedIds.size === 0) return
+
+    markLiveMessageViewMutation(sessionId)
+    for (const id of removedIds) {
+      messageCache.value.delete(id)
+      parsedMessageCache.delete(id)
+    }
+    messageIds.value = messageIds.value.filter((id) => !removedIds.has(id))
+    lastPersistedRevision.value += 1
+  }
+
   function applyPersistedMessageRecords(records: ChatMessageRecord[]): void {
     const sessionId = records[0]?.sessionId
     if (
@@ -1076,6 +1102,7 @@ export const useMessageStore = defineStore('message', () => {
     getMessage,
     addOptimisticUserMessage,
     removeOptimisticMessage,
+    truncateMessagesFromOrderSeq,
     applyPersistedMessageRecords,
     clearStreamingState,
     clearStreamingStateForOtherSession,

--- a/src/shared/imageGenerationSettings.ts
+++ b/src/shared/imageGenerationSettings.ts
@@ -99,7 +99,11 @@ const isOpenAICompatibleProvider = (target: OpenAIImageGenerationSettingsTarget)
     return false
   }
 
-  if (providerKind === 'openai-responses' || providerKind === 'openai-compatible') {
+  if (
+    providerKind === 'openai-codex' ||
+    providerKind === 'openai-responses' ||
+    providerKind === 'openai-compatible'
+  ) {
     return true
   }
 
@@ -107,12 +111,18 @@ const isOpenAICompatibleProvider = (target: OpenAIImageGenerationSettingsTarget)
     return true
   }
 
-  if (providerId === 'openai' || providerId === 'openai-responses' || providerId === 'new-api') {
+  if (
+    providerId === 'openai' ||
+    providerId === 'openai-codex' ||
+    providerId === 'openai-responses' ||
+    providerId === 'new-api'
+  ) {
     return true
   }
 
   if (
     providerApiType === 'openai' ||
+    providerApiType === 'openai-codex' ||
     providerApiType === 'openai-responses' ||
     providerApiType === 'openai-compatible' ||
     providerApiType === 'openai-completions' ||

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -1280,8 +1280,9 @@ describe('DeepChatAgentHarness', () => {
       projectDir: prepared.projectDir,
       emitRefreshBeforeStream: true,
       preserveResolvedRepresentations: true,
+      ...(prepared.sourceMessageId ? { preStreamAnchorMessageId: prepared.sourceMessageId } : {}),
       beforeHistoryPreparation: () =>
-        transcriptMutations.commitRetryMessage(sessionId, prepared.sourceOrderSeq)
+        transcriptMutations.commitRetryMessage(sessionId, prepared.retryFromOrderSeq)
     })
   }
 
@@ -11690,9 +11691,11 @@ describe('DeepChatAgentHarness', () => {
       sqlitePresenter.deepchatSessionsTable.rewindMemoryCursorOrderSeq.mockClear()
       await retryMessage('s1', 'retry-assistant')
 
+      // Retry keeps the user prompt in place and truncates from the retried
+      // assistant message, so the memory cursor only rewinds to just before it.
       expect(sqlitePresenter.deepchatSessionsTable.rewindMemoryCursorOrderSeq).toHaveBeenCalledWith(
         's1',
-        4
+        5
       )
     })
 
@@ -14116,11 +14119,15 @@ describe('DeepChatAgentHarness', () => {
         estimateToolReserveTokens(providerTools) +
         providerMaxTokens
 
-      expect(llmProvider.generateText).toHaveBeenCalled()
+      // Retry kept the user prompt in the transcript, so the pre-stream
+      // compaction already fit the request below the budget and no further
+      // runtime compaction is needed. The durable signal is the conversation
+      // checkpoint that the compaction added to the assembled request.
+      const runMessages = (callArgs as { run: { messages: ChatMessage[] } }).run.messages
       expect(providerCoreStream).toHaveBeenCalledTimes(1)
       expect(providerMessages[0].content).toBe(baseSystemPrompt)
       expect(
-        providerMessages.some(
+        runMessages.some(
           (message: any) =>
             message.role === 'user' && String(message.content).includes('Persisted Rolling Summary')
         )
@@ -14175,6 +14182,46 @@ describe('DeepChatAgentHarness', () => {
       expectPublished('chat.stream.failed', {
         error: expect.stringContaining('Request was not sent')
       })
+    })
+
+    it('does not duplicate a retried user prompt in the assembled request', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      installSessionRows([
+        makeDeepchatUserRow(1, 'hello one', 'user-1'),
+        makeDeepchatAssistantRow(2, 'reply one', 'assistant-1'),
+        makeDeepchatUserRow(3, 'retry me now', 'retry-user'),
+        makeDeepchatAssistantRow(4, 'failed reply', 'retry-assistant', 'error')
+      ])
+
+      await retryMessage('s1', 'retry-user')
+
+      const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const runMessages = (callArgs as { run: { messages: ChatMessage[] } }).run.messages
+      const retriedPromptCount = runMessages.filter(
+        (message) => message.role === 'user' && String(message.content).includes('retry me now')
+      ).length
+      // The retried user prompt stays in the transcript and is re-sent as the
+      // live turn, so it must appear exactly once in the assembled request.
+      expect(retriedPromptCount).toBe(1)
+    })
+
+    it('does not duplicate a pinned first user prompt on retry', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      installSessionRows([
+        makeDeepchatUserRow(1, 'pinned retry me', 'retry-user'),
+        makeDeepchatAssistantRow(2, 'failed reply', 'retry-assistant', 'error')
+      ])
+
+      await retryMessage('s1', 'retry-user')
+
+      const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const runMessages = (callArgs as { run: { messages: ChatMessage[] } }).run.messages
+      const retriedPromptCount = runMessages.filter(
+        (message) => message.role === 'user' && String(message.content).includes('pinned retry me')
+      ).length
+      // The retried prompt is also the pinned first user; it must still appear
+      // exactly once (as the live turn, not also as the pinned leading message).
+      expect(retriedPromptCount).toBe(1)
     })
   })
 

--- a/test/main/agent/deepchat/runtime/generationSettings.test.ts
+++ b/test/main/agent/deepchat/runtime/generationSettings.test.ts
@@ -2,6 +2,7 @@ import type { ProviderSettingsPort } from '@/provider/settings'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { SessionGenerationSettings } from '@shared/types/agent-interface'
+import { ApiEndpointType, ModelType } from '@shared/model'
 import {
   buildPersistedGenerationSettingsPatch,
   mapPersistedGenerationPatch,
@@ -284,5 +285,36 @@ describe('generation settings policy', () => {
       imageGeneration: { size: '1024x1024', quality: 'high' },
       videoGeneration: { duration: 8, generateAudio: true }
     })
+  })
+
+  it('preserves OpenAI Codex image options during session sanitization', async () => {
+    const providerSettings = createProviderSettings()
+    vi.mocked(providerSettings.getProviderById).mockReturnValue({
+      id: 'openai-codex',
+      name: 'OpenAI Codex',
+      apiType: 'openai-codex',
+      apiKey: '',
+      baseUrl: 'https://chatgpt.com/backend-api/codex',
+      enable: true
+    })
+    vi.mocked(providerSettings.getModelConfig).mockReturnValue({
+      contextLength: 8_192,
+      maxTokens: 8_192,
+      temperature: 0.7,
+      timeout: 60_000,
+      type: ModelType.ImageGeneration,
+      apiEndpoint: ApiEndpointType.Image,
+      imageGeneration: { size: '1024x1024', quality: 'high' }
+    })
+
+    const result = await sanitizeGenerationSettings(
+      providerSettings,
+      { getDefaultSystemPrompt: vi.fn().mockResolvedValue('default prompt') },
+      'openai-codex',
+      'gpt-image-2',
+      { imageGeneration: { size: '1536x1024', quality: 'medium' } }
+    )
+
+    expect(result.imageGeneration).toEqual({ size: '1536x1024', quality: 'medium' })
   })
 })

--- a/test/main/provider/aiSdkProviderFactory.test.ts
+++ b/test/main/provider/aiSdkProviderFactory.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { generateText, streamText } from 'ai'
+import { generateImage, generateText, streamText } from 'ai'
+
+const codexAuthState = vi.hoisted(() => ({
+  getBackendAuth: vi.fn(),
+  forceRefreshBackendAuth: vi.fn()
+}))
 
 vi.mock('../../../src/main/platform/proxy', () => ({
   proxyConfig: {
     getProxyUrl: vi.fn().mockReturnValue(null)
   }
+}))
+
+vi.mock('../../../src/main/provider/auth/openaiCodex', () => ({
+  getGlobalOpenAICodexAuth: () => codexAuthState
 }))
 
 import {
@@ -239,6 +248,65 @@ describe('AI SDK provider factory', () => {
       'https://example.openai.azure.com/openai/v1/images/generations?api-version=v1'
     )
     expect(context.resolvedModelId).toBe('my-gpt-4.1-deployment')
+  })
+
+  it('generates images through the OpenAI Codex image endpoint', async () => {
+    const imageBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          created: 1,
+          data: [{ b64_json: imageBase64 }]
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    codexAuthState.getBackendAuth.mockResolvedValueOnce({
+      accessToken: 'codex-token',
+      accountId: 'acct-1'
+    })
+
+    const context = createAiSdkProviderContext({
+      providerKind: 'openai-codex',
+      provider: {
+        id: 'openai-codex',
+        name: 'OpenAI Codex',
+        apiType: 'openai-codex',
+        apiKey: '',
+        baseUrl: 'https://chatgpt.com/backend-api/codex',
+        enable: true
+      } as any,
+      providerSettings: {} as any,
+      defaultHeaders: {},
+      modelId: 'gpt-image-2',
+      wrapThinkReasoning: false
+    })
+
+    expect(context.imageModel).toBeDefined()
+    expect(context.endpoint).toBe('https://chatgpt.com/backend-api/codex/responses')
+    expect(context.imageEndpoint).toBe('https://chatgpt.com/backend-api/codex/images/generations')
+
+    const result = await generateImage({
+      model: context.imageModel,
+      prompt: 'A red fox in a field',
+      size: '1024x1024'
+    })
+
+    expect(result.image.base64).toBe(imageBase64)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(requestUrl).toBe('https://chatgpt.com/backend-api/codex/images/generations')
+    expect(JSON.parse(String(requestInit.body))).toEqual({
+      model: 'gpt-image-2',
+      prompt: 'A red fox in a field',
+      n: 1,
+      size: '1024x1024'
+    })
   })
 
   it('uses deployment ids from azure deployment-scoped urls', () => {

--- a/test/main/provider/openaiCodexAdapter.test.ts
+++ b/test/main/provider/openaiCodexAdapter.test.ts
@@ -129,6 +129,36 @@ describe('OpenAI Codex adapter', () => {
     expect(body).not.toHaveProperty('max_output_tokens')
   })
 
+  it('preserves image request bodies and asks the Codex backend for JSON', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(new Response('{}', { status: 200 })))
+    authState.getBackendAuth.mockResolvedValueOnce({
+      accessToken: 'token',
+      accountId: 'acct-1'
+    })
+
+    const { createOpenAICodexFetch } = await import('../../../src/main/provider/openaiCodexAdapter')
+    const fetcher = createOpenAICodexFetch({})
+    const imageBody = JSON.stringify({
+      model: 'gpt-image-2',
+      prompt: 'A red fox in a field',
+      quality: 'medium',
+      size: '1024x1024'
+    })
+
+    await fetcher('https://chatgpt.com/backend-api/codex/images/generations', {
+      method: 'POST',
+      body: imageBody
+    })
+
+    const requestInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+    const headers = requestInit.headers as Headers
+    expect(requestInit.body).toBe(imageBody)
+    expect(headers.get('Accept')).toBe('application/json')
+    expect(headers.get('Content-Type')).toBe('application/json')
+    expect(headers.get('Authorization')).toBe('Bearer token')
+    expect(headers.get('ChatGPT-Account-ID')).toBe('acct-1')
+  })
+
   it('preserves streaming responses and abort signals', async () => {
     const streamBody = 'data: {"type":"response.output_text.delta","delta":"hello"}\n\n'
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(new Response(streamBody, { status: 200 })))

--- a/test/main/provider/openaiCodexProvider.test.ts
+++ b/test/main/provider/openaiCodexProvider.test.ts
@@ -7,7 +7,13 @@ import { AiSdkProvider } from '../../../src/main/provider/providers/aiSdkProvide
 import { resolveAiSdkProviderDefinition } from '../../../src/main/provider/providerRegistry'
 import type { LLM_PROVIDER } from '@shared/types/provider'
 
-const CODEX_5_6_RESOURCE_MODEL_IDS = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra']
+const CODEX_RESOURCE_MODEL_IDS = [
+  'gpt-5.6',
+  'gpt-5.6-sol',
+  'gpt-5.6-luna',
+  'gpt-5.6-terra',
+  'gpt-image-2'
+]
 
 describe('OpenAI Codex provider registration', () => {
   it('keeps OpenAI Codex separate from the OpenAI API-key provider', () => {
@@ -39,14 +45,14 @@ describe('OpenAI Codex provider registration', () => {
     expect(definition?.checkModelId).toBe('gpt-5.6-luna')
   })
 
-  it('has Codex 5.6 models in the bundled OpenAI provider database', async () => {
+  it('has curated Codex models in the bundled OpenAI provider database', async () => {
     const fs = await vi.importActual<typeof import('fs')>('fs')
     const providerDbPath = path.join(process.cwd(), 'resources', 'model-db', 'providers.json')
     const db = JSON.parse(fs.readFileSync(providerDbPath, 'utf-8'))
     const openaiProvider = db.providers.openai
     const modelIds = new Set(openaiProvider.models.map((model: { id: string }) => model.id))
 
-    for (const modelId of CODEX_5_6_RESOURCE_MODEL_IDS) {
+    for (const modelId of CODEX_RESOURCE_MODEL_IDS) {
       expect(modelIds.has(modelId)).toBe(true)
     }
   })
@@ -140,6 +146,15 @@ describe('OpenAI Codex provider registration', () => {
           limit: { context: 1050000, output: 128000 },
           tool_call: true,
           reasoning: { supported: true }
+        },
+        {
+          id: 'gpt-image-2',
+          display_name: 'GPT Image 2',
+          modalities: { input: ['text', 'image'], output: ['image'] },
+          limit: { context: 8192, output: 8192 },
+          type: 'imageGeneration',
+          tool_call: false,
+          reasoning: { supported: false }
         }
       ]
     } as any)
@@ -155,7 +170,8 @@ describe('OpenAI Codex provider registration', () => {
       'gpt-5.6-luna',
       'gpt-5.4',
       'gpt-5.4-mini',
-      'gpt-5.3-codex-spark'
+      'gpt-5.3-codex-spark',
+      'gpt-image-2'
     ])
     expect(models.some((model) => model.id === 'gpt-5.6')).toBe(false)
     expect(models.every((model) => model.group === 'Codex')).toBe(true)

--- a/test/main/provider/providerDbModelConfig.test.ts
+++ b/test/main/provider/providerDbModelConfig.test.ts
@@ -73,6 +73,13 @@ describe('Provider DB strict matching and user overrides', () => {
               tool_call: true
             },
             {
+              id: 'gpt-image-2',
+              type: 'imageGeneration',
+              limit: { context: 8192, output: 8192 },
+              modalities: { input: ['text', 'image'], output: ['image'] },
+              tool_call: false
+            },
+            {
               id: 'opaque-renderer',
               type: 'imageGeneration',
               limit: { context: 65_536, output: 8_192 },
@@ -305,6 +312,21 @@ describe('Provider DB strict matching and user overrides', () => {
       maxTokens: 32_000,
       reasoning: true
     })
+  })
+
+  it('resolves the OpenAI Codex image model through the OpenAI catalog identity', () => {
+    const helper = new ModelConfigHelper()
+
+    const config = helper.getModelConfig('gpt-image-2', 'openai-codex')
+
+    expect(config).toMatchObject({
+      type: ModelType.ImageGeneration,
+      apiEndpoint: ApiEndpointType.Image,
+      vision: false,
+      functionCall: false
+    })
+
+    expect(helper.getModelConfig('gpt-image-2', 'openai').vision).toBe(true)
   })
 
   it('applies partial fallbacks when limit fields are missing', () => {

--- a/test/main/session/assignment.test.ts
+++ b/test/main/session/assignment.test.ts
@@ -660,7 +660,10 @@ describe('SessionAssignment', () => {
       const send = vi.fn().mockResolvedValue({ requestId: 'request-1', messageId: 'message-1' })
       const prepareRetryMessage = vi.fn().mockResolvedValue({
         content: { text: 'Retry', files: [] },
-        projectDir: '/source'
+        projectDir: '/source',
+        sourceOrderSeq: 1,
+        retryFromOrderSeq: 2,
+        sourceMessageId: 'user-1'
       })
       const resolveSession = vi.fn(() => {
         observedAgentIds.push(harness.records.get('s1')?.agentId ?? 'missing')

--- a/test/main/session/session.integration.test.ts
+++ b/test/main/session/session.integration.test.ts
@@ -148,7 +148,9 @@ function createMockDeepChatAgent() {
     prepareRetryMessage: vi.fn().mockResolvedValue({
       content: { text: 'retry', files: [] },
       projectDir: null,
-      sourceOrderSeq: 1
+      sourceOrderSeq: 1,
+      retryFromOrderSeq: 2,
+      sourceMessageId: 'user-1'
     }),
     commitRetryMessage: vi.fn(),
     retryMessage: vi.fn().mockResolvedValue(undefined),
@@ -2474,7 +2476,9 @@ describe('Session application coordinators', () => {
       deepChatAgent.prepareRetryMessage.mockResolvedValueOnce({
         content: { text: 'Retry body', files: [] },
         projectDir: '/retry/project',
-        sourceOrderSeq: 3
+        sourceOrderSeq: 3,
+        retryFromOrderSeq: 4,
+        sourceMessageId: 'user-1'
       })
 
       await turn.retryMessage('s1', 'message-1')
@@ -2487,12 +2491,13 @@ describe('Session application coordinators', () => {
           projectDir: '/retry/project',
           emitRefreshBeforeStream: true,
           preserveResolvedRepresentations: true,
+          preStreamAnchorMessageId: 'user-1',
           beforeHistoryPreparation: expect.any(Function)
         }
       )
       const retryContext = deepChatAgent.processMessage.mock.calls[0][2]
       retryContext.beforeHistoryPreparation()
-      expect(deepChatAgent.commitRetryMessage).toHaveBeenCalledWith('s1', 3)
+      expect(deepChatAgent.commitRetryMessage).toHaveBeenCalledWith('s1', 4)
       expect(deepChatAgent.prepareRetryMessage.mock.invocationCallOrder[0]).toBeLessThan(
         deepChatAgent.processMessage.mock.invocationCallOrder[0]
       )

--- a/test/main/session/transcriptMutations.test.ts
+++ b/test/main/session/transcriptMutations.test.ts
@@ -15,18 +15,59 @@ describe('SessionTranscriptMutations', () => {
     const runtime = {
       prepareRetry: vi.fn().mockResolvedValue({ projectDir: '/repo' })
     }
+    const transcript = {
+      getMessage: vi.fn(() => message),
+      updateMessageStatus: vi.fn()
+    }
     const mutations = new SessionTranscriptMutations({
-      transcript: { getMessage: vi.fn(() => message) },
+      transcript,
       runtime
     } as any)
 
     await expect(mutations.prepareRetryMessage('s1', 'steer-1')).resolves.toEqual({
       content: { text: 'Retry steer', files: [], search: false },
       projectDir: '/repo',
-      sourceOrderSeq: 3
+      sourceOrderSeq: 3,
+      retryFromOrderSeq: 4,
+      sourceMessageId: 'steer-1'
     })
     expect(runtime.prepareRetry).toHaveBeenCalledWith('s1', {
       allowRestartHeldQueue: true
+    })
+    // The failed Steer prompt is kept as the pre-stream anchor, so it must be
+    // restored to 'sent' to remain visible to context history filtering.
+    expect(transcript.updateMessageStatus).toHaveBeenCalledWith('steer-1', 'sent')
+  })
+
+  it('keeps the user prompt in place when retrying a user message directly', async () => {
+    const message = {
+      id: 'user-1',
+      sessionId: 's1',
+      orderSeq: 3,
+      role: 'user',
+      content: JSON.stringify({ text: 'Retry prompt', files: [] }),
+      status: 'sent',
+      metadata: '{}'
+    }
+    const runtime = {
+      prepareRetry: vi.fn().mockResolvedValue({ projectDir: '/repo' })
+    }
+    const mutations = new SessionTranscriptMutations({
+      transcript: { getMessage: vi.fn(() => message) },
+      runtime
+    } as any)
+
+    await expect(mutations.prepareRetryMessage('s1', 'user-1')).resolves.toEqual({
+      content: { text: 'Retry prompt', files: [], search: false },
+      projectDir: '/repo',
+      sourceOrderSeq: 3,
+      // Truncate from the message after the prompt so the prompt survives, and
+      // anchor it so the same record is re-sent instead of a fresh duplicate.
+      retryFromOrderSeq: 4,
+      sourceMessageId: 'user-1'
+    })
+    expect(runtime.prepareRetry).toHaveBeenCalledWith('s1', {
+      allowRestartHeldQueue: false
     })
   })
 

--- a/test/main/session/turn.test.ts
+++ b/test/main/session/turn.test.ts
@@ -142,7 +142,9 @@ function createHarness(
     prepareRetryMessage: vi.fn().mockResolvedValue({
       content: { text: 'Retry', files: [] },
       projectDir: '/retry',
-      sourceOrderSeq: 3
+      sourceOrderSeq: 3,
+      retryFromOrderSeq: 4,
+      sourceMessageId: 'user-1'
     }),
     commitRetryMessage: vi.fn(),
     deleteMessage: vi.fn().mockResolvedValue(undefined),
@@ -517,12 +519,13 @@ describe('SessionTurn', () => {
         projectDir: '/retry',
         emitRefreshBeforeStream: true,
         preserveResolvedRepresentations: true,
+        preStreamAnchorMessageId: 'user-1',
         beforeHistoryPreparation: expect.any(Function)
       }
     })
     const retryContext = harness.send.mock.calls[0][0].context
     retryContext?.beforeHistoryPreparation?.()
-    expect(harness.transcript.commitRetryMessage).toHaveBeenCalledWith('s1', 3)
+    expect(harness.transcript.commitRetryMessage).toHaveBeenCalledWith('s1', 4)
     expect(harness.cancel).not.toHaveBeenCalled()
 
     await harness.coordinator.deleteMessage('s1', 'message-1')

--- a/test/renderer/components/ChatStatusBar.test.ts
+++ b/test/renderer/components/ChatStatusBar.test.ts
@@ -1758,17 +1758,24 @@ describe('ChatStatusBar model and session panels', () => {
     expect((wrapper.vm as any).localSettings.thinkingBudget).toBe(512)
   })
 
-  it('uses the dedicated image settings panel for gpt-image-2', async () => {
+  it.each([
+    { providerId: 'openai', providerName: 'OpenAI', apiType: 'openai' },
+    {
+      providerId: 'openai-codex',
+      providerName: 'OpenAI Codex',
+      apiType: 'openai-codex'
+    }
+  ])('uses the dedicated image settings panel for gpt-image-2 on $providerId', async (provider) => {
     const { wrapper } = await setup({
       agentId: 'deepchat',
       hasActiveSession: false,
-      preferredModel: { providerId: 'openai', modelId: 'gpt-image-2' },
-      defaultModel: { providerId: 'openai', modelId: 'gpt-image-2' },
+      preferredModel: { providerId: provider.providerId, modelId: 'gpt-image-2' },
+      defaultModel: { providerId: provider.providerId, modelId: 'gpt-image-2' },
       extraModelGroups: [
         {
-          providerId: 'openai',
-          providerName: 'OpenAI',
-          apiType: 'openai',
+          providerId: provider.providerId,
+          providerName: provider.providerName,
+          apiType: provider.apiType,
           models: [{ id: 'gpt-image-2', name: 'GPT Image 2', type: 'imageGeneration' }]
         }
       ],
@@ -1780,7 +1787,7 @@ describe('ChatStatusBar model and session panels', () => {
       }
     })
 
-    await (wrapper.vm as any).selectModel('openai', 'gpt-image-2')
+    await (wrapper.vm as any).selectModel(provider.providerId, 'gpt-image-2')
     await flushPromises()
 
     expect((wrapper.vm as any).showOpenAIImageGenerationSettings).toBe(true)

--- a/test/renderer/components/MarkdownRenderer.test.ts
+++ b/test/renderer/components/MarkdownRenderer.test.ts
@@ -559,4 +559,77 @@ describe('MarkdownRenderer', () => {
     referenceElement.dispatchEvent(new MouseEvent('mouseout'))
     expect(hideReferenceMock).toHaveBeenCalled()
   })
+
+  it('splits long streaming content into a static prefix and a live tail', async () => {
+    const longContent = Array.from(
+      { length: 400 },
+      (_, index) => `paragraph ${index} of text`
+    ).join('\n\n')
+    const { wrapper } = await setup({ streaming: true, content: longContent })
+    await flushPromises()
+
+    const renderers = wrapper.findAll('[data-testid="node-renderer"]')
+    expect(renderers).toHaveLength(2)
+
+    const prefix = renderers[0]
+    const tail = renderers[1]
+    expect(prefix.attributes('data-final')).toBe('true')
+    expect(prefix.attributes('data-custom-id')).toMatch(/::prefix$/)
+    expect(tail.attributes('data-final')).toBe('false')
+    expect(tail.attributes('data-custom-id')).toMatch(/::tail$/)
+    // Prefix + tail together reconstruct the whole document.
+    expect(prefix.attributes('data-content') + tail.attributes('data-content')).toBe(longContent)
+  })
+
+  it('does not split inside a single oversized code fence', async () => {
+    const fencedContent = '```\n' + 'a'.repeat(6500) + '\n```'
+    const { wrapper } = await setup({ streaming: true, content: fencedContent })
+    await flushPromises()
+
+    const renderers = wrapper.findAll('[data-testid="node-renderer"]')
+    expect(renderers).toHaveLength(1)
+    // The whole fence stays in the single streaming renderer, never split.
+    expect(renderers[0].attributes('data-content')).toBe(fencedContent)
+  })
+
+  it('does not split when mixed fence markers are unbalanced', async () => {
+    // One unclosed ``` fence and one unclosed ~~~ fence: combined parity looks
+    // even, but each marker type must be balanced independently.
+    const mixedContent =
+      '```\n' + 'a'.repeat(2000) + '\n\n~~~\n' + 'b'.repeat(2000) + '\n\n' + 'c'.repeat(2000)
+    const { wrapper } = await setup({ streaming: true, content: mixedContent })
+    await flushPromises()
+
+    const renderers = wrapper.findAll('[data-testid="node-renderer"]')
+    expect(renderers).toHaveLength(1)
+    expect(renderers[0].attributes('data-content')).toBe(mixedContent)
+  })
+
+  it('does not split mid-paragraph when no blank-line boundary exists', async () => {
+    const noBlankContent = 'word '.repeat(2500)
+    const { wrapper } = await setup({ streaming: true, content: noBlankContent })
+    await flushPromises()
+
+    const renderers = wrapper.findAll('[data-testid="node-renderer"]')
+    expect(renderers).toHaveLength(1)
+    expect(renderers[0].attributes('data-content')).toBe(noBlankContent)
+  })
+
+  it('resets the split when a stream shrinks and restarts', async () => {
+    const longContent = Array.from(
+      { length: 400 },
+      (_, index) => `paragraph ${index} of text`
+    ).join('\n\n')
+    const { wrapper } = await setup({ streaming: true, content: longContent })
+    await flushPromises()
+    expect(wrapper.findAll('[data-testid="node-renderer"]')).toHaveLength(2)
+
+    const restartedContent = 'short regenerated answer'
+    await wrapper.setProps({ content: restartedContent })
+    await flushPromises()
+
+    const renderers = wrapper.findAll('[data-testid="node-renderer"]')
+    expect(renderers).toHaveLength(1)
+    expect(renderers[0].attributes('data-content')).toBe(restartedContent)
+  })
 })

--- a/test/renderer/components/MemoryDiagnosticsPanel.test.ts
+++ b/test/renderer/components/MemoryDiagnosticsPanel.test.ts
@@ -180,13 +180,13 @@ describe('MemoryDiagnosticsPanel', () => {
     expect(clearCopy.clearConfirmBody).toContain('Standing directives are kept')
   })
 
-  it('renders Agent recall and process-wide pipeline pressure', async () => {
+  it('renders formatted diagnostics and process-wide pipeline pressure', async () => {
     const health: MemoryHealthDto = structuredClone(baseHealth)
     health.runtime.agent.retrieval.recall.latencyMs.total = {
       samples: 4,
-      p50: 12,
-      p95: 48,
-      max: 50
+      p50: 685.7158329999074,
+      p95: Number.POSITIVE_INFINITY,
+      max: 804
     }
     health.runtime.agent.retrieval.recall.degradationCounts.vectorCold = 3
     health.runtime.process.extractionQueue.depth = 2
@@ -199,18 +199,44 @@ describe('MemoryDiagnosticsPanel', () => {
     health.runtime.process.providerAdmission.admissionDecisions.rateLimited = 2
     const providerPressureSummary =
       'Rate limit {rateLimited} · Capacity {capacityRejected} · Deadline {deadline} · Aborted {aborted} · Late settle {lateSettled}'
-    const { wrapper, t } = await setup(baseStatus, {
+    const { wrapper, memoryClient, t } = await setup(baseStatus, {
       health,
       messages: { 'settings.memory.redesign.providerPressureSummary': providerPressureSummary }
     })
+    memoryClient.getArchiveCandidateLifecyclePreview.mockResolvedValueOnce({
+      ...basePreview,
+      lifecycles: [
+        {
+          memoryId: 'memory-with-floating-point-diagnostics',
+          decayTier: 'archive_candidate',
+          forget: {
+            ageDays: 12.3456,
+            decayScore: 0.123456
+          }
+        }
+      ]
+    })
+    await refreshButton(wrapper).trigger('click')
+    await flushPromises()
 
     const pipeline = wrapper.get('[data-testid="runtime-pipeline"]')
-    expect(pipeline.text()).toContain('12')
-    expect(pipeline.text()).toContain('48')
+    const archiveCandidates = wrapper.get('[data-testid="archive-candidates"]')
+    const pipelineValues = pipeline.findAll('.tabular-nums').map((node) => node.text())
+    const archiveCandidateMetrics = archiveCandidates
+      .findAll('.text-muted-foreground > span')
+      .map((node) => node.text())
+    expect(pipelineValues).toContain('685.716')
+    expect(pipelineValues).toContain('Infinity')
     expect(pipeline.text()).toContain('1250')
     expect(pipeline.text()).toContain('7')
     expect(pipeline.text()).toContain('Rate limit 2')
     expect(pipeline.text()).toContain('Deadline 1')
+    expect(archiveCandidateMetrics).toContain(
+      'settings.deepchatAgents.memoryManager.health.archivePrediction.ageDays: 12.3'
+    )
+    expect(archiveCandidateMetrics).toContain(
+      'settings.deepchatAgents.memoryManager.health.archivePrediction.decayScore: 0.123'
+    )
     expect(t).toHaveBeenCalledWith('settings.memory.redesign.providerPressureSummary', {
       rateLimited: 2,
       capacityRejected: 0,

--- a/test/renderer/components/ModelConfigDialog.test.ts
+++ b/test/renderer/components/ModelConfigDialog.test.ts
@@ -999,12 +999,15 @@ describe('ModelConfigDialog reasoning portraits', () => {
 })
 
 describe('ModelConfigDialog OpenAI image generation settings', () => {
-  it('uses the image settings form for gpt-image-2', async () => {
+  it.each([
+    { providerId: 'openai', providerApiType: 'openai' },
+    { providerId: 'openai-codex', providerApiType: 'openai-codex' }
+  ])('uses the image settings form for gpt-image-2 on $providerId', async (provider) => {
     const { wrapper } = await setup({
-      providerId: 'openai',
+      providerId: provider.providerId,
       modelId: 'gpt-image-2',
       modelName: 'GPT Image 2',
-      providerApiType: 'openai',
+      providerApiType: provider.providerApiType,
       modelConfig: {
         imageGeneration: {
           size: '1024x1024'
@@ -1039,12 +1042,15 @@ describe('ModelConfigDialog OpenAI image generation settings', () => {
     expect(wrapper.text()).toContain('settings.model.modelConfig.maxTokens.label')
   })
 
-  it('saves normalized image settings for gpt-image-2', async () => {
+  it.each([
+    { providerId: 'openai', providerApiType: 'openai' },
+    { providerId: 'openai-codex', providerApiType: 'openai-codex' }
+  ])('saves normalized image settings for gpt-image-2 on $providerId', async (provider) => {
     const { wrapper, modelConfigStore } = await setup({
-      providerId: 'openai',
+      providerId: provider.providerId,
       modelId: 'gpt-image-2',
       modelName: 'GPT Image 2',
-      providerApiType: 'openai',
+      providerApiType: provider.providerApiType,
       modelConfig: {
         topP: 0.4
       }
@@ -1062,7 +1068,7 @@ describe('ModelConfigDialog OpenAI image generation settings', () => {
 
     expect(modelConfigStore.setModelConfig).toHaveBeenCalledWith(
       'gpt-image-2',
-      'openai',
+      provider.providerId,
       expect.objectContaining({
         topP: 0.4,
         imageGeneration: {

--- a/test/renderer/features/chat-page/composables/useMessageActions.test.ts
+++ b/test/renderer/features/chat-page/composables/useMessageActions.test.ts
@@ -7,7 +7,15 @@ function createHarness() {
   const sessionId = ref('s1')
   const isReadOnly = ref(false)
   const isBlocking = ref(false)
-  const messageStore = { clearStreamingState: vi.fn() }
+  const messageCache = new Map<string, any>()
+  const messages: any[] = []
+  const messageStore = {
+    clearStreamingState: vi.fn(),
+    messageCache,
+    messages,
+    messageIds: [] as string[],
+    truncateMessagesFromOrderSeq: vi.fn()
+  }
   const sessionStore = { fetchSessions: vi.fn(), selectSession: vi.fn() }
   const sessionClient = {
     retryMessage: vi.fn().mockResolvedValue(undefined),
@@ -107,6 +115,46 @@ describe('useMessageActions', () => {
     harness.stop()
   })
 
+  it('truncates the display from the retried message when a retry is accepted', async () => {
+    const harness = createHarness()
+    const records = [
+      { id: 'user-1', sessionId: 's1', role: 'user', orderSeq: 10 },
+      { id: 'assistant-1', sessionId: 's1', role: 'assistant', orderSeq: 20 },
+      { id: 'user-2', sessionId: 's1', role: 'user', orderSeq: 30 }
+    ]
+    for (const record of records) {
+      harness.messageStore.messageCache.set(record.id, record)
+      harness.messageStore.messages.push(record)
+    }
+
+    await harness.actions.onMessageRetry('assistant-1')
+
+    expect(harness.messageStore.truncateMessagesFromOrderSeq).toHaveBeenCalledWith('s1', 20)
+    expect(harness.beginPlanTurn).toHaveBeenCalledWith('s1')
+    harness.stop()
+  })
+
+  it('keeps the user prompt in place when retrying a user message directly', async () => {
+    const harness = createHarness()
+    const records = [
+      { id: 'user-1', sessionId: 's1', role: 'user', orderSeq: 10 },
+      { id: 'assistant-1', sessionId: 's1', role: 'assistant', orderSeq: 20 },
+      { id: 'user-2', sessionId: 's1', role: 'user', orderSeq: 30 }
+    ]
+    for (const record of records) {
+      harness.messageStore.messageCache.set(record.id, record)
+      harness.messageStore.messages.push(record)
+    }
+
+    await harness.actions.onMessageRetry('user-1')
+
+    // Truncate from the next order sequence so the retried user prompt stays
+    // mounted and is not re-created as a fresh row.
+    expect(harness.messageStore.truncateMessagesFromOrderSeq).toHaveBeenCalledWith('s1', 11)
+    expect(harness.beginPlanTurn).toHaveBeenCalledWith('s1')
+    harness.stop()
+  })
+
   it('keeps history intact when retry preflight blocks and supports explicit degradation', async () => {
     const harness = createHarness()
     const attachmentPreparation = {
@@ -126,7 +174,7 @@ describe('useMessageActions', () => {
 
     expect(harness.actions.retryAttachmentPreparationSummary.value).toEqual(attachmentPreparation)
     expect(harness.beginPlanTurn).not.toHaveBeenCalled()
-    expect(harness.loadMessagesForSession).not.toHaveBeenCalled()
+    expect(harness.loadMessagesForSession).toHaveBeenCalledTimes(1)
 
     await harness.actions.retryBlockedMessageWithoutImageContent()
 


### PR DESCRIPTION
## Release v1.1.1-beta.4

Beta release. Fast-forward merge to `main` after approval; do **not** use the GitHub merge button or "Update branch".

### Changes since v1.1.1-beta.3
- Added Codex image generation support for providers
- Reduced markdown streaming stalls with split rendering and gentle prefix batching
- Kept the user message mounted on retry, fixed retry budget double counting and duplicate pinned prompts
- Fixed decimal value formatting in the memory diagnostics panel
- 新增 Provider 的 Codex 图片生成支持
- 通过分段渲染与温和的前缀批处理减少 Markdown 流式渲染卡顿
- 重试时保留用户消息挂载，修复重试预算重复计算与重复固定提示词
- 修复内存诊断面板中十进制数值的格式化

### Included PRs
- #2200 perf(markdown): reduce streaming stalls with split rendering
- #2201 fix(ui): format decimal values in memory diagnostics panel
- #2202 perf(markdown): gentle prefix batching + fix(retry): keep user message on retry
- #2204 feat(provider): support Codex image generation

### Publish after approval
\`\`\`bash
pnpm run release:ff -- release/v1.1.1-beta.4 --tag v1.1.1-beta.4
\`\`\`