### PR TITLE
fix(startup): unblock interactive startup tasks

### DIFF
--- a/src/main/app/startupWorkloadCoordinator/index.ts
+++ b/src/main/app/startupWorkloadCoordinator/index.ts
@@ -292,7 +292,14 @@ export class StartupWorkloadCoordinator {
     })
 
     for (const task of sortedPending) {
-      if (this.runningCounts[task.resource] >= MAX_CONCURRENCY[task.resource]) {
+      // Interactive work is short and latency-critical (startup bootstrap, first session
+      // page). The concurrency caps protect the event loop / disk from heavy background
+      // work; when long-running background io tasks (MCP / remote runtime init) hold every
+      // lane, an interactive task would otherwise starve and delay the first paint. Admit
+      // interactive tasks even at capacity — they still count toward runningCounts, so
+      // isIdle()/cancel/dedupe semantics stay intact.
+      const atCapacity = this.runningCounts[task.resource] >= MAX_CONCURRENCY[task.resource]
+      if (atCapacity && task.phase !== 'interactive') {
         continue
       }
 

--- a/test/main/app/startupWorkloadCoordinator.test.ts
+++ b/test/main/app/startupWorkloadCoordinator.test.ts
@@ -278,4 +278,68 @@ describe('StartupWorkloadCoordinator', () => {
 
     expect(onFailure).not.toHaveBeenCalled()
   })
+
+  it('does not starve interactive io work behind occupied background lanes', async () => {
+    const { StartupWorkloadCoordinator } = await import('@/app/startupWorkloadCoordinator')
+    const coordinator = new StartupWorkloadCoordinator()
+    coordinator.createRun('main')
+
+    // Fill both io lanes with long-running background work so an interactive task
+    // would otherwise wait for a lane to free up.
+    const gate = createDeferred<void>()
+    const interactiveStarted = createDeferred<void>()
+    let backgroundDone = false
+
+    const backgroundTaskA = coordinator.scheduleTask({
+      id: 'main:mcp-init',
+      target: 'main',
+      phase: 'background',
+      resource: 'io',
+      labelKey: 'startup.main.mcpInit',
+      run: async () => {
+        await gate.promise
+        backgroundDone = true
+      }
+    })
+    const backgroundTaskB = coordinator.scheduleTask({
+      id: 'main:remote-runtime',
+      target: 'main',
+      phase: 'background',
+      resource: 'io',
+      labelKey: 'startup.main.remoteRuntime',
+      run: async () => {
+        await gate.promise
+      }
+    })
+
+    await new Promise((resolve) => setImmediate(resolve))
+
+    const interactiveTask = coordinator.scheduleTask({
+      id: 'main.bootstrap:route',
+      target: 'main',
+      phase: 'interactive',
+      resource: 'io',
+      labelKey: 'startup.main.bootstrap',
+      visibleId: 'main.bootstrap',
+      run: async () => {
+        interactiveStarted.resolve()
+      }
+    })
+
+    // The interactive task must start while both background io lanes are still occupied;
+    // failing fast keeps this a regression signal instead of a hanging test.
+    await Promise.race([
+      interactiveStarted.promise,
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error('interactive task starved behind occupied background io lanes')),
+          1000
+        )
+      )
+    ])
+    expect(backgroundDone).toBe(false)
+
+    gate.resolve()
+    await Promise.all([backgroundTaskA, backgroundTaskB, interactiveTask])
+  })
 })


### PR DESCRIPTION
## Summary

`StartupWorkloadCoordinator` caps io concurrency at 2 and never preempts a running task. Long-running background io tasks (MCP / remote-runtime init) used to occupy every lane, so the interactive `main.bootstrap` task queued for ~15s even though its body only needs ~5ms. Since the renderer's first paint is gated on bootstrap, this delayed the whole startup.

Interactive-phase tasks are now admitted even when a resource lane is at capacity, while still counting toward `runningCounts` — so `isIdle()`, cancellation, and dedupe semantics stay intact. Background/deferred tasks keep the existing `cpu=1`/`io=2` caps.

## Verification

- Measured in a real run: `main.bootstrap` queued for ~15s before the fix, 0ms after (its body is ~5ms).
- Regression test added: interactive io work starts while background lanes are fully occupied; confirmed it fails on the old code and passes on the fix.
- `pnpm typecheck:node` / `pnpm typecheck:web` pass
- CI: `static`, `test-main`, `test-renderer`, `test-native-memory`, `build` pass
