### PR TITLE
fix(chat): release stuck pending permission approvals (#2210)

### DIFF
--- a/src/main/agent/deepchat/harness/deepChatAgentHarness.ts
+++ b/src/main/agent/deepchat/harness/deepChatAgentHarness.ts
@@ -228,6 +228,13 @@ export class DeepChatAgentHarness
     )
   }
 
+  readonly dismissToolInteraction = (
+    sessionId: string,
+    messageId: string,
+    toolCallId: string
+  ): Promise<boolean> =>
+    this.services.interactionCoordinator.dismiss(sessionId, messageId, toolCallId)
+
   async setPermissionMode(sessionId: string, mode: PermissionMode): Promise<void> {
     await this.services.sessionSettings.setPermissionMode(sessionId, mode)
   }
@@ -275,11 +282,10 @@ export class DeepChatAgentHarness
 
   async cancelGeneration(sessionId: string): Promise<void> {
     const instance = this.services.runtime.getHydratedScope(toAppSessionId(sessionId))?.instance
-    if (instance) {
+    if (instance)
       try {
         this.services.toolSurfaceDiagnostics.cancelPending(instance)
       } catch {}
-    }
     await this.services.runLifecycle.cancel(sessionId)
   }
 
@@ -288,9 +294,7 @@ export class DeepChatAgentHarness
   }
 
   async cancelGenerationByEventId(sessionId: string, eventId: string): Promise<boolean> {
-    if (this.services.runLifecycle.getActiveGeneration(sessionId)?.eventId !== eventId) {
-      return false
-    }
+    if (this.services.runLifecycle.getActiveGeneration(sessionId)?.eventId !== eventId) return false
     await this.cancelGeneration(sessionId)
     return true
   }

--- a/src/main/agent/deepchat/runtime/interactionCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/interactionCoordinator.ts
@@ -747,6 +747,51 @@ export class InteractionCoordinator {
     }
   }
 
+  /**
+   * Closes a stale pending interaction (permission/question) whose backing run
+   * can no longer resolve it. The block is marked denied/resolved in the
+   * transcript so the approval does not linger across session reloads or block
+   * new turns. No tool executes and no run resumes.
+   */
+  async dismiss(sessionId: string, messageId: string, toolCallId: string): Promise<boolean> {
+    const message = await this.ports.messageStore.getMessage(messageId)
+    if (!message || message.role !== 'assistant' || message.sessionId !== sessionId) {
+      return false
+    }
+
+    const blocks = parseAssistantBlocks(message.content)
+    const entry = collectPendingInteractionEntries(messageId, blocks).find(
+      ({ interaction }) => interaction.toolCallId === toolCallId
+    )
+    if (!entry) {
+      return false
+    }
+
+    const actionBlock = blocks[entry.blockIndex]
+    if (actionBlock.action_type === 'tool_call_permission') {
+      const permissionType = parsePermissionPayload(actionBlock)?.permissionType ?? 'write'
+      markPermissionResolved(actionBlock, false, permissionType)
+      updateToolCallResponse(blocks, toolCallId, 'User denied the request.', true)
+    } else if (actionBlock.action_type === 'question_request') {
+      markQuestionResolved(actionBlock, '')
+    } else {
+      return false
+    }
+
+    const metadata = stampInteractionResolution(
+      parseMessageMetadata(message.metadata),
+      'cancelled'
+    )
+    this.ports.messageStore.updateAssistantContent(messageId, blocks, JSON.stringify(metadata))
+    this.ports.messageProjection.refresh(sessionId, messageId)
+    const instance = this.ports.registry.getOrHydrateScope(toAppSessionId(sessionId)).instance
+    replacePendingInteractions(
+      instance,
+      collectPendingInteractionEntries(messageId, blocks)
+    )
+    return true
+  }
+
   private readLatestPendingInteraction(
     sessionId: string,
     messageId: string,

--- a/src/main/agent/deepchat/runtime/interactionCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/interactionCoordinator.ts
@@ -774,6 +774,7 @@ export class InteractionCoordinator {
       updateToolCallResponse(blocks, toolCallId, 'User denied the request.', true)
     } else if (actionBlock.action_type === 'question_request') {
       markQuestionResolved(actionBlock, '')
+      updateToolCallResponse(blocks, toolCallId, 'Question dismissed.', false)
     } else {
       return false
     }
@@ -782,12 +783,23 @@ export class InteractionCoordinator {
       parseMessageMetadata(message.metadata),
       'cancelled'
     )
-    this.ports.messageStore.updateAssistantContent(messageId, blocks, JSON.stringify(metadata))
+    const metadataJson = JSON.stringify(metadata)
+    const remainingPending = collectPendingInteractionEntries(messageId, blocks)
+    if (remainingPending.length === 0) {
+      // Nothing is left to resolve in this message: finalize it so it no longer
+      // reads as a pending assistant message after the reload.
+      this.ports.messageStore.finalizeAssistantMessage(messageId, blocks, metadataJson)
+    } else {
+      this.ports.messageStore.updateAssistantContent(messageId, blocks, metadataJson)
+    }
     this.ports.messageProjection.refresh(sessionId, messageId)
+    // Remove only the dismissed entry from the instance queue, preserving pending
+    // interactions that belong to other messages.
     const instance = this.ports.registry.getOrHydrateScope(toAppSessionId(sessionId)).instance
-    replacePendingInteractions(
-      instance,
-      collectPendingInteractionEntries(messageId, blocks)
+    instance.replacePendingInteractions(
+      instance.getPendingInteractions().filter(
+        (pending) => pending.messageId !== messageId || pending.toolCallId !== toolCallId
+      )
     )
     return true
   }

--- a/src/main/agent/manager/deepChatAgentBackend.ts
+++ b/src/main/agent/manager/deepChatAgentBackend.ts
@@ -96,6 +96,11 @@ export interface DeepChatAgentBackendPort {
     toolCallId: string,
     response: ToolInteractionResponse
   ): Promise<ToolInteractionResult>
+  dismissToolInteraction(
+    sessionId: AppSessionId,
+    messageId: string,
+    toolCallId: string
+  ): Promise<boolean>
   getActiveGeneration(sessionId: AppSessionId): AgentActiveGeneration | null
   cancelGenerationByEventId(sessionId: AppSessionId, eventId: string): Promise<boolean>
   setSessionAgentContext(sessionId: AppSessionId, config: SessionAgentContextUpdate): Promise<void>
@@ -183,7 +188,9 @@ export function createDeepChatAgentBackend(
       },
       toolInteractions: {
         respond: (messageId, toolCallId, response) =>
-          port.respondToolInteraction(sessionId, messageId, toolCallId, response)
+          port.respondToolInteraction(sessionId, messageId, toolCallId, response),
+        dismiss: (messageId, toolCallId) =>
+          port.dismissToolInteraction(sessionId, messageId, toolCallId)
       },
       send: (input) => port.send(sessionId, input),
       cancel: () => port.cancelGeneration(sessionId),

--- a/src/main/agent/manager/directAcpAgentBackend.ts
+++ b/src/main/agent/manager/directAcpAgentBackend.ts
@@ -21,7 +21,13 @@ import type {
 export interface DirectAcpAgentBackendOptions {
   runtime: AcpAgentRuntime
   sessionState: SessionStatePort
-  transcript: Pick<SessionTranscriptReadPort, 'getMessage' | 'hasMessages'>
+  transcript: Pick<SessionTranscriptReadPort, 'getMessage' | 'hasMessages'> & {
+    updateAssistantContent(
+      messageId: string,
+      blocks: AssistantMessageBlock[],
+      metadata?: string
+    ): void
+  }
   tape: Pick<SessionTapePort, 'linkSubagentTape'>
   deleteDurableSession(sessionId: AppSessionId): Promise<void>
   resolveInput(
@@ -216,7 +222,16 @@ export const createDirectAcpAgentBackend = (
           )
           const requestId = block?.extra?.permissionRequestId?.trim()
           if (!requestId) return false
-          return runtime.getHydrated(sessionId)?.resolvePermissionRequest(requestId, false) ?? false
+          if (runtime.getHydrated(sessionId)?.resolvePermissionRequest(requestId, false)) {
+            return true
+          }
+          // No live ACP runtime can resolve the request: persist a durable denied
+          // block so the stale approval does not reappear after a reload.
+          if (!block) return false
+          block.status = 'denied'
+          block.extra = { ...block.extra, needsUserAction: false }
+          transcript.updateAssistantContent(messageId, blocks)
+          return true
         }
       },
       async send(input): Promise<MessageStartResult> {

--- a/src/main/agent/manager/directAcpAgentBackend.ts
+++ b/src/main/agent/manager/directAcpAgentBackend.ts
@@ -201,6 +201,22 @@ export const createDirectAcpAgentBackend = (
             ?.resolvePermissionRequest(requestId, response.granted)
           if (!resolved) throw new Error(`Unknown ACP permission request: ${requestId}`)
           return { resumed: false }
+        },
+        async dismiss(messageId: string, toolCallId: string) {
+          const message = await transcript.getMessage(messageId)
+          if (!message || message.sessionId !== sessionId || message.role !== 'assistant') {
+            return false
+          }
+          const blocks = JSON.parse(message.content) as AssistantMessageBlock[]
+          const block = blocks.find(
+            (candidate) =>
+              candidate.type === 'action' &&
+              candidate.action_type === 'tool_call_permission' &&
+              candidate.tool_call?.id === toolCallId
+          )
+          const requestId = block?.extra?.permissionRequestId?.trim()
+          if (!requestId) return false
+          return runtime.getHydrated(sessionId)?.resolvePermissionRequest(requestId, false) ?? false
         }
       },
       async send(input): Promise<MessageStartResult> {

--- a/src/main/agent/manager/sessionHandles.ts
+++ b/src/main/agent/manager/sessionHandles.ts
@@ -64,6 +64,7 @@ export interface AgentToolInteractionFacet {
     toolCallId: string,
     response: ToolInteractionResponse
   ): Promise<ToolInteractionResult>
+  dismiss(messageId: string, toolCallId: string): Promise<boolean>
 }
 
 export interface AgentSessionHandle {

--- a/src/main/session/chatService.ts
+++ b/src/main/session/chatService.ts
@@ -43,6 +43,7 @@ export interface ChatServiceTurnPort {
     toolCallId: string,
     response: ToolInteractionResponse
   ): Promise<ToolInteractionResult>
+  dismissToolInteraction(sessionId: string, messageId: string, toolCallId: string): Promise<boolean>
 }
 
 export interface ChatRespondToolInteractionInput {
@@ -294,6 +295,24 @@ export class ChatService {
       accepted: true,
       ...result
     }
+  }
+
+  async dismissToolInteraction(input: {
+    sessionId: string
+    messageId: string
+    toolCallId: string
+  }): Promise<{ dismissed: boolean }> {
+    const dismissed = await this.deps.scheduler.timeout({
+      task: this.deps.turn.dismissToolInteraction(
+        input.sessionId,
+        input.messageId,
+        input.toolCallId
+      ),
+      ms: CHAT_INTERACTION_TIMEOUT_MS,
+      reason: `chat.dismissToolInteraction:${input.sessionId}:${input.toolCallId}`
+    })
+
+    return { dismissed }
   }
 
   private async bestEffortCancel(sessionId: string, reason: string): Promise<void> {

--- a/src/main/session/contracts.ts
+++ b/src/main/session/contracts.ts
@@ -376,6 +376,7 @@ export interface SessionTurnPort {
     toolCallId: string,
     response: ToolInteractionResponse
   ): Promise<ToolInteractionResult>
+  dismissToolInteraction(sessionId: string, messageId: string, toolCallId: string): Promise<boolean>
 }
 
 export interface SessionAssignmentCatalogPort {

--- a/src/main/session/routes.ts
+++ b/src/main/session/routes.ts
@@ -1,5 +1,6 @@
 import {
   chatCancelSubmissionRoute,
+  chatDismissToolInteractionRoute,
   chatRespondToolInteractionRoute,
   chatSendMessageRoute,
   chatSteerActiveTurnRoute,
@@ -850,6 +851,15 @@ export function createSessionRoutes(deps: {
         const input = chatRespondToolInteractionRoute.input.parse(rawInput)
         return chatRespondToolInteractionRoute.output.parse(
           await chatService.respondToolInteraction(input)
+        )
+      }
+    ],
+    [
+      chatDismissToolInteractionRoute.name,
+      async (rawInput) => {
+        const input = chatDismissToolInteractionRoute.input.parse(rawInput)
+        return chatDismissToolInteractionRoute.output.parse(
+          await chatService.dismissToolInteraction(input)
         )
       }
     ]

--- a/src/main/session/turn.ts
+++ b/src/main/session/turn.ts
@@ -468,6 +468,17 @@ export class SessionTurn implements SessionTurnPort, SessionInitialTurnPort {
       .toolInteractions.respond(messageId, toolCallId, response)
   }
 
+  async dismissToolInteraction(
+    sessionId: string,
+    messageId: string,
+    toolCallId: string
+  ): Promise<boolean> {
+    this.requireSession(sessionId)
+    return await this.dependencies.runtime
+      .resolveSession(toAppSessionId(sessionId))
+      .toolInteractions.dismiss(messageId, toolCallId)
+  }
+
   private promoteDraft(sessionId: string, input: SendMessageInput): void {
     const title = input.text.trim().slice(0, 50) || 'New Chat'
     this.dependencies.sessions.update(sessionId, { isDraft: false, title })

--- a/src/renderer/api/ChatClient.ts
+++ b/src/renderer/api/ChatClient.ts
@@ -9,6 +9,7 @@ import {
 import type { DeepchatRouteInput } from '@shared/contracts/routes'
 import {
   chatCancelSubmissionRoute,
+  chatDismissToolInteractionRoute,
   chatSendMessageRoute,
   chatSteerActiveTurnRoute,
   chatStopStreamRoute,
@@ -67,6 +68,17 @@ export function createChatClient(bridge: DeepchatBridge = getDeepchatBridge()) {
     )
   }
 
+  async function dismissToolInteraction(input: {
+    sessionId: string
+    messageId: string
+    toolCallId: string
+  }) {
+    return await bridge.invoke(
+      chatDismissToolInteractionRoute.name,
+      input as DeepchatRouteInput<typeof chatDismissToolInteractionRoute.name>
+    )
+  }
+
   function onStreamUpdated(
     listener: (payload: DeepchatEventPayload<'chat.stream.updated'>) => void
   ) {
@@ -93,6 +105,7 @@ export function createChatClient(bridge: DeepchatBridge = getDeepchatBridge()) {
     cancelSubmission,
     stopStream,
     respondToolInteraction,
+    dismissToolInteraction,
     onStreamUpdated,
     onStreamCompleted,
     onStreamFailed,

--- a/src/renderer/src/features/chat-page/composables/useToolInteraction.ts
+++ b/src/renderer/src/features/chat-page/composables/useToolInteraction.ts
@@ -33,7 +33,7 @@ type ChatClientLike = {
     messageId: string
     toolCallId: string
     response: ToolInteractionResponse
-  }) => Promise<{ handledInline?: boolean }>
+  }) => Promise<{ handledInline?: boolean; waitingForUserMessage?: boolean }>
 }
 
 type UseToolInteractionOptions = {
@@ -66,6 +66,24 @@ function parseSubagentProgress(value: unknown): SubagentProgressPayload | null {
  */
 export function useToolInteraction(options: UseToolInteractionOptions) {
   const isHandlingInteraction = ref(false)
+
+  // Interactions the main process could not resolve (their backing run is gone,
+  // the session was replaced mid-response, or the subagent session vanished).
+  // Keeping them in the list would trap the approval UI on an interaction that
+  // can never close and block access to newer pending approvals.
+  const staleInteractionKeys = ref<Set<string>>(new Set())
+
+  const interactionKey = (interaction: {
+    sessionId: string
+    messageId: string
+    toolCallId: string
+  }) => `${interaction.sessionId}:${interaction.messageId}:${interaction.toolCallId}`
+
+  const markStale = (interaction: { sessionId: string; messageId: string; toolCallId: string }) => {
+    const key = interactionKey(interaction)
+    if (staleInteractionKeys.value.has(key)) return
+    staleInteractionKeys.value = new Set(staleInteractionKeys.value).add(key)
+  }
 
   const pendingInteractions = computed<PendingInteractionView[]>(() => {
     const list: PendingInteractionView[] = []
@@ -130,7 +148,12 @@ export function useToolInteraction(options: UseToolInteractionOptions) {
       }
     }
 
-    return list
+    if (staleInteractionKeys.value.size === 0) {
+      return list
+    }
+
+    const stale = staleInteractionKeys.value
+    return list.filter((entry) => !stale.has(interactionKey(entry)))
   })
 
   const activePendingInteraction = computed(() => pendingInteractions.value[0] ?? null)
@@ -144,6 +167,18 @@ export function useToolInteraction(options: UseToolInteractionOptions) {
     const sessionId = options.sessionId()
     const requestId = options.currentRestoreRequestId()
     isHandlingInteraction.value = true
+    const isCurrentView = () => options.canWriteSessionView(sessionId, requestId)
+    const refreshAfterResponse = async () => {
+      if (!isCurrentView()) return false
+      const restoredSession = await options.loadMessagesForSession(sessionId)
+      if (!isCurrentView()) return false
+      options.applyRestoredSessionSummary(restoredSession)
+      return true
+    }
+    const isStillPending = () =>
+      pendingInteractions.value.some(
+        (entry) => interactionKey(entry) === interactionKey(interaction)
+      )
     try {
       const result = await options.chatClient.respondToolInteraction({
         sessionId: interaction.sessionId,
@@ -151,15 +186,30 @@ export function useToolInteraction(options: UseToolInteractionOptions) {
         toolCallId: interaction.toolCallId,
         response
       })
-      if (!options.canWriteSessionView(sessionId, requestId)) return
-      const restoredSession = await options.loadMessagesForSession(sessionId)
-      if (!options.canWriteSessionView(sessionId, requestId)) return
-      options.applyRestoredSessionSummary(restoredSession)
-      if (result.handledInline) {
+      const refreshed = await refreshAfterResponse()
+      if (!refreshed || result.handledInline || result.waitingForUserMessage) {
         return
+      }
+      // The main process resolves a handled interaction by persisting a
+      // non-pending block status. If it is still pending after the reload, its
+      // backing run is gone and the approval can never be closed here. Drop it
+      // so the UI advances to the next pending approval instead of staying stuck.
+      if (isStillPending()) {
+        markStale(interaction)
       }
     } catch (error) {
       console.error('[ChatPage] respond tool interaction failed:', error)
+      // A rejected respond is itself a strong staleness signal (a resolvable
+      // interaction would not be rejected). Reload once and, if the interaction
+      // is still pending, release the UI from the uncloseable approval.
+      try {
+        const refreshed = await refreshAfterResponse()
+        if (refreshed && isStillPending()) {
+          markStale(interaction)
+        }
+      } catch (refreshError) {
+        console.error('[ChatPage] refresh after failed tool interaction response:', refreshError)
+      }
     } finally {
       isHandlingInteraction.value = false
     }

--- a/src/renderer/src/features/chat-page/composables/useToolInteraction.ts
+++ b/src/renderer/src/features/chat-page/composables/useToolInteraction.ts
@@ -34,6 +34,11 @@ type ChatClientLike = {
     toolCallId: string
     response: ToolInteractionResponse
   }) => Promise<{ handledInline?: boolean; waitingForUserMessage?: boolean }>
+  dismissToolInteraction: (input: {
+    sessionId: string
+    messageId: string
+    toolCallId: string
+  }) => Promise<{ dismissed: boolean }>
 }
 
 type UseToolInteractionOptions = {
@@ -179,6 +184,21 @@ export function useToolInteraction(options: UseToolInteractionOptions) {
       pendingInteractions.value.some(
         (entry) => interactionKey(entry) === interactionKey(interaction)
       )
+    // Best-effort durable close on the main-process transcript so the orphaned
+    // block stops blocking new turns and does not reappear after a session reload.
+    const dismissStale = async () => {
+      if (!isStillPending()) return
+      markStale(interaction)
+      try {
+        await options.chatClient.dismissToolInteraction({
+          sessionId: interaction.sessionId,
+          messageId: interaction.messageId,
+          toolCallId: interaction.toolCallId
+        })
+      } catch (error) {
+        console.error('[ChatPage] dismiss stale tool interaction failed:', error)
+      }
+    }
     try {
       const result = await options.chatClient.respondToolInteraction({
         sessionId: interaction.sessionId,
@@ -194,9 +214,7 @@ export function useToolInteraction(options: UseToolInteractionOptions) {
       // non-pending block status. If it is still pending after the reload, its
       // backing run is gone and the approval can never be closed here. Drop it
       // so the UI advances to the next pending approval instead of staying stuck.
-      if (isStillPending()) {
-        markStale(interaction)
-      }
+      await dismissStale()
     } catch (error) {
       console.error('[ChatPage] respond tool interaction failed:', error)
       // A rejected respond is itself a strong staleness signal (a resolvable
@@ -204,8 +222,8 @@ export function useToolInteraction(options: UseToolInteractionOptions) {
       // is still pending, release the UI from the uncloseable approval.
       try {
         const refreshed = await refreshAfterResponse()
-        if (refreshed && isStillPending()) {
-          markStale(interaction)
+        if (refreshed) {
+          await dismissStale()
         }
       } catch (refreshError) {
         console.error('[ChatPage] refresh after failed tool interaction response:', refreshError)

--- a/src/renderer/src/features/chat-page/composables/useToolInteraction.ts
+++ b/src/renderer/src/features/chat-page/composables/useToolInteraction.ts
@@ -1,7 +1,7 @@
 import { computed, ref } from 'vue'
 import type { DisplayAssistantMessageBlock } from '@/features/chat-page/model/displayMessage'
 import type { useMessageStore } from '@/stores/ui/message'
-import type { ToolInteractionResponse } from '@shared/types/agent-interface'
+import type { ToolInteractionResponse, ToolInteractionResult } from '@shared/types/agent-interface'
 
 type MessageStore = ReturnType<typeof useMessageStore>
 
@@ -33,7 +33,7 @@ type ChatClientLike = {
     messageId: string
     toolCallId: string
     response: ToolInteractionResponse
-  }) => Promise<{ handledInline?: boolean; waitingForUserMessage?: boolean }>
+  }) => Promise<ToolInteractionResult>
   dismissToolInteraction: (input: {
     sessionId: string
     messageId: string

--- a/src/shared/contracts/routes.ts
+++ b/src/shared/contracts/routes.ts
@@ -37,6 +37,7 @@ import {
 } from './routes/computerUse.routes'
 import {
   chatCancelSubmissionRoute,
+  chatDismissToolInteractionRoute,
   chatRespondToolInteractionRoute,
   chatSendMessageRoute,
   chatSteerActiveTurnRoute,
@@ -1075,6 +1076,7 @@ const DEEPCHAT_ROUTE_CATALOG_PART_5 = {
   [chatSteerActiveTurnRoute.name]: chatSteerActiveTurnRoute,
   [chatStopStreamRoute.name]: chatStopStreamRoute,
   [chatRespondToolInteractionRoute.name]: chatRespondToolInteractionRoute,
+  [chatDismissToolInteractionRoute.name]: chatDismissToolInteractionRoute,
   [databaseSecurityGetStatusRoute.name]: databaseSecurityGetStatusRoute,
   [databaseSecurityEnableRoute.name]: databaseSecurityEnableRoute,
   [databaseSecurityChangePasswordRoute.name]: databaseSecurityChangePasswordRoute,

--- a/src/shared/contracts/routes/chat.routes.ts
+++ b/src/shared/contracts/routes/chat.routes.ts
@@ -85,3 +85,15 @@ export const chatRespondToolInteractionRoute = defineRouteContract({
     })
     .extend(ToolInteractionResultSchema.shape)
 })
+
+export const chatDismissToolInteractionRoute = defineRouteContract({
+  name: 'chat.dismissToolInteraction',
+  input: z.object({
+    sessionId: EntityIdSchema,
+    messageId: EntityIdSchema,
+    toolCallId: EntityIdSchema
+  }),
+  output: z.object({
+    dismissed: z.boolean()
+  })
+})

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -17526,6 +17526,87 @@ describe('DeepChatAgentHarness', () => {
     })
   })
 
+  describe('dismissToolInteraction', () => {
+    it('resolves a stale pending permission block in the transcript', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      installPendingPermission({
+        toolName: 'write_file',
+        serverName: 'agent-filesystem',
+        shellProfile: 'posix',
+        paths: ['/workspace/file.txt']
+      })
+
+      const dismissed = await agent.dismissToolInteraction('s1', 'm1', 'tc1')
+
+      expect(dismissed).toBe(true)
+      const blocks = getLatestUpdatedBlocks('m1')
+      const permissionBlock = blocks.find(
+        (block) =>
+          block.type === 'action' &&
+          block.action_type === 'tool_call_permission' &&
+          block.tool_call?.id === 'tc1'
+      )
+      expect(permissionBlock?.status).toBe('denied')
+      expect(permissionBlock?.extra?.needsUserAction).toBe(false)
+      expect(
+        agent.deepChatRuntime.getHydrated(toAppSessionId('s1'))?.hasPendingInteractions()
+      ).toBe(false)
+    })
+
+    it('stamps the interaction as cancelled in the message metadata', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      installPendingPermission({
+        toolName: 'write_file',
+        serverName: 'agent-filesystem',
+        shellProfile: 'posix',
+        paths: ['/workspace/file.txt']
+      })
+
+      await agent.dismissToolInteraction('s1', 'm1', 'tc1')
+
+      const metadataUpdate = sqlitePresenter.deepchatMessagesTable.updateMetadata.mock.calls.find(
+        ([id]) => id === 'm1'
+      )
+      expect(JSON.parse(metadataUpdate?.[1] ?? '{}')).toMatchObject({
+        interactionResolution: 'cancelled'
+      })
+    })
+
+    it('resolves a pending question block in the transcript', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      installPendingQuestion()
+
+      const dismissed = await agent.dismissToolInteraction('s1', 'm1', 'pending-question')
+
+      expect(dismissed).toBe(true)
+      const blocks = getLatestUpdatedBlocks('m1')
+      const questionBlock = blocks.find(
+        (block) => block.type === 'action' && block.action_type === 'question_request'
+      )
+      expect(questionBlock?.status).toBe('success')
+      expect(questionBlock?.extra?.needsUserAction).toBe(false)
+    })
+
+    it('returns false for a non-pending interaction without writing', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      installPendingPermission({
+        toolName: 'write_file',
+        serverName: 'agent-filesystem',
+        shellProfile: 'posix',
+        paths: ['/workspace/file.txt']
+      })
+      const persistedUpdateCount =
+        sqlitePresenter.deepchatMessagesTable.updateContent.mock.calls.length
+
+      const dismissed = await agent.dismissToolInteraction('s1', 'm1', 'missing-tool-call')
+
+      expect(dismissed).toBe(false)
+      expect(sqlitePresenter.deepchatMessagesTable.updateContent.mock.calls.length).toBe(
+        persistedUpdateCount
+      )
+    })
+  })
+
   describe('permission mode', () => {
     it('setPermissionMode updates runtime and db', async () => {
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -17527,7 +17527,15 @@ describe('DeepChatAgentHarness', () => {
   })
 
   describe('dismissToolInteraction', () => {
-    it('resolves a stale pending permission block in the transcript', async () => {
+    const getFinalizedWrite = (messageId: string) => {
+      const call = sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls.find(
+        ([id]) => id === messageId
+      )
+      expect(call).toBeDefined()
+      return call as [string, string, string, string]
+    }
+
+    it('resolves a stale pending permission block and finalizes the message', async () => {
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
       installPendingPermission({
         toolName: 'write_file',
@@ -17539,7 +17547,9 @@ describe('DeepChatAgentHarness', () => {
       const dismissed = await agent.dismissToolInteraction('s1', 'm1', 'tc1')
 
       expect(dismissed).toBe(true)
-      const blocks = getLatestUpdatedBlocks('m1')
+      const [, content, status, metadataJson] = getFinalizedWrite('m1')
+      expect(status).toBe('sent')
+      const blocks = JSON.parse(content) as AssistantMessageBlock[]
       const permissionBlock = blocks.find(
         (block) =>
           block.type === 'action' &&
@@ -17548,43 +17558,53 @@ describe('DeepChatAgentHarness', () => {
       )
       expect(permissionBlock?.status).toBe('denied')
       expect(permissionBlock?.extra?.needsUserAction).toBe(false)
+      expect(JSON.parse(metadataJson)).toMatchObject({ interactionResolution: 'cancelled' })
       expect(
         agent.deepChatRuntime.getHydrated(toAppSessionId('s1'))?.hasPendingInteractions()
       ).toBe(false)
     })
 
-    it('stamps the interaction as cancelled in the message metadata', async () => {
-      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
-      installPendingPermission({
-        toolName: 'write_file',
-        serverName: 'agent-filesystem',
-        shellProfile: 'posix',
-        paths: ['/workspace/file.txt']
-      })
-
-      await agent.dismissToolInteraction('s1', 'm1', 'tc1')
-
-      const metadataUpdate = sqlitePresenter.deepchatMessagesTable.updateMetadata.mock.calls.find(
-        ([id]) => id === 'm1'
-      )
-      expect(JSON.parse(metadataUpdate?.[1] ?? '{}')).toMatchObject({
-        interactionResolution: 'cancelled'
-      })
-    })
-
-    it('resolves a pending question block in the transcript', async () => {
+    it('resolves a pending question block and its paired tool call', async () => {
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
       installPendingQuestion()
 
       const dismissed = await agent.dismissToolInteraction('s1', 'm1', 'pending-question')
 
       expect(dismissed).toBe(true)
-      const blocks = getLatestUpdatedBlocks('m1')
+      const [, content] = getFinalizedWrite('m1')
+      const blocks = JSON.parse(content) as AssistantMessageBlock[]
       const questionBlock = blocks.find(
         (block) => block.type === 'action' && block.action_type === 'question_request'
       )
+      const toolBlock = blocks.find(
+        (block) => block.type === 'tool_call' && block.tool_call?.id === 'pending-question'
+      )
       expect(questionBlock?.status).toBe('success')
       expect(questionBlock?.extra?.needsUserAction).toBe(false)
+      expect(toolBlock?.status).toBe('success')
+    })
+
+    it('preserves pending interactions from other messages when dismissing one', async () => {
+      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+      installPendingPermission({
+        messageId: 'm1',
+        toolName: 'write_file',
+        serverName: 'agent-filesystem',
+        shellProfile: 'posix',
+        paths: ['/workspace/a.txt']
+      })
+      const instance = agent.deepChatRuntime.getOrHydrate(toAppSessionId('s1'))
+      instance.replacePendingInteractions([
+        { messageId: 'm1', toolCallId: 'tc1', origin: 'pre-check-permission', order: 0 },
+        { messageId: 'm2', toolCallId: 'tc2', origin: 'pre-check-permission', order: 1 }
+      ])
+
+      const dismissed = await agent.dismissToolInteraction('s1', 'm1', 'tc1')
+
+      expect(dismissed).toBe(true)
+      expect(instance.getPendingInteractions()).toEqual([
+        { messageId: 'm2', toolCallId: 'tc2', origin: 'pre-check-permission', order: 1 }
+      ])
     })
 
     it('returns false for a non-pending interaction without writing', async () => {
@@ -17595,14 +17615,18 @@ describe('DeepChatAgentHarness', () => {
         shellProfile: 'posix',
         paths: ['/workspace/file.txt']
       })
-      const persistedUpdateCount =
-        sqlitePresenter.deepchatMessagesTable.updateContent.mock.calls.length
+      const contentWrites = sqlitePresenter.deepchatMessagesTable.updateContent.mock.calls.length
+      const finalizeWrites =
+        sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls.length
 
       const dismissed = await agent.dismissToolInteraction('s1', 'm1', 'missing-tool-call')
 
       expect(dismissed).toBe(false)
       expect(sqlitePresenter.deepchatMessagesTable.updateContent.mock.calls.length).toBe(
-        persistedUpdateCount
+        contentWrites
+      )
+      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls.length).toBe(
+        finalizeWrites
       )
     })
   })

--- a/test/main/agent/manager/directAcpAgentBackend.test.ts
+++ b/test/main/agent/manager/directAcpAgentBackend.test.ts
@@ -80,7 +80,8 @@ function createHarness() {
           extra: { permissionRequestId: 'permission-request' }
         }
       ])
-    })
+    }),
+    updateAssistantContent: vi.fn()
   }
   const tape = {
     linkSubagentTape: vi.fn().mockImplementation(async (input) => ({
@@ -336,6 +337,26 @@ describe('direct ACP agent backend', () => {
       'permission-request',
       false
     )
+  })
+
+  it('durably dismisses an ACP permission when the runtime is unavailable', async () => {
+    const harness = createHarness()
+    harness.runtime.getHydrated.mockReturnValue(undefined)
+    const handle = harness.backend.open(sessionId, descriptor)
+
+    await expect(handle.toolInteractions.dismiss('assistant', 'tool-call')).resolves.toBe(true)
+
+    expect(harness.transcript.updateAssistantContent).toHaveBeenCalledTimes(1)
+    const [messageId, blocks] = harness.transcript.updateAssistantContent.mock.calls[0] as [
+      string,
+      AssistantMessageBlock[]
+    ]
+    expect(messageId).toBe('assistant')
+    const block = blocks.find(
+      (candidate) => candidate.type === 'action' && candidate.action_type === 'tool_call_permission'
+    )
+    expect(block?.status).toBe('denied')
+    expect(block?.extra?.needsUserAction).toBe(false)
   })
 
   it('exposes direct transfer, pending, subagent, generation, and close facets', async () => {

--- a/test/main/session/turn.test.ts
+++ b/test/main/session/turn.test.ts
@@ -73,7 +73,8 @@ function createHarness(
     delete: vi.fn().mockResolvedValue(undefined)
   }
   const toolInteractions = {
-    respond: vi.fn().mockResolvedValue({ resumed: true })
+    respond: vi.fn().mockResolvedValue({ resumed: true }),
+    dismiss: vi.fn().mockResolvedValue(true)
   }
   const send = vi.fn().mockResolvedValue({ requestId: 'request-1', messageId: 'message-1' })
   const cancel = vi.fn().mockResolvedValue(undefined)

--- a/test/renderer/features/chat-page/composables/useToolInteraction.test.ts
+++ b/test/renderer/features/chat-page/composables/useToolInteraction.test.ts
@@ -182,7 +182,7 @@ describe('useToolInteraction', () => {
     harness.stop()
   })
 
-  it('releases the response lock and drops an unresolvable interaction when the client rejects', async () => {
+  it('drops an unresolvable interaction when the client rejects', async () => {
     const error = new Error('response failed')
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     const harness = createHarness([

--- a/test/renderer/features/chat-page/composables/useToolInteraction.test.ts
+++ b/test/renderer/features/chat-page/composables/useToolInteraction.test.ts
@@ -13,12 +13,16 @@ function createAssistantMessage(id: string, blocks: unknown[]) {
 
 function createHarness(messages: Array<Record<string, unknown>>) {
   const sessionId = ref('s1')
+  const messageRecords = ref(messages)
   const messageStore = {
-    messages,
+    get messages() {
+      return messageRecords.value
+    },
     getAssistantMessageBlocks: vi.fn((message: { content: string }) => JSON.parse(message.content))
   }
   const chatClient = {
-    respondToolInteraction: vi.fn().mockResolvedValue({ handledInline: false })
+    respondToolInteraction: vi.fn().mockResolvedValue({ handledInline: false }),
+    dismissToolInteraction: vi.fn().mockResolvedValue({ dismissed: true })
   }
   const loadMessagesForSession = vi.fn().mockResolvedValue({ id: 'restored' })
   const applyRestoredSessionSummary = vi.fn()
@@ -45,6 +49,7 @@ function createHarness(messages: Array<Record<string, unknown>>) {
   return {
     toolInteraction,
     sessionId,
+    messageRecords,
     chatClient,
     loadMessagesForSession,
     applyRestoredSessionSummary,
@@ -200,6 +205,11 @@ describe('useToolInteraction', () => {
     // A rejected respond is treated as a stale interaction: the page refreshes
     // and, because the block is still pending, releases the approval UI.
     expect(harness.loadMessagesForSession).toHaveBeenCalledWith('s1')
+    expect(harness.chatClient.dismissToolInteraction).toHaveBeenCalledWith({
+      sessionId: 's1',
+      messageId: 'm1',
+      toolCallId: 'tool-1'
+    })
     expect(harness.toolInteraction.pendingInteractions.value).toEqual([])
     expect(harness.toolInteraction.activePendingInteraction.value).toBeNull()
     expect(harness.toolInteraction.isHandlingInteraction.value).toBe(false)
@@ -237,7 +247,13 @@ describe('useToolInteraction', () => {
     } as any)
 
     expect(harness.loadMessagesForSession).toHaveBeenCalledWith('s1')
-    // The stale approval is dropped and the next pending interaction surfaces.
+    // The stale approval is dropped, durably dismissed on the main process, and
+    // the next pending interaction surfaces.
+    expect(harness.chatClient.dismissToolInteraction).toHaveBeenCalledWith({
+      sessionId: 's1',
+      messageId: 'm1',
+      toolCallId: 'tool-1'
+    })
     expect(harness.toolInteraction.pendingInteractions.value).toMatchObject([
       { messageId: 'm2', toolCallId: 'tool-2', actionType: 'question_request' }
     ])
@@ -249,7 +265,7 @@ describe('useToolInteraction', () => {
   })
 
   it('keeps a responded interaction when the main process resolved its block', async () => {
-    const messages = [
+    const harness = createHarness([
       createAssistantMessage('m1', [
         {
           type: 'action',
@@ -258,15 +274,21 @@ describe('useToolInteraction', () => {
           tool_call: { id: 'tool-1', name: 'write_file', params: '{}' }
         }
       ])
-    ]
-    const harness = createHarness(messages)
+    ])
     harness.chatClient.respondToolInteraction.mockResolvedValue({ resumed: true })
     // Simulate the main process persisting a resolved block before the reload.
     harness.loadMessagesForSession.mockImplementation(async () => {
-      const blocks = JSON.parse(messages[0].content as string) as Array<Record<string, any>>
-      blocks[0].status = 'granted'
-      blocks[0].extra = { needsUserAction: false }
-      messages[0].content = JSON.stringify(blocks)
+      harness.messageRecords.value = [
+        createAssistantMessage('m1', [
+          {
+            type: 'action',
+            action_type: 'tool_call_permission',
+            status: 'granted',
+            extra: { needsUserAction: false },
+            tool_call: { id: 'tool-1', name: 'write_file', params: '{}' }
+          }
+        ])
+      ]
       return { id: 'restored' }
     })
 
@@ -277,6 +299,7 @@ describe('useToolInteraction', () => {
 
     expect(harness.toolInteraction.pendingInteractions.value).toEqual([])
     expect(harness.toolInteraction.activePendingInteraction.value).toBeNull()
+    expect(harness.chatClient.dismissToolInteraction).not.toHaveBeenCalled()
     expect(harness.loadMessagesForSession).toHaveBeenCalledWith('s1')
     harness.stop()
   })

--- a/test/renderer/features/chat-page/composables/useToolInteraction.test.ts
+++ b/test/renderer/features/chat-page/composables/useToolInteraction.test.ts
@@ -177,7 +177,7 @@ describe('useToolInteraction', () => {
     harness.stop()
   })
 
-  it('releases the response lock without refreshing when the client rejects', async () => {
+  it('releases the response lock and drops an unresolvable interaction when the client rejects', async () => {
     const error = new Error('response failed')
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     const harness = createHarness([
@@ -197,10 +197,87 @@ describe('useToolInteraction', () => {
       granted: true
     } as any)
 
-    expect(harness.loadMessagesForSession).not.toHaveBeenCalled()
+    // A rejected respond is treated as a stale interaction: the page refreshes
+    // and, because the block is still pending, releases the approval UI.
+    expect(harness.loadMessagesForSession).toHaveBeenCalledWith('s1')
+    expect(harness.toolInteraction.pendingInteractions.value).toEqual([])
+    expect(harness.toolInteraction.activePendingInteraction.value).toBeNull()
     expect(harness.toolInteraction.isHandlingInteraction.value).toBe(false)
     expect(consoleError).toHaveBeenCalledWith('[ChatPage] respond tool interaction failed:', error)
     consoleError.mockRestore()
+    harness.stop()
+  })
+
+  it('drops a responded interaction that stays pending after reload so the UI advances', async () => {
+    const harness = createHarness([
+      createAssistantMessage('m1', [
+        {
+          type: 'action',
+          action_type: 'tool_call_permission',
+          status: 'pending',
+          tool_call: { id: 'tool-1', name: 'write_file', params: '{}' }
+        }
+      ]),
+      createAssistantMessage('m2', [
+        {
+          type: 'action',
+          action_type: 'question_request',
+          status: 'pending',
+          tool_call: { id: 'tool-2', name: 'ask', params: '{}' }
+        }
+      ])
+    ])
+    // The main process returns without resolving the first interaction (its
+    // backing run is gone): the block stays pending after the reload.
+    harness.chatClient.respondToolInteraction.mockResolvedValue({ resumed: false })
+
+    await harness.toolInteraction.onToolInteractionRespond({
+      kind: 'permission',
+      granted: true
+    } as any)
+
+    expect(harness.loadMessagesForSession).toHaveBeenCalledWith('s1')
+    // The stale approval is dropped and the next pending interaction surfaces.
+    expect(harness.toolInteraction.pendingInteractions.value).toMatchObject([
+      { messageId: 'm2', toolCallId: 'tool-2', actionType: 'question_request' }
+    ])
+    expect(harness.toolInteraction.activePendingInteraction.value).toMatchObject({
+      messageId: 'm2',
+      toolCallId: 'tool-2'
+    })
+    harness.stop()
+  })
+
+  it('keeps a responded interaction when the main process resolved its block', async () => {
+    const messages = [
+      createAssistantMessage('m1', [
+        {
+          type: 'action',
+          action_type: 'tool_call_permission',
+          status: 'pending',
+          tool_call: { id: 'tool-1', name: 'write_file', params: '{}' }
+        }
+      ])
+    ]
+    const harness = createHarness(messages)
+    harness.chatClient.respondToolInteraction.mockResolvedValue({ resumed: true })
+    // Simulate the main process persisting a resolved block before the reload.
+    harness.loadMessagesForSession.mockImplementation(async () => {
+      const blocks = JSON.parse(messages[0].content as string) as Array<Record<string, any>>
+      blocks[0].status = 'granted'
+      blocks[0].extra = { needsUserAction: false }
+      messages[0].content = JSON.stringify(blocks)
+      return { id: 'restored' }
+    })
+
+    await harness.toolInteraction.onToolInteractionRespond({
+      kind: 'permission',
+      granted: true
+    } as any)
+
+    expect(harness.toolInteraction.pendingInteractions.value).toEqual([])
+    expect(harness.toolInteraction.activePendingInteraction.value).toBeNull()
+    expect(harness.loadMessagesForSession).toHaveBeenCalledWith('s1')
     harness.stop()
   })
 })


### PR DESCRIPTION
## Problem

Closes #2210: 权限审批页面在长时间未回复后卡死无法关闭。

When a pending tool permission / question interaction is no longer backed by a
running generation (the run ended, the session was replaced mid-response, or
the subagent session vanished), the main process cannot resolve its action
block. The renderer derives the approval UI from the persisted block
(`status === 'pending'` + `needsUserAction !== false`), so the approval stays
shown as the first pending interaction forever. No button closes it, newer
approvals queued behind it are never reached, and the orphaned block keeps
blocking new turns.

## Fix

Two layers:

**Renderer** (`useToolInteraction`): after responding to a pending interaction
we reload the session. If that interaction is **still pending after the reload**
(the main process did not resolve it) — or the respond was rejected — it is a
stale interaction: drop it from the pending list so the UI advances to the next
approval, and ask the main process to dismiss it durably.

**Main process** (new `chat.dismissToolInteraction` route): marks the orphaned
`tool_call_permission` / `question_request` block as resolved (`denied` /
`success`, `needsUserAction: false`) and persists it in the transcript with
`interactionResolution: 'cancelled'`. No tool executes and no run resumes. This
removes the lingering block so it no longer reappears after a session reload or
blocks new turns.

Normal resolutions, `handledInline` (skill-draft view), and
`waitingForUserMessage` (question_other follow-up) are left untouched.

## BEFORE

```
 pending approval (stale, run gone)  ← always shown
 └─ Allow / Deny  → nothing happens, page stuck
 (newer approvals queued but never reached)
 new message      → blocked: "resolve pending interactions first"
```

## AFTER

```
 pending approval (stale, run gone)  → respond → dropped + dismissed durably
 next pending approval now shown
 new message      → allowed (orphaned block resolved in transcript)
```

## Tests

- `test/renderer/.../useToolInteraction.test.ts`
  - stale interaction dropped + dismissed after a non-resolving respond
  - rejected respond refreshes + drops the unresolvable interaction
  - resolved interaction is kept (no dismiss)
- `test/main/.../deepChatAgentHarness.test.ts` (`dismissToolInteraction`)
  - resolves a stale pending permission / question block in the transcript
  - stamps `interactionResolution: 'cancelled'`
  - returns false for a non-pending interaction without writing

Verified: format / lint / i18n / typecheck (node + web) / full main harness
(375) / session+manager (702) / full renderer suite (266 files, 2355 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool interactions that require a user response.
  * Automatically refreshes conversations after failed or rejected tool responses.
  * Permanently dismisses stale permission and question prompts after refresh.
  * Prevents outdated prompts from blocking conversations or resuming runs unexpectedly.
  * Preserves successfully resolved interactions and unrelated pending prompts.
  * Ensures dismissed prompts are recorded correctly, including when the runtime is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->