### PR TITLE
feat(provider): add RunInfra support

### DIFF
--- a/src/main/provider/defaults.ts
+++ b/src/main/provider/defaults.ts
@@ -32,6 +32,21 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
     }
   },
   {
+    id: 'runinfra',
+    name: 'RunInfra',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://api.runinfra.ai/v1',
+    enable: false,
+    websites: {
+      official: 'https://runinfra.ai/',
+      apiKey: 'https://runinfra.ai/settings/api-keys',
+      docs: 'https://runinfra.ai/docs/api-reference/model-apis-quickstart',
+      models: 'https://runinfra.ai/inference-api',
+      defaultBaseUrl: 'https://api.runinfra.ai/v1'
+    }
+  },
+  {
     id: 'greenpt',
     name: 'GreenPT',
     apiType: 'openai-completions',

--- a/src/main/provider/providerRegistry.ts
+++ b/src/main/provider/providerRegistry.ts
@@ -499,6 +499,14 @@ const PROVIDER_ID_REGISTRY = new Map<string, AiSdkProviderDefinition>([
     })
   ],
   [
+    'runinfra',
+    createDefinition({
+      ...OPENAI_BASE,
+      credentialStrategy: 'api-key',
+      embeddingStrategy: 'none'
+    })
+  ],
+  [
     'silicon',
     createDefinition({
       ...CHINESE_SUMMARY_OPENAI,

--- a/src/renderer/src/assets/llm-icons/runinfra.svg
+++ b/src/renderer/src/assets/llm-icons/runinfra.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 256" fill="currentColor" shape-rendering="crispEdges" role="img">
+  <title>RunInfra</title>
+  <rect x="0" y="0" width="64" height="64" />
+  <rect x="64" y="0" width="64" height="64" />
+  <rect x="0" y="64" width="64" height="64" />
+  <rect x="128" y="64" width="64" height="64" />
+  <rect x="0" y="128" width="64" height="64" />
+  <rect x="64" y="128" width="64" height="64" />
+  <rect x="0" y="192" width="64" height="64" />
+  <rect x="128" y="192" width="64" height="64" />
+</svg>

--- a/src/renderer/src/components/icons/modelIconRegistry.ts
+++ b/src/renderer/src/components/icons/modelIconRegistry.ts
@@ -64,6 +64,7 @@ import qiniuIcon from '@/assets/llm-icons/qiniu.svg?url'
 import grokColorIcon from '@/assets/llm-icons/grok.svg?url'
 import groqColorIcon from '@/assets/llm-icons/groq.svg?url'
 import greenptColorIcon from '@/assets/llm-icons/greenpt.svg?url'
+import runinfraIcon from '@/assets/llm-icons/runinfra.svg?url'
 import amdIcon from '@/assets/llm-icons/amd.svg?url'
 import nvidiaColorIcon from '@/assets/llm-icons/nvidia-color.svg?url'
 import huggingfaceColorIcon from '@/assets/llm-icons/huggingface-color.svg?url'
@@ -111,6 +112,7 @@ export const modelIcons = {
   grok: grokColorIcon,
   groq: groqColorIcon,
   greenpt: greenptColorIcon,
+  runinfra: runinfraIcon,
   'amd-developer': amdIcon,
   nvidia: nvidiaColorIcon,
   huggingface: huggingfaceColorIcon,
@@ -242,6 +244,7 @@ const monoIconUrls = new Set<string>([
   qiniuIcon,
   grokColorIcon,
   groqColorIcon,
+  runinfraIcon,
   metaColorIcon,
   lmstudioColorIcon,
   _302aiIcon,

--- a/test/main/provider/basicApiKeyProviders.test.ts
+++ b/test/main/provider/basicApiKeyProviders.test.ts
@@ -1,6 +1,7 @@
 import type { ProviderSettingsPort } from '@/provider/settings'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { LLM_PROVIDER } from '@shared/types/provider'
+import { DEFAULT_PROVIDERS } from '../../../src/main/provider/defaults'
 import { AiSdkProvider } from '../../../src/main/provider/providers/aiSdkProvider'
 import { resolveAiSdkProviderDefinition } from '../../../src/main/provider/providerRegistry'
 
@@ -156,6 +157,55 @@ describe('basic API-key provider registrations', () => {
       routeStrategy: 'none',
       embeddingStrategy: 'openai'
     })
+  })
+
+  it('discovers RunInfra models and checks credentials without generating text', async () => {
+    const defaults = DEFAULT_PROVIDERS.find((provider) => provider.id === 'runinfra')!
+    expect(defaults).toBeDefined()
+    const fetchMock = vi.fn().mockImplementation(async () =>
+      Response.json({
+        object: 'list',
+        data: [{ id: 'deepseek-v4-flash', object: 'model', owned_by: 'runinfra' }]
+      })
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const config = { ...defaults, apiKey: 'test-key' }
+    const provider = new AiSdkProvider(config, createProviderSettings())
+    expect(resolveAiSdkProviderDefinition(config)).toMatchObject({
+      runtimeKind: 'openai-compatible',
+      modelSource: 'openai',
+      checkStrategy: 'fetch-models',
+      credentialStrategy: 'api-key',
+      embeddingStrategy: 'none'
+    })
+    await expect(provider.fetchModels({ suppressErrors: false })).resolves.toEqual([
+      expect.objectContaining({
+        id: 'deepseek-v4-flash',
+        providerId: 'runinfra',
+        ownedBy: 'runinfra'
+      })
+    ])
+    await expect(provider.check()).resolves.toEqual({ isOk: true, errorMsg: null })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.runinfra.ai/v1/models',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Authorization: 'Bearer test-key' })
+      })
+    )
+
+    fetchMock.mockResolvedValueOnce(
+      Response.json(
+        { error: { message: 'Invalid API key', type: 'authentication_error' } },
+        { status: 401 }
+      )
+    )
+    await expect(provider.check()).resolves.toMatchObject({
+      isOk: false,
+      errorMsg: expect.stringContaining('Invalid API key')
+    })
+    expect(mockRunAiSdkGenerateText).not.toHaveBeenCalled()
   })
 
   it('discovers AMD GPU Cloud models through the OpenAI-compatible endpoint', async () => {


### PR DESCRIPTION
RunInfra users currently need a custom provider profile. This PR adds a built-in `runinfra` profile with the official workspace API endpoint and logo.

- Reuse `AiSdkProvider` with the OpenAI-compatible Chat Completions transport at `https://api.runinfra.ai/v1`; no new adapter or dependency.
- Discover models and check credentials through authenticated `GET /v1/models`, without generating billable inference. API keys use existing main-process provider storage.
- Add the static official SVG mark with the existing monochrome light/dark theme handling.
- Cover default-profile model discovery, Bearer authentication, and invalid-key errors with a focused contract test.

Validation passed:

- `pnpm run format` and `pnpm run format:check`
- `pnpm run i18n`
- `pnpm run lint`
- `pnpm run typecheck`
- 100 main tests across provider defaults, registration, runtime, factory, reasoning wire, and OpenAI compatibility.
- 37 renderer tests covering provider settings, API configuration, and model icons.
- SVG checked at small sizes in light and dark themes.

```text
BEFORE
Provider catalog -> RunInfra unavailable

AFTER
Provider catalog -> [R] RunInfra
                         |
                         v
Provider settings -> API Key [********]  [Refresh models]
```

API contract: [RunInfra quickstart](https://runinfra.ai/docs/api-reference/model-apis-quickstart) and [model discovery](https://runinfra.ai/docs/api-reference/models).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RunInfra as a supported AI provider.
  * Added RunInfra model discovery through its models endpoint.
  * Added API key authentication and provider connection validation.
  * Added RunInfra branding and icon support.

* **Tests**
  * Added coverage for model discovery, successful authentication, and invalid API key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->