### PR TITLE
fix(orchestration): inherit parent tool mode in delegated sessions

### DIFF
--- a/src/main/app/composition.ts
+++ b/src/main/app/composition.ts
@@ -1595,6 +1595,7 @@ export async function createMainProcessControl(dependencies: {
           projectDir: session.projectDir ?? null,
           permissionMode,
           orchestrationPolicy: session.orchestrationPolicy,
+          toolModeOverride: session.toolModeOverride ?? null,
           generationSettings,
           disabledAgentTools,
           activeSkills,

--- a/src/main/orchestration/liveDelegationSafety.ts
+++ b/src/main/orchestration/liveDelegationSafety.ts
@@ -1,4 +1,5 @@
 import type { PermissionMode, SessionGenerationSettings } from '@shared/types/agent-interface'
+import type { ToolModeOverride } from '@shared/toolMode'
 import type { ConversationSessionInfo } from '@/tool/runtimePorts'
 import type {
   SessionAgentAssignmentPort,
@@ -10,6 +11,7 @@ export interface LiveDelegationTurnExecutionSnapshot {
   providerId: string
   modelId: string
   generationSettings: SessionGenerationSettings | null
+  toolModeOverride: ToolModeOverride
 }
 
 export interface PrepareLiveDelegationTurnInput {

--- a/src/main/orchestration/liveDelegationService.ts
+++ b/src/main/orchestration/liveDelegationService.ts
@@ -1058,7 +1058,7 @@ export class LiveDelegationService {
           providerId: executionSnapshot.providerId,
           modelId: executionSnapshot.modelId,
           permissionMode: safety.parent.permissionMode,
-          toolModeOverride: safety.parent.toolModeOverride,
+          toolModeOverride: executionSnapshot.toolModeOverride,
           generationSettings: executionSnapshot.generationSettings ?? undefined,
           disabledAgentTools: safety.parent.disabledAgentTools,
           activeSkills: safety.parent.activeSkills,
@@ -2033,7 +2033,8 @@ function createTurnExecutionSnapshot(
     modelId: session.modelId,
     generationSettings: session.generationSettings
       ? structuredClone(session.generationSettings)
-      : null
+      : null,
+    toolModeOverride: session.toolModeOverride
   }
 }
 

--- a/src/main/orchestration/liveDelegationService.ts
+++ b/src/main/orchestration/liveDelegationService.ts
@@ -1058,6 +1058,7 @@ export class LiveDelegationService {
           providerId: executionSnapshot.providerId,
           modelId: executionSnapshot.modelId,
           permissionMode: safety.parent.permissionMode,
+          toolModeOverride: safety.parent.toolModeOverride,
           generationSettings: executionSnapshot.generationSettings ?? undefined,
           disabledAgentTools: safety.parent.disabledAgentTools,
           activeSkills: safety.parent.activeSkills,

--- a/src/main/session/assignmentPolicy.ts
+++ b/src/main/session/assignmentPolicy.ts
@@ -1,4 +1,5 @@
 import { resolveAcpAgentAlias } from '@shared/utils/acpAgentAlias'
+import { normalizeToolModeOverride } from '@shared/toolMode'
 import type {
   DeepChatAgentConfig,
   PermissionMode,
@@ -123,7 +124,8 @@ export class SessionAssignmentPolicy implements SessionAssignmentPolicyPort {
         permissionMode: resolveAssignmentPermissionMode(input.permissionMode),
         generationSettings: { systemPrompt: '' },
         disabledAgentTools: [],
-        activeSkills: []
+        activeSkills: [],
+        toolModeOverride: null
       }
     }
 
@@ -132,6 +134,7 @@ export class SessionAssignmentPolicy implements SessionAssignmentPolicyPort {
     const parentAgentId = input.parentAgentId?.trim() || null
     const isCrossAgent = Boolean(parentAgentId && parentAgentId !== descriptor.id)
     const targetAgentId = input.targetAgentId?.trim() ? descriptor.id : null
+    const toolModeOverride = normalizeToolModeOverride(input.toolModeOverride)
 
     if (!isCrossAgent) {
       return {
@@ -142,7 +145,8 @@ export class SessionAssignmentPolicy implements SessionAssignmentPolicyPort {
         permissionMode: resolveAssignmentPermissionMode(input.permissionMode),
         generationSettings: input.generationSettings,
         disabledAgentTools: normalizeDisabledAgentTools(input.disabledAgentTools),
-        activeSkills: normalizeActiveSkills(input.activeSkills)
+        activeSkills: normalizeActiveSkills(input.activeSkills),
+        toolModeOverride
       }
     }
 
@@ -172,7 +176,8 @@ export class SessionAssignmentPolicy implements SessionAssignmentPolicyPort {
         { disabledAgentTools: input.disabledAgentTools },
         { disabledAgentTools: agentConfig?.disabledAgentTools }
       ).disabledAgentTools,
-      activeSkills: normalizeActiveSkills(input.activeSkills)
+      activeSkills: normalizeActiveSkills(input.activeSkills),
+      toolModeOverride
     }
   }
 

--- a/src/main/session/contracts.ts
+++ b/src/main/session/contracts.ts
@@ -422,6 +422,7 @@ export interface SubagentAssignmentInput {
   generationSettings?: Partial<SessionGenerationSettings>
   disabledAgentTools?: string[]
   activeSkills?: string[]
+  toolModeOverride?: ToolModeOverride
 }
 
 export interface ResolvedSubagentAssignment {
@@ -433,6 +434,7 @@ export interface ResolvedSubagentAssignment {
   generationSettings?: Partial<SessionGenerationSettings>
   disabledAgentTools: string[]
   activeSkills: string[]
+  toolModeOverride: ToolModeOverride
 }
 
 export interface ResolvedTransferTarget {
@@ -584,6 +586,7 @@ export interface SessionLifecycleSubagentInput {
   generationSettings?: Partial<SessionGenerationSettings>
   disabledAgentTools?: string[]
   activeSkills?: string[]
+  toolModeOverride?: ToolModeOverride
   liveDelegationContext?: LiveDelegationSubagentContext
 }
 

--- a/src/main/session/lifecycle.ts
+++ b/src/main/session/lifecycle.ts
@@ -311,7 +311,8 @@ export class SessionLifecycle implements SessionLifecyclePort {
       permissionMode: input.permissionMode,
       generationSettings: input.generationSettings,
       disabledAgentTools: input.disabledAgentTools,
-      activeSkills: input.activeSkills
+      activeSkills: input.activeSkills,
+      toolModeOverride: input.toolModeOverride
     })
     return await this.dependencies.agentLifecycle.runWithAgentOperation(
       runtimeConfig.agentId,
@@ -352,6 +353,7 @@ export class SessionLifecycle implements SessionLifecyclePort {
           isDraft: false,
           disabledAgentTools: runtimeConfig.disabledAgentTools,
           orchestrationPolicy: DEFAULT_ORCHESTRATION_POLICY,
+          toolModeOverride: runtimeConfig.toolModeOverride,
           sessionKind: 'subagent',
           parentSessionId,
           subagentMeta

--- a/src/main/tool/agentTools/liveDelegationTool.ts
+++ b/src/main/tool/agentTools/liveDelegationTool.ts
@@ -85,6 +85,8 @@ export class LiveDelegationAgentTool {
         description: [
           'Control persistent direct-child Sessions for adaptive multi-Agent collaboration.',
           DEEPCHAT_SUBAGENT_MODEL_GUIDANCE,
+          "A spawned child Session inherits this Session's permission mode and tool mode, so its",
+          'tool calls run under the same trust boundary as approved here.',
           'Use spawn for one bounded task, send to leave a message without starting a turn,',
           'follow_up to start a later child turn, wait for bounded completion mailbox events,',
           'use list or inspect instead of wait to check permission or question states,',

--- a/src/main/tool/runtimePorts.ts
+++ b/src/main/tool/runtimePorts.ts
@@ -19,6 +19,7 @@ import type {
 } from '@shared/types/agent-interface'
 import type { LiveDelegationSubagentContext } from '@shared/orchestration/liveDelegation'
 import type { OrchestrationPolicy } from '@shared/orchestration/policy'
+import type { ToolModeOverride } from '@shared/toolMode'
 import type {
   LiveDelegationDetail,
   LiveDelegationEventSummary,
@@ -54,6 +55,7 @@ export interface ConversationSessionInfo {
   projectDir: string | null
   permissionMode: PermissionMode
   orchestrationPolicy: OrchestrationPolicy
+  toolModeOverride: ToolModeOverride
   generationSettings: SessionGenerationSettings | null
   disabledAgentTools: string[]
   activeSkills: string[]
@@ -85,6 +87,7 @@ export interface CreateSubagentSessionInput {
   providerId: string
   modelId: string
   permissionMode: PermissionMode
+  toolModeOverride?: ToolModeOverride
   generationSettings?: Partial<SessionGenerationSettings>
   disabledAgentTools?: string[]
   activeSkills?: string[]

--- a/test/main/orchestration/liveDelegationSafety.test.ts
+++ b/test/main/orchestration/liveDelegationSafety.test.ts
@@ -28,6 +28,7 @@ function createChild(overrides: Partial<ConversationSessionInfo> = {}): Conversa
     projectDir: '/repo',
     permissionMode: 'default',
     orchestrationPolicy: 'explicit',
+    toolModeOverride: null,
     generationSettings: { systemPrompt: 'Current prompt' },
     disabledAgentTools: [],
     activeSkills: [],
@@ -56,7 +57,8 @@ function createHarness(overrides: Partial<ConversationSessionInfo> = {}) {
     permissionMode: BASE_INPUT.parentPermissionMode,
     generationSettings: child?.generationSettings ?? undefined,
     disabledAgentTools: child?.disabledAgentTools ?? [],
-    activeSkills: child?.activeSkills ?? []
+    activeSkills: child?.activeSkills ?? [],
+    toolModeOverride: null
   }))
   const clearSessionPermissions = vi.fn(() => events.push('clear'))
   const setPermissionMode = vi.fn(async (_sessionId: string, permissionMode: string) => {

--- a/test/main/orchestration/liveDelegationService.test.ts
+++ b/test/main/orchestration/liveDelegationService.test.ts
@@ -1041,6 +1041,7 @@ describeIfSqlite('LiveDelegationService', () => {
     service.start()
     harness.parent.providerId = 'openai'
     harness.parent.modelId = 'model-frozen'
+    harness.parent.toolModeOverride = 'code'
     harness.parent.generationSettings = {
       systemPrompt: 'Frozen prompt',
       temperature: 0.2,
@@ -1056,6 +1057,7 @@ describeIfSqlite('LiveDelegationService', () => {
     })
     harness.parent.providerId = 'anthropic'
     harness.parent.modelId = 'model-later'
+    harness.parent.toolModeOverride = 'agent'
     harness.parent.generationSettings!.systemPrompt = 'Changed after scheduling'
     harness.parent.permissionMode = 'full_access'
     harness.parent.projectDir = '/repo-later'
@@ -1068,6 +1070,7 @@ describeIfSqlite('LiveDelegationService', () => {
         providerId: 'openai',
         modelId: 'model-frozen',
         permissionMode: 'full_access',
+        toolModeOverride: 'code',
         projectDir: '/repo-later',
         generationSettings: expect.objectContaining({ systemPrompt: 'Frozen prompt' })
       })
@@ -2986,6 +2989,7 @@ function createSessionInfo(
     projectDir: '/repo',
     permissionMode: 'default',
     orchestrationPolicy: 'explicit',
+    toolModeOverride: null,
     generationSettings: null,
     disabledAgentTools: [],
     activeSkills: [],

--- a/test/main/session/assignmentPolicy.test.ts
+++ b/test/main/session/assignmentPolicy.test.ts
@@ -153,7 +153,8 @@ describe('SessionAssignmentPolicy', () => {
       permissionMode: 'full_access',
       generationSettings: { systemPrompt: '' },
       disabledAgentTools: [],
-      activeSkills: []
+      activeSkills: [],
+      toolModeOverride: null
     })
     expect(catalog.resolveAgent).toHaveBeenCalledWith('claude-acp')
     await expect(policy.resolveTransferTarget('claude-acp', null)).rejects.toThrow(
@@ -175,7 +176,8 @@ describe('SessionAssignmentPolicy', () => {
         permissionMode: 'default',
         generationSettings: { systemPrompt: 'parent prompt', temperature: 0.2 },
         disabledAgentTools: ['exec'],
-        activeSkills: ['skill-a', 'skill-b']
+        activeSkills: ['skill-a', 'skill-b'],
+        toolModeOverride: 'code'
       })
     ).resolves.toEqual({
       agentId: 'deepchat',
@@ -185,7 +187,8 @@ describe('SessionAssignmentPolicy', () => {
       permissionMode: 'default',
       generationSettings: { systemPrompt: 'parent prompt', temperature: 0.2 },
       disabledAgentTools: ['exec'],
-      activeSkills: ['skill-a', 'skill-b']
+      activeSkills: ['skill-a', 'skill-b'],
+      toolModeOverride: 'code'
     })
   })
 
@@ -223,7 +226,8 @@ describe('SessionAssignmentPolicy', () => {
         temperature: 0.4
       },
       disabledAgentTools: ['exec', 'read', 'write'],
-      activeSkills: ['skill-a', 'skill-b', 'skill-c']
+      activeSkills: ['skill-a', 'skill-b', 'skill-c'],
+      toolModeOverride: null
     })
   })
 


### PR DESCRIPTION
## Summary

Delegated subagent sessions did not inherit the parent session's tool mode override. The spawn snapshot carried permission mode, model, and generation settings, but the child's tool mode was resolved from the model catalog default. As a result, a child of an explicitly agent-mode parent could silently run in code mode when the model catalog defaults to `code` (e.g. DeepSeek), since the child uses the same model as the parent and therefore the same catalog default.

## Changes

- Expose `toolModeOverride` on `ConversationSessionInfo` so the parent's resolved override is visible to orchestration
- Carry `toolModeOverride` through `CreateSubagentSessionInput`, the subagent assignment policy, and subagent session creation
- Assignment policy semantics: the parent's override is passed through for DeepChat children and forced to `null` for ACP children (tool mode does not apply to ACP sessions)
- Document in the `deepchat_subagents` tool description that a spawned child inherits the parent's permission mode and tool mode, so its tool calls run under the same trust boundary as approved at spawn time
- Extend the delegation snapshot regression test: the child receives the parent's override as of spawn time, and later parent mutations do not leak into the already-created child
- Update test fixtures for the new required field

## Testing

- `pnpm typecheck` (node + web): pass
- `pnpm format` / `pnpm lint`: pass
- `test/main/session/assignment.test.ts` (21 tests) and `test/main/orchestration/liveDelegationSafety.test.ts` (7 tests): pass
- `test/main/orchestration/liveDelegationService.test.ts` is gated on the native SQLite module in this environment and self-skips; the policy-layer behavior was additionally verified directly (parent override passthrough, missing override normalizes to `null`, ACP children force `null`)

## Notes

- Cross-agent children inherit the parent's tool mode intent as-is. Unlike permission mode, tool mode has no strictness ordering (`agent` / `code` / `minimal` are trade-offs, not a severity scale), so the target agent config does not intersect it.
- Deliberately out of scope: whether cell-internal subagent orchestration should be allowed under the `proactive` policy (the direct-tool carve-out keeps delegation out of the code-mode sandbox). That is a separate product decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Child sessions now inherit the parent session’s tool mode and permission settings, keeping delegated tool use within the approved trust boundary.
  * Tool mode overrides are preserved when creating and managing child sessions.
  * Delegated sessions consistently report their effective tool mode, including when no override is configured.

* **Tests**
  * Added coverage confirming tool mode settings remain consistent for child sessions, even when the parent session changes later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->