### PR TITLE
perf(tape): faster turns, atomic message facts

### DIFF
--- a/.github/workflows/prcheck.yml
+++ b/.github/workflows/prcheck.yml
@@ -176,6 +176,8 @@ jobs:
           test/main/session/data/tapeLineage.test.ts
           test/main/session/data/tapeRecall.test.ts
           test/main/session/data/tapeViewReplay.test.ts
+          test/main/session/data/tables/deepchatTapeEntriesTable.test.ts
+          test/main/session/data/transcriptAtomicity.test.ts
 
       - name: Validate encrypted OCR artifact storage
         env:

--- a/src/main/agent/deepchat/runtime/process.ts
+++ b/src/main/agent/deepchat/runtime/process.ts
@@ -42,7 +42,10 @@ import {
 } from '@/agent/deepchat/loop/loopRun'
 import { emitDeepChatLoopNotification } from '@/agent/deepchat/loop/notificationObserver'
 import type { OutputSink } from '@/agent/deepchat/loop/ports'
-import { buildTapeToolFactInputs } from '@/tape/application/factPersistence'
+import {
+  buildTapeToolFactInputs,
+  buildTapeToolFactProvenanceKey
+} from '@/tape/application/factPersistence'
 import {
   ExecutionJournalCorruptionError,
   ExecutionJournalError,
@@ -1000,6 +1003,9 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
   logger.info(`[ProcessStream] start session=${io.sessionId} message=${io.messageId}`)
   let eventCount = 0
   let pendingToolSurfaceCandidateRelease: PendingToolSurfaceCandidateRelease | null = null
+  // Every round replays all settled tool blocks of the message; facts appended by an earlier
+  // round of this Run are skipped here instead of round-tripping the store's idempotency check.
+  const appendedToolFactKeys = new Set<string>()
   const commits: DeepChatLoopCommitCallbacks<StreamState, ProcessResult, ProcessResult> = {
     updateOutput: ({ outcome }) => {
       if (outcome === 'halted' || firstProviderRoundReady || state.blocks.length === 0) {
@@ -1028,7 +1034,10 @@ export async function processStream(params: ProcessParams): Promise<ProcessResul
       const toolResultBySourceId = new Map<string, TapeToolResultFactReference>()
       try {
         for (const input of buildTapeToolFactInputs(record)) {
+          const factKey = buildTapeToolFactProvenanceKey(input)
+          if (factKey && appendedToolFactKeys.has(factKey)) continue
           const receipt = await params.io.tapeToolFactWriter.appendToolFact(input)
+          if (factKey) appendedToolFactKeys.add(factKey)
           if (input.provenance.source === 'tool_result' && receipt.toolResult) {
             toolResultBySourceId.set(input.provenance.sourceId, receipt.toolResult)
           }

--- a/src/main/data/connectionConfig.ts
+++ b/src/main/data/connectionConfig.ts
@@ -2,14 +2,6 @@ import type Database from 'better-sqlite3-multiple-ciphers'
 
 export const SQLCIPHER_COMPATIBILITY_VERSION = 4
 
-/**
- * Page cache ceiling in KiB (negative `cache_size` values are KiB). SQLCipher decrypts every page
- * it loads, so the whole-session Tape reads that run before each provider request pay the
- * decryption cost again whenever the session no longer fits in the cache. 64 MiB keeps a
- * 10k-entry session resident; the cache only grows to the pages actually touched.
- */
-export const SQLITE_PAGE_CACHE_KIB = 65_536
-
 export function configureSQLCipherCompatibility(db: Database.Database): void {
   db.pragma("cipher='sqlcipher'")
   db.pragma(`legacy=${SQLCIPHER_COMPATIBILITY_VERSION}`)
@@ -26,5 +18,7 @@ export function configureSQLiteConnection(db: Database.Database, password?: stri
   }
 
   db.pragma('journal_mode = WAL')
-  db.pragma(`cache_size = -${SQLITE_PAGE_CACHE_KIB}`)
+  // 64 MiB page cache (negative = KiB). SQLCipher decrypts every page it loads, so the
+  // whole-session Tape reads before each provider request must stay resident to be cheap.
+  db.pragma('cache_size = -65536')
 }

--- a/src/main/data/connectionConfig.ts
+++ b/src/main/data/connectionConfig.ts
@@ -18,7 +18,9 @@ export function configureSQLiteConnection(db: Database.Database, password?: stri
   }
 
   db.pragma('journal_mode = WAL')
-  // 64 MiB page cache (negative = KiB). SQLCipher decrypts every page it loads, so the
-  // whole-session Tape reads before each provider request must stay resident to be cheap.
+  // 64 MiB page cache ceiling (negative = KiB) for every connection opened through this helper.
+  // It is sized for the main database: SQLCipher decrypts every page it loads, so the whole-session
+  // Tape reads before each provider request must stay resident to be cheap. Other connections
+  // (importer, OCR store, utility hosts) only grow the cache to the pages they actually touch.
   db.pragma('cache_size = -65536')
 }

--- a/src/main/data/connectionConfig.ts
+++ b/src/main/data/connectionConfig.ts
@@ -2,6 +2,14 @@ import type Database from 'better-sqlite3-multiple-ciphers'
 
 export const SQLCIPHER_COMPATIBILITY_VERSION = 4
 
+/**
+ * Page cache ceiling in KiB (negative `cache_size` values are KiB). SQLCipher decrypts every page
+ * it loads, so the whole-session Tape reads that run before each provider request pay the
+ * decryption cost again whenever the session no longer fits in the cache. 64 MiB keeps a
+ * 10k-entry session resident; the cache only grows to the pages actually touched.
+ */
+export const SQLITE_PAGE_CACHE_KIB = 65_536
+
 export function configureSQLCipherCompatibility(db: Database.Database): void {
   db.pragma("cipher='sqlcipher'")
   db.pragma(`legacy=${SQLCIPHER_COMPATIBILITY_VERSION}`)
@@ -18,4 +26,5 @@ export function configureSQLiteConnection(db: Database.Database, password?: stri
   }
 
   db.pragma('journal_mode = WAL')
+  db.pragma(`cache_size = -${SQLITE_PAGE_CACHE_KIB}`)
 }

--- a/src/main/session/data/tables/deepchatMessages.ts
+++ b/src/main/session/data/tables/deepchatMessages.ts
@@ -47,6 +47,10 @@ const COMPACTION_RECOVERY_INDEX_SQL = `
     WHERE ${COMPACTION_RECOVERY_PREDICATE};
 `
 
+/**
+ * Every UPDATE here must stamp `updated_at = Date.now()`: the Tape reconciler treats an unchanged
+ * `(count, max(order_seq), max(updated_at))` as proof the session transcript did not change.
+ */
 export class DeepChatMessagesTable extends BaseTable {
   constructor(db: Database.Database) {
     super(db, 'deepchat_messages')

--- a/src/main/session/data/tables/deepchatMessages.ts
+++ b/src/main/session/data/tables/deepchatMessages.ts
@@ -49,7 +49,7 @@ const COMPACTION_RECOVERY_INDEX_SQL = `
 
 /**
  * Every UPDATE here must stamp `updated_at = Date.now()`: the Tape reconciler treats an unchanged
- * `(count, max(order_seq), max(updated_at))` as proof the session transcript did not change.
+ * `(count, max(updated_at))` as proof the session transcript did not change.
  */
 export class DeepChatMessagesTable extends BaseTable {
   constructor(db: Database.Database) {

--- a/src/main/session/data/tables/deepchatMessages.ts
+++ b/src/main/session/data/tables/deepchatMessages.ts
@@ -48,8 +48,8 @@ const COMPACTION_RECOVERY_INDEX_SQL = `
 `
 
 /**
- * Every UPDATE here must stamp `updated_at = Date.now()`: the Tape reconciler treats an unchanged
- * `(count, max(updated_at))` as proof the session transcript did not change.
+ * Every UPDATE here must stamp `updated_at = Date.now()`: the Tape reconciler treats unchanged
+ * per-row `(id, order_seq, status, updated_at)` as proof the session transcript did not change.
  */
 export class DeepChatMessagesTable extends BaseTable {
   constructor(db: Database.Database) {

--- a/src/main/session/data/transcript.ts
+++ b/src/main/session/data/transcript.ts
@@ -245,18 +245,20 @@ export class SessionTranscript {
   ): string {
     const id = nanoid()
     const serializedContent = JSON.stringify(content)
-    this.database.deepchatMessagesTable.insert({
-      id,
-      sessionId,
-      orderSeq,
-      role: 'user',
-      content: serializedContent,
-      status: options?.status ?? 'sent',
-      ...(options?.metadata ? { metadata: JSON.stringify(options.metadata) } : {})
+    this.runInDatabaseTransaction(() => {
+      this.database.deepchatMessagesTable.insert({
+        id,
+        sessionId,
+        orderSeq,
+        role: 'user',
+        content: serializedContent,
+        status: options?.status ?? 'sent',
+        ...(options?.metadata ? { metadata: JSON.stringify(options.metadata) } : {})
+      })
+      this.persistUserContent(id, content)
+      this.upsertMessageSearchDocument(sessionId, id, 'user', serializedContent)
+      this.appendLiveTapeFacts(id)
     })
-    this.persistUserContent(id, content)
-    this.upsertMessageSearchDocument(sessionId, id, 'user', serializedContent)
-    this.appendLiveTapeFacts(id)
     return id
   }
 
@@ -462,16 +464,18 @@ export class SessionTranscript {
     blocks: AssistantMessageBlock[],
     metadata: string
   ): void {
-    this.database.deepchatAssistantBlocksTable.replaceForMessage(messageId, blocks)
-    this.database.deepchatMessagesTable.updateContentAndStatus(
-      messageId,
-      JSON.stringify(blocks),
-      'sent',
-      metadata
-    )
-    this.upsertAssistantSearchDocument(messageId, blocks)
-    this.persistUsageStats(messageId, metadata, 'live')
-    this.appendLiveTapeFacts(messageId)
+    this.runInDatabaseTransaction(() => {
+      this.database.deepchatAssistantBlocksTable.replaceForMessage(messageId, blocks)
+      this.database.deepchatMessagesTable.updateContentAndStatus(
+        messageId,
+        JSON.stringify(blocks),
+        'sent',
+        metadata
+      )
+      this.upsertAssistantSearchDocument(messageId, blocks)
+      this.persistUsageStats(messageId, metadata, 'live')
+      this.appendLiveTapeFacts(messageId)
+    })
   }
 
   updateCompactionMessage(
@@ -512,27 +516,29 @@ export class SessionTranscript {
   }
 
   setMessageError(messageId: string, blocks: AssistantMessageBlock[], metadata?: string): void {
-    this.database.deepchatAssistantBlocksTable.replaceForMessage(messageId, blocks)
-    const serializedBlocks = JSON.stringify(blocks)
-    if (metadata === undefined) {
+    this.runInDatabaseTransaction(() => {
+      this.database.deepchatAssistantBlocksTable.replaceForMessage(messageId, blocks)
+      const serializedBlocks = JSON.stringify(blocks)
+      if (metadata === undefined) {
+        this.database.deepchatMessagesTable.updateContentAndStatus(
+          messageId,
+          serializedBlocks,
+          'error'
+        )
+        this.upsertAssistantSearchDocument(messageId, blocks)
+        this.appendLiveTapeFacts(messageId)
+        return
+      }
       this.database.deepchatMessagesTable.updateContentAndStatus(
         messageId,
         serializedBlocks,
-        'error'
+        'error',
+        metadata
       )
       this.upsertAssistantSearchDocument(messageId, blocks)
+      this.persistUsageStats(messageId, metadata, 'live')
       this.appendLiveTapeFacts(messageId)
-      return
-    }
-    this.database.deepchatMessagesTable.updateContentAndStatus(
-      messageId,
-      serializedBlocks,
-      'error',
-      metadata
-    )
-    this.upsertAssistantSearchDocument(messageId, blocks)
-    this.persistUsageStats(messageId, metadata, 'live')
-    this.appendLiveTapeFacts(messageId)
+    })
   }
 
   getMessages(sessionId: string): ChatMessageRecord[] {
@@ -631,6 +637,10 @@ export class SessionTranscript {
   }
 
   updateMessageContent(messageId: string, content: string): void {
+    this.runInDatabaseTransaction(() => this.applyMessageContentUpdate(messageId, content))
+  }
+
+  private applyMessageContentUpdate(messageId: string, content: string): void {
     this.database.deepchatMessagesTable.updateContent(messageId, content)
     const row = this.database.deepchatMessagesTable.get(messageId)
     if (!row) {

--- a/src/main/tape/application/factPersistence.ts
+++ b/src/main/tape/application/factPersistence.ts
@@ -25,7 +25,7 @@ export { tapeEntryToMessageRecord } from '@/tape/domain/effectiveSemantics'
 export type { TapeFactSource } from '@/tape/domain/facts'
 
 type TapeFactWriter = Pick<TapeEntryStore, 'append' | 'appendEvent'> & TapeBootstrapStore
-type TapeFactStore = TapeFactWriter & Pick<TapeEntryStore, 'getBySessionExcludingContext'>
+type TapeFactStore = TapeFactWriter & Pick<TapeEntryStore, 'getEffectiveViewInputRows'>
 
 interface TapeToolRevisionState {
   semanticFingerprint: string
@@ -519,7 +519,7 @@ export function appendMessageReplacementToTape(
   const toolInputs = options.revisionKind === 'record' ? buildTapeToolFactInputs(record) : []
   const toolRevisionIndex =
     toolInputs.length > 0
-      ? buildTapeToolRevisionIndex(table.getBySessionExcludingContext(record.sessionId))
+      ? buildTapeToolRevisionIndex(table.getEffectiveViewInputRows(record.sessionId))
       : null
 
   table.append({

--- a/src/main/tape/application/factPersistence.ts
+++ b/src/main/tape/application/factPersistence.ts
@@ -273,6 +273,21 @@ function describeTapeToolFact(input: TapeToolFactInput): {
   }
 }
 
+/**
+ * The provenance key a live `appendTapeToolFact` would assign to this input; null when the input
+ * is not appendable. Callers use it to recognise facts they already appended without a lookup.
+ */
+export function buildTapeToolFactProvenanceKey(input: TapeToolFactInput): string | null {
+  const prepared = prepareTapeToolFact(input)
+  if (!prepared) return null
+  return buildToolFactProvenanceKey(
+    prepared.kind,
+    input.messageId,
+    prepared.toolCallId,
+    prepared.payload
+  )
+}
+
 export function buildTapeToolRevisionIndex(rows: DeepChatTapeEntryRow[]): TapeToolRevisionIndex {
   const revisions: TapeToolRevisionIndex = new Map()
   for (const row of rows) {

--- a/src/main/tape/application/factService.ts
+++ b/src/main/tape/application/factService.ts
@@ -285,7 +285,7 @@ export class TapeFactService
   }
 
   getMessageRecords(sessionId: string): ChatMessageRecord[] {
-    return buildEffectiveTapeView(this.table.getBySessionExcludingContext(sessionId), {
+    return buildEffectiveTapeView(this.table.getEffectiveViewInputRows(sessionId), {
       includePending: true
     }).messageRecords
   }

--- a/src/main/tape/application/reconcilerService.ts
+++ b/src/main/tape/application/reconcilerService.ts
@@ -10,11 +10,29 @@ type TapeReconcilerProviders = Pick<
   'getEntryStore' | 'getLegacySummaryReader'
 >
 
+/**
+ * What the last completed backfill of a session saw. Every transcript mutation either changes the
+ * row count or stamps a row with `updated_at = Date.now()`, and every Tape reset mints a new
+ * incarnation, so an identical snapshot proves the backfill has nothing left to do.
+ */
+interface ReconciledTranscriptSnapshot {
+  messageCount: number
+  maxOrderSeq: number
+  maxUpdatedAt: number
+  tapeIncarnationId: string
+}
+
 function legacySummaryProvenanceKey(sessionId: string): string {
   return `summary:${sessionId}:legacy-summary:v1`
 }
 
 export class TapeReconcilerService {
+  /**
+   * Keyed by session id; absent until the first completed backfill in this process. Entries are
+   * never evicted: a stale one costs ~100 bytes and can only ever force a full backfill.
+   */
+  private readonly reconciled = new Map<string, ReconciledTranscriptSnapshot>()
+
   constructor(
     private readonly providers: TapeReconcilerProviders,
     private readonly facts: TapeFactService
@@ -29,13 +47,34 @@ export class TapeReconcilerService {
     messageStore: TapeTranscriptReader
   ): TapeBackfillResult {
     const table = this.table
+    const observedAt = Date.now()
     const historyRecords = [...messageStore.getMessages(sessionId)].sort(
       (left, right) => left.orderSeq - right.orderSeq
     )
-    const maxOrderSeq = historyRecords.reduce(
-      (currentMax, record) => Math.max(currentMax, record.orderSeq),
-      0
-    )
+    let maxOrderSeq = 0
+    let maxUpdatedAt = 0
+    for (const record of historyRecords) {
+      maxOrderSeq = Math.max(maxOrderSeq, record.orderSeq)
+      maxUpdatedAt = Math.max(maxUpdatedAt, record.updatedAt)
+    }
+
+    const previous = this.reconciled.get(sessionId)
+    if (
+      previous &&
+      previous.messageCount === historyRecords.length &&
+      previous.maxOrderSeq === maxOrderSeq &&
+      previous.maxUpdatedAt === maxUpdatedAt &&
+      previous.tapeIncarnationId === table.getBootstrapIncarnation(sessionId)
+    ) {
+      return {
+        sessionId,
+        migrationState: 'ready',
+        messageCount: historyRecords.length,
+        maxOrderSeq,
+        appendedFactCount: 0,
+        historyRecords: this.facts.getMessageRecords(sessionId)
+      }
+    }
 
     table.ensureBootstrapAnchor(sessionId)
 
@@ -65,6 +104,21 @@ export class TapeReconcilerService {
       },
       idempotent: true
     })
+
+    // `updated_at` has millisecond resolution: a mutation landing in the same millisecond as the
+    // newest row we saw would be indistinguishable from it, so only remember snapshots whose newest
+    // write is already strictly in the past.
+    const tapeIncarnationId = table.getBootstrapIncarnation(sessionId)
+    if (tapeIncarnationId && maxUpdatedAt < observedAt) {
+      this.reconciled.set(sessionId, {
+        messageCount: historyRecords.length,
+        maxOrderSeq,
+        maxUpdatedAt,
+        tapeIncarnationId
+      })
+    } else {
+      this.reconciled.delete(sessionId)
+    }
 
     return {
       sessionId,

--- a/src/main/tape/application/reconcilerService.ts
+++ b/src/main/tape/application/reconcilerService.ts
@@ -40,9 +40,7 @@ export class TapeReconcilerService {
     table.ensureBootstrapAnchor(sessionId)
 
     let appendedFactCount = 0
-    const toolRevisionIndex = buildTapeToolRevisionIndex(
-      table.getBySessionExcludingContext(sessionId)
-    )
+    const toolRevisionIndex = buildTapeToolRevisionIndex(table.getEffectiveViewInputRows(sessionId))
     for (const record of historyRecords) {
       appendedFactCount += appendMessageRecordToTape(table, record, 'backfill', {
         toolRevisionIndex

--- a/src/main/tape/application/reconcilerService.ts
+++ b/src/main/tape/application/reconcilerService.ts
@@ -12,14 +12,17 @@ type TapeReconcilerProviders = Pick<
 
 /**
  * What the last completed backfill of a session saw. Every transcript mutation either changes the
- * row count or stamps a row with `updated_at = Date.now()`, and every Tape reset mints a new
- * incarnation, so an identical snapshot proves the backfill has nothing left to do.
+ * row count or stamps a row with `updated_at = Date.now()`, every Tape reset mints a new
+ * incarnation, and every Tape append moves the head, so an identical snapshot proves the backfill
+ * has nothing left to do. The head also catches the database file being swapped underneath a live
+ * process (sync restore, maintenance reopen), where the incarnation is copied rather than minted.
  */
 interface ReconciledTranscriptSnapshot {
   messageCount: number
   maxOrderSeq: number
   maxUpdatedAt: number
   tapeIncarnationId: string
+  tapeHeadEntryId: number
 }
 
 function legacySummaryProvenanceKey(sessionId: string): string {
@@ -58,13 +61,17 @@ export class TapeReconcilerService {
       maxUpdatedAt = Math.max(maxUpdatedAt, record.updatedAt)
     }
 
+    // A clock that stepped back to or before the newest remembered write could stamp a later
+    // mutation with a smaller `updated_at`, so the snapshot is only trusted while time is ahead of it.
     const previous = this.reconciled.get(sessionId)
     if (
       previous &&
+      previous.maxUpdatedAt < observedAt &&
       previous.messageCount === historyRecords.length &&
       previous.maxOrderSeq === maxOrderSeq &&
       previous.maxUpdatedAt === maxUpdatedAt &&
-      previous.tapeIncarnationId === table.getBootstrapIncarnation(sessionId)
+      previous.tapeIncarnationId === table.getBootstrapIncarnation(sessionId) &&
+      previous.tapeHeadEntryId === table.getMaxEntryId(sessionId)
     ) {
       return {
         sessionId,
@@ -107,14 +114,16 @@ export class TapeReconcilerService {
 
     // `updated_at` has millisecond resolution: a mutation landing in the same millisecond as the
     // newest row we saw would be indistinguishable from it, so only remember snapshots whose newest
-    // write is already strictly in the past.
+    // write is already strictly in the past. Inside a host transaction the appends above are not
+    // committed yet and could still roll back, so nothing is remembered there either.
     const tapeIncarnationId = table.getBootstrapIncarnation(sessionId)
-    if (tapeIncarnationId && maxUpdatedAt < observedAt) {
+    if (tapeIncarnationId && maxUpdatedAt < observedAt && !table.isInTransaction()) {
       this.reconciled.set(sessionId, {
         messageCount: historyRecords.length,
         maxOrderSeq,
         maxUpdatedAt,
-        tapeIncarnationId
+        tapeIncarnationId,
+        tapeHeadEntryId: table.getMaxEntryId(sessionId)
       })
     } else {
       this.reconciled.delete(sessionId)

--- a/src/main/tape/application/reconcilerService.ts
+++ b/src/main/tape/application/reconcilerService.ts
@@ -19,7 +19,6 @@ type TapeReconcilerProviders = Pick<
  */
 interface ReconciledTranscriptSnapshot {
   messageCount: number
-  maxOrderSeq: number
   maxUpdatedAt: number
   tapeIncarnationId: string
   tapeHeadEntryId: number
@@ -68,7 +67,6 @@ export class TapeReconcilerService {
       previous &&
       previous.maxUpdatedAt < observedAt &&
       previous.messageCount === historyRecords.length &&
-      previous.maxOrderSeq === maxOrderSeq &&
       previous.maxUpdatedAt === maxUpdatedAt &&
       previous.tapeIncarnationId === table.getBootstrapIncarnation(sessionId) &&
       previous.tapeHeadEntryId === table.getMaxEntryId(sessionId)
@@ -120,7 +118,6 @@ export class TapeReconcilerService {
     if (tapeIncarnationId && maxUpdatedAt < observedAt && !table.isInTransaction()) {
       this.reconciled.set(sessionId, {
         messageCount: historyRecords.length,
-        maxOrderSeq,
         maxUpdatedAt,
         tapeIncarnationId,
         tapeHeadEntryId: table.getMaxEntryId(sessionId)

--- a/src/main/tape/application/reconcilerService.ts
+++ b/src/main/tape/application/reconcilerService.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import type { ChatMessageRecord } from '@shared/types/agent-interface'
 import type { TapeApplicationProviders } from '../ports/application'
 import type { TapeBackfillResult, TapeTranscriptReader } from '../ports/capabilities'
@@ -11,17 +12,25 @@ type TapeReconcilerProviders = Pick<
 >
 
 /**
- * What the last completed backfill of a session saw. Every transcript mutation either changes the
- * row count or stamps a row with `updated_at = Date.now()`, every Tape reset mints a new
- * incarnation, and every Tape append moves the head, so an identical snapshot proves the backfill
- * has nothing left to do. The head also catches the database file being swapped underneath a live
- * process (sync restore, maintenance reopen), where the incarnation is copied rather than minted.
+ * What the last completed backfill of a session saw. The transcript digest covers exactly the row
+ * fields the backfill keys its facts on (identity, order, status, `updated_at`), so an unchanged
+ * digest means a rerun could append nothing new; unlike a clock-based check it does not care which
+ * direction time moved. Every Tape reset mints a new incarnation and every Tape append moves the
+ * head; the head also catches the database file being swapped underneath a live process (sync
+ * restore, maintenance reopen), where the incarnation is copied rather than minted.
  */
 interface ReconciledTranscriptSnapshot {
-  messageCount: number
-  maxUpdatedAt: number
+  transcriptDigest: string
   tapeIncarnationId: string
   tapeHeadEntryId: number
+}
+
+function digestTranscript(records: readonly ChatMessageRecord[]): string {
+  const hash = createHash('sha256')
+  for (const record of records) {
+    hash.update(`${record.id}\n${record.orderSeq}\n${record.status}\n${record.updatedAt}\n`)
+  }
+  return hash.digest('base64')
 }
 
 function legacySummaryProvenanceKey(sessionId: string): string {
@@ -49,25 +58,19 @@ export class TapeReconcilerService {
     messageStore: TapeTranscriptReader
   ): TapeBackfillResult {
     const table = this.table
-    const observedAt = Date.now()
     const historyRecords = [...messageStore.getMessages(sessionId)].sort(
       (left, right) => left.orderSeq - right.orderSeq
     )
-    let maxOrderSeq = 0
-    let maxUpdatedAt = 0
-    for (const record of historyRecords) {
-      maxOrderSeq = Math.max(maxOrderSeq, record.orderSeq)
-      maxUpdatedAt = Math.max(maxUpdatedAt, record.updatedAt)
-    }
+    const maxOrderSeq = historyRecords.reduce(
+      (currentMax, record) => Math.max(currentMax, record.orderSeq),
+      0
+    )
+    const transcriptDigest = digestTranscript(historyRecords)
 
-    // A clock that stepped back to or before the newest remembered write could stamp a later
-    // mutation with a smaller `updated_at`, so the snapshot is only trusted while time is ahead of it.
     const previous = this.reconciled.get(sessionId)
     if (
       previous &&
-      previous.maxUpdatedAt < observedAt &&
-      previous.messageCount === historyRecords.length &&
-      previous.maxUpdatedAt === maxUpdatedAt &&
+      previous.transcriptDigest === transcriptDigest &&
       previous.tapeIncarnationId === table.getBootstrapIncarnation(sessionId) &&
       previous.tapeHeadEntryId === table.getMaxEntryId(sessionId)
     ) {
@@ -110,15 +113,12 @@ export class TapeReconcilerService {
       idempotent: true
     })
 
-    // `updated_at` has millisecond resolution: a mutation landing in the same millisecond as the
-    // newest row we saw would be indistinguishable from it, so only remember snapshots whose newest
-    // write is already strictly in the past. Inside a host transaction the appends above are not
-    // committed yet and could still roll back, so nothing is remembered there either.
+    // Inside a host transaction the appends above are not committed yet and could still roll back,
+    // so nothing is remembered there.
     const tapeIncarnationId = table.getBootstrapIncarnation(sessionId)
-    if (tapeIncarnationId && maxUpdatedAt < observedAt && !table.isInTransaction()) {
+    if (tapeIncarnationId && !table.isInTransaction()) {
       this.reconciled.set(sessionId, {
-        messageCount: historyRecords.length,
-        maxUpdatedAt,
+        transcriptDigest,
         tapeIncarnationId,
         tapeHeadEntryId: table.getMaxEntryId(sessionId)
       })

--- a/src/main/tape/application/viewReplayService.ts
+++ b/src/main/tape/application/viewReplayService.ts
@@ -322,7 +322,7 @@ export class TapeViewReplayService {
     messageId?: string
   ): TapeViewManifestAssemblySources {
     const table = this.table
-    const rows = table.getBySessionExcludingContext(sessionId)
+    const rows = table.getEffectiveViewInputRows(sessionId)
     const entryIdByMessageId = new Map<string, number>()
     const messageContentHashByMessageId = new Map<string, string>()
     const toolCallEntryIdByToolId = new Map<string, number>()

--- a/src/main/tape/domain/effectiveSemantics.ts
+++ b/src/main/tape/domain/effectiveSemantics.ts
@@ -3,8 +3,6 @@ import type { DeepChatTapeEntryRow } from './entry'
 
 const TERMINAL_TAPE_TOOL_STATUSES = new Set(['success', 'error'])
 
-export const MESSAGE_RETRACTION_EVENT_NAME = 'message/retracted'
-
 /**
  * Rows that can change effective message/tool state or anchor positions. Every other row
  * (ViewManifests, Journal, provider attempts, contracts, tool-surface provenance, indicators) is
@@ -19,7 +17,7 @@ export function isEffectiveViewInputRow(row: { kind: string; name: string | null
     case 'anchor':
       return true
     case 'event':
-      return row.name === MESSAGE_RETRACTION_EVENT_NAME
+      return row.name === 'message/retracted'
     default:
       return false
   }
@@ -132,7 +130,7 @@ export function tapeMessageRank(record: ChatMessageRecord, includePending: boole
 }
 
 export function readTapeMessageRetractionId(row: DeepChatTapeEntryRow): string | null {
-  if (row.kind !== 'event' || row.name !== MESSAGE_RETRACTION_EVENT_NAME) {
+  if (row.kind !== 'event' || row.name !== 'message/retracted') {
     return null
   }
 

--- a/src/main/tape/domain/effectiveSemantics.ts
+++ b/src/main/tape/domain/effectiveSemantics.ts
@@ -3,6 +3,28 @@ import type { DeepChatTapeEntryRow } from './entry'
 
 const TERMINAL_TAPE_TOOL_STATUSES = new Set(['success', 'error'])
 
+export const MESSAGE_RETRACTION_EVENT_NAME = 'message/retracted'
+
+/**
+ * Rows that can change effective message/tool state or anchor positions. Every other row
+ * (ViewManifests, Journal, provider attempts, contracts, tool-surface provenance, indicators) is
+ * evidence the effective view only passes through, so readers that need effective state can skip
+ * it at the store. Must stay in sync with `TapeEntryStore.getEffectiveViewInputRows`.
+ */
+export function isEffectiveViewInputRow(row: { kind: string; name: string | null }): boolean {
+  switch (row.kind) {
+    case 'message':
+    case 'tool_call':
+    case 'tool_result':
+    case 'anchor':
+      return true
+    case 'event':
+      return row.name === MESSAGE_RETRACTION_EVENT_NAME
+    default:
+      return false
+  }
+}
+
 export interface DeepChatTapeToolIdentity {
   key: string
   messageId: string
@@ -110,7 +132,7 @@ export function tapeMessageRank(record: ChatMessageRecord, includePending: boole
 }
 
 export function readTapeMessageRetractionId(row: DeepChatTapeEntryRow): string | null {
-  if (row.kind !== 'event' || row.name !== 'message/retracted') {
+  if (row.kind !== 'event' || row.name !== MESSAGE_RETRACTION_EVENT_NAME) {
     return null
   }
 

--- a/src/main/tape/infrastructure/sqlite/tapeEntryStore.ts
+++ b/src/main/tape/infrastructure/sqlite/tapeEntryStore.ts
@@ -1259,6 +1259,22 @@ export class DeepChatTapeEntriesTable
       .all(sessionId) as DeepChatTapeEntryRow[]
   }
 
+  /** SQL mirror of `isEffectiveViewInputRow`; skips the bulky rows the effective view ignores. */
+  getEffectiveViewInputRows(sessionId: string): DeepChatTapeEntryRow[] {
+    return this.db
+      .prepare(
+        `SELECT *
+         FROM deepchat_tape_entries
+         WHERE session_id = ?
+           AND (
+             kind IN ('message', 'tool_call', 'tool_result', 'anchor')
+             OR (kind = 'event' AND name = 'message/retracted')
+           )
+         ORDER BY entry_id ASC`
+      )
+      .all(sessionId) as DeepChatTapeEntryRow[]
+  }
+
   getByEntryIds(sessionId: string, entryIds: readonly number[]): DeepChatTapeEntryRow[] {
     const normalizedIds = [...new Set(entryIds)]
       .filter((entryId) => Number.isSafeInteger(entryId) && entryId > 0)

--- a/src/main/tape/infrastructure/sqlite/tapeEntryStore.ts
+++ b/src/main/tape/infrastructure/sqlite/tapeEntryStore.ts
@@ -16,6 +16,7 @@ import {
   type TapeEventAppendInput
 } from '@/tape/domain/entry'
 import { DEFAULT_EXCLUDED_TAPE_EVENT_NAMES } from '@/tape/domain/effectiveView'
+import { parseTapeJsonObject } from '@/tape/domain/effectiveSemantics'
 import {
   EXECUTION_JOURNAL_EVENT_NAMES,
   isExecutionJournalReservedName,
@@ -1353,10 +1354,9 @@ export class DeepChatTapeEntriesTable
       )
       .get(sessionId) as { meta_json: string } | undefined
     if (!row) return undefined
-    const value = JSON.parse(row.meta_json) as Record<string, unknown>
-    return typeof value[TAPE_INCARNATION_META_KEY] === 'string'
-      ? value[TAPE_INCARNATION_META_KEY]
-      : undefined
+    // Callers treat `undefined` as "bootstrap missing or invalid"; unreadable meta is the latter.
+    const value = parseTapeJsonObject(row.meta_json)[TAPE_INCARNATION_META_KEY]
+    return typeof value === 'string' ? value : undefined
   }
 
   getMaxEventSourceSeq(

--- a/src/main/tape/ports/storage.ts
+++ b/src/main/tape/ports/storage.ts
@@ -87,6 +87,8 @@ export interface TapeEntryStore {
     limit: number
   ): DeepChatTapeEntryRow[]
   getBySessionExcludingContext(sessionId: string): DeepChatTapeEntryRow[]
+  /** Rows selected by `isEffectiveViewInputRow`, ordered by entry_id. */
+  getEffectiveViewInputRows(sessionId: string): DeepChatTapeEntryRow[]
   getByEntryIds(sessionId: string, entryIds: readonly number[]): DeepChatTapeEntryRow[]
   getMessageSourceEntries(sessionId: string, messageId: string): DeepChatTapeEntryRow[]
   getLatestViewManifestEvent(sessionId: string): DeepChatTapeEntryRow | undefined

--- a/test/main/agent/acp/compatibility/adapters.test.ts
+++ b/test/main/agent/acp/compatibility/adapters.test.ts
@@ -161,6 +161,7 @@ function createProjectionHarness() {
     deepchatUsageStatsTable: { upsert: vi.fn() },
     deepchatTapeEntriesTable: {
       ensureBootstrapAnchor: vi.fn(),
+      getBootstrapIncarnation: vi.fn(),
       append: vi.fn(appendTape),
       appendEvent: vi.fn(
         (input: {

--- a/test/main/agent/acp/compatibility/adapters.test.ts
+++ b/test/main/agent/acp/compatibility/adapters.test.ts
@@ -128,6 +128,7 @@ function createProjectionHarness() {
     return row
   }
   const sqlitePresenter = {
+    getDatabase: () => ({ transaction: (operation: () => unknown) => operation }),
     newSessionsTable: { get: vi.fn() },
     deepchatMessagesTable,
     deepchatSessionsTable: {

--- a/test/main/agent/acp/compatibility/adapters.test.ts
+++ b/test/main/agent/acp/compatibility/adapters.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@/agent/acp/compatibility/adapters'
 import { SessionTranscript } from '@/session/data/transcript'
 import { SessionTape } from '@/session/data/tape'
+import { isEffectiveViewInputRow } from '@/tape/domain/effectiveSemantics'
 import type { MainDatabase } from '@/data/mainDatabase'
 
 const publishDeepchatEvent = vi.fn()
@@ -182,6 +183,9 @@ function createProjectionHarness() {
       ),
       getBySessionExcludingContext: vi.fn((sessionId: string) =>
         tapeRows.filter((row) => row.session_id === sessionId && row.kind !== 'context')
+      ),
+      getEffectiveViewInputRows: vi.fn((sessionId: string) =>
+        tapeRows.filter((row) => row.session_id === sessionId && isEffectiveViewInputRow(row))
       )
     }
   } as unknown as MainDatabase

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -31,6 +31,7 @@ import {
   getUsableContextLength
 } from '@/agent/deepchat/runtime/contextBudget'
 import { appendMessageRecordToTape } from '@/session/data/tapeFacts'
+import { isEffectiveViewInputRow } from '@/tape/domain/effectiveSemantics'
 import { resolveInterleavedReasoningConfig } from '@/agent/deepchat/runtime/generationSettings'
 import { toAcpRemoteSessionId, toAppSessionId } from '@/agent/shared/agentSessionIds'
 import { createLoopRun, type LoopRunRequestToolSurfaceBinding } from '@/agent/deepchat/loop/loopRun'
@@ -556,6 +557,11 @@ function createMockSqlitePresenter() {
       ),
       getBySessionExcludingContext: vi.fn((sessionId: string) =>
         tapeEntries.filter((entry) => entry.session_id === sessionId && entry.kind !== 'context')
+      ),
+      getEffectiveViewInputRows: vi.fn((sessionId: string) =>
+        tapeEntries.filter(
+          (entry) => entry.session_id === sessionId && isEffectiveViewInputRow(entry)
+        )
       ),
       getByEntryIds: vi.fn((sessionId: string, entryIds: readonly number[]) => {
         const selected = new Set(entryIds)

--- a/test/main/agent/deepchat/runtime/process.test.ts
+++ b/test/main/agent/deepchat/runtime/process.test.ts
@@ -1039,7 +1039,7 @@ describe('processStream', () => {
       expect(messageStore.setMessageError).not.toHaveBeenCalled()
     })
 
-    it('persists each tool round before entering the next provider round', async () => {
+    it('persists each tool round once before entering the next provider round', async () => {
       const order: string[] = []
       observeCommitOrder(order)
       let providerRound = 0
@@ -1090,14 +1090,13 @@ describe('processStream', () => {
         'message:update',
         'tape:tool_call',
         'tape:tool_result',
-        'tape:tool_call',
-        'tape:tool_result',
         'journal:terminal',
         'message:complete',
         'renderer:update',
         'renderer:complete'
       ])
-      expect(tapeToolFactWriter.appendToolFact).toHaveBeenCalledTimes(6)
+      // Round 2 replays the whole message but must not re-append the facts round 1 settled.
+      expect(tapeToolFactWriter.appendToolFact).toHaveBeenCalledTimes(4)
       expect(
         tapeToolFactWriter.appendToolFact.mock.calls.map(([input]) => [
           input.provenance.source,
@@ -1105,8 +1104,6 @@ describe('processStream', () => {
           input.provenance.sequence
         ])
       ).toEqual([
-        ['tool_call', 'm1:tc1', 0],
-        ['tool_result', 'm1:tc1', 0],
         ['tool_call', 'm1:tc1', 0],
         ['tool_result', 'm1:tc1', 0],
         ['tool_call', 'm1:tc2', 1],
@@ -1129,6 +1126,58 @@ describe('processStream', () => {
       expect(result.status).toBe('completed')
       expect(coreStream).toHaveBeenCalledTimes(2)
       expect(tapeToolFactWriter.appendToolFact).toHaveBeenCalledTimes(1)
+    })
+
+    it('retries a tool fact in the next round when its earlier append failed', async () => {
+      tapeToolFactWriter.appendToolFact
+        .mockImplementationOnce(async (input) => tapeToolFactReceipt(input))
+        .mockRejectedValueOnce(new Error('tape unavailable'))
+      let providerRound = 0
+      const coreStream = vi.fn(() => {
+        providerRound += 1
+        if (providerRound <= 2) {
+          const toolCallId = `tc${providerRound}`
+          return (async function* () {
+            yield {
+              type: 'tool_call_start',
+              tool_call_id: toolCallId,
+              tool_call_name: 'action'
+            } as LLMCoreStreamEvent
+            yield {
+              type: 'tool_call_end',
+              tool_call_id: toolCallId,
+              tool_call_arguments_complete: '{}'
+            } as LLMCoreStreamEvent
+            yield { type: 'stop', stop_reason: 'tool_use' } as LLMCoreStreamEvent
+          })()
+        }
+        return (async function* () {
+          yield { type: 'text', content: 'Done' } as LLMCoreStreamEvent
+          yield { type: 'stop', stop_reason: 'complete' } as LLMCoreStreamEvent
+        })()
+      }) as unknown as ProcessParams['coreStream']
+
+      const result = await processStream(
+        createParams({
+          coreStream,
+          toolExecution: createToolExecutionPort(createMockToolService({ action: 'ok' })),
+          tools: [makeTool('action')]
+        })
+      )
+
+      expect(result.status).toBe('completed')
+      expect(
+        tapeToolFactWriter.appendToolFact.mock.calls.map(([input]) => [
+          input.provenance.source,
+          input.provenance.sourceId
+        ])
+      ).toEqual([
+        ['tool_call', 'm1:tc1'],
+        ['tool_result', 'm1:tc1'], // round 1: rejected
+        ['tool_result', 'm1:tc1'], // round 2: retried, tool_call not repeated
+        ['tool_call', 'm1:tc2'],
+        ['tool_result', 'm1:tc2']
+      ])
     })
 
     it('releases ToolSearch candidates only after the settled round is persisted', async () => {

--- a/test/main/data/databaseConnection.test.ts
+++ b/test/main/data/databaseConnection.test.ts
@@ -45,7 +45,8 @@ describe('main database connection configuration', () => {
     expect(mocks.pragma.mock.calls.map(([statement]) => statement)).toEqual([
       `cipher='sqlcipher'`,
       'legacy=4',
-      'journal_mode = WAL'
+      'journal_mode = WAL',
+      'cache_size = -65536'
     ])
     expect(mocks.key).toHaveBeenCalledWith(Buffer.from(password, 'utf8'))
     expect(mocks.key.mock.invocationCallOrder[0]).toBeGreaterThan(
@@ -60,13 +61,16 @@ describe('main database connection configuration', () => {
     expect(mocks.pragma).not.toHaveBeenCalledWith(expect.stringContaining(password))
   })
 
-  it('enables WAL directly for unencrypted databases', async () => {
+  it('enables WAL and the page cache ceiling directly for unencrypted databases', async () => {
     const { openSQLiteDatabase } = await import('../../../src/main/data/databaseConnection')
     const dbPath = path.join(process.cwd(), 'agent.db')
 
     openSQLiteDatabase(dbPath)
 
-    expect(mocks.pragma.mock.calls.map(([statement]) => statement)).toEqual(['journal_mode = WAL'])
+    expect(mocks.pragma.mock.calls.map(([statement]) => statement)).toEqual([
+      'journal_mode = WAL',
+      'cache_size = -65536'
+    ])
   })
 
   it('closes the database when connection configuration fails', async () => {

--- a/test/main/session/data/tables/deepchatTapeEntriesTable.test.ts
+++ b/test/main/session/data/tables/deepchatTapeEntriesTable.test.ts
@@ -467,6 +467,20 @@ describeIfSqlite('DeepChatTapeEntriesTable', () => {
     db.close()
   })
 
+  it('reports an unreadable bootstrap anchor as a missing incarnation instead of throwing', () => {
+    const { db, table } = createTable()
+    table.ensureBootstrapAnchor('s1')
+    expect(table.getBootstrapIncarnation('s1')).toEqual(expect.any(String))
+
+    db.prepare(
+      "UPDATE deepchat_tape_entries SET meta_json = '{not json' WHERE session_id = 's1' AND entry_id = 1"
+    ).run()
+
+    expect(table.getBootstrapIncarnation('s1')).toBeUndefined()
+
+    db.close()
+  })
+
   it('deletes Tape and its mutation projection through the lifecycle adapter', () => {
     const db = new DatabaseCtor(':memory:')
     const projection = {

--- a/test/main/session/data/tables/deepchatTapeEntriesTable.test.ts
+++ b/test/main/session/data/tables/deepchatTapeEntriesTable.test.ts
@@ -4,6 +4,7 @@ import {
   TOOL_SURFACE_TAPE_EVENT_NAMES
 } from '@/tape/domain/toolSurfaceFacts'
 import { buildTapeProviderAttemptEvent } from '@/tape/domain/providerAttempt'
+import { isEffectiveViewInputRow } from '@/tape/domain/effectiveSemantics'
 import { TapeProviderAttemptService } from '@/tape/application/providerAttemptService'
 
 const sqliteModule = await import('better-sqlite3-multiple-ciphers').catch(() => null)
@@ -728,6 +729,75 @@ describeIfSqlite('DeepChatTapeEntriesTable', () => {
     expect(table.search('s1', '100%')).toMatchObject([
       { session_id: 's1', name: 'run/literal-percent' }
     ])
+
+    db.close()
+  })
+
+  it('reads effective source rows with the same predicate the effective view applies', () => {
+    const { db, table } = createTable()
+
+    table.appendEvent({ sessionId: 's1', name: 'view/assembled', data: {}, createdAt: 100 })
+    table.append({
+      sessionId: 's1',
+      kind: 'message',
+      name: 'message/user',
+      source: { type: 'message', id: 'u1', seq: 0 },
+      payload: { record: { id: 'u1' } },
+      createdAt: 101
+    })
+    table.append({
+      sessionId: 's1',
+      kind: 'tool_call',
+      name: 'read',
+      source: { type: 'tool_call', id: 'a1:t1', seq: 0 },
+      payload: { toolCall: { id: 't1' } },
+      createdAt: 102
+    })
+    table.append({
+      sessionId: 's1',
+      kind: 'tool_result',
+      name: 'read',
+      source: { type: 'tool_result', id: 'a1:t1', seq: 0 },
+      payload: { toolCallId: 't1', response: 'ok' },
+      createdAt: 103
+    })
+    table.appendEvent({
+      sessionId: 's1',
+      name: 'message/retracted',
+      source: { type: 'message', id: 'u1', seq: 1 },
+      data: { messageId: 'u1' },
+      createdAt: 104
+    })
+    table.appendEvent({
+      sessionId: 's1',
+      name: 'message/compaction_indicator',
+      data: { messageId: 'c1' },
+      createdAt: 105
+    })
+    table.appendAnchor({
+      sessionId: 's1',
+      name: 'compaction/manual',
+      state: { summary: 'one', cursorOrderSeq: 1 },
+      createdAt: 106
+    })
+    db.prepare(
+      `INSERT INTO deepchat_tape_entries
+         (session_id, entry_id, kind, name, payload_json, meta_json, created_at)
+       VALUES ('s1', 8, 'context', 'skill/materialized', '{}', '{}', 107)`
+    ).run()
+    table.append({
+      sessionId: 's2',
+      kind: 'message',
+      name: 'message/user',
+      source: { type: 'message', id: 'u2', seq: 0 },
+      payload: { record: { id: 'u2' } },
+      createdAt: 108
+    })
+
+    const effective = table.getEffectiveViewInputRows('s1')
+
+    expect(effective.map((row) => row.entry_id)).toEqual([2, 3, 4, 5, 7])
+    expect(effective).toEqual(table.getBySession('s1').filter(isEffectiveViewInputRow))
 
     db.close()
   })

--- a/test/main/session/data/tapeReconciler.test.ts
+++ b/test/main/session/data/tapeReconciler.test.ts
@@ -99,6 +99,90 @@ describe('SessionTape reconciliation and facts', () => {
     expect(entries.filter((entry) => entry.name === 'migration/backfill')).toHaveLength(1)
   })
 
+  describe('backfill short-circuit', () => {
+    function createReconcileHarness(initialRecords: any[]) {
+      const { table, entries } = createTapeTableMock()
+      let records = initialRecords
+      const messageStore = { getMessages: vi.fn(() => records) }
+      const service = new SessionTape({
+        deepchatTapeEntriesTable: table,
+        deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
+      } as any)
+      const backfillAttempts = () => table.append.mock.calls.length
+      return {
+        table,
+        entries,
+        service,
+        messageStore,
+        backfillAttempts,
+        setRecords: (next: any[]) => {
+          records = next
+        }
+      }
+    }
+
+    it('skips the backfill while the transcript and Tape incarnation are unchanged', () => {
+      const { service, messageStore, backfillAttempts } = createReconcileHarness([
+        createRecord({ id: 'u1', orderSeq: 1, updatedAt: 100 }),
+        createRecord({ id: 'a1', orderSeq: 2, role: 'assistant', content: '[]', updatedAt: 200 })
+      ])
+
+      const first = service.ensureSessionTapeReady('s1', messageStore as any)
+      const attemptsAfterFirst = backfillAttempts()
+      const second = service.ensureSessionTapeReady('s1', messageStore as any)
+
+      expect(first.appendedFactCount).toBe(2)
+      expect(second).toEqual({ ...first, appendedFactCount: 0 })
+      expect(backfillAttempts()).toBe(attemptsAfterFirst)
+    })
+
+    it('backfills again after a transcript write that bypassed Tape', () => {
+      // Retrying a failed steer restores its prompt with updateMessageStatus, which does not write
+      // Tape; the next backfill must pick the new status up or the prompt drops out of context.
+      const failed = createRecord({ id: 'u1', orderSeq: 1, status: 'error', updatedAt: 100 })
+      const { service, messageStore, setRecords } = createReconcileHarness([failed])
+      service.ensureSessionTapeReady('s1', messageStore as any)
+
+      setRecords([{ ...failed, status: 'sent', updatedAt: 150 }])
+      const result = service.ensureSessionTapeReady('s1', messageStore as any)
+
+      expect(result.appendedFactCount).toBe(1)
+      expect(result.historyRecords.map((record) => record.status)).toEqual(['sent'])
+    })
+
+    it('backfills again when the Tape was reset under an unchanged transcript', () => {
+      const { service, messageStore, table, entries } = createReconcileHarness([
+        createRecord({ id: 'u1', orderSeq: 1, updatedAt: 100 })
+      ])
+      service.ensureSessionTapeReady('s1', messageStore as any)
+
+      table.deleteBySession('s1')
+      expect(entries).toEqual([])
+      const result = service.ensureSessionTapeReady('s1', messageStore as any)
+
+      expect(result.appendedFactCount).toBe(1)
+      expect(result.historyRecords.map((record) => record.id)).toEqual(['u1'])
+    })
+
+    it('does not trust a snapshot whose newest write shares the current millisecond', () => {
+      const now = Date.now()
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now)
+      try {
+        const { service, messageStore, backfillAttempts } = createReconcileHarness([
+          createRecord({ id: 'u1', orderSeq: 1, updatedAt: now })
+        ])
+        service.ensureSessionTapeReady('s1', messageStore as any)
+        const attemptsAfterFirst = backfillAttempts()
+
+        service.ensureSessionTapeReady('s1', messageStore as any)
+
+        expect(backfillAttempts()).toBeGreaterThan(attemptsAfterFirst)
+      } finally {
+        nowSpy.mockRestore()
+      }
+    })
+  })
+
   it('keeps A to B to A tool result revisions effective during backfill', () => {
     const { table, entries } = createTapeTableMock()
     let response = 'response-a'

--- a/test/main/session/data/tapeReconciler.test.ts
+++ b/test/main/session/data/tapeReconciler.test.ts
@@ -140,13 +140,13 @@ describe('SessionTape reconciliation and facts', () => {
       // Retrying a failed steer restores its prompt with updateMessageStatus, which does not write
       // Tape; the next backfill must pick the new status up or the prompt drops out of context.
       const failed = createRecord({ id: 'u1', orderSeq: 1, status: 'error', updatedAt: 100 })
-      const { service, messageStore, setRecords } = createReconcileHarness([failed])
+      const { service, messageStore, entries, setRecords } = createReconcileHarness([failed])
       service.ensureSessionTapeReady('s1', messageStore as any)
 
       setRecords([{ ...failed, status: 'sent', updatedAt: 150 }])
       const result = service.ensureSessionTapeReady('s1', messageStore as any)
 
-      expect(result.appendedFactCount).toBe(1)
+      expect(entries.filter((entry) => entry.kind === 'message')).toHaveLength(2)
       expect(result.historyRecords.map((record) => record.status)).toEqual(['sent'])
     })
 
@@ -164,40 +164,24 @@ describe('SessionTape reconciliation and facts', () => {
       expect(result.historyRecords.map((record) => record.id)).toEqual(['u1'])
     })
 
-    it('does not trust a snapshot whose newest write shares the current millisecond', () => {
-      const now = Date.now()
-      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now)
-      try {
-        const { service, messageStore, backfillAttempts } = createReconcileHarness([
-          createRecord({ id: 'u1', orderSeq: 1, updatedAt: now })
-        ])
-        service.ensureSessionTapeReady('s1', messageStore as any)
-        const attemptsAfterFirst = backfillAttempts()
+    it('backfills again after a bypass write stamped by a clock that had stepped back', () => {
+      // u2 is restored while the clock is behind u1's stamp, so count and max(updated_at) are
+      // unchanged; only a per-row comparison can see the write once the clock recovers.
+      const newest = createRecord({ id: 'u1', orderSeq: 1, updatedAt: 4_000 })
+      const failed = createRecord({ id: 'u2', orderSeq: 2, status: 'error', updatedAt: 2_000 })
+      const { service, messageStore, entries, setRecords } = createReconcileHarness([
+        newest,
+        failed
+      ])
+      service.ensureSessionTapeReady('s1', messageStore as any)
 
-        service.ensureSessionTapeReady('s1', messageStore as any)
+      setRecords([newest, { ...failed, status: 'sent', updatedAt: 3_000 }])
+      const result = service.ensureSessionTapeReady('s1', messageStore as any)
 
-        expect(backfillAttempts()).toBeGreaterThan(attemptsAfterFirst)
-      } finally {
-        nowSpy.mockRestore()
-      }
-    })
-
-    it('backfills again when the clock stepped back to the remembered newest write', () => {
-      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(5_000)
-      try {
-        const { service, messageStore, backfillAttempts } = createReconcileHarness([
-          createRecord({ id: 'u1', orderSeq: 1, updatedAt: 4_000 })
-        ])
-        service.ensureSessionTapeReady('s1', messageStore as any)
-        const attemptsAfterFirst = backfillAttempts()
-
-        nowSpy.mockReturnValue(4_000)
-        service.ensureSessionTapeReady('s1', messageStore as any)
-
-        expect(backfillAttempts()).toBeGreaterThan(attemptsAfterFirst)
-      } finally {
-        nowSpy.mockRestore()
-      }
+      expect(
+        entries.filter((entry) => entry.kind === 'message' && entry.source_id === 'u2')
+      ).toHaveLength(2)
+      expect(result.historyRecords.map((record) => record.status)).toEqual(['sent', 'sent'])
     })
 
     it('backfills again when the Tape head moved under an unchanged transcript', () => {

--- a/test/main/session/data/tapeReconciler.test.ts
+++ b/test/main/session/data/tapeReconciler.test.ts
@@ -181,6 +181,52 @@ describe('SessionTape reconciliation and facts', () => {
         nowSpy.mockRestore()
       }
     })
+
+    it('backfills again when the clock stepped back to the remembered newest write', () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(5_000)
+      try {
+        const { service, messageStore, backfillAttempts } = createReconcileHarness([
+          createRecord({ id: 'u1', orderSeq: 1, updatedAt: 4_000 })
+        ])
+        service.ensureSessionTapeReady('s1', messageStore as any)
+        const attemptsAfterFirst = backfillAttempts()
+
+        nowSpy.mockReturnValue(4_000)
+        service.ensureSessionTapeReady('s1', messageStore as any)
+
+        expect(backfillAttempts()).toBeGreaterThan(attemptsAfterFirst)
+      } finally {
+        nowSpy.mockRestore()
+      }
+    })
+
+    it('backfills again when the Tape head moved under an unchanged transcript', () => {
+      // A restored backup keeps the copied incarnation but carries a different Tape.
+      const { service, messageStore, table, entries, backfillAttempts } = createReconcileHarness([
+        createRecord({ id: 'u1', orderSeq: 1, updatedAt: 100 })
+      ])
+      service.ensureSessionTapeReady('s1', messageStore as any)
+      const attemptsAfterFirst = backfillAttempts()
+      const headAfterFirst = table.getMaxEntryId('s1')
+
+      entries.splice(entries.length - 1, 1)
+      expect(table.getMaxEntryId('s1')).toBeLessThan(headAfterFirst)
+      service.ensureSessionTapeReady('s1', messageStore as any)
+
+      expect(backfillAttempts()).toBeGreaterThan(attemptsAfterFirst)
+    })
+
+    it('does not remember a backfill performed inside a host transaction', () => {
+      const { service, messageStore, table, backfillAttempts } = createReconcileHarness([
+        createRecord({ id: 'u1', orderSeq: 1, updatedAt: 100 })
+      ])
+      table.runInTransaction(() => service.ensureSessionTapeReady('s1', messageStore as any))
+      const attemptsAfterFirst = backfillAttempts()
+
+      service.ensureSessionTapeReady('s1', messageStore as any)
+
+      expect(backfillAttempts()).toBeGreaterThan(attemptsAfterFirst)
+    })
   })
 
   it('keeps A to B to A tool result revisions effective during backfill', () => {

--- a/test/main/session/data/tapeTestHarness.ts
+++ b/test/main/session/data/tapeTestHarness.ts
@@ -17,6 +17,7 @@ import {
 import { buildRequestRefs } from '@/session/data/tapeViewManifest'
 import { DeepChatTapeEntriesTable } from '@/session/data/tables/deepchatTapeEntries'
 import { DeepChatExecutionJournalStore } from '@/tape/infrastructure/sqlite/tapeEntryStore'
+import { isEffectiveViewInputRow } from '@/tape/domain/effectiveSemantics'
 import { EXECUTION_JOURNAL_EVENT_NAMES } from '@/tape/domain/executionJournal'
 import { SqliteTapeLifecycleAdapter } from '@/tape/infrastructure/sqlite/tapeLifecycleAdapter'
 import type { TapeTransactionRunner } from '@/tape/ports/storage'
@@ -437,6 +438,9 @@ function createTapeTableMock() {
     ),
     getBySessionExcludingContext: vi.fn((sessionId: string) =>
       entries.filter((entry) => entry.session_id === sessionId && entry.kind !== 'context')
+    ),
+    getEffectiveViewInputRows: vi.fn((sessionId: string) =>
+      entries.filter((entry) => entry.session_id === sessionId && isEffectiveViewInputRow(entry))
     ),
     getByEntryIds: vi.fn((sessionId: string, entryIds: readonly number[]) => {
       const selected = new Set(entryIds)

--- a/test/main/session/data/tapeViewReplay.test.ts
+++ b/test/main/session/data/tapeViewReplay.test.ts
@@ -425,7 +425,8 @@ describe('SessionTape view and replay', () => {
     const sourceMaps = service.getViewManifestSourceMaps('s1')
     expect(sourceMaps.latestEntryId).toBe(receipt.entryId)
     expect(table.getBySession).not.toHaveBeenCalled()
-    expect(table.getBySessionExcludingContext).toHaveBeenCalledWith('s1')
+    expect(table.getBySessionExcludingContext).not.toHaveBeenCalled()
+    expect(table.getEffectiveViewInputRows).toHaveBeenCalledWith('s1')
     const { sessionId: _sessionId, ...authoritativeRef } = buildTapeSkillMaterializationRef(receipt)
     const baseInput: TapeViewManifestBuildInput = {
       sessionId: 's1',

--- a/test/main/session/data/transcriptAtomicity.test.ts
+++ b/test/main/session/data/transcriptAtomicity.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import type { AssistantMessageBlock } from '@shared/types/agent-interface'
+
+const sqliteModule = await import('better-sqlite3-multiple-ciphers').catch(() => null)
+const mainDatabaseModule = sqliteModule ? await import('@/data/mainDatabase') : null
+const sessionDatabaseModule = sqliteModule ? await import('@/session/data/database') : null
+const sessionTapeModule = sqliteModule ? await import('@/tape/application/sessionTape') : null
+const transcriptModule = sqliteModule ? await import('@/session/data/transcript') : null
+
+const Database = sqliteModule?.default
+const MainDatabaseCtor = mainDatabaseModule?.MainDatabase!
+const SessionDatabaseCtor = sessionDatabaseModule?.SessionDatabase!
+const SessionTapeCtor = sessionTapeModule?.SessionTape!
+const SessionTranscriptCtor = transcriptModule?.SessionTranscript!
+
+let sqliteAvailable = false
+if (Database) {
+  try {
+    new Database(':memory:').close()
+    sqliteAvailable = true
+  } catch {
+    sqliteAvailable = false
+  }
+}
+
+const describeIfSqlite = sqliteAvailable ? describe : describe.skip
+
+const userContent = { text: 'hello', files: [], links: [], search: false, think: false }
+const blocks: AssistantMessageBlock[] = [
+  { type: 'content', content: 'done', status: 'success', timestamp: 1 }
+]
+
+/**
+ * `tape-system.md` promises transcript message mutations and their Tape facts commit in one
+ * transaction. These tests make the Tape writer fail on demand and assert the transcript rows
+ * roll back with it instead of committing a message the Tape never saw.
+ */
+describeIfSqlite('SessionTranscript keeps transcript and Tape writes atomic', () => {
+  function createTranscript() {
+    const connection = new MainDatabaseCtor(':memory:')
+    const database = new SessionDatabaseCtor(connection)
+    const tape = new SessionTapeCtor(database)
+    let failTape = false
+    const failing = <T extends (...args: never[]) => unknown>(method: T) =>
+      ((...args: Parameters<T>) => {
+        if (failTape) throw new Error('tape unavailable')
+        return method(...args)
+      }) as T
+    const tapeFacts = {
+      appendMessageRecord: failing(tape.appendMessageRecord.bind(tape)),
+      appendMessageReplacement: failing(tape.appendMessageReplacement.bind(tape)),
+      appendMessageRetraction: failing(tape.appendMessageRetraction.bind(tape)),
+      appendCompactionModelCall: failing(tape.appendCompactionModelCall.bind(tape))
+    }
+    const transcript = new SessionTranscriptCtor(database, tapeFacts)
+    return {
+      connection,
+      database,
+      transcript,
+      setTapeFailing: (value: boolean) => {
+        failTape = value
+      }
+    }
+  }
+
+  it('does not commit a user message whose Tape fact failed to append', () => {
+    const { connection, database, transcript, setTapeFailing } = createTranscript()
+    try {
+      setTapeFailing(true)
+
+      expect(() => transcript.createUserMessage('s1', 1, userContent)).toThrow('tape unavailable')
+
+      expect(database.deepchatMessagesTable.getBySession('s1')).toEqual([])
+      expect(
+        database.getDatabase().prepare('SELECT count(*) AS c FROM deepchat_user_messages').get()
+      ).toEqual({ c: 0 })
+      expect(database.deepchatTapeEntriesTable.getBySession('s1')).toEqual([])
+    } finally {
+      connection.close()
+    }
+  })
+
+  it('keeps the assistant message pending when its terminal Tape fact fails', () => {
+    const { connection, database, transcript, setTapeFailing } = createTranscript()
+    try {
+      transcript.createUserMessage('s1', 1, userContent)
+      const assistantId = transcript.createAssistantMessage('s1', 2)
+      setTapeFailing(true)
+
+      expect(() => transcript.finalizeAssistantMessage(assistantId, blocks, '{}')).toThrow(
+        'tape unavailable'
+      )
+      expect(() => transcript.setMessageError(assistantId, blocks)).toThrow('tape unavailable')
+
+      const row = database.deepchatMessagesTable.get(assistantId)
+      expect(row).toMatchObject({ status: 'pending', content: '[]' })
+      expect(database.deepchatAssistantBlocksTable.listByMessageIds([assistantId])).toEqual([])
+      expect(
+        database.deepchatTapeEntriesTable.getBySession('s1').filter((r) => r.kind === 'message')
+      ).toHaveLength(1)
+
+      setTapeFailing(false)
+      transcript.finalizeAssistantMessage(assistantId, blocks, '{}')
+
+      expect(database.deepchatMessagesTable.get(assistantId)?.status).toBe('sent')
+      expect(
+        database.deepchatTapeEntriesTable.getBySession('s1').filter((r) => r.kind === 'message')
+      ).toHaveLength(2)
+    } finally {
+      connection.close()
+    }
+  })
+
+  it('keeps the previous content when an edit cannot record its Tape replacement', () => {
+    const { connection, database, transcript, setTapeFailing } = createTranscript()
+    try {
+      const userId = transcript.createUserMessage('s1', 1, userContent)
+      const before = database.deepchatMessagesTable.get(userId)!
+      setTapeFailing(true)
+
+      expect(() =>
+        transcript.updateMessageContent(userId, JSON.stringify({ ...userContent, text: 'edited' }))
+      ).toThrow('tape unavailable')
+
+      expect(database.deepchatMessagesTable.get(userId)).toEqual(before)
+      expect(transcript.getMessage(userId)?.content).toContain('hello')
+    } finally {
+      connection.close()
+    }
+  })
+})

--- a/test/main/session/data/transcriptAtomicity.test.ts
+++ b/test/main/session/data/transcriptAtomicity.test.ts
@@ -23,7 +23,10 @@ if (Database) {
   }
 }
 
-const describeIfSqlite = sqliteAvailable ? describe : describe.skip
+// CI rebuilds the native module for the Node ABI and sets this flag; a silent skip there would
+// hide a regression, so an unavailable module must fail the suite instead of skipping it.
+const describeIfSqlite =
+  sqliteAvailable || process.env.DEEPCHAT_REQUIRE_NATIVE_SQLITE === '1' ? describe : describe.skip
 
 const userContent = { text: 'hello', files: [], links: [], search: false, think: false }
 const blocks: AssistantMessageBlock[] = [

--- a/test/main/session/runtimeIntegration.test.ts
+++ b/test/main/session/runtimeIntegration.test.ts
@@ -14,6 +14,7 @@ import { createSessionQueryFixture } from './queryFixture'
 import { createSessionFixture } from './sessionFixture'
 import { createSessionData, createSessionDataFromDatabase } from '@/session/data'
 import { SessionTranscriptMutations } from '@/session/transcriptMutations'
+import { isEffectiveViewInputRow } from '@/tape/domain/effectiveSemantics'
 import { createPassthroughModelRequestPolicy } from '@shared/modelRequestPolicy'
 import { POSIX_COMMAND_SHELL } from '../../helpers/commandShell'
 
@@ -172,6 +173,11 @@ function createMockSqlitePresenter() {
     ),
     getBySessionExcludingContext: vi.fn((sessionId: string) =>
       tapeEntries.filter((entry) => entry.session_id === sessionId && entry.kind !== 'context')
+    ),
+    getEffectiveViewInputRows: vi.fn((sessionId: string) =>
+      tapeEntries.filter(
+        (entry) => entry.session_id === sessionId && isEffectiveViewInputRow(entry)
+      )
     ),
     getByEntryIds: vi.fn((sessionId: string, entryIds: readonly number[]) => {
       const requestedIds = new Set(entryIds)

--- a/test/main/session/usageStatsService.test.ts
+++ b/test/main/session/usageStatsService.test.ts
@@ -437,6 +437,7 @@ function createMockSqlitePresenter() {
   }
 
   return {
+    getDatabase: () => ({ transaction: (operation: () => unknown) => operation }),
     compactionUsageReader,
     deepchatSessionsTable,
     deepchatMessagesTable,


### PR DESCRIPTION
## Summary

Every provider request in a long session read the whole Tape three times, re-appended the same tool facts every round, and let the transcript and its Tape facts commit separately. This is the "stop the bleeding" slice of the Tape review: no schema, fact name, provenance key or contract change. Tape semantics are equivalent by construction.

Measured on a 10k-entry encrypted session (66.8 MB database), three whole-session reads per turn:

| | first turn | steady state |
|---|---|---|
| `dev` | 1043 ms | 961 ms |
| this branch | 162 ms | 15.5 ms |

## What changed

- **Page cache 16 → 64 MiB.** SQLCipher decrypts every page it loads; with the default cache the per-turn reads of a large session evicted each other and the same pages were decrypted again every turn (640 ms → 16 ms for one whole-session read). A ceiling, not an allocation.
- **Hot-path reads filter in SQL.** The reconciler and ViewManifest source maps read the entire session with `SELECT *` and discarded everything except messages, tool facts, anchors and `message/retracted` events, about 60% of the bytes in a 1000-turn session. `getEffectiveViewInputRows` applies the same predicate the effective view uses; a real-SQLite test asserts both select identical rows.
- **Transcript writes and Tape facts commit together.** `createUserMessage`, `finalizeAssistantMessage`, `setMessageError` and `updateMessageContent` autocommitted each statement and appended the Tape fact last, so a failed append left a message the Tape never saw; for user edits the replacement fact was lost for good. They now run in one transaction, as `tape-system.md` promises. Callers holding a transaction nest it as a savepoint; no Execution Journal write is reachable inside.
- **Tool facts appended once per run.** `afterRoundPersisted` replayed every settled tool block after every round (O(n²) appends, each neutralized by two idempotency lookups). The run now skips keys it already appended; a skipped input is exactly an idempotent hit, and a failed append is retried. The terminal replay in finalize is kept: it is the only live writer for ACP, permission-denied and error paths.
- **Backfill skipped when nothing changed.** `ensureSessionTapeReady` remembers what the last completed backfill saw (message count, `max(updated_at)`, Tape incarnation, Tape head). Every transcript writer stamps `updated_at` or changes the count, so writes that bypass Tape still trigger a full backfill; the snapshot is also distrusted across same-millisecond writes, clock regression, a swapped database file (sync restore, maintenance reopen) and host transactions. Mainly helps steer/resume and idle-time IPC.

## Compatibility

- Existing Tapes read identically; `getBySessionExcludingContext` stays for readers that need events.
- Behavior change: a Tape append failure inside finalize now rolls the assistant row back to `pending` instead of committing without its fact. The only non-IO trigger is a tool fact whose name collides with a reserved namespace (`execution/...`); MCP names are validated to `^[a-zA-Z0-9_-]+$`, and that collision already breaks backfill on every later turn today. Follow-up: isolate tool fact names from reserved namespaces.
- Deferred, pre-existing: metadata-only assistant updates never reach Tape; the structural items from the review (double-write of message bodies, O(N²) manifest `excluded` lists, per-request effective view fold).

## Validation

- `format:check`, `i18n`, `lint`, `typecheck` (node + web): pass
- `test/main`: all 634 files, 0 new failures. Three pre-existing failures reproduce on untouched `dev`: `sessionDataMigrations.sqlite` (2), `deepchatPendingInputsTable` (4, Electron ABI only), `buildCli` (4, environment)
- Real SQLite under the Electron ABI: `test/main/tape`, `test/main/session`, ACP adapter, process and compaction suites, 792 passed
- Every fix ships with a regression test that fails on the parent commit (transcript atomicity, tool fact retry, backfill invalidation triggers, SQL filter vs. predicate, unreadable bootstrap anchor). The two new real-SQLite suites are added to the CI native allowlist; `postinstall` builds the module for the Electron ABI, so they would otherwise be skipped silently.

Commits are independent and individually revertible; please merge with a merge commit rather than squash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate tool facts from being saved across processing rounds while allowing failed saves to retry.
  * Improved transcript and Tape update reliability by making related changes atomic.
  * Corrected Tape view reconstruction to use only entries that affect the effective conversation state.
  * Prevented corrupted Tape metadata from causing read failures.
  * Reduced unnecessary Tape reconciliation work when session data is unchanged.

* **Performance**
  * Increased SQLite’s cache allocation to improve encrypted session data access.

* **Tests**
  * Added coverage for atomic updates, reconciliation skipping, effective Tape views, retries, and corrupted metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->