### PR TITLE
refactor(tape): make implicit contracts explicit

### DIFF
--- a/docs/architecture/baselines/agent-system-layered-runtime-baseline.json
+++ b/docs/architecture/baselines/agent-system-layered-runtime-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "goal": "agent-system-layered-runtime",
-  "headCommit": "f3a53f60629162c692eed56b480a823d973f82fa",
+  "headCommit": "ed7adc34c5fa87a681f324de2f5f1ac1a66b50ef",
   "relevantWorkingTree": {
     "dirty": false,
     "files": []
@@ -495,7 +495,7 @@
       "src/shared/contracts/routes/window.routes.ts",
       "src/shared/contracts/routes/workspace.routes.ts"
     ],
-    "sha256": "f846ec8ca18abe70f548b5739007c2fc232c527de20606d039bc007489227d62"
+    "sha256": "fe38e410c549358f61969450c43acf85a057bb560b6bfa85b8b21c1116ee01d4"
   },
   "storage": {
     "sqlite": {

--- a/docs/architecture/baselines/dependency-report.md
+++ b/docs/architecture/baselines/dependency-report.md
@@ -4,8 +4,8 @@ Generated on 2026-09-04.
 
 ## main
 
-- Total files: 853
-- Internal dependency edges: 3009
+- Total files: 859
+- Internal dependency edges: 3021
 - Cycles detected: 13
 
 ### Top outgoing dependencies
@@ -33,14 +33,14 @@ Generated on 2026-09-04.
 - `data/baseTable.ts`: 44
 - `routes/routeRegistry.ts`: 43
 - `remote/types.ts`: 39
+- `tape/ports/capabilities.ts`: 36
 - `agent/settings.ts`: 35
 - `config/settingsStore.ts`: 35
-- `tape/ports/capabilities.ts`: 35
 - `tape/domain/entry.ts`: 34
 - `tape/domain/canonicalJson.ts`: 31
 - `agent/deepchat/runtime/types.ts`: 28
-- `tape/domain/executionJournal.ts`: 26
 - `agent/deepchat/runtime/toolSurface.ts`: 25
+- `tape/domain/executionJournal.ts`: 25
 - `memory/types.ts`: 24
 - `agent/deepchat/instance/deepChatAgentRuntime.ts`: 23
 

--- a/src/main/agent/deepchat/runtime/contextOccupancyCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/contextOccupancyCoordinator.ts
@@ -1,7 +1,7 @@
 import type { SessionContextOccupancySnapshot } from '@shared/types/agent-interface'
 import { toAppSessionId } from '@/agent/shared/agentSessionIds'
 import type { DeepChatAgentRuntime } from '@/agent/deepchat/instance/deepChatAgentRuntime'
-import type { SessionTape } from '@/tape/application/sessionTape'
+import type { TapeContextOccupancyReader } from '@/tape/ports/capabilities'
 import type { SessionSettingsCoordinator } from './sessionSettingsCoordinator'
 import type { SessionStateResolver } from './sessionStateResolver'
 import { resolveEffectiveContextBudget } from './contextBudget'
@@ -10,7 +10,7 @@ type ContextOccupancyDependencies = {
   runtime: Pick<DeepChatAgentRuntime, 'getOrHydrateScope'>
   sessionState: Pick<SessionStateResolver, 'getSummary'>
   sessionSettings: Pick<SessionSettingsCoordinator, 'getEffectiveGenerationSettings'>
-  tape: Pick<SessionTape, 'getContextOccupancyEvidence'>
+  tape: TapeContextOccupancyReader
 }
 
 export function unavailableContextOccupancy(): SessionContextOccupancySnapshot {

--- a/src/main/data/connectionConfig.ts
+++ b/src/main/data/connectionConfig.ts
@@ -18,6 +18,12 @@ export function configureSQLiteConnection(db: Database.Database, password?: stri
   }
 
   db.pragma('journal_mode = WAL')
+  // NORMAL is what every connection has been running with: the bundled
+  // better-sqlite3-multiple-ciphers build compiles in SQLITE_DEFAULT_WAL_SYNCHRONOUS=1, which
+  // applies only while the application never sets the pragma itself. Stating it here keeps the
+  // durability contract (commits survive a process crash, a power loss may drop the newest
+  // committed transactions but never corrupts the file) independent of that build flag.
+  db.pragma('synchronous = NORMAL')
   // 64 MiB page cache ceiling (negative = KiB) for every connection opened through this helper.
   // It is sized for the main database: SQLCipher decrypts every page it loads, so the whole-session
   // Tape reads before each provider request must stay resident to be cheap. Other connections

--- a/src/main/session/data/index.ts
+++ b/src/main/session/data/index.ts
@@ -6,7 +6,11 @@ import type { ChatMessageRecord } from '@shared/types/agent-interface'
 import { SessionPendingInputStore } from './pendingInputStore'
 import { SessionPendingInputs } from './pendingInputs'
 import { SessionSettingsStore } from './settings'
-import { normalizeTapeHandoffState, SessionTape } from '@/tape/application/sessionTape'
+import {
+  normalizeTapeHandoffState,
+  SessionTape,
+  type SessionTapeCapabilities
+} from '@/tape/application/sessionTape'
 import { ExecutionJournalService } from '@/tape/application/executionJournalService'
 import type {
   ExecutionJournalWriter,
@@ -33,7 +37,10 @@ export function createSessionDataFromDatabase(
   database: SessionDatabase,
   events: SessionDataEvents
 ) {
-  const tapeStore = new SessionTape(database)
+  // The concrete facade stays inside this composition root: the SessionTapePort wrappers below
+  // call its direct read helpers, while everything handed out reaches Tape only through ports.
+  const sessionTape = new SessionTape(database)
+  const tapeStore: SessionTapeCapabilities = sessionTape
   const programmaticJournalService = new ExecutionJournalService(
     () => database.deepchatExecutionJournalStore
   )
@@ -45,7 +52,8 @@ export function createSessionDataFromDatabase(
   })
   const transcript = new SessionTranscript(database, tapeStore, tapeStore, tapeStore)
   const pendingInputStore = new SessionPendingInputStore(database)
-  const ensureTape = (sessionId: string) => tapeStore.ensureSessionTapeReady(sessionId, transcript)
+  const ensureTape = (sessionId: string) =>
+    sessionTape.ensureSessionTapeReady(sessionId, transcript)
   const toTapeAnchor = (row: DeepChatTapeEntryRow) => ({
     sessionId: row.session_id,
     entryId: row.entry_id,
@@ -58,57 +66,57 @@ export function createSessionDataFromDatabase(
   const tape: SessionTapePort = {
     getTapeInfo(sessionId) {
       ensureTape(sessionId)
-      return Promise.resolve(tapeStore.info(sessionId))
+      return Promise.resolve(sessionTape.info(sessionId))
     },
     searchTape(sessionId, query, options) {
       if (!options?.scope || options.scope === 'current') ensureTape(sessionId)
-      return Promise.resolve(tapeStore.search(sessionId, query, options))
+      return Promise.resolve(sessionTape.search(sessionId, query, options))
     },
     getTapeContext(sessionId, entryIds, options) {
       if (!options?.sourceSessionId || options.sourceSessionId.trim() === sessionId) {
         ensureTape(sessionId)
       }
-      return Promise.resolve(tapeStore.getContext(sessionId, entryIds, options))
+      return Promise.resolve(sessionTape.getContext(sessionId, entryIds, options))
     },
     listTapeAnchors(sessionId, options) {
       ensureTape(sessionId)
-      return Promise.resolve(tapeStore.anchors(sessionId, options))
+      return Promise.resolve(sessionTape.anchors(sessionId, options))
     },
     handoffTape(sessionId, name, state) {
       normalizeTapeHandoffState(state)
       ensureTape(sessionId)
-      return Promise.resolve(toTapeAnchor(tapeStore.handoff(sessionId, name, state)))
+      return Promise.resolve(toTapeAnchor(sessionTape.handoff(sessionId, name, state)))
     },
     listMessageViewManifests(sessionId, messageId) {
       ensureTape(sessionId)
-      return Promise.resolve(tapeStore.listViewManifestsByMessage(sessionId, messageId))
+      return Promise.resolve(sessionTape.listViewManifestsByMessage(sessionId, messageId))
     },
     listNestedExecutionAuditForMessage(sessionId, messageId) {
       ensureTape(sessionId)
-      return Promise.resolve(tapeStore.listNestedExecutionAuditForMessage(sessionId, messageId))
+      return Promise.resolve(sessionTape.listNestedExecutionAuditForMessage(sessionId, messageId))
     },
     exportMessageTapeReplaySlice(sessionId, messageId, options) {
       ensureTape(sessionId)
-      return Promise.resolve(tapeStore.exportReplaySlice(sessionId, messageId, options))
+      return Promise.resolve(sessionTape.exportReplaySlice(sessionId, messageId, options))
     },
     // Inspector reads must not bootstrap or write Tape state. Incarnation mismatches are returned
     // through the read contract instead.
     listTapeInspectorPage(input) {
-      return tapeStore.listTapeInspectorPage(input)
+      return sessionTape.listTapeInspectorPage(input)
     },
     resolveTapeInspectorEvidenceEntries(input) {
-      return tapeStore.resolveTapeInspectorEvidenceEntries(input)
+      return sessionTape.resolveTapeInspectorEvidenceEntries(input)
     },
     getTapeInspectorRecordDetail(input) {
-      return tapeStore.getTapeInspectorRecordDetail(input)
+      return sessionTape.getTapeInspectorRecordDetail(input)
     },
     exportTapeInspectorSupportFacts(input) {
-      return tapeStore.exportTapeInspectorSupportFacts(input)
+      return sessionTape.exportTapeInspectorSupportFacts(input)
     },
     linkSubagentTape(input) {
       ensureTape(input.parentSessionId)
       ensureTape(input.childSessionId)
-      return Promise.resolve(tapeStore.linkSubagentTape(input))
+      return Promise.resolve(sessionTape.linkSubagentTape(input))
     }
   }
 

--- a/src/main/tape/application/contracts.ts
+++ b/src/main/tape/application/contracts.ts
@@ -1,10 +1,9 @@
 import type { AgentTapeAnchorResult } from '@shared/types/agent-interface'
-import type { DeepChatTapeViewManifestRecord } from '@shared/types/tape-view-manifest'
-import type { TapeProviderAttemptRecord } from '../domain/providerAttempt'
 import type { TapeMigrationState } from '../ports/capabilities'
 
 export type {
   TapeBackfillResult,
+  TapeContextOccupancyEvidence,
   TapeMigrationState,
   TapeViewManifestAssemblySources
 } from '../ports/capabilities'
@@ -35,9 +34,3 @@ export type TapeSearchResult = {
 }
 
 export type TapeAnchorResult = AgentTapeAnchorResult
-
-export type TapeContextOccupancyEvidence = {
-  manifest: DeepChatTapeViewManifestRecord | null
-  providerAttempt: TapeProviderAttemptRecord | null
-  latestReconstructionAnchorEntryId: number | null
-}

--- a/src/main/tape/application/factService.ts
+++ b/src/main/tape/application/factService.ts
@@ -36,7 +36,6 @@ import {
   assertTapeToolFactPhysicalEnvelope
 } from './factPersistence'
 import { parseJsonObject, readCanonicalTapeIncarnationId } from './common'
-import type { TapeAnchorResult } from './contracts'
 
 type TapeFactProviders = Pick<TapeApplicationProviders, 'getEntryStore'>
 
@@ -314,23 +313,5 @@ export class TapeFactService
         handoff: true
       }
     })
-  }
-
-  handoffResult(
-    sessionId: string,
-    name: string,
-    state: AgentTapeHandoffState,
-    meta: Record<string, unknown> = {}
-  ): TapeAnchorResult {
-    const row = this.handoff(sessionId, name, state, meta)
-    return {
-      sessionId: row.session_id,
-      entryId: row.entry_id,
-      kind: row.kind,
-      name: row.name,
-      payload: parseJsonObject(row.payload_json),
-      meta: parseJsonObject(row.meta_json),
-      createdAt: row.created_at
-    }
   }
 }

--- a/src/main/tape/application/sessionTape.ts
+++ b/src/main/tape/application/sessionTape.ts
@@ -74,6 +74,7 @@ import type {
   TapeProviderAttemptWriter,
   TapeCompactionModelCallReader,
   TapeCompactionModelCallWriter,
+  TapeContextOccupancyReader,
   TapeToolSurfaceViewReader,
   TapeToolSurfaceViewWriter,
   ExecutionJournalAuditReader,
@@ -140,38 +141,43 @@ export type {
 }
 export { AgentTapeViewError, normalizeSubagentTapeLinkInput, normalizeTapeHandoffState }
 
-export class SessionTape
-  implements
-    TapeToolFactWriter,
-    TapeMessageFactWriter,
-    TapeProviderAttemptReader,
-    TapeProviderAttemptWriter,
-    TapeCompactionModelCallReader,
-    TapeCompactionModelCallWriter,
-    TapeNonContextEntryReader,
-    TapeReconciliationPort,
-    TapeViewManifestReader,
-    TapeEffectiveUserMessageSourceReader,
-    TapeExecutionViewManifestReader,
-    TapeSkillRequestAuthorityReader,
-    TapeRunViewManifestReader,
-    TapeViewManifestWriter,
-    TapeToolSurfaceViewReader,
-    TapeToolSurfaceViewWriter,
-    TapeAnchorReader,
-    TapeAnchorWriter,
-    TapeInspectionReader,
-    TapeSessionInspectionReader,
-    TapeLifecycleAdmin,
-    ExecutionJournalWriter,
-    ExecutionJournalAuditReader,
-    ExecutionJournalRecoveryReader,
-    TapeIncarnationReader,
-    TapeSkillViewResultFactWriter,
-    TapeRuntimeSkillViewContextReader,
-    TapeSkillMaterializationWriter,
-    TapeSkillMaterializationReader
-{
+/**
+ * Every capability the composed facade offers to consumers. Composition exposes the facade under
+ * this type, so a consumer can only reach what some port declares; the facade's own plumbing and
+ * the direct read helpers the composition root wraps stay off the shared surface.
+ */
+export type SessionTapeCapabilities = TapeToolFactWriter &
+  TapeMessageFactWriter &
+  TapeProviderAttemptReader &
+  TapeProviderAttemptWriter &
+  TapeCompactionModelCallReader &
+  TapeCompactionModelCallWriter &
+  TapeContextOccupancyReader &
+  TapeNonContextEntryReader &
+  TapeReconciliationPort &
+  TapeViewManifestReader &
+  TapeEffectiveUserMessageSourceReader &
+  TapeExecutionViewManifestReader &
+  TapeSkillRequestAuthorityReader &
+  TapeRunViewManifestReader &
+  TapeViewManifestWriter &
+  TapeToolSurfaceViewReader &
+  TapeToolSurfaceViewWriter &
+  TapeAnchorReader &
+  TapeAnchorWriter &
+  TapeInspectionReader &
+  TapeSessionInspectionReader &
+  TapeLifecycleAdmin &
+  ExecutionJournalWriter &
+  ExecutionJournalAuditReader &
+  ExecutionJournalRecoveryReader &
+  TapeIncarnationReader &
+  TapeSkillViewResultFactWriter &
+  TapeRuntimeSkillViewContextReader &
+  TapeSkillMaterializationWriter &
+  TapeSkillMaterializationReader
+
+export class SessionTape implements SessionTapeCapabilities {
   private readonly providers: TapeApplicationProviders
   private readonly facts: TapeFactService
   private readonly reconciler: TapeReconcilerService
@@ -462,15 +468,6 @@ export class SessionTape
     meta: Record<string, unknown> = {}
   ): DeepChatTapeEntryRow {
     return this.facts.handoff(sessionId, name, state, meta)
-  }
-
-  handoffResult(
-    sessionId: string,
-    name: string,
-    state: AgentTapeHandoffState,
-    meta: Record<string, unknown> = {}
-  ): TapeAnchorResult {
-    return this.facts.handoffResult(sessionId, name, state, meta)
   }
 
   linkSubagentTape(input: SubagentTapeLinkInput): SubagentTapeLinkReceipt {

--- a/src/main/tape/application/toolSurfaceProvenanceService.ts
+++ b/src/main/tape/application/toolSurfaceProvenanceService.ts
@@ -12,6 +12,7 @@ import {
   TAPE_PROGRAMMATIC_TOOL_SURFACE_EVENT_NAME,
   TAPE_TOOL_CATALOG_EVENT_NAME,
   TAPE_TOOL_SURFACE_EVENT_NAME,
+  ToolSurfaceFactError,
   buildTapeToolResultPayloadHash,
   createTapeProgrammaticToolSurfaceFact,
   createTapeToolCatalogFact,
@@ -1053,7 +1054,7 @@ export class ToolSurfaceProvenanceService
       })
     } catch (error) {
       if (error instanceof ToolSurfaceProvenanceError) throw error
-      if (error instanceof TypeError) {
+      if (error instanceof ToolSurfaceFactError) {
         throw new ToolSurfaceProvenanceError(
           'Tool surface provenance input is invalid.',
           'invalid_input',

--- a/src/main/tape/domain/effectiveView.ts
+++ b/src/main/tape/domain/effectiveView.ts
@@ -1,9 +1,7 @@
 import type { ChatMessageRecord } from '@shared/types/agent-interface'
 import type { DeepChatTapeEntryKind, DeepChatTapeEntryRow, DeepChatTapeSearchInput } from './entry'
-import { TAPE_COMPACTION_MODEL_CALL_EVENT_NAME } from './compactionUsage'
-import { EXECUTION_JOURNAL_EVENT_NAMES } from './executionJournal'
-import { CONTRACT_TAPE_EVENT_NAMES, isContractTapeReservedName } from './contractFacts'
-import { TOOL_SURFACE_TAPE_EVENT_NAMES } from './toolSurfaceFacts'
+import { isContractTapeReservedName } from './contractFacts'
+import { RESERVED_AUDIT_TAPE_EVENT_NAMES } from './reservedNamespaces'
 import { TAPE_VIEW_MANIFEST_EVENT_NAME } from './viewManifest'
 import {
   TAPE_MESSAGE_RETRACTED_EVENT_NAME,
@@ -44,16 +42,18 @@ interface EffectiveTapeViewOptions {
   includeAuditEvents?: boolean
 }
 
-export const DEFAULT_EXCLUDED_TAPE_EVENT_NAMES = [
+/**
+ * Event names hidden from effective views and ordinary search. Retractions, compaction markers,
+ * backfill receipts and View manifests are bookkeeping written through the generic append path;
+ * every other audit event is declared by the strict writer that owns it.
+ */
+export const DEFAULT_EXCLUDED_TAPE_EVENT_NAMES: readonly string[] = [
   TAPE_MESSAGE_RETRACTED_EVENT_NAME,
   'message/compaction_indicator',
   'migration/backfill',
-  TAPE_COMPACTION_MODEL_CALL_EVENT_NAME,
   TAPE_VIEW_MANIFEST_EVENT_NAME,
-  ...TOOL_SURFACE_TAPE_EVENT_NAMES,
-  ...CONTRACT_TAPE_EVENT_NAMES,
-  ...EXECUTION_JOURNAL_EVENT_NAMES
-] as const
+  ...RESERVED_AUDIT_TAPE_EVENT_NAMES
+]
 
 const DEFAULT_EXCLUDED_TAPE_EVENT_NAME_SET = new Set<string>(DEFAULT_EXCLUDED_TAPE_EVENT_NAMES)
 

--- a/src/main/tape/domain/reservedNamespaces.ts
+++ b/src/main/tape/domain/reservedNamespaces.ts
@@ -1,10 +1,10 @@
 import { TAPE_COMPACTION_MODEL_CALL_EVENT_NAME } from './compactionUsage'
 import { CONTRACT_TAPE_EVENT_NAMES, isContractTapeReservedName } from './contractFacts'
-import type { DeepChatTapeAppendInput } from './entry'
+import type { DeepChatTapeAppendInput, DeepChatTapeEntryKind } from './entry'
 import { EXECUTION_JOURNAL_EVENT_NAMES, isExecutionJournalReservedName } from './executionJournal'
 import { TAPE_PROVIDER_ATTEMPT_EVENT_NAME } from './providerAttempt'
 import { SKILL_MATERIALIZATION_NAME } from './skillMaterialization'
-import { isToolSurfaceTapeReservedName } from './toolSurfaceFacts'
+import { TOOL_SURFACE_TAPE_EVENT_NAMES } from './toolSurfaceFacts'
 
 /**
  * Strict writers that own a slice of the Tape namespace. A generic append may not produce a
@@ -18,6 +18,88 @@ export type TapeReservedNamespace =
   | 'provider-attempt'
   | 'compaction-usage'
 
+/** Everything one strict writer's slice declares about itself. */
+interface TapeReservedNamespaceRule {
+  /** The exact fact names the strict writer may append. */
+  readonly names: readonly string[]
+  /** Entry kind the slice is bound to: generic appends of that kind are rejected as a whole. */
+  readonly kind?: DeepChatTapeEntryKind
+  /** Widens the generic rejection beyond `names`, so unknown sibling names stay reserved. */
+  readonly reservesName?: (name: string) => boolean
+  /**
+   * Whether the slice's event facts are audit evidence, kept out of effective views and ordinary
+   * search unless a reader asks for audit events explicitly.
+   */
+  readonly auditEvents: boolean
+  /** Error for a generic append that lands in the slice by name. */
+  readonly genericRejection: string
+  /** Error for a generic append that lands in the slice by kind alone; defaults to the name error. */
+  readonly kindRejection?: string
+  /** What the strict writer tried to append when it stepped outside its own facts. */
+  readonly strictRejection: string
+}
+
+/** Declaration order is the order generic appends are checked in. */
+const TAPE_RESERVED_NAMESPACE_RULES: Readonly<
+  Record<TapeReservedNamespace, TapeReservedNamespaceRule>
+> = {
+  execution: {
+    names: EXECUTION_JOURNAL_EVENT_NAMES,
+    reservesName: isExecutionJournalReservedName,
+    auditEvents: true,
+    genericRejection:
+      'The execution/* namespace is reserved for the strict Execution Journal writer.',
+    strictRejection: 'Execution Journal event name'
+  },
+  contract: {
+    names: CONTRACT_TAPE_EVENT_NAMES,
+    reservesName: isContractTapeReservedName,
+    auditEvents: true,
+    genericRejection: 'The contract/* namespace is reserved for the strict Contract writer.',
+    strictRejection: 'Contract event name'
+  },
+  'tool-surface': {
+    names: TOOL_SURFACE_TAPE_EVENT_NAMES,
+    auditEvents: true,
+    genericRejection: 'The View Tool Surface namespace is reserved for its provenance writer.',
+    strictRejection: 'View Tool Surface event name'
+  },
+  'skill-materialized': {
+    names: [SKILL_MATERIALIZATION_NAME],
+    kind: 'context',
+    // `context` rows never reach effective views or search; readers skip the kind itself.
+    auditEvents: false,
+    genericRejection: 'skill/materialized is reserved for the strict materialization writer.',
+    kindRejection: 'The context entry kind is reserved for the strict materialization writer.',
+    strictRejection: 'Skill materialization fact'
+  },
+  'provider-attempt': {
+    names: [TAPE_PROVIDER_ATTEMPT_EVENT_NAME],
+    // Effective views keep attempt outcomes: the latest one feeds the tape_info cache metrics.
+    auditEvents: false,
+    genericRejection:
+      'provider/attempt_completed is reserved for the strict provider-attempt writer.',
+    strictRejection: 'provider-attempt event name'
+  },
+  'compaction-usage': {
+    names: [TAPE_COMPACTION_MODEL_CALL_EVENT_NAME],
+    auditEvents: true,
+    genericRejection:
+      'compaction/model_call_completed is reserved for the strict compaction-usage writer.',
+    strictRejection: 'compaction-usage event name'
+  }
+}
+
+const RULES_IN_ORDER = Object.values(TAPE_RESERVED_NAMESPACE_RULES)
+
+/**
+ * Event names every reserved slice marks as audit evidence. Effective views and ordinary search
+ * exclude them by default so the strict-writer declarations stay the single place that decides.
+ */
+export const RESERVED_AUDIT_TAPE_EVENT_NAMES: readonly string[] = RULES_IN_ORDER.filter(
+  (rule) => rule.auditEvents
+).flatMap((rule) => rule.names)
+
 /**
  * Rejects an append that crosses a namespace boundary. Every Tape store implementation,
  * including test doubles, runs this before persisting a row so the reserved set and the
@@ -28,63 +110,39 @@ export function assertTapeAppendAuthorized(
   authorizedNamespace: TapeReservedNamespace | null
 ): void {
   if (authorizedNamespace) {
-    const rejected = strictWriterRejection(authorizedNamespace, kind, name)
-    if (rejected) throw new Error(`Unsupported ${rejected}: ${name}.`)
+    const rule = TAPE_RESERVED_NAMESPACE_RULES[authorizedNamespace]
+    if (!ownsFact(rule, kind, name)) {
+      throw new Error(`Unsupported ${rule.strictRejection}: ${name}.`)
+    }
     return
   }
-  if (isExecutionJournalReservedName(name)) {
-    throw new Error(
-      'The execution/* namespace is reserved for the strict Execution Journal writer.'
-    )
-  }
-  if (isContractTapeReservedName(name)) {
-    throw new Error('The contract/* namespace is reserved for the strict Contract writer.')
-  }
-  if (isToolSurfaceTapeReservedName(name)) {
-    throw new Error('The View Tool Surface namespace is reserved for its provenance writer.')
-  }
-  if (name === SKILL_MATERIALIZATION_NAME) {
-    throw new Error('skill/materialized is reserved for the strict materialization writer.')
-  }
-  if (kind === 'context') {
-    throw new Error('The context entry kind is reserved for the strict materialization writer.')
-  }
-  if (name === TAPE_PROVIDER_ATTEMPT_EVENT_NAME) {
-    throw new Error(
-      'provider/attempt_completed is reserved for the strict provider-attempt writer.'
-    )
-  }
-  if (name === TAPE_COMPACTION_MODEL_CALL_EVENT_NAME) {
-    throw new Error(
-      'compaction/model_call_completed is reserved for the strict compaction-usage writer.'
-    )
+  for (const rule of RULES_IN_ORDER) {
+    const rejection = genericAppendRejection(rule, kind, name)
+    if (rejection) throw new Error(rejection)
   }
 }
 
-/** Names the rejected fact when a strict writer steps outside its own facts; null when allowed. */
-function strictWriterRejection(
-  namespace: TapeReservedNamespace,
-  kind: DeepChatTapeAppendInput['kind'],
+/** A strict writer may append only its declared names, on its declared kind when it has one. */
+function ownsFact(
+  rule: TapeReservedNamespaceRule,
+  kind: DeepChatTapeEntryKind,
+  name: DeepChatTapeAppendInput['name']
+): boolean {
+  if (typeof name !== 'string' || !rule.names.includes(name)) return false
+  return rule.kind === undefined || kind === rule.kind
+}
+
+/** Names why a generic append lands in the slice: exact or reserved sibling name first, then kind. */
+function genericAppendRejection(
+  rule: TapeReservedNamespaceRule,
+  kind: DeepChatTapeEntryKind,
   name: DeepChatTapeAppendInput['name']
 ): string | null {
-  switch (namespace) {
-    case 'execution':
-      return (EXECUTION_JOURNAL_EVENT_NAMES as readonly string[]).includes(name ?? '')
-        ? null
-        : 'Execution Journal event name'
-    case 'contract':
-      return (CONTRACT_TAPE_EVENT_NAMES as readonly string[]).includes(name ?? '')
-        ? null
-        : 'Contract event name'
-    case 'tool-surface':
-      return isToolSurfaceTapeReservedName(name) ? null : 'View Tool Surface event name'
-    case 'skill-materialized':
-      return kind === 'context' && name === SKILL_MATERIALIZATION_NAME
-        ? null
-        : 'Skill materialization fact'
-    case 'provider-attempt':
-      return name === TAPE_PROVIDER_ATTEMPT_EVENT_NAME ? null : 'provider-attempt event name'
-    case 'compaction-usage':
-      return name === TAPE_COMPACTION_MODEL_CALL_EVENT_NAME ? null : 'compaction-usage event name'
+  if (typeof name === 'string' && (rule.names.includes(name) || rule.reservesName?.(name))) {
+    return rule.genericRejection
   }
+  if (rule.kind !== undefined && kind === rule.kind) {
+    return rule.kindRejection ?? rule.genericRejection
+  }
+  return null
 }

--- a/src/main/tape/domain/reservedNamespaces.ts
+++ b/src/main/tape/domain/reservedNamespaces.ts
@@ -31,18 +31,14 @@ interface TapeReservedNamespaceRule {
    * search unless a reader asks for audit events explicitly.
    */
   readonly auditEvents: boolean
-  /** Error for a generic append that lands in the slice by name. */
+  /** Error for a generic append that lands in the slice. */
   readonly genericRejection: string
-  /** Error for a generic append that lands in the slice by kind alone; defaults to the name error. */
-  readonly kindRejection?: string
   /** What the strict writer tried to append when it stepped outside its own facts. */
   readonly strictRejection: string
 }
 
 /** Declaration order is the order generic appends are checked in. */
-const TAPE_RESERVED_NAMESPACE_RULES: Readonly<
-  Record<TapeReservedNamespace, TapeReservedNamespaceRule>
-> = {
+const TAPE_RESERVED_NAMESPACE_RULES: Record<TapeReservedNamespace, TapeReservedNamespaceRule> = {
   execution: {
     names: EXECUTION_JOURNAL_EVENT_NAMES,
     reservesName: isExecutionJournalReservedName,
@@ -69,8 +65,8 @@ const TAPE_RESERVED_NAMESPACE_RULES: Readonly<
     kind: 'context',
     // `context` rows never reach effective views or search; readers skip the kind itself.
     auditEvents: false,
-    genericRejection: 'skill/materialized is reserved for the strict materialization writer.',
-    kindRejection: 'The context entry kind is reserved for the strict materialization writer.',
+    genericRejection:
+      'The context entry kind and skill/materialized are reserved for the strict materialization writer.',
     strictRejection: 'Skill materialization fact'
   },
   'provider-attempt': {
@@ -117,8 +113,7 @@ export function assertTapeAppendAuthorized(
     return
   }
   for (const rule of RULES_IN_ORDER) {
-    const rejection = genericAppendRejection(rule, kind, name)
-    if (rejection) throw new Error(rejection)
+    if (claimsGenericAppend(rule, kind, name)) throw new Error(rule.genericRejection)
   }
 }
 
@@ -132,17 +127,13 @@ function ownsFact(
   return rule.kind === undefined || kind === rule.kind
 }
 
-/** Names why a generic append lands in the slice: exact or reserved sibling name first, then kind. */
-function genericAppendRejection(
+/** A generic append lands in the slice by exact name, reserved sibling name, or reserved kind. */
+function claimsGenericAppend(
   rule: TapeReservedNamespaceRule,
   kind: DeepChatTapeEntryKind,
   name: DeepChatTapeAppendInput['name']
-): string | null {
-  if (typeof name === 'string' && (rule.names.includes(name) || rule.reservesName?.(name))) {
-    return rule.genericRejection
-  }
-  if (rule.kind !== undefined && kind === rule.kind) {
-    return rule.kindRejection ?? rule.genericRejection
-  }
-  return null
+): boolean {
+  if (rule.kind !== undefined && kind === rule.kind) return true
+  if (typeof name !== 'string') return false
+  return rule.names.includes(name) || rule.reservesName?.(name) === true
 }

--- a/src/main/tape/domain/toolSurfaceFacts.ts
+++ b/src/main/tape/domain/toolSurfaceFacts.ts
@@ -16,6 +16,14 @@ import { CANONICAL_UUID_PATTERN, compareUtf16, deepFreeze, SHA256_HEX_PATTERN } 
 import { isDeepChatTaskContractRef } from './taskContract'
 import { normalizeAbsoluteWorkspacePath } from './workspacePath'
 
+/** A Tool Surface fact input broke its canonical contract: shape, limits, hashes or ordering. */
+export class ToolSurfaceFactError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'ToolSurfaceFactError'
+  }
+}
+
 export const TAPE_TOOL_CATALOG_EVENT_NAME = 'view/tool_catalog'
 export const TAPE_TOOL_SURFACE_EVENT_NAME = 'view/tool_surface'
 export const TAPE_PROGRAMMATIC_TOOL_SURFACE_EVENT_NAME = 'view/programmatic_tool_surface'
@@ -375,7 +383,7 @@ function assertBoundedProxyFreePlainData(value: unknown, maxBytes: number): void
     }
     nodes += 1
     if (nodes > MAX_PLAIN_DATA_NODES || visit.depth > MAX_PLAIN_DATA_DEPTH) {
-      throw new TypeError('Tool fact input exceeds its structure limit.')
+      throw new ToolSurfaceFactError('Tool fact input exceeds its structure limit.')
     }
     const current = visit.value
     if (current === null || typeof current === 'boolean') {
@@ -389,23 +397,23 @@ function assertBoundedProxyFreePlainData(value: unknown, maxBytes: number): void
     if (typeof current === 'string') {
       minimumBytes += Buffer.byteLength(current, 'utf8') + 2
       if (minimumBytes > maxBytes) {
-        throw new TypeError('Tool fact input exceeds its canonical byte limit.')
+        throw new ToolSurfaceFactError('Tool fact input exceeds its canonical byte limit.')
       }
       continue
     }
     if (!current || typeof current !== 'object' || nodeTypes.isProxy(current)) {
-      throw new TypeError('Tool fact input contains a non-plain JSON value.')
+      throw new ToolSurfaceFactError('Tool fact input contains a non-plain JSON value.')
     }
     if (ancestors.has(current)) {
-      throw new TypeError('Tool fact input contains a circular reference.')
+      throw new ToolSurfaceFactError('Tool fact input contains a circular reference.')
     }
     const isArray = Array.isArray(current)
     const prototype = Object.getPrototypeOf(current)
     if (!isArray && prototype !== Object.prototype && prototype !== null) {
-      throw new TypeError('Tool fact input contains a non-plain object.')
+      throw new ToolSurfaceFactError('Tool fact input contains a non-plain object.')
     }
     if (Object.getOwnPropertySymbols(current).length > 0) {
-      throw new TypeError('Tool fact input contains a symbol property.')
+      throw new ToolSurfaceFactError('Tool fact input contains a symbol property.')
     }
     const names = Object.getOwnPropertyNames(current)
     const itemNames = isArray ? names.filter((name) => name !== 'length') : names
@@ -413,7 +421,7 @@ function assertBoundedProxyFreePlainData(value: unknown, maxBytes: number): void
       (isArray && itemNames.length !== current.length) ||
       nodes + itemNames.length > MAX_PLAIN_DATA_NODES
     ) {
-      throw new TypeError('Tool fact input exceeds its structure limit.')
+      throw new ToolSurfaceFactError('Tool fact input exceeds its structure limit.')
     }
     minimumBytes += 2
     ancestors.add(current)
@@ -422,11 +430,11 @@ function assertBoundedProxyFreePlainData(value: unknown, maxBytes: number): void
       const name = itemNames[index]
       const descriptor = Object.getOwnPropertyDescriptor(current, name)
       if (!descriptor?.enumerable || !('value' in descriptor)) {
-        throw new TypeError('Tool fact input contains a non-data property.')
+        throw new ToolSurfaceFactError('Tool fact input contains a non-data property.')
       }
       if (!isArray) minimumBytes += Buffer.byteLength(name, 'utf8') + 3
       if (minimumBytes > maxBytes) {
-        throw new TypeError('Tool fact input exceeds its canonical byte limit.')
+        throw new ToolSurfaceFactError('Tool fact input exceeds its canonical byte limit.')
       }
       stack.push({ kind: 'enter', value: descriptor.value, depth: visit.depth + 1 })
     }
@@ -437,7 +445,7 @@ function detachBoundedPlainData<T>(value: T, maxBytes: number): T {
   assertBoundedProxyFreePlainData(value, maxBytes)
   const serialized = canonicalJsonStringifyData(value)
   if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
-    throw new TypeError('Tool fact input exceeds its canonical byte limit.')
+    throw new ToolSurfaceFactError('Tool fact input exceeds its canonical byte limit.')
   }
   return JSON.parse(serialized) as T
 }
@@ -530,7 +538,7 @@ function cloneCatalogEntryFields(entry: TapeToolCatalogSourceEntry): TapeToolCat
 
 function cloneCatalogEntry(entry: TapeToolCatalogSourceEntry): TapeToolCatalogSourceEntry {
   if (!isCatalogEntry(entry)) {
-    throw new TypeError('Tool catalog fact contains an invalid entry.')
+    throw new ToolSurfaceFactError('Tool catalog fact contains an invalid entry.')
   }
   return cloneCatalogEntryFields(entry)
 }
@@ -646,7 +654,7 @@ function createTapeToolCatalogFactFromData(
     !Array.isArray(input.entries) ||
     input.entries.length > MAX_SOURCE_CATALOG_ENTRIES
   ) {
-    throw new TypeError('Tool catalog fact input is invalid.')
+    throw new ToolSurfaceFactError('Tool catalog fact input is invalid.')
   }
 
   const entries = input.entries
@@ -655,12 +663,14 @@ function createTapeToolCatalogFactFromData(
   const targetByVisibleName = new Map<string, string>()
   for (let index = 0; index < entries.length; index += 1) {
     if (index > 0 && entries[index - 1].stableTargetKey === entries[index].stableTargetKey) {
-      throw new TypeError('Tool catalog fact contains a duplicate stable target.')
+      throw new ToolSurfaceFactError('Tool catalog fact contains a duplicate stable target.')
     }
     const entry = entries[index]
     const previousTarget = targetByVisibleName.get(entry.target.providerVisibleName)
     if (previousTarget !== undefined && previousTarget !== entry.stableTargetKey) {
-      throw new TypeError('Tool catalog fact contains a conflicting provider-visible name.')
+      throw new ToolSurfaceFactError(
+        'Tool catalog fact contains a conflicting provider-visible name.'
+      )
     }
     targetByVisibleName.set(entry.target.providerVisibleName, entry.stableTargetKey)
   }
@@ -669,7 +679,7 @@ function createTapeToolCatalogFactFromData(
     entries
   })
   if (expectedFullCatalogHash !== input.fullCatalogHash) {
-    throw new TypeError('Tool catalog fact does not match its full catalog hash.')
+    throw new ToolSurfaceFactError('Tool catalog fact does not match its full catalog hash.')
   }
 
   const maximumRetainedCount = Math.min(entries.length, MAX_TAPE_TOOL_CATALOG_PROJECTION_ENTRIES)
@@ -683,7 +693,7 @@ function createTapeToolCatalogFactFromData(
   const retainedEntryCount = findLargestFittingPrefix(maximumRetainedCount, buildWithRetainedCount)
   const fact = buildWithRetainedCount(retainedEntryCount)
   if (canonicalBytes(fact) > MAX_TAPE_TOOL_FACT_BYTES) {
-    throw new TypeError('Tool catalog fact exceeds its canonical byte limit.')
+    throw new ToolSurfaceFactError('Tool catalog fact exceeds its canonical byte limit.')
   }
   return deepFreeze(fact)
 }
@@ -914,7 +924,7 @@ function isBudget(value: unknown): value is TapeToolSurfaceBudgetObservation {
 
 function cloneActiveEntry(entry: TapeToolSurfaceActiveEntry): TapeToolSurfaceActiveEntry {
   if (!isActiveEntry(entry))
-    throw new TypeError('Tool surface fact contains an invalid active entry.')
+    throw new ToolSurfaceFactError('Tool surface fact contains an invalid active entry.')
   return {
     ...cloneCatalogEntryFields(entry),
     activationOrdinal: entry.activationOrdinal,
@@ -923,7 +933,8 @@ function cloneActiveEntry(entry: TapeToolSurfaceActiveEntry): TapeToolSurfaceAct
 }
 
 function cloneSearchRef(ref: TapeToolSurfaceSearchResultRef): TapeToolSurfaceSearchResultRef {
-  if (!isSearchRef(ref)) throw new TypeError('Tool surface fact contains an invalid search ref.')
+  if (!isSearchRef(ref))
+    throw new ToolSurfaceFactError('Tool surface fact contains an invalid search ref.')
   return { ...ref, toolResult: { ...ref.toolResult } }
 }
 
@@ -931,7 +942,7 @@ function cloneCandidateRejection(
   rejection: TapeToolSurfaceCandidateRejection
 ): TapeToolSurfaceCandidateRejection {
   if (!isCandidateRejection(rejection)) {
-    throw new TypeError('Tool surface fact contains an invalid candidate rejection.')
+    throw new ToolSurfaceFactError('Tool surface fact contains an invalid candidate rejection.')
   }
   return { ...rejection, toolResult: { ...rejection.toolResult } }
 }
@@ -994,10 +1005,10 @@ function validateActiveEntryOrder(entries: readonly TapeToolSurfaceActiveEntry[]
   for (const entry of entries) {
     const previousTarget = targetByVisibleName.get(entry.target.providerVisibleName)
     if (targets.has(entry.stableTargetKey) || entry.activationOrdinal <= previousOrdinal) {
-      throw new TypeError('Tool surface active entries are duplicated or out of order.')
+      throw new ToolSurfaceFactError('Tool surface active entries are duplicated or out of order.')
     }
     if (previousTarget !== undefined && previousTarget !== entry.stableTargetKey) {
-      throw new TypeError('Tool surface contains a conflicting provider-visible name.')
+      throw new ToolSurfaceFactError('Tool surface contains a conflicting provider-visible name.')
     }
     targets.add(entry.stableTargetKey)
     targetByVisibleName.set(entry.target.providerVisibleName, entry.stableTargetKey)
@@ -1052,7 +1063,9 @@ function validateToolSearchPresence(
       (reservedNameEntries.length !== 1 || !isToolSearchActiveEntry(reservedNameEntries[0]))) ||
     (adapterMode !== 'native-activation' && reservedNameEntries.length !== 0)
   ) {
-    throw new TypeError('Tool surface ToolSearch identity or selection reason is invalid.')
+    throw new ToolSurfaceFactError(
+      'Tool surface ToolSearch identity or selection reason is invalid.'
+    )
   }
 }
 
@@ -1152,7 +1165,7 @@ function validateSearchProvenance(
       activeEntry.canonicalToolDefinitionHash !== ref.canonicalToolDefinitionHash ||
       (previousAccepted !== null && compareSearchRefs(previousAccepted, ref) >= 0)
     ) {
-      throw new TypeError('Tool surface accepted search provenance is invalid.')
+      throw new ToolSurfaceFactError('Tool surface accepted search provenance is invalid.')
     }
     seenAcceptedTargets.add(ref.stableTargetKey)
     latestAcceptedRequestSeq = Math.max(latestAcceptedRequestSeq, ref.originRequestSeq)
@@ -1175,7 +1188,7 @@ function validateSearchProvenance(
       activeByTarget.has(rejection.stableTargetKey) ||
       (previousRejected !== null && compareSearchRefs(previousRejected, rejection) >= 0)
     ) {
-      throw new TypeError('Tool surface rejected search provenance is invalid.')
+      throw new ToolSurfaceFactError('Tool surface rejected search provenance is invalid.')
     }
     seenRejectedTargets.add(rejection.stableTargetKey)
     rejectionRequestSeq = rejection.originRequestSeq
@@ -1193,7 +1206,7 @@ function requireCompleteAcceptedSearchProvenance(
     .sort(compareUtf16)
   const actualTargets = searchResultRefs.map((ref) => ref.stableTargetKey).sort(compareUtf16)
   if (canonicalJsonStringifyData(expectedTargets) !== canonicalJsonStringifyData(actualTargets)) {
-    throw new TypeError('Tool surface is missing accepted ToolSearch result provenance.')
+    throw new ToolSurfaceFactError('Tool surface is missing accepted ToolSearch result provenance.')
   }
 }
 
@@ -1253,7 +1266,7 @@ function createTapeToolSurfaceFactFromData(
       (!Array.isArray(input.candidateRejections) ||
         input.candidateRejections.length > MAX_SOURCE_ACTIVATION_DECISIONS))
   ) {
-    throw new TypeError('Tool surface fact input is invalid.')
+    throw new ToolSurfaceFactError('Tool surface fact input is invalid.')
   }
 
   const allActiveEntries = input.activeEntries.map(cloneActiveEntry)
@@ -1266,10 +1279,14 @@ function createTapeToolSurfaceFactFromData(
         entry.target.providerVisibleName === 'exec' && !isCanonicalAgentExecToolSurfaceEntry(entry)
     )
   ) {
-    throw new TypeError('A CLI Programmatic provider surface contains a non-canonical Agent exec.')
+    throw new ToolSurfaceFactError(
+      'A CLI Programmatic provider surface contains a non-canonical Agent exec.'
+    )
   }
   if (input.contractBearing && allActiveEntries.length > MAX_TAPE_TOOL_SURFACE_ACTIVE_ENTRIES) {
-    throw new TypeError('Contract-bearing Tool surface exceeds its complete active-entry limit.')
+    throw new ToolSurfaceFactError(
+      'Contract-bearing Tool surface exceeds its complete active-entry limit.'
+    )
   }
   const maximumActiveEntries = selectActiveProjection(
     allActiveEntries,
@@ -1296,7 +1313,9 @@ function createTapeToolSurfaceFactFromData(
       allSearchRefs.length > 0 ||
       allCandidateRejections.length > 0)
   ) {
-    throw new TypeError('A CLI Programmatic provider surface cannot contain native search state.')
+    throw new ToolSurfaceFactError(
+      'A CLI Programmatic provider surface cannot contain native search state.'
+    )
   }
   if (
     !input.virtualizationTriggered &&
@@ -1306,7 +1325,9 @@ function createTapeToolSurfaceFactFromData(
       input.budget.eligibleToolCount !== input.budget.activeToolCount ||
       input.budget.eligibleDefinitionTokens !== input.budget.activeDefinitionTokens)
   ) {
-    throw new TypeError('A non-virtualized Tool surface cannot contain search provenance.')
+    throw new ToolSurfaceFactError(
+      'A non-virtualized Tool surface cannot contain search provenance.'
+    )
   }
   const candidateRejections = allCandidateRejections.slice(0, MAX_TAPE_TOOL_SURFACE_REJECTIONS)
   const buildWithLengths = (
@@ -1379,7 +1400,7 @@ function createTapeToolSurfaceFactFromData(
     fact = buildWithLengths(activeLength, searchRefLength, rejectionLength)
   }
   if (canonicalBytes(fact) > MAX_TAPE_TOOL_FACT_BYTES) {
-    throw new TypeError(
+    throw new ToolSurfaceFactError(
       input.contractBearing
         ? 'Contract-bearing Tool surface fact exceeds its canonical byte limit.'
         : 'Tool surface fact exceeds its canonical byte limit.'
@@ -1558,7 +1579,9 @@ export function buildTapeProgrammaticWorkspacePathHash(normalizedAbsolutePath: s
     !isNormalizedBoundedString(normalizedAbsolutePath, 32 * 1024) ||
     normalizeAbsoluteWorkspacePath(normalizedAbsolutePath)?.path !== normalizedAbsolutePath
   ) {
-    throw new TypeError('Programmatic workspace path must already be normalized and absolute.')
+    throw new ToolSurfaceFactError(
+      'Programmatic workspace path must already be normalized and absolute.'
+    )
   }
   return {
     hashVersion: TAPE_PROGRAMMATIC_WORKSPACE_PATH_HASH_VERSION,
@@ -1701,22 +1724,28 @@ function validateProgrammaticEntries(entries: readonly TapeToolCatalogSourceEntr
   for (let index = 0; index < entries.length; index += 1) {
     const entry = entries[index]
     if (entry.target.source !== 'mcp' || entry.exposure !== 'user-configurable') {
-      throw new TypeError(
+      throw new ToolSurfaceFactError(
         'Programmatic Tool Surface entries must be user-configurable MCP targets.'
       )
     }
     if (index > 0) {
       const order = compareUtf16(entries[index - 1].stableTargetKey, entry.stableTargetKey)
       if (order === 0) {
-        throw new TypeError('Programmatic Tool Surface contains a duplicate stable target.')
+        throw new ToolSurfaceFactError(
+          'Programmatic Tool Surface contains a duplicate stable target.'
+        )
       }
       if (order > 0) {
-        throw new TypeError('Programmatic Tool Surface entries are not in canonical order.')
+        throw new ToolSurfaceFactError(
+          'Programmatic Tool Surface entries are not in canonical order.'
+        )
       }
     }
     const prior = visibleNames.get(entry.target.providerVisibleName)
     if (prior !== undefined && prior !== entry.stableTargetKey) {
-      throw new TypeError('Programmatic Tool Surface contains a conflicting provider-visible name.')
+      throw new ToolSurfaceFactError(
+        'Programmatic Tool Surface contains a conflicting provider-visible name.'
+      )
     }
     visibleNames.set(entry.target.providerVisibleName, entry.stableTargetKey)
   }
@@ -1770,7 +1799,7 @@ export function createTapeProgrammaticToolSurfaceFact(
     !isProgrammaticCeilings(data.ceilings) ||
     !isProgrammaticQuotas(data.quotas)
   ) {
-    throw new TypeError('Programmatic Tool Surface fact input is invalid.')
+    throw new ToolSurfaceFactError('Programmatic Tool Surface fact input is invalid.')
   }
   const entries = data.entries
     .map(cloneCatalogEntry)
@@ -1784,13 +1813,13 @@ export function createTapeProgrammaticToolSurfaceFact(
       entries
     }) !== data.programmaticSurfaceHash
   ) {
-    throw new TypeError('Programmatic Tool Surface does not match its surface hash.')
+    throw new ToolSurfaceFactError('Programmatic Tool Surface does not match its surface hash.')
   }
   if (
     data.ceilings.maxToolEffect === 'read' &&
     entries.some((entry) => entry.execution.effect === 'write')
   ) {
-    throw new TypeError('Programmatic Tool Surface exceeds its effect ceiling.')
+    throw new ToolSurfaceFactError('Programmatic Tool Surface exceeds its effect ceiling.')
   }
   const maximum = Math.min(entries.length, MAX_TAPE_TOOL_CATALOG_PROJECTION_ENTRIES)
   const build = (length: number) =>
@@ -1798,7 +1827,9 @@ export function createTapeProgrammaticToolSurfaceFact(
   const retained = findLargestFittingPrefix(maximum, build)
   const fact = build(retained)
   if (canonicalBytes(fact) > MAX_TAPE_TOOL_FACT_BYTES) {
-    throw new TypeError('Programmatic Tool Surface fact exceeds its canonical byte limit.')
+    throw new ToolSurfaceFactError(
+      'Programmatic Tool Surface fact exceeds its canonical byte limit.'
+    )
   }
   return deepFreeze(fact)
 }

--- a/src/main/tape/ports/capabilities.ts
+++ b/src/main/tape/ports/capabilities.ts
@@ -14,6 +14,7 @@ import type {
 } from '../domain/facts'
 import type {
   TapeProviderAttemptInput,
+  TapeProviderAttemptRecord,
   TapeProviderContextPressureRecord
 } from '../domain/providerAttempt'
 import type {
@@ -343,6 +344,17 @@ export interface TapeAnchorReader {
     sessionId: string,
     compactionAttemptId: string
   ): DeepChatTapeEntryRow | undefined
+}
+
+export type TapeContextOccupancyEvidence = {
+  manifest: DeepChatTapeViewManifestRecord | null
+  providerAttempt: TapeProviderAttemptRecord | null
+  latestReconstructionAnchorEntryId: number | null
+}
+
+/** Context occupancy reads the latest View manifest, its provider attempt and the anchor cursor. */
+export interface TapeContextOccupancyReader {
+  getContextOccupancyEvidence(sessionId: string): TapeContextOccupancyEvidence
 }
 
 export interface TapeAnchorWriter {

--- a/test/main/data/databaseConnection.test.ts
+++ b/test/main/data/databaseConnection.test.ts
@@ -46,6 +46,7 @@ describe('main database connection configuration', () => {
       `cipher='sqlcipher'`,
       'legacy=4',
       'journal_mode = WAL',
+      'synchronous = NORMAL',
       'cache_size = -65536'
     ])
     expect(mocks.key).toHaveBeenCalledWith(Buffer.from(password, 'utf8'))
@@ -61,7 +62,7 @@ describe('main database connection configuration', () => {
     expect(mocks.pragma).not.toHaveBeenCalledWith(expect.stringContaining(password))
   })
 
-  it('enables WAL and the page cache ceiling directly for unencrypted databases', async () => {
+  it('enables WAL, NORMAL sync and the page cache ceiling directly for unencrypted databases', async () => {
     const { openSQLiteDatabase } = await import('../../../src/main/data/databaseConnection')
     const dbPath = path.join(process.cwd(), 'agent.db')
 
@@ -69,6 +70,7 @@ describe('main database connection configuration', () => {
 
     expect(mocks.pragma.mock.calls.map(([statement]) => statement)).toEqual([
       'journal_mode = WAL',
+      'synchronous = NORMAL',
       'cache_size = -65536'
     ])
   })

--- a/test/main/session/data/tapeToolSurfacePersistence.test.ts
+++ b/test/main/session/data/tapeToolSurfacePersistence.test.ts
@@ -813,6 +813,23 @@ describe('ToolSurfaceProvenanceService', () => {
     expect(entries).toEqual([])
   })
 
+  it('reports a TypeError thrown inside the transaction as a persistence failure', () => {
+    const { table } = createTapeTableMock()
+    const service = createTapeService(table)
+    table.appendToolSurfaceEvent.mockImplementationOnce(() => {
+      throw new TypeError("Cannot read properties of undefined (reading 'entry_id')")
+    })
+
+    let caught: unknown
+    try {
+      service.commitToolSurfaceView(createCommitInput())
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(ToolSurfaceProvenanceError)
+    expect((caught as ToolSurfaceProvenanceError).code).toBe('persistence_failed')
+  })
+
   it('recovers one hash-verified surface fact by provider request identity', () => {
     const { table } = createTapeTableMock()
     const service = createTapeService(table)

--- a/test/main/tape/layerBoundaries.test.ts
+++ b/test/main/tape/layerBoundaries.test.ts
@@ -26,6 +26,7 @@ const CAPABILITY_SCOPED_CONSUMER_FILES = [
   'agent/acp/compatibility/adapters.ts',
   'agent/acp/compatibility/dependencies.ts',
   'agent/deepchat/memory/memoryRuntimeCoordinator.ts',
+  'agent/deepchat/runtime/contextOccupancyCoordinator.ts',
   'agent/deepchat/runtime/deepChatLoopRunner.ts',
   'agent/deepchat/runtime/turnCoordinator.ts',
   'app/startupMigrations/legacyChatImportService.ts',

--- a/test/main/tape/skillMaterialization.test.ts
+++ b/test/main/tape/skillMaterialization.test.ts
@@ -845,7 +845,7 @@ describeSqlite('Tape Skill materialization SQLite capability', () => {
         name: 'custom/context',
         payload: {}
       })
-    ).toThrow('context entry kind is reserved')
+    ).toThrow('context entry kind')
     expect(table.search('session-1', 'hello 🌍')).toEqual([])
     expect(table.search('session-1', 'hello 🌍', { kinds: ['context'] })).toEqual([])
     expect(

--- a/test/main/tape/skillMaterialization.test.ts
+++ b/test/main/tape/skillMaterialization.test.ts
@@ -845,7 +845,9 @@ describeSqlite('Tape Skill materialization SQLite capability', () => {
         name: 'custom/context',
         payload: {}
       })
-    ).toThrow('context entry kind')
+    ).toThrow(
+      'The context entry kind and skill/materialized are reserved for the strict materialization writer.'
+    )
     expect(table.search('session-1', 'hello 🌍')).toEqual([])
     expect(table.search('session-1', 'hello 🌍', { kinds: ['context'] })).toEqual([])
     expect(


### PR DESCRIPTION
## Summary

Four places in the Tape stack relied on something that was true but written down nowhere, or written down in several places at once. Every SQLite connection ran with `synchronous=NORMAL` because the bundled `better-sqlite3-multiple-ciphers` build compiles that default in. The six strict-writer namespaces were spelled out three times: as generic-append rejections, as a strict-writer switch, and again as the audit-event exclusion list in `effectiveView.ts`. The Tool Surface domain signalled a contract violation by throwing the built-in `TypeError`, and the application layer classified on that. And `createSessionDataFromDatabase` handed out the concrete `SessionTape` class, so one runtime module typed its dependency as `Pick<SessionTape, ...>` because the read it needed had no port.

This branch states each of those in code, once. No schema, fact name, provenance key, hash format or IPC change. Existing Tapes read identically.

## What changed

**`synchronous = NORMAL` is set explicitly.** `configureSQLiteConnection` now issues the pragma after `journal_mode = WAL`. Measured on both encrypted and plain WAL connections under the current native build, the effective value was already `1`; the pragma keeps that durability contract independent of a future rebuild of the native module without `SQLITE_DEFAULT_WAL_SYNCHRONOUS=1`, which would otherwise fall back to FULL and add an fsync per commit.

**Reserved namespaces are one rule table.** `reservedNamespaces.ts` describes each strict-writer slice once: its exact fact names, the entry kind it is bound to, the reserved sibling prefix (`execution/`, `contract/`), whether its events are audit evidence, and its error texts. `assertTapeAppendAuthorized` walks the rules in declaration order, and `effectiveView.ts` derives `DEFAULT_EXCLUDED_TAPE_EVENT_NAMES` from the rules flagged `auditEvents: true` plus the four bookkeeping events written through the generic path. The check order, the resulting exclusion set (14 names) and the strict-writer error texts are unchanged.

While deriving the list I checked whether `provider/attempt_completed` was missing from it. It is not: `getLastEffectiveTapeMetrics` reads the latest attempt outcome from effective rows for the `tape_info` cache metrics, so the rule declares `auditEvents: false` with that reason next to it. Before, that only followed from the name being absent.

**Tool Surface facts throw their own error.** `commitToolSurfaceView` classified every `TypeError` escaping its transaction as `invalid_input`. The forty contract checks in `toolSurfaceFacts.ts` do throw for bad input, but so does any programming error inside the transaction, such as reading a property of an undefined row, and those were reported as if the caller had sent invalid data. The domain now throws `ToolSurfaceFactError` (the other Tape domains already carry their own error classes) and the service classifies on that type. A regression test pins a store `TypeError` inside the transaction to `persistence_failed`.

**The facade is exposed through its ports.** `SessionTape` now implements a single `SessionTapeCapabilities` alias, and `createSessionDataFromDatabase` returns `tapeStore` under that type. The concrete instance stays inside the composition root, whose `SessionTapePort` wrappers are the only callers of the facade's direct read helpers (`info`, `search`, `getContext`, `anchors`, `handoff`, `exportReplaySlice`). Context occupancy gets a `TapeContextOccupancyReader` port, `TapeContextOccupancyEvidence` moves next to it in `ports/capabilities.ts` (still re-exported from `application/contracts.ts`), and `contextOccupancyCoordinator.ts` joins the layer test's list of consumers that must not import the concrete facade. `handoffResult` is removed from the facade and the fact service; nothing in `src`, `test` or `docs` called it.

**Architecture baselines** record the two moved edges (`contextOccupancyCoordinator -> tape/ports/capabilities`, and `effectiveView` no longer importing `executionJournal`). The rest of that diff (six more `main` files, the shared routes digest) predates this branch: the baselines were last generated at f3a53f606 and dev has merged #2229 and #2233 since.

## Compatibility

- `ToolSurfaceProvenanceError.code` for a non-domain failure inside the Tool Surface transaction is now `persistence_failed` instead of `invalid_input`. No caller branches on that code; the loop runner rethrows the error as-is.
- Domain validation errors from `toolSurfaceFacts.ts` have `name === 'ToolSurfaceFactError'` instead of `'TypeError'`. Nothing in `src/main` or `src/shared` tested for `TypeError` other than the one classification site this branch changes.
- A generic append of a `context` row now fails with one message that names both the kind and `skill/materialized`; previously the two cases had separate texts. One test substring was adjusted.
- `SessionData.tapeStore` is typed as `SessionTapeCapabilities`. Consumers can only reach methods some port declares; the runtime object is the same instance as before.
- `DEFAULT_EXCLUDED_TAPE_EVENT_NAMES` is `readonly string[]` rather than a literal tuple, and the order of names inside the SQL `NOT IN (...)` changed. Both consumers only need the set.

## Validation

- `format:check`, `i18n`, `lint`, `typecheck` (node + web): pass
- `test/main`, run in directory chunks because the one-shot runner is killed locally by `scripts/buildCli.test.ts` (it executes the CLI bundle with `process.execPath`, which in this sandbox is not a plain Node binary; unrelated to this branch): `tape` + `session` + `data` 54 files, 878 passed; `agent` 110 files, 2109 passed; remaining directories 576 files, 8134 passed; `scripts` 29 of 30 files passed
- Real SQLite under the Electron ABI on the CI native allowlist: 13 files, 296 passed (one more than #2233: the new regression test)
- `architectureBaseline.test.ts` passes before and after the refresh; cycle counts are unchanged (13 / 2 / 0 / 0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added context-occupancy evidence access for session runtime components.
  - Added dedicated validation errors for tool-surface data.
  - Centralized reserved audit-event and namespace authorization rules.

- **Bug Fixes**
  - Database connections now use NORMAL synchronization for consistent durability behavior.
  - Tool-surface persistence errors are classified more accurately.

- **Refactor**
  - Simplified session tape capability exposure and internal boundaries.
  - Removed the obsolete handoff result API.

- **Documentation**
  - Refreshed architecture baseline and dependency reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->