### PR TITLE
refactor(tape): derive the transcript from message facts

### DIFF
--- a/.github/workflows/prcheck.yml
+++ b/.github/workflows/prcheck.yml
@@ -181,6 +181,7 @@ jobs:
           test/main/session/data/tables/deepchatTapeEntriesTable.test.ts
           test/main/session/data/messageContent.test.ts
           test/main/session/data/transcriptAtomicity.test.ts
+          test/main/session/data/transcriptProjection.test.ts
 
       - name: Validate encrypted OCR artifact storage
         env:

--- a/.github/workflows/prcheck.yml
+++ b/.github/workflows/prcheck.yml
@@ -179,6 +179,7 @@ jobs:
           test/main/session/data/tapeToolSurfacePersistence.test.ts
           test/main/session/data/tapeViewReplay.test.ts
           test/main/session/data/tables/deepchatTapeEntriesTable.test.ts
+          test/main/session/data/messageContent.test.ts
           test/main/session/data/transcriptAtomicity.test.ts
 
       - name: Validate encrypted OCR artifact storage

--- a/docs/architecture/baselines/agent-system-layered-runtime-baseline.json
+++ b/docs/architecture/baselines/agent-system-layered-runtime-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "goal": "agent-system-layered-runtime",
-  "headCommit": "ed7adc34c5fa87a681f324de2f5f1ac1a66b50ef",
+  "headCommit": "c197fe2353f978e357b1bc991730248ba52cf99e",
   "relevantWorkingTree": {
     "dirty": false,
     "files": []
@@ -505,7 +505,7 @@
         "src/main/data/schemaTypes.ts"
       ],
       "tableIdentifiers": [],
-      "sha256": "2fc461f7d57c80f60c0ce3598ade2ebc0d0d4fae8470869ac2f2ebeb44e9fa14"
+      "sha256": "6e42c951463b29919331fe327d5f59a20736ba4b5297f31de48eb2c60f0aa8bf"
     },
     "memoryDuckDbSidecar": {
       "files": [

--- a/docs/architecture/baselines/dependency-report.md
+++ b/docs/architecture/baselines/dependency-report.md
@@ -1,28 +1,28 @@
 # Dependency Baseline
 
-Generated on 2026-09-04.
+Generated on 2026-09-06.
 
 ## main
 
-- Total files: 859
-- Internal dependency edges: 3021
-- Cycles detected: 13
+- Total files: 862
+- Internal dependency edges: 3035
+- Cycles detected: 14
 
 ### Top outgoing dependencies
 
 - `app/composition.ts`: 183
 - `agent/deepchat/runtime/deepChatLoopRunner.ts`: 61
 - `agent/deepchat/runtime/turnCoordinator.ts`: 53
-- `data/schemaCatalog.ts`: 45
+- `data/schemaCatalog.ts`: 46
 - `agent/deepchat/harness/createDeepChatAgentHarness.ts`: 42
 - `tool/agentTools/agentToolManager.ts`: 37
 - `agent/deepchat/harness/runtimeServices.ts`: 35
 - `agent/deepchat/runtime/dispatch.ts`: 27
 - `agent/deepchat/runtime/interactionCoordinator.ts`: 27
 - `agent/deepchat/runtime/compactionRuntimeCoordinator.ts`: 24
+- `session/data/database.ts`: 24
 - `tool/index.ts`: 24
 - `memory/index.ts`: 23
-- `session/data/database.ts`: 23
 - `tape/application/sessionTape.ts`: 22
 - `agent/deepchat/runtime/deferredToolExecutor.ts`: 20
 
@@ -30,13 +30,13 @@ Generated on 2026-09-04.
 
 - `provider/settings.ts`: 49
 - `agent/shared/agentSessionIds.ts`: 46
-- `data/baseTable.ts`: 44
+- `data/baseTable.ts`: 45
 - `routes/routeRegistry.ts`: 43
 - `remote/types.ts`: 39
 - `tape/ports/capabilities.ts`: 36
 - `agent/settings.ts`: 35
 - `config/settingsStore.ts`: 35
-- `tape/domain/entry.ts`: 34
+- `tape/domain/entry.ts`: 35
 - `tape/domain/canonicalJson.ts`: 31
 - `agent/deepchat/runtime/types.ts`: 28
 - `agent/deepchat/runtime/toolSurface.ts`: 25
@@ -46,6 +46,7 @@ Generated on 2026-09-04.
 
 ### Cycle samples
 
+- `session/data/tables/deepchatAssistantBlocks.ts -> session/data/messageContent.ts -> session/data/tables/deepchatAssistantBlocks.ts`
 - `memory/types.ts -> memory/injection.ts -> memory/core/injectionPort.ts -> memory/types.ts`
 - `memory/core/injectionPort.ts -> memory/core/directiveContribution.ts -> memory/core/injectionPort.ts`
 - `agent/acp/runtime/acpProcessManager.ts -> agent/deepchat/runtime/types.ts -> session/contracts.ts -> agent/manager/sessionHandles.ts -> agent/acp/instance/index.ts -> agent/acp/instance/acpAgentInstance.ts -> agent/acp/runtime/acpSessionManager.ts -> agent/acp/runtime/acpProcessManager.ts`

--- a/docs/architecture/baselines/main-kernel-boundary-baseline.md
+++ b/docs/architecture/baselines/main-kernel-boundary-baseline.md
@@ -1,6 +1,6 @@
 # Main Kernel Boundary Baseline
 
-Generated on 2026-09-04.
+Generated on 2026-09-06.
 Current phase: P5.
 
 ## Metric Snapshot

--- a/docs/architecture/baselines/main-kernel-migration-scoreboard.json
+++ b/docs/architecture/baselines/main-kernel-migration-scoreboard.json
@@ -1,6 +1,6 @@
 {
   "program": "main-kernel-refactor",
-  "generatedOn": "2026-09-04",
+  "generatedOn": "2026-09-06",
   "currentPhase": "P5",
   "metrics": {
     "renderer.usePresenter.count": 0,

--- a/docs/architecture/baselines/main-kernel-migration-scoreboard.md
+++ b/docs/architecture/baselines/main-kernel-migration-scoreboard.md
@@ -1,6 +1,6 @@
 # Main Kernel Migration Scoreboard
 
-Generated on 2026-09-04.
+Generated on 2026-09-06.
 Current phase: P5.
 
 Phase 0 establishes the comparison baseline. Later phases should update this report and compare against this checkpoint.

--- a/docs/architecture/baselines/zero-inbound-candidates.md
+++ b/docs/architecture/baselines/zero-inbound-candidates.md
@@ -1,6 +1,6 @@
 # Zero Inbound Candidates
 
-Generated on 2026-09-04.
+Generated on 2026-09-06.
 
 These files have no in-repo importers inside their scope and need manual classification before deletion.
 

--- a/docs/architecture/tape-system.md
+++ b/docs/architecture/tape-system.md
@@ -23,10 +23,12 @@ Tape 是 Session 同寿命的 append-only fact store，在同一个物理 entry 
 - Execution Journal 保存 Run、工具副作用和终态的原生边界事实，服务失败分类与崩溃后对账；
 - Contract lineage 保存冻结的任务语义和验收裁决，服务 live delegation 的约束、交接、评价与审计。
 
-message transcript 是活跃 message state 和 UI read model，也是当前 Context Tape message fact 的生产
-来源；它不是 Execution Journal 的 authority。legacy transcript reconciliation 只可重建 Context Tape，
-不得制造 `execution/*` 或 `contract/*` 事实。live-delegation row 和 mailbox 是 Contract fact 的在线
-projection；Tape 保存历史事实，但不成为在线权限或编排状态的 authority。
+message transcript 是 Context Tape message fact 的派生投影和 UI read model：终态消息先 append 为
+fact，再在同一事务内由 `TranscriptProjectionApplier` 从该 fact 的 record 派生 transcript 各表；流式
+中间态只留在 transcript 的 pending 区。transcript 不是 Execution Journal 的 authority。transcript
+reconciliation 只在 Session 尚无当前 incarnation 的投影游标时把既有 transcript 一次性回填进 Context
+Tape，不得制造 `execution/*` 或 `contract/*` 事实。live-delegation row 和 mailbox 是 Contract fact 的
+在线 projection；Tape 保存历史事实，但不成为在线权限或编排状态的 authority。
 
 ## 所有权和分层
 
@@ -71,7 +73,7 @@ modules 曾作为冻结的 deprecated compatibility re-export 存在，生产代
 | Interaction coordinator | deferred approval recovery 所需的 `ExecutionJournalRecoveryReader`、exact execution ViewManifest reader 与 tool-surface fact reader 窄组合 |
 | Live delegation repository | `ParentTaskContractWriter`、`TaskContractWriter`、`TaskEvaluationWriter` |
 | Turn coordinator / ACP compatibility | `TapeReconciliationPort` |
-| Transcript | `TapeMessageFactWriter` |
+| Transcript | `TapeMessageFactWriter`、`TapeProjectionHeadReader`；同时实现 reconciliation 依赖的 `TapeTranscriptProjection` |
 | Memory runtime | `TapeNonContextEntryReader`、`TapeAnchorWriter` |
 | Settings / compaction | `TapeAnchorReader`、`TapeAnchorWriter`、`TapeLifecycleAdmin` |
 | Memory routes | `TapeInspectionReader` |
@@ -102,7 +104,9 @@ domain policy；外部方法的签名、同步/异步行为、异常和 fallback
   live-delegation 的宿主事务。每个 Contract fact 分别与它触发或证明的 runtime mutation 原子提交；不同
   lifecycle boundary 之间不共享一个长事务。
 - transcript message mutation 与 replacement/retraction fact、summary compare-and-set 与 anchor append
-  使用同一个 SQLite connection 和调用方 transaction，拆层不能拆开其原子边界。
+  使用同一个 SQLite connection 和调用方 transaction，拆层不能拆开其原子边界。终态 transcript 写入的顺序
+  固定为 fact append → 表投影 → 推进 `deepchat_transcript_projection_meta` 游标；游标只由 reconciliation
+  的一次性回填创建，写入只能推进已建立的游标。
 - `clearMessages` 在同一外层 transaction 中删除 pending input、transcript projection 并 reset Tape；
   Tape generation transaction 作为 savepoint 嵌套，任一 hard failure 会同时恢复三类数据。
 - `resetSessionTape` 在同一 transaction 内删除 entry、mutation projection、search/FTS projection 并
@@ -374,11 +378,15 @@ authority。
 
 ## Message projection 与 Context facts
 
-- user/assistant/reasoning/tool terminal result 在 projection 完成后写入对应 Context Tape fact；
+- user/assistant terminal result 先写入对应 Context Tape fact，再由同一事务内的投影派生 transcript
+  表；tool fact 由 loop runner 在每轮结算后写入，终态 message fact 以幂等 provenance 补齐其
+  `tool_call`/`tool_result` 事实；
 - provider/tool retry 不得重复提交 terminal fact；
-- Context Tape 写失败按当前 settlement policy 记录/隔离，不能把已经完成的用户回复变成无限挂起；
-- transcript reconciliation 可以回填 legacy Context facts，但 classifier 只读取原生 `execution/*` v1
-  events，二者不得互相伪造；
+- Context Tape 写失败按当前 settlement policy 记录/隔离，不能把已经完成的用户回复变成无限挂起；同事务
+  的 fact append 失败会连带回滚 transcript 写入；
+- readiness 以投影游标比对 Tape head：游标缺失或 incarnation 不匹配时把 transcript 一次性回填进 Context
+  Tape 并建立游标，否则只重放游标之后的 message fact 与 retraction；classifier 只读取原生
+  `execution/*` v1 events，二者不得互相伪造；
 - replay 从 manifest 和 facts 重建 provider-visible context，不从 renderer block 猜测执行语义。
 
 ## Model capability
@@ -425,7 +433,8 @@ stored manifest validation、legacy `hashVersion` normalization、entry-id colle
 属于 `src/main/tape/domain/replay.ts` 的纯逻辑；SQLite row parsing、message trace 和 terminal evidence
 读取仍属于 `TapeViewReplayService`，不能反向放进 domain。
 
-关键行为测试位于 `test/main/session/data/tape*.test.ts`，分层守护位于
+关键行为测试位于 `test/main/session/data/tape*.test.ts`、`transcriptAtomicity.test.ts`、
+`transcriptProjection.test.ts` 与 `messageContent.test.ts`，分层守护位于
 `test/main/tape/layerBoundaries.test.ts`；runtime 和 tool 契约继续位于
 `test/main/agent/deepchat/` 与 `test/main/tool/`。历史的 Tape increment SDD 已合并到本文，详细实施
 顺序从 Git 历史查询。

--- a/docs/architecture/tape-system.md
+++ b/docs/architecture/tape-system.md
@@ -385,8 +385,8 @@ authority。
 - Context Tape 写失败按当前 settlement policy 记录/隔离，不能把已经完成的用户回复变成无限挂起；同事务
   的 fact append 失败会连带回滚 transcript 写入；
 - readiness 以投影游标比对 Tape head：游标缺失或 incarnation 不匹配时把 transcript 一次性回填进 Context
-  Tape 并建立游标，否则只重放游标之后的 message fact 与 retraction；classifier 只读取原生
-  `execution/*` v1 events，二者不得互相伪造；
+  Tape、把 Tape 中 transcript 没有的有效消息投影回表，再建立游标；否则只重放游标之后的 message fact 与
+  retraction。classifier 只读取原生 `execution/*` v1 events，二者不得互相伪造；
 - replay 从 manifest 和 facts 重建 provider-visible context，不从 renderer block 猜测执行语义。
 
 ## Model capability

--- a/docs/architecture/tape-transcript-projection/plan.md
+++ b/docs/architecture/tape-transcript-projection/plan.md
@@ -1,0 +1,85 @@
+# Tape Transcript Projection Implementation Plan
+
+Spec: [spec.md](./spec.md). One branch, one PR; each slice below is one reviewable commit that
+leaves `pnpm typecheck` and the session/tape suites green on its own.
+
+## Slice 1: Make idempotent message appends observable
+
+- [ ] In `factPersistence.ts` `appendMessageRecordToTape`, compare the returned row's
+      `payload.record` with the record when the provenance key was derived; warn once with session
+      id, message id, source and differing field names (`content`, `status`, `orderSeq`,
+      `metadata`). Skip the comparison when the stored `payload_json` equals the serialized payload.
+- [ ] Guard test: identical re-append logs nothing; a re-append with different content logs one
+      warning naming `content`.
+
+Completion: the warning exists and fires only on divergence. No behavior change for callers.
+
+## Slice 2: Canonical record and the applier as the single terminal writer
+
+- [ ] Extract the persist and read field mappings for user files and assistant blocks into pure
+      functions in `src/main/session/data/messageContent.ts`, used by both the tables' write path
+      and `toMessageFile` / `toAssistantBlock`.
+- [ ] Add `canonicalizeMessageContent(role, rawContent, updatedAt)` on top of those mappings.
+- [ ] Add `TranscriptProjectionApplier` (`transcriptProjection.ts`) with `applyRecord` and
+      `applyRetraction`; move the table-writing bodies of the terminal methods into it.
+- [ ] Route every terminal method in `SessionTranscript` through the applier while keeping the
+      current order (tables, read back, fact). Behavior is unchanged in this slice.
+- [ ] Round-trip guard test: `materialize(persist(canonical)) === canonical` for user content with
+      files, links, active skills, inline items, and for each persisted assistant block type.
+
+Completion: `SessionTranscript` no longer writes terminal rows directly; all existing tests pass.
+
+## Slice 3: Fact-first terminal writes
+
+- [ ] Reorder every method in the spec's write-direction table: canonical record in memory, fact
+      append, `applyRecord`/`applyRetraction`. Remove `appendLiveTapeFacts`.
+- [ ] Fork: `cloneSentMessagesToSession` appends `message/<role>` facts with `meta.source = 'fork'`
+      before applying.
+- [ ] `recoverPendingMessages` and legacy import `backfillMessageRow` append their facts before
+      applying; the table-level `deepchatMessages.recoverPendingMessages` is removed if unused.
+- [ ] `prepareRetryMessage` restores the prompt through a replacement fact
+      (`reason: 'retry_restored_prompt'`) instead of `updateMessageStatus`.
+- [ ] Acceptance test: after each terminal write, `getMessage(id)` deep-equals the latest effective
+      fact record (except `traceCount`); fork/recover/import/retry leave no fact-less row.
+
+Completion: no transcript terminal write happens without its fact in the same transaction.
+
+## Slice 4: Projection cursor, replay and head-comparison readiness
+
+- [ ] Add `deepchat_transcript_projection_meta` table and registration in `SessionDatabase`;
+      `clearMessages` deletes the row in its transaction.
+- [ ] Every fact-first write advances the row to the Tape head in the same transaction.
+- [ ] `TranscriptProjectionApplier.replay(sessionId, afterEntryId)` over effective message input
+      rows: message facts via `applyRecord`, retractions via `applyRetraction`, compaction
+      indicators skipped; UPSERT-only.
+- [ ] `TapeReconcilerService.ensureSessionTapeReady` implements readiness steps 1–5 from the spec:
+      one head query, one-time legacy backfill for absent meta, incarnation mismatch handling,
+      incremental replay, unchanged `historyRecords`. Remove the `reconciled` map and
+      `digestTranscript`.
+- [ ] Tests: unchanged Session performs no transcript read (spy on `getMessages`); absent meta with
+      transcript rows backfills once and deletes nothing; meta deleted plus a direct Tape append
+      materializes the message; incarnation mismatch re-runs the backfill.
+
+Completion: `ensureSessionTapeReady` is O(delta) and the transcript digest is gone.
+
+## Slice 5: Documentation and test alignment
+
+- [ ] `docs/architecture/tape-system.md`: lines 26–27 describe the transcript as the derived
+      projection and UI read model of Context Tape message facts; the "Message projection 与 Context
+      facts" section states fact-first order and the one-time migration backfill.
+- [ ] Rewrite `tapeReconciler.test.ts` cases that assert transcript-bypass backfill into projection
+      replay cases; keep the tool-revision and legacy-summary cases.
+- [ ] Update `tapeTestHarness.ts` / `tapeTableMockContract.test.ts` only where the new meta table or
+      applier needs a mock surface.
+
+Completion: docs match code; no test asserts the removed backfill direction.
+
+## Whole-change review and gates
+
+- [ ] Review against the spec for hidden side effects, compatibility, failure behavior,
+      performance, security, naming and maintenance cost before each commit.
+- [ ] `pnpm run format`, `pnpm run i18n`, `pnpm run lint`, `pnpm run typecheck`.
+- [ ] `test/main/session`, `test/main/tape`, `test/main/agent/deepchat`; real-SQLite contract
+      suites under the Electron ABI.
+- [ ] Manual: new chat, resume, edit, delete, steer, manual compaction, fork, legacy import; compare
+      Inspector rows with the UI.

--- a/docs/architecture/tape-transcript-projection/plan.md
+++ b/docs/architecture/tape-transcript-projection/plan.md
@@ -51,19 +51,21 @@ Completion: no transcript terminal write happens without its fact in the same tr
 
 ## Slice 4: Projection cursor, replay and head-comparison readiness
 
-- [ ] Add `deepchat_transcript_projection_meta` table and registration in `SessionDatabase`;
-      `clearMessages` deletes the row in its transaction.
-- [ ] Every fact-first write advances the row to the Tape head in the same transaction.
-- [ ] `TranscriptProjectionApplier.replay(sessionId, afterEntryId)` over effective message input
-      rows: message facts via `applyRecord`, retractions via `applyRetraction`, compaction
-      indicators skipped; UPSERT-only.
-- [ ] `TapeReconcilerService.ensureSessionTapeReady` implements readiness steps 1–5 from the spec:
-      one head query, one-time legacy backfill for absent meta, incarnation mismatch handling,
-      incremental replay, unchanged `historyRecords`. Remove the `reconciled` map and
-      `digestTranscript`.
-- [ ] Tests: unchanged Session performs no transcript read (spy on `getMessages`); absent meta with
-      transcript rows backfills once and deletes nothing; meta deleted plus a direct Tape append
-      materializes the message; incarnation mismatch re-runs the backfill.
+- [x] `deepchat_transcript_projection_meta` table (`tables/deepchatTranscriptProjectionMeta.ts`),
+      registered in the schema catalog and `SessionDatabase`; `deleteBySession` drops the row inside
+      the `clearMessages` transaction.
+- [x] Every fact-first write moves an established cursor to the Tape head (`getProjectionHead`);
+      a Session without a cursor for the current incarnation waits for reconciliation to backfill.
+- [x] `TranscriptProjectionApplier.applyTapeEntries` replays message facts and retractions in entry
+      order; compaction indicators are skipped. `getEffectiveMessageInputRowsAfter` reads the range.
+- [x] `TapeReconcilerService.ensureSessionTapeReady` compares cursor and head in one store
+      transaction: absent or foreign-incarnation cursor backfills the transcript once, a cursor
+      behind the head replays the increment. The `reconciled` map and `digestTranscript` are gone.
+- [x] Tests: cursor suite in `tapeReconciler.test.ts`; real-SQLite `transcriptProjection.test.ts`
+      (cursor established by readiness and moved by writes, direct Tape facts materialized,
+      pre-projection rows backfilled without deletion, reset rebuilds the cursor) in the native CI
+      step; harness doubles gain the meta table and drop the cursor where they install history
+      behind the projection's back.
 
 Completion: `ensureSessionTapeReady` is O(delta) and the transcript digest is gone.
 

--- a/docs/architecture/tape-transcript-projection/plan.md
+++ b/docs/architecture/tape-transcript-projection/plan.md
@@ -27,27 +27,25 @@ Completion: the warning exists and fires only on divergence. No behavior change 
 
 Completion: one mapping per direction; the canonical form is pinned to the tables' behavior.
 
-## Slice 2b: The applier as the single terminal writer
+## Slice 2b + 3: Fact-first terminal writes through one applier
 
-- [ ] Add `TranscriptProjectionApplier` (`transcriptProjection.ts`) with `applyRecord` and
-      `applyRetraction`; move the table-writing bodies of the terminal methods into it.
-- [ ] Route every terminal method in `SessionTranscript` through the applier while keeping the
-      current order (tables, read back, fact). Behavior is unchanged in this slice.
+Landed as one commit: routing the terminal writes through the applier while keeping the old order
+would have meant a temporary read-back path and a second rewrite of every table double.
 
-Completion: `SessionTranscript` no longer writes terminal rows directly; all existing tests pass.
-
-## Slice 3: Fact-first terminal writes
-
-- [ ] Reorder every method in the spec's write-direction table: canonical record in memory, fact
-      append, `applyRecord`/`applyRetraction`. Remove `appendLiveTapeFacts`.
-- [ ] Fork: `cloneSentMessagesToSession` appends `message/<role>` facts with `meta.source = 'fork'`
-      before applying.
-- [ ] `recoverPendingMessages` and legacy import `backfillMessageRow` append their facts before
-      applying; the table-level `deepchatMessages.recoverPendingMessages` is removed if unused.
-- [ ] `prepareRetryMessage` restores the prompt through a replacement fact
-      (`reason: 'retry_restored_prompt'`) instead of `updateMessageStatus`.
-- [ ] Acceptance test: after each terminal write, `getMessage(id)` deep-equals the latest effective
-      fact record (except `traceCount`); fork/recover/import/retry leave no fact-less row.
+- [x] `TranscriptProjectionApplier` (`transcriptProjection.ts`) with `applyRecord` and
+      `applyRetractions`; the table-writing bodies, search document and usage-stats writes live
+      there. `deepchat_messages` gains `upsert` and `deleteByIds`.
+- [x] Every method in the spec's write-direction table builds the canonical record in memory,
+      appends its fact, then applies it. `appendLiveTapeFacts` and the read-back are gone.
+- [x] Fork appends a live `message/<role>` fact per copied row in one transaction;
+      `recoverPendingMessages` appends a revision fact per recovered row, one transaction each;
+      legacy import calls `importMessageRow`, which replaces the importer's direct insert.
+- [x] `restoreUserMessage` replaces the retry path's `updateMessageStatus('sent')`;
+      `updateMessageStatus` accepts only `'pending'`.
+- [x] Compaction shift keeps its single `incrementOrderSeqFrom` UPDATE, now stamped with the same
+      `updatedAt` the order replacement facts carry; range deletes keep their table-level statement.
+- [x] Tests: the transcript double returns appended rows; assertions follow `upsert`; fork,
+      retry-restore and import pin fact and row from the same record.
 
 Completion: no transcript terminal write happens without its fact in the same transaction.
 

--- a/docs/architecture/tape-transcript-projection/plan.md
+++ b/docs/architecture/tape-transcript-projection/plan.md
@@ -71,22 +71,27 @@ Completion: `ensureSessionTapeReady` is O(delta) and the transcript digest is go
 
 ## Slice 5: Documentation and test alignment
 
-- [ ] `docs/architecture/tape-system.md`: lines 26–27 describe the transcript as the derived
-      projection and UI read model of Context Tape message facts; the "Message projection 与 Context
-      facts" section states fact-first order and the one-time migration backfill.
-- [ ] Rewrite `tapeReconciler.test.ts` cases that assert transcript-bypass backfill into projection
-      replay cases; keep the tool-revision and legacy-summary cases.
-- [ ] Update `tapeTestHarness.ts` / `tapeTableMockContract.test.ts` only where the new meta table or
-      applier needs a mock surface.
+- [x] `docs/architecture/tape-system.md`: the transcript is described as the derived projection and
+      UI read model of Context Tape message facts; the transaction-boundary and "Message projection
+      与 Context facts" sections state the fact-first order, the cursor rule and the one-time
+      backfill; the test map names the new suites.
+- [x] `tapeReconciler.test.ts` cases that asserted transcript-bypass backfill became projection
+      cursor cases; tool-revision and legacy-summary cases stay.
+- [x] `tapeTestHarness.ts` gained `createTranscriptProjectionMock` and the range read;
+      `tapeTableMockContract.test.ts` pins the range read against the real store.
 
 Completion: docs match code; no test asserts the removed backfill direction.
 
 ## Whole-change review and gates
 
-- [ ] Review against the spec for hidden side effects, compatibility, failure behavior,
+- [x] Review against the spec for hidden side effects, compatibility, failure behavior,
       performance, security, naming and maintenance cost before each commit.
-- [ ] `pnpm run format`, `pnpm run i18n`, `pnpm run lint`, `pnpm run typecheck`.
-- [ ] `test/main/session`, `test/main/tape`, `test/main/agent/deepchat`; real-SQLite contract
-      suites under the Electron ABI.
+- [x] `pnpm run format`, `pnpm run lint`, `pnpm run typecheck` (no user copy changed, so `i18n`
+      was not needed).
+- [x] `test/main/session`, `test/main/tape`, `test/main/agent`, `test/main/app`, `test/main/data`,
+      `test/main/memory` under the Electron ABI: 4268 passed; the 17 failures are pre-existing
+      local environment failures (`acpTerminalAuthRunner` PTY timeout,
+      `sessionDataMigrations.sqlite`, `mainDatabase`, `deepchatPendingInputsTable`) verified on
+      the base commit.
 - [ ] Manual: new chat, resume, edit, delete, steer, manual compaction, fork, legacy import; compare
       Inspector rows with the UI.

--- a/docs/architecture/tape-transcript-projection/plan.md
+++ b/docs/architecture/tape-transcript-projection/plan.md
@@ -5,27 +5,34 @@ leaves `pnpm typecheck` and the session/tape suites green on its own.
 
 ## Slice 1: Make idempotent message appends observable
 
-- [ ] In `factPersistence.ts` `appendMessageRecordToTape`, compare the returned row's
+- [x] In `factPersistence.ts` `appendMessageRecordToTape`, compare the returned row's
       `payload.record` with the record when the provenance key was derived; warn once with session
       id, message id, source and differing field names (`content`, `status`, `orderSeq`,
       `metadata`). Skip the comparison when the stored `payload_json` equals the serialized payload.
-- [ ] Guard test: identical re-append logs nothing; a re-append with different content logs one
+- [x] Guard test: identical re-append logs nothing; a re-append with different content logs one
       warning naming `content`.
 
 Completion: the warning exists and fires only on divergence. No behavior change for callers.
 
-## Slice 2: Canonical record and the applier as the single terminal writer
+## Slice 2a: Canonical record on shared table mappings
 
-- [ ] Extract the persist and read field mappings for user files and assistant blocks into pure
-      functions in `src/main/session/data/messageContent.ts`, used by both the tables' write path
-      and `toMessageFile` / `toAssistantBlock`.
-- [ ] Add `canonicalizeMessageContent(role, rawContent, updatedAt)` on top of those mappings.
+- [x] Move the persist and read field mappings for user files and assistant blocks into
+      `src/main/session/data/messageContent.ts`; `deepchat_assistant_blocks.replaceForMessage`,
+      `persistUserContent` and `materializeContent` use them.
+- [x] Add `canonicalizeMessageContent(role, rawContent, updatedAt)` on top of those mappings.
+- [x] Round-trip guard test against real SQLite: the canonical string equals what the tables return
+      after persisting the raw content, for user content with files, links, active skills and inline
+      items, and for assistant blocks covering reasoning, tool call, image, action and error shapes
+      including a block without a timestamp. The test runs in the native Tape storage CI step.
+
+Completion: one mapping per direction; the canonical form is pinned to the tables' behavior.
+
+## Slice 2b: The applier as the single terminal writer
+
 - [ ] Add `TranscriptProjectionApplier` (`transcriptProjection.ts`) with `applyRecord` and
       `applyRetraction`; move the table-writing bodies of the terminal methods into it.
 - [ ] Route every terminal method in `SessionTranscript` through the applier while keeping the
       current order (tables, read back, fact). Behavior is unchanged in this slice.
-- [ ] Round-trip guard test: `materialize(persist(canonical)) === canonical` for user content with
-      files, links, active skills, inline items, and for each persisted assistant block type.
 
 Completion: `SessionTranscript` no longer writes terminal rows directly; all existing tests pass.
 

--- a/docs/architecture/tape-transcript-projection/spec.md
+++ b/docs/architecture/tape-transcript-projection/spec.md
@@ -156,11 +156,13 @@ the Tape reset; the legacy import overwrite clears it with the other legacy-owne
 `ensureSessionTapeReady(sessionId)` becomes:
 
 1. Read `(tape incarnation, tape max entry id)` and the meta row in one query.
-2. If the meta row is absent and the transcript has rows: run the existing legacy backfill
-   (transcript to Tape, idempotent, `source: 'backfill'`), append the `migration/backfill` event as
-   today, then write the meta row. This is the upgrade path for Sessions whose Tape fell behind
-   before this change (a fork, import or recovery that was never followed by a turn), and it is what
-   keeps the applier from ever replaying an empty Tape over a populated transcript.
+2. If the meta row is absent: run the existing legacy backfill (transcript to Tape, idempotent,
+   `source: 'backfill'`), then project the other way any effective Tape message whose id the
+   transcript does not hold, append the `migration/backfill` event as today, and write the meta row.
+   The backfill is the upgrade path for Sessions whose Tape fell behind before this change (a fork,
+   import or recovery that was never followed by a turn) and keeps the applier from replaying an
+   empty Tape over a populated transcript; the reverse projection keeps the cursor honest for a fact
+   that entered the Tape without going through the transcript, which no path produces today.
 3. If the meta row exists but its incarnation differs from the Tape's: the Tape was reset under the
    transcript. Treat the row as absent and run step 2, which overwrites it.
 4. If `max_entry_id` is behind the Tape head: `replay(sessionId, max_entry_id)`, then advance the
@@ -181,9 +183,10 @@ records through `TapeProjectionHeadReader.getProjectionHead`.
 
 `appendMessageRecordToTape` compares the row the store returned with the record it tried to
 append whenever the provenance key was derived and the append is live (a `sent` record written by
-the transcript, including fork, import and recovery). If `content`, `status`, `orderSeq` or
-`metadata` differ, it logs one warning with the session id, message id, source and the names of the
-differing fields. Payload text is never logged. Backfill appends do not report: a backfill of an
+the transcript, including fork, import and recovery). If `content`, `status`, `orderSeq`,
+`metadata` or `isContextEdge` differ, it logs one warning with the session id, message id and the
+names of the differing fields. `sessionId` and `id` are not compared: the derived key is scoped to
+both, so a hit already proves they match. Payload text is never logged. Backfill appends do not report: a backfill of an
 old Session compares today's materialized content with a fact written by an earlier version, and
 that is format history, not a bypassed write. The append result is unchanged; the guard only makes
 a divergence visible.
@@ -205,8 +208,9 @@ import the applier.
 ## Compatibility
 
 - No Tape schema, fact name, provenance key, hash version or payload field changes. Records written
-  fact-first serialize to the same `payload.record` shape as records read back from the tables did;
-  `traceCount` is `0`, which is what the live read-back reported as well.
+  fact-first serialize to the same `payload.record` shape as records read back from the tables did.
+  `traceCount` is pinned to `0`; the previous read-back carried a snapshot that could be above zero
+  when request tracing was enabled. No reader takes `traceCount` from a Tape record.
 - Rollback is a code revert. The meta table is ignored by earlier code; the earlier reconciler's
   backfill finds every fact already present through provenance keys and appends nothing.
 - `SessionTranscript`'s public method signatures are unchanged. `TapeBackfillResult` is unchanged.

--- a/docs/architecture/tape-transcript-projection/spec.md
+++ b/docs/architecture/tape-transcript-projection/spec.md
@@ -163,6 +163,12 @@ the Tape reset; the legacy import overwrite clears it with the other legacy-owne
    import or recovery that was never followed by a turn) and keeps the applier from replaying an
    empty Tape over a populated transcript; the reverse projection keeps the cursor honest for a fact
    that entered the Tape without going through the transcript, which no path produces today.
+   This step only adds. A transcript row whose Tape fact was retracted is kept and the retraction is
+   not applied: with no cursor, the transcript is the record the user has been looking at, and a
+   Session without a cursor is exactly the one whose Tape may be stale. Deleting a row here would
+   trust the stale side. No path produces that state either (delete removes the row and appends the
+   retraction in one transaction); once a cursor exists, the incremental replay in step 4 applies
+   retractions as they arrive.
 3. If the meta row exists but its incarnation differs from the Tape's: the Tape was reset under the
    transcript. Treat the row as absent and run step 2, which overwrites it.
 4. If `max_entry_id` is behind the Tape head: `replay(sessionId, max_entry_id)`, then advance the

--- a/docs/architecture/tape-transcript-projection/spec.md
+++ b/docs/architecture/tape-transcript-projection/spec.md
@@ -67,7 +67,8 @@ derived from it in the same transaction.
 | Family | Role | Producer |
 | --- | --- | --- |
 | Tape `message/*` facts, `message/retracted` and `message/compaction_indicator` events | Terminal message facts | `TapeMessageFactWriter` called by transcript terminal writes |
-| Transcript terminal rows (`deepchat_messages` with status `sent`/`error`, `deepchat_user_messages`, `_files`, `_links`, `deepchat_assistant_blocks`, `deepchat_search_documents`, `deepchat_usage_stats` message rows) | UI read model, derived | `TranscriptProjectionApplier` |
+| Transcript terminal rows (`deepchat_messages` with status `sent`/`error`, `deepchat_user_messages`, `_files`, `_links`, `deepchat_assistant_blocks`, `deepchat_search_documents`) | UI read model, derived | `TranscriptProjectionApplier` |
+| `deepchat_usage_stats` message rows | Provider call accounting | Assistant terminal writes and the pending-region metadata update, as today |
 | Transcript pending region (`deepchat_messages` status `pending` and its block rows) | Live streaming buffer | `SessionTranscript` directly, as today |
 | Sidecars (`deepchat_message_traces`, `deepchat_message_search_results`) | Runtime evidence | Runtime, as today |
 
@@ -96,10 +97,13 @@ Owned by `src/main/session/data/`. It is the only code that writes terminal stat
 transcript tables.
 
 - `applyRecord(record)`: UPSERT `deepchat_messages` (id, session, order, role, content, status,
-  is_context_edge, metadata, created_at, updated_at), replace the role tables from `content`,
-  upsert the search document for `sent`/`error` rows, and upsert usage stats for assistant rows with
-  usage metadata. Compaction marker rows (`metadata.messageType === 'compaction'`) are applied with
-  the same UPSERT.
+  is_context_edge, metadata, created_at, updated_at), replace the role tables from `content`, and
+  upsert the search document (user rows always, assistant rows once terminal). Compaction marker
+  rows (`metadata.messageType === 'compaction'`) are applied with the same UPSERT. Usage stats are
+  not part of the projection: they count provider calls, and the same record reaches the applier
+  again on fork, import, recovery and replay without a call having happened. The assistant
+  terminal writes (`finalizeAssistantMessage`, `setMessageError` with metadata) record usage
+  themselves, as the pending-region metadata update already does.
 - `applyRetraction(messageId)`: delete the eight message-scoped rows exactly as
   `deleteMessageWithReason` does today, including the two sidecars.
 - `replay(sessionId, afterEntryId)`: read effective message input rows with `entry_id >
@@ -147,7 +151,7 @@ same transaction. A write does not create the row: a Session without a cursor fo
 incarnation may still hold transcript rows the Tape never saw (rows written before the projection
 existed, or before a Tape reset), and only readiness step 2 below may declare the two aligned.
 `clearMessages` deletes the row inside its existing transaction, next to the transcript delete and
-the Tape reset.
+the Tape reset; the legacy import overwrite clears it with the other legacy-owned tables.
 
 `ensureSessionTapeReady(sessionId)` becomes:
 
@@ -176,10 +180,13 @@ records through `TapeProjectionHeadReader.getProjectionHead`.
 ### Idempotent payload guard
 
 `appendMessageRecordToTape` compares the row the store returned with the record it tried to
-append whenever the provenance key was derived (a `sent` record appended live or by backfill). If
-`content`, `status`, `orderSeq` or `metadata` differ, it logs one warning with the session id,
-message id, source and the names of the differing fields. Payload text is never logged. The append
-result is unchanged; the guard only makes a divergence visible.
+append whenever the provenance key was derived and the append is live (a `sent` record written by
+the transcript, including fork, import and recovery). If `content`, `status`, `orderSeq` or
+`metadata` differ, it logs one warning with the session id, message id, source and the names of the
+differing fields. Payload text is never logged. Backfill appends do not report: a backfill of an
+old Session compares today's materialized content with a fact written by an earlier version, and
+that is format history, not a bypassed write. The append result is unchanged; the guard only makes
+a divergence visible.
 
 ### Ownership and layering
 

--- a/docs/architecture/tape-transcript-projection/spec.md
+++ b/docs/architecture/tape-transcript-projection/spec.md
@@ -142,9 +142,12 @@ one transaction of their own.
 
 A new table `deepchat_transcript_projection_meta(session_id PRIMARY KEY, tape_incarnation_id,
 max_entry_id, projection_version, updated_at)` follows the `deepchat_memory_ingestion_projection_meta`
-pattern. Every fact-first write sets the row to the Tape head after its append, in the same
-transaction. `clearMessages` deletes the row inside its existing transaction, next to the transcript
-delete and the Tape reset.
+pattern. Every fact-first write moves an established row to the Tape head after its append, in the
+same transaction. A write does not create the row: a Session without a cursor for the current
+incarnation may still hold transcript rows the Tape never saw (rows written before the projection
+existed, or before a Tape reset), and only readiness step 2 below may declare the two aligned.
+`clearMessages` deletes the row inside its existing transaction, next to the transcript delete and
+the Tape reset.
 
 `ensureSessionTapeReady(sessionId)` becomes:
 
@@ -155,14 +158,20 @@ delete and the Tape reset.
    before this change (a fork, import or recovery that was never followed by a turn), and it is what
    keeps the applier from ever replaying an empty Tape over a populated transcript.
 3. If the meta row exists but its incarnation differs from the Tape's: the Tape was reset under the
-   transcript. Delete the meta row and fall through to step 2.
+   transcript. Treat the row as absent and run step 2, which overwrites it.
 4. If `max_entry_id` is behind the Tape head: `replay(sessionId, max_entry_id)`, then advance the
    row to the head. Non-message appends (manifests, journal, anchors) advance the cursor with an
    empty replay.
 5. Return `historyRecords` from the effective Tape view as today.
 
-The in-process `reconciled` map and the transcript digest are removed. The result type
-`TapeBackfillResult` keeps its shape; `appendedFactCount` counts facts appended by step 2.
+Steps 1–4 run in one store transaction. The in-process `reconciled` map and the transcript digest
+are removed. The result type `TapeBackfillResult` keeps its shape; `messageCount` and `maxOrderSeq`
+derive from the Tape records and `appendedFactCount` counts facts appended by step 2.
+
+The Tape side of this contract is `TapeTranscriptProjection` in `ports/capabilities.ts`
+(`getMessages`, `readProjectionCursor`, `writeProjectionCursor`, `applyTapeEntries`), implemented by
+`SessionTranscript`; the reconciler never imports session code. The transcript reads the head it
+records through `TapeProjectionHeadReader.getProjectionHead`.
 
 ### Idempotent payload guard
 

--- a/docs/architecture/tape-transcript-projection/spec.md
+++ b/docs/architecture/tape-transcript-projection/spec.md
@@ -105,7 +105,8 @@ transcript tables.
   terminal writes (`finalizeAssistantMessage`, `setMessageError` with metadata) record usage
   themselves, as the pending-region metadata update already does.
 - `applyRetractions(messageIds)`: delete the eight message-scoped rows exactly as
-  `deleteMessageWithReason` does today, including the two sidecars.
+  `deleteMessageWithReason` does today, including the two sidecars, in chunks of 500 ids so a range
+  delete over a whole Session stays below SQLite's bound-variable floor on every table.
 - `applyTapeEntries(rows)`: the reconciler reads the effective message input rows with `entry_id`
   past the cursor and hands them over in entry order; message facts go through
   `applyRecord(payload.record)` and `message/retracted` events through `applyRetractions`. It never
@@ -162,7 +163,9 @@ the Tape reset; the legacy import overwrite clears it with the other legacy-owne
    The backfill is the upgrade path for Sessions whose Tape fell behind before this change (a fork,
    import or recovery that was never followed by a turn) and keeps the applier from replaying an
    empty Tape over a populated transcript; the reverse projection keeps the cursor honest for a fact
-   that entered the Tape without going through the transcript, which no path produces today.
+   that entered the Tape without going through the transcript, which no path produces today. A
+   fact whose record names another Session is skipped with one warning per Session rather than
+   projected, since applying it would move a row between Sessions and fail every readiness check.
    This step only adds. A transcript row whose Tape fact was retracted is kept and the retraction is
    not applied: with no cursor, the transcript is the record the user has been looking at, and a
    Session without a cursor is exactly the one whose Tape may be stale. Deleting a row here would

--- a/docs/architecture/tape-transcript-projection/spec.md
+++ b/docs/architecture/tape-transcript-projection/spec.md
@@ -86,7 +86,9 @@ same instant within the same transaction.
 Invariant: for every record `r` produced by the canonicalizer,
 `materialize(persist(r)) === r.content`. A guard test pins this for user content with files, links,
 active skills and inline items, and for assistant content covering every block type the renderer
-persists. Any new persisted field must be added to both mappings or the guard fails.
+persists. Any new persisted field must be added to both mappings or the guard fails. Fields the
+tables do not persist today (`artifact`, the `maximum_tool_calls_reached` action type) are dropped
+by the canonical form exactly as the read path drops them; the fact carries what the UI can show.
 
 ### TranscriptProjectionApplier
 

--- a/docs/architecture/tape-transcript-projection/spec.md
+++ b/docs/architecture/tape-transcript-projection/spec.md
@@ -163,9 +163,7 @@ the Tape reset; the legacy import overwrite clears it with the other legacy-owne
    The backfill is the upgrade path for Sessions whose Tape fell behind before this change (a fork,
    import or recovery that was never followed by a turn) and keeps the applier from replaying an
    empty Tape over a populated transcript; the reverse projection keeps the cursor honest for a fact
-   that entered the Tape without going through the transcript, which no path produces today. A
-   fact whose record names another Session is skipped with one warning per Session rather than
-   projected, since applying it would move a row between Sessions and fail every readiness check.
+   that entered the Tape without going through the transcript, which no path produces today.
    This step only adds. A transcript row whose Tape fact was retracted is kept and the retraction is
    not applied: with no cursor, the transcript is the record the user has been looking at, and a
    Session without a cursor is exactly the one whose Tape may be stale. Deleting a row here would

--- a/docs/architecture/tape-transcript-projection/spec.md
+++ b/docs/architecture/tape-transcript-projection/spec.md
@@ -121,19 +121,22 @@ fact append disappears.
 | `createUserMessage` | `appendMessageRecord` | `applyRecord` |
 | `finalizeAssistantMessage`, `setMessageError` | `appendMessageRecord` (pending shell becomes terminal) | `applyRecord` |
 | `insertCompactionMessageRecord`, `updateCompactionMessage` | `appendMessageRecord` (compaction indicator event) | `applyRecord` |
-| `appendCompactionOrderShiftFacts` | per-message `appendMessageReplacement('order')` | `applyRecord` per shifted record |
+| compaction shift (`shiftMessagesFrom`) | per-message `appendMessageReplacement('order')` | none: one `incrementOrderSeqFrom` UPDATE stamped with the facts' `updatedAt`; content is unchanged so re-materializing N rows would only add writes |
 | `markSteerMessagesRead`, `settleSteerMessages`, `failPendingSteerMessages` | `appendMessageReplacement('record')` | `applyRecord` |
 | `updateMessageContent` | `appendMessageReplacement('record')` | `applyRecord` |
 | `deleteMessageWithReason`, `deleteFromOrderSeq` | `appendMessageRetraction` | `applyRetraction` |
-| `prepareRetryMessage` status restore | `appendMessageReplacement('record', reason 'retry_restored_prompt')` | `applyRecord` |
-| `cloneSentMessagesToSession` (fork) | `appendMessageRecord` with `meta.source = 'fork'` | `applyRecord` |
+| `restoreUserMessage` (retry of a failed prompt, called from `prepareRetryMessage`) | `appendMessageReplacement('record', reason 'retry_restored_prompt')` | `applyRecord` |
+| `cloneSentMessagesToSession` (fork) | `appendMessageRecord` per copied row, in the fork Session's Tape | `applyRecord` |
 | `recoverPendingMessages` | `appendMessageRecord` (revision key, status `error`) | `applyRecord` |
-| legacy import `backfillMessageRow` | `appendMessageRecord` with source `backfill` | `applyRecord` |
+| legacy import `importMessageRow` | `appendMessageRecord` | `applyRecord` (replaces the importer's direct insert) |
 
-Fork does not introduce a `fork/*` fact name; `tape-system.md` records that Tape has no fork writer.
-The fork facts are ordinary `message/<role>` facts whose `meta.source` records their origin.
+Fork does not introduce a `fork/*` fact name or a new fact source; `tape-system.md` records that
+Tape has no fork writer. The copied rows are ordinary live `message/<role>` facts of the fork
+Session, created at fork time. Their origin is the fork Session's own metadata, not the fact.
 
-The steer methods keep relying on the caller's `runInTransaction`, as today.
+`updateMessageStatus` narrows to the pending region (`'pending'` only). The steer methods keep
+relying on the caller's `runInTransaction`, as today; `recoverPendingMessages` and fork run inside
+one transaction of their own.
 
 ### Projection cursor and readiness
 
@@ -186,10 +189,10 @@ import the applier.
 ## Compatibility
 
 - No Tape schema, fact name, provenance key, hash version or payload field changes. Records written
-  fact-first serialize to the same `payload.record` shape as records read back from the tables did.
+  fact-first serialize to the same `payload.record` shape as records read back from the tables did;
+  `traceCount` is `0`, which is what the live read-back reported as well.
 - Rollback is a code revert. The meta table is ignored by earlier code; the earlier reconciler's
-  backfill finds every fact already present through provenance keys and appends nothing. Fork facts
-  with `meta.source = 'fork'` read as ordinary message facts.
+  backfill finds every fact already present through provenance keys and appends nothing.
 - `SessionTranscript`'s public method signatures are unchanged. `TapeBackfillResult` is unchanged.
 - The order in which `deepchat_search_documents` and `deepchat_usage_stats` rows are written inside
   a terminal transaction changes; both are read only after commit.

--- a/docs/architecture/tape-transcript-projection/spec.md
+++ b/docs/architecture/tape-transcript-projection/spec.md
@@ -104,14 +104,14 @@ transcript tables.
   again on fork, import, recovery and replay without a call having happened. The assistant
   terminal writes (`finalizeAssistantMessage`, `setMessageError` with metadata) record usage
   themselves, as the pending-region metadata update already does.
-- `applyRetraction(messageId)`: delete the eight message-scoped rows exactly as
+- `applyRetractions(messageIds)`: delete the eight message-scoped rows exactly as
   `deleteMessageWithReason` does today, including the two sidecars.
-- `replay(sessionId, afterEntryId)`: read effective message input rows with `entry_id >
-  afterEntryId`, apply message facts in entry order via `applyRecord(payload.record)`, and apply
-  `message/retracted` events via `applyRetraction`. It never deletes a transcript row that Tape has
-  not retracted and never touches a `pending` row that has no fact. `message/compaction_indicator`
-  events are skipped; compaction marker recovery stays with `reconcileCompactionMessages`, which
-  already decides marker state from the reconstruction anchor.
+- `applyTapeEntries(rows)`: the reconciler reads the effective message input rows with `entry_id`
+  past the cursor and hands them over in entry order; message facts go through
+  `applyRecord(payload.record)` and `message/retracted` events through `applyRetractions`. It never
+  deletes a transcript row that Tape has not retracted and never touches a `pending` row that has
+  no fact. `message/compaction_indicator` events are skipped; compaction marker recovery stays with
+  `reconcileCompactionMessages`, which already decides marker state from the reconstruction anchor.
 
 ### Write direction for terminal state
 
@@ -128,7 +128,7 @@ fact append disappears.
 | compaction shift (`shiftMessagesFrom`) | per-message `appendMessageReplacement('order')` | none: one `incrementOrderSeqFrom` UPDATE stamped with the facts' `updatedAt`; content is unchanged so re-materializing N rows would only add writes |
 | `markSteerMessagesRead`, `settleSteerMessages`, `failPendingSteerMessages` | `appendMessageReplacement('record')` | `applyRecord` |
 | `updateMessageContent` | `appendMessageReplacement('record')` | `applyRecord` |
-| `deleteMessageWithReason`, `deleteFromOrderSeq` | `appendMessageRetraction` | `applyRetraction` |
+| `deleteMessageWithReason`, `deleteFromOrderSeq` | `appendMessageRetraction` | `applyRetractions` |
 | `restoreUserMessage` (retry of a failed prompt, called from `prepareRetryMessage`) | `appendMessageReplacement('record', reason 'retry_restored_prompt')` | `applyRecord` |
 | `cloneSentMessagesToSession` (fork) | `appendMessageRecord` per copied row, in the fork Session's Tape | `applyRecord` |
 | `recoverPendingMessages` | `appendMessageRecord` (revision key, status `error`) | `applyRecord` |

--- a/docs/architecture/tape-transcript-projection/spec.md
+++ b/docs/architecture/tape-transcript-projection/spec.md
@@ -1,0 +1,232 @@
+# Tape Transcript Projection Specification
+
+## Background
+
+The message transcript (`deepchat_messages` and its five structured side tables) is the UI read
+model for a Session. The Context Tape holds the `message/*` facts that context assembly, recall,
+replay, Memory ingestion and the Inspector read. Today the transcript produces those facts: every
+terminal write in `SessionTranscript` updates the tables first, reads the row back, and appends a
+copy of the materialized record as a Tape fact (`transcript.ts` `appendLiveTapeFacts`).
+
+Since a7967db34 the main terminal paths perform both writes in one SQLite transaction, so a
+crashed process cannot leave a transcript row without its fact. The remaining consistency gap is
+structural rather than transactional:
+
+- Four transcript writes bypass Tape and rely on the reconciler to backfill later: fork
+  (`cloneSentMessagesToSession`), startup recovery (`recoverPendingMessages`), legacy chat import
+  (`backfillMessageRow`), and the retry path that restores a failed user prompt to `sent`
+  (`transcriptMutations.ts` `prepareRetryMessage`). Nothing stops the next such path from being
+  added.
+- A `sent` record's live fact uses a provenance key derived from the message id only. The store
+  returns the existing entry on a key hit without comparing payloads, so a transcript row whose
+  content changed without a replacement fact leaves Tape silently stale. No path does this today;
+  the guarantee rests on convention.
+- `ensureSessionTapeReady` reads the whole transcript on every call to compute a digest and reads
+  every Tape message row to return `historyRecords`. Any transcript change, which every user turn
+  causes, re-runs an idempotent backfill over all N records. Phase 0 page-cache tuning made this
+  cheap per row, but it stays linear in Session length on the main thread.
+
+The Tape model DeepChat follows (tape.systems; `docs/architecture/tape-system.md`) states that
+derivatives never replace original facts. With the transcript as the producer, the Tape copy is the
+derivative while also serving as the fact source for provider context. This specification reverses
+the direction for terminal message state: the fact is appended first and the transcript tables are
+derived from it in the same transaction.
+
+## Goals
+
+1. Make the appended `message/*` fact the only producer of terminal transcript state. Every
+   terminal transcript write goes through one materialization component whose input is the record
+   carried by the fact.
+2. Remove the transcript-to-Tape backfill from the per-call reconciler path. Readiness becomes a
+   head comparison between the Tape and a transcript projection cursor, with replay of missing
+   facts when the projection is behind.
+3. Close the four bypass paths by routing them through the same fact-first component.
+4. Make a silent fact/transcript divergence observable: an idempotent message append whose stored
+   payload differs from the record being appended logs a bounded warning.
+5. Keep the persisted Tape format, fact names, provenance keys, hashes, effective-view semantics,
+   ViewManifest and replay contracts unchanged. Existing Tapes read identically before and after.
+
+## Non-Goals
+
+- Storing only a content hash in message facts (option "a" from the analysis). Tape keeps the full
+  record so recall, replay, Memory and provider context stay self-sufficient.
+- Recording streaming intermediate state (`createAssistantMessage` shells, per-chunk
+  `updateAssistantContent`, `updateAssistantMetadata`, `updateMessageStatus('pending')`) in Tape.
+- Changing `execution/*`, `contract/*`, `context` kind, ViewManifest, Journal, search projection or
+  Memory ingestion projection behavior.
+- Replacing the N per-message `revisionKind: 'order'` replacement facts written by compaction shift
+  with a new fact type.
+- Deriving `deepchat_message_traces` or `deepchat_message_search_results` from Tape. They remain
+  runtime sidecars keyed by message id; their delete cascade is unchanged.
+- Any archive-on-reset behavior. `resetSessionTape` stays a lifecycle exception.
+
+## Design
+
+### Data families after the change
+
+| Family | Role | Producer |
+| --- | --- | --- |
+| Tape `message/*` facts, `message/retracted` and `message/compaction_indicator` events | Terminal message facts | `TapeMessageFactWriter` called by transcript terminal writes |
+| Transcript terminal rows (`deepchat_messages` with status `sent`/`error`, `deepchat_user_messages`, `_files`, `_links`, `deepchat_assistant_blocks`, `deepchat_search_documents`, `deepchat_usage_stats` message rows) | UI read model, derived | `TranscriptProjectionApplier` |
+| Transcript pending region (`deepchat_messages` status `pending` and its block rows) | Live streaming buffer | `SessionTranscript` directly, as today |
+| Sidecars (`deepchat_message_traces`, `deepchat_message_search_results`) | Runtime evidence | Runtime, as today |
+
+### Canonical record
+
+The fact payload carries `ChatMessageRecord` with `content` in the materialized form the transcript
+returns from `getMessage`: user content is the JSON of `{ text, files, links, search, think,
+activeSkills?, inlineItems? }` with each file normalized through the same field mapping the tables
+use; assistant content is the JSON block array normalized the same way `toAssistantBlock` reads a
+block row. Today that form is obtained by writing the tables and reading back. A pure
+`canonicalizeMessageContent(role, rawContent, updatedAt)` produces the same string without table
+access by applying the persist mapping and the read mapping in memory. Blocks without a
+`timestamp` receive `updatedAt`; today they report the block row's own write time, which is the
+same instant within the same transaction.
+
+Invariant: for every record `r` produced by the canonicalizer,
+`materialize(persist(r)) === r.content`. A guard test pins this for user content with files, links,
+active skills and inline items, and for assistant content covering every block type the renderer
+persists. Any new persisted field must be added to both mappings or the guard fails.
+
+### TranscriptProjectionApplier
+
+Owned by `src/main/session/data/`. It is the only code that writes terminal state into the
+transcript tables.
+
+- `applyRecord(record)`: UPSERT `deepchat_messages` (id, session, order, role, content, status,
+  is_context_edge, metadata, created_at, updated_at), replace the role tables from `content`,
+  upsert the search document for `sent`/`error` rows, and upsert usage stats for assistant rows with
+  usage metadata. Compaction marker rows (`metadata.messageType === 'compaction'`) are applied with
+  the same UPSERT.
+- `applyRetraction(messageId)`: delete the eight message-scoped rows exactly as
+  `deleteMessageWithReason` does today, including the two sidecars.
+- `replay(sessionId, afterEntryId)`: read effective message input rows with `entry_id >
+  afterEntryId`, apply message facts in entry order via `applyRecord(payload.record)`, and apply
+  `message/retracted` events via `applyRetraction`. It never deletes a transcript row that Tape has
+  not retracted and never touches a `pending` row that has no fact. `message/compaction_indicator`
+  events are skipped; compaction marker recovery stays with `reconcileCompactionMessages`, which
+  already decides marker state from the reconstruction anchor.
+
+### Write direction for terminal state
+
+Every terminal transcript method builds the canonical record in memory, appends its fact through
+`TapeMessageFactWriter`, then calls `applyRecord`, all inside the existing
+`runInDatabaseTransaction`. The table write no longer precedes the fact; the read-back before the
+fact append disappears.
+
+| Transcript method | Fact | Applier call |
+| --- | --- | --- |
+| `createUserMessage` | `appendMessageRecord` | `applyRecord` |
+| `finalizeAssistantMessage`, `setMessageError` | `appendMessageRecord` (pending shell becomes terminal) | `applyRecord` |
+| `insertCompactionMessageRecord`, `updateCompactionMessage` | `appendMessageRecord` (compaction indicator event) | `applyRecord` |
+| `appendCompactionOrderShiftFacts` | per-message `appendMessageReplacement('order')` | `applyRecord` per shifted record |
+| `markSteerMessagesRead`, `settleSteerMessages`, `failPendingSteerMessages` | `appendMessageReplacement('record')` | `applyRecord` |
+| `updateMessageContent` | `appendMessageReplacement('record')` | `applyRecord` |
+| `deleteMessageWithReason`, `deleteFromOrderSeq` | `appendMessageRetraction` | `applyRetraction` |
+| `prepareRetryMessage` status restore | `appendMessageReplacement('record', reason 'retry_restored_prompt')` | `applyRecord` |
+| `cloneSentMessagesToSession` (fork) | `appendMessageRecord` with `meta.source = 'fork'` | `applyRecord` |
+| `recoverPendingMessages` | `appendMessageRecord` (revision key, status `error`) | `applyRecord` |
+| legacy import `backfillMessageRow` | `appendMessageRecord` with source `backfill` | `applyRecord` |
+
+Fork does not introduce a `fork/*` fact name; `tape-system.md` records that Tape has no fork writer.
+The fork facts are ordinary `message/<role>` facts whose `meta.source` records their origin.
+
+The steer methods keep relying on the caller's `runInTransaction`, as today.
+
+### Projection cursor and readiness
+
+A new table `deepchat_transcript_projection_meta(session_id PRIMARY KEY, tape_incarnation_id,
+max_entry_id, projection_version, updated_at)` follows the `deepchat_memory_ingestion_projection_meta`
+pattern. Every fact-first write sets the row to the Tape head after its append, in the same
+transaction. `clearMessages` deletes the row inside its existing transaction, next to the transcript
+delete and the Tape reset.
+
+`ensureSessionTapeReady(sessionId)` becomes:
+
+1. Read `(tape incarnation, tape max entry id)` and the meta row in one query.
+2. If the meta row is absent and the transcript has rows: run the existing legacy backfill
+   (transcript to Tape, idempotent, `source: 'backfill'`), append the `migration/backfill` event as
+   today, then write the meta row. This is the upgrade path for Sessions whose Tape fell behind
+   before this change (a fork, import or recovery that was never followed by a turn), and it is what
+   keeps the applier from ever replaying an empty Tape over a populated transcript.
+3. If the meta row exists but its incarnation differs from the Tape's: the Tape was reset under the
+   transcript. Delete the meta row and fall through to step 2.
+4. If `max_entry_id` is behind the Tape head: `replay(sessionId, max_entry_id)`, then advance the
+   row to the head. Non-message appends (manifests, journal, anchors) advance the cursor with an
+   empty replay.
+5. Return `historyRecords` from the effective Tape view as today.
+
+The in-process `reconciled` map and the transcript digest are removed. The result type
+`TapeBackfillResult` keeps its shape; `appendedFactCount` counts facts appended by step 2.
+
+### Idempotent payload guard
+
+`appendMessageRecordToTape` compares the row the store returned with the record it tried to
+append whenever the provenance key was derived (a `sent` record appended live or by backfill). If
+`content`, `status`, `orderSeq` or `metadata` differ, it logs one warning with the session id,
+message id, source and the names of the differing fields. Payload text is never logged. The append
+result is unchanged; the guard only makes a divergence visible.
+
+### Ownership and layering
+
+| Component | Location |
+| --- | --- |
+| `canonicalizeMessageContent` and the persist/read field mappings | `src/main/session/data/messageContent.ts` (pure) |
+| `TranscriptProjectionApplier` | `src/main/session/data/transcriptProjection.ts` |
+| `deepchat_transcript_projection_meta` table | `src/main/session/data/tables/deepchatTranscriptProjectionMeta.ts` |
+| Reconciler head comparison and migration backfill | `src/main/tape/application/reconcilerService.ts` |
+| Payload guard | `src/main/tape/application/factPersistence.ts` |
+
+The applier reads Tape rows through the existing `TapeTranscriptReader`-style port direction: Tape
+exposes effective message input rows; session data derives tables from them. Tape code does not
+import the applier.
+
+## Compatibility
+
+- No Tape schema, fact name, provenance key, hash version or payload field changes. Records written
+  fact-first serialize to the same `payload.record` shape as records read back from the tables did.
+- Rollback is a code revert. The meta table is ignored by earlier code; the earlier reconciler's
+  backfill finds every fact already present through provenance keys and appends nothing. Fork facts
+  with `meta.source = 'fork'` read as ordinary message facts.
+- `SessionTranscript`'s public method signatures are unchanged. `TapeBackfillResult` is unchanged.
+- The order in which `deepchat_search_documents` and `deepchat_usage_stats` rows are written inside
+  a terminal transaction changes; both are read only after commit.
+- `deepchat_messages.created_at` for fact-first rows comes from the record instead of the insert
+  default. Both were `Date.now()` at the same point.
+
+## Invariants Preserved
+
+1. Tape entries are append-only. Replay writes tables from facts; nothing writes Tape from tables
+   except the one-time migration backfill in readiness step 2.
+2. Corrections stay appended: edit, delete, steer state and compaction shift remain replacement or
+   retraction facts.
+3. `context` kind rows never reach the transcript, search or Memory. The applier reads only
+   `message` rows and `message/retracted` events.
+4. `execution/*` and `contract/*` are untouched; the transcript projection does not join their
+   transactions.
+5. Replay output (entry order, role, tool pairing, anchor cursor, policy and builder versions,
+   synthetic provenance) is unchanged because no fact changes.
+6. A Context Tape write failure inside a terminal transaction rolls back the transcript write with
+   it, as it does today; a completed reply is never left hanging.
+
+## Acceptance Criteria
+
+- After any terminal transcript write, `getMessage(id)` deep-equals the `payload.record` of the
+  latest effective message fact for that id, except `traceCount`.
+- Fork, startup recovery, legacy import and retry-restore leave no transcript row without a
+  corresponding effective fact, without a later reconciler pass.
+- `ensureSessionTapeReady` on an unchanged Session performs no transcript read and appends nothing.
+- A Session whose meta row is absent and whose transcript has rows gets a full backfill exactly once,
+  and no transcript row is deleted by that call.
+- Deleting the meta row and appending a message fact directly to Tape, then calling
+  `ensureSessionTapeReady`, materializes the message into the transcript tables.
+- A `sent` live append whose derived key already exists with a different `content` logs one warning
+  naming the field; identical payloads log nothing.
+- `test/main/session/data`, `test/main/tape`, `test/main/agent/deepchat` and the real-SQLite
+  contract suites pass. Manual: new chat, resume, edit, delete, steer, manual compaction, fork and
+  legacy import show the same rows in the Inspector and the UI.
+
+## Open Questions
+
+None. Decisions that were open in the preceding analysis (`provider/attempt_completed` exclusion,
+compaction shift fact shape, sidecar ownership) are settled above or in `tape-system.md`.

--- a/src/main/agent/deepchat/runtime/compactionRuntimeCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/compactionRuntimeCoordinator.ts
@@ -17,7 +17,7 @@ import type { DeepChatToolResolver } from './toolResolver'
 import type { RunLifecycleCoordinator } from './runLifecycleCoordinator'
 import type { SessionSettingsCoordinator } from './sessionSettingsCoordinator'
 import type { TapeReconciliationPort } from '@/tape/ports/capabilities'
-import type { TapeTranscriptReader } from '@/tape/ports/capabilities'
+import type { TapeTranscriptProjection } from '@/tape/ports/capabilities'
 import type { SessionScopeRegistry } from '@/agent/deepchat/instance/deepChatAgentRuntime'
 import type { MessageProjectionService } from './messageProjectionService'
 import type { PromptAssemblyService } from './promptAssemblyService'
@@ -72,7 +72,7 @@ type CompactionSessionStore = Pick<
   | 'resetSummaryState'
 >
 
-type CompactionTranscript = TapeTranscriptReader &
+type CompactionTranscript = TapeTranscriptProjection &
   Pick<
     SessionTranscript,
     | 'createCompactionMessage'

--- a/src/main/app/startupMigrations/legacyChatImportService.ts
+++ b/src/main/app/startupMigrations/legacyChatImportService.ts
@@ -174,6 +174,7 @@ export class LegacyChatImportService {
         DELETE FROM deepchat_messages;
         DELETE FROM deepchat_usage_stats;
         DELETE FROM deepchat_tape_entries;
+        DELETE FROM deepchat_transcript_projection_meta;
         DELETE FROM deepchat_memory_ingestion_projection;
         DELETE FROM deepchat_memory_ingestion_projection_meta;
         DELETE FROM deepchat_tape_search_projection;

--- a/src/main/app/startupMigrations/legacyChatImportService.ts
+++ b/src/main/app/startupMigrations/legacyChatImportService.ts
@@ -549,21 +549,7 @@ export class LegacyChatImportService {
             this.pickNumber(row, ['created_at']) ??
             Date.now()
 
-          this.sessionDatabase.deepchatMessagesTable.insert({
-            id: messageId,
-            sessionId,
-            orderSeq: nextOrderSeq,
-            role: role as 'user' | 'assistant',
-            content: normalizedContent,
-            status,
-            isContextEdge: this.pickNumber(selectedVariant, ['is_context_edge']) === 1 ? 1 : 0,
-            metadata: this.normalizeMetadata(
-              this.pickString(selectedVariant, ['metadata']) || '{}'
-            ),
-            createdAt,
-            updatedAt: createdAt
-          })
-          this.messageStore.backfillMessageRow({
+          this.messageStore.importMessageRow({
             id: messageId,
             session_id: sessionId,
             order_seq: nextOrderSeq,

--- a/src/main/app/startupMigrations/legacyChatImportService.ts
+++ b/src/main/app/startupMigrations/legacyChatImportService.ts
@@ -10,12 +10,8 @@ import type {
 import type { SearchResult } from '@shared/types/core/search'
 import { isReasoningEffort } from '@shared/types/model-db'
 import { resolveAcpAgentAlias } from '@shared/utils/acpAgentAlias'
-import { SessionTranscript } from '@/session/data/transcript'
+import { SessionTranscript, type TranscriptTapePort } from '@/session/data/transcript'
 import { SessionDatabase } from '@/session/data/database'
-import type {
-  TapeCompactionModelCallWriter,
-  TapeMessageFactWriter
-} from '@/tape/ports/capabilities'
 import type { ProjectDatabase } from '@/project/data/database'
 import type { AppDatabase } from '@/app/data/database'
 import type { MemoryDatabase } from '@/memory/data/database'
@@ -49,7 +45,7 @@ export class LegacyChatImportService {
     sessionDatabase: SessionDatabase,
     projectDatabase: ProjectDatabase,
     memoryDatabase: MemoryDatabase,
-    tapeFacts: TapeMessageFactWriter & TapeCompactionModelCallWriter,
+    tapeFacts: TranscriptTapePort,
     sourceDbPath?: string,
     notifyEnvironmentProjectionChanged: () => void = () => undefined
   ) {

--- a/src/main/app/startupMigrations/sessionDataMigrations.ts
+++ b/src/main/app/startupMigrations/sessionDataMigrations.ts
@@ -161,7 +161,8 @@ const backfillNormalizedMessageRow = (
   } else {
     sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage(
       row.id,
-      parseAssistantBlocks(row.content)
+      parseAssistantBlocks(row.content),
+      row.updated_at
     )
   }
 

--- a/src/main/data/schemaCatalog.ts
+++ b/src/main/data/schemaCatalog.ts
@@ -22,6 +22,7 @@ import { DeepChatPendingInputsTable } from '@/session/data/tables/deepchatPendin
 import { DeepChatUsageStatsTable } from '@/session/data/tables/deepchatUsageStats'
 import { DeepChatTapeEntriesTable } from '@/tape/infrastructure/sqlite/tapeEntryStore'
 import { DeepChatMemoryIngestionProjectionTable } from '@/memory/data/tables/deepchatMemoryIngestionProjection'
+import { DeepChatTranscriptProjectionMetaTable } from '@/session/data/tables/deepchatTranscriptProjectionMeta'
 import { DeepChatTapeSearchProjectionTable } from '@/tape/infrastructure/sqlite/tapeSearchProjectionStore'
 import { DeepChatSessionMetadataTable } from '@/session/data/tables/deepchatSessionMetadata'
 import { LegacyImportStatusTable } from '@/app/data/tables/legacyImportStatus'
@@ -276,6 +277,10 @@ const CATALOG_DEFINITIONS: CatalogDefinition[] = [
     createTable: (db) => new DeepChatMemoryIngestionProjectionTable(db)
   },
   {
+    name: 'deepchat_transcript_projection_meta',
+    createTable: (db) => new DeepChatTranscriptProjectionMetaTable(db)
+  },
+  {
     name: 'deepchat_tape_search_projection',
     createTable: (db) => new DeepChatTapeSearchProjectionTable(db)
   },
@@ -481,6 +486,7 @@ export function createMainSchemaCatalog(db: Database.Database): MainSchemaCatalo
   const usageStats = new DeepChatUsageStatsTable(db)
   const memoryIngestionProjection = new DeepChatMemoryIngestionProjectionTable(db)
   const tapeEntries = new DeepChatTapeEntriesTable(db, memoryIngestionProjection)
+  const transcriptProjectionMeta = new DeepChatTranscriptProjectionMetaTable(db)
   const tapeSearchProjection = new DeepChatTapeSearchProjectionTable(db)
   const sessionMetadata = new DeepChatSessionMetadataTable(db)
   const legacyImportStatus = new LegacyImportStatusTable(db)
@@ -522,6 +528,7 @@ export function createMainSchemaCatalog(db: Database.Database): MainSchemaCatalo
     usageStats,
     memoryIngestionProjection,
     tapeEntries,
+    transcriptProjectionMeta,
     tapeSearchProjection,
     sessionMetadata,
     legacyImportStatus,

--- a/src/main/session/data/database.ts
+++ b/src/main/session/data/database.ts
@@ -28,6 +28,7 @@ import type {
 import { SqliteTapeLifecycleAdapter } from '@/tape/infrastructure/sqlite/tapeLifecycleAdapter'
 import { DeepChatTapeSearchProjectionTable } from '@/tape/infrastructure/sqlite/tapeSearchProjectionStore'
 import { DeepChatSessionMetadataTable } from './tables/deepchatSessionMetadata'
+import { DeepChatTranscriptProjectionMetaTable } from './tables/deepchatTranscriptProjectionMeta'
 import { NewSessionActiveSkillsTable } from './tables/newSessionActiveSkills'
 import { NewSessionDisabledAgentToolsTable } from './tables/newSessionDisabledAgentTools'
 
@@ -119,6 +120,10 @@ export class SessionDatabase {
 
   get deepchatTapeSearchProjectionTable() {
     return new DeepChatTapeSearchProjectionTable(this.getDatabase())
+  }
+
+  get deepchatTranscriptProjectionMetaTable() {
+    return new DeepChatTranscriptProjectionMetaTable(this.getDatabase())
   }
 
   get deepchatSessionMetadataTable() {

--- a/src/main/session/data/messageContent.ts
+++ b/src/main/session/data/messageContent.ts
@@ -82,7 +82,7 @@ export function parseAssistantBlocks(rawContent: string): AssistantMessageBlock[
 // User files: the values `deepchat_user_message_files.replaceForMessage` receives and the columns
 // it reads back.
 
-export interface UserMessageFileRowInput {
+interface UserMessageFileRowInput {
   name?: string
   path: string
   mimeType?: string
@@ -90,7 +90,7 @@ export interface UserMessageFileRowInput {
   metadataJson?: string | null
 }
 
-export type StoredUserMessageFile = Pick<
+type StoredUserMessageFile = Pick<
   DeepChatUserMessageFileRow,
   'name' | 'path' | 'mime_type' | 'size' | 'metadata_json'
 >
@@ -187,7 +187,7 @@ export type PersistedBlockExtra = {
   reasoningTime?: number
 }
 
-export type AssistantBlockRowInput = Omit<DeepChatAssistantBlockRow, 'message_id' | 'block_index'>
+type AssistantBlockRowInput = Omit<DeepChatAssistantBlockRow, 'message_id' | 'block_index'>
 
 function buildPersistedExtra(block: AssistantMessageBlock): PersistedBlockExtra {
   return {

--- a/src/main/session/data/messageContent.ts
+++ b/src/main/session/data/messageContent.ts
@@ -1,0 +1,340 @@
+import type {
+  AssistantMessageBlock,
+  MessageFile,
+  UserMessageContent
+} from '@shared/types/agent-interface'
+import {
+  normalizeAttachmentRepresentationPreference,
+  normalizeAttachmentResolvedRepresentation,
+  normalizePdfEmbeddedTextCoverage
+} from '@shared/utils/attachmentRepresentation'
+import type { DeepChatAssistantBlockRow } from './tables/deepchatAssistantBlocks'
+import type { DeepChatUserMessageFileRow } from './tables/deepchatUserMessageFiles'
+
+/**
+ * The transcript stores a message twice: as the raw content string on `deepchat_messages` and
+ * as structured rows (user text/files/links, assistant blocks). `getMessage` rebuilds `content`
+ * from the structured rows, so what every reader sees is the raw content after one trip through
+ * the persist mapping and the read mapping. This module owns both mappings and
+ * `canonicalizeMessageContent`, which performs that trip in memory. Anything persisted by one
+ * mapping must be read back by the other; the round-trip guard test fails otherwise.
+ */
+
+function parseJson<T>(raw: string | null | undefined, fallback: T): T {
+  if (!raw) {
+    return fallback
+  }
+
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
+}
+
+function normalizeActiveSkills(activeSkills?: string[]): string[] {
+  if (!Array.isArray(activeSkills)) {
+    return []
+  }
+
+  return Array.from(
+    new Set(
+      activeSkills
+        .filter((item): item is string => typeof item === 'string')
+        .map((item) => item.trim())
+        .filter(Boolean)
+    )
+  )
+}
+
+export function parseUserContent(rawContent: string): UserMessageContent | null {
+  try {
+    const parsed = JSON.parse(rawContent) as Partial<UserMessageContent>
+    if (!parsed || typeof parsed !== 'object') {
+      return null
+    }
+
+    return {
+      text: typeof parsed.text === 'string' ? parsed.text : '',
+      files: Array.isArray(parsed.files) ? (parsed.files.filter(Boolean) as MessageFile[]) : [],
+      links: Array.isArray(parsed.links)
+        ? parsed.links.filter((item): item is string => typeof item === 'string')
+        : [],
+      search: parsed.search === true,
+      think: parsed.think === true,
+      activeSkills: normalizeActiveSkills(parsed.activeSkills),
+      inlineItems: Array.isArray(parsed.inlineItems) ? parsed.inlineItems : []
+    }
+  } catch {
+    return null
+  }
+}
+
+export function parseAssistantBlocks(rawContent: string): AssistantMessageBlock[] {
+  try {
+    const parsed = JSON.parse(rawContent) as AssistantMessageBlock[]
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+// User files: the values `deepchat_user_message_files.replaceForMessage` receives and the columns
+// it reads back.
+
+export interface UserMessageFileRowInput {
+  name?: string
+  path: string
+  mimeType?: string
+  size?: number
+  metadataJson?: string | null
+}
+
+export type StoredUserMessageFile = Pick<
+  DeepChatUserMessageFileRow,
+  'name' | 'path' | 'mime_type' | 'size' | 'metadata_json'
+>
+
+export function toUserMessageFileRowInput(file: MessageFile): UserMessageFileRowInput {
+  return {
+    name: file.name,
+    path: file.path,
+    mimeType: file.mimeType ?? file.type,
+    size: file.size,
+    metadataJson: JSON.stringify({
+      type: file.type,
+      content: file.content,
+      token: file.token,
+      thumbnail: file.thumbnail,
+      metadata: file.metadata,
+      requestedRepresentation: normalizeAttachmentRepresentationPreference(
+        file.requestedRepresentation
+      ),
+      pdfTextCoverage: normalizePdfEmbeddedTextCoverage(file.pdfTextCoverage),
+      resolvedRepresentation: normalizeAttachmentResolvedRepresentation(file.resolvedRepresentation)
+    })
+  }
+}
+
+export function toMessageFile(row: StoredUserMessageFile): MessageFile {
+  const extra = parseJson<Record<string, unknown>>(row.metadata_json, {})
+  return {
+    name: row.name ?? '',
+    path: row.path,
+    type: typeof extra.type === 'string' ? extra.type : (row.mime_type ?? undefined),
+    size: row.size ?? undefined,
+    content: typeof extra.content === 'string' ? extra.content : undefined,
+    mimeType: row.mime_type ?? undefined,
+    token: typeof extra.token === 'number' ? extra.token : undefined,
+    thumbnail: typeof extra.thumbnail === 'string' ? extra.thumbnail : undefined,
+    requestedRepresentation: normalizeAttachmentRepresentationPreference(
+      extra.requestedRepresentation
+    ),
+    pdfTextCoverage: normalizePdfEmbeddedTextCoverage(extra.pdfTextCoverage),
+    resolvedRepresentation: normalizeAttachmentResolvedRepresentation(extra.resolvedRepresentation),
+    metadata:
+      extra.metadata && typeof extra.metadata === 'object' && !Array.isArray(extra.metadata)
+        ? (extra.metadata as MessageFile['metadata'])
+        : undefined
+  }
+}
+
+/** The stored shape of a file input: SQLite keeps a missing value as NULL. */
+function toStoredUserMessageFile(input: UserMessageFileRowInput): StoredUserMessageFile {
+  return {
+    name: input.name ?? null,
+    path: input.path,
+    mime_type: input.mimeType ?? null,
+    size: input.size ?? null,
+    metadata_json: input.metadataJson ?? null
+  }
+}
+
+interface AssembledUserContentInput {
+  text: string
+  files: MessageFile[]
+  links: string[]
+  search: boolean
+  think: boolean
+  activeSkills: string[]
+  inlineItems: NonNullable<UserMessageContent['inlineItems']>
+}
+
+export function assembleUserContent(input: AssembledUserContentInput): string {
+  return JSON.stringify({
+    text: input.text,
+    files: input.files,
+    links: input.links,
+    search: input.search,
+    think: input.think,
+    ...(input.activeSkills.length > 0 ? { activeSkills: input.activeSkills } : {}),
+    ...(input.inlineItems.length > 0 ? { inlineItems: input.inlineItems } : {})
+  } satisfies UserMessageContent)
+}
+
+// Assistant blocks: the column values `deepchat_assistant_blocks.replaceForMessage` writes and the
+// block it reads back.
+
+export type PersistedBlockExtra = {
+  id?: string
+  timestamp?: number
+  imageData?: string
+  extra?: AssistantMessageBlock['extra']
+  toolCallExtra?: Omit<
+    NonNullable<AssistantMessageBlock['tool_call']>,
+    'id' | 'name' | 'params' | 'response'
+  >
+  reasoningTime?: number
+}
+
+export type AssistantBlockRowInput = Omit<DeepChatAssistantBlockRow, 'message_id' | 'block_index'>
+
+function buildPersistedExtra(block: AssistantMessageBlock): PersistedBlockExtra {
+  return {
+    id: block.id,
+    timestamp: block.timestamp,
+    imageData: block.image_data?.data,
+    extra: block.extra,
+    toolCallExtra: block.tool_call
+      ? {
+          rtkApplied: block.tool_call.rtkApplied,
+          rtkMode: block.tool_call.rtkMode,
+          rtkFallbackReason: block.tool_call.rtkFallbackReason,
+          imagePreviews: block.tool_call.imagePreviews,
+          server_name: block.tool_call.server_name,
+          server_icons: block.tool_call.server_icons,
+          server_description: block.tool_call.server_description,
+          mcpResult: block.tool_call.mcpResult
+        }
+      : undefined,
+    reasoningTime: typeof block.reasoning_time === 'number' ? block.reasoning_time : undefined
+  }
+}
+
+export function toAssistantBlockRowInput(
+  block: AssistantMessageBlock,
+  updatedAt: number
+): AssistantBlockRowInput {
+  const reasoningRange =
+    block.reasoning_time &&
+    typeof block.reasoning_time === 'object' &&
+    typeof block.reasoning_time.start === 'number' &&
+    typeof block.reasoning_time.end === 'number'
+      ? block.reasoning_time
+      : null
+
+  return {
+    block_type: block.type,
+    status: block.status,
+    text_content: block.content ?? null,
+    tool_call_id: block.tool_call?.id ?? null,
+    tool_name: block.tool_call?.name ?? null,
+    tool_params: block.tool_call?.params ?? null,
+    tool_response: block.tool_call?.response ?? null,
+    action_type: block.action_type ?? null,
+    image_mime_type: block.image_data?.mimeType ?? null,
+    reasoning_start_at: reasoningRange?.start ?? null,
+    reasoning_end_at: reasoningRange?.end ?? null,
+    extra_json: JSON.stringify(buildPersistedExtra(block)),
+    updated_at: updatedAt
+  }
+}
+
+function normalizePersistedActionType(
+  actionType: string | null
+): AssistantMessageBlock['action_type'] | undefined {
+  if (
+    actionType === 'tool_call_permission' ||
+    actionType === 'question_request' ||
+    actionType === 'rate_limit'
+  ) {
+    return actionType
+  }
+
+  return undefined
+}
+
+export function toAssistantBlock(row: AssistantBlockRowInput): AssistantMessageBlock {
+  const extra = parseJson<PersistedBlockExtra>(row.extra_json, {})
+
+  const toolCall =
+    row.tool_call_id || row.tool_name || row.tool_params || row.tool_response || extra.toolCallExtra
+      ? {
+          ...extra.toolCallExtra,
+          id: row.tool_call_id ?? undefined,
+          name: row.tool_name ?? undefined,
+          params: row.tool_params ?? undefined,
+          response: row.tool_response ?? undefined
+        }
+      : undefined
+
+  const reasoningTime =
+    typeof extra.reasoningTime === 'number'
+      ? extra.reasoningTime
+      : row.reasoning_start_at !== null && row.reasoning_end_at !== null
+        ? {
+            start: row.reasoning_start_at,
+            end: row.reasoning_end_at
+          }
+        : undefined
+
+  const imageData = extra.imageData?.trim()
+  const actionType = normalizePersistedActionType(row.action_type)
+
+  return {
+    id: extra.id,
+    type: row.block_type as AssistantMessageBlock['type'],
+    content: row.text_content ?? undefined,
+    status: row.status as AssistantMessageBlock['status'],
+    timestamp: extra.timestamp ?? row.updated_at,
+    reasoning_time: reasoningTime,
+    image_data:
+      imageData && row.image_mime_type
+        ? {
+            data: imageData,
+            mimeType: row.image_mime_type
+          }
+        : undefined,
+    tool_call: toolCall as AssistantMessageBlock['tool_call'],
+    extra: extra.extra,
+    ...(actionType ? { action_type: actionType } : {})
+  }
+}
+
+/**
+ * The content string `getMessage` would return after `rawContent` has been persisted and read
+ * back, computed without touching the tables. Content the tables would not structure (unparseable
+ * user JSON, an empty or invalid block array) is returned as is, which is also what the read path
+ * does when it finds no structured rows.
+ */
+export function canonicalizeMessageContent(
+  role: 'user' | 'assistant',
+  rawContent: string,
+  updatedAt: number
+): string {
+  if (role === 'user') {
+    const parsed = parseUserContent(rawContent)
+    if (!parsed) {
+      return rawContent
+    }
+    return assembleUserContent({
+      text: parsed.text,
+      files: parsed.files.map((file) =>
+        toMessageFile(toStoredUserMessageFile(toUserMessageFileRowInput(file)))
+      ),
+      links: parsed.links,
+      search: parsed.search === true,
+      think: parsed.think === true,
+      activeSkills: parsed.activeSkills ?? [],
+      inlineItems: parsed.inlineItems ?? []
+    })
+  }
+
+  const blocks = parseAssistantBlocks(rawContent)
+  if (blocks.length === 0) {
+    return rawContent
+  }
+  return JSON.stringify(
+    blocks.map((block) => toAssistantBlock(toAssistantBlockRowInput(block, updatedAt)))
+  )
+}

--- a/src/main/session/data/tables/deepchatAssistantBlocks.ts
+++ b/src/main/session/data/tables/deepchatAssistantBlocks.ts
@@ -3,6 +3,7 @@ import { isDeepStrictEqual } from 'node:util'
 import { BaseTable } from '@/data/baseTable'
 import type { AssistantMessageBlock } from '@shared/types/agent-interface'
 import type { McpAppDescriptor } from '@shared/types/mcp'
+import { toAssistantBlockRowInput, type PersistedBlockExtra } from '../messageContent'
 
 export interface DeepChatAssistantBlockRow {
   message_id: string
@@ -32,44 +33,10 @@ export interface DeepChatAssistantResultBlockRow {
 
 const NORMALIZATION_SCHEMA_VERSION = 26
 
-type PersistedBlockExtra = {
-  id?: string
-  timestamp?: number
-  imageData?: string
-  extra?: AssistantMessageBlock['extra']
-  toolCallExtra?: Omit<
-    NonNullable<AssistantMessageBlock['tool_call']>,
-    'id' | 'name' | 'params' | 'response'
-  >
-  reasoningTime?: number
-}
-
 type McpAppSourceRow = Pick<
   DeepChatAssistantBlockRow,
   'tool_call_id' | 'tool_params' | 'extra_json'
 >
-
-function buildPersistedExtra(block: AssistantMessageBlock): PersistedBlockExtra {
-  return {
-    id: block.id,
-    timestamp: block.timestamp,
-    imageData: block.image_data?.data,
-    extra: block.extra,
-    toolCallExtra: block.tool_call
-      ? {
-          rtkApplied: block.tool_call.rtkApplied,
-          rtkMode: block.tool_call.rtkMode,
-          rtkFallbackReason: block.tool_call.rtkFallbackReason,
-          imagePreviews: block.tool_call.imagePreviews,
-          server_name: block.tool_call.server_name,
-          server_icons: block.tool_call.server_icons,
-          server_description: block.tool_call.server_description,
-          mcpResult: block.tool_call.mcpResult
-        }
-      : undefined,
-    reasoningTime: typeof block.reasoning_time === 'number' ? block.reasoning_time : undefined
-  }
-}
 
 export class DeepChatAssistantBlocksTable extends BaseTable {
   constructor(db: Database.Database) {
@@ -135,31 +102,25 @@ export class DeepChatAssistantBlocksTable extends BaseTable {
 
     this.db.transaction(() => {
       this.delete(messageId)
+      const updatedAt = Date.now()
       blocks.forEach((block, index) => {
-        const reasoningRange =
-          block.reasoning_time &&
-          typeof block.reasoning_time === 'object' &&
-          typeof block.reasoning_time.start === 'number' &&
-          typeof block.reasoning_time.end === 'number'
-            ? block.reasoning_time
-            : null
-
+        const row = toAssistantBlockRowInput(block, updatedAt)
         insert.run(
           messageId,
           index,
-          block.type,
-          block.status,
-          block.content ?? null,
-          block.tool_call?.id ?? null,
-          block.tool_call?.name ?? null,
-          block.tool_call?.params ?? null,
-          block.tool_call?.response ?? null,
-          block.action_type ?? null,
-          block.image_data?.mimeType ?? null,
-          reasoningRange?.start ?? null,
-          reasoningRange?.end ?? null,
-          JSON.stringify(buildPersistedExtra(block)),
-          Date.now()
+          row.block_type,
+          row.status,
+          row.text_content,
+          row.tool_call_id,
+          row.tool_name,
+          row.tool_params,
+          row.tool_response,
+          row.action_type,
+          row.image_mime_type,
+          row.reasoning_start_at,
+          row.reasoning_end_at,
+          row.extra_json,
+          row.updated_at
         )
       })
     })()

--- a/src/main/session/data/tables/deepchatAssistantBlocks.ts
+++ b/src/main/session/data/tables/deepchatAssistantBlocks.ts
@@ -79,7 +79,15 @@ export class DeepChatAssistantBlocksTable extends BaseTable {
     return NORMALIZATION_SCHEMA_VERSION
   }
 
-  replaceForMessage(messageId: string, blocks: AssistantMessageBlock[]): void {
+  /**
+   * `updatedAt` is what a block without its own timestamp reports back; the projection passes the
+   * record's time so replaying a fact reproduces the rows it wrote the first time.
+   */
+  replaceForMessage(
+    messageId: string,
+    blocks: AssistantMessageBlock[],
+    updatedAt: number = Date.now()
+  ): void {
     const insert = this.db.prepare(
       `INSERT INTO deepchat_assistant_blocks (
         message_id,
@@ -102,7 +110,6 @@ export class DeepChatAssistantBlocksTable extends BaseTable {
 
     this.db.transaction(() => {
       this.delete(messageId)
-      const updatedAt = Date.now()
       blocks.forEach((block, index) => {
         const row = toAssistantBlockRowInput(block, updatedAt)
         insert.run(

--- a/src/main/session/data/tables/deepchatMessages.ts
+++ b/src/main/session/data/tables/deepchatMessages.ts
@@ -136,6 +136,62 @@ export class DeepChatMessagesTable extends BaseTable {
       )
   }
 
+  /**
+   * Writes the whole row from a terminal message record. The record is authoritative for every
+   * column, including `created_at`, so a replayed fact reproduces the row it was appended from.
+   */
+  upsert(row: {
+    id: string
+    sessionId: string
+    orderSeq: number
+    role: 'user' | 'assistant'
+    content: string
+    status: 'pending' | 'sent' | 'error'
+    isContextEdge: number
+    metadata: string
+    createdAt: number
+    updatedAt: number
+  }): void {
+    this.db
+      .prepare(
+        `INSERT INTO deepchat_messages (
+           id,
+           session_id,
+           order_seq,
+           role,
+           content,
+           status,
+           is_context_edge,
+           metadata,
+           created_at,
+           updated_at
+         )
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           session_id = excluded.session_id,
+           order_seq = excluded.order_seq,
+           role = excluded.role,
+           content = excluded.content,
+           status = excluded.status,
+           is_context_edge = excluded.is_context_edge,
+           metadata = excluded.metadata,
+           created_at = excluded.created_at,
+           updated_at = excluded.updated_at`
+      )
+      .run(
+        row.id,
+        row.sessionId,
+        row.orderSeq,
+        row.role,
+        row.content,
+        row.status,
+        row.isContextEdge,
+        row.metadata,
+        row.createdAt,
+        row.updatedAt
+      )
+  }
+
   updateContent(messageId: string, content: string): void {
     this.db
       .prepare('UPDATE deepchat_messages SET content = ?, updated_at = ? WHERE id = ?')
@@ -154,12 +210,12 @@ export class DeepChatMessagesTable extends BaseTable {
       .run(metadata, Date.now(), messageId)
   }
 
-  incrementOrderSeqFrom(sessionId: string, fromOrderSeq: number): void {
+  incrementOrderSeqFrom(sessionId: string, fromOrderSeq: number, updatedAt: number): void {
     this.db
       .prepare(
         'UPDATE deepchat_messages SET order_seq = order_seq + 1, updated_at = ? WHERE session_id = ? AND order_seq >= ?'
       )
-      .run(Date.now(), sessionId, fromOrderSeq)
+      .run(updatedAt, sessionId, fromOrderSeq)
   }
 
   updateContentAndStatus(
@@ -415,6 +471,14 @@ export class DeepChatMessagesTable extends BaseTable {
     this.db.prepare('DELETE FROM deepchat_messages WHERE id = ?').run(messageId)
   }
 
+  deleteByIds(messageIds: string[]): void {
+    if (messageIds.length === 0) return
+    const placeholders = messageIds.map(() => '?').join(', ')
+    this.db
+      .prepare(`DELETE FROM deepchat_messages WHERE id IN (${placeholders})`)
+      .run(...messageIds)
+  }
+
   deleteFromOrderSeq(sessionId: string, fromOrderSeq: number): void {
     this.db
       .prepare('DELETE FROM deepchat_messages WHERE session_id = ? AND order_seq >= ?')
@@ -431,14 +495,5 @@ export class DeepChatMessagesTable extends BaseTable {
       )
       .all(sessionId, fromOrderSeq) as Array<{ id: string }>
     return rows.map((row) => row.id)
-  }
-
-  recoverPendingMessages(): number {
-    const result = this.db
-      .prepare(
-        "UPDATE deepchat_messages SET status = 'error', updated_at = ? WHERE status = 'pending'"
-      )
-      .run(Date.now())
-    return result.changes
   }
 }

--- a/src/main/session/data/tables/deepchatMessages.ts
+++ b/src/main/session/data/tables/deepchatMessages.ts
@@ -139,6 +139,8 @@ export class DeepChatMessagesTable extends BaseTable {
   /**
    * Writes the whole row from a terminal message record. The record is authoritative for every
    * column, including `created_at`, so a replayed fact reproduces the row it was appended from.
+   * A row never moves between Sessions: an id that already belongs to another Session is refused,
+   * the way `insert` refused the duplicate key.
    */
   upsert(row: {
     id: string
@@ -152,7 +154,7 @@ export class DeepChatMessagesTable extends BaseTable {
     createdAt: number
     updatedAt: number
   }): void {
-    this.db
+    const result = this.db
       .prepare(
         `INSERT INTO deepchat_messages (
            id,
@@ -168,7 +170,6 @@ export class DeepChatMessagesTable extends BaseTable {
          )
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(id) DO UPDATE SET
-           session_id = excluded.session_id,
            order_seq = excluded.order_seq,
            role = excluded.role,
            content = excluded.content,
@@ -176,7 +177,8 @@ export class DeepChatMessagesTable extends BaseTable {
            is_context_edge = excluded.is_context_edge,
            metadata = excluded.metadata,
            created_at = excluded.created_at,
-           updated_at = excluded.updated_at`
+           updated_at = excluded.updated_at
+         WHERE deepchat_messages.session_id = excluded.session_id`
       )
       .run(
         row.id,
@@ -190,6 +192,9 @@ export class DeepChatMessagesTable extends BaseTable {
         row.createdAt,
         row.updatedAt
       )
+    if (result.changes === 0) {
+      throw new Error(`Message ${row.id} belongs to another session; refusing to move it.`)
+    }
   }
 
   updateContent(messageId: string, content: string): void {
@@ -472,11 +477,12 @@ export class DeepChatMessagesTable extends BaseTable {
   }
 
   deleteByIds(messageIds: string[]): void {
-    if (messageIds.length === 0) return
-    const placeholders = messageIds.map(() => '?').join(', ')
-    this.db
-      .prepare(`DELETE FROM deepchat_messages WHERE id IN (${placeholders})`)
-      .run(...messageIds)
+    // Chunked below SQLite's bound-variable floor; a range delete can hand over a whole Session.
+    for (let offset = 0; offset < messageIds.length; offset += 500) {
+      const chunk = messageIds.slice(offset, offset + 500)
+      const placeholders = chunk.map(() => '?').join(', ')
+      this.db.prepare(`DELETE FROM deepchat_messages WHERE id IN (${placeholders})`).run(...chunk)
+    }
   }
 
   deleteFromOrderSeq(sessionId: string, fromOrderSeq: number): void {

--- a/src/main/session/data/tables/deepchatTranscriptProjectionMeta.ts
+++ b/src/main/session/data/tables/deepchatTranscriptProjectionMeta.ts
@@ -1,0 +1,90 @@
+import Database from 'better-sqlite3-multiple-ciphers'
+import { BaseTable } from '@/data/baseTable'
+import type { TapeProjectionCursor } from '@/tape/ports/capabilities'
+
+/**
+ * Bump when the transcript tables derived from a message fact change shape in a way that makes a
+ * stored cursor meaningless; older rows are then treated as absent and the Session is projected
+ * again from its transcript and Tape.
+ */
+const TRANSCRIPT_PROJECTION_VERSION = 1
+
+/**
+ * How far the transcript tables have followed a Session's Tape: the Tape incarnation they were
+ * derived from and the highest entry id whose message facts they reflect. Written inside the same
+ * transaction as each terminal transcript write, so it is never ahead of the tables or behind the
+ * fact that was just appended.
+ */
+export class DeepChatTranscriptProjectionMetaTable extends BaseTable {
+  constructor(db: Database.Database) {
+    super(db, 'deepchat_transcript_projection_meta')
+  }
+
+  getCreateTableSQL(): string {
+    return `
+      CREATE TABLE IF NOT EXISTS deepchat_transcript_projection_meta (
+        session_id TEXT PRIMARY KEY,
+        tape_incarnation_id TEXT NOT NULL,
+        max_entry_id INTEGER NOT NULL,
+        projection_version INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+    `
+  }
+
+  getMigrationSQL(_version: number): string | null {
+    return null
+  }
+
+  getLatestVersion(): number {
+    return 0
+  }
+
+  get(sessionId: string): TapeProjectionCursor | null {
+    const row = this.db
+      .prepare(
+        `SELECT tape_incarnation_id, max_entry_id, projection_version
+         FROM deepchat_transcript_projection_meta
+         WHERE session_id = ?`
+      )
+      .get(sessionId) as
+      | { tape_incarnation_id: string; max_entry_id: number; projection_version: number }
+      | undefined
+    if (!row || row.projection_version !== TRANSCRIPT_PROJECTION_VERSION) {
+      return null
+    }
+    return { tapeIncarnationId: row.tape_incarnation_id, maxEntryId: row.max_entry_id }
+  }
+
+  upsert(sessionId: string, cursor: TapeProjectionCursor): void {
+    this.db
+      .prepare(
+        `INSERT INTO deepchat_transcript_projection_meta (
+           session_id,
+           tape_incarnation_id,
+           max_entry_id,
+           projection_version,
+           updated_at
+         )
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(session_id) DO UPDATE SET
+           tape_incarnation_id = excluded.tape_incarnation_id,
+           max_entry_id = excluded.max_entry_id,
+           projection_version = excluded.projection_version,
+           updated_at = excluded.updated_at`
+      )
+      .run(
+        sessionId,
+        cursor.tapeIncarnationId,
+        cursor.maxEntryId,
+        TRANSCRIPT_PROJECTION_VERSION,
+        Date.now()
+      )
+  }
+
+  delete(sessionId: string): void {
+    this.db
+      .prepare('DELETE FROM deepchat_transcript_projection_meta WHERE session_id = ?')
+      .run(sessionId)
+  }
+}

--- a/src/main/session/data/transcript.ts
+++ b/src/main/session/data/transcript.ts
@@ -3,7 +3,6 @@ import type { SessionDatabase } from './database'
 import type {
   ChatMessagePageResult,
   ChatMessageRecord,
-  MessageFile,
   MessageMetadata,
   MessagePageCursor,
   MessageTraceRecord,
@@ -33,12 +32,15 @@ import type {
   TapeMessageFactWriter
 } from '@/tape/ports/capabilities'
 import type { TapeCompactionModelCallInput } from '@/tape/domain/compactionUsage'
+import { getAttachmentSearchableText } from '@shared/utils/attachmentRepresentation'
 import {
-  getAttachmentSearchableText,
-  normalizeAttachmentRepresentationPreference,
-  normalizeAttachmentResolvedRepresentation,
-  normalizePdfEmbeddedTextCoverage
-} from '@shared/utils/attachmentRepresentation'
+  assembleUserContent,
+  parseAssistantBlocks,
+  parseUserContent,
+  toAssistantBlock,
+  toMessageFile,
+  toUserMessageFileRowInput
+} from './messageContent'
 
 const MAX_SEARCHABLE_ATTACHMENT_CHARACTERS = 32_000
 const SEARCH_ATTACHMENT_TRUNCATION_MARKER = '[Attachment search text truncated]'
@@ -118,20 +120,6 @@ type StructuredMessageMaps = {
   fileRows: Map<string, DeepChatUserMessageFileRow[]>
   linkRows: Map<string, DeepChatUserMessageLinkRow[]>
   assistantRows: Map<string, DeepChatAssistantBlockRow[]>
-}
-
-function normalizePersistedActionType(
-  actionType: string | null
-): AssistantMessageBlock['action_type'] | undefined {
-  if (
-    actionType === 'tool_call_permission' ||
-    actionType === 'question_request' ||
-    actionType === 'rate_limit'
-  ) {
-    return actionType
-  }
-
-  return undefined
 }
 
 function extractSearchableMessageContent(rawContent: string): string {
@@ -648,7 +636,7 @@ export class SessionTranscript {
     }
 
     if (row.role === 'user') {
-      const parsed = this.parseUserContent(content)
+      const parsed = parseUserContent(content)
       if (parsed) {
         this.persistUserContent(messageId, parsed)
         this.upsertMessageSearchDocument(row.session_id, messageId, 'user', content, row.updated_at)
@@ -663,7 +651,7 @@ export class SessionTranscript {
       return
     }
 
-    const blocks = this.parseAssistantBlocks(content)
+    const blocks = parseAssistantBlocks(content)
     this.database.deepchatAssistantBlocksTable.replaceForMessage(messageId, blocks)
     if (row.status === 'sent' || row.status === 'error') {
       this.upsertMessageSearchDocument(
@@ -873,14 +861,14 @@ export class SessionTranscript {
         metadata: record.metadata
       })
       if (record.role === 'user') {
-        const userContent = this.parseUserContent(record.content)
+        const userContent = parseUserContent(record.content)
         if (userContent) {
           this.persistUserContent(nextId, userContent)
         }
       } else {
         this.database.deepchatAssistantBlocksTable.replaceForMessage(
           nextId,
-          this.parseAssistantBlocks(record.content)
+          parseAssistantBlocks(record.content)
         )
       }
       this.upsertMessageSearchDocument(
@@ -910,9 +898,7 @@ export class SessionTranscript {
         continue
       }
       if (row.role === 'assistant') {
-        const blocks = this.parseAssistantBlocks(
-          recoveredRecords.get(row.id)?.content ?? row.content
-        )
+        const blocks = parseAssistantBlocks(recoveredRecords.get(row.id)?.content ?? row.content)
         const recoveredBlocks = buildTerminalErrorBlocks(blocks, 'common.error.sessionInterrupted')
         this.database.deepchatAssistantBlocksTable.replaceForMessage(row.id, recoveredBlocks)
         this.database.deepchatMessagesTable.updateContentAndStatus(
@@ -978,14 +964,14 @@ export class SessionTranscript {
 
   backfillMessageRow(row: DeepChatMessageRow): void {
     if (row.role === 'user') {
-      const content = this.parseUserContent(row.content)
+      const content = parseUserContent(row.content)
       if (content) {
         this.persistUserContent(row.id, content)
       }
     } else {
       this.database.deepchatAssistantBlocksTable.replaceForMessage(
         row.id,
-        this.parseAssistantBlocks(row.content)
+        parseAssistantBlocks(row.content)
       )
     }
 
@@ -1004,7 +990,7 @@ export class SessionTranscript {
     if (row.role === 'user') {
       return parseMessageMetadata(row.metadata).inputReceipt?.mode === 'steer'
     }
-    const blocks = this.parseAssistantBlocks(this.materializeContent(row))
+    const blocks = parseAssistantBlocks(this.materializeContent(row))
     return blocks.some(
       (block) =>
         block.type === 'action' &&
@@ -1063,18 +1049,16 @@ export class SessionTranscript {
         ? (maps.linkRows.get(row.id) ?? [])
         : this.database.deepchatUserMessageLinksTable.listByMessageIds([row.id])
 
-      const rawUserContent = this.parseUserContent(row.content)
-      const activeSkills = rawUserContent?.activeSkills ?? []
-      const inlineItems = rawUserContent?.inlineItems ?? []
-      return JSON.stringify({
+      const rawUserContent = parseUserContent(row.content)
+      return assembleUserContent({
         text: userRow.text,
-        files: fileRows.map((fileRow) => this.toMessageFile(fileRow)),
+        files: fileRows.map((fileRow) => toMessageFile(fileRow)),
         links: linkRows.map((linkRow) => linkRow.url),
         search: userRow.search_enabled === 1,
         think: userRow.think_enabled === 1,
-        ...(activeSkills.length > 0 ? { activeSkills } : {}),
-        ...(inlineItems.length > 0 ? { inlineItems } : {})
-      } satisfies UserMessageContent)
+        activeSkills: rawUserContent?.activeSkills ?? [],
+        inlineItems: rawUserContent?.inlineItems ?? []
+      })
     }
 
     const assistantRows = maps
@@ -1084,54 +1068,7 @@ export class SessionTranscript {
       return row.content
     }
 
-    return JSON.stringify(assistantRows.map((blockRow) => this.toAssistantBlock(blockRow)))
-  }
-
-  private parseAssistantBlocks(rawContent: string): AssistantMessageBlock[] {
-    try {
-      const parsed = JSON.parse(rawContent) as AssistantMessageBlock[]
-      return Array.isArray(parsed) ? parsed : []
-    } catch {
-      return []
-    }
-  }
-
-  private parseUserContent(rawContent: string): UserMessageContent | null {
-    try {
-      const parsed = JSON.parse(rawContent) as Partial<UserMessageContent>
-      if (!parsed || typeof parsed !== 'object') {
-        return null
-      }
-
-      return {
-        text: typeof parsed.text === 'string' ? parsed.text : '',
-        files: Array.isArray(parsed.files) ? (parsed.files.filter(Boolean) as MessageFile[]) : [],
-        links: Array.isArray(parsed.links)
-          ? parsed.links.filter((item): item is string => typeof item === 'string')
-          : [],
-        search: parsed.search === true,
-        think: parsed.think === true,
-        activeSkills: this.normalizeActiveSkills(parsed.activeSkills),
-        inlineItems: Array.isArray(parsed.inlineItems) ? parsed.inlineItems : []
-      }
-    } catch {
-      return null
-    }
-  }
-
-  private normalizeActiveSkills(activeSkills?: string[]): string[] {
-    if (!Array.isArray(activeSkills)) {
-      return []
-    }
-
-    return Array.from(
-      new Set(
-        activeSkills
-          .filter((item): item is string => typeof item === 'string')
-          .map((item) => item.trim())
-          .filter(Boolean)
-      )
-    )
+    return JSON.stringify(assistantRows.map((blockRow) => toAssistantBlock(blockRow)))
   }
 
   private buildCompactionBlocks(status: 'compacting' | 'compacted'): AssistantMessageBlock[] {
@@ -1172,111 +1109,9 @@ export class SessionTranscript {
     })
     this.database.deepchatUserMessageFilesTable.replaceForMessage(
       messageId,
-      content.files.map((file) => ({
-        name: file.name,
-        path: file.path,
-        mimeType: file.mimeType ?? file.type,
-        size: file.size,
-        metadataJson: JSON.stringify({
-          type: file.type,
-          content: file.content,
-          token: file.token,
-          thumbnail: file.thumbnail,
-          metadata: file.metadata,
-          requestedRepresentation: normalizeAttachmentRepresentationPreference(
-            file.requestedRepresentation
-          ),
-          pdfTextCoverage: normalizePdfEmbeddedTextCoverage(file.pdfTextCoverage),
-          resolvedRepresentation: normalizeAttachmentResolvedRepresentation(
-            file.resolvedRepresentation
-          )
-        })
-      }))
+      content.files.map((file) => toUserMessageFileRowInput(file))
     )
     this.database.deepchatUserMessageLinksTable.replaceForMessage(messageId, content.links)
-  }
-
-  private toMessageFile(row: DeepChatUserMessageFileRow): MessageFile {
-    const extra = this.parseJson<Record<string, unknown>>(row.metadata_json, {})
-    return {
-      name: row.name ?? '',
-      path: row.path,
-      type: typeof extra.type === 'string' ? extra.type : (row.mime_type ?? undefined),
-      size: row.size ?? undefined,
-      content: typeof extra.content === 'string' ? extra.content : undefined,
-      mimeType: row.mime_type ?? undefined,
-      token: typeof extra.token === 'number' ? extra.token : undefined,
-      thumbnail: typeof extra.thumbnail === 'string' ? extra.thumbnail : undefined,
-      requestedRepresentation: normalizeAttachmentRepresentationPreference(
-        extra.requestedRepresentation
-      ),
-      pdfTextCoverage: normalizePdfEmbeddedTextCoverage(extra.pdfTextCoverage),
-      resolvedRepresentation: normalizeAttachmentResolvedRepresentation(
-        extra.resolvedRepresentation
-      ),
-      metadata:
-        extra.metadata && typeof extra.metadata === 'object' && !Array.isArray(extra.metadata)
-          ? (extra.metadata as MessageFile['metadata'])
-          : undefined
-    }
-  }
-
-  private toAssistantBlock(row: DeepChatAssistantBlockRow): AssistantMessageBlock {
-    const extra = this.parseJson<{
-      id?: string
-      timestamp?: number
-      imageData?: string
-      extra?: AssistantMessageBlock['extra']
-      toolCallExtra?: Record<string, unknown>
-      reasoningTime?: number
-    }>(row.extra_json, {})
-
-    const toolCall =
-      row.tool_call_id ||
-      row.tool_name ||
-      row.tool_params ||
-      row.tool_response ||
-      extra.toolCallExtra
-        ? {
-            ...extra.toolCallExtra,
-            id: row.tool_call_id ?? undefined,
-            name: row.tool_name ?? undefined,
-            params: row.tool_params ?? undefined,
-            response: row.tool_response ?? undefined
-          }
-        : undefined
-
-    const reasoningTime =
-      typeof extra.reasoningTime === 'number'
-        ? extra.reasoningTime
-        : row.reasoning_start_at !== null && row.reasoning_end_at !== null
-          ? {
-              start: row.reasoning_start_at,
-              end: row.reasoning_end_at
-            }
-          : undefined
-
-    const imageData = extra.imageData?.trim()
-    const actionType = normalizePersistedActionType(row.action_type)
-
-    return {
-      id: extra.id,
-      type: row.block_type as AssistantMessageBlock['type'],
-      content: row.text_content ?? undefined,
-      status: row.status as AssistantMessageBlock['status'],
-      timestamp: extra.timestamp ?? row.updated_at,
-      reasoning_time: reasoningTime,
-      image_data:
-        imageData && row.image_mime_type
-          ? {
-              data: imageData,
-              mimeType: row.image_mime_type
-            }
-          : undefined,
-      tool_call: toolCall as AssistantMessageBlock['tool_call'],
-      extra: extra.extra,
-      ...(actionType ? { action_type: actionType } : {})
-    }
   }
 
   private loadStructuredMaps(messageIds: string[]): StructuredMessageMaps {
@@ -1339,18 +1174,6 @@ export class SessionTranscript {
       content: extractSearchableMessageContent(rawContent),
       updatedAt
     })
-  }
-
-  private parseJson<T>(raw: string | null | undefined, fallback: T): T {
-    if (!raw) {
-      return fallback
-    }
-
-    try {
-      return JSON.parse(raw) as T
-    } catch {
-      return fallback
-    }
   }
 
   private persistUsageStats(

--- a/src/main/session/data/transcript.ts
+++ b/src/main/session/data/transcript.ts
@@ -18,32 +18,25 @@ import type { DeepChatAssistantBlockRow } from '@/session/data/tables/deepchatAs
 import type { DeepChatUserMessageFileRow } from '@/session/data/tables/deepchatUserMessageFiles'
 import type { DeepChatUserMessageLinkRow } from '@/session/data/tables/deepchatUserMessageLinks'
 import type { DeepChatUserMessageRow } from '@/session/data/tables/deepchatUserMessages'
-import {
-  buildCompactionUsageStatsRecord,
-  buildUsageStatsRecord,
-  parseMessageMetadata,
-  resolveUsageModelId,
-  resolveUsageProviderId
-} from '@/session/usageStats'
+import { buildCompactionUsageStatsRecord, parseMessageMetadata } from '@/session/usageStats'
 import type {
   ExecutionJournalAuditReader,
   TapeAnchorReader,
   TapeCompactionModelCallWriter,
   TapeMessageFactWriter
 } from '@/tape/ports/capabilities'
+import type { TapeMessageReplacementOptions } from '@/tape/domain/facts'
 import type { TapeCompactionModelCallInput } from '@/tape/domain/compactionUsage'
-import { getAttachmentSearchableText } from '@shared/utils/attachmentRepresentation'
 import {
   assembleUserContent,
+  canonicalizeMessageContent,
   parseAssistantBlocks,
   parseUserContent,
   toAssistantBlock,
-  toMessageFile,
-  toUserMessageFileRowInput
+  toMessageFile
 } from './messageContent'
+import { persistMessageUsageStats, TranscriptProjectionApplier } from './transcriptProjection'
 
-const MAX_SEARCHABLE_ATTACHMENT_CHARACTERS = 32_000
-const SEARCH_ATTACHMENT_TRUNCATION_MARKER = '[Attachment search text truncated]'
 const COMPACTION_SHIFT_MATERIALIZATION_BATCH_SIZE = 500
 const MAX_COMPACTION_ATTEMPT_ID_CHARACTERS = 128
 
@@ -122,84 +115,11 @@ type StructuredMessageMaps = {
   assistantRows: Map<string, DeepChatAssistantBlockRow[]>
 }
 
-function extractSearchableMessageContent(rawContent: string): string {
-  try {
-    const parsed = JSON.parse(rawContent) as
-      | UserMessageContent
-      | Array<{
-          type?: string
-          content?: string
-          text?: string
-          error?: string
-        }>
-
-    if (Array.isArray(parsed)) {
-      const segments = parsed
-        .flatMap((block) => {
-          if (!block || typeof block !== 'object') {
-            return []
-          }
-
-          const values = [block.content, block.text, block.error]
-          return values.filter(
-            (value): value is string => typeof value === 'string' && value.trim().length > 0
-          )
-        })
-        .map((value) => value.trim())
-
-      if (segments.length > 0) {
-        return segments.join('\n')
-      }
-    } else if (parsed && typeof parsed === 'object') {
-      const segments: string[] = []
-      if (typeof parsed.text === 'string' && parsed.text.trim()) {
-        segments.push(parsed.text.trim())
-      }
-      const searchableAttachmentText = buildSearchableAttachmentText(parsed.files)
-      if (searchableAttachmentText) segments.push(searchableAttachmentText)
-      return segments.join('\n')
-    }
-  } catch {
-    // Plain-text fallback.
-  }
-
-  return rawContent.trim()
-}
-
-function buildSearchableAttachmentText(files: unknown): string {
-  if (!Array.isArray(files)) return ''
-  const text = files
-    .flatMap((file) => {
-      const searchableText = getAttachmentSearchableText(file).trim()
-      return searchableText ? [searchableText] : []
-    })
-    .join('\n')
-  if (text.length <= MAX_SEARCHABLE_ATTACHMENT_CHARACTERS) return text
-
-  const marker = `\n${SEARCH_ATTACHMENT_TRUNCATION_MARKER}\n`
-  const retainedCharacters = Math.max(
-    0,
-    Math.floor((MAX_SEARCHABLE_ATTACHMENT_CHARACTERS - marker.length) / 2)
-  )
-  let headEnd = retainedCharacters
-  if (isHighSurrogate(text.charCodeAt(headEnd - 1))) headEnd -= 1
-  let tailStart = text.length - retainedCharacters
-  if (isLowSurrogate(text.charCodeAt(tailStart))) tailStart += 1
-  return `${text.slice(0, headEnd).trimEnd()}${marker}${text.slice(tailStart).trimStart()}`
-}
-
-function isHighSurrogate(code: number): boolean {
-  return code >= 0xd800 && code <= 0xdbff
-}
-
-function isLowSurrogate(code: number): boolean {
-  return code >= 0xdc00 && code <= 0xdfff
-}
-
 export class SessionTranscript {
   private database: SessionDatabase
   private readonly tapeFacts: TapeMessageFactWriter
   private readonly compactionUsage: TapeCompactionModelCallWriter
+  private readonly projection: TranscriptProjectionApplier
 
   constructor(
     database: SessionDatabase,
@@ -216,6 +136,7 @@ export class SessionTranscript {
     this.database = database
     this.tapeFacts = tapeFacts
     this.compactionUsage = tapeFacts
+    this.projection = new TranscriptProjectionApplier(database)
   }
 
   private runInDatabaseTransaction<T>(operation: () => T): T {
@@ -232,21 +153,20 @@ export class SessionTranscript {
     }
   ): string {
     const id = nanoid()
-    const serializedContent = JSON.stringify(content)
-    this.runInDatabaseTransaction(() => {
-      this.database.deepchatMessagesTable.insert({
-        id,
-        sessionId,
-        orderSeq,
-        role: 'user',
-        content: serializedContent,
-        status: options?.status ?? 'sent',
-        ...(options?.metadata ? { metadata: JSON.stringify(options.metadata) } : {})
-      })
-      this.persistUserContent(id, content)
-      this.upsertMessageSearchDocument(sessionId, id, 'user', serializedContent)
-      this.appendLiveTapeFacts(id)
+    const now = Date.now()
+    const record = this.terminalRecord({
+      id,
+      sessionId,
+      orderSeq,
+      role: 'user',
+      content: JSON.stringify(content),
+      status: options?.status ?? 'sent',
+      isContextEdge: 0,
+      metadata: options?.metadata ? JSON.stringify(options.metadata) : '{}',
+      createdAt: now,
+      updatedAt: now
     })
+    this.runInDatabaseTransaction(() => this.commitRecord(record))
     return id
   }
 
@@ -271,23 +191,28 @@ export class SessionTranscript {
     options: CompactionMessageOptions
   ): string {
     const id = nanoid()
-    this.database.deepchatMessagesTable.insert({
-      id,
-      sessionId,
-      orderSeq,
-      role: 'assistant',
-      content: JSON.stringify(this.buildCompactionBlocks(status)),
-      status: 'sent',
-      metadata: JSON.stringify(
-        this.buildCompactionMetadata(
-          status,
-          summaryUpdatedAt,
-          options.compactionAttemptId,
-          options.boundaryReason
-        )
-      )
-    })
-    this.appendLiveTapeFacts(id)
+    const now = Date.now()
+    this.commitRecord(
+      this.terminalRecord({
+        id,
+        sessionId,
+        orderSeq,
+        role: 'assistant',
+        content: JSON.stringify(this.buildCompactionBlocks(status)),
+        status: 'sent',
+        isContextEdge: 0,
+        metadata: JSON.stringify(
+          this.buildCompactionMetadata(
+            status,
+            summaryUpdatedAt,
+            options.compactionAttemptId,
+            options.boundaryReason
+          )
+        ),
+        createdAt: now,
+        updatedAt: now
+      })
+    )
     return id
   }
 
@@ -313,12 +238,7 @@ export class SessionTranscript {
     let messageId = ''
     this.runInDatabaseTransaction(() => {
       if (options?.shiftExistingMessages) {
-        const shiftedMessageIds = this.database.deepchatMessagesTable.getIdsFromOrderSeq(
-          sessionId,
-          orderSeq
-        )
-        this.database.deepchatMessagesTable.incrementOrderSeqFrom(sessionId, orderSeq)
-        this.appendCompactionOrderShiftFacts(sessionId, shiftedMessageIds)
+        this.shiftMessagesFrom(sessionId, orderSeq)
       }
       messageId = this.insertCompactionMessageRecord(
         sessionId,
@@ -331,9 +251,17 @@ export class SessionTranscript {
     return messageId
   }
 
-  private appendCompactionOrderShiftFacts(sessionId: string, messageIds: string[]): void {
-    if (messageIds.length === 0) return
-
+  /**
+   * Compaction inserts its marker in front of the messages it summarised. The shifted rows keep
+   * their content; each records its new position as an order replacement fact, and the table moves
+   * them in one statement stamped with the same time the facts carry.
+   */
+  private shiftMessagesFrom(sessionId: string, fromOrderSeq: number): void {
+    const shiftedAt = Date.now()
+    const messageIds = this.database.deepchatMessagesTable.getIdsFromOrderSeq(
+      sessionId,
+      fromOrderSeq
+    )
     const shiftedRecords: ChatMessageRecord[] = []
     for (
       let offset = 0;
@@ -351,11 +279,12 @@ export class SessionTranscript {
       throw new Error('Failed to materialize every message shifted by compaction.')
     }
     for (const record of shiftedRecords) {
-      this.tapeFacts.appendMessageReplacement(record, {
-        reason: 'compaction_order_shifted',
-        revisionKind: 'order'
-      })
+      this.tapeFacts.appendMessageReplacement(
+        { ...record, orderSeq: record.orderSeq + 1, updatedAt: shiftedAt },
+        { reason: 'compaction_order_shifted', revisionKind: 'order' }
+      )
     }
+    this.database.deepchatMessagesTable.incrementOrderSeqFrom(sessionId, fromOrderSeq, shiftedAt)
   }
 
   updateAssistantContent(
@@ -372,10 +301,18 @@ export class SessionTranscript {
 
   updateAssistantMetadata(messageId: string, metadata: string): void {
     this.database.deepchatMessagesTable.updateMetadata(messageId, metadata)
-    this.persistUsageStats(messageId, metadata, 'live')
+    const row = this.database.deepchatMessagesTable.get(messageId)
+    if (row?.role === 'assistant') {
+      persistMessageUsageStats(this.database, { ...this.recordFromRow(row), metadata })
+    }
   }
 
-  updateMessageStatus(messageId: string, status: 'pending' | 'sent' | 'error'): void {
+  /**
+   * Only the pending region is written in place. Terminal status arrives through a fact-backed
+   * method (`finalizeAssistantMessage`, `setMessageError`, `settleSteerMessages`,
+   * `restoreUserMessage`), never by flipping the column.
+   */
+  updateMessageStatus(messageId: string, status: 'pending'): void {
     this.database.deepchatMessagesTable.updateStatus(messageId, status)
   }
 
@@ -389,24 +326,20 @@ export class SessionTranscript {
       if (metadata.inputReceipt?.mode !== 'steer' || metadata.inputReceipt.readAt !== null) {
         throw new Error(`Message ${messageId} is not an unread steer message.`)
       }
-      this.database.deepchatMessagesTable.updateMetadata(
-        messageId,
-        JSON.stringify({
-          ...metadata,
-          inputReceipt: {
-            mode: 'steer',
-            readAt
-          }
-        } satisfies MessageMetadata)
+      this.commitReplacement(
+        {
+          ...message,
+          metadata: JSON.stringify({
+            ...metadata,
+            inputReceipt: {
+              mode: 'steer',
+              readAt
+            }
+          } satisfies MessageMetadata),
+          updatedAt: Date.now()
+        },
+        { reason: 'steer_message_read', revisionKind: 'record' }
       )
-      const updated = this.getMessage(messageId)
-      if (!updated) {
-        throw new Error(`Failed to mark steer message read: ${messageId}`)
-      }
-      this.tapeFacts.appendMessageReplacement(updated, {
-        reason: 'steer_message_read',
-        revisionKind: 'record'
-      })
     }
     return messageIds.map((messageId) => this.requireMessage(messageId))
   }
@@ -417,12 +350,10 @@ export class SessionTranscript {
       if (!message || message.role !== 'user' || message.status !== 'pending') {
         throw new Error(`Pending steer message not found: ${messageId}`)
       }
-      this.database.deepchatMessagesTable.updateStatus(messageId, 'sent')
-      const updated = this.requireMessage(messageId)
-      this.tapeFacts.appendMessageReplacement(updated, {
-        reason: 'steer_message_settled',
-        revisionKind: 'record'
-      })
+      this.commitReplacement(
+        { ...message, status: 'sent', updatedAt: Date.now() },
+        { reason: 'steer_message_settled', revisionKind: 'record' }
+      )
     }
     return messageIds.map((messageId) => this.requireMessage(messageId))
   }
@@ -437,14 +368,29 @@ export class SessionTranscript {
       if (metadata.inputReceipt?.mode !== 'steer' || metadata.inputReceipt.readAt !== null) {
         throw new Error(`Message ${messageId} is not an unread steer message.`)
       }
-      this.database.deepchatMessagesTable.updateStatus(messageId, 'error')
-      const updated = this.requireMessage(messageId)
-      this.tapeFacts.appendMessageReplacement(updated, {
-        reason: 'steer_message_restart_failed',
-        revisionKind: 'record'
-      })
+      this.commitReplacement(
+        { ...message, status: 'error', updatedAt: Date.now() },
+        { reason: 'steer_message_restart_failed', revisionKind: 'record' }
+      )
     }
     return messageIds.map((messageId) => this.requireMessage(messageId))
+  }
+
+  /**
+   * A retried prompt whose row had failed (for example a Steer prompt that could not restart) is
+   * kept and re-sent, so it must count as sent again for context history.
+   */
+  restoreUserMessage(messageId: string): void {
+    this.runInDatabaseTransaction(() => {
+      const message = this.getMessage(messageId)
+      if (!message || message.role !== 'user' || message.status === 'sent') {
+        return
+      }
+      this.commitReplacement(
+        { ...message, status: 'sent', updatedAt: Date.now() },
+        { reason: 'retry_restored_prompt', revisionKind: 'record' }
+      )
+    })
   }
 
   finalizeAssistantMessage(
@@ -453,16 +399,18 @@ export class SessionTranscript {
     metadata: string
   ): void {
     this.runInDatabaseTransaction(() => {
-      this.database.deepchatAssistantBlocksTable.replaceForMessage(messageId, blocks)
-      this.database.deepchatMessagesTable.updateContentAndStatus(
-        messageId,
-        JSON.stringify(blocks),
-        'sent',
-        metadata
+      const row = this.database.deepchatMessagesTable.get(messageId)
+      if (!row) return
+      this.commitRecord(
+        this.terminalRecord({
+          ...this.recordFromRow(row),
+          role: 'assistant',
+          content: JSON.stringify(blocks),
+          status: 'sent',
+          metadata,
+          updatedAt: Date.now()
+        })
       )
-      this.upsertAssistantSearchDocument(messageId, blocks)
-      this.persistUsageStats(messageId, metadata, 'live')
-      this.appendLiveTapeFacts(messageId)
     })
   }
 
@@ -473,20 +421,25 @@ export class SessionTranscript {
     options: CompactionMessageOptions
   ): void {
     this.runInDatabaseTransaction(() => {
-      this.database.deepchatMessagesTable.updateContentAndStatus(
-        messageId,
-        JSON.stringify(this.buildCompactionBlocks(status)),
-        'sent',
-        JSON.stringify(
-          this.buildCompactionMetadata(
-            status,
-            summaryUpdatedAt,
-            options.compactionAttemptId,
-            options.boundaryReason
-          )
-        )
+      const row = this.database.deepchatMessagesTable.get(messageId)
+      if (!row) return
+      this.commitRecord(
+        this.terminalRecord({
+          ...this.recordFromRow(row),
+          role: 'assistant',
+          content: JSON.stringify(this.buildCompactionBlocks(status)),
+          status: 'sent',
+          metadata: JSON.stringify(
+            this.buildCompactionMetadata(
+              status,
+              summaryUpdatedAt,
+              options.compactionAttemptId,
+              options.boundaryReason
+            )
+          ),
+          updatedAt: Date.now()
+        })
       )
-      this.appendLiveTapeFacts(messageId)
     })
   }
 
@@ -505,27 +458,18 @@ export class SessionTranscript {
 
   setMessageError(messageId: string, blocks: AssistantMessageBlock[], metadata?: string): void {
     this.runInDatabaseTransaction(() => {
-      this.database.deepchatAssistantBlocksTable.replaceForMessage(messageId, blocks)
-      const serializedBlocks = JSON.stringify(blocks)
-      if (metadata === undefined) {
-        this.database.deepchatMessagesTable.updateContentAndStatus(
-          messageId,
-          serializedBlocks,
-          'error'
-        )
-        this.upsertAssistantSearchDocument(messageId, blocks)
-        this.appendLiveTapeFacts(messageId)
-        return
-      }
-      this.database.deepchatMessagesTable.updateContentAndStatus(
-        messageId,
-        serializedBlocks,
-        'error',
-        metadata
+      const row = this.database.deepchatMessagesTable.get(messageId)
+      if (!row) return
+      this.commitRecord(
+        this.terminalRecord({
+          ...this.recordFromRow(row),
+          role: 'assistant',
+          content: JSON.stringify(blocks),
+          status: 'error',
+          metadata: metadata ?? row.metadata,
+          updatedAt: Date.now()
+        })
       )
-      this.upsertAssistantSearchDocument(messageId, blocks)
-      this.persistUsageStats(messageId, metadata, 'live')
-      this.appendLiveTapeFacts(messageId)
     })
   }
 
@@ -629,46 +573,14 @@ export class SessionTranscript {
   }
 
   private applyMessageContentUpdate(messageId: string, content: string): void {
-    this.database.deepchatMessagesTable.updateContent(messageId, content)
     const row = this.database.deepchatMessagesTable.get(messageId)
     if (!row) {
       return
     }
-
-    if (row.role === 'user') {
-      const parsed = parseUserContent(content)
-      if (parsed) {
-        this.persistUserContent(messageId, parsed)
-        this.upsertMessageSearchDocument(row.session_id, messageId, 'user', content, row.updated_at)
-      }
-      const updated = this.getMessage(messageId)
-      if (updated) {
-        this.tapeFacts.appendMessageReplacement(updated, {
-          reason: 'message_content_updated',
-          revisionKind: 'record'
-        })
-      }
-      return
-    }
-
-    const blocks = parseAssistantBlocks(content)
-    this.database.deepchatAssistantBlocksTable.replaceForMessage(messageId, blocks)
-    if (row.status === 'sent' || row.status === 'error') {
-      this.upsertMessageSearchDocument(
-        row.session_id,
-        messageId,
-        'assistant',
-        content,
-        row.updated_at
-      )
-    }
-    const updated = this.getMessage(messageId)
-    if (updated) {
-      this.tapeFacts.appendMessageReplacement(updated, {
-        reason: 'message_content_updated',
-        revisionKind: 'record'
-      })
-    }
+    this.commitReplacement(
+      this.terminalRecord({ ...this.recordFromRow(row), content, updatedAt: Date.now() }),
+      { reason: 'message_content_updated', revisionKind: 'record' }
+    )
   }
 
   getNextOrderSeq(sessionId: string): number {
@@ -693,17 +605,7 @@ export class SessionTranscript {
   private deleteMessageWithReason(messageId: string, reason: string): void {
     this.runInDatabaseTransaction(() => {
       const record = this.getMessage(messageId)
-      if (record) {
-        this.tapeFacts.appendMessageRetraction(record, reason)
-      }
-      this.database.deepchatSearchDocumentsTable.delete(`message:${messageId}`)
-      this.database.deepchatAssistantBlocksTable.delete(messageId)
-      this.database.deepchatUserMessageLinksTable.delete(messageId)
-      this.database.deepchatUserMessageFilesTable.delete(messageId)
-      this.database.deepchatUserMessagesTable.delete(messageId)
-      this.database.deepchatMessageTracesTable.deleteByMessageIds([messageId])
-      this.database.deepchatMessageSearchResultsTable.deleteByMessageIds([messageId])
-      this.database.deepchatMessagesTable.delete(messageId)
+      this.commitRetractions(record ? [record] : [], reason, [messageId])
     })
   }
 
@@ -712,19 +614,13 @@ export class SessionTranscript {
       const records = this.getMessages(sessionId).filter(
         (record) => record.orderSeq >= fromOrderSeq
       )
-      for (const record of records) {
-        this.tapeFacts.appendMessageRetraction(record, 'messages_deleted_from_order_seq')
-      }
-      const messageIds = records.map((record) => record.id)
-      if (messageIds.length > 0) {
-        this.database.deepchatSearchDocumentsTable.deleteByMessageIds(messageIds)
-        this.database.deepchatAssistantBlocksTable.deleteByMessageIds(messageIds)
-        this.database.deepchatUserMessageLinksTable.deleteByMessageIds(messageIds)
-        this.database.deepchatUserMessageFilesTable.deleteByMessageIds(messageIds)
-        this.database.deepchatUserMessagesTable.deleteByMessageIds(messageIds)
-        this.database.deepchatMessageTracesTable.deleteByMessageIds(messageIds)
-        this.database.deepchatMessageSearchResultsTable.deleteByMessageIds(messageIds)
-      }
+      this.commitRetractions(
+        records,
+        'messages_deleted_from_order_seq',
+        records.map((record) => record.id)
+      )
+      // The range delete is the table-level guarantee this method has always given: no row of the
+      // Session at or past `fromOrderSeq` survives, whatever the read above surfaced.
       this.database.deepchatMessagesTable.deleteFromOrderSeq(sessionId, fromOrderSeq)
     })
   }
@@ -846,40 +742,25 @@ export class SessionTranscript {
           row.status === 'sent' && parseMessageMetadata(row.metadata).messageType !== 'compaction'
       )
     const sourceRecords = this.toRecords(sourceRows)
+    const forkedAt = Date.now()
 
-    let nextOrderSeq = 1
-    for (const record of sourceRecords) {
-      const nextId = nanoid()
-      this.database.deepchatMessagesTable.insert({
-        id: nextId,
-        sessionId: targetSessionId,
-        orderSeq: nextOrderSeq,
-        role: record.role,
-        content: record.content,
-        status: 'sent',
-        isContextEdge: record.isContextEdge,
-        metadata: record.metadata
-      })
-      if (record.role === 'user') {
-        const userContent = parseUserContent(record.content)
-        if (userContent) {
-          this.persistUserContent(nextId, userContent)
-        }
-      } else {
-        this.database.deepchatAssistantBlocksTable.replaceForMessage(
-          nextId,
-          parseAssistantBlocks(record.content)
+    this.runInDatabaseTransaction(() => {
+      let nextOrderSeq = 1
+      for (const record of sourceRecords) {
+        this.commitRecord(
+          this.terminalRecord({
+            ...record,
+            id: nanoid(),
+            sessionId: targetSessionId,
+            orderSeq: nextOrderSeq,
+            status: 'sent',
+            createdAt: forkedAt,
+            updatedAt: forkedAt
+          })
         )
+        nextOrderSeq += 1
       }
-      this.upsertMessageSearchDocument(
-        targetSessionId,
-        nextId,
-        record.role,
-        record.content,
-        record.updatedAt
-      )
-      nextOrderSeq += 1
-    }
+    })
 
     return sourceRecords.length
   }
@@ -888,27 +769,30 @@ export class SessionTranscript {
     forceRecoverMessagesBySession?: ReadonlyMap<string, ReadonlySet<string>>
   }): number {
     const pendingRows = this.database.deepchatMessagesTable.getByStatus('pending')
-    const recoveredRecords = new Map(
-      this.toRecords(pendingRows).map((record) => [record.id, record])
-    )
+    const pendingRecords = new Map(this.toRecords(pendingRows).map((record) => [record.id, record]))
     let recoveredCount = 0
     for (const row of pendingRows) {
       const forceRecovery = options?.forceRecoverMessagesBySession?.get(row.session_id)?.has(row.id)
       if (!forceRecovery && this.shouldKeepPending(row)) {
         continue
       }
-      if (row.role === 'assistant') {
-        const blocks = parseAssistantBlocks(recoveredRecords.get(row.id)?.content ?? row.content)
-        const recoveredBlocks = buildTerminalErrorBlocks(blocks, 'common.error.sessionInterrupted')
-        this.database.deepchatAssistantBlocksTable.replaceForMessage(row.id, recoveredBlocks)
-        this.database.deepchatMessagesTable.updateContentAndStatus(
-          row.id,
-          JSON.stringify(recoveredBlocks),
-          'error'
+      const record = pendingRecords.get(row.id) ?? this.recordFromRow(row)
+      const content =
+        row.role === 'assistant'
+          ? JSON.stringify(
+              buildTerminalErrorBlocks(
+                parseAssistantBlocks(record.content),
+                'common.error.sessionInterrupted'
+              )
+            )
+          : record.content
+      // One transaction per message, as the row updates were before: a message that cannot be
+      // recovered does not undo the ones already settled.
+      this.runInDatabaseTransaction(() =>
+        this.commitRecord(
+          this.terminalRecord({ ...record, content, status: 'error', updatedAt: Date.now() })
         )
-      } else {
-        this.database.deepchatMessagesTable.updateStatus(row.id, 'error')
-      }
+      )
       recoveredCount += 1
     }
     return recoveredCount
@@ -962,28 +846,9 @@ export class SessionTranscript {
     return { compacted, retracted, failed }
   }
 
-  backfillMessageRow(row: DeepChatMessageRow): void {
-    if (row.role === 'user') {
-      const content = parseUserContent(row.content)
-      if (content) {
-        this.persistUserContent(row.id, content)
-      }
-    } else {
-      this.database.deepchatAssistantBlocksTable.replaceForMessage(
-        row.id,
-        parseAssistantBlocks(row.content)
-      )
-    }
-
-    if (row.status === 'sent' || row.status === 'error') {
-      this.upsertMessageSearchDocument(
-        row.session_id,
-        row.id,
-        row.role,
-        this.materializeContent(row),
-        row.updated_at
-      )
-    }
+  /** Legacy chat import: the row becomes a message fact and its transcript projection. */
+  importMessageRow(row: DeepChatMessageRow): void {
+    this.commitRecord(this.terminalRecord(this.recordFromRow(row)))
   }
 
   private shouldKeepPending(row: DeepChatMessageRow): boolean {
@@ -1001,12 +866,58 @@ export class SessionTranscript {
     )
   }
 
-  private appendLiveTapeFacts(messageId: string): void {
-    const record = this.getMessage(messageId)
-    if (!record) {
-      return
-    }
+  /**
+   * Terminal state is written fact-first: the record is appended to Tape, then the transcript
+   * tables are derived from that same record. Both happen inside the caller's transaction, so a
+   * failed append leaves no transcript row behind and a committed row always has its fact.
+   */
+  private commitRecord(record: ChatMessageRecord): void {
     this.tapeFacts.appendMessageRecord(record)
+    this.projection.applyRecord(record)
+  }
+
+  private commitReplacement(
+    record: ChatMessageRecord,
+    options: TapeMessageReplacementOptions
+  ): void {
+    this.tapeFacts.appendMessageReplacement(record, options)
+    this.projection.applyRecord(record)
+  }
+
+  private commitRetractions(
+    records: ChatMessageRecord[],
+    reason: string,
+    messageIds: string[]
+  ): void {
+    for (const record of records) {
+      this.tapeFacts.appendMessageRetraction(record, reason)
+    }
+    this.projection.applyRetractions(messageIds)
+  }
+
+  /** The record a fact carries: content in the form the tables will hand back after the write. */
+  private terminalRecord(record: ChatMessageRecord): ChatMessageRecord {
+    return {
+      ...record,
+      content: canonicalizeMessageContent(record.role, record.content, record.updatedAt),
+      traceCount: 0
+    }
+  }
+
+  private recordFromRow(row: DeepChatMessageRow): ChatMessageRecord {
+    return {
+      id: row.id,
+      sessionId: row.session_id,
+      orderSeq: row.order_seq,
+      role: row.role,
+      content: row.content,
+      status: row.status,
+      isContextEdge: row.is_context_edge,
+      metadata: row.metadata,
+      traceCount: 0,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    }
   }
 
   private toRecord(row: DeepChatMessageRow): ChatMessageRecord {
@@ -1100,20 +1011,6 @@ export class SessionTranscript {
     }
   }
 
-  private persistUserContent(messageId: string, content: UserMessageContent): void {
-    this.database.deepchatUserMessagesTable.upsert({
-      messageId,
-      text: content.text,
-      searchEnabled: content.search === true,
-      thinkEnabled: content.think === true
-    })
-    this.database.deepchatUserMessageFilesTable.replaceForMessage(
-      messageId,
-      content.files.map((file) => toUserMessageFileRowInput(file))
-    )
-    this.database.deepchatUserMessageLinksTable.replaceForMessage(messageId, content.links)
-  }
-
   private loadStructuredMaps(messageIds: string[]): StructuredMessageMaps {
     const userRows = this.database.deepchatUserMessagesTable.listByMessageIds(messageIds)
     const fileRows = this.database.deepchatUserMessageFilesTable.listByMessageIds(messageIds)
@@ -1139,87 +1036,5 @@ export class SessionTranscript {
       }
     }
     return grouped
-  }
-
-  private upsertAssistantSearchDocument(messageId: string, blocks: AssistantMessageBlock[]): void {
-    const messageRow = this.database.deepchatMessagesTable.get(messageId)
-    if (!messageRow) {
-      return
-    }
-
-    this.upsertMessageSearchDocument(
-      messageRow.session_id,
-      messageId,
-      'assistant',
-      JSON.stringify(blocks),
-      messageRow.updated_at
-    )
-  }
-
-  private upsertMessageSearchDocument(
-    sessionId: string,
-    messageId: string,
-    role: 'user' | 'assistant',
-    rawContent: string,
-    updatedAt: number = Date.now()
-  ): void {
-    const sessionTitle = this.database.newSessionsTable.get(sessionId)?.title ?? ''
-    this.database.deepchatSearchDocumentsTable.upsert({
-      documentKey: `message:${messageId}`,
-      sessionId,
-      messageId,
-      documentKind: 'message',
-      role,
-      title: sessionTitle,
-      content: extractSearchableMessageContent(rawContent),
-      updatedAt
-    })
-  }
-
-  private persistUsageStats(
-    messageId: string,
-    metadataRaw: string,
-    source: 'backfill' | 'live'
-  ): void {
-    const usageStatsTable = this.database.deepchatUsageStatsTable
-    const messageRow = this.database.deepchatMessagesTable.get(messageId)
-    if (!messageRow || messageRow.role !== 'assistant') {
-      return
-    }
-
-    try {
-      const metadata = parseMessageMetadata(metadataRaw)
-      if (metadata.messageType === 'compaction') {
-        return
-      }
-
-      const sessionRow = this.database.deepchatSessionsTable.get(messageRow.session_id)
-      const providerId = resolveUsageProviderId(metadata, sessionRow?.provider_id)
-      const modelId = resolveUsageModelId(metadata, sessionRow?.model_id)
-
-      if (!providerId || !modelId) {
-        return
-      }
-
-      const usageRecord = buildUsageStatsRecord({
-        messageId: messageRow.id,
-        sessionId: messageRow.session_id,
-        createdAt: messageRow.created_at,
-        updatedAt: messageRow.updated_at,
-        providerId,
-        modelId,
-        metadata,
-        source
-      })
-
-      if (!usageRecord) {
-        return
-      }
-
-      usageStatsTable.upsert(usageRecord)
-    } catch (error) {
-      logger.error('Failed to persist deepchat usage stats', { messageId, source }, error)
-      return
-    }
   }
 }

--- a/src/main/session/data/transcript.ts
+++ b/src/main/session/data/transcript.ts
@@ -23,7 +23,10 @@ import type {
   ExecutionJournalAuditReader,
   TapeAnchorReader,
   TapeCompactionModelCallWriter,
-  TapeMessageFactWriter
+  TapeMessageFactWriter,
+  TapeProjectionCursor,
+  TapeProjectionHeadReader,
+  TapeTranscriptProjection
 } from '@/tape/ports/capabilities'
 import type { TapeMessageReplacementOptions } from '@/tape/domain/facts'
 import type { TapeCompactionModelCallInput } from '@/tape/domain/compactionUsage'
@@ -115,15 +118,21 @@ type StructuredMessageMaps = {
   assistantRows: Map<string, DeepChatAssistantBlockRow[]>
 }
 
-export class SessionTranscript {
+/** The Tape capabilities the transcript needs: message facts, compaction usage, and the head. */
+export type TranscriptTapePort = TapeMessageFactWriter &
+  TapeCompactionModelCallWriter &
+  TapeProjectionHeadReader
+
+export class SessionTranscript implements TapeTranscriptProjection {
   private database: SessionDatabase
   private readonly tapeFacts: TapeMessageFactWriter
+  private readonly tapeHead: TapeProjectionHeadReader
   private readonly compactionUsage: TapeCompactionModelCallWriter
   private readonly projection: TranscriptProjectionApplier
 
   constructor(
     database: SessionDatabase,
-    tapeFacts: TapeMessageFactWriter & TapeCompactionModelCallWriter,
+    tapeFacts: TranscriptTapePort,
     private readonly executionAudit?: Pick<
       ExecutionJournalAuditReader,
       'listMessageIdsWithNestedExecutionAudit'
@@ -135,8 +144,24 @@ export class SessionTranscript {
   ) {
     this.database = database
     this.tapeFacts = tapeFacts
+    this.tapeHead = tapeFacts
     this.compactionUsage = tapeFacts
     this.projection = new TranscriptProjectionApplier(database)
+  }
+
+  // TapeTranscriptProjection: reconciliation reads where the tables stand, replays what the Tape
+  // holds past that point, and moves the cursor. Terminal writes below move it themselves.
+
+  readProjectionCursor(sessionId: string): TapeProjectionCursor | null {
+    return this.database.deepchatTranscriptProjectionMetaTable.get(sessionId)
+  }
+
+  writeProjectionCursor(sessionId: string, cursor: TapeProjectionCursor): void {
+    this.database.deepchatTranscriptProjectionMetaTable.upsert(sessionId, cursor)
+  }
+
+  applyTapeEntries(rows: readonly DeepChatTapeEntryRow[]): void {
+    this.projection.applyTapeEntries(rows)
   }
 
   private runInDatabaseTransaction<T>(operation: () => T): T {
@@ -285,6 +310,7 @@ export class SessionTranscript {
       )
     }
     this.database.deepchatMessagesTable.incrementOrderSeqFrom(sessionId, fromOrderSeq, shiftedAt)
+    this.markProjectionCurrent(sessionId)
   }
 
   updateAssistantContent(
@@ -588,6 +614,7 @@ export class SessionTranscript {
   }
 
   deleteBySession(sessionId: string): void {
+    this.database.deepchatTranscriptProjectionMetaTable.delete(sessionId)
     this.database.deepchatSearchDocumentsTable.deleteBySession(sessionId)
     this.database.deepchatAssistantBlocksTable.deleteBySession(sessionId)
     this.database.deepchatUserMessageLinksTable.deleteBySession(sessionId)
@@ -605,7 +632,11 @@ export class SessionTranscript {
   private deleteMessageWithReason(messageId: string, reason: string): void {
     this.runInDatabaseTransaction(() => {
       const record = this.getMessage(messageId)
-      this.commitRetractions(record ? [record] : [], reason, [messageId])
+      if (!record) {
+        this.projection.applyRetractions([messageId])
+        return
+      }
+      this.commitRetractions(record.sessionId, [record], reason, [messageId])
     })
   }
 
@@ -615,6 +646,7 @@ export class SessionTranscript {
         (record) => record.orderSeq >= fromOrderSeq
       )
       this.commitRetractions(
+        sessionId,
         records,
         'messages_deleted_from_order_seq',
         records.map((record) => record.id)
@@ -874,6 +906,7 @@ export class SessionTranscript {
   private commitRecord(record: ChatMessageRecord): void {
     this.tapeFacts.appendMessageRecord(record)
     this.projection.applyRecord(record)
+    this.markProjectionCurrent(record.sessionId)
   }
 
   private commitReplacement(
@@ -882,9 +915,11 @@ export class SessionTranscript {
   ): void {
     this.tapeFacts.appendMessageReplacement(record, options)
     this.projection.applyRecord(record)
+    this.markProjectionCurrent(record.sessionId)
   }
 
   private commitRetractions(
+    sessionId: string,
     records: ChatMessageRecord[],
     reason: string,
     messageIds: string[]
@@ -893,6 +928,22 @@ export class SessionTranscript {
       this.tapeFacts.appendMessageRetraction(record, reason)
     }
     this.projection.applyRetractions(messageIds)
+    this.markProjectionCurrent(sessionId)
+  }
+
+  /**
+   * The tables now reflect every message fact up to the Tape head, including the one just
+   * appended, so an established cursor moves to the head. A Session without a cursor for this
+   * incarnation is left alone: its transcript may still hold rows the Tape never saw (written
+   * before the projection existed, or before a Tape reset), and only reconciliation's one-time
+   * backfill may declare the two aligned.
+   */
+  private markProjectionCurrent(sessionId: string): void {
+    const head = this.tapeHead.getProjectionHead(sessionId)
+    if (!head) return
+    const current = this.readProjectionCursor(sessionId)
+    if (current?.tapeIncarnationId !== head.tapeIncarnationId) return
+    this.writeProjectionCursor(sessionId, head)
   }
 
   /** The record a fact carries: content in the form the tables will hand back after the write. */

--- a/src/main/session/data/transcript.ts
+++ b/src/main/session/data/transcript.ts
@@ -18,7 +18,13 @@ import type { DeepChatAssistantBlockRow } from '@/session/data/tables/deepchatAs
 import type { DeepChatUserMessageFileRow } from '@/session/data/tables/deepchatUserMessageFiles'
 import type { DeepChatUserMessageLinkRow } from '@/session/data/tables/deepchatUserMessageLinks'
 import type { DeepChatUserMessageRow } from '@/session/data/tables/deepchatUserMessages'
-import { buildCompactionUsageStatsRecord, parseMessageMetadata } from '@/session/usageStats'
+import {
+  buildCompactionUsageStatsRecord,
+  buildUsageStatsRecord,
+  parseMessageMetadata,
+  resolveUsageModelId,
+  resolveUsageProviderId
+} from '@/session/usageStats'
 import type {
   ExecutionJournalAuditReader,
   TapeAnchorReader,
@@ -38,7 +44,7 @@ import {
   toAssistantBlock,
   toMessageFile
 } from './messageContent'
-import { persistMessageUsageStats, TranscriptProjectionApplier } from './transcriptProjection'
+import { TranscriptProjectionApplier } from './transcriptProjection'
 
 const COMPACTION_SHIFT_MATERIALIZATION_BATCH_SIZE = 500
 const MAX_COMPACTION_ATTEMPT_ID_CHARACTERS = 128
@@ -329,7 +335,7 @@ export class SessionTranscript implements TapeTranscriptProjection {
     this.database.deepchatMessagesTable.updateMetadata(messageId, metadata)
     const row = this.database.deepchatMessagesTable.get(messageId)
     if (row?.role === 'assistant') {
-      persistMessageUsageStats(this.database, { ...this.recordFromRow(row), metadata })
+      this.persistUsageStats({ ...this.recordFromRow(row), metadata })
     }
   }
 
@@ -436,7 +442,7 @@ export class SessionTranscript implements TapeTranscriptProjection {
         updatedAt: Date.now()
       })
       this.commitRecord(record)
-      persistMessageUsageStats(this.database, record)
+      this.persistUsageStats(record)
     })
   }
 
@@ -496,7 +502,7 @@ export class SessionTranscript implements TapeTranscriptProjection {
       })
       this.commitRecord(record)
       if (metadata !== undefined) {
-        persistMessageUsageStats(this.database, record)
+        this.persistUsageStats(record)
       }
     })
   }
@@ -638,7 +644,7 @@ export class SessionTranscript implements TapeTranscriptProjection {
         this.projection.applyRetractions([messageId])
         return
       }
-      this.commitRetractions(record.sessionId, [record], reason, [messageId])
+      this.commitRetractions(record.sessionId, [record], reason)
     })
   }
 
@@ -647,12 +653,7 @@ export class SessionTranscript implements TapeTranscriptProjection {
       const records = this.getMessages(sessionId).filter(
         (record) => record.orderSeq >= fromOrderSeq
       )
-      this.commitRetractions(
-        sessionId,
-        records,
-        'messages_deleted_from_order_seq',
-        records.map((record) => record.id)
-      )
+      this.commitRetractions(sessionId, records, 'messages_deleted_from_order_seq')
       // The range delete is the table-level guarantee this method has always given: no row of the
       // Session at or past `fromOrderSeq` survives, whatever the read above surfaced.
       this.database.deepchatMessagesTable.deleteFromOrderSeq(sessionId, fromOrderSeq)
@@ -920,16 +921,11 @@ export class SessionTranscript implements TapeTranscriptProjection {
     this.markProjectionCurrent(record.sessionId)
   }
 
-  private commitRetractions(
-    sessionId: string,
-    records: ChatMessageRecord[],
-    reason: string,
-    messageIds: string[]
-  ): void {
+  private commitRetractions(sessionId: string, records: ChatMessageRecord[], reason: string): void {
     for (const record of records) {
       this.tapeFacts.appendMessageRetraction(record, reason)
     }
-    this.projection.applyRetractions(messageIds)
+    this.projection.applyRetractions(records.map((record) => record.id))
     this.markProjectionCurrent(sessionId)
   }
 
@@ -958,6 +954,48 @@ export class SessionTranscript implements TapeTranscriptProjection {
       ...record,
       content: canonicalizeMessageContent(record.role, record.content, record.updatedAt),
       traceCount: 0
+    }
+  }
+
+  /**
+   * Usage stats count provider calls, so only the assistant writes that follow one record them:
+   * the pending-region metadata update while a reply streams and the terminal write at its end.
+   * Fork, import, recovery and replay carry the same record without a call and stay out.
+   */
+  private persistUsageStats(record: ChatMessageRecord): void {
+    if (record.role !== 'assistant') return
+    try {
+      const metadata = parseMessageMetadata(record.metadata)
+      if (metadata.messageType === 'compaction') {
+        return
+      }
+
+      const sessionRow = this.database.deepchatSessionsTable.get(record.sessionId)
+      const providerId = resolveUsageProviderId(metadata, sessionRow?.provider_id)
+      const modelId = resolveUsageModelId(metadata, sessionRow?.model_id)
+      if (!providerId || !modelId) {
+        return
+      }
+
+      const usageRecord = buildUsageStatsRecord({
+        messageId: record.id,
+        sessionId: record.sessionId,
+        createdAt: record.createdAt,
+        updatedAt: record.updatedAt,
+        providerId,
+        modelId,
+        metadata,
+        source: 'live'
+      })
+      if (usageRecord) {
+        this.database.deepchatUsageStatsTable.upsert(usageRecord)
+      }
+    } catch (error) {
+      logger.error(
+        'Failed to persist deepchat usage stats',
+        { messageId: record.id, source: 'live' },
+        error
+      )
     }
   }
 

--- a/src/main/session/data/transcript.ts
+++ b/src/main/session/data/transcript.ts
@@ -427,16 +427,16 @@ export class SessionTranscript implements TapeTranscriptProjection {
     this.runInDatabaseTransaction(() => {
       const row = this.database.deepchatMessagesTable.get(messageId)
       if (!row) return
-      this.commitRecord(
-        this.terminalRecord({
-          ...this.recordFromRow(row),
-          role: 'assistant',
-          content: JSON.stringify(blocks),
-          status: 'sent',
-          metadata,
-          updatedAt: Date.now()
-        })
-      )
+      const record = this.terminalRecord({
+        ...this.recordFromRow(row),
+        role: 'assistant',
+        content: JSON.stringify(blocks),
+        status: 'sent',
+        metadata,
+        updatedAt: Date.now()
+      })
+      this.commitRecord(record)
+      persistMessageUsageStats(this.database, record)
     })
   }
 
@@ -486,16 +486,18 @@ export class SessionTranscript implements TapeTranscriptProjection {
     this.runInDatabaseTransaction(() => {
       const row = this.database.deepchatMessagesTable.get(messageId)
       if (!row) return
-      this.commitRecord(
-        this.terminalRecord({
-          ...this.recordFromRow(row),
-          role: 'assistant',
-          content: JSON.stringify(blocks),
-          status: 'error',
-          metadata: metadata ?? row.metadata,
-          updatedAt: Date.now()
-        })
-      )
+      const record = this.terminalRecord({
+        ...this.recordFromRow(row),
+        role: 'assistant',
+        content: JSON.stringify(blocks),
+        status: 'error',
+        metadata: metadata ?? row.metadata,
+        updatedAt: Date.now()
+      })
+      this.commitRecord(record)
+      if (metadata !== undefined) {
+        persistMessageUsageStats(this.database, record)
+      }
     })
   }
 
@@ -937,6 +939,10 @@ export class SessionTranscript implements TapeTranscriptProjection {
    * incarnation is left alone: its transcript may still hold rows the Tape never saw (written
    * before the projection existed, or before a Tape reset), and only reconciliation's one-time
    * backfill may declare the two aligned.
+   *
+   * Moving straight to the head relies on message facts entering the Tape only through this
+   * class and reconciliation's backfill. A third writer of `message/*` facts would have to replay
+   * the rows between the cursor and the head before advancing it.
    */
   private markProjectionCurrent(sessionId: string): void {
     const head = this.tapeHead.getProjectionHead(sessionId)

--- a/src/main/session/data/transcriptProjection.ts
+++ b/src/main/session/data/transcriptProjection.ts
@@ -1,0 +1,220 @@
+import type { ChatMessageRecord, UserMessageContent } from '@shared/types/agent-interface'
+import logger from '@shared/logger'
+import { getAttachmentSearchableText } from '@shared/utils/attachmentRepresentation'
+import {
+  buildUsageStatsRecord,
+  parseMessageMetadata,
+  resolveUsageModelId,
+  resolveUsageProviderId
+} from '@/session/usageStats'
+import type { SessionDatabase } from './database'
+import { parseAssistantBlocks, parseUserContent, toUserMessageFileRowInput } from './messageContent'
+
+const MAX_SEARCHABLE_ATTACHMENT_CHARACTERS = 32_000
+const SEARCH_ATTACHMENT_TRUNCATION_MARKER = '[Attachment search text truncated]'
+
+/**
+ * Writes terminal message state into the transcript tables from a `ChatMessageRecord`. The record
+ * is the one carried by the message fact, so live writes and replay from Tape run the same code
+ * and cannot leave a table behind. Every write is an UPSERT or a replace keyed by message id;
+ * nothing here deletes a row except `applyRetractions`, and nothing here opens a transaction.
+ */
+export class TranscriptProjectionApplier {
+  constructor(private readonly database: SessionDatabase) {}
+
+  applyRecord(record: ChatMessageRecord): void {
+    this.database.deepchatMessagesTable.upsert({
+      id: record.id,
+      sessionId: record.sessionId,
+      orderSeq: record.orderSeq,
+      role: record.role,
+      content: record.content,
+      status: record.status,
+      isContextEdge: record.isContextEdge,
+      metadata: record.metadata,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt
+    })
+
+    if (record.role === 'user') {
+      const content = parseUserContent(record.content)
+      if (content) {
+        this.persistUserContent(record.id, content)
+      }
+      this.upsertSearchDocument(record)
+      return
+    }
+
+    this.database.deepchatAssistantBlocksTable.replaceForMessage(
+      record.id,
+      parseAssistantBlocks(record.content)
+    )
+    if (record.status !== 'pending') {
+      this.upsertSearchDocument(record)
+    }
+    this.persistUsageStats(record)
+  }
+
+  /** Removes every message-scoped row, including the runtime sidecars keyed by message id. */
+  applyRetractions(messageIds: string[]): void {
+    if (messageIds.length === 0) return
+    this.database.deepchatSearchDocumentsTable.deleteByMessageIds(messageIds)
+    this.database.deepchatAssistantBlocksTable.deleteByMessageIds(messageIds)
+    this.database.deepchatUserMessageLinksTable.deleteByMessageIds(messageIds)
+    this.database.deepchatUserMessageFilesTable.deleteByMessageIds(messageIds)
+    this.database.deepchatUserMessagesTable.deleteByMessageIds(messageIds)
+    this.database.deepchatMessageTracesTable.deleteByMessageIds(messageIds)
+    this.database.deepchatMessageSearchResultsTable.deleteByMessageIds(messageIds)
+    this.database.deepchatMessagesTable.deleteByIds(messageIds)
+  }
+
+  private persistUserContent(messageId: string, content: UserMessageContent): void {
+    this.database.deepchatUserMessagesTable.upsert({
+      messageId,
+      text: content.text,
+      searchEnabled: content.search === true,
+      thinkEnabled: content.think === true
+    })
+    this.database.deepchatUserMessageFilesTable.replaceForMessage(
+      messageId,
+      content.files.map((file) => toUserMessageFileRowInput(file))
+    )
+    this.database.deepchatUserMessageLinksTable.replaceForMessage(messageId, content.links)
+  }
+
+  private upsertSearchDocument(record: ChatMessageRecord): void {
+    const sessionTitle = this.database.newSessionsTable.get(record.sessionId)?.title ?? ''
+    this.database.deepchatSearchDocumentsTable.upsert({
+      documentKey: `message:${record.id}`,
+      sessionId: record.sessionId,
+      messageId: record.id,
+      documentKind: 'message',
+      role: record.role,
+      title: sessionTitle,
+      content: extractSearchableMessageContent(record.content),
+      updatedAt: record.updatedAt
+    })
+  }
+
+  private persistUsageStats(record: ChatMessageRecord): void {
+    persistMessageUsageStats(this.database, record)
+  }
+}
+
+/**
+ * Usage stats derive from an assistant message's metadata. The pending region updates them while a
+ * reply streams; the applier writes them once more from the terminal record.
+ */
+export function persistMessageUsageStats(
+  database: SessionDatabase,
+  record: ChatMessageRecord
+): void {
+  if (record.role !== 'assistant') return
+  try {
+    const metadata = parseMessageMetadata(record.metadata)
+    if (metadata.messageType === 'compaction') {
+      return
+    }
+
+    const sessionRow = database.deepchatSessionsTable.get(record.sessionId)
+    const providerId = resolveUsageProviderId(metadata, sessionRow?.provider_id)
+    const modelId = resolveUsageModelId(metadata, sessionRow?.model_id)
+    if (!providerId || !modelId) {
+      return
+    }
+
+    const usageRecord = buildUsageStatsRecord({
+      messageId: record.id,
+      sessionId: record.sessionId,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+      providerId,
+      modelId,
+      metadata,
+      source: 'live'
+    })
+    if (usageRecord) {
+      database.deepchatUsageStatsTable.upsert(usageRecord)
+    }
+  } catch (error) {
+    logger.error(
+      'Failed to persist deepchat usage stats',
+      { messageId: record.id, source: 'live' },
+      error
+    )
+  }
+}
+
+export function extractSearchableMessageContent(rawContent: string): string {
+  try {
+    const parsed = JSON.parse(rawContent) as
+      | UserMessageContent
+      | Array<{
+          type?: string
+          content?: string
+          text?: string
+          error?: string
+        }>
+
+    if (Array.isArray(parsed)) {
+      const segments = parsed
+        .flatMap((block) => {
+          if (!block || typeof block !== 'object') {
+            return []
+          }
+
+          const values = [block.content, block.text, block.error]
+          return values.filter(
+            (value): value is string => typeof value === 'string' && value.trim().length > 0
+          )
+        })
+        .map((value) => value.trim())
+
+      if (segments.length > 0) {
+        return segments.join('\n')
+      }
+    } else if (parsed && typeof parsed === 'object') {
+      const segments: string[] = []
+      if (typeof parsed.text === 'string' && parsed.text.trim()) {
+        segments.push(parsed.text.trim())
+      }
+      const searchableAttachmentText = buildSearchableAttachmentText(parsed.files)
+      if (searchableAttachmentText) segments.push(searchableAttachmentText)
+      return segments.join('\n')
+    }
+  } catch {
+    // Plain-text fallback.
+  }
+
+  return rawContent.trim()
+}
+
+function buildSearchableAttachmentText(files: unknown): string {
+  if (!Array.isArray(files)) return ''
+  const text = files
+    .flatMap((file) => {
+      const searchableText = getAttachmentSearchableText(file).trim()
+      return searchableText ? [searchableText] : []
+    })
+    .join('\n')
+  if (text.length <= MAX_SEARCHABLE_ATTACHMENT_CHARACTERS) return text
+
+  const marker = `\n${SEARCH_ATTACHMENT_TRUNCATION_MARKER}\n`
+  const retainedCharacters = Math.max(
+    0,
+    Math.floor((MAX_SEARCHABLE_ATTACHMENT_CHARACTERS - marker.length) / 2)
+  )
+  let headEnd = retainedCharacters
+  if (isHighSurrogate(text.charCodeAt(headEnd - 1))) headEnd -= 1
+  let tailStart = text.length - retainedCharacters
+  if (isLowSurrogate(text.charCodeAt(tailStart))) tailStart += 1
+  return `${text.slice(0, headEnd).trimEnd()}${marker}${text.slice(tailStart).trimStart()}`
+}
+
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff
+}
+
+function isLowSurrogate(code: number): boolean {
+  return code >= 0xdc00 && code <= 0xdfff
+}

--- a/src/main/session/data/transcriptProjection.ts
+++ b/src/main/session/data/transcriptProjection.ts
@@ -7,6 +7,12 @@ import {
   resolveUsageModelId,
   resolveUsageProviderId
 } from '@/session/usageStats'
+import type { DeepChatTapeEntryRow } from '@/tape/domain/entry'
+import {
+  parseTapeJsonObject,
+  TAPE_MESSAGE_RETRACTED_EVENT_NAME,
+  tapeEntryToMessageRecord
+} from '@/tape/domain/effectiveSemantics'
 import type { SessionDatabase } from './database'
 import { parseAssistantBlocks, parseUserContent, toUserMessageFileRowInput } from './messageContent'
 
@@ -53,6 +59,31 @@ export class TranscriptProjectionApplier {
       this.upsertSearchDocument(record)
     }
     this.persistUsageStats(record)
+  }
+
+  /**
+   * Replays message facts and retractions the Tape holds past the projection cursor, in entry
+   * order. Compaction indicator events are left to `reconcileCompactionMessages`, which settles
+   * marker rows from the reconstruction anchor.
+   */
+  applyTapeEntries(rows: readonly DeepChatTapeEntryRow[]): void {
+    for (const row of rows) {
+      if (row.kind === 'message') {
+        const record = tapeEntryToMessageRecord(row)
+        if (record) this.applyRecord(record)
+        continue
+      }
+      if (row.kind === 'event' && row.name === TAPE_MESSAGE_RETRACTED_EVENT_NAME) {
+        const data = parseTapeJsonObject(row.payload_json).data
+        const messageId =
+          data && typeof data === 'object' && !Array.isArray(data)
+            ? (data as { messageId?: unknown }).messageId
+            : undefined
+        if (typeof messageId === 'string' && messageId) {
+          this.applyRetractions([messageId])
+        }
+      }
+    }
   }
 
   /** Removes every message-scoped row, including the runtime sidecars keyed by message id. */

--- a/src/main/session/data/transcriptProjection.ts
+++ b/src/main/session/data/transcriptProjection.ts
@@ -24,6 +24,10 @@ const SEARCH_ATTACHMENT_TRUNCATION_MARKER = '[Attachment search text truncated]'
  * is the one carried by the message fact, so live writes and replay from Tape run the same code
  * and cannot leave a table behind. Every write is an UPSERT or a replace keyed by message id;
  * nothing here deletes a row except `applyRetractions`, and nothing here opens a transaction.
+ *
+ * Usage stats are not part of the projection. They count provider calls, and a record reaches the
+ * applier again on fork, import, recovery and replay without any call having happened; the
+ * assistant terminal writes record usage themselves.
  */
 export class TranscriptProjectionApplier {
   constructor(private readonly database: SessionDatabase) {}
@@ -58,7 +62,6 @@ export class TranscriptProjectionApplier {
     if (record.status !== 'pending') {
       this.upsertSearchDocument(record)
     }
-    this.persistUsageStats(record)
   }
 
   /**
@@ -126,15 +129,11 @@ export class TranscriptProjectionApplier {
       updatedAt: record.updatedAt
     })
   }
-
-  private persistUsageStats(record: ChatMessageRecord): void {
-    persistMessageUsageStats(this.database, record)
-  }
 }
 
 /**
  * Usage stats derive from an assistant message's metadata. The pending region updates them while a
- * reply streams; the applier writes them once more from the terminal record.
+ * reply streams and the assistant terminal writes record them once more from the final record.
  */
 export function persistMessageUsageStats(
   database: SessionDatabase,

--- a/src/main/session/data/transcriptProjection.ts
+++ b/src/main/session/data/transcriptProjection.ts
@@ -89,17 +89,23 @@ export class TranscriptProjectionApplier {
     }
   }
 
-  /** Removes every message-scoped row, including the runtime sidecars keyed by message id. */
+  /**
+   * Removes every message-scoped row, including the runtime sidecars keyed by message id. A range
+   * delete can hand over a whole Session, so the ids go through in chunks that stay below SQLite's
+   * bound-variable floor on every table.
+   */
   applyRetractions(messageIds: string[]): void {
-    if (messageIds.length === 0) return
-    this.database.deepchatSearchDocumentsTable.deleteByMessageIds(messageIds)
-    this.database.deepchatAssistantBlocksTable.deleteByMessageIds(messageIds)
-    this.database.deepchatUserMessageLinksTable.deleteByMessageIds(messageIds)
-    this.database.deepchatUserMessageFilesTable.deleteByMessageIds(messageIds)
-    this.database.deepchatUserMessagesTable.deleteByMessageIds(messageIds)
-    this.database.deepchatMessageTracesTable.deleteByMessageIds(messageIds)
-    this.database.deepchatMessageSearchResultsTable.deleteByMessageIds(messageIds)
-    this.database.deepchatMessagesTable.deleteByIds(messageIds)
+    for (let offset = 0; offset < messageIds.length; offset += 500) {
+      const chunk = messageIds.slice(offset, offset + 500)
+      this.database.deepchatSearchDocumentsTable.deleteByMessageIds(chunk)
+      this.database.deepchatAssistantBlocksTable.deleteByMessageIds(chunk)
+      this.database.deepchatUserMessageLinksTable.deleteByMessageIds(chunk)
+      this.database.deepchatUserMessageFilesTable.deleteByMessageIds(chunk)
+      this.database.deepchatUserMessagesTable.deleteByMessageIds(chunk)
+      this.database.deepchatMessageTracesTable.deleteByMessageIds(chunk)
+      this.database.deepchatMessageSearchResultsTable.deleteByMessageIds(chunk)
+      this.database.deepchatMessagesTable.deleteByIds(chunk)
+    }
   }
 
   private persistUserContent(messageId: string, content: UserMessageContent): void {

--- a/src/main/session/data/transcriptProjection.ts
+++ b/src/main/session/data/transcriptProjection.ts
@@ -1,12 +1,5 @@
 import type { ChatMessageRecord, UserMessageContent } from '@shared/types/agent-interface'
-import logger from '@shared/logger'
 import { getAttachmentSearchableText } from '@shared/utils/attachmentRepresentation'
-import {
-  buildUsageStatsRecord,
-  parseMessageMetadata,
-  resolveUsageModelId,
-  resolveUsageProviderId
-} from '@/session/usageStats'
 import type { DeepChatTapeEntryRow } from '@/tape/domain/entry'
 import {
   parseTapeJsonObject,
@@ -131,51 +124,7 @@ export class TranscriptProjectionApplier {
   }
 }
 
-/**
- * Usage stats derive from an assistant message's metadata. The pending region updates them while a
- * reply streams and the assistant terminal writes record them once more from the final record.
- */
-export function persistMessageUsageStats(
-  database: SessionDatabase,
-  record: ChatMessageRecord
-): void {
-  if (record.role !== 'assistant') return
-  try {
-    const metadata = parseMessageMetadata(record.metadata)
-    if (metadata.messageType === 'compaction') {
-      return
-    }
-
-    const sessionRow = database.deepchatSessionsTable.get(record.sessionId)
-    const providerId = resolveUsageProviderId(metadata, sessionRow?.provider_id)
-    const modelId = resolveUsageModelId(metadata, sessionRow?.model_id)
-    if (!providerId || !modelId) {
-      return
-    }
-
-    const usageRecord = buildUsageStatsRecord({
-      messageId: record.id,
-      sessionId: record.sessionId,
-      createdAt: record.createdAt,
-      updatedAt: record.updatedAt,
-      providerId,
-      modelId,
-      metadata,
-      source: 'live'
-    })
-    if (usageRecord) {
-      database.deepchatUsageStatsTable.upsert(usageRecord)
-    }
-  } catch (error) {
-    logger.error(
-      'Failed to persist deepchat usage stats',
-      { messageId: record.id, source: 'live' },
-      error
-    )
-  }
-}
-
-export function extractSearchableMessageContent(rawContent: string): string {
+function extractSearchableMessageContent(rawContent: string): string {
   try {
     const parsed = JSON.parse(rawContent) as
       | UserMessageContent

--- a/src/main/session/data/transcriptProjection.ts
+++ b/src/main/session/data/transcriptProjection.ts
@@ -43,6 +43,12 @@ export class TranscriptProjectionApplier {
       const content = parseUserContent(record.content)
       if (content) {
         this.persistUserContent(record.id, content)
+      } else {
+        // Nothing structured to derive: drop what an earlier record left so the read path falls
+        // back to the content column instead of showing the previous message.
+        this.database.deepchatUserMessageLinksTable.deleteByMessageIds([record.id])
+        this.database.deepchatUserMessageFilesTable.deleteByMessageIds([record.id])
+        this.database.deepchatUserMessagesTable.deleteByMessageIds([record.id])
       }
       this.upsertSearchDocument(record)
       return
@@ -50,7 +56,8 @@ export class TranscriptProjectionApplier {
 
     this.database.deepchatAssistantBlocksTable.replaceForMessage(
       record.id,
-      parseAssistantBlocks(record.content)
+      parseAssistantBlocks(record.content),
+      record.updatedAt
     )
     if (record.status !== 'pending') {
       this.upsertSearchDocument(record)

--- a/src/main/session/transcriptMutations.ts
+++ b/src/main/session/transcriptMutations.ts
@@ -73,7 +73,7 @@ export class SessionTranscriptMutations {
     // restored to 'sent' so context history filtering keeps it; otherwise the
     // prompt silently drops out of future turns.
     if (sourceUserMessage.status !== 'sent') {
-      this.dependencies.transcript.updateMessageStatus(sourceUserMessage.id, 'sent')
+      this.dependencies.transcript.restoreUserMessage(sourceUserMessage.id)
     }
 
     return {

--- a/src/main/tape/application/factPersistence.ts
+++ b/src/main/tape/application/factPersistence.ts
@@ -131,7 +131,13 @@ function buildMessageProvenanceKey(
   return `message:${record.id}:revision:${record.status}:${record.updatedAt}`
 }
 
-const MESSAGE_RECORD_DIVERGENCE_FIELDS = ['content', 'status', 'orderSeq', 'metadata'] as const
+const MESSAGE_RECORD_DIVERGENCE_FIELDS = [
+  'content',
+  'status',
+  'orderSeq',
+  'metadata',
+  'isContextEdge'
+] as const
 
 /**
  * A sent record's live or backfill fact is keyed by message id alone, so the store returns the

--- a/src/main/tape/application/factPersistence.ts
+++ b/src/main/tape/application/factPersistence.ts
@@ -145,8 +145,7 @@ const MESSAGE_RECORD_DIVERGENCE_FIELDS = ['content', 'status', 'orderSeq', 'meta
 function warnOnDivergentMessageFact(
   row: DeepChatTapeEntryRow,
   payload: Record<string, unknown>,
-  record: ChatMessageRecord,
-  source: TapeFactSource
+  record: ChatMessageRecord
 ): void {
   if (row.payload_json === JSON.stringify(payload)) {
     return
@@ -163,7 +162,6 @@ function warnOnDivergentMessageFact(
     sessionId: record.sessionId,
     messageId: record.id,
     entryId: row.entry_id,
-    source,
     fields
   })
 }
@@ -547,7 +545,7 @@ export function appendMessageRecordToTape(
     idempotent: true
   })
   if (provenanceKey === undefined && source === 'live') {
-    warnOnDivergentMessageFact(row, payload, record, source)
+    warnOnDivergentMessageFact(row, payload, record)
   }
 
   const toolInputs = buildTapeToolFactInputs(record)

--- a/src/main/tape/application/factPersistence.ts
+++ b/src/main/tape/application/factPersistence.ts
@@ -138,7 +138,9 @@ const MESSAGE_RECORD_DIVERGENCE_FIELDS = ['content', 'status', 'orderSeq', 'meta
  * entry it already holds without looking at the payload. That is the intended idempotency for a
  * message that is finalized once; it also means a transcript row whose content changed without a
  * replacement fact would leave Tape stale in silence. Compare what came back with what was asked
- * for and say so when they differ. Payload text stays out of the log.
+ * for and say so when they differ. Payload text stays out of the log. Only live appends report:
+ * a backfill re-reading an old Session compares today's materialized content with a fact written
+ * by an earlier version, and that difference is format history rather than a bypassed write.
  */
 function warnOnDivergentMessageFact(
   row: DeepChatTapeEntryRow,
@@ -544,7 +546,7 @@ export function appendMessageRecordToTape(
     createdAt: record.createdAt,
     idempotent: true
   })
-  if (provenanceKey === undefined) {
+  if (provenanceKey === undefined && source === 'live') {
     warnOnDivergentMessageFact(row, payload, record, source)
   }
 

--- a/src/main/tape/application/factPersistence.ts
+++ b/src/main/tape/application/factPersistence.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessageBlock, ChatMessageRecord } from '@shared/types/agent-interface'
+import logger from '@shared/logger'
 import {
   toTapeSessionId,
   type TapeFactSource,
@@ -11,7 +12,8 @@ import {
   parseAssistantBlocks,
   parseTapeJsonObject,
   readTapeToolIdentity,
-  readTapeToolStatus
+  readTapeToolStatus,
+  tapeEntryToMessageRecord
 } from '@/tape/domain/effectiveSemantics'
 import { hashJson } from '@/tape/domain/viewManifest'
 import {
@@ -127,6 +129,41 @@ function buildMessageProvenanceKey(
     return undefined
   }
   return `message:${record.id}:revision:${record.status}:${record.updatedAt}`
+}
+
+const MESSAGE_RECORD_DIVERGENCE_FIELDS = ['content', 'status', 'orderSeq', 'metadata'] as const
+
+/**
+ * A sent record's live or backfill fact is keyed by message id alone, so the store returns the
+ * entry it already holds without looking at the payload. That is the intended idempotency for a
+ * message that is finalized once; it also means a transcript row whose content changed without a
+ * replacement fact would leave Tape stale in silence. Compare what came back with what was asked
+ * for and say so when they differ. Payload text stays out of the log.
+ */
+function warnOnDivergentMessageFact(
+  row: DeepChatTapeEntryRow,
+  payload: Record<string, unknown>,
+  record: ChatMessageRecord,
+  source: TapeFactSource
+): void {
+  if (row.payload_json === JSON.stringify(payload)) {
+    return
+  }
+  const stored = tapeEntryToMessageRecord(row)
+  if (!stored) {
+    return
+  }
+  const fields = MESSAGE_RECORD_DIVERGENCE_FIELDS.filter((field) => stored[field] !== record[field])
+  if (fields.length === 0) {
+    return
+  }
+  logger.warn('[Tape] message fact append returned an existing entry with a different record', {
+    sessionId: record.sessionId,
+    messageId: record.id,
+    entryId: row.entry_id,
+    source,
+    fields
+  })
 }
 
 function buildMessageReplacementProvenanceKey(
@@ -471,7 +508,23 @@ export function appendMessageRecordToTape(
     return 1
   }
 
-  table.append({
+  const provenanceKey = buildMessageProvenanceKey(record, source)
+  const payload = {
+    record: {
+      id: record.id,
+      sessionId: record.sessionId,
+      orderSeq: record.orderSeq,
+      role: record.role,
+      content: record.content,
+      status: record.status,
+      isContextEdge: record.isContextEdge,
+      metadata: record.metadata,
+      traceCount: record.traceCount,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt
+    }
+  }
+  const row = table.append({
     sessionId: record.sessionId,
     kind: 'message',
     name: `message/${record.role}`,
@@ -480,22 +533,8 @@ export function appendMessageRecordToTape(
       id: record.id,
       seq: 0
     },
-    provenanceKey: buildMessageProvenanceKey(record, source),
-    payload: {
-      record: {
-        id: record.id,
-        sessionId: record.sessionId,
-        orderSeq: record.orderSeq,
-        role: record.role,
-        content: record.content,
-        status: record.status,
-        isContextEdge: record.isContextEdge,
-        metadata: record.metadata,
-        traceCount: record.traceCount,
-        createdAt: record.createdAt,
-        updatedAt: record.updatedAt
-      }
-    },
+    provenanceKey,
+    payload,
     meta: {
       source,
       orderSeq: record.orderSeq,
@@ -505,6 +544,9 @@ export function appendMessageRecordToTape(
     createdAt: record.createdAt,
     idempotent: true
   })
+  if (provenanceKey === undefined) {
+    warnOnDivergentMessageFact(row, payload, record, source)
+  }
 
   const toolInputs = buildTapeToolFactInputs(record)
   return (

--- a/src/main/tape/application/factService.ts
+++ b/src/main/tape/application/factService.ts
@@ -23,6 +23,8 @@ import type {
   TapeAnchorWriter,
   TapeIncarnationReader,
   TapeMessageFactWriter,
+  TapeProjectionCursor,
+  TapeProjectionHeadReader,
   TapeToolFactAppendReceipt,
   TapeSkillViewResultFactWriter,
   TapeToolFactWriter
@@ -106,6 +108,7 @@ export class TapeFactService
     TapeSkillViewResultFactWriter,
     TapeIncarnationReader,
     TapeMessageFactWriter,
+    TapeProjectionHeadReader,
     TapeAnchorWriter
 {
   constructor(private readonly providers: TapeFactProviders) {}
@@ -283,6 +286,12 @@ export class TapeFactService
     return buildEffectiveTapeView(this.table.getEffectiveMessageInputRows(sessionId), {
       includePending: true
     }).messageRecords
+  }
+
+  getProjectionHead(sessionId: string): TapeProjectionCursor | null {
+    const tapeIncarnationId = this.table.getBootstrapIncarnation(sessionId)
+    if (!tapeIncarnationId) return null
+    return { tapeIncarnationId, maxEntryId: this.table.getMaxEntryId(sessionId) }
   }
 
   appendAnchor(input: TapeAnchorAppendInput): DeepChatTapeEntryRow {

--- a/src/main/tape/application/reconcilerService.ts
+++ b/src/main/tape/application/reconcilerService.ts
@@ -1,5 +1,7 @@
 import type { ChatMessageRecord } from '@shared/types/agent-interface'
+import logger from '@shared/logger'
 import type { TapeApplicationProviders } from '../ports/application'
+import type { DeepChatTapeEntryRow } from '../domain/entry'
 import type {
   TapeBackfillResult,
   TapeProjectionCursor,
@@ -145,15 +147,27 @@ export class TapeReconcilerService {
     transcriptRecords: readonly ChatMessageRecord[]
   ): void {
     const transcriptIds = new Set(transcriptRecords.map((record) => record.id))
-    const tapeOnlyRows = buildEffectiveTapeView(
-      this.table.getEffectiveMessageInputRows(sessionId),
-      {
-        includePending: true
-      }
-    ).rows.filter((row) => {
+    const tapeOnlyRows: DeepChatTapeEntryRow[] = []
+    let foreignSessionCount = 0
+    for (const row of buildEffectiveTapeView(this.table.getEffectiveMessageInputRows(sessionId), {
+      includePending: true
+    }).rows) {
       const record = tapeEntryToMessageRecord(row)
-      return record !== null && !transcriptIds.has(record.id)
-    })
+      if (record === null || transcriptIds.has(record.id)) continue
+      // A fact whose record names another Session cannot be projected here without moving a row
+      // between Sessions; skipping it keeps one corrupt entry from failing every readiness check.
+      if (record.sessionId !== sessionId) {
+        foreignSessionCount += 1
+        continue
+      }
+      tapeOnlyRows.push(row)
+    }
+    if (foreignSessionCount > 0) {
+      logger.warn('[Tape] skipped message facts whose record names another session', {
+        sessionId,
+        count: foreignSessionCount
+      })
+    }
     if (tapeOnlyRows.length > 0) {
       transcript.applyTapeEntries(tapeOnlyRows)
     }

--- a/src/main/tape/application/reconcilerService.ts
+++ b/src/main/tape/application/reconcilerService.ts
@@ -1,7 +1,5 @@
 import type { ChatMessageRecord } from '@shared/types/agent-interface'
-import logger from '@shared/logger'
 import type { TapeApplicationProviders } from '../ports/application'
-import type { DeepChatTapeEntryRow } from '../domain/entry'
 import type {
   TapeBackfillResult,
   TapeProjectionCursor,
@@ -147,27 +145,13 @@ export class TapeReconcilerService {
     transcriptRecords: readonly ChatMessageRecord[]
   ): void {
     const transcriptIds = new Set(transcriptRecords.map((record) => record.id))
-    const tapeOnlyRows: DeepChatTapeEntryRow[] = []
-    let foreignSessionCount = 0
-    for (const row of buildEffectiveTapeView(this.table.getEffectiveMessageInputRows(sessionId), {
-      includePending: true
-    }).rows) {
+    const tapeOnlyRows = buildEffectiveTapeView(
+      this.table.getEffectiveMessageInputRows(sessionId),
+      { includePending: true }
+    ).rows.filter((row) => {
       const record = tapeEntryToMessageRecord(row)
-      if (record === null || transcriptIds.has(record.id)) continue
-      // A fact whose record names another Session cannot be projected here without moving a row
-      // between Sessions; skipping it keeps one corrupt entry from failing every readiness check.
-      if (record.sessionId !== sessionId) {
-        foreignSessionCount += 1
-        continue
-      }
-      tapeOnlyRows.push(row)
-    }
-    if (foreignSessionCount > 0) {
-      logger.warn('[Tape] skipped message facts whose record names another session', {
-        sessionId,
-        count: foreignSessionCount
-      })
-    }
+      return record !== null && !transcriptIds.has(record.id)
+    })
     if (tapeOnlyRows.length > 0) {
       transcript.applyTapeEntries(tapeOnlyRows)
     }

--- a/src/main/tape/application/reconcilerService.ts
+++ b/src/main/tape/application/reconcilerService.ts
@@ -1,7 +1,10 @@
-import { createHash } from 'crypto'
 import type { ChatMessageRecord } from '@shared/types/agent-interface'
 import type { TapeApplicationProviders } from '../ports/application'
-import type { TapeBackfillResult, TapeTranscriptReader } from '../ports/capabilities'
+import type {
+  TapeBackfillResult,
+  TapeProjectionCursor,
+  TapeTranscriptProjection
+} from '../ports/capabilities'
 import { appendMessageRecordToTape, buildTapeToolRevisionIndex } from './factPersistence'
 import type { TapeFactService } from './factService'
 import { migrationProvenanceKey } from './common'
@@ -11,39 +14,25 @@ type TapeReconcilerProviders = Pick<
   'getEntryStore' | 'getLegacySummaryReader'
 >
 
-/**
- * What the last completed backfill of a session saw. The transcript digest covers exactly the row
- * fields the backfill keys its facts on (identity, order, status, `updated_at`), so an unchanged
- * digest means a rerun could append nothing new; unlike a clock-based check it does not care which
- * direction time moved. Every Tape reset mints a new incarnation and every Tape append moves the
- * head; the head also catches the database file being swapped underneath a live process (sync
- * restore, maintenance reopen), where the incarnation is copied rather than minted.
- */
-interface ReconciledTranscriptSnapshot {
-  transcriptDigest: string
-  tapeIncarnationId: string
-  tapeHeadEntryId: number
-}
-
-function digestTranscript(records: readonly ChatMessageRecord[]): string {
-  const hash = createHash('sha256')
-  for (const record of records) {
-    hash.update(`${record.id}\n${record.orderSeq}\n${record.status}\n${record.updatedAt}\n`)
-  }
-  return hash.digest('base64')
-}
-
 function legacySummaryProvenanceKey(sessionId: string): string {
   return `summary:${sessionId}:legacy-summary:v1`
 }
 
+/**
+ * Keeps a Session's transcript tables and its Tape describing the same messages.
+ *
+ * Terminal transcript writes append their message fact and derive the tables from it in one
+ * transaction, then record the Tape head they reached as the transcript projection cursor. This
+ * service only has to answer "did anything reach the Tape that the tables have not seen": it
+ * compares the cursor with the head and replays the message rows in between, which is empty after
+ * an ordinary turn because manifests, journal and provider events are not message facts.
+ *
+ * A Session without a cursor predates the projection or lost its Tape to a reset. Its transcript
+ * is the only complete record, so it is backfilled into the Tape once, the way the reconciler
+ * always did, and the cursor is written at the head that backfill reached. Nothing here reads the
+ * transcript otherwise.
+ */
 export class TapeReconcilerService {
-  /**
-   * Keyed by session id; absent until the first completed backfill in this process. Entries are
-   * never evicted: a stale one costs ~100 bytes and can only ever force a full backfill.
-   */
-  private readonly reconciled = new Map<string, ReconciledTranscriptSnapshot>()
-
   constructor(
     private readonly providers: TapeReconcilerProviders,
     private readonly facts: TapeFactService
@@ -55,35 +44,48 @@ export class TapeReconcilerService {
 
   ensureSessionTapeReady(
     sessionId: string,
-    messageStore: TapeTranscriptReader
+    transcript: TapeTranscriptProjection
   ): TapeBackfillResult {
     const table = this.table
-    const historyRecords = [...messageStore.getMessages(sessionId)].sort(
+    const appendedFactCount = table.runInTransaction(() => {
+      const cursor = transcript.readProjectionCursor(sessionId)
+      const tapeIncarnationId = table.getBootstrapIncarnation(sessionId)
+      if (!cursor || !tapeIncarnationId || cursor.tapeIncarnationId !== tapeIncarnationId) {
+        return this.backfillFromTranscript(sessionId, transcript)
+      }
+
+      const head: TapeProjectionCursor = {
+        tapeIncarnationId,
+        maxEntryId: table.getMaxEntryId(sessionId)
+      }
+      if (head.maxEntryId > cursor.maxEntryId) {
+        transcript.applyTapeEntries(
+          table.getEffectiveMessageInputRowsAfter(sessionId, cursor.maxEntryId)
+        )
+        transcript.writeProjectionCursor(sessionId, head)
+      }
+      return 0
+    })
+
+    const historyRecords = this.facts.getMessageRecords(sessionId)
+    return {
+      sessionId,
+      migrationState: 'ready',
+      messageCount: historyRecords.length,
+      maxOrderSeq: historyRecords.reduce(
+        (currentMax, record) => Math.max(currentMax, record.orderSeq),
+        0
+      ),
+      appendedFactCount,
+      historyRecords
+    }
+  }
+
+  private backfillFromTranscript(sessionId: string, transcript: TapeTranscriptProjection): number {
+    const table = this.table
+    const historyRecords = [...transcript.getMessages(sessionId)].sort(
       (left, right) => left.orderSeq - right.orderSeq
     )
-    const maxOrderSeq = historyRecords.reduce(
-      (currentMax, record) => Math.max(currentMax, record.orderSeq),
-      0
-    )
-    const transcriptDigest = digestTranscript(historyRecords)
-
-    const previous = this.reconciled.get(sessionId)
-    if (
-      previous &&
-      previous.transcriptDigest === transcriptDigest &&
-      previous.tapeIncarnationId === table.getBootstrapIncarnation(sessionId) &&
-      previous.tapeHeadEntryId === table.getMaxEntryId(sessionId)
-    ) {
-      return {
-        sessionId,
-        migrationState: 'ready',
-        messageCount: historyRecords.length,
-        maxOrderSeq,
-        appendedFactCount: 0,
-        historyRecords: this.facts.getMessageRecords(sessionId)
-      }
-    }
-
     table.ensureBootstrapAnchor(sessionId)
 
     let appendedFactCount = 0
@@ -108,32 +110,22 @@ export class TapeReconcilerService {
       data: {
         source: 'deepchat_messages',
         messageCount: historyRecords.length,
-        maxOrderSeq
+        maxOrderSeq: historyRecords.reduce(
+          (currentMax, record) => Math.max(currentMax, record.orderSeq),
+          0
+        )
       },
       idempotent: true
     })
 
-    // Inside a host transaction the appends above are not committed yet and could still roll back,
-    // so nothing is remembered there.
     const tapeIncarnationId = table.getBootstrapIncarnation(sessionId)
-    if (tapeIncarnationId && !table.isInTransaction()) {
-      this.reconciled.set(sessionId, {
-        transcriptDigest,
+    if (tapeIncarnationId) {
+      transcript.writeProjectionCursor(sessionId, {
         tapeIncarnationId,
-        tapeHeadEntryId: table.getMaxEntryId(sessionId)
+        maxEntryId: table.getMaxEntryId(sessionId)
       })
-    } else {
-      this.reconciled.delete(sessionId)
     }
-
-    return {
-      sessionId,
-      migrationState: 'ready',
-      messageCount: historyRecords.length,
-      maxOrderSeq,
-      appendedFactCount,
-      historyRecords: this.facts.getMessageRecords(sessionId)
-    }
+    return appendedFactCount
   }
 
   private backfillLegacySummaryAnchor(

--- a/src/main/tape/application/reconcilerService.ts
+++ b/src/main/tape/application/reconcilerService.ts
@@ -5,6 +5,8 @@ import type {
   TapeProjectionCursor,
   TapeTranscriptProjection
 } from '../ports/capabilities'
+import { tapeEntryToMessageRecord } from '../domain/effectiveSemantics'
+import { buildEffectiveTapeView } from '../domain/effectiveView'
 import { appendMessageRecordToTape, buildTapeToolRevisionIndex } from './factPersistence'
 import type { TapeFactService } from './factService'
 import { migrationProvenanceKey } from './common'
@@ -29,7 +31,9 @@ function legacySummaryProvenanceKey(sessionId: string): string {
  *
  * A Session without a cursor predates the projection or lost its Tape to a reset. Its transcript
  * is the only complete record, so it is backfilled into the Tape once, the way the reconciler
- * always did, and the cursor is written at the head that backfill reached. Nothing here reads the
+ * always did. Before the cursor is written at the head that backfill reached, any effective Tape
+ * message the transcript does not hold is projected the other way, so a fact that entered the Tape
+ * without going through the transcript is not declared aligned unseen. Nothing here reads the
  * transcript otherwise.
  */
 export class TapeReconcilerService {
@@ -97,6 +101,7 @@ export class TapeReconcilerService {
     }
 
     this.backfillLegacySummaryAnchor(sessionId, historyRecords)
+    this.projectTapeOnlyMessages(sessionId, transcript, historyRecords)
 
     table.appendEvent({
       sessionId,
@@ -126,6 +131,32 @@ export class TapeReconcilerService {
       })
     }
     return appendedFactCount
+  }
+
+  /**
+   * The backfill above made the Tape a superset of the transcript. The cursor it is about to write
+   * claims the reverse as well, so the effective Tape messages the transcript lacks are projected
+   * first. Ordinarily there are none; every message fact comes from the transcript or from this
+   * backfill.
+   */
+  private projectTapeOnlyMessages(
+    sessionId: string,
+    transcript: TapeTranscriptProjection,
+    transcriptRecords: readonly ChatMessageRecord[]
+  ): void {
+    const transcriptIds = new Set(transcriptRecords.map((record) => record.id))
+    const tapeOnlyRows = buildEffectiveTapeView(
+      this.table.getEffectiveMessageInputRows(sessionId),
+      {
+        includePending: true
+      }
+    ).rows.filter((row) => {
+      const record = tapeEntryToMessageRecord(row)
+      return record !== null && !transcriptIds.has(record.id)
+    })
+    if (tapeOnlyRows.length > 0) {
+      transcript.applyTapeEntries(tapeOnlyRows)
+    }
   }
 
   private backfillLegacySummaryAnchor(

--- a/src/main/tape/application/sessionTape.ts
+++ b/src/main/tape/application/sessionTape.ts
@@ -91,7 +91,9 @@ import type {
   TapeReconciliationPort,
   TapeToolFactAppendReceipt,
   TapeToolFactWriter,
-  TapeTranscriptReader,
+  TapeProjectionCursor,
+  TapeProjectionHeadReader,
+  TapeTranscriptProjection,
   TapeMemoryViewManifestInspection,
   CommitTapeToolSurfaceViewInput,
   TapeToolSurfaceViewCommitReceipt,
@@ -148,6 +150,7 @@ export { AgentTapeViewError, normalizeSubagentTapeLinkInput, normalizeTapeHandof
  */
 export type SessionTapeCapabilities = TapeToolFactWriter &
   TapeMessageFactWriter &
+  TapeProjectionHeadReader &
   TapeProviderAttemptReader &
   TapeProviderAttemptWriter &
   TapeCompactionModelCallReader &
@@ -210,7 +213,7 @@ export class SessionTape implements SessionTapeCapabilities {
 
   ensureSessionTapeReady(
     sessionId: string,
-    messageStore: TapeTranscriptReader
+    messageStore: TapeTranscriptProjection
   ): TapeBackfillResult {
     return this.reconciler.ensureSessionTapeReady(sessionId, messageStore)
   }
@@ -228,6 +231,10 @@ export class SessionTape implements SessionTapeCapabilities {
 
   appendMessageRetraction(record: ChatMessageRecord, reason: string): number {
     return this.facts.appendMessageRetraction(record, reason)
+  }
+
+  getProjectionHead(sessionId: string): TapeProjectionCursor | null {
+    return this.facts.getProjectionHead(sessionId)
   }
 
   appendToolFact(input: TapeToolFactInput): Promise<TapeToolFactAppendReceipt> {

--- a/src/main/tape/infrastructure/sqlite/tapeEntryStore.ts
+++ b/src/main/tape/infrastructure/sqlite/tapeEntryStore.ts
@@ -266,11 +266,8 @@ const EXECUTION_JOURNAL_EVENT_NAMES_SQL = EXECUTION_JOURNAL_EVENT_NAMES.map(
  * are disjoint because `EffectiveInputKind` cannot name `event`; the kind lists are the same
  * constants the JS predicates test.
  */
-function effectiveInputRowsSql(
-  kinds: readonly EffectiveInputKind[],
-  options: { afterEntryId?: boolean } = {}
-): string {
-  const lowerBound = options.afterEntryId ? ' AND entry_id > $afterEntryId' : ''
+function effectiveInputRowsSql(kinds: readonly EffectiveInputKind[], afterEntryId = false): string {
+  const lowerBound = afterEntryId ? ' AND entry_id > $afterEntryId' : ''
   const ranges = [
     ...kinds.map(
       (kind) =>
@@ -286,9 +283,7 @@ const EFFECTIVE_VIEW_INPUT_ROWS_SQL = effectiveInputRowsSql(EFFECTIVE_VIEW_INPUT
 const EFFECTIVE_MESSAGE_INPUT_ROWS_SQL = effectiveInputRowsSql(EFFECTIVE_MESSAGE_INPUT_KINDS)
 const EFFECTIVE_MESSAGE_INPUT_ROWS_AFTER_SQL = effectiveInputRowsSql(
   EFFECTIVE_MESSAGE_INPUT_KINDS,
-  {
-    afterEntryId: true
-  }
+  true
 )
 
 export const UNTERMINATED_EXECUTION_JOURNAL_EVENTS_SQL = `

--- a/src/main/tape/infrastructure/sqlite/tapeEntryStore.ts
+++ b/src/main/tape/infrastructure/sqlite/tapeEntryStore.ts
@@ -266,20 +266,30 @@ const EXECUTION_JOURNAL_EVENT_NAMES_SQL = EXECUTION_JOURNAL_EVENT_NAMES.map(
  * are disjoint because `EffectiveInputKind` cannot name `event`; the kind lists are the same
  * constants the JS predicates test.
  */
-function effectiveInputRowsSql(kinds: readonly EffectiveInputKind[]): string {
+function effectiveInputRowsSql(
+  kinds: readonly EffectiveInputKind[],
+  options: { afterEntryId?: boolean } = {}
+): string {
+  const lowerBound = options.afterEntryId ? ' AND entry_id > $afterEntryId' : ''
   const ranges = [
     ...kinds.map(
       (kind) =>
-        `SELECT * FROM deepchat_tape_entries WHERE session_id = $session AND kind = '${kind}'`
+        `SELECT * FROM deepchat_tape_entries WHERE session_id = $session AND kind = '${kind}'${lowerBound}`
     ),
     `SELECT * FROM deepchat_tape_entries
-     WHERE session_id = $session AND kind = 'event' AND name = '${TAPE_MESSAGE_RETRACTED_EVENT_NAME}'`
+     WHERE session_id = $session AND kind = 'event' AND name = '${TAPE_MESSAGE_RETRACTED_EVENT_NAME}'${lowerBound}`
   ]
   return `SELECT * FROM (${ranges.join(' UNION ALL ')}) ORDER BY entry_id ASC`
 }
 
 const EFFECTIVE_VIEW_INPUT_ROWS_SQL = effectiveInputRowsSql(EFFECTIVE_VIEW_INPUT_KINDS)
 const EFFECTIVE_MESSAGE_INPUT_ROWS_SQL = effectiveInputRowsSql(EFFECTIVE_MESSAGE_INPUT_KINDS)
+const EFFECTIVE_MESSAGE_INPUT_ROWS_AFTER_SQL = effectiveInputRowsSql(
+  EFFECTIVE_MESSAGE_INPUT_KINDS,
+  {
+    afterEntryId: true
+  }
+)
 
 export const UNTERMINATED_EXECUTION_JOURNAL_EVENTS_SQL = `
   WITH unterminated_runs AS (
@@ -1243,6 +1253,16 @@ export class DeepChatTapeEntriesTable
     return this.db
       .prepare(EFFECTIVE_MESSAGE_INPUT_ROWS_SQL)
       .all({ session: sessionId }) as DeepChatTapeEntryRow[]
+  }
+
+  /** The message facts and retractions appended after `afterEntryId`, in entry order. */
+  getEffectiveMessageInputRowsAfter(
+    sessionId: string,
+    afterEntryId: number
+  ): DeepChatTapeEntryRow[] {
+    return this.db
+      .prepare(EFFECTIVE_MESSAGE_INPUT_ROWS_AFTER_SQL)
+      .all({ session: sessionId, afterEntryId }) as DeepChatTapeEntryRow[]
   }
 
   getByEntryIds(sessionId: string, entryIds: readonly number[]): DeepChatTapeEntryRow[] {

--- a/src/main/tape/ports/capabilities.ts
+++ b/src/main/tape/ports/capabilities.ts
@@ -78,8 +78,34 @@ export interface TapeTranscriptReader {
   getMessages(sessionId: string): ChatMessageRecord[]
 }
 
+/** Where the transcript tables stand relative to a Session's Tape. */
+export interface TapeProjectionCursor {
+  tapeIncarnationId: string
+  maxEntryId: number
+}
+
+/**
+ * The transcript as a projection of the Session's message facts. Tape reconciliation reads the
+ * cursor, hands the message rows appended past it to `applyTapeEntries`, and advances the cursor
+ * in the same transaction. `getMessages` remains the source for the one-time backfill of a Session
+ * whose Tape predates the cursor.
+ */
+export interface TapeTranscriptProjection extends TapeTranscriptReader {
+  readProjectionCursor(sessionId: string): TapeProjectionCursor | null
+  writeProjectionCursor(sessionId: string, cursor: TapeProjectionCursor): void
+  applyTapeEntries(rows: readonly DeepChatTapeEntryRow[]): void
+}
+
 export interface TapeReconciliationPort {
-  ensureSessionTapeReady(sessionId: string, messageStore: TapeTranscriptReader): TapeBackfillResult
+  ensureSessionTapeReady(
+    sessionId: string,
+    transcript: TapeTranscriptProjection
+  ): TapeBackfillResult
+}
+
+/** The head a terminal transcript write records as its projection cursor after appending. */
+export interface TapeProjectionHeadReader {
+  getProjectionHead(sessionId: string): TapeProjectionCursor | null
 }
 
 export type TapeViewManifestAssemblySources = {

--- a/src/main/tape/ports/capabilities.ts
+++ b/src/main/tape/ports/capabilities.ts
@@ -74,10 +74,6 @@ export type TapeBackfillResult = {
   historyRecords: ChatMessageRecord[]
 }
 
-export interface TapeTranscriptReader {
-  getMessages(sessionId: string): ChatMessageRecord[]
-}
-
 /** Where the transcript tables stand relative to a Session's Tape. */
 export interface TapeProjectionCursor {
   tapeIncarnationId: string
@@ -87,10 +83,11 @@ export interface TapeProjectionCursor {
 /**
  * The transcript as a projection of the Session's message facts. Tape reconciliation reads the
  * cursor, hands the message rows appended past it to `applyTapeEntries`, and advances the cursor
- * in the same transaction. `getMessages` remains the source for the one-time backfill of a Session
+ * in the same transaction. `getMessages` is the source for the one-time backfill of a Session
  * whose Tape predates the cursor.
  */
-export interface TapeTranscriptProjection extends TapeTranscriptReader {
+export interface TapeTranscriptProjection {
+  getMessages(sessionId: string): ChatMessageRecord[]
   readProjectionCursor(sessionId: string): TapeProjectionCursor | null
   writeProjectionCursor(sessionId: string, cursor: TapeProjectionCursor): void
   applyTapeEntries(rows: readonly DeepChatTapeEntryRow[]): void

--- a/src/main/tape/ports/storage.ts
+++ b/src/main/tape/ports/storage.ts
@@ -91,6 +91,7 @@ export interface TapeEntryStore {
   getEffectiveViewInputRows(sessionId: string): DeepChatTapeEntryRow[]
   /** Rows selected by `isEffectiveMessageInputRow`, ordered by entry_id. */
   getEffectiveMessageInputRows(sessionId: string): DeepChatTapeEntryRow[]
+  getEffectiveMessageInputRowsAfter(sessionId: string, afterEntryId: number): DeepChatTapeEntryRow[]
   getByEntryIds(sessionId: string, entryIds: readonly number[]): DeepChatTapeEntryRow[]
   getMessageSourceEntries(sessionId: string, messageId: string): DeepChatTapeEntryRow[]
   getLatestViewManifestEvent(sessionId: string): DeepChatTapeEntryRow | undefined

--- a/test/main/agent/acp/compatibility/adapters.test.ts
+++ b/test/main/agent/acp/compatibility/adapters.test.ts
@@ -86,6 +86,39 @@ function createProjectionHarness() {
           .map((message) => message.order_seq)
       )
     ),
+    upsert: vi.fn(
+      (input: {
+        id: string
+        sessionId: string
+        orderSeq: number
+        role: 'user' | 'assistant'
+        content: string
+        status: 'pending' | 'sent' | 'error'
+        isContextEdge: number
+        metadata: string
+        createdAt: number
+        updatedAt: number
+      }) => {
+        const existing = messages.get(input.id)
+        const row = {
+          id: input.id,
+          session_id: input.sessionId,
+          order_seq: input.orderSeq,
+          role: input.role,
+          content: input.content,
+          status: input.status,
+          is_context_edge: input.isContextEdge,
+          metadata: input.metadata,
+          trace_count: existing?.trace_count ?? 0,
+          created_at: input.createdAt,
+          updated_at: input.updatedAt
+        }
+        messages.set(input.id, existing ? Object.assign(existing, row) : row)
+      }
+    ),
+    deleteByIds: vi.fn((ids: string[]) => {
+      for (const id of ids) messages.delete(id)
+    }),
     updateStatus: vi.fn((id: string, status: MessageRow['status']) => {
       const message = messages.get(id)
       if (message) Object.assign(message, { status, updated_at: clock++ })

--- a/test/main/agent/acp/compatibility/adapters.test.ts
+++ b/test/main/agent/acp/compatibility/adapters.test.ts
@@ -195,9 +195,25 @@ function createProjectionHarness() {
       maxRequestSeqByMessageId: vi.fn(() => 0)
     },
     deepchatUsageStatsTable: { upsert: vi.fn() },
+    deepchatTranscriptProjectionMetaTable: (() => {
+      const cursors = new Map<string, { tapeIncarnationId: string; maxEntryId: number }>()
+      return {
+        get: vi.fn((sessionId: string) => cursors.get(sessionId) ?? null),
+        upsert: vi.fn(
+          (sessionId: string, cursor: { tapeIncarnationId: string; maxEntryId: number }) => {
+            cursors.set(sessionId, { ...cursor })
+          }
+        ),
+        delete: vi.fn((sessionId: string) => {
+          cursors.delete(sessionId)
+        })
+      }
+    })(),
     deepchatTapeEntriesTable: {
+      runInTransaction: vi.fn((operation: () => unknown) => operation()),
       ensureBootstrapAnchor: vi.fn(),
       getBootstrapIncarnation: vi.fn(),
+      getMaxEntryId: vi.fn(() => tapeRows.length),
       append: vi.fn(appendTape),
       appendEvent: vi.fn(
         (input: {

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -629,6 +629,14 @@ function createMockSqlitePresenter() {
           (entry) => entry.session_id === sessionId && isEffectiveMessageInputRow(entry)
         )
       ),
+      getEffectiveMessageInputRowsAfter: vi.fn((sessionId: string, afterEntryId: number) =>
+        tapeEntries.filter(
+          (entry) =>
+            entry.session_id === sessionId &&
+            entry.entry_id > afterEntryId &&
+            isEffectiveMessageInputRow(entry)
+        )
+      ),
       getByEntryIds: vi.fn((sessionId: string, entryIds: readonly number[]) => {
         const selected = new Set(entryIds)
         return tapeEntries.filter(
@@ -927,6 +935,20 @@ function createMockSqlitePresenter() {
     deepchatUsageStatsTable: {
       upsert: vi.fn()
     },
+    deepchatTranscriptProjectionMetaTable: (() => {
+      const cursors = new Map<string, { tapeIncarnationId: string; maxEntryId: number }>()
+      return {
+        get: vi.fn((sessionId: string) => cursors.get(sessionId) ?? null),
+        upsert: vi.fn(
+          (sessionId: string, cursor: { tapeIncarnationId: string; maxEntryId: number }) => {
+            cursors.set(sessionId, { ...cursor })
+          }
+        ),
+        delete: vi.fn((sessionId: string) => {
+          cursors.delete(sessionId)
+        })
+      }
+    })(),
     deepchatMessageSearchResultsTable: {
       add: vi.fn(),
       listByMessageId: vi.fn().mockReturnValue([]),
@@ -2584,6 +2606,9 @@ describe('DeepChatAgentHarness', () => {
 
   function installSessionRows(initialRows: any[]) {
     let rows = [...initialRows]
+    // Rows installed here never went through a fact-first write, so the Session has no cursor and
+    // the next readiness check backfills them into the Tape.
+    sqlitePresenter.deepchatTranscriptProjectionMetaTable.delete('s1')
     sqlitePresenter.deepchatMessagesTable.insert.mockImplementation((row: any) => {
       const now = Date.now()
       rows.push({
@@ -12011,6 +12036,9 @@ describe('DeepChatAgentHarness', () => {
         makeDeepchatAssistantRow(8, '', assistantMessageId, 'pending')
       ]
       sqlitePresenter.deepchatMessagesTable.getBySession.mockReturnValue(records)
+      // The history is installed behind the projection's back, so drop the cursor: the next
+      // readiness check then backfills it into the Tape as it would for a pre-projection Session.
+      sqlitePresenter.deepchatTranscriptProjectionMetaTable.delete('s1')
       return [
         { role: 'system', content: systemPrompt },
         ...records
@@ -13647,6 +13675,7 @@ describe('DeepChatAgentHarness', () => {
       })
       await agent.processMessage('s1', 'Hello', { maxProviderRounds: 1 })
       sqlitePresenter.deepchatMessagesTable.getBySession.mockReturnValue(createSentTurnRecords(3))
+      sqlitePresenter.deepchatTranscriptProjectionMetaTable.delete('s1')
       llmProvider.generateText.mockClear()
 
       const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -296,13 +296,66 @@ function createMockSqlitePresenter() {
       }
     })
   }
-  const deepchatMessagesTable = {
-    insert: vi.fn(),
-    updateContent: vi.fn(),
-    updateMetadata: vi.fn(),
-    updateStatus: vi.fn(),
+  // Rows written through `insert`/`upsert` are readable through `get`, the way the terminal
+  // message writes need them. The real table UPSERTs terminal records in one statement; the double
+  // keeps `insert` and `updateContentAndStatus` as the observable seams so a test can tell a new
+  // row from a terminal update, and routes `upsert` to whichever the row's existence calls for.
+  const messageRows = new Map<string, any>()
+  const messageRowFromInput = (row: any) => ({
+    id: row.id,
+    session_id: row.sessionId,
+    order_seq: row.orderSeq,
+    role: row.role,
+    content: row.content,
+    status: row.status,
+    is_context_edge: row.isContextEdge ?? 0,
+    metadata: row.metadata ?? '{}',
+    created_at: row.createdAt ?? Date.now(),
+    updated_at: row.updatedAt ?? row.createdAt ?? Date.now()
+  })
+  const deepchatMessagesTable: Record<string, any> = {
+    insert: vi.fn((row: any) => {
+      messageRows.set(row.id, messageRowFromInput(row))
+    }),
+    upsert: vi.fn((row: any) => {
+      // nanoid is pinned to one id in these tests, so every row shares it and existence cannot be
+      // read off the id. User rows written here are new prompts (tests that replace user rows go
+      // through `installSessionRows`); an assistant row exists once its shell was inserted or a
+      // test installed it through `get`.
+      const exists =
+        row.role === 'assistant' && (messageRows.has(row.id) || deepchatMessagesTable.get(row.id))
+      if (exists) {
+        deepchatMessagesTable.updateContentAndStatus(row.id, row.content, row.status, row.metadata)
+        const existing = messageRows.get(row.id)
+        if (existing) {
+          Object.assign(existing, { order_seq: row.orderSeq, updated_at: row.updatedAt })
+        }
+        return
+      }
+      deepchatMessagesTable.insert(row)
+    }),
+    updateContent: vi.fn((id: string, content: string) => {
+      const row = messageRows.get(id)
+      if (row) Object.assign(row, { content, updated_at: Date.now() })
+    }),
+    updateMetadata: vi.fn((id: string, metadata: string) => {
+      const row = messageRows.get(id)
+      if (row) Object.assign(row, { metadata, updated_at: Date.now() })
+    }),
+    updateStatus: vi.fn((id: string, status: string) => {
+      const row = messageRows.get(id)
+      if (row) Object.assign(row, { status, updated_at: Date.now() })
+    }),
     incrementOrderSeqFrom: vi.fn(),
-    updateContentAndStatus: vi.fn(),
+    updateContentAndStatus: vi.fn(
+      (id: string, content: string, status: string, metadata?: string) => {
+        const row = messageRows.get(id)
+        if (row) {
+          Object.assign(row, { content, status, updated_at: Date.now() })
+          if (metadata !== undefined) row.metadata = metadata
+        }
+      }
+    ),
     getBySession: vi.fn().mockReturnValue([]),
     hasBySession: vi.fn().mockReturnValue(false),
     getBySessionUpToOrderSeq: vi.fn().mockReturnValue([]),
@@ -311,11 +364,16 @@ function createMockSqlitePresenter() {
     getCompactionRecoveryCandidates: vi.fn().mockReturnValue([]),
     getIdsBySession: vi.fn().mockReturnValue([]),
     getIdsFromOrderSeq: vi.fn().mockReturnValue([]),
-    get: vi.fn(),
+    get: vi.fn((id: string) => messageRows.get(id)),
     getLastUserMessageBeforeOrAtOrderSeq: vi.fn(),
     getMaxOrderSeq: vi.fn().mockReturnValue(0),
     deleteBySession: vi.fn(),
-    delete: vi.fn(),
+    delete: vi.fn((id: string) => {
+      messageRows.delete(id)
+    }),
+    deleteByIds: vi.fn((ids: string[]) => {
+      for (const id of ids) messageRows.delete(id)
+    }),
     deleteFromOrderSeq: vi.fn(),
     recoverPendingMessages: vi.fn().mockReturnValue(0)
   }
@@ -2567,6 +2625,9 @@ describe('DeepChatAgentHarness', () => {
         rows = rows.filter((row) => row.session_id !== sessionId || row.order_seq < fromOrderSeq)
       }
     )
+    sqlitePresenter.deepchatMessagesTable.deleteByIds.mockImplementation((ids: string[]) => {
+      rows = rows.filter((row) => !ids.includes(row.id))
+    })
     sqlitePresenter.deepchatMessagesTable.incrementOrderSeqFrom.mockImplementation(
       (sessionId: string, fromOrderSeq: number) => {
         rows = rows.map((row) =>
@@ -2610,6 +2671,32 @@ describe('DeepChatAgentHarness', () => {
         }
       }
     )
+    sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mockImplementation(
+      (messageId: string, content: string, status: string, metadata?: string) => {
+        const row = rows.find((candidate) => candidate.id === messageId)
+        if (row) {
+          row.content = content
+          row.status = status
+          if (metadata !== undefined) row.metadata = metadata
+          row.updated_at = Date.now()
+        }
+      }
+    )
+    sqlitePresenter.deepchatMessagesTable.upsert.mockImplementation((row: any) => {
+      const existing = rows.find((candidate) => candidate.id === row.id)
+      if (existing) {
+        sqlitePresenter.deepchatMessagesTable.updateContentAndStatus(
+          row.id,
+          row.content,
+          row.status,
+          row.metadata
+        )
+        existing.order_seq = row.orderSeq
+        existing.updated_at = row.updatedAt
+        return
+      }
+      sqlitePresenter.deepchatMessagesTable.insert(row)
+    })
 
     return {
       getRows: () => rows
@@ -10553,9 +10640,9 @@ describe('DeepChatAgentHarness', () => {
 
       await vi.waitFor(() => expect(commitRunStarted).toHaveBeenCalledOnce())
       await vi.waitFor(() =>
-        expect(sqlitePresenter.deepchatMessagesTable.delete).toHaveBeenCalledWith(
+        expect(sqlitePresenter.deepchatMessagesTable.deleteByIds).toHaveBeenCalledWith([
           'journal-send-assistant'
-        )
+        ])
       )
       expect(await agent.listPendingInputs('s1')).toEqual([])
       expect(processStream).not.toHaveBeenCalled()
@@ -13113,7 +13200,7 @@ describe('DeepChatAgentHarness', () => {
       expect(llmProvider.generateText).not.toHaveBeenCalled()
       expect(secondProviderMessages).not.toContainEqual({ role: 'user', content: oldHistoryText })
       expect(secondProviderMaxTokens).toBeLessThan(firstProviderMaxTokens)
-      expect(sqlitePresenter.deepchatMessagesTable.delete).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatMessagesTable.deleteByIds).not.toHaveBeenCalled()
     })
 
     it('returns local budget guidance when trim-only retry still overflows', async () => {
@@ -13635,7 +13722,7 @@ describe('DeepChatAgentHarness', () => {
       expect(llmProvider.generateText).not.toHaveBeenCalled()
       expect(providerMessages).not.toContainEqual({ role: 'user', content: oldHistoryText })
       expect(requestMessages).not.toContainEqual({ role: 'user', content: oldHistoryText })
-      expect(sqlitePresenter.deepchatMessagesTable.delete).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatMessagesTable.deleteByIds).not.toHaveBeenCalled()
       expect(totalRequestTokens).toBeLessThanOrEqual(getUsableContextLength(8192))
     })
 
@@ -14068,7 +14155,7 @@ describe('DeepChatAgentHarness', () => {
         'sent',
         expect.stringContaining('"compactionStatus":"compacted"')
       ])
-      expect(sqlitePresenter.deepchatMessagesTable.delete).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatMessagesTable.deleteByIds).not.toHaveBeenCalled()
     })
 
     it('emits idle when clearMessages resets compaction state', async () => {
@@ -14949,7 +15036,8 @@ describe('DeepChatAgentHarness', () => {
       expect(result).toEqual({ resumed: true })
       expect(sqlitePresenter.deepchatMessagesTable.incrementOrderSeqFrom).toHaveBeenCalledWith(
         's1',
-        3
+        3,
+        expect.any(Number)
       )
       const compactionInsert = sqlitePresenter.deepchatMessagesTable.insert.mock.calls.find(
         ([row]: any[]) =>

--- a/test/main/session/data/messageContent.test.ts
+++ b/test/main/session/data/messageContent.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AssistantMessageBlock } from '@shared/types/agent-interface'
+import { Database, nativeSqliteDescribeIf } from '../../nativeSqliteHarness'
+import {
+  assembleUserContent,
+  canonicalizeMessageContent,
+  parseAssistantBlocks,
+  toAssistantBlock,
+  toMessageFile,
+  toUserMessageFileRowInput
+} from '@/session/data/messageContent'
+
+const tables = Database
+  ? {
+      DeepChatUserMessagesTable: (await import('@/session/data/tables/deepchatUserMessages'))
+        .DeepChatUserMessagesTable,
+      DeepChatUserMessageFilesTable: (
+        await import('@/session/data/tables/deepchatUserMessageFiles')
+      ).DeepChatUserMessageFilesTable,
+      DeepChatUserMessageLinksTable: (
+        await import('@/session/data/tables/deepchatUserMessageLinks')
+      ).DeepChatUserMessageLinksTable,
+      DeepChatAssistantBlocksTable: (await import('@/session/data/tables/deepchatAssistantBlocks'))
+        .DeepChatAssistantBlocksTable
+    }
+  : null
+
+const describeIfSqlite = nativeSqliteDescribeIf(
+  Boolean(tables),
+  'transcript table modules need the native SQLite module'
+)
+
+const MESSAGE_ID = 'm1'
+const UPDATED_AT = 1_700_000_000_000
+
+const USER_CONTENT = JSON.stringify({
+  text: 'summarise the attached report',
+  files: [
+    {
+      name: 'report.pdf',
+      path: '/tmp/report.pdf',
+      type: 'application/pdf',
+      size: 2048,
+      content: 'extracted text',
+      token: 512,
+      thumbnail: 'data:image/png;base64,AAA',
+      requestedRepresentation: 'text',
+      pdfTextCoverage: { sampledPages: 2, pagesWithText: 2, textCharacterCount: 900 },
+      metadata: { fileName: 'report.pdf', fileSize: 2048, pageCount: 3 }
+    },
+    { name: '', path: '/tmp/no-metadata.bin' }
+  ],
+  links: ['https://example.com/a', 'https://example.com/b'],
+  search: true,
+  think: false,
+  activeSkills: ['  pdf ', 'pdf', 'write', ''],
+  inlineItems: [{ type: 'skill', offset: 0, skillName: 'pdf' }]
+})
+
+const ASSISTANT_BLOCKS: AssistantMessageBlock[] = [
+  {
+    type: 'reasoning_content',
+    content: 'thinking',
+    status: 'success',
+    timestamp: 1,
+    reasoning_time: { start: 1, end: 5 }
+  },
+  {
+    type: 'reasoning_content',
+    content: 'more',
+    status: 'success',
+    timestamp: 2,
+    reasoning_time: 4 as never
+  },
+  { type: 'content', content: 'Here is the answer.', status: 'success', timestamp: 3, id: 'b3' },
+  {
+    type: 'tool_call',
+    status: 'success',
+    timestamp: 4,
+    tool_call: {
+      id: 'tc1',
+      name: 'search',
+      params: '{"q":"x"}',
+      response: 'result',
+      rtkApplied: true,
+      rtkMode: 'rewrite',
+      imagePreviews: [{ mimeType: 'image/png', data: 'AAA' }] as never,
+      server_name: 'web',
+      server_icons: 'icon',
+      server_description: 'search the web'
+    }
+  },
+  {
+    type: 'image',
+    status: 'success',
+    timestamp: 5,
+    image_data: { data: 'BBB', mimeType: 'image/png' }
+  },
+  {
+    type: 'action',
+    status: 'pending',
+    timestamp: 6,
+    action_type: 'tool_call_permission',
+    tool_call: { id: 'tc2', name: 'write_file' },
+    extra: { needsUserAction: true, permissionType: 'write', toolName: 'write_file' }
+  },
+  { type: 'error', content: 'boom', status: 'error' } as AssistantMessageBlock
+]
+
+describeIfSqlite('canonicalizeMessageContent matches the transcript tables', () => {
+  let db: InstanceType<NonNullable<typeof Database>>
+
+  beforeEach(() => {
+    db = new Database!(':memory:')
+    vi.useFakeTimers()
+    vi.setSystemTime(UPDATED_AT)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    db.close()
+  })
+
+  it('reproduces user content after the user tables persist and read it back', () => {
+    const users = new tables!.DeepChatUserMessagesTable(db)
+    const files = new tables!.DeepChatUserMessageFilesTable(db)
+    const links = new tables!.DeepChatUserMessageLinksTable(db)
+    for (const table of [users, files, links]) table.createTable()
+
+    const parsed = JSON.parse(USER_CONTENT)
+    users.upsert({
+      messageId: MESSAGE_ID,
+      text: parsed.text,
+      searchEnabled: parsed.search === true,
+      thinkEnabled: parsed.think === true
+    })
+    files.replaceForMessage(MESSAGE_ID, parsed.files.map(toUserMessageFileRowInput))
+    links.replaceForMessage(MESSAGE_ID, parsed.links)
+
+    const userRow = users.get(MESSAGE_ID)!
+    const stored = assembleUserContent({
+      text: userRow.text,
+      files: files.listByMessageIds([MESSAGE_ID]).map(toMessageFile),
+      links: links.listByMessageIds([MESSAGE_ID]).map((row) => row.url),
+      search: userRow.search_enabled === 1,
+      think: userRow.think_enabled === 1,
+      activeSkills: ['pdf', 'write'],
+      inlineItems: parsed.inlineItems
+    })
+
+    const canonical = canonicalizeMessageContent('user', USER_CONTENT, UPDATED_AT)
+    expect(canonical).toBe(stored)
+    expect(canonicalizeMessageContent('user', canonical, UPDATED_AT)).toBe(canonical)
+    expect(JSON.parse(canonical).activeSkills).toEqual(['pdf', 'write'])
+  })
+
+  it('reproduces assistant content after the block table persists and reads it back', () => {
+    const blocks = new tables!.DeepChatAssistantBlocksTable(db)
+    blocks.createTable()
+    const raw = JSON.stringify(ASSISTANT_BLOCKS)
+
+    blocks.replaceForMessage(MESSAGE_ID, parseAssistantBlocks(raw))
+    const stored = JSON.stringify(blocks.listByMessageId(MESSAGE_ID).map(toAssistantBlock))
+
+    const canonical = canonicalizeMessageContent('assistant', raw, UPDATED_AT)
+    expect(canonical).toBe(stored)
+    expect(canonicalizeMessageContent('assistant', canonical, UPDATED_AT)).toBe(canonical)
+    // A block that arrived without a timestamp reports the write time once persisted.
+    expect(JSON.parse(canonical).at(-1).timestamp).toBe(UPDATED_AT)
+  })
+})
+
+describe('canonicalizeMessageContent without structured rows', () => {
+  it('returns content the tables would not structure unchanged', () => {
+    expect(canonicalizeMessageContent('user', 'plain text', 1)).toBe('plain text')
+    expect(canonicalizeMessageContent('assistant', '[]', 1)).toBe('[]')
+    expect(canonicalizeMessageContent('assistant', '{"not":"an array"}', 1)).toBe(
+      '{"not":"an array"}'
+    )
+  })
+})

--- a/test/main/session/data/settings.test.ts
+++ b/test/main/session/data/settings.test.ts
@@ -699,7 +699,8 @@ describeIfSqlite('Session transcript and Tape order consistency', () => {
         appendMessageRecord: vi.fn().mockReturnValue(1),
         appendMessageReplacement: vi.fn().mockReturnValue(1),
         appendMessageRetraction: vi.fn().mockReturnValue(1),
-        appendCompactionModelCall: vi.fn()
+        appendCompactionModelCall: vi.fn(),
+        getProjectionHead: vi.fn(() => null)
       }
       const transcript = new SessionTranscriptCtor(database, tapeFacts)
       database.getDatabase().transaction(() => {

--- a/test/main/session/data/tapeRecall.test.ts
+++ b/test/main/session/data/tapeRecall.test.ts
@@ -19,6 +19,7 @@ import {
   itIfSqlite,
   createTapeTableMock,
   createRecord,
+  createTranscriptProjectionMock,
   createTapeService
 } from './tapeTestHarness'
 import { TapeSkillMaterializationService } from '@/tape/application/skillMaterializationService'
@@ -234,22 +235,20 @@ describe('SessionTape recall', () => {
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
     } as any)
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([
-        createRecord({ id: 'u1' }),
-        createRecord({
-          id: 'a1',
-          orderSeq: 2,
-          role: 'assistant',
-          content: JSON.stringify([
-            { type: 'content', content: 'answer', status: 'success', timestamp: 101 }
-          ]),
-          metadata: JSON.stringify({ totalTokens: 9 }),
-          createdAt: 101,
-          updatedAt: 101
-        })
-      ])
-    }
+    const messageStore = createTranscriptProjectionMock([
+      createRecord({ id: 'u1' }),
+      createRecord({
+        id: 'a1',
+        orderSeq: 2,
+        role: 'assistant',
+        content: JSON.stringify([
+          { type: 'content', content: 'answer', status: 'success', timestamp: 101 }
+        ]),
+        metadata: JSON.stringify({ totalTokens: 9 }),
+        createdAt: 101,
+        updatedAt: 101
+      })
+    ])
 
     service.ensureSessionTapeReady('s1', messageStore as any)
     service.handoff('s1', 'phase_done', { summary: '  done  ' })

--- a/test/main/session/data/tapeReconciler.test.ts
+++ b/test/main/session/data/tapeReconciler.test.ts
@@ -118,9 +118,23 @@ describe('SessionTape reconciliation and facts', () => {
       const record = createRecord({ id: 'u1', orderSeq: 1 })
 
       appendMessageRecordToTape(table as any, record, 'live')
-      appendMessageRecordToTape(table as any, { ...record, traceCount: 3 }, 'backfill')
+      appendMessageRecordToTape(table as any, { ...record, traceCount: 3 }, 'live')
 
       expect(entries.filter((entry) => entry.kind === 'message')).toHaveLength(1)
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
+
+    it('does not report a backfill that meets a fact written by an earlier version', () => {
+      const { table } = createTapeTableMock()
+      const record = createRecord({ id: 'u1', orderSeq: 1 })
+
+      appendMessageRecordToTape(table as any, record, 'live')
+      appendMessageRecordToTape(
+        table as any,
+        { ...record, content: JSON.stringify({ text: 'hello', files: [], links: [] }) },
+        'backfill'
+      )
+
       expect(logger.warn).not.toHaveBeenCalled()
     })
 

--- a/test/main/session/data/tapeReconciler.test.ts
+++ b/test/main/session/data/tapeReconciler.test.ts
@@ -12,7 +12,8 @@ import {
   appendMessageRetractionToTape,
   createTapeTableMock,
   createRecord,
-  createTapeService
+  createTapeService,
+  createTranscriptProjectionMock
 } from './tapeTestHarness'
 import {
   TAPE_TOOL_RESULT_PAYLOAD_HASH_VERSION,
@@ -89,9 +90,7 @@ describe('SessionTape reconciliation and facts', () => {
       }),
       createRecord({ id: 'u1', orderSeq: 1 })
     ]
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue(records)
-    }
+    const messageStore = createTranscriptProjectionMock(records)
     const service = new SessionTape({
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
@@ -162,117 +161,106 @@ describe('SessionTape reconciliation and facts', () => {
     })
   })
 
-  describe('backfill short-circuit', () => {
+  describe('transcript projection cursor', () => {
     function createReconcileHarness(initialRecords: any[]) {
       const { table, entries } = createTapeTableMock()
-      let records = initialRecords
-      const messageStore = { getMessages: vi.fn(() => records) }
+      const transcript = createTranscriptProjectionMock(initialRecords)
       const service = new SessionTape({
         deepchatTapeEntriesTable: table,
         deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
       } as any)
       const backfillAttempts = () => table.append.mock.calls.length
-      return {
-        table,
-        entries,
-        service,
-        messageStore,
-        backfillAttempts,
-        setRecords: (next: any[]) => {
-          records = next
-        }
-      }
+      return { table, entries, service, transcript, backfillAttempts }
     }
 
-    it('skips the backfill while the transcript and Tape incarnation are unchanged', () => {
-      const { service, messageStore, backfillAttempts } = createReconcileHarness([
+    it('backfills a Session without a cursor once and leaves the cursor at the head', () => {
+      const { service, transcript, table, backfillAttempts } = createReconcileHarness([
         createRecord({ id: 'u1', orderSeq: 1, updatedAt: 100 }),
         createRecord({ id: 'a1', orderSeq: 2, role: 'assistant', content: '[]', updatedAt: 200 })
       ])
 
-      const first = service.ensureSessionTapeReady('s1', messageStore as any)
+      const first = service.ensureSessionTapeReady('s1', transcript as any)
       const attemptsAfterFirst = backfillAttempts()
-      const second = service.ensureSessionTapeReady('s1', messageStore as any)
+      const second = service.ensureSessionTapeReady('s1', transcript as any)
 
       expect(first.appendedFactCount).toBe(2)
       expect(second).toEqual({ ...first, appendedFactCount: 0 })
       expect(backfillAttempts()).toBe(attemptsAfterFirst)
+      expect(transcript.getMessages).toHaveBeenCalledTimes(1)
+      expect(transcript.cursor).toEqual({
+        tapeIncarnationId: table.getBootstrapIncarnation('s1'),
+        maxEntryId: table.getMaxEntryId('s1')
+      })
+      expect(transcript.applied).toEqual([])
     })
 
-    it('backfills again after a transcript write that bypassed Tape', () => {
-      // Retrying a failed steer restores its prompt with updateMessageStatus, which does not write
-      // Tape; the next backfill must pick the new status up or the prompt drops out of context.
-      const failed = createRecord({ id: 'u1', orderSeq: 1, status: 'error', updatedAt: 100 })
-      const { service, messageStore, entries, setRecords } = createReconcileHarness([failed])
-      service.ensureSessionTapeReady('s1', messageStore as any)
+    it('replays only the message rows appended past the cursor', () => {
+      const { service, transcript, table, entries } = createReconcileHarness([])
+      service.ensureSessionTapeReady('s1', transcript as any)
+      const cursorAfterBootstrap = transcript.cursor!
 
-      setRecords([{ ...failed, status: 'sent', updatedAt: 150 }])
-      const result = service.ensureSessionTapeReady('s1', messageStore as any)
+      // A manifest-like event moves the head without adding a message.
+      table.appendEvent({
+        sessionId: 's1',
+        name: 'view/assembled',
+        source: { type: 'runtime_event', id: 'r1', seq: 1 },
+        payload: {},
+        data: {},
+        idempotent: false
+      })
+      service.ensureSessionTapeReady('s1', transcript as any)
+      expect(transcript.applied).toEqual([])
+      expect(transcript.cursor!.maxEntryId).toBe(table.getMaxEntryId('s1'))
 
-      expect(entries.filter((entry) => entry.kind === 'message')).toHaveLength(2)
-      expect(result.historyRecords.map((record) => record.status)).toEqual(['sent'])
+      // A message fact appended directly to Tape reaches the transcript on the next readiness.
+      appendMessageRecordToTape(table as any, createRecord({ id: 'u9', orderSeq: 9 }), 'live')
+      appendMessageRetractionToTape(
+        table as any,
+        createRecord({ id: 'u8', orderSeq: 8 }),
+        'message_deleted'
+      )
+      const result = service.ensureSessionTapeReady('s1', transcript as any)
+
+      expect(transcript.applied.map((row) => [row.kind, row.name])).toEqual([
+        ['message', 'message/user'],
+        ['event', 'message/retracted']
+      ])
+      expect(
+        transcript.applied.every((row) => row.entry_id > cursorAfterBootstrap.maxEntryId)
+      ).toBe(true)
+      expect(transcript.cursor!.maxEntryId).toBe(entries[entries.length - 1].entry_id)
+      expect(result.historyRecords.map((record) => record.id)).toEqual(['u9'])
+      expect(transcript.getMessages).toHaveBeenCalledTimes(1)
     })
 
-    it('backfills again when the Tape was reset under an unchanged transcript', () => {
-      const { service, messageStore, table, entries } = createReconcileHarness([
+    it('backfills again when the Tape was reset under a cursor from the old incarnation', () => {
+      const { service, transcript, table, entries } = createReconcileHarness([
         createRecord({ id: 'u1', orderSeq: 1, updatedAt: 100 })
       ])
-      service.ensureSessionTapeReady('s1', messageStore as any)
+      service.ensureSessionTapeReady('s1', transcript as any)
+      const staleCursor = transcript.cursor!
 
       table.deleteBySession('s1')
       expect(entries).toEqual([])
-      const result = service.ensureSessionTapeReady('s1', messageStore as any)
+      const result = service.ensureSessionTapeReady('s1', transcript as any)
 
       expect(result.appendedFactCount).toBe(1)
       expect(result.historyRecords.map((record) => record.id)).toEqual(['u1'])
+      expect(transcript.cursor!.tapeIncarnationId).not.toBe(staleCursor.tapeIncarnationId)
+      expect(transcript.applied).toEqual([])
     })
 
-    it('backfills again after a bypass write stamped by a clock that had stepped back', () => {
-      // u2 is restored while the clock is behind u1's stamp, so count and max(updated_at) are
-      // unchanged; only a per-row comparison can see the write once the clock recovers.
-      const newest = createRecord({ id: 'u1', orderSeq: 1, updatedAt: 4_000 })
-      const failed = createRecord({ id: 'u2', orderSeq: 2, status: 'error', updatedAt: 2_000 })
-      const { service, messageStore, entries, setRecords } = createReconcileHarness([
-        newest,
-        failed
+    it('does not delete a transcript row the backfill did not find a fact for', () => {
+      // The upgrade case: rows written before the projection existed, Tape behind or empty.
+      const { service, transcript } = createReconcileHarness([
+        createRecord({ id: 'u1', orderSeq: 1 }),
+        createRecord({ id: 'a1', orderSeq: 2, role: 'assistant', content: '[]' })
       ])
-      service.ensureSessionTapeReady('s1', messageStore as any)
 
-      setRecords([newest, { ...failed, status: 'sent', updatedAt: 3_000 }])
-      const result = service.ensureSessionTapeReady('s1', messageStore as any)
+      const result = service.ensureSessionTapeReady('s1', transcript as any)
 
-      expect(
-        entries.filter((entry) => entry.kind === 'message' && entry.source_id === 'u2')
-      ).toHaveLength(2)
-      expect(result.historyRecords.map((record) => record.status)).toEqual(['sent', 'sent'])
-    })
-
-    it('backfills again when the Tape head moved under an unchanged transcript', () => {
-      // A restored backup keeps the copied incarnation but carries a different Tape.
-      const { service, messageStore, table, entries, backfillAttempts } = createReconcileHarness([
-        createRecord({ id: 'u1', orderSeq: 1, updatedAt: 100 })
-      ])
-      service.ensureSessionTapeReady('s1', messageStore as any)
-      const attemptsAfterFirst = backfillAttempts()
-      const headAfterFirst = table.getMaxEntryId('s1')
-
-      entries.splice(entries.length - 1, 1)
-      expect(table.getMaxEntryId('s1')).toBeLessThan(headAfterFirst)
-      service.ensureSessionTapeReady('s1', messageStore as any)
-
-      expect(backfillAttempts()).toBeGreaterThan(attemptsAfterFirst)
-    })
-
-    it('does not remember a backfill performed inside a host transaction', () => {
-      const { service, messageStore, table, backfillAttempts } = createReconcileHarness([
-        createRecord({ id: 'u1', orderSeq: 1, updatedAt: 100 })
-      ])
-      table.runInTransaction(() => service.ensureSessionTapeReady('s1', messageStore as any))
-      const attemptsAfterFirst = backfillAttempts()
-
-      service.ensureSessionTapeReady('s1', messageStore as any)
-
-      expect(backfillAttempts()).toBeGreaterThan(attemptsAfterFirst)
+      expect(result.historyRecords.map((record) => record.id)).toEqual(['u1', 'a1'])
+      expect(transcript.applyTapeEntries).not.toHaveBeenCalled()
     })
   })
 
@@ -280,30 +268,32 @@ describe('SessionTape reconciliation and facts', () => {
     const { table, entries } = createTapeTableMock()
     let response = 'response-a'
     let updatedAt = 100
-    const messageStore = {
-      getMessages: vi.fn(() => [
-        createRecord({
-          id: 'a1',
-          orderSeq: 2,
-          role: 'assistant',
-          status: 'error',
-          content: JSON.stringify([
-            {
-              type: 'tool_call',
-              status: 'error',
-              timestamp: 90,
-              tool_call: {
-                id: 'tc1',
-                name: 'search',
-                params: '{"q":"x"}',
-                response
-              }
+    // Three backfills of a changing transcript, as a Session whose Tape keeps being reset would
+    // see: the cursor stays absent so each readiness call backfills again.
+    const messageStore = createTranscriptProjectionMock()
+    messageStore.readProjectionCursor.mockReturnValue(null)
+    messageStore.getMessages.mockImplementation(() => [
+      createRecord({
+        id: 'a1',
+        orderSeq: 2,
+        role: 'assistant',
+        status: 'error',
+        content: JSON.stringify([
+          {
+            type: 'tool_call',
+            status: 'error',
+            timestamp: 90,
+            tool_call: {
+              id: 'tc1',
+              name: 'search',
+              params: '{"q":"x"}',
+              response
             }
-          ]),
-          updatedAt
-        })
-      ])
-    }
+          }
+        ]),
+        updatedAt
+      })
+    ])
     const service = new SessionTape({
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
@@ -603,9 +593,7 @@ describe('SessionTape reconciliation and facts', () => {
         updatedAt: 121
       })
     ]
-    const legacyMessageStore = {
-      getMessages: vi.fn().mockReturnValue(records)
-    }
+    const legacyMessageStore = createTranscriptProjectionMock(records)
     const service = new SessionTape({
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
@@ -663,17 +651,15 @@ describe('SessionTape reconciliation and facts', () => {
 
   it('migrates legacy session summary into a tape anchor during backfill', () => {
     const { table, entries } = createTapeTableMock()
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([
-        createRecord({ id: 'u1', orderSeq: 1 }),
-        createRecord({
-          id: 'a1',
-          orderSeq: 2,
-          role: 'assistant',
-          content: JSON.stringify([{ type: 'content', content: 'answer', status: 'success' }])
-        })
-      ])
-    }
+    const messageStore = createTranscriptProjectionMock([
+      createRecord({ id: 'u1', orderSeq: 1 }),
+      createRecord({
+        id: 'a1',
+        orderSeq: 2,
+        role: 'assistant',
+        content: JSON.stringify([{ type: 'content', content: 'answer', status: 'success' }])
+      })
+    ])
     const service = new SessionTape({
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: {
@@ -716,18 +702,16 @@ describe('SessionTape reconciliation and facts', () => {
         }
       }
     ]
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([
-        createRecord({
-          id: 'a1',
-          orderSeq: 1,
-          role: 'assistant',
-          status: 'pending',
-          content: JSON.stringify(pendingBlocks),
-          updatedAt: 100
-        })
-      ])
-    }
+    const messageStore = createTranscriptProjectionMock([
+      createRecord({
+        id: 'a1',
+        orderSeq: 1,
+        role: 'assistant',
+        status: 'pending',
+        content: JSON.stringify(pendingBlocks),
+        updatedAt: 100
+      })
+    ])
     const service = new SessionTape({
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
@@ -767,32 +751,33 @@ describe('SessionTape reconciliation and facts', () => {
         }
       }
     ]
-    const messageStore = {
-      getMessages: vi
-        .fn()
-        .mockReturnValueOnce([
-          createRecord({
-            id: 'a1',
-            orderSeq: 1,
-            role: 'assistant',
-            status: 'pending',
-            content: JSON.stringify(pendingBlocks),
-            metadata: JSON.stringify({ totalTokens: 1 }),
-            updatedAt: 100
-          })
-        ])
-        .mockReturnValue([
-          createRecord({
-            id: 'a1',
-            orderSeq: 1,
-            role: 'assistant',
-            status: 'sent',
-            content: JSON.stringify(finalBlocks),
-            metadata: JSON.stringify({ totalTokens: 7 }),
-            updatedAt: 200
-          })
-        ])
-    }
+    // Two backfills of the same message, pending then final: the cursor is kept absent so the
+    // second readiness call backfills the terminal record over the pending fact.
+    const messageStore = createTranscriptProjectionMock()
+    messageStore.readProjectionCursor.mockReturnValue(null)
+    messageStore.getMessages
+      .mockReturnValueOnce([
+        createRecord({
+          id: 'a1',
+          orderSeq: 1,
+          role: 'assistant',
+          status: 'pending',
+          content: JSON.stringify(pendingBlocks),
+          metadata: JSON.stringify({ totalTokens: 1 }),
+          updatedAt: 100
+        })
+      ])
+      .mockReturnValue([
+        createRecord({
+          id: 'a1',
+          orderSeq: 1,
+          role: 'assistant',
+          status: 'sent',
+          content: JSON.stringify(finalBlocks),
+          metadata: JSON.stringify({ totalTokens: 7 }),
+          updatedAt: 200
+        })
+      ])
     const service = new SessionTape({
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
@@ -823,9 +808,7 @@ describe('SessionTape reconciliation and facts', () => {
   it('uses effective message facts after replacement and retraction events', () => {
     const { table, entries } = createTapeTableMock()
     const original = createRecord({ id: 'u1', orderSeq: 1 })
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([original])
-    }
+    const messageStore = createTranscriptProjectionMock([original])
     const service = new SessionTape({
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }

--- a/test/main/session/data/tapeReconciler.test.ts
+++ b/test/main/session/data/tapeReconciler.test.ts
@@ -1,8 +1,9 @@
+import { beforeEach, vi } from 'vitest'
+import logger from '@shared/logger'
 import {
   describe,
   expect,
   it,
-  vi,
   buildContext,
   toAppSessionId,
   SessionTape,
@@ -18,6 +19,15 @@ import {
   buildTapeToolResultPayloadHash
 } from '@/tape/domain/toolSurfaceFacts'
 import { TOOL_SEARCH_AGENT_TOOL_NAME } from '@shared/agentTools'
+
+vi.mock('@shared/logger', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn()
+  }
+}))
 
 describe('SessionTape reconciliation and facts', () => {
   it('uses the explicit replacement revision kind instead of the reason text', () => {
@@ -97,6 +107,59 @@ describe('SessionTape reconciliation and facts', () => {
     expect(entries.filter((entry) => entry.kind === 'tool_call')).toHaveLength(1)
     expect(entries.filter((entry) => entry.kind === 'tool_result')).toHaveLength(1)
     expect(entries.filter((entry) => entry.name === 'migration/backfill')).toHaveLength(1)
+  })
+
+  describe('sent message fact re-append', () => {
+    beforeEach(() => {
+      vi.mocked(logger.warn).mockClear()
+    })
+
+    it('stays silent while the existing entry carries the same record', () => {
+      const { table, entries } = createTapeTableMock()
+      const record = createRecord({ id: 'u1', orderSeq: 1 })
+
+      appendMessageRecordToTape(table as any, record, 'live')
+      appendMessageRecordToTape(table as any, { ...record, traceCount: 3 }, 'backfill')
+
+      expect(entries.filter((entry) => entry.kind === 'message')).toHaveLength(1)
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
+
+    it('warns once and names the field when the existing entry holds a different record', () => {
+      const { table, entries } = createTapeTableMock()
+      const record = createRecord({ id: 'u1', orderSeq: 1 })
+
+      appendMessageRecordToTape(table as any, record, 'live')
+      appendMessageRecordToTape(
+        table as any,
+        {
+          ...record,
+          content: JSON.stringify({
+            text: 'edited without a replacement fact',
+            files: [],
+            links: [],
+            search: false,
+            think: false
+          }),
+          updatedAt: 200
+        },
+        'live'
+      )
+
+      expect(entries.filter((entry) => entry.kind === 'message')).toHaveLength(1)
+      expect(logger.warn).toHaveBeenCalledTimes(1)
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('different record'),
+        expect.objectContaining({
+          sessionId: 's1',
+          messageId: 'u1',
+          entryId: entries.find((entry) => entry.kind === 'message')?.entry_id,
+          source: 'live',
+          fields: ['content']
+        })
+      )
+      expect(vi.mocked(logger.warn).mock.calls[0]?.[1]).not.toHaveProperty('content')
+    })
   })
 
   describe('backfill short-circuit', () => {

--- a/test/main/session/data/tapeReconciler.test.ts
+++ b/test/main/session/data/tapeReconciler.test.ts
@@ -167,7 +167,6 @@ describe('SessionTape reconciliation and facts', () => {
           sessionId: 's1',
           messageId: 'u1',
           entryId: entries.find((entry) => entry.kind === 'message')?.entry_id,
-          source: 'live',
           fields: ['content']
         })
       )

--- a/test/main/session/data/tapeReconciler.test.ts
+++ b/test/main/session/data/tapeReconciler.test.ts
@@ -263,6 +263,23 @@ describe('SessionTape reconciliation and facts', () => {
       expect(transcript.applied).toEqual([])
     })
 
+    it('projects Tape messages the transcript lacks before writing the first cursor', () => {
+      const { service, transcript, table } = createReconcileHarness([])
+      appendMessageRecordToTape(
+        table as any,
+        createRecord({ id: 'tape-only', orderSeq: 1 }),
+        'live'
+      )
+
+      const result = service.ensureSessionTapeReady('s1', transcript as any)
+
+      expect(transcript.applied.map((row) => [row.kind, row.source_id])).toEqual([
+        ['message', 'tape-only']
+      ])
+      expect(result.historyRecords.map((record) => record.id)).toEqual(['tape-only'])
+      expect(transcript.cursor!.maxEntryId).toBe(table.getMaxEntryId('s1'))
+    })
+
     it('does not delete a transcript row the backfill did not find a fact for', () => {
       // The upgrade case: rows written before the projection existed, Tape behind or empty.
       const { service, transcript } = createReconcileHarness([

--- a/test/main/session/data/tapeReconciler.test.ts
+++ b/test/main/session/data/tapeReconciler.test.ts
@@ -280,31 +280,6 @@ describe('SessionTape reconciliation and facts', () => {
       expect(transcript.cursor!.maxEntryId).toBe(table.getMaxEntryId('s1'))
     })
 
-    it('skips a Tape-only fact whose record names another session and says so once', () => {
-      vi.mocked(logger.warn).mockClear()
-      const { service, transcript, table } = createReconcileHarness([])
-      // Appended under s1 but describing s2: projecting it would move a row between Sessions.
-      table.append({
-        sessionId: 's1',
-        kind: 'message',
-        name: 'message/user',
-        source: { type: 'message', id: 'foreign', seq: 0 },
-        payload: { record: createRecord({ id: 'foreign', sessionId: 's2', orderSeq: 1 }) },
-        meta: { source: 'live', orderSeq: 1, role: 'user', status: 'sent' },
-        idempotent: true
-      })
-
-      const result = service.ensureSessionTapeReady('s1', transcript as any)
-
-      expect(transcript.applyTapeEntries).not.toHaveBeenCalled()
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('another session'),
-        expect.objectContaining({ sessionId: 's1', count: 1 })
-      )
-      expect(result.historyRecords.map((record) => record.id)).toEqual(['foreign'])
-      expect(transcript.cursor!.maxEntryId).toBe(table.getMaxEntryId('s1'))
-    })
-
     it('keeps a transcript row whose Tape fact was retracted when there is no cursor yet', () => {
       // Unreachable by construction (delete removes the row and appends the retraction in one
       // transaction); pinned because the first projection must only add.

--- a/test/main/session/data/tapeReconciler.test.ts
+++ b/test/main/session/data/tapeReconciler.test.ts
@@ -280,6 +280,46 @@ describe('SessionTape reconciliation and facts', () => {
       expect(transcript.cursor!.maxEntryId).toBe(table.getMaxEntryId('s1'))
     })
 
+    it('skips a Tape-only fact whose record names another session and says so once', () => {
+      vi.mocked(logger.warn).mockClear()
+      const { service, transcript, table } = createReconcileHarness([])
+      // Appended under s1 but describing s2: projecting it would move a row between Sessions.
+      table.append({
+        sessionId: 's1',
+        kind: 'message',
+        name: 'message/user',
+        source: { type: 'message', id: 'foreign', seq: 0 },
+        payload: { record: createRecord({ id: 'foreign', sessionId: 's2', orderSeq: 1 }) },
+        meta: { source: 'live', orderSeq: 1, role: 'user', status: 'sent' },
+        idempotent: true
+      })
+
+      const result = service.ensureSessionTapeReady('s1', transcript as any)
+
+      expect(transcript.applyTapeEntries).not.toHaveBeenCalled()
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('another session'),
+        expect.objectContaining({ sessionId: 's1', count: 1 })
+      )
+      expect(result.historyRecords.map((record) => record.id)).toEqual(['foreign'])
+      expect(transcript.cursor!.maxEntryId).toBe(table.getMaxEntryId('s1'))
+    })
+
+    it('keeps a transcript row whose Tape fact was retracted when there is no cursor yet', () => {
+      // Unreachable by construction (delete removes the row and appends the retraction in one
+      // transaction); pinned because the first projection must only add.
+      const stale = createRecord({ id: 'u1', orderSeq: 1 })
+      const { service, transcript, table } = createReconcileHarness([stale])
+      appendMessageRecordToTape(table as any, stale, 'live')
+      appendMessageRetractionToTape(table as any, stale, 'test_delete')
+
+      const result = service.ensureSessionTapeReady('s1', transcript as any)
+
+      expect(transcript.applyTapeEntries).not.toHaveBeenCalled()
+      expect(result.historyRecords).toEqual([])
+      expect(transcript.cursor!.maxEntryId).toBe(table.getMaxEntryId('s1'))
+    })
+
     it('does not delete a transcript row the backfill did not find a fact for', () => {
       // The upgrade case: rows written before the projection existed, Tape behind or empty.
       const { service, transcript } = createReconcileHarness([

--- a/test/main/session/data/tapeTableMockContract.test.ts
+++ b/test/main/session/data/tapeTableMockContract.test.ts
@@ -519,6 +519,10 @@ describe('Tape table mock contract', () => {
         excludingContext: (store) => store.getBySessionExcludingContext(SESSION),
         effectiveViewInputs: (store) => store.getEffectiveViewInputRows(SESSION),
         effectiveMessageInputs: (store) => store.getEffectiveMessageInputRows(SESSION),
+        effectiveMessageInputsAfterHead: (store) =>
+          store.getEffectiveMessageInputRowsAfter(SESSION, store.getMaxEntryId(SESSION)),
+        effectiveMessageInputsAfterEntry: (store) =>
+          store.getEffectiveMessageInputRowsAfter(SESSION, 3),
         lineage: (store) => store.getSubagentLineageEvents(SESSION),
         effectiveSearchAtHeads: (store) =>
           store.searchEffectiveSourcesAtHeads(

--- a/test/main/session/data/tapeTestHarness.ts
+++ b/test/main/session/data/tapeTestHarness.ts
@@ -32,6 +32,8 @@ import {
 } from '@/tape/domain/reservedNamespaces'
 import { SqliteTapeLifecycleAdapter } from '@/tape/infrastructure/sqlite/tapeLifecycleAdapter'
 import type { TapeTransactionRunner } from '@/tape/ports/storage'
+import type { TapeProjectionCursor } from '@/tape/ports/capabilities'
+import type { DeepChatTapeEntryRow } from '@/tape/domain/entry'
 import {
   DEEPCHAT_TAPE_SEARCH_PROJECTION_VERSION,
   DeepChatTapeSearchProjectionTable
@@ -446,6 +448,14 @@ function createTapeTableMock() {
     getEffectiveMessageInputRows: vi.fn((sessionId: string) =>
       entries.filter((entry) => entry.session_id === sessionId && isEffectiveMessageInputRow(entry))
     ),
+    getEffectiveMessageInputRowsAfter: vi.fn((sessionId: string, afterEntryId: number) =>
+      entries.filter(
+        (entry) =>
+          entry.session_id === sessionId &&
+          entry.entry_id > afterEntryId &&
+          isEffectiveMessageInputRow(entry)
+      )
+    ),
     getByEntryIds: vi.fn((sessionId: string, entryIds: readonly number[]) => {
       const selected = new Set(entryIds)
       return entries.filter(
@@ -705,6 +715,29 @@ function createRecord(overrides: Partial<ChatMessageRecord>): ChatMessageRecord 
     createdAt: 100,
     updatedAt: 100,
     ...overrides
+  }
+}
+
+/**
+ * A transcript standing in for `TapeTranscriptProjection`: `getMessages` feeds the one-time
+ * backfill, the cursor lives in memory, and replayed rows are collected in `applied`.
+ */
+function createTranscriptProjectionMock(records: ChatMessageRecord[] = []) {
+  let cursor: TapeProjectionCursor | null = null
+  const applied: DeepChatTapeEntryRow[] = []
+  return {
+    getMessages: vi.fn(() => records),
+    readProjectionCursor: vi.fn(() => cursor),
+    writeProjectionCursor: vi.fn((_sessionId: string, next: TapeProjectionCursor) => {
+      cursor = { ...next }
+    }),
+    applyTapeEntries: vi.fn((rows: readonly DeepChatTapeEntryRow[]) => {
+      applied.push(...rows)
+    }),
+    applied,
+    get cursor() {
+      return cursor
+    }
   }
 }
 
@@ -1008,6 +1041,7 @@ export {
   itIfSqlite,
   createTapeTableMock,
   createRecord,
+  createTranscriptProjectionMock,
   createTraceRow,
   createMessageRow,
   createObservationManifest,

--- a/test/main/session/data/tapeViewReplay.test.ts
+++ b/test/main/session/data/tapeViewReplay.test.ts
@@ -28,6 +28,7 @@ import {
   itIfSqlite,
   createTapeTableMock,
   createRecord,
+  createTranscriptProjectionMock,
   createTraceRow,
   createMessageRow,
   createObservationManifest,
@@ -905,9 +906,7 @@ describe('SessionTape view and replay', () => {
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
     } as any)
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([createRecord({ id: 'u1', orderSeq: 1 })])
-    }
+    const messageStore = createTranscriptProjectionMock([createRecord({ id: 'u1', orderSeq: 1 })])
 
     service.ensureSessionTapeReady('s1', messageStore as any)
     const sourceMaps = service.getViewManifestSourceMaps('s1')
@@ -995,9 +994,7 @@ describe('SessionTape view and replay', () => {
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
     } as any)
     const original = createRecord({ id: 'u1', orderSeq: 1, content: 'original task' })
-    service.ensureSessionTapeReady('s1', {
-      getMessages: vi.fn().mockReturnValue([original])
-    } as any)
+    service.ensureSessionTapeReady('s1', createTranscriptProjectionMock([original]) as any)
 
     const initialSources = service.getViewManifestSourceMaps('s1')
     const initialEntryId = initialSources.entryIdByMessageId.get('u1')
@@ -1335,9 +1332,7 @@ describe('SessionTape view and replay', () => {
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
     } as any)
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([createRecord({ id: 'u1', orderSeq: 1 })])
-    }
+    const messageStore = createTranscriptProjectionMock([createRecord({ id: 'u1', orderSeq: 1 })])
     service.ensureSessionTapeReady('s1', messageStore as any)
     const sourceMaps = service.getViewManifestSourceMaps('s1')
     const manifest = createTapeViewManifest({
@@ -1388,9 +1383,7 @@ describe('SessionTape view and replay', () => {
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
     } as any)
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([createRecord({ id: 'u1', orderSeq: 1 })])
-    }
+    const messageStore = createTranscriptProjectionMock([createRecord({ id: 'u1', orderSeq: 1 })])
     service.ensureSessionTapeReady('s1', messageStore as any)
     const sourceMaps = service.getViewManifestSourceMaps('s1')
     const manifest = createTapeViewManifest({
@@ -1438,9 +1431,7 @@ describe('SessionTape view and replay', () => {
       deepchatTapeEntriesTable: table,
       deepchatSessionsTable: { getSummaryState: vi.fn().mockReturnValue(null) }
     } as any)
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([createRecord({ id: 'u1', orderSeq: 1 })])
-    }
+    const messageStore = createTranscriptProjectionMock([createRecord({ id: 'u1', orderSeq: 1 })])
     service.ensureSessionTapeReady('s1', messageStore as any)
     const sourceMaps = service.getViewManifestSourceMaps('s1')
     const baseInput = {
@@ -1576,9 +1567,7 @@ describe('SessionTape view and replay', () => {
   it('bounds replay slices to the selected view instead of pre-cursor history', () => {
     const { table } = createTapeTableMock()
     const service = createTapeService(table)
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([createRecord({ id: 'u1', orderSeq: 1 })])
-    }
+    const messageStore = createTranscriptProjectionMock([createRecord({ id: 'u1', orderSeq: 1 })])
 
     service.ensureSessionTapeReady('s1', messageStore as any)
     const sourceMaps = service.getViewManifestSourceMaps('s1')
@@ -1641,9 +1630,7 @@ describe('SessionTape view and replay', () => {
   it('exports replay slices with metadata-only payloads by default', () => {
     const { table } = createTapeTableMock()
     const service = createTapeService(table, [createTraceRow()])
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([createRecord({ id: 'u1', orderSeq: 1 })])
-    }
+    const messageStore = createTranscriptProjectionMock([createRecord({ id: 'u1', orderSeq: 1 })])
 
     service.ensureSessionTapeReady('s1', messageStore as any)
     const sourceMaps = service.getViewManifestSourceMaps('s1')
@@ -1785,9 +1772,7 @@ describe('SessionTape view and replay', () => {
         body_json: '{"messages":[{"role":"tool","content":"done"}]}'
       })
     ])
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([createRecord({ id: 'u1', orderSeq: 1 })])
-    }
+    const messageStore = createTranscriptProjectionMock([createRecord({ id: 'u1', orderSeq: 1 })])
 
     service.ensureSessionTapeReady('s1', messageStore as any)
     const sourceMaps = service.getViewManifestSourceMaps('s1')
@@ -1874,9 +1859,7 @@ describe('SessionTape view and replay', () => {
         body_json: '{"messages":[{"role":"tool","content":"second-request"}]}'
       })
     ])
-    const messageStore = {
-      getMessages: vi.fn().mockReturnValue([createRecord({ id: 'u1', orderSeq: 1 })])
-    }
+    const messageStore = createTranscriptProjectionMock([createRecord({ id: 'u1', orderSeq: 1 })])
 
     service.ensureSessionTapeReady('s1', messageStore as any)
     const sourceMaps = service.getViewManifestSourceMaps('s1')

--- a/test/main/session/data/transcript.test.ts
+++ b/test/main/session/data/transcript.test.ts
@@ -99,8 +99,15 @@ function createMockSqlitePresenter() {
     deepchatUsageStatsTable: {
       upsert: vi.fn()
     },
+    deepchatTranscriptProjectionMetaTable: {
+      get: vi.fn(() => null),
+      upsert: vi.fn(),
+      delete: vi.fn()
+    },
     deepchatTapeEntriesTable: {
       ensureBootstrapAnchor: vi.fn(),
+      getBootstrapIncarnation: vi.fn(() => undefined),
+      getMaxEntryId: vi.fn(() => 0),
       // The store contract returns the appended row; the fact writer reads its payload back.
       append: vi.fn((input: { sessionId: string; kind: string; payload?: unknown }) => ({
         session_id: input.sessionId,
@@ -1194,6 +1201,8 @@ describe('SessionTranscript', () => {
       sqlitePresenter.getDatabase = vi.fn().mockReturnValue({ transaction })
       sqlitePresenter.deepchatTapeEntriesTable = {
         ensureBootstrapAnchor: vi.fn(),
+        getBootstrapIncarnation: vi.fn(() => undefined),
+        getMaxEntryId: vi.fn(() => 0),
         appendEvent: vi.fn(() => {
           throw new Error('append failed')
         })
@@ -1215,6 +1224,8 @@ describe('SessionTranscript', () => {
       sqlitePresenter.getDatabase = vi.fn().mockReturnValue({ transaction })
       sqlitePresenter.deepchatTapeEntriesTable = {
         ensureBootstrapAnchor: vi.fn(),
+        getBootstrapIncarnation: vi.fn(() => undefined),
+        getMaxEntryId: vi.fn(() => 0),
         appendEvent
       }
       sqlitePresenter.deepchatMessagesTable.get.mockReturnValue(
@@ -1336,6 +1347,8 @@ describe('SessionTranscript', () => {
       sqlitePresenter.getDatabase = vi.fn().mockReturnValue({ transaction })
       sqlitePresenter.deepchatTapeEntriesTable = {
         ensureBootstrapAnchor: vi.fn(),
+        getBootstrapIncarnation: vi.fn(() => undefined),
+        getMaxEntryId: vi.fn(() => 0),
         appendEvent
       }
       sqlitePresenter.deepchatMessagesTable.getBySession.mockReturnValue([

--- a/test/main/session/data/transcript.test.ts
+++ b/test/main/session/data/transcript.test.ts
@@ -21,6 +21,7 @@ function createMockSqlitePresenter() {
     },
     deepchatMessagesTable: {
       insert: vi.fn(),
+      upsert: vi.fn(),
       updateContent: vi.fn(),
       updateStatus: vi.fn(),
       updateMetadata: vi.fn(),
@@ -38,6 +39,7 @@ function createMockSqlitePresenter() {
       getMaxOrderSeq: vi.fn().mockReturnValue(0),
       deleteBySession: vi.fn(),
       delete: vi.fn(),
+      deleteByIds: vi.fn(),
       deleteFromOrderSeq: vi.fn(),
       recoverPendingMessages: vi.fn().mockReturnValue(0)
     },
@@ -99,7 +101,20 @@ function createMockSqlitePresenter() {
     },
     deepchatTapeEntriesTable: {
       ensureBootstrapAnchor: vi.fn(),
-      append: vi.fn(),
+      // The store contract returns the appended row; the fact writer reads its payload back.
+      append: vi.fn((input: { sessionId: string; kind: string; payload?: unknown }) => ({
+        session_id: input.sessionId,
+        entry_id: 1,
+        kind: input.kind,
+        name: null,
+        source_type: null,
+        source_id: null,
+        source_seq: null,
+        provenance_key: null,
+        payload_json: JSON.stringify(input.payload ?? {}),
+        meta_json: '{}',
+        created_at: 0
+      })),
       appendEvent: vi.fn()
     }
   } as any
@@ -158,7 +173,22 @@ describe('SessionTranscript', () => {
       const id = store.createUserMessage('s1', 1, content)
 
       expect(id).toBe('mock-msg-id')
-      expect(sqlitePresenter.deepchatMessagesTable.insert).toHaveBeenCalledWith({
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'mock-msg-id',
+          sessionId: 's1',
+          orderSeq: 1,
+          role: 'user',
+          content: JSON.stringify(content),
+          status: 'sent',
+          metadata: '{}'
+        })
+      )
+      // The fact carries the same record the tables were written from.
+      const appended = sqlitePresenter.deepchatTapeEntriesTable.append.mock.calls.find(
+        ([input]: any[]) => input.kind === 'message'
+      )?.[0]
+      expect(appended?.payload.record).toMatchObject({
         id: 'mock-msg-id',
         sessionId: 's1',
         orderSeq: 1,
@@ -518,18 +548,45 @@ describe('SessionTranscript', () => {
         { type: 'content' as const, content: 'done', status: 'success' as const, timestamp: 1000 }
       ]
       const metadata = '{"totalTokens":100}'
+      sqlitePresenter.deepchatMessagesTable.get.mockReturnValue(
+        createMessageRow({ role: 'assistant', status: 'pending', content: '[]' })
+      )
       store.finalizeAssistantMessage('m1', blocks, metadata)
 
       expect(sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage).toHaveBeenCalledWith(
         'm1',
         blocks
       )
-      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).toHaveBeenCalledWith(
-        'm1',
-        JSON.stringify(blocks),
-        'sent',
-        metadata
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'm1',
+          sessionId: 's1',
+          orderSeq: 1,
+          role: 'assistant',
+          content: JSON.stringify(blocks),
+          status: 'sent',
+          metadata,
+          createdAt: 1000
+        })
       )
+      const appended = sqlitePresenter.deepchatTapeEntriesTable.append.mock.calls.find(
+        ([input]: any[]) => input.kind === 'message'
+      )?.[0]
+      expect(appended?.payload.record).toMatchObject({
+        id: 'm1',
+        content: JSON.stringify(blocks),
+        status: 'sent',
+        metadata
+      })
+    })
+
+    it('leaves nothing behind when the pending row no longer exists', () => {
+      sqlitePresenter.deepchatMessagesTable.get.mockReturnValue(undefined)
+      store.finalizeAssistantMessage('m1', [], '{}')
+
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatTapeEntriesTable.append).not.toHaveBeenCalled()
     })
 
     it('persists usage stats for assistant messages with usage metadata', () => {
@@ -615,16 +672,28 @@ describe('SessionTranscript', () => {
       const blocks = [
         { type: 'error' as const, content: 'failed', status: 'error' as const, timestamp: 1000 }
       ]
+      sqlitePresenter.deepchatMessagesTable.get.mockReturnValue(
+        createMessageRow({
+          role: 'assistant',
+          status: 'pending',
+          content: '[]',
+          metadata: '{"provider":"kept"}'
+        })
+      )
       store.setMessageError('m1', blocks)
 
       expect(sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage).toHaveBeenCalledWith(
         'm1',
         blocks
       )
-      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).toHaveBeenCalledWith(
-        'm1',
-        JSON.stringify(blocks),
-        'error'
+      // Without new metadata the row keeps what it had.
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'm1',
+          content: JSON.stringify(blocks),
+          status: 'error',
+          metadata: '{"provider":"kept"}'
+        })
       )
     })
 
@@ -633,17 +702,99 @@ describe('SessionTranscript', () => {
         { type: 'error' as const, content: 'failed', status: 'error' as const, timestamp: 1000 }
       ]
       const metadata = '{"provider":"openai","model":"gpt-4"}'
+      sqlitePresenter.deepchatMessagesTable.get.mockReturnValue(
+        createMessageRow({ role: 'assistant', status: 'pending', content: '[]' })
+      )
       store.setMessageError('m1', blocks, metadata)
 
       expect(sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage).toHaveBeenCalledWith(
         'm1',
         blocks
       )
-      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).toHaveBeenCalledWith(
-        'm1',
-        JSON.stringify(blocks),
-        'error',
-        metadata
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'm1',
+          content: JSON.stringify(blocks),
+          status: 'error',
+          metadata
+        })
+      )
+    })
+  })
+
+  describe('restoreUserMessage', () => {
+    it('re-sends a failed prompt through a replacement fact and the same record', () => {
+      sqlitePresenter.deepchatMessagesTable.get.mockReturnValue(
+        createMessageRow({ status: 'error', updated_at: 2000 })
+      )
+      sqlitePresenter.deepchatUserMessagesTable.get.mockReturnValue({
+        message_id: 'm1',
+        text: 'hello',
+        search_enabled: 0,
+        think_enabled: 0
+      })
+      const now = vi.spyOn(Date, 'now').mockReturnValue(5000)
+      try {
+        store.restoreUserMessage('m1')
+      } finally {
+        now.mockRestore()
+      }
+
+      const replacement = sqlitePresenter.deepchatTapeEntriesTable.append.mock.calls.find(
+        ([input]: any[]) => input.kind === 'message'
+      )?.[0]
+      expect(replacement).toMatchObject({
+        provenanceKey: 'message:m1:revision:5000',
+        meta: expect.objectContaining({ correction: true, reason: 'retry_restored_prompt' })
+      })
+      expect(replacement.payload.record).toMatchObject({
+        id: 'm1',
+        status: 'sent',
+        updatedAt: 5000
+      })
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'm1', status: 'sent', updatedAt: 5000 })
+      )
+    })
+
+    it('leaves a prompt that is already sent alone', () => {
+      sqlitePresenter.deepchatMessagesTable.get.mockReturnValue(
+        createMessageRow({ status: 'sent' })
+      )
+      store.restoreUserMessage('m1')
+
+      expect(sqlitePresenter.deepchatTapeEntriesTable.append).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('importMessageRow', () => {
+    it('turns a legacy row into a message fact and its projection with the row times', () => {
+      store.importMessageRow(
+        createMessageRow({
+          id: 'legacy-1',
+          content: '{"text":"old chat"}',
+          created_at: 111,
+          updated_at: 222
+        })
+      )
+
+      const fact = sqlitePresenter.deepchatTapeEntriesTable.append.mock.calls.find(
+        ([input]: any[]) => input.kind === 'message'
+      )?.[0]
+      expect(fact.payload.record).toMatchObject({
+        id: 'legacy-1',
+        role: 'user',
+        status: 'sent',
+        createdAt: 111,
+        updatedAt: 222
+      })
+      expect(JSON.parse(fact.payload.record.content)).toMatchObject({ text: 'old chat' })
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'legacy-1', createdAt: 111, updatedAt: 222 })
+      )
+      expect(sqlitePresenter.deepchatUserMessagesTable.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ messageId: 'legacy-1', text: 'old chat' })
       )
     })
   })
@@ -965,16 +1116,22 @@ describe('SessionTranscript', () => {
       ])
 
       expect(store.cloneSentMessagesToSession('source', 'fork', 3)).toBe(2)
-      expect(sqlitePresenter.deepchatMessagesTable.insert).toHaveBeenCalledTimes(2)
-      expect(sqlitePresenter.deepchatMessagesTable.insert.mock.calls).toEqual([
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledTimes(2)
+      expect(sqlitePresenter.deepchatMessagesTable.upsert.mock.calls).toEqual([
         [expect.objectContaining({ sessionId: 'fork', orderSeq: 1, role: 'user' })],
         [expect.objectContaining({ sessionId: 'fork', orderSeq: 2, role: 'assistant' })]
       ])
-      expect(sqlitePresenter.deepchatMessagesTable.insert).not.toHaveBeenCalledWith(
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).not.toHaveBeenCalledWith(
         expect.objectContaining({
           metadata: expect.stringContaining('source-attempt')
         })
       )
+      // Each forked row is a message fact in the fork's own Tape, not a later backfill.
+      const forkedFacts = sqlitePresenter.deepchatTapeEntriesTable.append.mock.calls
+        .map(([input]: any[]) => input)
+        .filter((input: any) => input.kind === 'message')
+      expect(forkedFacts.map((input: any) => input.payload.record.orderSeq)).toEqual([1, 2])
+      expect(forkedFacts.every((input: any) => input.sessionId === 'fork')).toBe(true)
     })
   })
 
@@ -1008,18 +1165,28 @@ describe('SessionTranscript', () => {
     it('deletes traces and search results before removing the message', () => {
       store.deleteMessage('m1')
 
-      expect(sqlitePresenter.deepchatSearchDocumentsTable.delete).toHaveBeenCalledWith('message:m1')
-      expect(sqlitePresenter.deepchatAssistantBlocksTable.delete).toHaveBeenCalledWith('m1')
-      expect(sqlitePresenter.deepchatUserMessageLinksTable.delete).toHaveBeenCalledWith('m1')
-      expect(sqlitePresenter.deepchatUserMessageFilesTable.delete).toHaveBeenCalledWith('m1')
-      expect(sqlitePresenter.deepchatUserMessagesTable.delete).toHaveBeenCalledWith('m1')
+      expect(sqlitePresenter.deepchatSearchDocumentsTable.deleteByMessageIds).toHaveBeenCalledWith([
+        'm1'
+      ])
+      expect(sqlitePresenter.deepchatAssistantBlocksTable.deleteByMessageIds).toHaveBeenCalledWith([
+        'm1'
+      ])
+      expect(sqlitePresenter.deepchatUserMessageLinksTable.deleteByMessageIds).toHaveBeenCalledWith(
+        ['m1']
+      )
+      expect(sqlitePresenter.deepchatUserMessageFilesTable.deleteByMessageIds).toHaveBeenCalledWith(
+        ['m1']
+      )
+      expect(sqlitePresenter.deepchatUserMessagesTable.deleteByMessageIds).toHaveBeenCalledWith([
+        'm1'
+      ])
       expect(sqlitePresenter.deepchatMessageTracesTable.deleteByMessageIds).toHaveBeenCalledWith([
         'm1'
       ])
       expect(
         sqlitePresenter.deepchatMessageSearchResultsTable.deleteByMessageIds
       ).toHaveBeenCalledWith(['m1'])
-      expect(sqlitePresenter.deepchatMessagesTable.delete).toHaveBeenCalledWith('m1')
+      expect(sqlitePresenter.deepchatMessagesTable.deleteByIds).toHaveBeenCalledWith(['m1'])
     })
 
     it('does not delete rows when tape retraction append fails inside transaction', () => {
@@ -1036,8 +1203,8 @@ describe('SessionTranscript', () => {
       expect(() => store.deleteMessage('m1')).toThrow('append failed')
 
       expect(transaction).toHaveBeenCalled()
-      expect(sqlitePresenter.deepchatMessagesTable.delete).not.toHaveBeenCalled()
-      expect(sqlitePresenter.deepchatSearchDocumentsTable.delete).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatMessagesTable.deleteByIds).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatSearchDocumentsTable.deleteByMessageIds).not.toHaveBeenCalled()
     })
   })
 
@@ -1064,28 +1231,35 @@ describe('SessionTranscript', () => {
         })
       )
 
-      store.updateCompactionMessage('compaction-message', 'compacted', 2000, {
-        compactionAttemptId: 'compaction-attempt-1',
-        boundaryReason: 'summary_unavailable'
-      })
+      const now = vi.spyOn(Date, 'now').mockReturnValue(4000)
+      try {
+        store.updateCompactionMessage('compaction-message', 'compacted', 2000, {
+          compactionAttemptId: 'compaction-attempt-1',
+          boundaryReason: 'summary_unavailable'
+        })
+      } finally {
+        now.mockRestore()
+      }
 
       expect(transaction).toHaveBeenCalled()
-      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).toHaveBeenCalledWith(
-        'compaction-message',
-        expect.any(String),
-        'sent',
-        JSON.stringify({
-          messageType: 'compaction',
-          compactionStatus: 'compacted',
-          compactionAttemptId: 'compaction-attempt-1',
-          compactionBoundaryReason: 'summary_unavailable',
-          summaryUpdatedAt: 2000
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'compaction-message',
+          status: 'sent',
+          updatedAt: 4000,
+          metadata: JSON.stringify({
+            messageType: 'compaction',
+            compactionStatus: 'compacted',
+            compactionAttemptId: 'compaction-attempt-1',
+            compactionBoundaryReason: 'summary_unavailable',
+            summaryUpdatedAt: 2000
+          })
         })
       )
       expect(appendEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'message/compaction_indicator',
-          provenanceKey: 'message:compaction-message:compaction_indicator:compacted:3000',
+          provenanceKey: 'message:compaction-message:compaction_indicator:compacted:4000',
           data: expect.objectContaining({
             status: 'compacted'
           })
@@ -1126,6 +1300,7 @@ describe('SessionTranscript', () => {
         'm2',
         'm3'
       ])
+      expect(sqlitePresenter.deepchatMessagesTable.deleteByIds).toHaveBeenCalledWith(['m2', 'm3'])
       expect(sqlitePresenter.deepchatMessagesTable.deleteFromOrderSeq).toHaveBeenCalledWith('s1', 2)
     })
 
@@ -1146,6 +1321,7 @@ describe('SessionTranscript', () => {
       ).not.toHaveBeenCalled()
       expect(sqlitePresenter.deepchatUserMessagesTable.deleteByMessageIds).not.toHaveBeenCalled()
       expect(sqlitePresenter.deepchatMessageTracesTable.deleteByMessageIds).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatMessagesTable.deleteByIds).not.toHaveBeenCalled()
       expect(sqlitePresenter.deepchatMessagesTable.deleteFromOrderSeq).toHaveBeenCalledWith('s1', 2)
     })
 
@@ -1172,6 +1348,7 @@ describe('SessionTranscript', () => {
 
       expect(transaction).toHaveBeenCalledOnce()
       expect(appendEvent).toHaveBeenCalledTimes(2)
+      expect(sqlitePresenter.deepchatMessagesTable.deleteByIds).not.toHaveBeenCalled()
       expect(sqlitePresenter.deepchatMessagesTable.deleteFromOrderSeq).not.toHaveBeenCalled()
       expect(sqlitePresenter.deepchatSearchDocumentsTable.deleteByMessageIds).not.toHaveBeenCalled()
       expect(sqlitePresenter.deepchatMessageTracesTable.deleteByMessageIds).not.toHaveBeenCalled()
@@ -1286,17 +1463,18 @@ describe('SessionTranscript', () => {
       ])
 
       expect(store.recoverPendingMessages()).toBe(1)
-      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).not.toHaveBeenCalledWith(
-        'm1',
-        expect.anything(),
-        expect.anything()
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).not.toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'm1' })
       )
       expect(sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage).toHaveBeenCalledWith(
         'm2',
         expect.any(Array)
       )
-      const [messageId, contentJson, status] =
-        sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls[0]
+      const {
+        id: messageId,
+        content: contentJson,
+        status
+      } = sqlitePresenter.deepchatMessagesTable.upsert.mock.calls[0][0]
       expect(messageId).toBe('m2')
       expect(status).toBe('error')
       expect(JSON.parse(contentJson)).toEqual([
@@ -1341,7 +1519,7 @@ describe('SessionTranscript', () => {
       ])
 
       expect(store.recoverPendingMessages()).toBe(0)
-      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).not.toHaveBeenCalled()
     })
 
     it('does not let interactionResolution drop a still-pending action', () => {
@@ -1371,7 +1549,7 @@ describe('SessionTranscript', () => {
       ])
 
       expect(store.recoverPendingMessages()).toBe(0)
-      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).not.toHaveBeenCalled()
     })
 
     it('does not keep an interaction after its pending action is settled', () => {
@@ -1400,10 +1578,8 @@ describe('SessionTranscript', () => {
       ])
 
       expect(store.recoverPendingMessages()).toBe(1)
-      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).toHaveBeenCalledWith(
-        'm1',
-        expect.any(String),
-        'error'
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'm1', status: 'error' })
       )
     })
 
@@ -1431,10 +1607,8 @@ describe('SessionTranscript', () => {
           forceRecoverMessagesBySession: new Map([['s1', new Set(['m1'])]])
         })
       ).toBe(1)
-      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).toHaveBeenCalledWith(
-        'm1',
-        expect.any(String),
-        'error'
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'm1', status: 'error' })
       )
     })
 
@@ -1462,7 +1636,7 @@ describe('SessionTranscript', () => {
           forceRecoverMessagesBySession: new Map([['s1', new Set(['m1'])]])
         })
       ).toBe(0)
-      expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).not.toHaveBeenCalled()
+      expect(sqlitePresenter.deepchatMessagesTable.upsert).not.toHaveBeenCalled()
     })
 
     it('adds an explicit error block when pending assistant content is empty', () => {
@@ -1480,8 +1654,11 @@ describe('SessionTranscript', () => {
         'm3',
         expect.any(Array)
       )
-      const [messageId, contentJson, status] =
-        sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls[0]
+      const {
+        id: messageId,
+        content: contentJson,
+        status
+      } = sqlitePresenter.deepchatMessagesTable.upsert.mock.calls[0][0]
       expect(messageId).toBe('m3')
       expect(status).toBe('error')
       expect(JSON.parse(contentJson)).toEqual([

--- a/test/main/session/data/transcript.test.ts
+++ b/test/main/session/data/transcript.test.ts
@@ -562,7 +562,8 @@ describe('SessionTranscript', () => {
 
       expect(sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage).toHaveBeenCalledWith(
         'm1',
-        blocks
+        blocks,
+        expect.any(Number)
       )
       expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -691,7 +692,8 @@ describe('SessionTranscript', () => {
 
       expect(sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage).toHaveBeenCalledWith(
         'm1',
-        blocks
+        blocks,
+        expect.any(Number)
       )
       // Without new metadata the row keeps what it had.
       expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
@@ -716,7 +718,8 @@ describe('SessionTranscript', () => {
 
       expect(sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage).toHaveBeenCalledWith(
         'm1',
-        blocks
+        blocks,
+        expect.any(Number)
       )
       expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1502,7 +1505,8 @@ describe('SessionTranscript', () => {
       )
       expect(sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage).toHaveBeenCalledWith(
         'm2',
-        expect.any(Array)
+        expect.any(Array),
+        expect.any(Number)
       )
       const {
         id: messageId,
@@ -1686,7 +1690,8 @@ describe('SessionTranscript', () => {
       expect(store.recoverPendingMessages()).toBe(1)
       expect(sqlitePresenter.deepchatAssistantBlocksTable.replaceForMessage).toHaveBeenCalledWith(
         'm3',
-        expect.any(Array)
+        expect.any(Array),
+        expect.any(Number)
       )
       const {
         id: messageId,

--- a/test/main/session/data/transcript.test.ts
+++ b/test/main/session/data/transcript.test.ts
@@ -1140,6 +1140,27 @@ describe('SessionTranscript', () => {
       expect(forkedFacts.map((input: any) => input.payload.record.orderSeq)).toEqual([1, 2])
       expect(forkedFacts.every((input: any) => input.sessionId === 'fork')).toBe(true)
     })
+
+    it('does not count the copied assistant usage a second time', () => {
+      sqlitePresenter.deepchatSessionsTable.get.mockReturnValue({
+        provider_id: 'openai',
+        model_id: 'gpt-4o'
+      })
+      sqlitePresenter.deepchatMessagesTable.getBySessionUpToOrderSeq.mockReturnValue([
+        createMessageRow({ id: 'user-1', order_seq: 1 }),
+        createMessageRow({
+          id: 'assistant-1',
+          order_seq: 2,
+          role: 'assistant',
+          content: '[]',
+          metadata: JSON.stringify({ inputTokens: 120, outputTokens: 30, totalTokens: 150 })
+        })
+      ])
+
+      store.cloneSentMessagesToSession('source', 'fork', 2)
+
+      expect(sqlitePresenter.deepchatUsageStatsTable.upsert).not.toHaveBeenCalled()
+    })
   })
 
   describe('deleteBySession', () => {

--- a/test/main/session/data/transcriptAtomicity.test.ts
+++ b/test/main/session/data/transcriptAtomicity.test.ts
@@ -53,7 +53,8 @@ describeIfSqlite('SessionTranscript keeps transcript and Tape writes atomic', ()
       appendMessageRecord: failing(tape.appendMessageRecord.bind(tape)),
       appendMessageReplacement: failing(tape.appendMessageReplacement.bind(tape)),
       appendMessageRetraction: failing(tape.appendMessageRetraction.bind(tape)),
-      appendCompactionModelCall: failing(tape.appendCompactionModelCall.bind(tape))
+      appendCompactionModelCall: failing(tape.appendCompactionModelCall.bind(tape)),
+      getProjectionHead: tape.getProjectionHead.bind(tape)
     }
     const transcript = new SessionTranscriptCtor(database, tapeFacts)
     return {

--- a/test/main/session/data/transcriptProjection.test.ts
+++ b/test/main/session/data/transcriptProjection.test.ts
@@ -77,7 +77,7 @@ describeIfSqlite('SessionTranscript follows the Tape through the projection curs
   })
 
   it('materializes message facts that reached the Tape behind the transcript', () => {
-    const { connection, tape, transcript, cursor, head } = createSession()
+    const { connection, database, tape, transcript, cursor, head } = createSession()
     try {
       const userId = transcript.createUserMessage('s1', 1, userContent)
       tape.ensureSessionTapeReady('s1', transcript)
@@ -116,6 +116,26 @@ describeIfSqlite('SessionTranscript follows the Tape through the projection curs
       tape.ensureSessionTapeReady('s1', transcript)
       expect(transcript.getMessage(userId)).toBeNull()
       expect(transcript.getMessages('s1').map((record) => record.id)).toEqual(['direct-1'])
+
+      // Without a cursor the backfill branch runs; a fact the transcript never held still lands,
+      // and a block that carries no timestamp reports the record's time, not the replay's.
+      database.deepchatTranscriptProjectionMetaTable.delete('s1')
+      tape.appendMessageRecord({
+        ...direct,
+        id: 'direct-2',
+        orderSeq: 3,
+        content: JSON.stringify([{ type: 'content', content: 'later', status: 'success' }]),
+        createdAt: 600,
+        updatedAt: 600
+      })
+      const ready = tape.ensureSessionTapeReady('s1', transcript)
+      expect(ready.historyRecords.map((record) => record.id)).toEqual(['direct-1', 'direct-2'])
+      expect(transcript.getMessages('s1').map((record) => record.id)).toEqual([
+        'direct-1',
+        'direct-2'
+      ])
+      expect(JSON.parse(transcript.getMessage('direct-2')!.content)[0].timestamp).toBe(600)
+      expect(cursor()).toEqual(head())
     } finally {
       connection.close()
     }
@@ -156,6 +176,31 @@ describeIfSqlite('SessionTranscript follows the Tape through the projection curs
 
       const again = tape.ensureSessionTapeReady('s1', transcript)
       expect(again.appendedFactCount).toBe(0)
+    } finally {
+      connection.close()
+    }
+  })
+
+  it('refuses to move a message row to another Session on an id collision', () => {
+    const { connection, database, transcript } = createSession()
+    try {
+      const id = transcript.createUserMessage('s1', 1, userContent)
+      const row = database.deepchatMessagesTable.get(id)!
+      expect(() =>
+        database.deepchatMessagesTable.upsert({
+          id,
+          sessionId: 's2',
+          orderSeq: 1,
+          role: 'user',
+          content: row.content,
+          status: 'sent',
+          isContextEdge: 0,
+          metadata: '{}',
+          createdAt: row.created_at,
+          updatedAt: row.updated_at
+        })
+      ).toThrow('belongs to another session')
+      expect(database.deepchatMessagesTable.get(id)?.session_id).toBe('s1')
     } finally {
       connection.close()
     }

--- a/test/main/session/data/transcriptProjection.test.ts
+++ b/test/main/session/data/transcriptProjection.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AssistantMessageBlock, ChatMessageRecord } from '@shared/types/agent-interface'
+
+const sqliteModule = await import('better-sqlite3-multiple-ciphers').catch(() => null)
+const mainDatabaseModule = sqliteModule ? await import('@/data/mainDatabase') : null
+const sessionDatabaseModule = sqliteModule ? await import('@/session/data/database') : null
+const sessionTapeModule = sqliteModule ? await import('@/tape/application/sessionTape') : null
+const transcriptModule = sqliteModule ? await import('@/session/data/transcript') : null
+
+const Database = sqliteModule?.default
+const MainDatabaseCtor = mainDatabaseModule?.MainDatabase!
+const SessionDatabaseCtor = sessionDatabaseModule?.SessionDatabase!
+const SessionTapeCtor = sessionTapeModule?.SessionTape!
+const SessionTranscriptCtor = transcriptModule?.SessionTranscript!
+
+let sqliteAvailable = false
+if (Database) {
+  try {
+    new Database(':memory:').close()
+    sqliteAvailable = true
+  } catch {
+    sqliteAvailable = false
+  }
+}
+
+// CI rebuilds the native module for the Node ABI and sets this flag; a silent skip there would
+// hide a regression, so an unavailable module must fail the suite instead of skipping it.
+const describeIfSqlite =
+  sqliteAvailable || process.env.DEEPCHAT_REQUIRE_NATIVE_SQLITE === '1' ? describe : describe.skip
+
+const userContent = { text: 'hello', files: [], links: [], search: false, think: false }
+const blocks: AssistantMessageBlock[] = [
+  { type: 'content', content: 'done', status: 'success', timestamp: 1 }
+]
+
+/**
+ * The transcript is a projection of the Session's message facts: terminal writes append the fact
+ * and derive the tables from it, readiness only replays what reached the Tape past the cursor,
+ * and a Session that predates the cursor is backfilled from its transcript exactly once.
+ */
+describeIfSqlite('SessionTranscript follows the Tape through the projection cursor', () => {
+  function createSession() {
+    const connection = new MainDatabaseCtor(':memory:')
+    const database = new SessionDatabaseCtor(connection)
+    const tape = new SessionTapeCtor(database)
+    const transcript = new SessionTranscriptCtor(database, tape)
+    const head = () => tape.getProjectionHead('s1')
+    const cursor = () => database.deepchatTranscriptProjectionMetaTable.get('s1')
+    return { connection, database, tape, transcript, head, cursor }
+  }
+
+  it('establishes the cursor through readiness and moves it with every terminal write', () => {
+    const { connection, tape, transcript, head, cursor } = createSession()
+    try {
+      const getMessages = vi.spyOn(transcript, 'getMessages')
+      transcript.createUserMessage('s1', 1, userContent)
+      // A write before the first readiness check appends its fact but does not invent a cursor.
+      expect(cursor()).toBeNull()
+
+      const first = tape.ensureSessionTapeReady('s1', transcript)
+      expect(first.historyRecords.map((record) => record.orderSeq)).toEqual([1])
+      expect(cursor()).toEqual(head())
+      expect(getMessages).toHaveBeenCalledTimes(1)
+
+      const assistantId = transcript.createAssistantMessage('s1', 2)
+      transcript.finalizeAssistantMessage(assistantId, blocks, '{}')
+      expect(cursor()).toEqual(head())
+
+      const second = tape.ensureSessionTapeReady('s1', transcript)
+      expect(second.appendedFactCount).toBe(0)
+      expect(second.historyRecords.map((record) => record.orderSeq)).toEqual([1, 2])
+      // Readiness did not have to read the transcript again.
+      expect(getMessages).toHaveBeenCalledTimes(1)
+    } finally {
+      connection.close()
+    }
+  })
+
+  it('materializes message facts that reached the Tape behind the transcript', () => {
+    const { connection, tape, transcript, cursor, head } = createSession()
+    try {
+      const userId = transcript.createUserMessage('s1', 1, userContent)
+      tape.ensureSessionTapeReady('s1', transcript)
+
+      const direct: ChatMessageRecord = {
+        id: 'direct-1',
+        sessionId: 's1',
+        orderSeq: 2,
+        role: 'assistant',
+        content: JSON.stringify(blocks),
+        status: 'sent',
+        isContextEdge: 0,
+        metadata: '{}',
+        traceCount: 0,
+        createdAt: 500,
+        updatedAt: 500
+      }
+      tape.appendMessageRecord(direct)
+      expect(transcript.getMessage('direct-1')).toBeNull()
+
+      tape.ensureSessionTapeReady('s1', transcript)
+      expect(transcript.getMessage('direct-1')).toMatchObject({
+        id: 'direct-1',
+        role: 'assistant',
+        orderSeq: 2,
+        status: 'sent',
+        createdAt: 500,
+        updatedAt: 500
+      })
+      expect(JSON.parse(transcript.getMessage('direct-1')!.content)).toMatchObject([
+        { type: 'content', content: 'done', status: 'success', timestamp: 1 }
+      ])
+      expect(cursor()).toEqual(head())
+
+      tape.appendMessageRetraction(transcript.getMessage(userId)!, 'test_delete')
+      tape.ensureSessionTapeReady('s1', transcript)
+      expect(transcript.getMessage(userId)).toBeNull()
+      expect(transcript.getMessages('s1').map((record) => record.id)).toEqual(['direct-1'])
+    } finally {
+      connection.close()
+    }
+  })
+
+  it('backfills a Session written before the projection existed without deleting any row', () => {
+    const { connection, database, tape, transcript, cursor } = createSession()
+    try {
+      // Rows from an earlier version: transcript only, no facts, no cursor.
+      for (const [orderSeq, role] of [
+        [1, 'user'],
+        [2, 'assistant'],
+        [3, 'user']
+      ] as const) {
+        database.deepchatMessagesTable.insert({
+          id: `legacy-${orderSeq}`,
+          sessionId: 's1',
+          orderSeq,
+          role,
+          content: role === 'user' ? JSON.stringify(userContent) : JSON.stringify(blocks),
+          status: 'sent'
+        })
+      }
+
+      // A deletion before the first readiness check appends its retraction but leaves the cursor
+      // unset, so the remaining rows still get their one-time backfill.
+      transcript.deleteMessage('legacy-3')
+      expect(cursor()).toBeNull()
+
+      const ready = tape.ensureSessionTapeReady('s1', transcript)
+      expect(ready.appendedFactCount).toBe(2)
+      expect(ready.historyRecords.map((record) => record.id)).toEqual(['legacy-1', 'legacy-2'])
+      expect(transcript.getMessages('s1').map((record) => record.id)).toEqual([
+        'legacy-1',
+        'legacy-2'
+      ])
+      expect(cursor()).not.toBeNull()
+
+      const again = tape.ensureSessionTapeReady('s1', transcript)
+      expect(again.appendedFactCount).toBe(0)
+    } finally {
+      connection.close()
+    }
+  })
+
+  it('drops the cursor with the Session transcript and rebuilds it after a Tape reset', () => {
+    const { connection, database, tape, transcript, cursor, head } = createSession()
+    try {
+      transcript.createUserMessage('s1', 1, userContent)
+      tape.ensureSessionTapeReady('s1', transcript)
+      const before = cursor()!
+
+      // clearMessages deletes the transcript rows and the cursor in one transaction.
+      database.getDatabase().transaction(() => {
+        transcript.deleteBySession('s1')
+        tape.resetSessionTape('s1')
+      })()
+      expect(cursor()).toBeNull()
+
+      transcript.createUserMessage('s1', 1, { ...userContent, text: 'after reset' })
+      const ready = tape.ensureSessionTapeReady('s1', transcript)
+      expect(ready.historyRecords).toHaveLength(1)
+      expect(JSON.parse(ready.historyRecords[0].content).text).toBe('after reset')
+      expect(cursor()).toEqual(head())
+      expect(cursor()!.tapeIncarnationId).not.toBe(before.tapeIncarnationId)
+    } finally {
+      connection.close()
+    }
+  })
+})

--- a/test/main/session/runtimeIntegration.test.ts
+++ b/test/main/session/runtimeIntegration.test.ts
@@ -187,6 +187,14 @@ function createMockSqlitePresenter() {
         (entry) => entry.session_id === sessionId && isEffectiveMessageInputRow(entry)
       )
     ),
+    getEffectiveMessageInputRowsAfter: vi.fn((sessionId: string, afterEntryId: number) =>
+      tapeEntries.filter(
+        (entry) =>
+          entry.session_id === sessionId &&
+          entry.entry_id > afterEntryId &&
+          isEffectiveMessageInputRow(entry)
+      )
+    ),
     getByEntryIds: vi.fn((sessionId: string, entryIds: readonly number[]) => {
       const requestedIds = new Set(entryIds)
       return tapeEntries.filter(
@@ -824,6 +832,20 @@ function createMockSqlitePresenter() {
     deepchatTapeEntriesTable: tapeTable,
     deepchatExecutionJournalStore: tapeTable,
     tapeLifecycle: tapeTable,
+    deepchatTranscriptProjectionMetaTable: (() => {
+      const cursors = new Map<string, { tapeIncarnationId: string; maxEntryId: number }>()
+      return {
+        get: vi.fn((sessionId: string) => cursors.get(sessionId) ?? null),
+        upsert: vi.fn(
+          (sessionId: string, cursor: { tapeIncarnationId: string; maxEntryId: number }) => {
+            cursors.set(sessionId, { ...cursor })
+          }
+        ),
+        delete: vi.fn((sessionId: string) => {
+          cursors.delete(sessionId)
+        })
+      }
+    })(),
     deepchatTapeSearchProjectionTable: {
       deleteBySession: vi.fn(),
       isCurrent: vi.fn().mockReturnValue(false),

--- a/test/main/session/runtimeIntegration.test.ts
+++ b/test/main/session/runtimeIntegration.test.ts
@@ -71,6 +71,12 @@ function createMockSqlitePresenter() {
   let tapeIncarnationSequence = 0
   let messagesList: any[] = []
 
+  const sessionMaxEntryId = (sessionId: string) =>
+    tapeEntries.reduce(
+      (maxEntryId, entry) =>
+        entry.session_id === sessionId ? Math.max(maxEntryId, entry.entry_id) : maxEntryId,
+      0
+    )
   const tapeTable = {
     runInTransaction: vi.fn((operation: () => unknown) => operation()),
     isInTransaction: vi.fn(() => false),
@@ -99,9 +105,10 @@ function createMockSqlitePresenter() {
         )
         if (existing) return existing
       }
+      // Entry ids are per Session, like the store: the Session's current maximum plus one.
       const row = {
         session_id: input.sessionId,
-        entry_id: tapeEntries.length + 1,
+        entry_id: sessionMaxEntryId(input.sessionId) + 1,
         kind: input.kind,
         name: input.name ?? null,
         source_type: input.source?.type ?? null,
@@ -249,9 +256,7 @@ function createMockSqlitePresenter() {
             .map((entry) => entry.source_seq)
         )
     ),
-    getMaxEntryId: vi.fn(
-      (sessionId: string) => tapeEntries.filter((entry) => entry.session_id === sessionId).length
-    ),
+    getMaxEntryId: vi.fn((sessionId: string) => sessionMaxEntryId(sessionId)),
     getLatestAnchor: vi.fn().mockReturnValue(undefined),
     getLatestSummaryAnchor: vi.fn().mockReturnValue(undefined),
     getLatestReconstructionAnchor: vi.fn().mockReturnValue(undefined),

--- a/test/main/session/runtimeIntegration.test.ts
+++ b/test/main/session/runtimeIntegration.test.ts
@@ -550,6 +550,24 @@ function createMockSqlitePresenter() {
         messagesStore.set(row.id, record)
         messagesList.push(record)
       }),
+      upsert: vi.fn((row: any) => {
+        const existing = messagesStore.get(row.id)
+        const record = {
+          ...row,
+          session_id: row.sessionId,
+          order_seq: row.orderSeq,
+          is_context_edge: row.isContextEdge,
+          metadata: row.metadata,
+          created_at: row.createdAt,
+          updated_at: row.updatedAt
+        }
+        if (existing) {
+          Object.assign(existing, record)
+          return
+        }
+        messagesStore.set(row.id, record)
+        messagesList.push(record)
+      }),
       updateContent: vi.fn((id: string, content: string) => {
         const msg = messagesStore.get(id)
         if (msg) msg.content = content
@@ -629,6 +647,10 @@ function createMockSqlitePresenter() {
       delete: vi.fn((id: string) => {
         messagesStore.delete(id)
         messagesList = messagesList.filter((item) => item.id !== id)
+      }),
+      deleteByIds: vi.fn((ids: string[]) => {
+        for (const id of ids) messagesStore.delete(id)
+        messagesList = messagesList.filter((item) => !ids.includes(item.id))
       }),
       deleteFromOrderSeq: vi.fn((sessionId: string, fromOrderSeq: number) => {
         const idsToDelete = messagesList
@@ -1134,21 +1156,24 @@ describe('Integration: createSession end-to-end', () => {
       })
     )
 
-    // 3. Messages created (user + assistant)
-    expect(sqlitePresenter.deepchatMessagesTable.insert).toHaveBeenCalledTimes(2)
-
-    const userInsert = sqlitePresenter.deepchatMessagesTable.insert.mock.calls[0][0]
-    expect(userInsert.role).toBe('user')
+    // 3. Messages created: the user prompt is a terminal record, the assistant a pending shell
+    const userInsert = sqlitePresenter.deepchatMessagesTable.upsert.mock.calls
+      .map(([row]: any[]) => row)
+      .find((row: any) => row.role === 'user')
+    expect(userInsert).toBeTruthy()
     const userContent = JSON.parse(userInsert.content)
     expect(userContent.text).toBe('Tell me a joke')
     expect(userContent.files).toHaveLength(1)
 
-    const assistantInsert = sqlitePresenter.deepchatMessagesTable.insert.mock.calls[1][0]
+    expect(sqlitePresenter.deepchatMessagesTable.insert).toHaveBeenCalledTimes(1)
+    const assistantInsert = sqlitePresenter.deepchatMessagesTable.insert.mock.calls[0][0]
     expect(assistantInsert.role).toBe('assistant')
     expect(assistantInsert.status).toBe('pending')
 
     // 4. Assistant message finalized with content
-    expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).toHaveBeenCalled()
+    expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'assistant', status: 'sent' })
+    )
 
     // 5. Typed events emitted with conversationId
     const activatedCalls = publishDeepchatEventMock.mock.calls.filter(
@@ -2046,9 +2071,12 @@ describe('Integration: crash recovery', () => {
     })
 
     expect(sqlitePresenter.deepchatMessagesTable.getByStatus).toHaveBeenCalledWith('pending')
-    expect(sqlitePresenter.deepchatMessagesTable.updateContentAndStatus).toHaveBeenCalledTimes(2)
-    const [messageId, contentJson, status] =
-      sqlitePresenter.deepchatMessagesTable.updateContentAndStatus.mock.calls[0]
+    expect(sqlitePresenter.deepchatMessagesTable.upsert).toHaveBeenCalledTimes(2)
+    const {
+      id: messageId,
+      content: contentJson,
+      status
+    } = sqlitePresenter.deepchatMessagesTable.upsert.mock.calls[0][0]
     expect(messageId).toBe('m1')
     expect(status).toBe('error')
     expect(JSON.parse(contentJson)).toEqual([

--- a/test/main/session/transcriptMutations.test.ts
+++ b/test/main/session/transcriptMutations.test.ts
@@ -17,7 +17,7 @@ describe('SessionTranscriptMutations', () => {
     }
     const transcript = {
       getMessage: vi.fn(() => message),
-      updateMessageStatus: vi.fn()
+      restoreUserMessage: vi.fn()
     }
     const mutations = new SessionTranscriptMutations({
       transcript,
@@ -36,7 +36,7 @@ describe('SessionTranscriptMutations', () => {
     })
     // The failed Steer prompt is kept as the pre-stream anchor, so it must be
     // restored to 'sent' to remain visible to context history filtering.
-    expect(transcript.updateMessageStatus).toHaveBeenCalledWith('steer-1', 'sent')
+    expect(transcript.restoreUserMessage).toHaveBeenCalledWith('steer-1')
   })
 
   it('keeps the user prompt in place when retrying a user message directly', async () => {

--- a/test/main/session/usageStatsService.test.ts
+++ b/test/main/session/usageStatsService.test.ts
@@ -217,6 +217,32 @@ function createMockSqlitePresenter() {
     get(messageId: string) {
       return messages.get(messageId)
     },
+    upsert(input: {
+      id: string
+      sessionId: string
+      orderSeq: number
+      role: MessageRow['role']
+      content: string
+      status: MessageRow['status']
+      isContextEdge: number
+      metadata: string
+      createdAt: number
+      updatedAt: number
+    }) {
+      messages.set(input.id, {
+        id: input.id,
+        session_id: input.sessionId,
+        order_seq: input.orderSeq,
+        role: input.role,
+        content: input.content,
+        status: input.status,
+        metadata: input.metadata,
+        is_context_edge: input.isContextEdge,
+        trace_count: 0,
+        created_at: input.createdAt,
+        updated_at: input.updatedAt
+      })
+    },
     updateContentAndStatus(
       messageId: string,
       content: string,

--- a/test/main/session/usageStatsService.test.ts
+++ b/test/main/session/usageStatsService.test.ts
@@ -494,6 +494,8 @@ function createMockSqlitePresenter() {
     },
     deepchatTapeEntriesTable: {
       ensureBootstrapAnchor: vi.fn(),
+      getBootstrapIncarnation: vi.fn(() => undefined),
+      getMaxEntryId: vi.fn(() => 0),
       // The store contract returns the appended row; the fact writer reads its payload back.
       append: vi.fn(
         (input: {
@@ -542,6 +544,11 @@ function createMockSqlitePresenter() {
       }
     },
     deepchatUsageStatsTable,
+    deepchatTranscriptProjectionMetaTable: {
+      get: vi.fn(() => null),
+      upsert: vi.fn(),
+      delete: vi.fn()
+    },
     newSessionsTable: {
       create: vi.fn(),
       get: vi.fn().mockReturnValue(null),

--- a/test/main/session/usageStatsService.test.ts
+++ b/test/main/session/usageStatsService.test.ts
@@ -468,7 +468,29 @@ function createMockSqlitePresenter() {
     },
     deepchatTapeEntriesTable: {
       ensureBootstrapAnchor: vi.fn(),
-      append: vi.fn(),
+      // The store contract returns the appended row; the fact writer reads its payload back.
+      append: vi.fn(
+        (input: {
+          sessionId: string
+          kind: DeepChatTapeEntryRow['kind']
+          name?: string | null
+          provenanceKey?: string | null
+          payload?: Record<string, unknown>
+          createdAt?: number
+        }): DeepChatTapeEntryRow => ({
+          session_id: input.sessionId,
+          entry_id: tapeEntries.length + 1,
+          kind: input.kind,
+          name: input.name ?? null,
+          source_type: null,
+          source_id: null,
+          source_seq: null,
+          provenance_key: input.provenanceKey ?? null,
+          payload_json: JSON.stringify(input.payload ?? {}),
+          meta_json: '{}',
+          created_at: input.createdAt ?? 0
+        })
+      ),
       listEventsByNamePage(
         name: string,
         cursor: { sessionId: string; entryId: number } | null,


### PR DESCRIPTION
## Summary

The transcript used to produce the Context Tape message facts: every terminal write updated the tables, read the row back and appended the copy. That left three things nobody could see from the code. Four writes (fork, startup recovery, legacy import, and the retry path that flips a failed prompt back to `sent`) skipped the fact and waited for the reconciler. A `sent` record's fact is keyed by message id alone, so a row whose content changed without a replacement fact left the Tape stale in silence. And `ensureSessionTapeReady` read the whole transcript on every call to digest it, then re-ran an idempotent backfill over all N records whenever a row had changed, which every user turn guarantees.

This branch reverses the direction for terminal message state. A terminal write builds the canonical record in memory, appends it as the fact, and hands the same record to one applier that writes `deepchat_messages` and its side tables. Readiness compares a per-Session cursor with the Tape head and replays only what arrived in between. Streaming state stays in the transcript's pending region, as before. No Tape schema, fact name, provenance key or hash changes; existing Tapes read identically.

## What changed

**A sent fact that meets a different record is reported.** `appendMessageRecordToTape` compares the entry the store returned with the record it tried to append when the provenance key was derived and the append is live. A difference in `content`, `status`, `orderSeq` or `metadata` logs one warning with the ids and field names; payload text stays out of the log. Backfills do not report, since a backfill of an old Session compares today's materialized content with a fact an earlier version wrote.

**One mapping per direction.** The persist and read field mappings for user files and assistant blocks live in `messageContent.ts`, used by the block table's write path and the transcript's read path. `canonicalizeMessageContent` performs the persist/read trip in memory, so a fact can carry the string `getMessage` will return without touching the tables. A real-SQLite guard pins the canonical string to what the tables hand back, including a block that arrives without a timestamp and a user message with files, links, active skills and inline items.

**Terminal writes go fact first.** `TranscriptProjectionApplier` is the only code that writes terminal rows; `SessionTranscript` appends the fact, applies the record, all inside the existing transaction. The four bypasses go through it too: fork appends a live fact per copied row in one transaction, recovery appends a revision fact per recovered row, the legacy importer's direct insert became `importMessageRow`, and the retry path calls `restoreUserMessage` instead of flipping a column. `updateMessageStatus` now accepts only `'pending'`. Compaction shift keeps its single `UPDATE`, stamped with the time the order facts carry; range deletes keep their statement. A finalize against a row that no longer exists writes nothing instead of leaving orphan block rows.

**Readiness follows a cursor.** `deepchat_transcript_projection_meta` records, per Session, the Tape incarnation and the highest entry id the tables reflect. Each fact-first write moves an established cursor to the head it reached. `ensureSessionTapeReady` compares cursor and head in one store transaction and replays only the message rows past the cursor, which after an ordinary turn is nothing. A Session without a cursor for the current incarnation is backfilled from its transcript once, the way the reconciler always did, and only that backfill creates the cursor: a write before it happens appends its fact but leaves the cursor unset, so rows written before this change (or before a Tape reset) still reach the Tape instead of being declared aligned by the first delete after an upgrade. The reconciler talks to the transcript through `TapeTranscriptProjection` and never imports session code; the in-process digest map is gone.

**Usage stats stay out of the projection.** They count provider calls, and the same record reaches the applier again on fork, import, recovery and replay without a call having happened. The assistant terminal writes record usage themselves, as the streaming metadata update already does.

`docs/architecture/tape-system.md` now describes the transcript as the derived projection of Context Tape message facts and states the write order and the cursor rule. The design record is in `docs/architecture/tape-transcript-projection/`.

## Compatibility

- Tape: no schema, fact name, provenance key, payload field or hash version change. Records written fact-first serialize to the same `payload.record` shape the read-back produced.
- New table `deepchat_transcript_projection_meta`, created through the schema catalog like the other projection meta tables. Older code ignores it; rolling back is a code revert, and the previous reconciler finds every fact already present through provenance keys.
- `deepchat_messages.content` now stores the canonical form for terminal rows. Readers rebuild content from the structured tables first, as before.
- Behavior differences: all terminal assistant rows write block rows (compaction markers included), the blocks of one message share one `updated_at`, forked rows carry the fork time as `created_at`, and a finalize or edit against a missing row is a no-op.
- `TapeReconciliationPort.ensureSessionTapeReady` takes `TapeTranscriptProjection`; `SessionTranscript` implements it. `SessionTapeCapabilities` gains `TapeProjectionHeadReader`. `deepchat_messages` gains `upsert` and `deleteByIds`; `incrementOrderSeqFrom` takes the write time. The table-level `recoverPendingMessages` had no callers and is removed.
- Fields the tables never persisted (`artifact`, the `maximum_tool_calls_reached` action type) are still dropped on read; the canonical form drops them the same way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved transcript synchronization with reliable replay, recovery, and incremental updates.
  * Message content, attachments, assistant responses, and search data are preserved more consistently.
  * Added safeguards for detecting message inconsistencies.

* **Bug Fixes**
  * Improved handling of imported, retried, recovered, and deleted messages.
  * Prevented transcript state from becoming out of sync with conversation history.

* **Documentation**
  * Updated architecture documentation for transcript projection and reconciliation.

* **Tests**
  * Expanded coverage for projection, replay, recovery, content round trips, and native SQLite storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->