### PR TITLE
fix(chat): preserve workspace session history

### DIFF
--- a/docs/issues/workspace-new-session-agent/spec.md
+++ b/docs/issues/workspace-new-session-agent/spec.md
@@ -1,0 +1,51 @@
+# Workspace new conversation Agent selection
+
+## Problem and root cause
+
+Creating or opening a conversation changes the same Agent selection that the sidebar uses to
+filter history. From All Agents, this hides other Agents' conversations and can make a workspace
+appear empty. Workspace creation also chooses a global Agent without consulting its history.
+
+## Behavior and ownership
+
+- The Agent store owns separate conversation selection and explicit history filter state.
+  Manual Agent selection updates both. Session activation, restoration, and creation update only
+  the conversation selection. All Agents remains selected until the user changes the filter.
+- A workspace's new conversation uses the explicit Agent filter first. Under All Agents, it uses
+  the Agent of that workspace's most recently updated regular, non-draft conversation, including
+  pinned conversations. If that Agent is unavailable, the workspace has no history, or the read
+  fails, the existing selected/active/first-enabled Agent fallback applies.
+- Global new conversation and Chats with an explicit null workspace retain the existing fallback.
+- The session store resolves workspace defaults through the existing typed lightweight query,
+  with a workspace filter, drafts excluded, and a one-item limit. The database applies filters
+  before pagination, so unloaded history is eligible without materializing all sessions.
+- Lightweight query options remain optional and preserve existing callers' defaults. Prioritized
+  records must satisfy the same filters. No schema migration or new IPC route is needed.
+- A delayed workspace lookup must not override a newer navigation or explicit Agent filter change.
+  Existing project intent handling and composer defaults continue to use the resolved Agent.
+- Removing or disabling an Agent clears its conversation selection and history filter independently.
+
+## Interaction
+
+```text
+BEFORE                         AFTER
+[All Agents] -> workspace +    [All Agents] -> workspace +
+[Agent A]                     [All Agents]
+  Agent A history               Agent A and Agent B history
+New conversation: Agent A     New conversation: latest workspace Agent
+```
+
+## Acceptance and validation
+
+- [x] Creating and opening conversations preserve the explicit history filter.
+- [x] Explicit Agent selection wins over workspace history; All Agents uses persisted workspace
+      history even when it is outside the loaded sidebar pages.
+- [x] Drafts, subagents, and other workspaces cannot determine the default Agent.
+- [x] Unavailable Agents, failed reads, and superseded lookups preserve usable navigation.
+- [x] Relevant regression suites, formatting, i18n, lint, and type checking pass.
+
+Validation: 100 session store, 5 Agent store, 72 sidebar, and 78 main-process tests pass. The
+persisted-history regression exercises route input parsing, SessionQuery, AppSessionService, and
+real SQLite together. Main-process suites run with Electron's Node runtime and
+`DEEPCHAT_REQUIRE_NATIVE_SQLITE=1`; renderer suites use the CI heap limit of 6144 MB.
+Formatting, i18n, lint, type checking, renderer architecture, and icon checks pass.

--- a/src/main/agent/shared/appSessionService.ts
+++ b/src/main/agent/shared/appSessionService.ts
@@ -110,6 +110,8 @@ export class AppSessionService implements AppSessionReadPort {
     limit?: number
     cursor?: SessionPageCursor | null
     agentId?: string
+    projectDir?: string
+    includeDrafts?: boolean
     includeSubagents?: boolean
     parentSessionId?: string
   }): {
@@ -121,6 +123,8 @@ export class AppSessionService implements AppSessionReadPort {
       limit: options?.limit,
       cursor: options?.cursor as SessionListPageCursor | null | undefined,
       agentId: options?.agentId,
+      projectDir: options?.projectDir,
+      includeDrafts: options?.includeDrafts,
       includeSubagents: options?.includeSubagents,
       parentSessionId: options?.parentSessionId
     })

--- a/src/main/session/contracts.ts
+++ b/src/main/session/contracts.ts
@@ -226,6 +226,8 @@ export interface SessionLightweightOptions {
   limit?: number
   cursor?: SessionPageCursor | null
   includeSubagents?: boolean
+  includeDrafts?: boolean
+  projectDir?: string
   agentId?: string
   prioritizeSessionId?: string
 }

--- a/src/main/session/data/tables/newSessions.ts
+++ b/src/main/session/data/tables/newSessions.ts
@@ -271,6 +271,8 @@ export class NewSessionsTable extends BaseTable {
     limit?: number
     cursor?: SessionListPageCursor | null
     agentId?: string
+    projectDir?: string
+    includeDrafts?: boolean
     includeSubagents?: boolean
     parentSessionId?: string
   }): SessionListPageResult {
@@ -278,6 +280,15 @@ export class NewSessionsTable extends BaseTable {
     let sql = 'SELECT * FROM new_sessions'
     const conditions: string[] = []
     const params: unknown[] = []
+
+    if (options?.projectDir !== undefined) {
+      conditions.push('project_dir = ?')
+      params.push(options.projectDir)
+    }
+
+    if (options?.includeDrafts === false) {
+      conditions.push('is_draft = 0')
+    }
 
     if (options?.agentId) {
       conditions.push('agent_id = ?')

--- a/src/main/session/query.ts
+++ b/src/main/session/query.ts
@@ -121,6 +121,8 @@ export class SessionQuery implements SessionProjectionReadPort, SessionProjectio
       limit: options?.limit,
       cursor: options?.cursor,
       agentId: options?.agentId,
+      projectDir: options?.projectDir,
+      includeDrafts: options?.includeDrafts,
       includeSubagents: options?.includeSubagents
     })
     const items = await Promise.all(
@@ -533,9 +535,11 @@ export class SessionQuery implements SessionProjectionReadPort, SessionProjectio
 
   private matchesLightweightFilter(
     record: SessionRecord,
-    options?: Pick<SessionLightweightOptions, 'includeSubagents' | 'agentId'>
+    options?: SessionLightweightOptions
   ): boolean {
     if (options?.agentId && record.agentId !== options.agentId) return false
+    if (options?.projectDir !== undefined && record.projectDir !== options.projectDir) return false
+    if (options?.includeDrafts === false && record.isDraft) return false
     return options?.includeSubagents === true || record.sessionKind !== 'subagent'
   }
 

--- a/src/renderer/api/SessionClient.ts
+++ b/src/renderer/api/SessionClient.ts
@@ -150,6 +150,8 @@ export function createSessionClient(bridge: DeepchatBridge = getDeepchatBridge()
     limit?: number
     cursor?: { updatedAt: number; id: string } | null
     includeSubagents?: boolean
+    includeDrafts?: boolean
+    projectDir?: string
     agentId?: string
     prioritizeSessionId?: string
   }) {

--- a/src/renderer/src/components/WindowSideBar.vue
+++ b/src/renderer/src/components/WindowSideBar.vue
@@ -807,16 +807,7 @@ const pluginsRouteActive = computed(() =>
 let agentSwitchSeq = 0
 let agentSwitchQueue: Promise<void> = Promise.resolve()
 
-const sidebarSelectedAgentId = computed(() => {
-  const activeSessionAgentId = sessionStore.activeSession?.agentId?.trim()
-  if (sessionStore.hasActiveSession && activeSessionAgentId) {
-    return activeSessionAgentId
-  }
-
-  const selectedAgentId =
-    typeof agentStore.selectedAgentId === 'string' ? agentStore.selectedAgentId.trim() : ''
-  return selectedAgentId || null
-})
+const sidebarSelectedAgentId = computed(() => agentStore.filterAgentId)
 
 const selectedAgentName = computed(() => {
   if (sidebarSelectedAgentId.value === null) {

--- a/src/renderer/src/stores/ui/agent.ts
+++ b/src/renderer/src/stores/ui/agent.ts
@@ -30,7 +30,8 @@ export const useAgentStore = defineStore('agent', () => {
 
   // --- State ---
   const agents = ref<UIAgent[]>([])
-  const selectedAgentId = ref<string | null>(null) // null = "All Agents"
+  const selectedAgentId = ref<string | null>(null)
+  const filterAgentId = ref<string | null>(null) // null = "All Agents"
   const loading = ref(false)
   const error = ref<string | null>(null)
 
@@ -62,13 +63,10 @@ export const useAgentStore = defineStore('agent', () => {
   }
 
   function syncSelectedAgent(): void {
-    if (selectedAgentId.value === null) {
-      return
-    }
-
-    const currentSelectedAgent = agents.value.find((agent) => agent.id === selectedAgentId.value)
-    if (!currentSelectedAgent || !currentSelectedAgent.enabled) {
-      selectedAgentId.value = null
+    for (const selection of [selectedAgentId, filterAgentId]) {
+      if (selection.value && !enabledAgents.value.some((agent) => agent.id === selection.value)) {
+        selection.value = null
+      }
     }
   }
 
@@ -185,12 +183,15 @@ export const useAgentStore = defineStore('agent', () => {
     }
   }
 
-  function setSelectedAgent(id: string | null): void {
+  function setSelectedAgent(id: string | null, options?: { preserveFilter?: boolean }): void {
     selectedAgentId.value = id
+    if (!options?.preserveFilter) {
+      filterAgentId.value = id
+    }
   }
 
   function selectAgent(id: string | null): void {
-    selectedAgentId.value = selectedAgentId.value === id ? null : id
+    setSelectedAgent(filterAgentId.value === id ? null : id)
   }
 
   if (!listenersRegistered) {
@@ -218,6 +219,7 @@ export const useAgentStore = defineStore('agent', () => {
   return {
     agents,
     selectedAgentId,
+    filterAgentId,
     loading,
     error,
     enabledAgents,

--- a/src/renderer/src/stores/ui/session.ts
+++ b/src/renderer/src/stores/ui/session.ts
@@ -725,6 +725,10 @@ export const useSessionStore = defineStore('session', () => {
   const hasActiveSession: ComputedRef<boolean> = computed(() => activeSessionId.value !== null)
 
   const newConversationTargetAgentId = computed(() => {
+    if (agentStore.filterAgentId) {
+      return agentStore.filterAgentId
+    }
+
     const selectedAgentId =
       typeof agentStore.selectedAgentId === 'string' ? agentStore.selectedAgentId.trim() : ''
     if (selectedAgentId) {
@@ -762,7 +766,7 @@ export const useSessionStore = defineStore('session', () => {
       return
     }
 
-    agentStore.setSelectedAgent(targetAgentId)
+    agentStore.setSelectedAgent(targetAgentId, { preserveFilter: true })
   }
 
   const applySessionStatus = (sessionId: string, status: string, version?: number): boolean => {
@@ -1234,7 +1238,36 @@ export const useSessionStore = defineStore('session', () => {
   async function startNewConversation(options: StartNewConversationOptions = {}): Promise<void> {
     error.value = null
 
-    const targetAgentId = newConversationTargetAgentId.value
+    const requestId = createActivationNavigationRequest()
+    const filterAgentId = agentStore.filterAgentId
+    const projectDir = options.projectDir?.trim()
+    let targetAgentId: string | null = null
+
+    if (!filterAgentId && projectDir) {
+      try {
+        const { items } = await sessionClient.listLightweight({
+          projectDir,
+          includeDrafts: false,
+          includeSubagents: false,
+          limit: 1
+        })
+        const latestAgentId = items[0]?.agentId
+        if (latestAgentId && agentStore.enabledAgents.some((agent) => agent.id === latestAgentId)) {
+          targetAgentId = latestAgentId
+        }
+      } catch (lookupError) {
+        console.warn('[sessionStore] Failed to resolve workspace Agent:', lookupError)
+      }
+
+      if (
+        activationNavigationRequestId !== requestId ||
+        agentStore.filterAgentId !== filterAgentId
+      ) {
+        return
+      }
+    }
+
+    targetAgentId ??= newConversationTargetAgentId.value
     if (!targetAgentId) {
       return
     }
@@ -1251,7 +1284,7 @@ export const useSessionStore = defineStore('session', () => {
       : null
 
     if (agentStore.selectedAgentId !== targetAgentId) {
-      agentStore.setSelectedAgent(targetAgentId)
+      agentStore.setSelectedAgent(targetAgentId, { preserveFilter: true })
     }
 
     if (hasActiveSession.value) {
@@ -1260,7 +1293,6 @@ export const useSessionStore = defineStore('session', () => {
     }
 
     pageRouter.goToNewThread({ refresh: options.refresh ?? true })
-    createActivationNavigationRequest()
   }
 
   function consumeNewConversationProjectDirIntent(intentId: number): void {

--- a/src/renderer/src/stores/ui/session.ts
+++ b/src/renderer/src/stores/ui/session.ts
@@ -956,9 +956,13 @@ export const useSessionStore = defineStore('session', () => {
         sessions.value = options.preserveExisting
           ? mergeSessions(sessions.value, nextSessions)
           : replaceSessionSnapshot(nextSessions, targetedCommitRevisionAtStart)
+        // Retained history belongs to the existing cursor chain. Refreshing its
+        // first page must not rewind pagination over rows that are already loaded.
+        if (!options.preserveExisting || !hasLoadedInitialPage.value) {
+          hasMore.value = result.hasMore
+          nextCursor.value = result.nextCursor
+        }
         hasLoadedInitialPage.value = true
-        hasMore.value = result.hasMore
-        nextCursor.value = result.nextCursor
         syncSelectedAgentToSession(activeSessionId.value)
       } catch (loadError) {
         if (requestId === initialPageRequestId && listEpoch === sessionListEpoch) {
@@ -973,7 +977,7 @@ export const useSessionStore = defineStore('session', () => {
       return
     }
 
-    if (loadingMore.value || !hasMore.value || !nextCursor.value) {
+    if (loading.value || loadingMore.value || !hasMore.value || !nextCursor.value) {
       return
     }
 
@@ -1018,6 +1022,7 @@ export const useSessionStore = defineStore('session', () => {
 
     const loadPromise = loadSessionPage({
       reset: true,
+      preserveExisting: hasLoadedInitialPage.value,
       prioritizeSessionId: activeSessionId.value ?? bootstrapActiveSession.value?.id ?? null
     })
     const currentFetchPromise = loadPromise.finally(() => {

--- a/src/shared/contracts/routes/sessions.routes.ts
+++ b/src/shared/contracts/routes/sessions.routes.ts
@@ -398,6 +398,8 @@ export const sessionsListLightweightRoute = defineRouteContract({
     limit: z.number().int().positive().max(100).optional(),
     cursor: SessionPageCursorSchema.nullable().optional(),
     includeSubagents: z.boolean().optional(),
+    includeDrafts: z.boolean().optional(),
+    projectDir: z.string().min(1).optional(),
     agentId: EntityIdSchema.optional(),
     prioritizeSessionId: EntityIdSchema.optional()
   }),

--- a/test/main/session/data/tables/newSessionsTable.test.ts
+++ b/test/main/session/data/tables/newSessionsTable.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, expect, it } from 'vitest'
 import { Database, nativeSqliteDescribeIf } from '../../../nativeSqliteHarness'
+import { AppSessionService } from '@/agent/shared/appSessionService'
+import { SessionQuery, type SessionQueryDependencies } from '@/session/query'
+import { sessionsListLightweightRoute } from '@shared/contracts/routes/sessions.routes'
 
 const sqliteModule = await import('better-sqlite3-multiple-ciphers').catch(() => null)
 const tableModule = sqliteModule
@@ -39,6 +42,69 @@ describeIfSqlite('NewSessionsTable', () => {
   afterEach(() => {
     db?.close()
     db = null
+  })
+
+  it('finds persisted workspace history before pagination and filters prioritized records', async () => {
+    const insert = db!.prepare(`INSERT INTO new_sessions
+      (id, agent_id, title, project_dir, session_kind, is_draft, is_pinned, created_at, updated_at)
+      VALUES (?, ?, 'Session', ?, ?, ?, ?, 100, ?)`)
+    insert.run('old', 'deepchat', '/work/app', 'regular', 0, 0, 100)
+    insert.run('latest', 'acp-a', '/work/app', 'regular', 0, 1, 200)
+    insert.run('child', 'child-agent', '/work/app', 'subagent', 0, 0, 300)
+    insert.run('draft', 'draft-agent', '/work/app', 'regular', 1, 0, 400)
+    for (let index = 0; index < 40; index++) {
+      insert.run(`other-${index}`, 'other-agent', '/work/other', 'regular', 0, 0, 500 + index)
+    }
+
+    const sessions = new AppSessionService(
+      {} as ConstructorParameters<typeof AppSessionService>[0],
+      { newSessionsTable: table } as ConstructorParameters<typeof AppSessionService>[1]
+    )
+    const query = new SessionQuery({
+      sessions,
+      runtime: { snapshotIfHydrated: async () => null }
+    } as unknown as SessionQueryDependencies)
+    const options = sessionsListLightweightRoute.input.parse({
+      projectDir: '/work/app',
+      includeDrafts: false,
+      includeSubagents: false,
+      limit: 1
+    })
+
+    const first = await query.listLightweight(options)
+    expect(first).toMatchObject({
+      items: [{ id: 'latest', agentId: 'acp-a', isPinned: true }],
+      hasMore: true,
+      nextCursor: { id: 'latest', updatedAt: 200 }
+    })
+    await expect(
+      query.listLightweight({ ...options, cursor: first.nextCursor })
+    ).resolves.toMatchObject({
+      items: [{ id: 'old' }],
+      hasMore: false,
+      nextCursor: null
+    })
+    for (const prioritizeSessionId of ['draft', 'child', 'other-0']) {
+      expect(await query.listLightweight({ ...options, prioritizeSessionId })).toEqual(first)
+    }
+
+    await expect(
+      query.listLightweight({ ...options, includeDrafts: undefined })
+    ).resolves.toMatchObject({
+      items: [{ id: 'draft' }]
+    })
+    await expect(
+      query.listLightweight({ ...options, includeSubagents: true })
+    ).resolves.toMatchObject({
+      items: [{ id: 'child' }]
+    })
+    await expect(query.listLightweight({ ...options, projectDir: '/work/empty' })).resolves.toEqual(
+      {
+        items: [],
+        hasMore: false,
+        nextCursor: null
+      }
+    )
   })
 
   it('clears regular project_dir, advances revision, and leaves subagent rows untouched', () => {

--- a/test/renderer/components/WindowSideBar.test.ts
+++ b/test/renderer/components/WindowSideBar.test.ts
@@ -9,6 +9,7 @@ vi.mock('pinia', async () => vi.importActual<typeof import('pinia')>('pinia'))
 type SetupOptions = {
   groupMode?: 'time' | 'project'
   selectedAgentId?: string | null
+  filterAgentId?: string | null
   enabledAgents?: Array<{ id: string; name: string; type?: 'deepchat' | 'acp'; enabled?: boolean }>
   activeSession?: { id: string; agentId: string } | null
   hasActiveSession?: boolean
@@ -198,7 +199,11 @@ const setup = async (options: SetupOptions = {}) => {
     state: 'disabled' as const
   }
   const agentStore = reactive({
-    selectedAgentId: (options.selectedAgentId ?? 'deepchat') as string | null,
+    selectedAgentId: options.selectedAgentId !== undefined ? options.selectedAgentId : 'deepchat',
+    filterAgentId:
+      options.filterAgentId !== undefined
+        ? options.filterAgentId
+        : (options.selectedAgentId ?? 'deepchat'),
     selectedAgentName: 'DeepChat',
     enabledAgents: (options.enabledAgents ?? [
       { id: 'acp-a', name: 'ACP A', type: 'acp' as const, enabled: true }
@@ -206,6 +211,7 @@ const setup = async (options: SetupOptions = {}) => {
     setSelectedAgent: vi.fn((id: string | null) => {
       operations.push(`set:${id ?? 'all'}`)
       agentStore.selectedAgentId = id
+      agentStore.filterAgentId = id
     })
   })
 
@@ -688,11 +694,12 @@ describe('WindowSideBar agent switch', () => {
     expect(sessionStore.startNewConversation).toHaveBeenCalledWith({ refresh: true })
   })
 
-  it(
-    'prefers the active session agent for selection state and filtering',
-    async () => {
+  it.each([null, 'deepchat'])(
+    'preserves the explicit %s filter when the active conversation uses another Agent',
+    async (filterAgentId) => {
       const { wrapper, sessionStore } = await setup({
-        selectedAgentId: 'deepchat',
+        selectedAgentId: 'acp-a',
+        filterAgentId,
         activeSession: {
           id: 'session-acp',
           agentId: 'acp-a'
@@ -705,9 +712,12 @@ describe('WindowSideBar agent switch', () => {
 
       await wrapper.vm.$nextTick()
 
-      expect(wrapper.text()).toContain('ACP A')
-      expect(sessionStore.getPinnedSessions).toHaveBeenCalledWith('acp-a')
-      expect(sessionStore.getFilteredGroups).toHaveBeenCalledWith('acp-a')
+      expect(
+        wrapper.get(`[data-agent-id="${filterAgentId ?? '__all__'}"]`).attributes('data-selected')
+      ).toBe('true')
+      expect(wrapper.get('[data-agent-id="acp-a"]').attributes('data-selected')).toBe('false')
+      expect(sessionStore.getPinnedSessions).toHaveBeenCalledWith(filterAgentId)
+      expect(sessionStore.getFilteredGroups).toHaveBeenCalledWith(filterAgentId)
     },
     TEST_TIMEOUT_MS
   )

--- a/test/renderer/stores/agentStore.test.ts
+++ b/test/renderer/stores/agentStore.test.ts
@@ -77,6 +77,41 @@ const setupStore = async (options?: {
 }
 
 describe('agent store incremental refresh', () => {
+  it('keeps history filtering explicit when conversation selection changes', async () => {
+    const { store } = await setupStore()
+
+    store.setSelectedAgent('deepchat', { preserveFilter: true })
+    expect(store.selectedAgentId.value).toBe('deepchat')
+    expect(store.filterAgentId.value).toBeNull()
+
+    store.setSelectedAgent('acp-1')
+    store.setSelectedAgent('deepchat', { preserveFilter: true })
+    expect(store.selectedAgentId.value).toBe('deepchat')
+    expect(store.filterAgentId.value).toBe('acp-1')
+
+    store.selectAgent('acp-1')
+    expect(store.selectedAgentId.value).toBeNull()
+    expect(store.filterAgentId.value).toBeNull()
+  })
+
+  it('clears unavailable Agent selections independently', async () => {
+    const { store } = await setupStore({ initialAgents: [createAgent('deepchat')] })
+    store.setSelectedAgent('removed-agent')
+    store.setSelectedAgent('deepchat', { preserveFilter: true })
+
+    await store.fetchAgents()
+
+    expect(store.selectedAgentId.value).toBe('deepchat')
+    expect(store.filterAgentId.value).toBeNull()
+
+    store.setSelectedAgent('deepchat')
+    store.setSelectedAgent('removed-agent', { preserveFilter: true })
+    await store.fetchAgents()
+
+    expect(store.selectedAgentId.value).toBeNull()
+    expect(store.filterAgentId.value).toBe('deepchat')
+  })
+
   it('refreshes only scoped ACP agents when agentIds are provided', async () => {
     const { store, sessionClient, configClient, emitAgentsChanged } = await setupStore({
       initialAgents: [

--- a/test/renderer/stores/sessionStore.test.ts
+++ b/test/renderer/stores/sessionStore.test.ts
@@ -17,6 +17,7 @@ type SetupStoreOptions = {
   failGetSetting?: boolean
   getSettingPromise?: Promise<unknown>
   selectedAgentId?: string | null
+  filterAgentId?: string | null
   enabledAgents?: Array<{ id: string; name?: string; type?: 'deepchat' | 'acp'; enabled?: boolean }>
   onboardingCurrentStepId?:
     | 'provider'
@@ -283,15 +284,24 @@ const setupStore = async (options: SetupStoreOptions = {}) => {
   }
   const agentStore = reactive({
     selectedAgentId: options.selectedAgentId ?? null,
+    filterAgentId:
+      options.filterAgentId !== undefined
+        ? options.filterAgentId
+        : (options.selectedAgentId ?? null),
     enabledAgents: (options.enabledAgents ?? []).map((agent) => ({
       name: agent.name ?? agent.id,
       type: agent.type ?? 'deepchat',
       enabled: agent.enabled ?? true,
       ...agent
     })),
-    setSelectedAgent: vi.fn((id: string | null) => {
-      agentStore.selectedAgentId = id
-    })
+    setSelectedAgent: vi.fn(
+      (id: string | null, selectionOptions?: { preserveFilter?: boolean }) => {
+        agentStore.selectedAgentId = id
+        if (!selectionOptions?.preserveFilter) {
+          agentStore.filterAgentId = id
+        }
+      }
+    )
   })
   const settings = { ...(options.initialSettings ?? {}) }
   const configClient = {
@@ -898,7 +908,8 @@ describe('sessionStore.startNewConversation', () => {
 
     await store.startNewConversation({ refresh: true })
 
-    expect(agentStore.setSelectedAgent).toHaveBeenCalledWith('deepchat')
+    expect(agentStore.selectedAgentId).toBe('deepchat')
+    expect(agentStore.filterAgentId).toBeNull()
     expect(sessionClient.deactivate).not.toHaveBeenCalled()
     expect(pageRouter.goToNewThread).toHaveBeenCalledWith({ refresh: true })
   })
@@ -914,7 +925,8 @@ describe('sessionStore.startNewConversation', () => {
 
     await store.startNewConversation({ refresh: true, projectDir: '/work/design' })
 
-    expect(agentStore.setSelectedAgent).toHaveBeenCalledWith('acp-a')
+    expect(agentStore.selectedAgentId).toBe('acp-a')
+    expect(agentStore.filterAgentId).toBeNull()
     expect(sessionClient.deactivate).toHaveBeenCalledTimes(1)
     expect(store.activeSessionId.value).toBeNull()
     expect(pageRouter.goToNewThread).toHaveBeenCalledWith({ refresh: true })
@@ -956,6 +968,109 @@ describe('sessionStore.startNewConversation', () => {
     expect(sessionClient.deactivate).not.toHaveBeenCalled()
     expect(pageRouter.goToNewThread).toHaveBeenCalledWith({ refresh: true })
   })
+
+  it('uses persisted workspace history under All Agents without hiding loaded conversations', async () => {
+    const { store, agentStore, sessionClient } = await setupStore({
+      selectedAgentId: 'deepchat',
+      filterAgentId: null,
+      enabledAgents: [{ id: 'deepchat' }, { id: 'acp-a', type: 'acp' }]
+    })
+    store.sessions.value = [
+      createSession({ id: 'other-workspace', projectDir: '/work/other', updatedAt: 500 }),
+      createSession({ id: 'older', projectDir: '/work/app', updatedAt: 100 })
+    ]
+    const history = store.getFilteredGroups(null)
+    sessionClient.listLightweight.mockResolvedValueOnce({
+      items: [
+        createSession({ id: 'latest', agentId: 'acp-a', projectDir: '/work/app', updatedAt: 300 })
+      ],
+      hasMore: true,
+      nextCursor: { id: 'latest', updatedAt: 300 }
+    })
+
+    await store.startNewConversation({ projectDir: '/work/app' })
+
+    expect(sessionClient.listLightweight).toHaveBeenCalledWith({
+      projectDir: '/work/app',
+      includeDrafts: false,
+      includeSubagents: false,
+      limit: 1
+    })
+    expect(agentStore.selectedAgentId).toBe('acp-a')
+    expect(agentStore.filterAgentId).toBeNull()
+    expect(store.getFilteredGroups(agentStore.filterAgentId)).toEqual(history)
+    expect(store.newConversationProjectDirIntent.value?.projectDir).toBe('/work/app')
+  })
+
+  it('prefers an explicit Agent filter over the active Agent and workspace history', async () => {
+    const { store, agentStore, sessionClient } = await setupStore({
+      selectedAgentId: 'deepchat',
+      filterAgentId: 'acp-a',
+      enabledAgents: [{ id: 'deepchat' }, { id: 'acp-a', type: 'acp' }]
+    })
+
+    await store.startNewConversation({ projectDir: '/work/app' })
+
+    expect(agentStore.selectedAgentId).toBe('acp-a')
+    expect(agentStore.filterAgentId).toBe('acp-a')
+    expect(sessionClient.listLightweight).not.toHaveBeenCalled()
+  })
+
+  it.each(['unavailable-agent', 'empty', 'failed'])(
+    'falls back when workspace history is %s',
+    async (scenario) => {
+      const { store, agentStore, sessionClient, pageRouter } = await setupStore({
+        enabledAgents: [{ id: 'deepchat' }]
+      })
+      if (scenario === 'failed') {
+        sessionClient.listLightweight.mockRejectedValueOnce(new Error('read failed'))
+      } else if (scenario === 'unavailable-agent') {
+        sessionClient.listLightweight.mockResolvedValueOnce({
+          items: [createSession({ agentId: 'removed-agent' })],
+          hasMore: false,
+          nextCursor: null
+        })
+      }
+
+      await store.startNewConversation({ projectDir: '/work/app' })
+
+      expect(agentStore.selectedAgentId).toBe('deepchat')
+      expect(agentStore.filterAgentId).toBeNull()
+      expect(pageRouter.goToNewThread).toHaveBeenCalledWith({ refresh: true })
+    }
+  )
+
+  it.each(['workspace', 'session', 'agent'])(
+    'ignores a workspace lookup superseded by a newer %s selection',
+    async (selection) => {
+      const { store, agentStore, sessionClient, pageRouter } = await setupStore({
+        enabledAgents: [{ id: 'deepchat' }, { id: 'acp-a', type: 'acp' }]
+      })
+      const pending = createDeferred<unknown>()
+      sessionClient.listLightweight.mockReturnValueOnce(pending.promise)
+      const first = store.startNewConversation({ projectDir: '/work/first' })
+
+      if (selection === 'workspace') {
+        await store.startNewConversation({ projectDir: '/work/second' })
+      } else if (selection === 'session') {
+        store.sessions.value = [createSession()]
+        await store.selectSession('session-1')
+      } else {
+        agentStore.setSelectedAgent('deepchat')
+      }
+      pageRouter.goToNewThread.mockClear()
+      pending.resolve({
+        items: [createSession({ agentId: 'acp-a' })],
+        hasMore: false,
+        nextCursor: null
+      })
+      await first
+
+      expect(agentStore.selectedAgentId).toBe('deepchat')
+      expect(pageRouter.goToNewThread).not.toHaveBeenCalled()
+      expect(store.newConversationProjectDirIntent.value?.projectDir).not.toBe('/work/first')
+    }
+  )
 })
 
 describe('sessionStore onboarding progress', () => {
@@ -1190,7 +1305,8 @@ describe('sessionStore streaming cleanup', () => {
   it('clears streaming state when switching active session', async () => {
     const { store, clearStreamingState, setCurrentSessionId, sessionClient, agentStore } =
       await setupStore({
-        selectedAgentId: 'deepchat'
+        selectedAgentId: 'deepchat',
+        filterAgentId: null
       })
     store.activeSessionId.value = 'session-a'
     store.sessions.value = [createSession({ id: 'session-b', agentId: 'acp-a' })]
@@ -1198,7 +1314,8 @@ describe('sessionStore streaming cleanup', () => {
     await store.selectSession('session-b')
 
     expect(sessionClient.activate).toHaveBeenCalledWith('session-b')
-    expect(agentStore.setSelectedAgent).toHaveBeenCalledWith('acp-a')
+    expect(agentStore.selectedAgentId).toBe('acp-a')
+    expect(agentStore.filterAgentId).toBeNull()
     expect(clearStreamingState).toHaveBeenCalledTimes(1)
     expect(setCurrentSessionId).toHaveBeenCalledWith('session-b')
   })
@@ -1227,7 +1344,8 @@ describe('sessionStore streaming cleanup', () => {
     expect(store.activeSession.value?.providerId).toBe('acp')
     expect(store.activeSession.value?.modelId).toBe('dimcode')
     expect(store.activeSession.value?.status).toBe('working')
-    expect(agentStore.setSelectedAgent).toHaveBeenCalledWith('dimcode')
+    expect(agentStore.selectedAgentId).toBe('dimcode')
+    expect(agentStore.filterAgentId).toBe('deepchat')
     expect(pageRouter.goToChat).toHaveBeenCalledWith('session-acp')
     expect(pageRouter.goToChat.mock.invocationCallOrder[0]).toBeGreaterThan(
       sessionClient.getActive.mock.invocationCallOrder[0]
@@ -1280,7 +1398,8 @@ describe('sessionStore streaming cleanup', () => {
 
     expect(store.activeSessionId.value).toBe('session-sync-1')
     expect(setCurrentSessionId).toHaveBeenCalledWith('session-sync-1')
-    expect(agentStore.setSelectedAgent).toHaveBeenCalledWith('acp-sync')
+    expect(agentStore.selectedAgentId).toBe('acp-sync')
+    expect(agentStore.filterAgentId).toBe('deepchat')
   })
 
   it('does not let a stale bootstrap shell overwrite a newer canonical session snapshot', async () => {
@@ -1555,7 +1674,8 @@ describe('sessionStore streaming cleanup', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(store.activeSessionId.value).toBe('session-external')
-    expect(agentStore.setSelectedAgent).toHaveBeenCalledWith('agent-b')
+    expect(agentStore.selectedAgentId).toBe('agent-b')
+    expect(agentStore.filterAgentId).toBe('deepchat')
     expect(pageRouter.goToChat).toHaveBeenCalledWith('session-external')
   })
 

--- a/test/renderer/stores/sessionStore.test.ts
+++ b/test/renderer/stores/sessionStore.test.ts
@@ -2576,7 +2576,7 @@ describe('sessionStore pagination', () => {
     expect(sessionClient.listLightweight).toHaveBeenCalledTimes(2)
   })
 
-  it('invalidates a pending pagination response when an initial refresh starts', async () => {
+  it('invalidates pending pagination without discarding loaded history on refresh', async () => {
     const { store, sessionClient } = await setupStore()
     const stalePage = createDeferred<{
       items: ReturnType<typeof createSession>[]
@@ -2609,9 +2609,9 @@ describe('sessionStore pagination', () => {
     })
     await loadMore
 
-    expect(store.sessions.value.map((session) => session.id)).toEqual(['session-c'])
+    expect(store.sessions.value.map((session) => session.id)).toEqual(['session-a', 'session-c'])
     expect(store.hasMore.value).toBe(true)
-    expect(store.nextCursor.value).toEqual({ updatedAt: 40, id: 'session-c' })
+    expect(store.nextCursor.value).toEqual({ updatedAt: 30, id: 'session-a' })
     expect(store.error.value).toBeNull()
     expect(store.loadingMore.value).toBe(false)
   })
@@ -2730,47 +2730,105 @@ describe('sessionStore pagination', () => {
     expect(store.loadingMore.value).toBe(false)
   })
 
-  it('does not deduplicate next-page loading while an initial fetch is in flight', async () => {
-    const { store, sessionClient } = await setupStore()
-
-    sessionClient.listLightweight.mockResolvedValueOnce({
-      items: [createSession({ id: 'session-a', title: 'Alpha', updatedAt: 30 })],
-      hasMore: true,
-      nextCursor: { updatedAt: 30, id: 'session-a' }
-    })
+  it('preserves workspace history and resumes pagination after a background refresh', async () => {
+    const { store, sessionClient, emitSessionUpdate } = await setupStore()
+    const recent = Array.from({ length: 30 }, (_, index) =>
+      createSession({
+        id: `recent-${index}`,
+        projectDir: '/work/recent',
+        updatedAt: 200 - index
+      })
+    )
+    const history = Array.from({ length: 30 }, (_, index) =>
+      createSession({ id: `history-${index}`, updatedAt: 100 - index })
+    )
+    const historyCursor = { updatedAt: 71, id: 'history-29' }
+    sessionClient.listLightweight
+      .mockResolvedValueOnce({
+        items: recent,
+        hasMore: true,
+        nextCursor: { updatedAt: 171, id: 'recent-29' }
+      })
+      .mockResolvedValueOnce({ items: history, hasMore: true, nextCursor: historyCursor })
     await store.fetchSessions()
+    await store.loadNextPage()
 
-    let resolveInitialFetch: (value: {
-      items: unknown[]
-      hasMore: boolean
-      nextCursor: null
-    }) => void = () => undefined
-    const initialFetchPromise = new Promise<{
-      items: unknown[]
-      hasMore: boolean
-      nextCursor: null
-    }>((resolve) => {
-      resolveInitialFetch = resolve
-    })
+    const created = createSession({ id: 'created', updatedAt: 300 })
+    sessionClient.create.mockResolvedValueOnce({ session: created })
+    await store.createSession({ message: '', agentId: 'deepchat', projectDir: '/tmp/workspace' })
 
-    sessionClient.listLightweight.mockReturnValueOnce(initialFetchPromise).mockResolvedValueOnce({
-      items: [createSession({ id: 'session-b', title: 'Bravo', updatedAt: 20 })],
+    const firstPage = createDeferred<{
+      items: ReturnType<typeof createSession>[]
+      hasMore: boolean
+      nextCursor: { updatedAt: number; id: string } | null
+    }>()
+    sessionClient.listLightweight.mockReturnValueOnce(firstPage.promise).mockResolvedValueOnce({
+      items: [createSession({ id: 'older', updatedAt: 50 })],
       hasMore: false,
       nextCursor: null
     })
 
-    const initialFetch = store.fetchSessions()
+    emitSessionUpdate({ reason: 'list-refreshed', sessionIds: [] })
+    const refresh = store.fetchSessions()
     await Promise.resolve()
     await store.loadNextPage()
 
     expect(sessionClient.listLightweight).toHaveBeenCalledTimes(3)
-    expect(sessionClient.listLightweight.mock.calls.at(-1)?.[0]).toMatchObject({
-      includeSubagents: false,
-      cursor: { updatedAt: 30, id: 'session-a' }
+    expect(store.loading.value).toBe(true)
+    firstPage.resolve({
+      items: [created, ...recent.slice(0, 29)],
+      hasMore: true,
+      nextCursor: { updatedAt: 172, id: 'recent-28' }
     })
+    await refresh
 
-    resolveInitialFetch({ items: [], hasMore: false, nextCursor: null })
-    await initialFetch
+    const workspaceIds = () =>
+      store
+        .getFilteredGroups('deepchat')
+        .find((group) => group.id === '/tmp/workspace')
+        ?.sessions.map((session) => session.id)
+    expect(workspaceIds()).toEqual(['created', ...history.map((session) => session.id)])
+    expect(store.nextCursor.value).toEqual(historyCursor)
+    expect(store.hasMore.value).toBe(true)
+
+    await store.loadNextPage()
+
+    expect(sessionClient.listLightweight.mock.calls.at(-1)?.[0].cursor).toEqual(historyCursor)
+    expect(workspaceIds()).toEqual(['created', ...history.map((session) => session.id), 'older'])
+    expect(store.sessions.value).toHaveLength(62)
+    expect(store.hasMore.value).toBe(false)
+    expect(store.nextCursor.value).toBeNull()
+    expect(store.loadingMore.value).toBe(false)
+    expect(store.error.value).toBeNull()
+  })
+
+  it('keeps exhausted pagination complete when refreshing the first page', async () => {
+    const { store, sessionClient } = await setupStore()
+    const sessions = Array.from({ length: 31 }, (_, index) =>
+      createSession({ id: `session-${index}`, updatedAt: 100 - index })
+    )
+    const firstPage = {
+      items: sessions.slice(0, 30),
+      hasMore: true,
+      nextCursor: { updatedAt: 71, id: 'session-29' }
+    }
+    sessionClient.listLightweight
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce({
+        items: sessions.slice(30),
+        hasMore: false,
+        nextCursor: null
+      })
+      .mockResolvedValueOnce(firstPage)
+    await store.fetchSessions()
+    await store.loadNextPage()
+    await store.fetchSessions()
+    await store.loadNextPage()
+
+    expect(store.sessions.value).toHaveLength(31)
+    expect(store.hasMore.value).toBe(false)
+    expect(store.nextCursor.value).toBeNull()
+    expect(sessionClient.listLightweight).toHaveBeenCalledTimes(3)
   })
 
   it('excludes subagent sessions from the initial sidebar page request', async () => {


### PR DESCRIPTION
Workspace history could disappear when starting a conversation: background refreshes replaced loaded pages and raced with pagination, while automatic Agent selection changed the sidebar filter and hid other Agents' history.

Preserve loaded sessions and their pagination position during background refreshes, block next-page requests until the first-page request settles, and retain stale-response guards. Refreshing an exhausted list keeps pagination complete.

Keep the sidebar Agent filter explicit across conversation creation, activation, and restoration. A workspace's new conversation uses the explicit Agent selection first. Under All Agents, it uses the Agent of that workspace's latest regular, non-draft conversation, including pinned conversations. Unavailable Agents, empty history, and failed reads use the existing fallback. A bounded lightweight database query finds unloaded history, and delayed results cannot override newer navigation or an explicit Agent filter change.

```text
BEFORE                          AFTER
[All Agents] -> workspace +     [All Agents] -> workspace +
[Agent A]                      [All Agents]
Workspace                      Workspace
  Agent A history only           Agent A history
  [older pages may vanish]       Agent B history
  [scroll cannot load more]      ... load more
New conversation: Agent A       New conversation: latest workspace Agent
```

Validation:

- Session store: 100 tests; Agent store: 5 tests; sidebar: 72 tests passed with the CI heap limit, `NODE_OPTIONS=--max-old-space-size=6144`.
- Main-process query, session service, route contracts, and session table: 78 tests passed using Electron's Node runtime with `DEEPCHAT_REQUIRE_NATIVE_SQLITE=1`. The persisted-history regression covers the typed query through real SQLite, filtering before pagination and excluding ineligible prioritized records.
- Regression coverage includes new-session creation with a delayed background refresh, stale pagination responses, exhausted pagination, explicit Agent precedence, unavailable history, and superseded workspace lookups.
- `pnpm run format`, `pnpm run format:check`, `pnpm run i18n`, `pnpm run lint`, `pnpm run typecheck`, `pnpm run architecture:renderer-baseline:check`, and `pnpm run icons:check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate Agent filtering that remains stable when opening or restoring conversations.
  - New workspace conversations can select the most recently used enabled Agent, with fallback behavior when unavailable.
  - Session history can now be filtered by workspace and draft status.

- **Bug Fixes**
  - Refreshing session history preserves previously loaded entries and pagination position.
  - Prevented duplicate or overlapping page loads during active requests.
  - Exhausted session history remains correctly marked after refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->