### PR TITLE
perf(provider): coalesce model discovery requests

### DIFF
--- a/src/main/provider/baseProvider.ts
+++ b/src/main/provider/baseProvider.ts
@@ -51,6 +51,7 @@ export abstract class BaseLLMProvider {
   protected isInitialized: boolean = false
   protected providerSettings: ProviderSettingsPort
   private readonly locale: ProviderLocalePort
+  private modelFetchPromise: Promise<MODEL_META[]> | null = null
 
   protected defaultHeaders: Record<string, string> = {
     'HTTP-Referer': 'https://deepchatai.cn',
@@ -113,6 +114,7 @@ export abstract class BaseLLMProvider {
 
   public updateConfig(provider: LLM_PROVIDER): void {
     this.provider = { ...provider }
+    this.modelFetchPromise = null
     this.loadCachedModels()
   }
 
@@ -267,7 +269,15 @@ export abstract class BaseLLMProvider {
     let models: MODEL_META[]
 
     try {
-      models = await this.fetchProviderModels()
+      if (!this.modelFetchPromise) {
+        const pending = this.fetchProviderModels().finally(() => {
+          if (this.modelFetchPromise === pending) {
+            this.modelFetchPromise = null
+          }
+        })
+        this.modelFetchPromise = pending
+      }
+      models = await this.modelFetchPromise
     } catch (e) {
       logger.error(
         `[Provider] fetchModels: Failed to fetch models for provider "${this.provider.id}":`,

--- a/src/main/provider/baseProvider.ts
+++ b/src/main/provider/baseProvider.ts
@@ -265,6 +265,7 @@ export abstract class BaseLLMProvider {
    * @returns 模型列表
    */
   public async fetchModels(options?: { suppressErrors?: boolean }): Promise<MODEL_META[]> {
+    const provider = this.provider
     const suppressErrors = options?.suppressErrors ?? true
     let models: MODEL_META[]
 
@@ -295,8 +296,10 @@ export abstract class BaseLLMProvider {
     logger.info(
       `[Provider] fetchModels: fetched ${models?.length || 0} models for provider "${this.provider.id}"`
     )
-    // Validate that all models have correct providerId
-    const validatedModels = models.map((model) => {
+    if (provider !== this.provider) return []
+
+    // Validate a private snapshot of the shared discovery result.
+    const validatedModels = structuredClone(models).map((model) => {
       if (model.providerId !== this.provider.id) {
         logger.warn(
           `[Provider] fetchModels: Model ${model.id} has incorrect providerId: expected "${this.provider.id}", got "${model.providerId}". Fixing it.`
@@ -307,7 +310,7 @@ export abstract class BaseLLMProvider {
     })
     this.models = validatedModels
     this.providerSettings.setProviderModels(this.provider.id, validatedModels)
-    return validatedModels
+    return structuredClone(validatedModels)
   }
 
   /**

--- a/test/main/provider/baseProvider.test.ts
+++ b/test/main/provider/baseProvider.test.ts
@@ -276,14 +276,68 @@ describe('BaseLLMProvider tool XML conversion', () => {
 
     provider.updateConfig({ ...provider.getProviderSnapshot(), apiKey: 'updated-key' })
     const second = provider.fetchModels()
-    resolveFirst([])
-    await first
+    resolveFirst([{ id: 'outdated-model', providerId: 'test-provider' }] as MODEL_META[])
+    await expect(first).resolves.toEqual([])
+    expect(providerSettings.setProviderModels).not.toHaveBeenCalled()
 
     const concurrent = provider.fetchModels()
     expect(fetchModels).toHaveBeenCalledTimes(2)
     const models = [{ id: 'updated-model', providerId: 'test-provider' }] as MODEL_META[]
     resolveSecond(models)
     await expect(Promise.all([second, concurrent])).resolves.toEqual([models, models])
+    expect(provider.getModels()).toEqual(models)
+  })
+
+  it('does not let stale discovery overwrite models from the current config', async () => {
+    let resolveFirst!: (models: MODEL_META[]) => void
+    const models = [{ id: 'updated-model', providerId: 'test-provider' }] as MODEL_META[]
+    const fetchModels = vi
+      .fn()
+      .mockReturnValueOnce(new Promise<MODEL_META[]>((resolve) => (resolveFirst = resolve)))
+      .mockResolvedValue(models)
+    const provider = new TestProvider(providerSettings, fetchModels)
+    const first = provider.fetchModels()
+
+    provider.updateConfig({ ...provider.getProviderSnapshot(), apiKey: 'updated-key' })
+    await expect(provider.fetchModels()).resolves.toEqual(models)
+    resolveFirst([{ id: 'outdated-model', providerId: 'test-provider' }] as MODEL_META[])
+
+    await expect(first).resolves.toEqual([])
+    expect(provider.getModels()).toEqual(models)
+    expect(providerSettings.setProviderModels).toHaveBeenCalledExactlyOnceWith(
+      'test-provider',
+      models
+    )
+  })
+
+  it('isolates discovered models from callers and the provider cache', async () => {
+    const models: MODEL_META[] = [
+      {
+        id: 'model-1',
+        name: 'Model 1',
+        group: 'default',
+        providerId: 'upstream-provider',
+        supportedEndpointTypes: ['openai'],
+        selectableEndpointTypes: ['openai']
+      }
+    ]
+    const fetchModels = vi.fn().mockResolvedValue(models)
+    const provider = new TestProvider(providerSettings, fetchModels)
+    const [first, second] = await Promise.all([provider.fetchModels(), provider.fetchModels()])
+    const expected = [{ ...models[0], providerId: 'test-provider' }]
+
+    first[0].providerId = 'caller-provider'
+    first[0].supportedEndpointTypes!.push('anthropic')
+    first[0].selectableEndpointTypes!.push('anthropic')
+
+    expect(fetchModels).toHaveBeenCalledTimes(1)
+    expect(second).toEqual(expected)
+    expect(provider.getModels()).toEqual(expected)
+    expect(models[0].providerId).toBe('upstream-provider')
+    expect(models[0].supportedEndpointTypes).toEqual(['openai'])
+    for (const [, persisted] of vi.mocked(providerSettings.setProviderModels).mock.calls) {
+      expect(persisted).toEqual(expected)
+    }
   })
 
   it('preserves the caller signal identity when no model timeout is configured', () => {

--- a/test/main/provider/baseProvider.test.ts
+++ b/test/main/provider/baseProvider.test.ts
@@ -226,22 +226,22 @@ describe('BaseLLMProvider tool XML conversion', () => {
     )
   })
 
-  it('suppresses asynchronous model fetch failures by default', async () => {
-    const provider = new TestProvider(providerSettings, async () => {
-      throw new Error('model endpoint returned 404')
-    })
+  it('preserves each caller error policy and retries failed model discovery', async () => {
+    const error = new Error('model endpoint returned 404')
+    const models = [{ id: 'model-1', providerId: 'test-provider' }] as MODEL_META[]
+    const fetchModels = vi.fn().mockRejectedValueOnce(error).mockResolvedValue(models)
+    const provider = new TestProvider(providerSettings, fetchModels)
 
-    await expect(provider.fetchModels()).resolves.toEqual([])
-  })
+    await expect(
+      Promise.allSettled([provider.fetchModels(), provider.fetchModels({ suppressErrors: false })])
+    ).resolves.toEqual([
+      { status: 'fulfilled', value: [] },
+      { status: 'rejected', reason: error }
+    ])
+    expect(fetchModels).toHaveBeenCalledTimes(1)
 
-  it('rethrows asynchronous model fetch failures when suppression is disabled', async () => {
-    const provider = new TestProvider(providerSettings, async () => {
-      throw new Error('model endpoint returned 404')
-    })
-
-    await expect(provider.fetchModels({ suppressErrors: false })).rejects.toThrow(
-      'model endpoint returned 404'
-    )
+    await expect(provider.fetchModels()).resolves.toEqual(models)
+    expect(fetchModels).toHaveBeenCalledTimes(2)
   })
 
   it('does not suppress provider model persistence failures', async () => {
@@ -262,6 +262,28 @@ describe('BaseLLMProvider tool XML conversion', () => {
     ])
 
     await expect(provider.fetchModels()).rejects.toThrow('model persistence failed')
+  })
+
+  it('starts fresh discovery after a config change while keeping new queries shared', async () => {
+    let resolveFirst!: (models: MODEL_META[]) => void
+    let resolveSecond!: (models: MODEL_META[]) => void
+    const fetchModels = vi
+      .fn()
+      .mockReturnValueOnce(new Promise<MODEL_META[]>((resolve) => (resolveFirst = resolve)))
+      .mockReturnValueOnce(new Promise<MODEL_META[]>((resolve) => (resolveSecond = resolve)))
+    const provider = new TestProvider(providerSettings, fetchModels)
+    const first = provider.fetchModels()
+
+    provider.updateConfig({ ...provider.getProviderSnapshot(), apiKey: 'updated-key' })
+    const second = provider.fetchModels()
+    resolveFirst([])
+    await first
+
+    const concurrent = provider.fetchModels()
+    expect(fetchModels).toHaveBeenCalledTimes(2)
+    const models = [{ id: 'updated-model', providerId: 'test-provider' }] as MODEL_META[]
+    resolveSecond(models)
+    await expect(Promise.all([second, concurrent])).resolves.toEqual([models, models])
   })
 
   it('preserves the caller signal identity when no model timeout is configured', () => {

--- a/test/main/provider/openAICompatibleProvider.test.ts
+++ b/test/main/provider/openAICompatibleProvider.test.ts
@@ -104,7 +104,7 @@ describe('AiSdkProvider openai-compatible', () => {
     }
   )
 
-  it('fetches models over the provider HTTP endpoint instead of the legacy SDK client', async () => {
+  it('shares model discovery across initialization and concurrent queries, then refreshes', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
@@ -113,9 +113,10 @@ describe('AiSdkProvider openai-compatible', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const provider = new AiSdkProvider(createProvider(), createProviderSettings())
-    const models = await provider.fetchModels()
+    const provider = new AiSdkProvider(createProvider({ enable: true }), createProviderSettings())
+    const results = await Promise.all(Array.from({ length: 8 }, () => provider.fetchModels()))
 
+    expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
       'https://mock.example.com/v1/models',
       expect.objectContaining({
@@ -125,12 +126,17 @@ describe('AiSdkProvider openai-compatible', () => {
         })
       })
     )
-    expect(models).toEqual([
-      expect.objectContaining({
-        id: 'gpt-4o',
-        providerId: 'novita'
-      })
-    ])
+    for (const models of results) {
+      expect(models).toEqual([
+        expect.objectContaining({
+          id: 'gpt-4o',
+          providerId: 'novita'
+        })
+      ])
+    }
+
+    await provider.fetchModels({ suppressErrors: false })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it.each([


### PR DESCRIPTION
Creating an enabled provider starts model discovery immediately. Initialization plus eight concurrent model-list queries produced 9 HTTP requests on `dev`.

Share the pending discovery request within each provider instance. The same workload produces 1 HTTP request, and a subsequent explicit refresh makes a fresh request. Configuration changes start a new request; results from the old configuration cannot overwrite the current cache or persisted catalog, regardless of completion order. Each caller receives an independent model snapshot, including endpoint arrays, so normalization and caller mutations cannot leak between requests or into cached models. Caller-specific error suppression remains intact, and persistence failures propagate.

Validation:

- Provider suite: 764 passed; the 5 native SQLite cases also passed under Electron (769 distinct tests).
- Regression coverage includes the 9-to-1 request count, retry and mixed error policies, both stale/current completion orders, nested model isolation, and persistence failures.
- Format check, i18n validation, lint, and node/web typechecks passed.

The request-count workload uses a deterministic HTTP fetch stub; it measures duplicate requests rather than internet latency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved model discovery reliability by sharing concurrent requests instead of issuing duplicates.
  - Ensured provider configuration changes trigger fresh discovery and prevent outdated results from being retained.
  - Preserved retry behavior after failed discovery attempts.
  - Prevented changes to returned model data from affecting cached or persisted results.

- **Tests**
  - Added coverage for concurrent request sharing, stale results, error handling, retries, data isolation, and refreshes after configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->