### PR TITLE
perf(plugin): query only hook history

### DIFF
--- a/src/main/plugin/userPluginHooks.ts
+++ b/src/main/plugin/userPluginHooks.ts
@@ -99,8 +99,7 @@ export class UserPluginHooks implements PluginContextPort {
     let history = cached?.incarnationId === incarnationId ? cached.history : undefined
     if (!history) {
       history = new Map()
-      for (const row of this.tape.getBySession(sessionId)) {
-        if (row.name !== 'plugin/context-hook') continue
+      for (const row of this.tape.getBySession(sessionId, 'plugin/context-hook')) {
         let invocation: Invocation
         try {
           invocation = JSON.parse(row.payload_json)?.state

--- a/src/main/tape/application/sessionTape.ts
+++ b/src/main/tape/application/sessionTape.ts
@@ -459,8 +459,8 @@ export class SessionTape implements SessionTapeCapabilities {
     return this.lineage.linkSubagentTape(input)
   }
 
-  getBySession(sessionId: string): DeepChatTapeEntryRow[] {
-    return this.providers.getEntryStore().getBySessionExcludingContext(sessionId)
+  getBySession(sessionId: string, name?: string): DeepChatTapeEntryRow[] {
+    return this.providers.getEntryStore().getBySessionExcludingContext(sessionId, name)
   }
 
   getTapeInspectorHead(sessionId: string): TapeInspectorHead | null {

--- a/src/main/tape/infrastructure/sqlite/tapeEntryStore.ts
+++ b/src/main/tape/infrastructure/sqlite/tapeEntryStore.ts
@@ -1227,15 +1227,15 @@ export class DeepChatTapeEntriesTable
       ) as DeepChatTapeEntryRow[]
   }
 
-  getBySessionExcludingContext(sessionId: string): DeepChatTapeEntryRow[] {
+  getBySessionExcludingContext(sessionId: string, name?: string): DeepChatTapeEntryRow[] {
     return this.db
       .prepare(
         `SELECT *
          FROM deepchat_tape_entries
-         WHERE session_id = ? AND kind != 'context'
+         WHERE session_id = ? AND kind != 'context'${name === undefined ? '' : ' AND name = ?'}
          ORDER BY entry_id ASC`
       )
-      .all(sessionId) as DeepChatTapeEntryRow[]
+      .all(...(name === undefined ? [sessionId] : [sessionId, name])) as DeepChatTapeEntryRow[]
   }
 
   getEffectiveViewInputRows(sessionId: string): DeepChatTapeEntryRow[] {

--- a/src/main/tape/ports/capabilities.ts
+++ b/src/main/tape/ports/capabilities.ts
@@ -358,7 +358,7 @@ export interface TapeMessageFactWriter {
 }
 
 export interface TapeNonContextEntryReader {
-  getBySession(sessionId: string): DeepChatTapeEntryRow[]
+  getBySession(sessionId: string, name?: string): DeepChatTapeEntryRow[]
 }
 
 export interface TapeAnchorReader {

--- a/src/main/tape/ports/storage.ts
+++ b/src/main/tape/ports/storage.ts
@@ -86,7 +86,7 @@ export interface TapeEntryStore {
     cursor: { sessionId: string; entryId: number } | null,
     limit: number
   ): DeepChatTapeEntryRow[]
-  getBySessionExcludingContext(sessionId: string): DeepChatTapeEntryRow[]
+  getBySessionExcludingContext(sessionId: string, name?: string): DeepChatTapeEntryRow[]
   /** Rows selected by `isEffectiveViewInputRow`, ordered by entry_id. */
   getEffectiveViewInputRows(sessionId: string): DeepChatTapeEntryRow[]
   /** Rows selected by `isEffectiveMessageInputRow`, ordered by entry_id. */

--- a/test/main/plugin/userPlugins.test.ts
+++ b/test/main/plugin/userPlugins.test.ts
@@ -50,7 +50,10 @@ function tape() {
       rows.length = 0
       incarnationId = randomUUID()
     },
-    getBySession: (sessionId: string) => rows.filter((row) => row.session_id === sessionId),
+    getBySession: (sessionId: string, name?: string) =>
+      rows.filter(
+        (row) => row.session_id === sessionId && (name === undefined || row.name === name)
+      ),
     appendAnchor(input: TapeAnchorAppendInput): DeepChatTapeEntryRow {
       const row: DeepChatTapeEntryRow = {
         session_id: input.sessionId,
@@ -226,6 +229,12 @@ describe('reviewed context hook execution', () => {
     const history = tape()
     history.appendAnchor({ sessionId: 's', name: 'plugin/context-hook', state: {} })
     history.rows[0].payload_json = '{broken'
+    history.appendAnchor({
+      sessionId: 's',
+      name: 'unrelated/anchor',
+      state: { invocationId: 'unrelated', status: 'completed' }
+    })
+    const readHistory = vi.spyOn(history, 'getBySession')
     const host = new UserPluginHooks(history)
     const owner = {
       pluginId: 'user.edit',
@@ -246,6 +255,7 @@ describe('reviewed context hook execution', () => {
     const restored = new UserPluginHooks(history)
     restored.register(owner)
     await restored.accept({ ...input, prompt: 'Edited' })
+    expect(readHistory).toHaveBeenCalledWith('s', 'plugin/context-hook')
     expect(history.rows).toHaveLength(count)
     expect(restored.getContext('s', 'm').map((item) => item.content)).toEqual(['startup', 'Edited'])
     history.reset()

--- a/test/main/session/data/tables/deepchatTapeEntriesTable.test.ts
+++ b/test/main/session/data/tables/deepchatTapeEntriesTable.test.ts
@@ -103,6 +103,33 @@ describeIfSqlite('DeepChatTapeEntriesTable', () => {
     db.close()
   })
 
+  it('filters non-context history by exact name without truncating or crossing sessions', () => {
+    const { db, table } = createTable()
+    try {
+      const expected = Array.from({ length: 25 }, (_, index) =>
+        table.appendAnchor({
+          sessionId: 's1',
+          name: 'plugin/context-hook',
+          state: { invocationId: `hook-${index}` }
+        })
+      )
+      table.appendAnchor({ sessionId: 's1', name: 'plugin/context-hook-extra', state: {} })
+      table.appendAnchor({ sessionId: 's2', name: 'plugin/context-hook', state: {} })
+      db.prepare(
+        `INSERT INTO deepchat_tape_entries
+           (session_id, entry_id, kind, name, payload_json, meta_json, created_at)
+         VALUES ('s1', 100, 'context', 'plugin/context-hook', '{}', '{}', 1)`
+      ).run()
+
+      expect(table.getBySessionExcludingContext('s1', 'plugin/context-hook')).toEqual(expected)
+      expect(table.getBySessionExcludingContext('s1')).toHaveLength(26)
+      expect(table.getBySessionExcludingContext('s1', 'plugin/%')).toEqual([])
+      expect(table.getBySessionExcludingContext('missing', 'plugin/context-hook')).toEqual([])
+    } finally {
+      db.close()
+    }
+  })
+
   it('reads the latest request evidence through indexed lookups', () => {
     const { db, table } = createTable()
 


### PR DESCRIPTION
Restoring plugin hook context loaded every non-context Tape row for the session before filtering by hook name. Long tool-heavy conversations therefore materialized unrelated payloads on the main process whenever the hook history cache was cold.

Pass the exact hook name through the existing Tape reader and bind it in SQLite. The existing `(session_id, name, entry_id)` index selects the complete ordered hook history without a schema migration or a history limit. Unfiltered callers retain their current behavior.

An in-memory SQLite workload containing 10,040 rows (40 hook rows, 2 KiB payloads) materialized 40 rows instead of 10,040. Eleven paired samples measured median read/filter time of 5.755 ms before and 0.055 ms after; returned histories were identical. These are synthetic in-memory query measurements, not disk latency or end-to-end response time.

Validation:
- Plugin suite: 181 tests passed in 8 files.
- Native Electron Tape/session-data suites: 662 passed, 1 intentionally skipped worker helper.
- Electron plugin install and context-hook E2E: 2 passed.
- Production Electron build and format, i18n, lint, and typecheck passed.
- Extended the existing restored-context regression with unrelated entries and retained prompt deduplication and Tape-clear behavior. The SQLite regression covers exact-name matching, session isolation, order, context exclusion, and histories larger than one page.

No visual layout or interaction changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tape history filtering to return only entries matching the requested event name.
  - Preserved session boundaries and excluded context entries from results.
  - Ensured exact-name matching, including correct handling of wildcard-like names.

- **Tests**
  - Added coverage for filtered tape retrieval, session isolation, context exclusion, and plugin hook reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->