### PR TITLE
perf(project): batch preference lookups

### DIFF
--- a/src/main/project/index.ts
+++ b/src/main/project/index.ts
@@ -50,22 +50,19 @@ export class ProjectService {
   }
 
   async getProjects(): Promise<Project[]> {
-    const rows = this.sqlitePresenter.newProjectsTable.getAll()
-    return rows
-      .filter((row) => !this.isRemovedEnvironment(row.path))
-      .map((row) => ({
-        path: row.path,
-        name: row.name,
-        icon: row.icon,
-        lastAccessedAt: row.last_accessed_at,
-        exists: fs.existsSync(row.path)
-      }))
+    return this.getRecentProjects(Number.POSITIVE_INFINITY)
   }
 
   async getRecentProjects(limit: number = 10): Promise<Project[]> {
     const rows = this.sqlitePresenter.newProjectsTable.getAll()
+    const removedPaths = new Set(
+      this.sqlitePresenter.newEnvironmentPreferencesTable
+        .list()
+        .filter((preference) => preference.status === 'removed')
+        .map((preference) => preference.path)
+    )
     return rows
-      .filter((row) => !this.isRemovedEnvironment(row.path))
+      .filter((row) => !removedPaths.has(row.path.trim()))
       .slice(0, limit)
       .map((row) => ({
         path: row.path,
@@ -114,9 +111,11 @@ export class ProjectService {
     // All reads are synchronous SQLite/settings reads in this process. Keep them in
     // one uninterrupted turn and stamp the resulting projection with its version.
     const version = this.snapshotVersion
+    const preferences = this.sqlitePresenter.newEnvironmentPreferencesTable.list()
+    const preferenceByPath = new Map(preferences.map((row) => [row.path, row]))
     const rows = this.sqlitePresenter.newProjectsTable
       .getAll()
-      .filter((row) => !this.isRemovedEnvironment(row.path))
+      .filter((row) => preferenceByPath.get(row.path.trim())?.status !== 'removed')
       .slice(0, limit)
     const projects = rows.map((row) => ({
       path: row.path,
@@ -126,9 +125,7 @@ export class ProjectService {
       exists: fs.existsSync(row.path)
     }))
     const environmentRows = this.sqlitePresenter.newEnvironmentsTable.list()
-    const preferences = this.sqlitePresenter.newEnvironmentPreferencesTable.list()
     const usageByPath = new Map(environmentRows.map((row) => [row.path, row]))
-    const preferenceByPath = new Map(preferences.map((row) => [row.path, row]))
     const paths = new Set<string>(environmentRows.map((row) => row.path))
     for (const preference of preferences) {
       paths.add(preference.path)

--- a/test/main/project/projectService.test.ts
+++ b/test/main/project/projectService.test.ts
@@ -104,7 +104,8 @@ describe('ProjectService', () => {
     it('returns projects, all environment states, and default path from one versioned snapshot', async () => {
       const settingsStore = createMockSettingsStore('/work/default')
       sqlitePresenter.newProjectsTable.getAll.mockReturnValue([
-        { path: '/work/project', name: 'project', icon: null, last_accessed_at: 10 }
+        { path: '/work/project', name: 'project', icon: null, last_accessed_at: 10 },
+        { path: ' /work/removed ', name: 'removed', icon: null, last_accessed_at: 5 }
       ])
       sqlitePresenter.newEnvironmentsTable.list.mockReturnValue([
         { path: '/work/project', session_count: 2, last_used_at: 20 }
@@ -146,6 +147,8 @@ describe('ProjectService', () => {
       expect(initial.defaultProjectPath).toBe('/work/default')
       expect(initial.defaultChatWorkspacePath).toBeNull()
       expect(updated.version).toBe(1)
+      expect(sqlitePresenter.newEnvironmentPreferencesTable.list).toHaveBeenCalledTimes(2)
+      expect(sqlitePresenter.newEnvironmentPreferencesTable.get).not.toHaveBeenCalled()
     })
 
     it('persists the snapshot version across ProjectService reconstruction', () => {
@@ -408,19 +411,38 @@ describe('ProjectService', () => {
       expect(projects[0].exists).toBe(true)
     })
 
-    it('filters removed projects from recent rows', async () => {
-      sqlitePresenter.newProjectsTable.getAll.mockReturnValue([
-        { path: '/recent1', name: 'recent1', icon: null, last_accessed_at: 3000 },
-        { path: '/removed', name: 'removed', icon: null, last_accessed_at: 2000 }
-      ])
-      sqlitePresenter.newEnvironmentPreferencesTable.get.mockImplementation((projectPath: string) =>
-        projectPath === '/removed' ? { status: 'removed' } : undefined
-      )
+    it.each(['getProjects', 'getRecentProjects'] as const)(
+      '%s filters removed rows with one preference read regardless of project count',
+      async (method) => {
+        const removed = Array.from({ length: 1000 }, (_, index) => ({
+          path: `/removed/${index}`,
+          name: `removed-${index}`,
+          icon: null,
+          last_accessed_at: 4000 + index
+        }))
+        sqlitePresenter.newProjectsTable.getAll.mockReturnValue([
+          ...removed,
+          { path: '/recent1', name: 'recent1', icon: null, last_accessed_at: 3000 },
+          { path: '/archived', name: 'archived', icon: null, last_accessed_at: 2000 }
+        ])
+        const preferences = [
+          ...removed.map(({ path }) => ({ path, status: 'removed' })),
+          { path: '/archived', status: 'archived' }
+        ]
+        sqlitePresenter.newEnvironmentPreferencesTable.list.mockReturnValue(preferences)
+        sqlitePresenter.newEnvironmentPreferencesTable.get.mockImplementation((path: string) =>
+          preferences.find((preference) => preference.path === path)
+        )
 
-      const projects = await presenter.getRecentProjects(2)
+        const projects = await (method === 'getProjects'
+          ? presenter.getProjects()
+          : presenter.getRecentProjects(2))
 
-      expect(projects.map((project) => project.path)).toEqual(['/recent1'])
-    })
+        expect(projects.map((project) => project.path)).toEqual(['/recent1', '/archived'])
+        expect(sqlitePresenter.newEnvironmentPreferencesTable.list).toHaveBeenCalledTimes(1)
+        expect(sqlitePresenter.newEnvironmentPreferencesTable.get).not.toHaveBeenCalled()
+      }
+    )
   })
 
   describe('getEnvironments', () => {


### PR DESCRIPTION
Opening the project list or refreshing the workspace snapshot executed one synchronous preference query for every saved project, including rows beyond the requested result limit. A profile with 5,000 projects therefore issued 5,000 lookups just to exclude removed environments.

Read preferences once for project lists and reuse the preference map already needed by the versioned snapshot. The complete and recent lists share their existing projection. Filtering still precedes the limit, archived projects remain visible, legacy path trimming is preserved, and snapshot reads remain in one uninterrupted main-process turn.

Native in-memory SQLite with 5,000 projects and 2,500 preferences returned identical results. Eleven samples measured median filtering time of 14.964 ms before and 0.856 ms after, with preference queries reduced from 5,000 to 1. These measurements exclude filesystem checks and are not whole-window latency claims.

Validation:
- Native project suites: 44 tests passed in 3 files.
- Replaced the small removed-row case with shared complete/recent-list coverage at 1,002 rows, retaining order, limit, archived visibility, and the constant query budget.
- Extended the versioned snapshot regression with a removed legacy path and the shared preference-read budget.
- The query-budget regression fails on the baseline.
- Format, i18n, lint, and typecheck passed.

No visual layout or interaction changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Project listings now include the full set of available recent projects instead of being limited.
  - Removed projects are consistently excluded from project and snapshot views, including paths with surrounding whitespace.
  - Project status filtering is now applied consistently when loading snapshots and recent projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->