### PR TITLE
test: refresh scheduler and migration fixtures

### DIFF
--- a/test/main/orchestration/liveDelegationMigration.test.ts
+++ b/test/main/orchestration/liveDelegationMigration.test.ts
@@ -5,28 +5,15 @@ import { Database, nativeSqliteDescribeIf } from '../nativeSqliteHarness'
 
 const fs = await vi.importActual<typeof import('node:fs')>('node:fs')
 const mainDatabaseModule = Database ? await import('@/data/mainDatabase').catch(() => null) : null
-const pendingInputsModule = Database
-  ? await import('@/session/data/tables/deepchatPendingInputs').catch(() => null)
-  : null
-const messageTracesModule = Database
-  ? await import('@/session/data/tables/deepchatMessageTraces').catch(() => null)
-  : null
 const liveDelegationsModule = Database
   ? await import('@/orchestration/data/tables/liveDelegations').catch(() => null)
   : null
 const MainDatabaseCtor = mainDatabaseModule?.MainDatabase!
-const LATEST_DATABASE_SCHEMA_VERSION =
-  liveDelegationsModule?.LIVE_DELEGATION_EVALUATION_DATABASE_SCHEMA_VERSION
 const CONTRACT_DATABASE_SCHEMA_VERSION =
   liveDelegationsModule?.LIVE_DELEGATION_CONTRACT_DATABASE_SCHEMA_VERSION
-const CURRENT_DATABASE_SCHEMA_VERSION = Math.max(
-  LATEST_DATABASE_SCHEMA_VERSION ?? 0,
-  pendingInputsModule?.PENDING_INPUT_RETRY_SCHEMA_VERSION ?? 0,
-  messageTracesModule?.TRACE_EVIDENCE_APPEND_INDEX_SCHEMA_VERSION ?? 0
-)
 const DatabaseCtor = Database!
 const describeIfSqlite = nativeSqliteDescribeIf(
-  Boolean(MainDatabaseCtor && CURRENT_DATABASE_SCHEMA_VERSION && CONTRACT_DATABASE_SCHEMA_VERSION),
+  Boolean(MainDatabaseCtor && CONTRACT_DATABASE_SCHEMA_VERSION),
   'Live delegation migration modules are unavailable'
 )
 
@@ -44,6 +31,7 @@ describeIfSqlite('live delegation schema migration', () => {
     tempDirectories.push(directory)
     const databasePath = path.join(directory, 'agent.db')
     const current = new MainDatabaseCtor(databasePath)
+    const latestSchemaVersion = current.getLatestSchemaVersion()
     current.close()
 
     const bootstrap = new DatabaseCtor(databasePath)
@@ -57,7 +45,7 @@ describeIfSqlite('live delegation schema migration', () => {
     bootstrap.close()
 
     const migrated = new MainDatabaseCtor(databasePath)
-    expect(migrated.getLatestSchemaVersion()).toBe(CURRENT_DATABASE_SCHEMA_VERSION)
+    expect(migrated.getLatestSchemaVersion()).toBe(latestSchemaVersion)
     migrated.close()
 
     const verification = new DatabaseCtor(databasePath)
@@ -79,7 +67,7 @@ describeIfSqlite('live delegation schema migration', () => {
     expect(
       verification.prepare('SELECT MAX(version) AS version FROM schema_versions').get()
     ).toEqual({
-      version: CURRENT_DATABASE_SCHEMA_VERSION
+      version: latestSchemaVersion
     })
     verification.close()
   })
@@ -89,6 +77,7 @@ describeIfSqlite('live delegation schema migration', () => {
     tempDirectories.push(directory)
     const databasePath = path.join(directory, 'agent.db')
     const current = new MainDatabaseCtor(databasePath)
+    const latestSchemaVersion = current.getLatestSchemaVersion()
     current.close()
 
     const bootstrap = new DatabaseCtor(databasePath)
@@ -112,7 +101,7 @@ describeIfSqlite('live delegation schema migration', () => {
     bootstrap.close()
 
     const migrated = new MainDatabaseCtor(databasePath)
-    expect(migrated.getLatestSchemaVersion()).toBe(CURRENT_DATABASE_SCHEMA_VERSION)
+    expect(migrated.getLatestSchemaVersion()).toBe(latestSchemaVersion)
     migrated.close()
 
     const verification = new DatabaseCtor(databasePath)
@@ -127,7 +116,7 @@ describeIfSqlite('live delegation schema migration', () => {
     ).toEqual({ effect_state: 'none', effect_evidence_json: null })
     expect(
       verification.prepare('SELECT MAX(version) AS version FROM schema_versions').get()
-    ).toEqual({ version: CURRENT_DATABASE_SCHEMA_VERSION })
+    ).toEqual({ version: latestSchemaVersion })
     verification.close()
   })
 
@@ -136,6 +125,7 @@ describeIfSqlite('live delegation schema migration', () => {
     tempDirectories.push(directory)
     const databasePath = path.join(directory, 'agent.db')
     const current = new MainDatabaseCtor(databasePath)
+    const latestSchemaVersion = current.getLatestSchemaVersion()
     current.close()
 
     const bootstrap = new DatabaseCtor(databasePath)
@@ -162,7 +152,7 @@ describeIfSqlite('live delegation schema migration', () => {
     bootstrap.close()
 
     const migrated = new MainDatabaseCtor(databasePath)
-    expect(migrated.getLatestSchemaVersion()).toBe(CURRENT_DATABASE_SCHEMA_VERSION)
+    expect(migrated.getLatestSchemaVersion()).toBe(latestSchemaVersion)
     migrated.close()
 
     const verification = new DatabaseCtor(databasePath)
@@ -177,7 +167,7 @@ describeIfSqlite('live delegation schema migration', () => {
     ).toEqual({ result_summary: 'Done.', result_ref_json: null })
     expect(
       verification.prepare('SELECT MAX(version) AS version FROM schema_versions').get()
-    ).toEqual({ version: CURRENT_DATABASE_SCHEMA_VERSION })
+    ).toEqual({ version: latestSchemaVersion })
     verification.close()
   })
 
@@ -186,6 +176,7 @@ describeIfSqlite('live delegation schema migration', () => {
     tempDirectories.push(directory)
     const databasePath = path.join(directory, 'agent.db')
     const current = new MainDatabaseCtor(databasePath)
+    const latestSchemaVersion = current.getLatestSchemaVersion()
     current.close()
 
     const bootstrap = new DatabaseCtor(databasePath)
@@ -214,7 +205,7 @@ describeIfSqlite('live delegation schema migration', () => {
     expect(columns.some((column) => column.name === 'result_ref_json')).toBe(true)
     expect(
       verification.prepare('SELECT MAX(version) AS version FROM schema_versions').get()
-    ).toEqual({ version: CURRENT_DATABASE_SCHEMA_VERSION })
+    ).toEqual({ version: latestSchemaVersion })
     verification.close()
   })
 
@@ -223,6 +214,7 @@ describeIfSqlite('live delegation schema migration', () => {
     tempDirectories.push(directory)
     const databasePath = path.join(directory, 'agent.db')
     const current = new MainDatabaseCtor(databasePath)
+    const latestSchemaVersion = current.getLatestSchemaVersion()
     current.close()
 
     const bootstrap = new DatabaseCtor(databasePath)
@@ -331,7 +323,7 @@ describeIfSqlite('live delegation schema migration', () => {
     ).toEqual({ content: 'Continue.', evaluation_json: null, evaluation_ref_json: null })
     expect(
       verification.prepare('SELECT MAX(version) AS version FROM schema_versions').get()
-    ).toEqual({ version: CURRENT_DATABASE_SCHEMA_VERSION })
+    ).toEqual({ version: latestSchemaVersion })
     verification.close()
   })
 
@@ -340,6 +332,7 @@ describeIfSqlite('live delegation schema migration', () => {
     tempDirectories.push(directory)
     const databasePath = path.join(directory, 'agent.db')
     const current = new MainDatabaseCtor(databasePath)
+    const latestSchemaVersion = current.getLatestSchemaVersion()
     current.close()
 
     const bootstrap = new DatabaseCtor(databasePath)
@@ -358,7 +351,7 @@ describeIfSqlite('live delegation schema migration', () => {
     bootstrap.close()
 
     const migrated = new MainDatabaseCtor(databasePath)
-    expect(migrated.getLatestSchemaVersion()).toBe(CURRENT_DATABASE_SCHEMA_VERSION)
+    expect(migrated.getLatestSchemaVersion()).toBe(latestSchemaVersion)
     migrated.close()
 
     const verification = new DatabaseCtor(databasePath)
@@ -374,7 +367,7 @@ describeIfSqlite('live delegation schema migration', () => {
     ).toEqual([])
     expect(
       verification.prepare('SELECT MAX(version) AS version FROM schema_versions').get()
-    ).toEqual({ version: CURRENT_DATABASE_SCHEMA_VERSION })
+    ).toEqual({ version: latestSchemaVersion })
     verification.close()
   })
 
@@ -383,6 +376,7 @@ describeIfSqlite('live delegation schema migration', () => {
     tempDirectories.push(directory)
     const databasePath = path.join(directory, 'agent.db')
     const current = new MainDatabaseCtor(databasePath)
+    const latestSchemaVersion = current.getLatestSchemaVersion()
     current.close()
 
     const bootstrap = new DatabaseCtor(databasePath)
@@ -416,7 +410,7 @@ describeIfSqlite('live delegation schema migration', () => {
     bootstrap.close()
 
     const migrated = new MainDatabaseCtor(databasePath)
-    expect(migrated.getLatestSchemaVersion()).toBe(CURRENT_DATABASE_SCHEMA_VERSION)
+    expect(migrated.getLatestSchemaVersion()).toBe(latestSchemaVersion)
     migrated.close()
 
     const verification = new DatabaseCtor(databasePath)
@@ -431,7 +425,7 @@ describeIfSqlite('live delegation schema migration', () => {
     ).toEqual({ content: 'Done.', evaluation_json: null, evaluation_ref_json: null })
     expect(
       verification.prepare('SELECT MAX(version) AS version FROM schema_versions').get()
-    ).toEqual({ version: CURRENT_DATABASE_SCHEMA_VERSION })
+    ).toEqual({ version: latestSchemaVersion })
     verification.close()
   })
 })

--- a/test/main/scheduler/schedulerService.test.ts
+++ b/test/main/scheduler/schedulerService.test.ts
@@ -876,7 +876,7 @@ describeIfSqlite('Cron Jobs persistence and service', () => {
           enabled: true
         }
       ]
-      const providerSettings = {
+      const agentSettings = {
         listAgents: vi.fn(async () => agents),
         resolveDeepChatAgentConfig: vi.fn(async () => ({ systemPrompt: 'system' }))
       }
@@ -884,7 +884,7 @@ describeIfSqlite('Cron Jobs persistence and service', () => {
         ...createRequiredSchedulerDeps(),
         database: sqlitePresenter as never,
         schedulerManager: schedulerManager as never,
-        providerSettings: providerSettings as never
+        agentSettings: agentSettings as never
       })
 
       const follow = await service.upsert({
@@ -897,7 +897,7 @@ describeIfSqlite('Cron Jobs persistence and service', () => {
       })
 
       expect(follow.job.agentSnapshot).toBeNull()
-      expect(providerSettings.resolveDeepChatAgentConfig).toHaveBeenCalledWith('agent-1')
+      expect(agentSettings.resolveDeepChatAgentConfig).toHaveBeenCalledWith('agent-1')
 
       const { job } = await service.upsert({
         name: 'Snapshot job',


### PR DESCRIPTION
Native scheduler and delegation suites failed after their production owners evolved: the snapshot test injected the retired `providerSettings` dependency, and seven migration tests computed the global database version from an incomplete list of table-specific constants.

Inject the current `agentSettings` dependency so the test actually exercises snapshot capture and disabled-Agent reconciliation. Read the latest version from the initialized database fixture, retaining migration, row preservation, repair, and constraint assertions. Remove the duplicated version calculation and unrelated module imports.

Validation: all 137 scheduler/orchestration tests pass in the Electron-compatible native SQLite runtime. Format, i18n, lint, and node/web typechecks pass. No production behavior or schema changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved database migration test coverage by deriving expected schema versions from newly created databases.
  * Updated scheduler reconciliation tests to use consistent agent configuration terminology.
  * Simplified test setup and strengthened validation of schema compatibility and disabled-agent handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->