### PR TITLE
test(cli): isolate the fixture executable

### DIFF
--- a/test/main/scripts/buildCli.test.ts
+++ b/test/main/scripts/buildCli.test.ts
@@ -30,22 +30,15 @@ async function runGeneratedLauncher(outputDirectory: string) {
 
 async function provisionElectronHost(outputDirectory: string): Promise<void> {
   const appRoot = path.resolve(outputDirectory, '..', '..', '..')
-  const hostName = process.platform === 'win32' ? 'DeepChat.exe' : 'DeepChat'
-  const hosts = [
-    path.join(appRoot, hostName),
-    path.join(appRoot, 'MacOS', 'DeepChat'),
-    path.join(appRoot, 'deepchat')
-  ]
-  for (const host of hosts) {
-    await mkdir(path.dirname(host), { recursive: true })
-    try {
-      await symlink(process.execPath, host)
-    } catch {
-      await copyFile(process.execPath, host)
-      if (process.platform !== 'win32') {
-        await chmod(host, 0o755)
-      }
-    }
+  const host =
+    process.platform === 'darwin'
+      ? path.join(appRoot, 'MacOS', 'DeepChat')
+      : path.join(appRoot, process.platform === 'win32' ? 'DeepChat.exe' : 'deepchat.bin')
+  await mkdir(path.dirname(host), { recursive: true })
+  // Keep the running interpreter outside the fixture, including on case-insensitive filesystems.
+  await copyFile(process.execPath, host)
+  if (process.platform !== 'win32') {
+    await chmod(host, 0o755)
   }
 }
 


### PR DESCRIPTION
The CLI bundle test could overwrite its own Node executable on a case-insensitive filesystem. It created both `DeepChat` and `deepchat`; the first path was a symlink to `process.execPath`, and the second creation failed with `EEXIST`. The broad copy fallback then followed that symlink and rewrote the running interpreter. On macOS this invalidated the cached code signature and killed unrelated test processes using the same binary.

Provision one standalone executable copy at the current platform's expected packaged-host path. Remove the redundant host aliases and symlink/copy fallback. Keep the existing generated-launcher, host selection, and packaging tests.

Validation: baseline isolated CLI tests reproduced four failures and invalidated the running Node image. With the fixture fixed, all 257 tests in 30 script suites pass; Node remains executable, and both Electron plugin E2E tests pass. Format, i18n, lint, and node/web typechecks pass. Production launchers are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified CLI build test host setup across macOS, Windows, and other platforms.
  * Improved consistency when creating the test host executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->