### PR TITLE
test(renderer): reuse session store fixtures

### DIFF
--- a/test/renderer/stores/sessionStore.test.ts
+++ b/test/renderer/stores/sessionStore.test.ts
@@ -1,9 +1,42 @@
-import { reactive } from 'vue'
+import { effectScope, reactive, type EffectScope } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   GUIDED_ONBOARDING_RESUME_REQUESTED_EVENT,
   GUIDED_ONBOARDING_RESUME_STORAGE_KEY
 } from '@/lib/onboardingResume'
+
+const dependencies = vi.hoisted(() => ({
+  createConfigClient: vi.fn(),
+  createOnboardingClient: vi.fn(),
+  createSessionClient: vi.fn(),
+  createChatClient: vi.fn(),
+  usePageRouterStore: vi.fn(),
+  useAttachmentPreparationStore: vi.fn(),
+  useAgentStore: vi.fn(),
+  useMessageStore: vi.fn(),
+  getRuntimeWebContentsId: vi.fn()
+}))
+
+vi.mock('pinia', async () => ({
+  ...(await vi.importActual<typeof import('pinia')>('pinia')),
+  defineStore: (_id: string, setup: () => unknown) => setup
+}))
+vi.mock('@api/ConfigClient', () => ({ createConfigClient: dependencies.createConfigClient }))
+vi.mock('@api/OnboardingClient', () => ({
+  createOnboardingClient: dependencies.createOnboardingClient
+}))
+vi.mock('@api/SessionClient', () => ({ createSessionClient: dependencies.createSessionClient }))
+vi.mock('@api/ChatClient', () => ({ createChatClient: dependencies.createChatClient }))
+vi.mock('@api/runtime', async () => ({
+  ...(await vi.importActual<typeof import('@api/runtime')>('@api/runtime')),
+  getRuntimeWebContentsId: dependencies.getRuntimeWebContentsId
+}))
+vi.mock('@/stores/ui/pageRouter', () => ({ usePageRouterStore: dependencies.usePageRouterStore }))
+vi.mock('@/stores/ui/attachmentPreparation', () => ({
+  useAttachmentPreparationStore: dependencies.useAttachmentPreparationStore
+}))
+vi.mock('@/stores/ui/agent', () => ({ useAgentStore: dependencies.useAgentStore }))
+vi.mock('@/stores/ui/message', () => ({ useMessageStore: dependencies.useMessageStore }))
 
 type SessionListTestItem = {
   id: string
@@ -30,6 +63,7 @@ type SetupStoreOptions = {
 }
 
 const SIDEBAR_GROUP_MODE_KEY = 'sidebar_group_mode'
+const storeScopes: EffectScope[] = []
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void
@@ -42,6 +76,7 @@ function createDeferred<T>() {
 }
 
 afterEach(() => {
+  storeScopes.splice(0).forEach((scope) => scope.stop())
   window.sessionStorage.removeItem(GUIDED_ONBOARDING_RESUME_STORAGE_KEY)
 })
 
@@ -64,7 +99,6 @@ const createSession = (overrides: Record<string, unknown> = {}) => ({
 })
 
 const setupStore = async (options: SetupStoreOptions = {}) => {
-  vi.resetModules()
   const sessionListeners: Array<(payload: any) => void> = []
   const sessionStatusListeners: Array<(payload: any) => void> = []
   const sessionCompactionListeners: Array<(payload: any) => void> = []
@@ -308,66 +342,32 @@ const setupStore = async (options: SetupStoreOptions = {}) => {
       settings[key] = value
     })
   }
-  vi.doMock('pinia', async () => {
-    const actual = await vi.importActual<typeof import('pinia')>('pinia')
-    return {
-      ...actual,
-      defineStore: (_id: string, setup: () => unknown) => setup
-    }
-  })
-
-  vi.doMock('../../../src/renderer/api/ConfigClient', () => ({
-    createConfigClient: vi.fn(() => configClient)
-  }))
-  vi.doMock('../../../src/renderer/api/OnboardingClient', () => ({
-    createOnboardingClient: vi.fn(() => onboardingClient)
-  }))
-  vi.doMock('../../../src/renderer/api/SessionClient', () => ({
-    createSessionClient: vi.fn(() => sessionClient)
-  }))
-  vi.doMock('../../../src/renderer/api/ChatClient', () => ({
-    createChatClient: vi.fn(() => chatClient)
-  }))
-  vi.doMock('@/stores/ui/pageRouter', () => ({
-    usePageRouterStore: () => pageRouter
-  }))
-  vi.doMock('@/stores/ui/attachmentPreparation', () => ({
-    useAttachmentPreparationStore: () => attachmentPreparationStore
-  }))
-  vi.doMock('@/stores/ui/agent', () => ({
-    useAgentStore: () => agentStore
-  }))
   const clearStreamingState = vi.fn()
   const setCurrentSessionId = vi.fn()
   const invalidateRecentSessionView = vi.fn()
   const purgeSessionTracking = vi.fn()
-  vi.doMock('@/stores/ui/message', () => ({
-    useMessageStore: () => ({
-      clearStreamingState,
-      invalidateRecentSessionView,
-      purgeSessionTracking,
-      loadMessages: vi.fn(),
-      setCurrentSessionId
-    })
-  }))
-  ;(window as any).deepchat = {
-    ...((window as any).deepchat ?? {}),
-    invoke: vi.fn(async (routeName: string) => {
-      if (routeName === 'window.getRuntimeIdentity') {
-        return (
-          options.runtimeIdentity ?? {
-            windowId: 1,
-            webContentsId: 1
-          }
-        )
-      }
-
-      return {}
-    })
-  }
+  dependencies.createConfigClient.mockReturnValue(configClient)
+  dependencies.createOnboardingClient.mockReturnValue(onboardingClient)
+  dependencies.createSessionClient.mockReturnValue(sessionClient)
+  dependencies.createChatClient.mockReturnValue(chatClient)
+  dependencies.usePageRouterStore.mockReturnValue(pageRouter)
+  dependencies.useAttachmentPreparationStore.mockReturnValue(attachmentPreparationStore)
+  dependencies.useAgentStore.mockReturnValue(agentStore)
+  dependencies.useMessageStore.mockReturnValue({
+    clearStreamingState,
+    invalidateRecentSessionView,
+    purgeSessionTracking,
+    loadMessages: vi.fn(),
+    setCurrentSessionId
+  })
+  dependencies.getRuntimeWebContentsId.mockImplementation(async () =>
+    options.runtimeIdentity ? (await options.runtimeIdentity).webContentsId : 1
+  )
 
   const { useSessionStore } = await import('@/stores/ui/session')
-  const store = useSessionStore()
+  const scope = effectScope()
+  storeScopes.push(scope)
+  const store = scope.run(() => useSessionStore())!
   await new Promise((resolve) => setTimeout(resolve, 0))
   const emitSessionUpdate = (payload: unknown) => {
     for (const handler of sessionListeners) {


### PR DESCRIPTION
The session store suite reloaded its Vue dependency graph for each fixture. Its 91 existing cases exhausted the default roughly 4 GB Node heap and aborted the renderer suite. Reuse hoisted mock factories with fresh per-fixture return values, keep runtime identity at its existing asynchronous boundary, and dispose each store's Vue effect scope after the test.

All 91 behavioral cases are retained. The isolated suite now finishes in 1.94 seconds with a reported final heap of 149 MB and maximum resident memory of about 306 MiB. No heap-limit increase or production scheduling change is needed.

Validation: the complete renderer suite passes (268 files, 2,377 tests). Format, i18n, lint, and both typechecks pass. The measurements describe test-runner resource use on macOS arm64, not application memory.
