### PR TITLE
fix(migration): preserve session recency

### DIFF
--- a/src/main/app/startupMigrations/sessionDataMigrations.ts
+++ b/src/main/app/startupMigrations/sessionDataMigrations.ts
@@ -442,16 +442,12 @@ export async function runDisabledAgentToolCapabilityCleanupMigration(
        ORDER BY id ASC
        LIMIT ?`
     )
-    const updateSessionDisabledTools = db.prepare<[string, number, string]>(
-      'UPDATE new_sessions SET disabled_agent_tools = ?, updated_at = ?, revision = revision + 1 WHERE id = ?'
+    const updateSessionDisabledTools = db.prepare<[string, string]>(
+      'UPDATE new_sessions SET disabled_agent_tools = ?, revision = revision + 1 WHERE id = ?'
     )
     const persistSessionDisabledTools = db.transaction(
       (sessionId: string, disabledAgentTools: string[]): boolean => {
-        const result = updateSessionDisabledTools.run(
-          JSON.stringify(disabledAgentTools),
-          Date.now(),
-          sessionId
-        )
+        const result = updateSessionDisabledTools.run(JSON.stringify(disabledAgentTools), sessionId)
         if (result.changes === 0) return false
         sqlitePresenter.newSessionDisabledAgentToolsTable.replaceForSession(
           sessionId,

--- a/test/main/app/startupMigrations/sessionDataMigrations.sqlite.test.ts
+++ b/test/main/app/startupMigrations/sessionDataMigrations.sqlite.test.ts
@@ -4,6 +4,7 @@ import {
   type SessionDataMigrationSQLitePort
 } from '@/app/startupMigrations/sessionDataMigrations'
 import { TAPE_TOOL_NAMES } from '@shared/agentTools'
+import { NewSessionActiveSkillsTable } from '@/session/data/tables/newSessionActiveSkills'
 
 const sqliteModule = await import('better-sqlite3-multiple-ciphers').catch(() => null)
 const sessionsModule = sqliteModule
@@ -57,6 +58,7 @@ describeIfSqlite('disabled Agent tool capability cleanup SQLite integration', ()
       const disabledTools = new NewSessionDisabledAgentToolsTableCtor(db)
       const environments = new NewEnvironmentsTableCtor(db)
       sessions.createTable()
+      new NewSessionActiveSkillsTable(db).createTable()
       disabledTools.createTable()
       environments.createTable()
 
@@ -100,7 +102,12 @@ describeIfSqlite('disabled Agent tool capability cleanup SQLite integration', ()
       expect(sessions.list().map((row) => row.id)).toEqual(['newer', 'older'])
       expect(sessions.get('older')).toMatchObject({
         disabled_agent_tools: JSON.stringify(['read']),
-        updated_at: 100
+        updated_at: 100,
+        revision: 1
+      })
+      expect(sessions.get('newer')).toMatchObject({
+        updated_at: 200,
+        revision: 0
       })
       expect(disabledTools.listBySession('older')).toEqual([
         { session_id: 'older', ordinal: 0, tool_name: 'read' }
@@ -120,6 +127,7 @@ describeIfSqlite('disabled Agent tool capability cleanup SQLite integration', ()
       const sessions = new NewSessionsTableCtor(db)
       const disabledTools = new NewSessionDisabledAgentToolsTableCtor(db)
       sessions.createTable()
+      new NewSessionActiveSkillsTable(db).createTable()
       disabledTools.createTable()
 
       const originalDisabledTools = [TAPE_TOOL_NAMES.search, 'read']
@@ -156,7 +164,8 @@ describeIfSqlite('disabled Agent tool capability cleanup SQLite integration', ()
 
       expect(sessions.get('session-1')).toMatchObject({
         disabled_agent_tools: JSON.stringify(originalDisabledTools),
-        updated_at: 100
+        updated_at: 100,
+        revision: 0
       })
       expect(disabledTools.listBySession('session-1')).toEqual([
         { session_id: 'session-1', ordinal: 0, tool_name: TAPE_TOOL_NAMES.search },

--- a/test/main/app/startupMigrations/sessionDataMigrations.test.ts
+++ b/test/main/app/startupMigrations/sessionDataMigrations.test.ts
@@ -16,12 +16,10 @@ function createFixture() {
   const sessionRows: Array<{ id: string }> = []
   const sessionDisabledTools = new Map<string, string[]>()
   const statements: string[] = []
-  const updateSessionDisabledTools = vi.fn(
-    (serialized: string, _updatedAt: number, sessionId: string) => ({
-      changes: sessionRows.some((row) => row.id === sessionId) ? 1 : 0,
-      serialized
-    })
-  )
+  const updateSessionDisabledTools = vi.fn((serialized: string, sessionId: string) => ({
+    changes: sessionRows.some((row) => row.id === sessionId) ? 1 : 0,
+    serialized
+  }))
   const replaceSessionDisabledTools = vi.fn((sessionId: string, disabledAgentTools: string[]) => {
     sessionDisabledTools.set(sessionId, disabledAgentTools)
   })
@@ -234,7 +232,6 @@ describe('session data migrations', () => {
     ])
     expect(fixture.updateSessionDisabledTools).toHaveBeenCalledWith(
       JSON.stringify(['cdp_send', 'custom_tool', 'exec']),
-      expect.any(Number),
       'session-1'
     )
     expect(fixture.providerSettings.updateDeepChatAgent).toHaveBeenCalledWith('deepchat', {
@@ -255,12 +252,6 @@ describe('session data migrations', () => {
         expect.stringMatching(/ORDER BY id ASC\s+LIMIT \?/),
         expect.stringMatching(/WHERE id > \?\s+ORDER BY id ASC\s+LIMIT \?/)
       ])
-    )
-    const sessionUpdate = fixture.statements.find((sql) =>
-      sql.startsWith('UPDATE new_sessions SET disabled_agent_tools')
-    )
-    expect(sessionUpdate).toBe(
-      'UPDATE new_sessions SET disabled_agent_tools = ?, updated_at = ?, revision = revision + 1 WHERE id = ?'
     )
   })
 


### PR DESCRIPTION
The disabled-tool startup migration changed `updated_at` while normalizing legacy tool names. An older affected conversation could jump ahead of a newer conversation, and the existing recency indexes were rewritten even though no user activity occurred.

Update only the disabled-tool payload and revision inside the existing transaction. Preserve conversation timestamps and environment recency, keep both normalized stores atomic, and leave already-completed migrations alone.

Repair the native fixture by creating the current active-Skills relation before inserting sessions. Keep the original order/recency and rollback assertions, verify revision advancement and rollback, and remove the mocked assertion that copied the faulty SQL verbatim. The repaired native test fails on the baseline because the older session is moved first.

Validation: all 14 focused migration tests pass in the Electron-compatible SQLite runtime. Format, i18n, lint, and node/web typechecks pass. No new schema version, dependency, or UI layout change.

Before / after (conversation order after startup migration):

```text
BEFORE                         AFTER
Older chat (migration time)     Newer chat (200)
Newer chat (200)                Older chat (100)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session data migrations now preserve existing session update timestamps when normalizing disabled tools.
  * Migration revision tracking is now handled consistently for migrated, unchanged, and rolled-back sessions.
  * Improved migration reliability across supported session database scenarios, including rollback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->