### PR TITLE
test(e2e): repair streaming state coverage

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,71 +1,67 @@
 # DeepChat E2E Smoke
 
-This suite runs manual smoke regression against the real local desktop environment by default.
+The suite launches the built Electron application. By default, each fixture creates a temporary
+`userData` profile, seeds completed onboarding and diagnostic logging, and removes the profile
+after closing the app. It does not use your normal desktop profile by default.
 
-It does not use mock providers, alternate `userData` directories, or E2E-only bootstrap state.
-The default `pnpm run e2e:smoke` command runs against the same local profile that the app normally
-uses.
+## Coverage
 
-## Scope
+The default suite covers startup, Settings navigation, typed IPC boundaries, workspace watchers,
+provider configuration, agent and plugin management, composer drafts, and local streaming.
+The plugin and streaming specs use loopback HTTP/MCP fixtures through the real application routes.
+They require no external provider credentials.
 
-- Launch the Electron app
-- Select an agent and start a real conversation
-- Send messages with the configured provider and model
-- Verify session persistence after restart
-- Open the Settings window and check core tabs
-- Optionally verify provider connectivity from the Settings window
+Five specs require `RUN_PROVIDER_INTEGRATION=true`: basic chat, session persistence, provider
+connectivity, chat scrollbar ownership, and composer width. Their default provider/model is
+`minimax` / `MiniMax-M2.7`; override these with `DEEPCHAT_E2E_PROVIDER_ID` and
+`DEEPCHAT_E2E_MODEL_ID`. The target model must be configured and enabled in the selected profile.
 
-## Defaults
-
-The smoke suite currently targets the following real provider setup:
-
-- Provider: `minimax`
-- Model: `MiniMax-M2.7`
-
-If you want to use a different provider or model, set `DEEPCHAT_E2E_PROVIDER_ID` and
-`DEEPCHAT_E2E_MODEL_ID`, or edit [testData.ts](./helpers/testData.ts).
-
-The CI command runs only the launch and Settings navigation smoke specs. It does not send chat
-requests and does not require provider credentials.
-
-## Prerequisites
-
-Before running the suite:
-
-1. Complete the app onboarding flow.
-2. Configure the target provider in your normal local profile.
-3. Make sure the target model is enabled and selectable.
-4. Build the app.
+The CI subset runs only launch and Settings navigation, using the same profile isolation.
 
 ## Commands
+
+Use Node >=20.19 and pnpm >=10.11. Build before running:
 
 ```bash
 pnpm run build
 pnpm run e2e:smoke
 ```
 
-For CI-style validation without real credentials:
+Run the smaller CI subset:
 
 ```bash
-pnpm run build
 pnpm run e2e:smoke:ci
 ```
 
-Set `RUN_PROVIDER_INTEGRATION=true` before running `pnpm run e2e:smoke` if you also want the
-live provider connectivity check in `05-settings-provider.smoke.spec.ts`.
+Run a specific deterministic workflow:
 
-## Artifacts
+```bash
+pnpm exec playwright test -c test/e2e/playwright.config.ts 36-chat-streaming
+```
 
-- `test-results/e2e`
-- `playwright-report`
+For live provider checks, select a dedicated configured test profile:
 
-The suite also attaches renderer console output and page errors to each test run.
+```bash
+DEEPCHAT_E2E_USER_DATA_DIR=/absolute/path/to/test-profile \
+RUN_PROVIDER_INTEGRATION=true \
+pnpm run e2e:smoke
+```
 
-## Notes
+`DEEPCHAT_E2E_USER_DATA_DIR` disables fixture ownership and automatic profile removal. Tests can
+create sessions and change application state in that directory. The fixture seeds settings only
+when `app-settings.json` does not already exist.
 
-- The suite creates real chat sessions in the current profile.
-- Tests are additive only and avoid deleting existing user data.
-- Settings checks use the real Settings window and the real provider configuration.
-- The provider connectivity check is opt-in because it requires live credentials and network access.
-- `pnpm run e2e:smoke:ci` uses the current profile and only runs non-provider smoke coverage; it is
-  intended for CI and Windows ARM64 validation.
+For a packaged executable, set `DEEPCHAT_E2E_APP_MODE=packaged` and
+`DEEPCHAT_E2E_EXECUTABLE_PATH` to its absolute path. Windows defaults to the matching unpacked
+architecture under `dist` when no executable override is supplied.
+
+## Artifacts and state contracts
+
+Results are written to `test-results/e2e` and `playwright-report`. Each test attaches renderer
+console output, page errors, and available main-process logs; failures retain screenshots,
+video, and traces.
+
+`chat-page-shell` owns `data-generating`. `chat-page` is the message scroll viewport.
+The generation helper observes the shell's generating-to-idle transition. The local streaming
+spec holds its response open while checking composer input, then releases it and verifies both
+completion and preservation of the draft.

--- a/test/e2e/helpers/wait.ts
+++ b/test/e2e/helpers/wait.ts
@@ -39,7 +39,7 @@ export async function waitForChatSurface(page: Page): Promise<void> {
 }
 
 export async function waitForGenerationDone(page: Page): Promise<void> {
-  const chatPage = page.getByTestId('chat-page')
+  const chatPage = page.getByTestId('chat-page-shell')
   await expect(chatPage).toBeVisible({ timeout: 60_000 })
 
   await expect
@@ -56,5 +56,5 @@ export async function waitForGenerationDone(page: Page): Promise<void> {
     })
     .toBe('false')
 
-  await expect(page.getByTestId('chat-send-button')).toBeVisible({ timeout: 30_000 })
+  await expect(chatPage.getByTestId('chat-send-button')).toBeVisible({ timeout: 30_000 })
 }

--- a/test/e2e/specs/36-chat-streaming.smoke.spec.ts
+++ b/test/e2e/specs/36-chat-streaming.smoke.spec.ts
@@ -106,6 +106,7 @@ test('local streaming preserves an editable composer and completes the response 
     const shell = app.page.getByTestId('chat-page-shell')
     await expect(shell).toHaveAttribute('data-generating', 'true')
     const completion = waitForGenerationDone(app.page)
+    void completion.catch(() => {})
     const editor = shell.getByTestId('chat-input-contenteditable')
     const draft = 'My next message stays editable during generation.'
     await editor.fill(draft)

--- a/test/e2e/specs/36-chat-streaming.smoke.spec.ts
+++ b/test/e2e/specs/36-chat-streaming.smoke.spec.ts
@@ -1,0 +1,124 @@
+import { createServer } from 'node:http'
+import { test, expect } from '../fixtures/electronApp'
+import { selectAgent, selectModel, sendMessage } from '../helpers/chat'
+import { waitForAppReady, waitForGenerationDone } from '../helpers/wait'
+
+test('local streaming preserves an editable composer and completes the response @smoke', async ({
+  app
+}) => {
+  let releaseResponse = () => {}
+  const released = new Promise<void>((resolve) => {
+    releaseResponse = resolve
+  })
+  const markdown = Array.from(
+    { length: 32 },
+    (_, index) => `## Section ${index}\n\n${'Local streaming content. '.repeat(12)}\n\n`
+  ).join('')
+  const server = createServer(async (request, response) => {
+    if (request.url === '/v1/models') {
+      response
+        .writeHead(200, { 'Content-Type': 'application/json' })
+        .end(JSON.stringify({ data: [{ id: 'fixture-model' }] }))
+      return
+    }
+    if (request.url !== '/v1/chat/completions') {
+      response.writeHead(404).end()
+      return
+    }
+    let body = ''
+    for await (const chunk of request) body += chunk
+    if (!JSON.parse(body).stream) {
+      response.writeHead(200, { 'Content-Type': 'application/json' }).end(
+        JSON.stringify({
+          id: 'fixture-title',
+          object: 'chat.completion',
+          created: 1,
+          model: 'fixture-model',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'Local streaming' },
+              finish_reason: 'stop'
+            }
+          ]
+        })
+      )
+      return
+    }
+    response.writeHead(200, { 'Content-Type': 'text/event-stream' })
+    const emit = (content: string, finishReason: string | null = null) =>
+      response.write(
+        `data: ${JSON.stringify({
+          id: 'fixture-stream',
+          object: 'chat.completion.chunk',
+          created: 1,
+          model: 'fixture-model',
+          choices: [{ index: 0, delta: { content }, finish_reason: finishReason }]
+        })}\n\n`
+      )
+    emit(markdown)
+    await released
+    if (!response.destroyed) {
+      emit('\n\nStream complete.', 'stop')
+      response.end('data: [DONE]\n\n')
+    }
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address() as { port: number }
+  try {
+    await waitForAppReady(app.page)
+    const providerId = await app.page.evaluate(async (baseUrl) => {
+      const id = `custom-${crypto.randomUUID()}`
+      await window.deepchat.invoke('providers.add', {
+        provider: {
+          id,
+          name: 'Streaming fixture',
+          apiType: 'openai-completions',
+          baseUrl,
+          apiKey: 'fixture-key',
+          enable: true,
+          custom: true
+        }
+      })
+      await window.deepchat.invoke('models.addCustom', {
+        providerId: id,
+        model: {
+          id: 'fixture-model',
+          name: 'Fixture',
+          enabled: true,
+          vision: false,
+          functionCall: false,
+          reasoning: false,
+          contextLength: 32000,
+          maxTokens: 8000
+        }
+      })
+      await window.deepchat.invoke('models.setStatus', {
+        providerId: id,
+        modelId: 'fixture-model',
+        enabled: true
+      })
+      return id
+    }, `http://127.0.0.1:${address.port}/v1`)
+    await selectAgent(app.page)
+    await selectModel(app.page, 'fixture-model', providerId)
+    await sendMessage(app.page, 'Render the local streaming fixture.')
+    const shell = app.page.getByTestId('chat-page-shell')
+    await expect(shell).toHaveAttribute('data-generating', 'true')
+    const completion = waitForGenerationDone(app.page)
+    const editor = shell.getByTestId('chat-input-contenteditable')
+    const draft = 'My next message stays editable during generation.'
+    await editor.fill(draft)
+    await expect(editor).toHaveText(draft)
+    await expect(shell).toHaveAttribute('data-generating', 'true')
+    releaseResponse()
+    await completion
+    await expect(app.page.getByTestId('chat-message-assistant')).toContainText('Stream complete.')
+    await expect(editor).toHaveText(draft)
+    expect(app.pageErrors).toEqual([])
+  } finally {
+    releaseResponse()
+    server.closeAllConnections()
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+})


### PR DESCRIPTION
The generation-completion helper read `data-generating` from `chat-page`, while the attribute belongs to `chat-page-shell`. Read the current owner and scope the send button and composer to that shell.

A local HTTP provider holds a Markdown response open, allows editing the active composer during generation, then verifies the final response and preserved next-message draft. Attach a rejection observer immediately when starting the completion wait, while retaining its final await so completion failures still fail the test. This prevents an intermediate assertion failure from leaving an unhandled rejection.

Refresh the E2E guide with fixture-owned temporary profiles, live-provider gates, current model/environment defaults, packaged mode, and artifact locations.

Validation:

- The local streaming Electron workflow passes without provider credentials.
- The combined performance-audit production build passed the full smoke suite: 33 passed, 5 existing live-provider skips.
- Format check, i18n validation, lint, and node/web typechecks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated end-to-end testing guidance with temporary profiles, seeded onboarding and diagnostics, supported commands, packaged-app configuration, CI coverage, artifact retention, and chat state expectations.
  - Documented local provider-integration requirements and expanded default test coverage.

- **Tests**
  - Added coverage for streaming chat responses, including editing a draft while generation is in progress.
  - Expanded validation of local provider and model integrations, streamed completions, final responses, and error-free chat behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->