### PR TITLE
fix(browser): restore macOS preview capture

### DIFF
--- a/src/main/desktop/browser/YoBrowserPresenter.ts
+++ b/src/main/desktop/browser/YoBrowserPresenter.ts
@@ -1495,9 +1495,12 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       host.contentView.addChildView(state.view)
       state.view.setBounds({ x: 0, y: 0, ...PREVIEW_VIEWPORT })
       state.view.setVisible(true)
-      state.page.contents.setBackgroundThrottling(false)
       if (isMac) {
+        // The shown host keeps frames active. Unthrottling while hidden breaks capture on macOS.
+        // https://github.com/electron/electron/pull/52844
         host.showInactive()
+      } else {
+        state.page.contents.setBackgroundThrottling(false)
       }
       state.previewHost = host
       host.once('closed', () => {
@@ -1509,7 +1512,7 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
           state.previewTargetWindowId = null
           state.previewEpoch += 1
           state.view.setVisible(false)
-          if (!state.page.contents.isDestroyed()) {
+          if (!state.page.contents.isDestroyed() && !state.page.contents.backgroundThrottling) {
             state.page.contents.setBackgroundThrottling(true)
           }
         }
@@ -1577,7 +1580,7 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       // Ignore already detached views during shutdown.
     }
     state.view.setVisible(false)
-    if (!state.page.contents.isDestroyed()) {
+    if (!state.page.contents.isDestroyed() && !state.page.contents.backgroundThrottling) {
       state.page.contents.setBackgroundThrottling(true)
     }
     host.destroy()

--- a/src/main/desktop/browser/YoBrowserPresenter.ts
+++ b/src/main/desktop/browser/YoBrowserPresenter.ts
@@ -63,6 +63,7 @@ type SessionBrowserState = {
   owner: 'agent' | 'user'
   agentRunId?: string
   previewHost: BaseWindow | null
+  previewThrottlingDisabled: boolean
   previewMode: BrowserPreviewMode
   previewSurface: BrowserPreviewSurface
   previewTargetWindowId: number | null
@@ -660,6 +661,7 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       lastBounds: null,
       owner: 'user',
       previewHost: null,
+      previewThrottlingDisabled: false,
       previewMode: 'stopped',
       previewSurface: 'none',
       previewTargetWindowId: null,
@@ -1499,8 +1501,9 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
         // The shown host keeps frames active. Unthrottling while hidden breaks capture on macOS.
         // https://github.com/electron/electron/pull/52844
         host.showInactive()
-      } else {
+      } else if (state.page.contents.backgroundThrottling) {
         state.page.contents.setBackgroundThrottling(false)
+        state.previewThrottlingDisabled = true
       }
       state.previewHost = host
       host.once('closed', () => {
@@ -1512,9 +1515,10 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
           state.previewTargetWindowId = null
           state.previewEpoch += 1
           state.view.setVisible(false)
-          if (!state.page.contents.isDestroyed() && !state.page.contents.backgroundThrottling) {
+          if (state.previewThrottlingDisabled && !state.page.contents.isDestroyed()) {
             state.page.contents.setBackgroundThrottling(true)
           }
+          state.previewThrottlingDisabled = false
         }
       })
       return true
@@ -1580,9 +1584,10 @@ export class YoBrowserPresenter implements IYoBrowserPresenter {
       // Ignore already detached views during shutdown.
     }
     state.view.setVisible(false)
-    if (!state.page.contents.isDestroyed() && !state.page.contents.backgroundThrottling) {
+    if (state.previewThrottlingDisabled && !state.page.contents.isDestroyed()) {
       state.page.contents.setBackgroundThrottling(true)
     }
+    state.previewThrottlingDisabled = false
     host.destroy()
   }
 

--- a/test/main/desktop/browser/YoBrowserPresenter.test.ts
+++ b/test/main/desktop/browser/YoBrowserPresenter.test.ts
@@ -200,7 +200,7 @@ describe('YoBrowserPresenter', () => {
     vi.useRealTimers()
   })
 
-  const setupPresenter = async () => {
+  const setupPresenter = async (backgroundThrottling = true) => {
     let nextWebContentsId = 100
     const windows = new Map<number, MockBrowserWindow>()
     const viewConfigs: Array<Record<string, any>> = []
@@ -217,6 +217,7 @@ describe('YoBrowserPresenter', () => {
         constructor(options: Record<string, any>) {
           viewConfigs.push(options)
           this.webContents = new MockWebContents(nextWebContentsId++)
+          this.webContents.backgroundThrottling = backgroundThrottling
         }
       }
 
@@ -813,30 +814,58 @@ describe('YoBrowserPresenter', () => {
     expect(previewHosts[0].destroyed).toBe(true)
   })
 
-  it('releases the hidden preview host when its Agent session becomes inactive', async () => {
-    const { presenter, windows, previewHosts, getSessionWebContents } = await setupPresenter()
-    windows.set(1, new MockBrowserWindow(1))
+  describe.each(['darwin', 'win32', 'linux'] as const)('preview cleanup on %s', (platform) => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
 
-    const loadPromise = presenter.loadUrl(
-      'session-a',
-      'https://example.com',
-      undefined,
-      1,
-      'agent',
-      'run-1'
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    })
+
+    it.each([
+      [true, 'release'],
+      [false, 'release'],
+      [true, 'close'],
+      [false, 'close']
+    ] as const)(
+      'preserves backgroundThrottling=%s after preview host %s',
+      async (backgroundThrottling, cleanup) => {
+        const { presenter, windows, previewHosts, getSessionWebContents } =
+          await setupPresenter(backgroundThrottling)
+        Object.defineProperty(process, 'platform', { value: platform })
+        windows.set(1, new MockBrowserWindow(1))
+
+        const loadPromise = presenter.loadUrl(
+          'session-a',
+          'https://example.com',
+          undefined,
+          1,
+          'agent',
+          'run-1'
+        )
+        await Promise.resolve()
+        const webContents = getSessionWebContents('session-a')
+        webContents?.emitDomReady()
+        await loadPromise
+
+        expect(previewHosts).toHaveLength(1)
+        expect(previewHosts[0].destroyed).toBe(false)
+        expect(webContents?.backgroundThrottling).toBe(
+          platform === 'darwin' && backgroundThrottling
+        )
+
+        if (cleanup === 'release') {
+          await presenter.releaseInactivePreview('session-a')
+        } else {
+          previewHosts[0].destroy()
+        }
+
+        expect(previewHosts[0].destroyed).toBe(true)
+        expect(webContents?.backgroundThrottling).toBe(backgroundThrottling)
+        if (platform === 'darwin' || !backgroundThrottling) {
+          expect(webContents?.setBackgroundThrottling).not.toHaveBeenCalled()
+        }
+      }
     )
-    await Promise.resolve()
-    const webContents = getSessionWebContents('session-a')
-    webContents?.emitDomReady()
-    await loadPromise
-
-    expect(previewHosts).toHaveLength(1)
-    expect(previewHosts[0].destroyed).toBe(false)
-
-    await presenter.releaseInactivePreview('session-a')
-
-    expect(previewHosts[0].destroyed).toBe(true)
-    expect(webContents?.backgroundThrottling).toBe(true)
   })
 
   it('resumes preview capture after a previous capture times out while stopping', async () => {

--- a/test/main/desktop/browser/YoBrowserPresenter.test.ts
+++ b/test/main/desktop/browser/YoBrowserPresenter.test.ts
@@ -70,7 +70,10 @@ class MockWebContents extends EventEmitter {
     this.emit('destroyed')
   })
   sendInputEvent = vi.fn()
-  setBackgroundThrottling = vi.fn()
+  backgroundThrottling = true
+  setBackgroundThrottling = vi.fn((allowed: boolean) => {
+    this.backgroundThrottling = allowed
+  })
   capturePage = vi.fn(async () => ({
     resize: vi.fn(() => ({
       toJPEG: vi.fn(() => Buffer.from('preview-frame'))
@@ -833,7 +836,7 @@ describe('YoBrowserPresenter', () => {
     await presenter.releaseInactivePreview('session-a')
 
     expect(previewHosts[0].destroyed).toBe(true)
-    expect(webContents?.setBackgroundThrottling).toHaveBeenLastCalledWith(true)
+    expect(webContents?.backgroundThrottling).toBe(true)
   })
 
   it('resumes preview capture after a previous capture times out while stopping', async () => {


### PR DESCRIPTION
Creating a YoBrowser preview host on macOS can leave the page without a capturable compositor surface. Preview frames repeatedly fail with `Current display surface not available for capture`, and CDP screenshots can fail or stall. Calling `setBackgroundThrottling(false)` while the host is hidden triggers [Electron #52844](https://github.com/electron/electron/pull/52844).

On macOS, leave the existing throttling setting unchanged and activate the preview host with `showInactive()`. The shown host continues producing frames. On other platforms, disable throttling only if it was enabled. Both explicit release and host-close cleanup restore it only when preview setup changed it.

Validation:

- Native Electron 41.10.4 on macOS, using the repository's preview-host creation and disposal methods: the original implementation fails its initial capture and retry; the updated implementation captures successfully on initial load and after 10 consecutive host reopenings, through both `capturePage` and `Page.captureScreenshot`.
- Background page liveness: 120 animation frames and 20 callbacks from a 100 ms interval over 2 seconds. Captured images inspected visually.
- 87 tests passed across YoBrowserPresenter, BrowserTab, YoBrowserToolHandler, agentToolManagerYoBrowser, and AgentPreviewCoordinator.
- Parameterized preview lifecycle tests cover macOS, Windows, and Linux platform branches with initially enabled or disabled throttling, through explicit release and host-close cleanup.
- Format, i18n, lint, and both typechecks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview behavior across platforms by preserving the existing background-throttling setting.
  * Prevented unnecessary changes to background throttling when previews are already configured without throttling.
  * Ensured background throttling is restored correctly when preview hosts are closed or released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->