### PR TITLE
feat(provider): add API Route

### DIFF
--- a/src/main/provider/defaults.ts
+++ b/src/main/provider/defaults.ts
@@ -32,6 +32,21 @@ export const DEFAULT_PROVIDERS: LLM_PROVIDER_BASE[] = [
     }
   },
   {
+    id: 'api-route',
+    name: 'API Route',
+    apiType: 'openai-completions',
+    apiKey: '',
+    baseUrl: 'https://global.api-route.com/v1',
+    enable: false,
+    websites: {
+      official: 'https://www.api-route.com/',
+      apiKey: 'https://www.api-route.com/api-keys',
+      docs: 'https://www.api-route.com/docs/quickstart',
+      models: 'https://www.api-route.com/pricing',
+      defaultBaseUrl: 'https://global.api-route.com/v1'
+    }
+  },
+  {
     id: 'runinfra',
     name: 'RunInfra',
     apiType: 'openai-completions',

--- a/src/main/provider/providerRegistry.ts
+++ b/src/main/provider/providerRegistry.ts
@@ -132,6 +132,14 @@ const PROVIDER_ID_REGISTRY = new Map<string, AiSdkProviderDefinition>([
     })
   ],
   [
+    'api-route',
+    createDefinition({
+      ...OPENAI_BASE,
+      credentialStrategy: 'api-key',
+      embeddingStrategy: 'none'
+    })
+  ],
+  [
     'amd-developer',
     createDefinition({
       ...OPENAI_BASE,

--- a/src/renderer/src/assets/llm-icons/api-route.svg
+++ b/src/renderer/src/assets/llm-icons/api-route.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="API Route">
+  <rect x="5" y="5" width="118" height="118" rx="31" fill="#fffaf5" stroke="#d97852" stroke-width="7"/>
+  <circle cx="29" cy="64" r="12" fill="#e77d56"/>
+  <path d="M43 64h15m0 0 24-25m-24 25 24 25" fill="none" stroke="#31251e" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="91" cy="34" r="10" fill="#fffaf5" stroke="#31251e" stroke-width="6"/>
+  <circle cx="91" cy="94" r="10" fill="#fffaf5" stroke="#31251e" stroke-width="6"/>
+  <circle cx="86" cy="64" r="4" fill="#d97852"/>
+  <circle cx="101" cy="64" r="4" fill="#d97852"/>
+  <circle cx="116" cy="64" r="4" fill="#d97852"/>
+</svg>

--- a/src/renderer/src/components/icons/modelIconRegistry.ts
+++ b/src/renderer/src/components/icons/modelIconRegistry.ts
@@ -86,6 +86,7 @@ import voiceAiColorIcon from '@/assets/llm-icons/voiceai.svg?url'
 import novitaAiIcon from '@/assets/llm-icons/novitaai.svg?url'
 import astraflowIcon from '@/assets/llm-icons/astraflow.png?url'
 import apimartIcon from '@/assets/llm-icons/apimart.ico?url'
+import apiRouteIcon from '@/assets/llm-icons/api-route.svg?url'
 
 export const modelIcons = {
   'kimi-for-coding': kimiColorIcon,
@@ -106,6 +107,7 @@ export const modelIcons = {
   'alibaba-token-plan-cn': dashscopeColorIcon,
   alibaba: dashscopeColorIcon,
   aihubmix: aihubmixColorIcon,
+  'api-route': apiRouteIcon,
   apimart: apimartIcon,
   dashscope: dashscopeColorIcon,
   hunyuan: hunyuanColorIcon,

--- a/test/main/provider/basicApiKeyProviders.test.ts
+++ b/test/main/provider/basicApiKeyProviders.test.ts
@@ -159,6 +159,25 @@ describe('basic API-key provider registrations', () => {
     })
   })
 
+  it('resolves API Route through authenticated OpenAI-compatible model discovery', () => {
+    expect(
+      resolveAiSdkProviderDefinition(
+        createProvider({
+          id: 'api-route',
+          name: 'API Route',
+          baseUrl: 'https://global.api-route.com/v1'
+        })
+      )
+    ).toMatchObject({
+      runtimeKind: 'openai-compatible',
+      modelSource: 'openai',
+      checkStrategy: 'fetch-models',
+      credentialStrategy: 'api-key',
+      routeStrategy: 'none',
+      embeddingStrategy: 'none'
+    })
+  })
+
   it('discovers RunInfra models and checks credentials without generating text', async () => {
     const defaults = DEFAULT_PROVIDERS.find((provider) => provider.id === 'runinfra')!
     expect(defaults).toBeDefined()

--- a/test/main/provider/defaultProviders.test.ts
+++ b/test/main/provider/defaultProviders.test.ts
@@ -2,6 +2,25 @@ import { describe, expect, it } from 'vitest'
 import { DEFAULT_PROVIDERS } from '../../../src/main/provider/defaults'
 
 describe('DEFAULT_PROVIDERS', () => {
+  it('includes API Route as a disabled built-in OpenAI-compatible provider', () => {
+    expect(DEFAULT_PROVIDERS).toContainEqual(
+      expect.objectContaining({
+        id: 'api-route',
+        name: 'API Route',
+        apiType: 'openai-completions',
+        baseUrl: 'https://global.api-route.com/v1',
+        enable: false,
+        websites: expect.objectContaining({
+          official: 'https://www.api-route.com/',
+          apiKey: 'https://www.api-route.com/api-keys',
+          docs: 'https://www.api-route.com/docs/quickstart',
+          models: 'https://www.api-route.com/pricing',
+          defaultBaseUrl: 'https://global.api-route.com/v1'
+        })
+      })
+    )
+  })
+
   it('includes AMD GPU Cloud as a disabled built-in OpenAI-compatible provider', () => {
     expect(DEFAULT_PROVIDERS).toContainEqual(
       expect.objectContaining({


### PR DESCRIPTION
## Summary

- add API Route as a disabled built-in OpenAI-compatible provider
- discover available models from the provider's `/models` endpoint instead of hardcoding a catalog
- add the API Route brand icon to the desktop provider list
- disable embeddings because the documented integration currently exposes chat completions and models

## UI

Before:

```text
Provider list
└── API Route is not available
```

After:

```text
Provider list
└── API Route [brand icon]
    ├── API URL: https://global.api-route.com/v1
    ├── API Key
    └── Refresh models
```

## Validation

- `vitest` provider defaults and registry tests: 31 passed
- `vitest` ModelIcon tests: 6 passed
- Node and web typechecks passed
- lint guards and oxlint passed
- i18n validation passed (20 locales)
- icon collection check passed
- changed-file formatting check passed

The full-repository formatting check reports existing Windows line-ending differences across the checkout; no unrelated files were reformatted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added API Route as a built-in OpenAI-compatible provider option.
  - Included API Route branding and provider details in the provider selection interface.
  - The provider is currently disabled and unavailable for use by default.

- **Tests**
  - Added coverage to verify API Route provider configuration, credentials, model discovery, and default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->