### PR TITLE
perf(renderer): memoize artifact extraction per block reference

### DIFF
--- a/src/renderer/src/components/sidepanel/WorkspacePanel.vue
+++ b/src/renderer/src/components/sidepanel/WorkspacePanel.vue
@@ -196,7 +196,7 @@ import { useI18n } from 'vue-i18n'
 import { createFileClient } from '@api/FileClient'
 import { createProjectClient } from '@api/ProjectClient'
 import { createWorkspaceClient } from '@api/WorkspaceClient'
-import { extractArtifactsFromContent } from '@/composables/useArtifacts'
+import { extractArtifactsFromBlock } from '@/composables/useArtifacts'
 import WorkspaceFileNode from '@/components/workspace/WorkspaceFileNode.vue'
 import LiveDelegationPanel from './LiveDelegationPanel.vue'
 import WorkspaceViewer from './WorkspaceViewer.vue'
@@ -279,7 +279,7 @@ const artifactItems = computed<ArtifactItem[]>(() => {
     }
 
     for (const block of messageStore.getAssistantMessageBlocks(message)) {
-      for (const artifact of extractArtifactsFromContent(block.content ?? '', block.status)) {
+      for (const artifact of extractArtifactsFromBlock(block)) {
         items.push({
           key: `${message.id}:${artifact.identifier}`,
           threadId: props.sessionId,

--- a/src/renderer/src/composables/useArtifacts.ts
+++ b/src/renderer/src/composables/useArtifacts.ts
@@ -89,6 +89,31 @@ export function extractArtifactsFromContent(
     }))
 }
 
+/**
+ * Block-reference memo for artifact extraction. The message store reuses block
+ * object references for settled blocks (reuseStableAssistantBlocks in
+ * stores/ui/message.ts), so a per-stream-chunk rescan only re-extracts blocks
+ * whose reference actually changed — typically the streaming tail. A status
+ * change always yields a new block object, so status is covered by the key.
+ * Returned arrays are shared between callers and must not be mutated.
+ */
+const artifactExtractionCache = new WeakMap<
+  DisplayAssistantMessageBlock,
+  readonly ParsedArtifactPart[]
+>()
+
+export function extractArtifactsFromBlock(
+  block: DisplayAssistantMessageBlock
+): readonly ParsedArtifactPart[] {
+  const cached = artifactExtractionCache.get(block)
+  if (cached) {
+    return cached
+  }
+  const result = Object.freeze(extractArtifactsFromContent(block.content ?? '', block.status))
+  artifactExtractionCache.set(block, result)
+  return result
+}
+
 // Precompiled once — never construct RegExp inside the scan loop.
 const ATTRIBUTE_REGEX = /(\w+)="([^"]*)"/g
 const THINKING_CLOSED_RE = /<antThinking>(.*?)<\/antThinking>/s

--- a/test/renderer/composables/useArtifacts.test.ts
+++ b/test/renderer/composables/useArtifacts.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { extractArtifactsFromContent, generatePart } from '@/composables/useArtifacts'
+import {
+  extractArtifactsFromBlock,
+  extractArtifactsFromContent,
+  generatePart
+} from '@/composables/useArtifacts'
 
 describe('useArtifacts generatePart', () => {
   it('parses closed thinking and artifact tags', () => {
@@ -83,5 +87,42 @@ describe('useArtifacts generatePart', () => {
         loading: false
       }
     ])
+  })
+
+  it('extractArtifactsFromBlock memoizes per block reference and re-extracts on change', () => {
+    const block = (content: string, status: 'loading' | 'success') => ({
+      type: 'content' as const,
+      content,
+      status,
+      timestamp: 0
+    })
+
+    // Same block reference: cache hit, same frozen array.
+    const settled = block(
+      '<antArtifact type="text/markdown" identifier="a" title="T">c</antArtifact>',
+      'success'
+    )
+    const first = extractArtifactsFromBlock(settled)
+    expect(first).toBe(extractArtifactsFromBlock(settled))
+    expect(Object.isFrozen(first)).toBe(true)
+
+    // New reference with different content (streaming tail): re-extracted.
+    const streaming = block(
+      '<antArtifact type="text/markdown" identifier="a" title="T">c2',
+      'loading'
+    )
+    const streamed = extractArtifactsFromBlock(streaming)
+    expect(streamed[0]).toMatchObject({ content: 'c2', loading: true })
+    expect(streamed).not.toBe(first)
+
+    // Yet another reference gets its own cached result.
+    const next = block(
+      '<antArtifact type="text/markdown" identifier="b" title="T2">c3</antArtifact>',
+      'success'
+    )
+    const nextResult = extractArtifactsFromBlock(next)
+    expect(nextResult[0]).toMatchObject({ identifier: 'b' })
+    expect(nextResult).not.toBe(first)
+    expect(nextResult).not.toBe(streamed)
   })
 })


### PR DESCRIPTION
## Summary

During streaming, every chunk replaces the streaming record in `messageCache`, which invalidates `WorkspacePanel`'s `artifactItems` computed. The recompute re-ran `extractArtifactsFromContent` (regex scan) over **every assistant block in the whole conversation** per chunk — cost grows linearly with conversation length.

This memoizes extraction per block object reference (`WeakMap<DisplayAssistantMessageBlock, readonly ParsedArtifactPart[]>`). The message store reuses block references for settled blocks (`reuseStableAssistantBlocks`), so a per-chunk rescan only re-extracts blocks whose reference actually changed (typically the streaming tail). Status changes always yield a new block object, so status is covered by the key. Cached arrays are frozen to protect the shared-cache contract.

Per-chunk cost drops from O(all blocks × content length) to O(1) lookups + one re-extract of the streaming tail. Reactive contract is unchanged — streaming artifacts still appear live.

## Test plan

- [x] `pnpm vitest run test/renderer/composables/useArtifacts.test.ts` (new memo-contract case)
- [x] `pnpm vitest run test/renderer/components/WorkspacePanel.test.ts test/renderer/components/ChatSidePanel.test.ts`
- [x] `pnpm typecheck:web`, `oxfmt --check`, `oxlint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact detection in the workspace panel, including while content is still streaming.
  * Ensured artifact listings stay consistent and update correctly when message content changes.
  * Improved responsiveness by reusing results for unchanged message blocks.
* **Reliability**
  * Prevented accidental changes to extracted artifact results, helping keep displayed information stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->