### PR TITLE
perf(renderer): fix message row render bailout

### DIFF
--- a/src/renderer/src/components/chat/MessageList.vue
+++ b/src/renderer/src/components/chat/MessageList.vue
@@ -18,9 +18,9 @@
         :is-read-only="isReadOnly"
         :allow-guard-stop-continue="item.id === latestAssistantMessageId"
         :disable-markdown-virtualization="shouldDisableMarkdownVirtualization"
-        :class="{ 'message-row-entrance': shouldAnimateEntrance(item) }"
+        :class="entranceClassFor(item)"
         :data-entrance-feedback="shouldAnimateEntrance(item) || undefined"
-        @animationend="onEntranceAnimationEnd(item, $event)"
+        @animationend="onRowAnimationEnd"
         @retry="onRetry"
         @delete="onDelete"
         @fork="onFork"
@@ -154,9 +154,21 @@ watch(
 
 const shouldAnimateEntrance = (item: MessageListItem) => animatingMessageIds.value.has(item.id)
 
-const onEntranceAnimationEnd = (item: MessageListItem, event: AnimationEvent) => {
-  if (event.target === event.currentTarget) {
-    animatingMessageIds.value.delete(item.id)
+// Stable string (not an object literal) so MessageListRow's props stay
+// referentially equal across parent re-renders and rows bail out of updates.
+const entranceClassFor = (item: MessageListItem) =>
+  shouldAnimateEntrance(item) ? 'message-row-entrance' : ''
+
+// Stable handler (no per-item closure): the row root carries data-message-id,
+// so the listener can resolve the message from the event itself. Inline
+// per-item handlers create a fresh function each render, which defeats the
+// MessageListRow props bailout and re-patches every mounted row per stream
+// chunk.
+const onRowAnimationEnd = (event: AnimationEvent) => {
+  if (event.target !== event.currentTarget) return
+  const messageId = (event.currentTarget as HTMLElement | null)?.getAttribute('data-message-id')
+  if (messageId) {
+    animatingMessageIds.value.delete(messageId)
   }
 }
 


### PR DESCRIPTION
## Summary

During streaming, **every mounted message row re-rendered on every chunk** — settled rows never bailed out of updates. Measured in the real renderer (200 settled rows, windowed; 50 synthetic stream chunks driven through the real message store):

| | before | after |
|---|---|---|
| reactive render+patch per chunk | avg 33.5ms, p50 17.2ms, **p95 128ms**, max 351ms | avg 22.4ms, p50 16.8ms, **p95 44.3ms**, max 199ms |
| `MessageListRow` patches | ~15 per chunk (all mounted rows) | ~0 (rows exit the top patchers entirely) |
| `MessageList` patch avg | 78ms | 4.6ms |

### Root cause

Two dynamic props on `MessageListRow` were recreated on every `MessageList` render, so Vue's `shouldUpdateComponent` props comparison always found a difference and re-rendered each row's whole subtree (assistant body, tooltips, toolbar):

1. `@animationend="onEntranceAnimationEnd(item, $event)"` — inline closure capturing the `v-for` `item` cannot be cached by the compiler; the handler prop gets a fresh function identity per render.
2. `:class="{ 'message-row-entrance': ... }"` — object literal identity differs per render.

### Fix

- `@animationend="onRowAnimationEnd"` — stable top-level handler; the row root already carries `data-message-id`, so the listener resolves the message from `event.currentTarget`.
- `:class="entranceClassFor(item)"` — stable string (`''` or `'message-row-entrance'`), equal across renders.

Entrance-animation behavior is unchanged (class still applies while animating; removed on `animationend`).

## Test plan

- [x] `pnpm vitest run test/renderer/components/MessageList.test.ts test/renderer/components/MessageListRow.test.ts test/renderer/components/ChatPage.test.ts` (121 passed)
- [x] `pnpm typecheck:web`, `oxfmt --check`, `oxlint`
- [x] Live-renderer A/B measurement described above (synthetic stream probe against the real message store)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved chat message list rendering during streaming by reducing unnecessary updates to already-mounted message rows.
  * Stabilized message row animations and event handling across parent re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->