### PR TITLE
fix(provider): sanitize empty DeepSeek reasoning replay

### DIFF
--- a/src/main/provider/deepseekResponsesAdapter.ts
+++ b/src/main/provider/deepseekResponsesAdapter.ts
@@ -198,11 +198,11 @@ export function createDeepSeekResponsesReplayProjector(
   }
 }
 
-const OPEN_RESPONSES_PROVIDER_OPTIONS_KEY = 'open-responses'
+const DEEPSEEK_PROVIDER_OPTIONS_KEY = 'deepseek'
 
 /**
  * `@ai-sdk/open-responses` re-serializes an assistant `reasoning` part as a Responses `reasoning`
- * item. When the part's provider options carry an un-replayable `open-responses.reasoningContent`
+ * item. When the part's provider options carry an un-replayable `deepseek.reasoningContent`
  * (a summary-only reasoning round from DeepSeek), its converter emits an item with no `content` at
  * all (`{}`), which the upstream thinking protocol rejects. Deleting the key lets the converter
  * fall back to materializing `reasoning_text` from the part text instead.
@@ -219,21 +219,21 @@ function isReplayableReasoningContent(value: unknown): boolean {
 
 function sanitizeReasoningProviderOptions(message: ChatMessage): ChatMessage {
   const providerOptions = message.reasoning_provider_options
-  const openResponses = providerOptions?.[OPEN_RESPONSES_PROVIDER_OPTIONS_KEY]
+  const deepseekOptions = providerOptions?.[DEEPSEEK_PROVIDER_OPTIONS_KEY]
   if (
-    !isRecord(openResponses) ||
-    !Object.prototype.hasOwnProperty.call(openResponses, 'reasoningContent') ||
-    isReplayableReasoningContent(openResponses.reasoningContent)
+    !isRecord(deepseekOptions) ||
+    !Object.prototype.hasOwnProperty.call(deepseekOptions, 'reasoningContent') ||
+    isReplayableReasoningContent(deepseekOptions.reasoningContent)
   ) {
     return message
   }
 
   const nextMessage = { ...message }
-  const sanitizedOpenResponses = { ...openResponses }
-  delete sanitizedOpenResponses.reasoningContent
+  const sanitizedDeepseekOptions = { ...deepseekOptions }
+  delete sanitizedDeepseekOptions.reasoningContent
   nextMessage.reasoning_provider_options = {
     ...providerOptions,
-    [OPEN_RESPONSES_PROVIDER_OPTIONS_KEY]: sanitizedOpenResponses
+    [DEEPSEEK_PROVIDER_OPTIONS_KEY]: sanitizedDeepseekOptions
   }
   return nextMessage
 }

--- a/src/main/provider/deepseekResponsesAdapter.ts
+++ b/src/main/provider/deepseekResponsesAdapter.ts
@@ -210,6 +210,7 @@ const OPEN_RESPONSES_PROVIDER_OPTIONS_KEY = 'open-responses'
 function isReplayableReasoningContent(value: unknown): boolean {
   return (
     Array.isArray(value) &&
+    value.length > 0 &&
     value.every(
       (part) => isRecord(part) && part.type === 'reasoning_text' && typeof part.text === 'string'
     )

--- a/src/main/provider/deepseekResponsesAdapter.ts
+++ b/src/main/provider/deepseekResponsesAdapter.ts
@@ -198,13 +198,53 @@ export function createDeepSeekResponsesReplayProjector(
   }
 }
 
+const OPEN_RESPONSES_PROVIDER_OPTIONS_KEY = 'open-responses'
+
+/**
+ * `@ai-sdk/open-responses` re-serializes an assistant `reasoning` part as a Responses `reasoning`
+ * item. When the part's provider options carry an un-replayable `open-responses.reasoningContent`
+ * (a summary-only reasoning round from DeepSeek), its converter emits an item with no `content` at
+ * all (`{}`), which the upstream thinking protocol rejects. Deleting the key lets the converter
+ * fall back to materializing `reasoning_text` from the part text instead.
+ */
+function isReplayableReasoningContent(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (part) => isRecord(part) && part.type === 'reasoning_text' && typeof part.text === 'string'
+    )
+  )
+}
+
+function sanitizeReasoningProviderOptions(message: ChatMessage): ChatMessage {
+  const providerOptions = message.reasoning_provider_options
+  const openResponses = providerOptions?.[OPEN_RESPONSES_PROVIDER_OPTIONS_KEY]
+  if (
+    !isRecord(openResponses) ||
+    !Object.prototype.hasOwnProperty.call(openResponses, 'reasoningContent') ||
+    isReplayableReasoningContent(openResponses.reasoningContent)
+  ) {
+    return message
+  }
+
+  const nextMessage = { ...message }
+  const sanitizedOpenResponses = { ...openResponses }
+  delete sanitizedOpenResponses.reasoningContent
+  nextMessage.reasoning_provider_options = {
+    ...providerOptions,
+    [OPEN_RESPONSES_PROVIDER_OPTIONS_KEY]: sanitizedOpenResponses
+  }
+  return nextMessage
+}
+
 function omitEmptyReasoning(messages: ChatMessage[]): ChatMessage[] {
   return messages.map((message) => {
-    if (
-      !Object.prototype.hasOwnProperty.call(message, 'reasoning_content') ||
-      (typeof message.reasoning_content === 'string' && message.reasoning_content.length > 0)
-    ) {
+    if (!Object.prototype.hasOwnProperty.call(message, 'reasoning_content')) {
       return message
+    }
+
+    if (typeof message.reasoning_content === 'string' && message.reasoning_content.length > 0) {
+      return sanitizeReasoningProviderOptions(message)
     }
 
     const nextMessage = { ...message }

--- a/test/main/provider/deepseekResponsesAdapter.test.ts
+++ b/test/main/provider/deepseekResponsesAdapter.test.ts
@@ -587,13 +587,13 @@ describe('DeepSeek Responses replay', () => {
     })
   })
 
-  it('sanitizes un-replayable open-responses reasoning metadata while keeping the text', () => {
+  it('sanitizes un-replayable deepseek reasoning metadata while keeping the text', () => {
     const summaryOnly: ChatMessage = {
       role: 'assistant',
       content: 'answer',
       reasoning_content: 'concise summary',
       reasoning_provider_options: {
-        'open-responses': {
+        deepseek: {
           itemId: 'rsn_summary_only',
           reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }],
           reasoningContent: null
@@ -605,7 +605,7 @@ describe('DeepSeek Responses replay', () => {
       content: 'answer',
       reasoning_content: 'full thinking',
       reasoning_provider_options: {
-        'open-responses': {
+        deepseek: {
           itemId: 'rsn_full',
           reasoningContent: [{ type: 'reasoning_text', text: 'full thinking' }]
         }
@@ -616,7 +616,7 @@ describe('DeepSeek Responses replay', () => {
       content: 'tool call without reasoning',
       reasoning_content: '',
       reasoning_provider_options: {
-        'open-responses': { itemId: 'rsn_empty', reasoningContent: null }
+        deepseek: { itemId: 'rsn_empty', reasoningContent: null }
       }
     }
 
@@ -625,14 +625,14 @@ describe('DeepSeek Responses replay', () => {
     expect(prepared[0]).not.toBe(summaryOnly)
     expect(prepared[0]?.reasoning_content).toBe('concise summary')
     expect(prepared[0]?.reasoning_provider_options).toEqual({
-      'open-responses': {
+      deepseek: {
         itemId: 'rsn_summary_only',
         reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }]
       }
     })
     expect(prepared[1]).toBe(fullContent)
     expect(prepared[1]?.reasoning_provider_options).toEqual({
-      'open-responses': {
+      deepseek: {
         itemId: 'rsn_full',
         reasoningContent: [{ type: 'reasoning_text', text: 'full thinking' }]
       }
@@ -642,7 +642,7 @@ describe('DeepSeek Responses replay', () => {
       content: 'tool call without reasoning'
     })
     expect(summaryOnly.reasoning_provider_options).toEqual({
-      'open-responses': {
+      deepseek: {
         itemId: 'rsn_summary_only',
         reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }],
         reasoningContent: null
@@ -656,7 +656,7 @@ describe('DeepSeek Responses replay', () => {
       content: 'answer',
       reasoning_content: 'concise summary',
       reasoning_provider_options: {
-        'open-responses': {
+        deepseek: {
           itemId: 'rsn_empty_array',
           reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }],
           reasoningContent: []
@@ -669,13 +669,13 @@ describe('DeepSeek Responses replay', () => {
     expect(prepared[0]).not.toBe(emptyArray)
     expect(prepared[0]?.reasoning_content).toBe('concise summary')
     expect(prepared[0]?.reasoning_provider_options).toEqual({
-      'open-responses': {
+      deepseek: {
         itemId: 'rsn_empty_array',
         reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }]
       }
     })
     expect(emptyArray.reasoning_provider_options).toEqual({
-      'open-responses': {
+      deepseek: {
         itemId: 'rsn_empty_array',
         reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }],
         reasoningContent: []
@@ -1077,6 +1077,79 @@ describe('DeepSeek Responses replay', () => {
         headers: {},
         body
       }
+    ])
+  })
+
+  it('sanitizes deepseek reasoning metadata before real SDK serialization', async () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', content: 'What was the result?' },
+      {
+        role: 'assistant',
+        content: 'Summary-only round.',
+        reasoning_content: 'concise summary',
+        reasoning_provider_options: {
+          deepseek: {
+            itemId: 'rsn_review_null',
+            reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }],
+            reasoningContent: null
+          }
+        }
+      },
+      {
+        role: 'assistant',
+        content: 'Empty array round.',
+        reasoning_content: 'empty array thinking',
+        reasoning_provider_options: {
+          deepseek: {
+            itemId: 'rsn_review_empty',
+            reasoningSummary: [{ type: 'summary_text', text: 'empty array thinking' }],
+            reasoningContent: []
+          }
+        }
+      }
+    ]
+    const fetchMock = vi.fn(async () => {
+      throw new Error('request captured')
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const firstEvent = await runAiSdkCoreStream(
+      createRuntimeContext(),
+      messages,
+      DEEPSEEK_RESPONSES_MODEL_ID,
+      { ...deepSeekModelConfig, reasoningEffort: 'max' },
+      0.7,
+      1024,
+      [
+        {
+          type: 'function',
+          function: {
+            name: 'read_file',
+            description: 'Read a file.',
+            parameters: {
+              type: 'object',
+              properties: { path: { type: 'string' } },
+              required: ['path']
+            }
+          },
+          server: { name: 'filesystem' }
+        } as any
+      ]
+    ).next()
+    expect(firstEvent).toMatchObject({
+      done: false,
+      value: { type: 'error', error_message: 'request captured' }
+    })
+
+    const body = JSON.parse(String((fetchMock.mock.calls[0]?.[1] as RequestInit).body)) as {
+      input: Array<Record<string, unknown>>
+    }
+    const reasoningItems = body.input.filter((item) => item.type === 'reasoning')
+    expect(reasoningItems).toHaveLength(2)
+    const contents = reasoningItems.map((item) => (item as { content: unknown }).content)
+    expect(contents).toEqual([
+      [{ type: 'reasoning_text', text: 'concise summary' }],
+      [{ type: 'reasoning_text', text: 'empty array thinking' }]
     ])
   })
 

--- a/test/main/provider/deepseekResponsesAdapter.test.ts
+++ b/test/main/provider/deepseekResponsesAdapter.test.ts
@@ -587,6 +587,69 @@ describe('DeepSeek Responses replay', () => {
     })
   })
 
+  it('sanitizes un-replayable open-responses reasoning metadata while keeping the text', () => {
+    const summaryOnly: ChatMessage = {
+      role: 'assistant',
+      content: 'answer',
+      reasoning_content: 'concise summary',
+      reasoning_provider_options: {
+        'open-responses': {
+          itemId: 'rsn_summary_only',
+          reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }],
+          reasoningContent: null
+        }
+      }
+    }
+    const fullContent: ChatMessage = {
+      role: 'assistant',
+      content: 'answer',
+      reasoning_content: 'full thinking',
+      reasoning_provider_options: {
+        'open-responses': {
+          itemId: 'rsn_full',
+          reasoningContent: [{ type: 'reasoning_text', text: 'full thinking' }]
+        }
+      }
+    }
+    const emptyText: ChatMessage = {
+      role: 'assistant',
+      content: 'tool call without reasoning',
+      reasoning_content: '',
+      reasoning_provider_options: {
+        'open-responses': { itemId: 'rsn_empty', reasoningContent: null }
+      }
+    }
+
+    const prepared = createAdapter().prepareMessages([summaryOnly, fullContent, emptyText])
+
+    expect(prepared[0]).not.toBe(summaryOnly)
+    expect(prepared[0]?.reasoning_content).toBe('concise summary')
+    expect(prepared[0]?.reasoning_provider_options).toEqual({
+      'open-responses': {
+        itemId: 'rsn_summary_only',
+        reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }]
+      }
+    })
+    expect(prepared[1]).toBe(fullContent)
+    expect(prepared[1]?.reasoning_provider_options).toEqual({
+      'open-responses': {
+        itemId: 'rsn_full',
+        reasoningContent: [{ type: 'reasoning_text', text: 'full thinking' }]
+      }
+    })
+    expect(prepared[2]).toEqual({
+      role: 'assistant',
+      content: 'tool call without reasoning'
+    })
+    expect(summaryOnly.reasoning_provider_options).toEqual({
+      'open-responses': {
+        itemId: 'rsn_summary_only',
+        reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }],
+        reasoningContent: null
+      }
+    })
+  })
+
   it('fails unmatched markers before network I/O', async () => {
     const baseFetch = vi.fn(async () => new Response(null, { status: 204 }))
     const wrappedFetch = createAdapter().wrapFetch(baseFetch)

--- a/test/main/provider/deepseekResponsesAdapter.test.ts
+++ b/test/main/provider/deepseekResponsesAdapter.test.ts
@@ -650,6 +650,39 @@ describe('DeepSeek Responses replay', () => {
     })
   })
 
+  it('treats empty reasoningContent arrays as un-replayable instead of content: []', () => {
+    const emptyArray: ChatMessage = {
+      role: 'assistant',
+      content: 'answer',
+      reasoning_content: 'concise summary',
+      reasoning_provider_options: {
+        'open-responses': {
+          itemId: 'rsn_empty_array',
+          reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }],
+          reasoningContent: []
+        }
+      }
+    }
+
+    const prepared = createAdapter().prepareMessages([emptyArray])
+
+    expect(prepared[0]).not.toBe(emptyArray)
+    expect(prepared[0]?.reasoning_content).toBe('concise summary')
+    expect(prepared[0]?.reasoning_provider_options).toEqual({
+      'open-responses': {
+        itemId: 'rsn_empty_array',
+        reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }]
+      }
+    })
+    expect(emptyArray.reasoning_provider_options).toEqual({
+      'open-responses': {
+        itemId: 'rsn_empty_array',
+        reasoningSummary: [{ type: 'summary_text', text: 'concise summary' }],
+        reasoningContent: []
+      }
+    })
+  })
+
   it('fails unmatched markers before network I/O', async () => {
     const baseFetch = vi.fn(async () => new Response(null, { status: 204 }))
     const wrappedFetch = createAdapter().wrapFetch(baseFetch)


### PR DESCRIPTION
Fixes #2272

## 问题

思考模型（deepseek-v4-flash）走 DeepSeek Responses 端点、会话中使用过原生 Web Search 时，从持久化历史重建请求会带出无法重放的 reasoning 元数据：`@ai-sdk/open-responses` 在把 assistant `reasoning` part 转成 Responses `reasoning` item 时，若 provider options 里 `open-responses.reasoningContent` 不可用（summary-only 轮次，值为 `null`），会静默输出一个**没有 `content` 的空 item**（`{}`），被上游 thinking 协议拒绝（`The reasoning_text in the thinking mode must be passed back to the API`）。提问暂停 → 续跑（以及重启续跑、重试、compaction 重建等所有"从持久化重建历史"路径）都会触发。

## 修复

在 `prepareMessages`（`omitEmptyReasoning`）中对 assistant 消息分三层处理，仅作用于 DeepSeek Responses 路由，不影响其他 provider：

1. 无 `reasoning_content` → 原样透传（不变）
2. `reasoning_content` 为空 `''` → 删除 reasoning 字段，整轮不发 reasoning item（原有行为）
3. `reasoning_content` 非空但 `open-responses.reasoningContent` 不可重放（非 `reasoning_text` 数组）→ 删除该元数据键，让转换器回退到用 part 文本生成 `reasoning_text` content，**保留推理内容并以可接受形态重放**

## 验证

- 新增用例覆盖：summary-only 元数据被清洗且文本保留、完整 `reasoning_text` 元数据原样透传（同一引用）、空文本整轮删除
- `test/main/provider` 全量 767 个用例通过
- oxfmt / oxlint / typecheck 通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved replay of DeepSeek reasoning messages by preserving reasoning text when provider metadata cannot be replayed.
  - Removed invalid or empty reasoning metadata during message preparation, including empty reasoning-content arrays.
  - Preserved complete, replayable reasoning content without modifying the original messages.
  - Corrected request serialization so reasoning text is retained when reasoning metadata is null or empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->