### PR TITLE
refactor(memory): unify write paths, stage recall, extract breaker and maintenance passes

### DIFF
--- a/src/main/memory/domain/stateModel.ts
+++ b/src/main/memory/domain/stateModel.ts
@@ -2,7 +2,8 @@ import type {
   AgentMemoryEmbeddingState,
   AgentMemoryKind,
   AgentMemoryLifecycleState,
-  AgentMemoryStatus
+  AgentMemoryStatus,
+  CanonicalAgentMemoryRow
 } from './types'
 import {
   AGENT_MEMORY_EMBEDDING_STATES,
@@ -148,6 +149,36 @@ export function isRecallableMemoryState(row: CanonicalMemoryStateSource): boolea
 
 export function isEmbeddingEligibleState(row: CanonicalMemoryStateSource): boolean {
   return isRecallableMemoryState(row) && row.embedding_state === 'pending'
+}
+
+// The only row shape a correction decision may UPDATE, SUPERSEDE, or CHALLENGE: owned by the
+// Agent, current head of its chain, active, and not already inside a conflict.
+export function isLiveDecisionTarget(
+  agentId: string,
+  row: CanonicalAgentMemoryRow | undefined
+): row is CanonicalAgentMemoryRow {
+  return (
+    !!row &&
+    row.agent_id === agentId &&
+    row.superseded_by === null &&
+    row.lifecycle_state === 'active' &&
+    row.conflict_state === null
+  )
+}
+
+// A chain head that is itself under challenge cannot absorb new evidence until the conflict
+// resolves; writes that land on it stay conservative no-ops.
+export function isChallengedDecisionHead(
+  agentId: string,
+  row: CanonicalAgentMemoryRow | undefined
+): row is CanonicalAgentMemoryRow {
+  return (
+    !!row &&
+    row.agent_id === agentId &&
+    row.lifecycle_state === 'active' &&
+    row.superseded_by === null &&
+    row.conflict_state === 'challenged'
+  )
 }
 
 export function assertValidMemoryInsertState(input: {

--- a/src/main/memory/domain/types.ts
+++ b/src/main/memory/domain/types.ts
@@ -615,10 +615,12 @@ export type ProvenanceHitResult =
   | { action: 'noop'; reason: string }
 
 /**
- * Side-effect-free classification of who currently owns a candidate's provenance key.
- * `archived` owners may be restored, `duplicate` owners may only absorb temporal metadata,
- * `suppressed` owners must stay untouched, `challenged` chains reject new evidence, and a
- * `superseded` owner exposes its live chain head (or null) for correction decisions.
+ * Who currently owns a candidate's provenance key. Classification itself never writes; the
+ * lookup that precedes it may lazily re-key a legacy owner, which is why resolvers accept the
+ * caller's dispatch-commit callback. `archived` owners may be restored, `duplicate` owners may
+ * only absorb temporal metadata, `suppressed` owners must stay untouched, `challenged` chains
+ * reject new evidence, and a `superseded` owner exposes its live chain head (or null) for
+ * correction decisions.
  */
 export type ClaimOwnership =
   | { state: 'unowned' }

--- a/src/main/memory/domain/types.ts
+++ b/src/main/memory/domain/types.ts
@@ -614,6 +614,20 @@ export type ProvenanceHitResult =
   | { action: 'continue' }
   | { action: 'noop'; reason: string }
 
+/**
+ * Side-effect-free classification of who currently owns a candidate's provenance key.
+ * `archived` owners may be restored, `duplicate` owners may only absorb temporal metadata,
+ * `suppressed` owners must stay untouched, `challenged` chains reject new evidence, and a
+ * `superseded` owner exposes its live chain head (or null) for correction decisions.
+ */
+export type ClaimOwnership =
+  | { state: 'unowned' }
+  | { state: 'archived'; owner: CanonicalAgentMemoryRow }
+  | { state: 'duplicate'; owner: CanonicalAgentMemoryRow }
+  | { state: 'suppressed'; owner: CanonicalAgentMemoryRow; reason: string }
+  | { state: 'challenged'; owner: CanonicalAgentMemoryRow; head: CanonicalAgentMemoryRow }
+  | { state: 'superseded'; owner: CanonicalAgentMemoryRow; head: CanonicalAgentMemoryRow | null }
+
 export type ContentUpdateResult =
   | { action: 'updated'; id: string }
   | { action: 'folded'; id: string; retiredHeadId?: string }

--- a/src/main/memory/index.ts
+++ b/src/main/memory/index.ts
@@ -319,8 +319,6 @@ export class MemoryService implements MemoryRuntimePort {
       policy,
       textGeneration: providerGateway,
       rows: this.rows,
-      retrieveForDecision: (agentId, query, now, scopeFilter) =>
-        this.retrieval.retrieveForDecision(agentId, query, now, scopeFilter),
       retrieveForDecisions: (
         agentId,
         candidates,

--- a/src/main/memory/index.ts
+++ b/src/main/memory/index.ts
@@ -218,8 +218,6 @@ export class MemoryService implements MemoryRuntimePort {
       embeddingGateway: providerGateway,
       vectorStore: this.vectorStore,
       rows: this.rows,
-      reindexEmbeddings: (agentId, force) => this.reindexEmbeddings(agentId, force),
-      backfillEmbeddings: (agentId) => this.backfillEmbeddings(agentId),
       diagnostics: this.diagnostics
     })
     this.workingMemory = new WorkingMemoryService({ ctx: this.runtime, repository })
@@ -311,7 +309,6 @@ export class MemoryService implements MemoryRuntimePort {
         const result = this.conflict.repairConflictIntegrity(agentId)
         return Object.values(result).some((count) => count > 0)
       },
-      runConsolidationPass: (agentId) => this.runConsolidationPass(agentId),
       diagnostics: this.diagnostics
     })
     this.maintenance = maintenanceService

--- a/src/main/memory/infra/embeddingPipeline.ts
+++ b/src/main/memory/infra/embeddingPipeline.ts
@@ -64,8 +64,6 @@ export interface EmbeddingPipelinePorts {
       options?: { allowHistoricalIdentity?: boolean }
     ): Promise<T>
   }
-  reindexEmbeddings: (agentId: string, force?: boolean) => Promise<void>
-  backfillEmbeddings: (agentId: string) => Promise<void>
   diagnostics?: {
     observeEmbeddingBacklog(pending: number, activeAgents: number): void
     recordEmbedding(
@@ -1017,7 +1015,7 @@ export class EmbeddingPipeline {
       if (!leaseResult.usable) {
         this.ports.vectorStore.clearReady(agentId)
         if (!this.reindexing.has(agentId)) {
-          void this.ports.reindexEmbeddings(agentId, true).catch((error) => {
+          void this.reindexEmbeddings(agentId, true).catch((error) => {
             logger.warn(`[Memory] store rebuild failed for ${agentId}: ${String(error)}`)
           })
         }
@@ -1033,7 +1031,7 @@ export class EmbeddingPipeline {
       const fingerprint = embeddingFingerprint(embedding.providerId, embedding.modelId)
       if (this.ports.repository.hasStaleEmbeddings(agentId, dimensions, fingerprint)) {
         this.ports.vectorStore.clearReady(agentId)
-        void this.ports.reindexEmbeddings(agentId).catch((error) => {
+        void this.reindexEmbeddings(agentId).catch((error) => {
           logger.warn(`[Memory] reindex failed for ${agentId}: ${String(error)}`)
         })
         return {
@@ -1055,7 +1053,7 @@ export class EmbeddingPipeline {
       if (!coverage.verified) {
         this.ports.vectorStore.clearReady(agentId)
         if (coverage.authoritativeListingTruncated && !this.reindexing.has(agentId)) {
-          void this.ports.reindexEmbeddings(agentId, true).catch((error) => {
+          void this.reindexEmbeddings(agentId, true).catch((error) => {
             logger.warn(
               `[Memory] incomplete vector store rebuild failed for ${agentId}: ${String(error)}`
             )
@@ -1072,7 +1070,7 @@ export class EmbeddingPipeline {
 
       this.ports.vectorStore.markReady(agentId, embedding, dimensions, coverage.generation)
       if (!this.reindexing.has(agentId)) {
-        void this.ports.backfillEmbeddings(agentId).catch((error) => {
+        void this.backfillEmbeddings(agentId).catch((error) => {
           logger.warn(`[Memory] backfill failed for ${agentId}: ${String(error)}`)
         })
       }

--- a/src/main/memory/infra/queryEmbeddingCircuit.ts
+++ b/src/main/memory/infra/queryEmbeddingCircuit.ts
@@ -1,0 +1,286 @@
+import logger from '@shared/logger'
+import { truncateUnicodeCodePoints } from '@shared/lib/unicodeText'
+
+import { isMemoryProviderDeadlineError } from '../core/providerCancellation'
+import {
+  RECALL_QUERY_EMBEDDING_BREAKER_COOLDOWN_MS,
+  RECALL_QUERY_EMBEDDING_BREAKER_FAILURE_THRESHOLD,
+  RECALL_QUERY_EMBEDDING_BREAKER_FAILURE_WINDOW_MS,
+  RECALL_QUERY_EMBEDDING_MAX_CODE_POINTS,
+  RECALL_QUERY_EMBEDDING_MAX_CONCURRENT,
+  RECALL_QUERY_EMBEDDING_STALE_MS
+} from '../runtimeConstants'
+import { embeddingFingerprint, type MemoryModelRef } from '../context'
+import type { MemoryEmbeddingGatewayPort } from '../ports'
+
+export type QueryEmbeddingCircuitEvent =
+  | 'failure'
+  | 'opened'
+  | 'halfOpen'
+  | 'closed'
+  | 'probeCancelled'
+  | 'skipped'
+
+export type QueryEmbeddingCircuitState = 'closed' | 'open' | 'halfOpen'
+
+export type QueryEmbeddingStartResult =
+  | { status: 'started'; promise: Promise<number[][]> }
+  | { status: 'capacity' }
+  | { status: 'circuitOpen' }
+
+export interface QueryEmbeddingCircuitDiagnostics {
+  recordQueryEmbeddingCircuitEvent?(agentId: string, event: QueryEmbeddingCircuitEvent): void
+  resetQueryEmbeddingCircuit?(agentId: string): void
+}
+
+interface CircuitState {
+  fingerprint: string
+  failuresInWindow: number
+  failureWindowStartedAt: number | null
+  openUntil: number
+  halfOpenProbe: boolean
+}
+
+interface InFlightEntry {
+  agentId: string
+  startedAt: number
+  promise: Promise<number[][]>
+  circuit: CircuitState
+  recoveryProbe: boolean
+  consumerSignals: Set<AbortSignal | undefined>
+  circuitSettled: boolean
+}
+
+/**
+ * Per-Agent, per-embedding-identity breaker for warm recall query embeddings. Consecutive
+ * deadline/transport failures inside a short window open the circuit; after the cooldown exactly
+ * one half-open probe may run and its result decides whether the circuit closes again. Concurrent
+ * recalls for the same query share one in-flight provider call, and cancellation by every consumer
+ * never counts as provider health. Timing uses the infrastructure clock, not the domain clock.
+ */
+export class QueryEmbeddingCircuitBreaker {
+  private readonly inFlight = new Map<string, Map<string, InFlightEntry>>()
+  private readonly circuits = new Map<string, CircuitState>()
+
+  constructor(
+    private readonly ports: {
+      embeddingGateway: MemoryEmbeddingGatewayPort
+      diagnostics?: QueryEmbeddingCircuitDiagnostics
+    }
+  ) {}
+
+  start(
+    agentId: string,
+    embedding: MemoryModelRef,
+    fullQuery: string,
+    signal?: AbortSignal
+  ): QueryEmbeddingStartResult {
+    const query = truncateUnicodeCodePoints(fullQuery, RECALL_QUERY_EMBEDDING_MAX_CODE_POINTS)
+    const fingerprint = embeddingFingerprint(embedding.providerId, embedding.modelId)
+    const key = `${agentId}::${fingerprint}`
+    const now = Date.now()
+    const circuit = this.circuitFor(agentId, fingerprint)
+    let group = this.inFlight.get(key)
+    let replacedStale = false
+    if (group) {
+      for (const [trackedQuery, entry] of group) {
+        if (entry.circuitSettled) {
+          group.delete(trackedQuery)
+        } else if (now - entry.startedAt >= RECALL_QUERY_EMBEDDING_STALE_MS) {
+          this.settleCancellation(entry)
+          group.delete(trackedQuery)
+          replacedStale = true
+        }
+      }
+      if (group.size === 0) {
+        this.inFlight.delete(key)
+        group = undefined
+      }
+    }
+    if (replacedStale) logger.warn(`[Memory] stale query embedding replaced for ${agentId}`)
+
+    if (circuit.halfOpenProbe || circuit.openUntil > now) {
+      this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(agentId, 'skipped')
+      return { status: 'circuitOpen' }
+    }
+
+    const recoveryProbe = circuit.openUntil > 0
+    const existing = group?.get(query)
+    if (!recoveryProbe && existing) {
+      existing.consumerSignals.add(signal)
+      return { status: 'started', promise: existing.promise }
+    }
+    if ((group?.size ?? 0) >= RECALL_QUERY_EMBEDDING_MAX_CONCURRENT) {
+      return { status: 'capacity' }
+    }
+
+    if (recoveryProbe) {
+      circuit.halfOpenProbe = true
+      this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(agentId, 'halfOpen')
+    }
+    if (!group) {
+      group = new Map()
+      this.inFlight.set(key, group)
+    }
+
+    let promise: Promise<number[][]>
+    try {
+      promise = this.ports.embeddingGateway.getEmbeddings(
+        agentId,
+        embedding.providerId,
+        embedding.modelId,
+        [query],
+        'query-embedding'
+      )
+    } catch (error) {
+      promise = Promise.reject(error)
+    }
+    const entry: InFlightEntry = {
+      agentId,
+      startedAt: now,
+      promise,
+      circuit,
+      recoveryProbe,
+      consumerSignals: new Set([signal]),
+      circuitSettled: false
+    }
+    group.set(query, entry)
+    void promise
+      .then(
+        () => {
+          if (consumersCancelled(entry)) this.settleCancellation(entry)
+          else this.settleSuccess(entry)
+        },
+        (error) => {
+          if (consumersCancelled(entry)) this.settleCancellation(entry)
+          else if (isCircuitFailure(error)) this.settleFailure(entry)
+          else this.settleCancellation(entry)
+        }
+      )
+      .finally(() => {
+        const currentGroup = this.inFlight.get(key)
+        if (currentGroup?.get(query) === entry) {
+          currentGroup.delete(query)
+          if (currentGroup.size === 0) this.inFlight.delete(key)
+        }
+      })
+      .catch(() => undefined)
+    return { status: 'started', promise }
+  }
+
+  state(agentId: string): QueryEmbeddingCircuitState {
+    const circuit = this.circuits.get(agentId)
+    if (!circuit) return 'closed'
+    if (circuit.halfOpenProbe) return 'halfOpen'
+    return circuit.openUntil > 0 ? 'open' : 'closed'
+  }
+
+  // Embedding identity changes and Agent cleanup drop both the breaker and any shared call.
+  reset(agentId: string): void {
+    this.clearInFlight(agentId)
+    this.circuits.delete(agentId)
+    this.ports.diagnostics?.resetQueryEmbeddingCircuit?.(agentId)
+  }
+
+  clear(): void {
+    this.inFlight.clear()
+    this.circuits.clear()
+  }
+
+  private circuitFor(agentId: string, fingerprint: string): CircuitState {
+    const existing = this.circuits.get(agentId)
+    if (existing?.fingerprint === fingerprint) return existing
+    if (existing) {
+      this.clearInFlight(agentId)
+      this.ports.diagnostics?.resetQueryEmbeddingCircuit?.(agentId)
+    }
+    const circuit: CircuitState = {
+      fingerprint,
+      failuresInWindow: 0,
+      failureWindowStartedAt: null,
+      openUntil: 0,
+      halfOpenProbe: false
+    }
+    this.circuits.set(agentId, circuit)
+    return circuit
+  }
+
+  private settleSuccess(entry: InFlightEntry): void {
+    if (entry.circuitSettled) return
+    entry.circuitSettled = true
+    if (this.circuits.get(entry.agentId) !== entry.circuit) return
+    if (!entry.recoveryProbe && entry.circuit.openUntil > 0) return
+    entry.circuit.failuresInWindow = 0
+    entry.circuit.failureWindowStartedAt = null
+    entry.circuit.openUntil = 0
+    entry.circuit.halfOpenProbe = false
+    this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(entry.agentId, 'closed')
+  }
+
+  private settleFailure(entry: InFlightEntry): void {
+    if (entry.circuitSettled) return
+    entry.circuitSettled = true
+    const circuit = entry.circuit
+    if (this.circuits.get(entry.agentId) !== circuit) return
+    this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(entry.agentId, 'failure')
+    const now = Date.now()
+    if (entry.recoveryProbe) {
+      circuit.halfOpenProbe = false
+      this.open(entry.agentId, circuit, now)
+      return
+    }
+    if (circuit.openUntil > now) return
+    if (
+      circuit.failureWindowStartedAt === null ||
+      now - circuit.failureWindowStartedAt > RECALL_QUERY_EMBEDDING_BREAKER_FAILURE_WINDOW_MS
+    ) {
+      circuit.failureWindowStartedAt = now
+      circuit.failuresInWindow = 1
+    } else {
+      circuit.failuresInWindow += 1
+    }
+    if (circuit.failuresInWindow >= RECALL_QUERY_EMBEDDING_BREAKER_FAILURE_THRESHOLD) {
+      this.open(entry.agentId, circuit, now)
+    }
+  }
+
+  private open(agentId: string, circuit: CircuitState, now: number): void {
+    circuit.openUntil = now + RECALL_QUERY_EMBEDDING_BREAKER_COOLDOWN_MS
+    this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(agentId, 'opened')
+    logger.warn(`[Memory] query embedding circuit opened for ${agentId}; vector recall paused`)
+  }
+
+  private settleCancellation(entry: InFlightEntry): void {
+    if (entry.circuitSettled) return
+    entry.circuitSettled = true
+    if (this.circuits.get(entry.agentId) !== entry.circuit) return
+    if (!entry.recoveryProbe) return
+    entry.circuit.halfOpenProbe = false
+    this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(entry.agentId, 'probeCancelled')
+  }
+
+  private clearInFlight(agentId: string): void {
+    const prefix = `${agentId}::`
+    for (const key of this.inFlight.keys()) {
+      if (key.startsWith(prefix)) this.inFlight.delete(key)
+    }
+  }
+}
+
+function consumersCancelled(entry: InFlightEntry): boolean {
+  return (
+    entry.consumerSignals.size > 0 &&
+    [...entry.consumerSignals].every((signal) => signal?.aborted === true)
+  )
+}
+
+/**
+ * Every provider failure except a cancellation counts, including 4xx rejections: a persistent
+ * 400 from a misconfigured model or proxy costs a failed round trip on every turn, and only the
+ * breaker bounds that to one probe per cooldown. Query truncation already keeps well-formed
+ * requests inside provider input limits, so a rejection is a health signal, not a request quirk.
+ */
+function isCircuitFailure(error: unknown): boolean {
+  if (isMemoryProviderDeadlineError(error)) return true
+  return (error as { name?: string } | null)?.name !== 'AbortError'
+}

--- a/src/main/memory/ports.ts
+++ b/src/main/memory/ports.ts
@@ -63,7 +63,6 @@ import type {
   MemoryVectorRef,
   NormalizedMemoryCandidate,
   ClaimOwnership,
-  ProvenanceHitResult,
   WriteMemoriesOptions
 } from './domain/types'
 
@@ -507,12 +506,8 @@ export interface MemoryWriteMutationPort extends MemoryProvenanceResolverPort {
     incoming: MemoryTemporalMetadata,
     beforeMutation?: () => void
   ): boolean
-  supersedeHead(agentId: string, row: AgentMemoryRow): AgentMemoryRow
-  handleProvenanceHit(
-    agentId: string,
-    existing: AgentMemoryRow,
-    options?: { allowDecisionForSuperseded?: boolean }
-  ): ProvenanceHitResult
+  // Ownership is classified in one place; callers switch on ClaimOwnership instead of composing
+  // the provenance-hit and chain-head primitives themselves.
   resolveClaimOwnership(
     agentId: string,
     kind: string,

--- a/src/main/memory/ports.ts
+++ b/src/main/memory/ports.ts
@@ -62,6 +62,7 @@ import type {
   MemoryVectorRecord,
   MemoryVectorRef,
   NormalizedMemoryCandidate,
+  ClaimOwnership,
   ProvenanceHitResult,
   WriteMemoriesOptions
 } from './domain/types'
@@ -512,6 +513,18 @@ export interface MemoryWriteMutationPort extends MemoryProvenanceResolverPort {
     existing: AgentMemoryRow,
     options?: { allowDecisionForSuperseded?: boolean }
   ): ProvenanceHitResult
+  resolveClaimOwnership(
+    agentId: string,
+    kind: string,
+    content: string,
+    scope: MemoryScope,
+    options: { allowSuperseded: boolean; beforeMutation?: () => void }
+  ): ClaimOwnership
+  classifyClaimOwner(
+    agentId: string,
+    owner: AgentMemoryRow,
+    options: { allowSuperseded: boolean }
+  ): Exclude<ClaimOwnership, { state: 'unowned' }>
   reviveSupersededAfterDecision(
     agentId: string,
     existing: AgentMemoryRow

--- a/src/main/memory/services/maintenanceService.ts
+++ b/src/main/memory/services/maintenanceService.ts
@@ -142,7 +142,6 @@ export class MaintenanceService {
         budget: MaintenanceBudget
       ) => Promise<MemoryMaintenanceStepResult>
       repairConflictIntegrity: (agentId: string) => boolean
-      runConsolidationPass: (agentId: string) => Promise<void>
       diagnostics?: {
         recordMaintenance(
           agentId: string,
@@ -337,7 +336,7 @@ export class MaintenanceService {
     const timer = setTimeout(() => {
       this.consolidationTimers.delete(agentId)
       this.consolidationTimerDueAt.delete(agentId)
-      void this.ports.runConsolidationPass(agentId).catch((error) => {
+      void this.runConsolidationPass(agentId).catch((error) => {
         logger.warn(`[Memory] consolidation pass failed for ${agentId}: ${String(error)}`)
       })
     }, delayMs)

--- a/src/main/memory/services/maintenanceService.ts
+++ b/src/main/memory/services/maintenanceService.ts
@@ -126,7 +126,7 @@ export class MaintenanceService {
       run: async ({ agentId, model, budget }) => {
         const pass = await this.ports.maybeReflect(agentId, model, budget)
         if (pass.result) {
-          this.writePassAudit(agentId, 'reflection', {
+          this.writePassAudit(agentId, {
             eventType: 'memory/reflect',
             actorType: 'scheduler',
             status: 'completed',
@@ -143,7 +143,7 @@ export class MaintenanceService {
       run: async ({ agentId, model, budget }) => {
         const pass = await this.ports.maybeEvolvePersona(agentId, model, budget)
         if (pass.result) {
-          this.writePassAudit(agentId, 'persona', {
+          this.writePassAudit(agentId, {
             eventType: 'persona/evolve',
             actorType: 'scheduler',
             status: 'completed',
@@ -165,13 +165,12 @@ export class MaintenanceService {
   // otherwise a successful reflection could be counted as an all-steps-failed pass.
   private writePassAudit(
     agentId: string,
-    step: MaintenanceBudgetStep,
     input: Parameters<MemoryRuntimeContext['writeAudit']>[1]
   ): void {
     try {
       this.ctx.writeAudit(agentId, input)
     } catch (error) {
-      logger.warn(`[Memory] ${step} audit write failed for ${agentId}: ${String(error)}`)
+      logger.warn(`[Memory] ${input.eventType} audit failed for ${agentId}: ${String(error)}`)
     }
   }
 

--- a/src/main/memory/services/maintenanceService.ts
+++ b/src/main/memory/services/maintenanceService.ts
@@ -126,7 +126,7 @@ export class MaintenanceService {
       run: async ({ agentId, model, budget }) => {
         const pass = await this.ports.maybeReflect(agentId, model, budget)
         if (pass.result) {
-          this.ctx.writeAudit(agentId, {
+          this.writePassAudit(agentId, 'reflection', {
             eventType: 'memory/reflect',
             actorType: 'scheduler',
             status: 'completed',
@@ -143,7 +143,7 @@ export class MaintenanceService {
       run: async ({ agentId, model, budget }) => {
         const pass = await this.ports.maybeEvolvePersona(agentId, model, budget)
         if (pass.result) {
-          this.ctx.writeAudit(agentId, {
+          this.writePassAudit(agentId, 'persona', {
             eventType: 'persona/evolve',
             actorType: 'scheduler',
             status: 'completed',
@@ -160,6 +160,20 @@ export class MaintenanceService {
       }
     }
   ]
+
+  // Audit is observability. A failed audit insert must not erase the step's LLM accounting,
+  // otherwise a successful reflection could be counted as an all-steps-failed pass.
+  private writePassAudit(
+    agentId: string,
+    step: MaintenanceBudgetStep,
+    input: Parameters<MemoryRuntimeContext['writeAudit']>[1]
+  ): void {
+    try {
+      this.ctx.writeAudit(agentId, input)
+    } catch (error) {
+      logger.warn(`[Memory] ${step} audit write failed for ${agentId}: ${String(error)}`)
+    }
+  }
 
   constructor(
     private readonly ports: {

--- a/src/main/memory/services/maintenanceService.ts
+++ b/src/main/memory/services/maintenanceService.ts
@@ -25,7 +25,7 @@ import {
 } from '../core/decision'
 import { normalizeMemoryCandidate } from '../core/candidates'
 import { estimateTokens } from '../core/injectionPort'
-import { MaintenanceBudget } from '../core/maintenanceBudget'
+import { MaintenanceBudget, type MaintenanceBudgetStep } from '../core/maintenanceBudget'
 import { AsyncSemaphore } from '../../lib/asyncSemaphore'
 import {
   CONSOLIDATION_COOLDOWN_MS,
@@ -79,6 +79,21 @@ import type {
 class MaintenanceRevisionConflictError extends Error {}
 class MaintenanceClaimSuppressedError extends Error {}
 
+interface HeavyMaintenanceRun {
+  agentId: string
+  now: number
+  model: MemoryModelRef
+  operationFence: MemoryOperationFence
+  budget: MaintenanceBudget
+}
+
+// One model-backed maintenance step. The scheduler owns cooldown, fence, concurrency, budget, and
+// audit; a pass only performs its own work and reports LLM usage plus whether claims changed.
+interface HeavyMaintenancePass {
+  readonly step: MaintenanceBudgetStep
+  run(run: HeavyMaintenanceRun): Promise<MemoryMaintenanceStepResult>
+}
+
 export class MaintenanceService {
   private readonly ctx: MemoryRuntimeContext
   private readonly consolidationTimers = new Map<string, NodeJS.Timeout>()
@@ -92,6 +107,59 @@ export class MaintenanceService {
   private readonly prewarmTimers = new Map<string, NodeJS.Timeout>()
   private maintenanceStarted = false
   private maintenancePaused = false
+
+  // Heavy passes run in this order under one shared budget; each is fenced independently so a
+  // stop request lands at the next boundary instead of after the whole sequence.
+  private readonly heavyPasses: readonly HeavyMaintenancePass[] = [
+    {
+      step: 'challenge',
+      run: ({ agentId, model, budget }) =>
+        this.ports.runChallengeResolutionPass(agentId, model, budget)
+    },
+    {
+      step: 'merge',
+      run: ({ agentId, now, model, operationFence, budget }) =>
+        this.mergeNearDuplicates(agentId, now, model, operationFence, budget)
+    },
+    {
+      step: 'reflection',
+      run: async ({ agentId, model, budget }) => {
+        const pass = await this.ports.maybeReflect(agentId, model, budget)
+        if (pass.result) {
+          this.ctx.writeAudit(agentId, {
+            eventType: 'memory/reflect',
+            actorType: 'scheduler',
+            status: 'completed',
+            inputRefs: { memoryIds: pass.result.sourceMemoryIds },
+            outputRefs: { memoryIds: pass.result.reflectionIds },
+            model
+          })
+        }
+        return { touched: pass.result !== null, calls: pass.calls, failures: pass.failures }
+      }
+    },
+    {
+      step: 'persona',
+      run: async ({ agentId, model, budget }) => {
+        const pass = await this.ports.maybeEvolvePersona(agentId, model, budget)
+        if (pass.result) {
+          this.ctx.writeAudit(agentId, {
+            eventType: 'persona/evolve',
+            actorType: 'scheduler',
+            status: 'completed',
+            outputRefs: {
+              draftId: pass.result.draftId,
+              needsReview: pass.result.needsReview,
+              changeRatio: pass.result.changeRatio
+            },
+            model
+          })
+        }
+        // A persona draft waits for user review; it does not change recallable claims.
+        return { touched: false, calls: pass.calls, failures: pass.failures }
+      }
+    }
+  ]
 
   constructor(
     private readonly ports: {
@@ -406,69 +474,19 @@ export class MaintenanceService {
       const previousLast = last ?? 0
       this.lastConsolidationAt.set(agentId, now)
 
-      let touched = false
       const llmStats: MemoryMaintenanceStepResult = { touched: false, calls: 0, failures: 0 }
       const budget = new MaintenanceBudget()
+      const run: HeavyMaintenanceRun = { agentId, now, model, operationFence, budget }
       let completedHeavyPass = false
       try {
-        try {
-          const challenge = await this.ports.runChallengeResolutionPass(agentId, model, budget)
-          this.addLlmStats(llmStats, challenge)
-          if (challenge.touched) touched = true
-        } catch (error) {
-          logger.warn(`[Memory] challenge resolution failed for ${agentId}: ${String(error)}`)
-        }
-        if (!this.ctx.canContinueOperation(operationFence)) return
-        try {
-          const merge = await this.mergeNearDuplicates(agentId, now, model, operationFence, budget)
-          this.addLlmStats(llmStats, merge)
-          if (merge.touched) touched = true
-        } catch (error) {
-          logger.warn(`[Memory] consolidation merge failed for ${agentId}: ${String(error)}`)
-        }
-        if (!this.ctx.canContinueOperation(operationFence)) return
-        try {
-          const reflectionPass = await this.ports.maybeReflect(agentId, model, budget)
-          this.addLlmStats(llmStats, reflectionPass)
-          const reflection = reflectionPass.result
-          if (reflection) {
-            this.ctx.writeAudit(agentId, {
-              eventType: 'memory/reflect',
-              actorType: 'scheduler',
-              status: 'completed',
-              inputRefs: { memoryIds: reflection.sourceMemoryIds },
-              outputRefs: { memoryIds: reflection.reflectionIds },
-              model
-            })
-            touched = true
+        for (const pass of this.heavyPasses) {
+          try {
+            this.addLlmStats(llmStats, await pass.run(run))
+          } catch (error) {
+            logger.warn(`[Memory] ${pass.step} pass failed for ${agentId}: ${String(error)}`)
           }
-        } catch (error) {
-          logger.warn(`[Memory] background reflection failed for ${agentId}: ${String(error)}`)
+          if (!this.ctx.canContinueOperation(operationFence)) return
         }
-        if (!this.ctx.canContinueOperation(operationFence)) return
-        try {
-          const personaPass = await this.ports.maybeEvolvePersona(agentId, model, budget)
-          this.addLlmStats(llmStats, personaPass)
-          const personaDraft = personaPass.result
-          if (personaDraft) {
-            this.ctx.writeAudit(agentId, {
-              eventType: 'persona/evolve',
-              actorType: 'scheduler',
-              status: 'completed',
-              outputRefs: {
-                draftId: personaDraft.draftId,
-                needsReview: personaDraft.needsReview,
-                changeRatio: personaDraft.changeRatio
-              },
-              model
-            })
-          }
-        } catch (error) {
-          logger.warn(
-            `[Memory] background persona evolution failed for ${agentId}: ${String(error)}`
-          )
-        }
-        if (!this.ctx.canContinueOperation(operationFence)) return
         if (this.didAllAttemptedLlmCallsFail(llmStats)) {
           this.lastConsolidationAt.set(agentId, previousLast)
           this.lastConsolidationFailureAt.set(agentId, now)
@@ -490,7 +508,7 @@ export class MaintenanceService {
           eventType: 'memory/maintenance_llm',
           actorType: 'scheduler',
           status: 'completed',
-          outputRefs: { touched, budget: budget.snapshot() },
+          outputRefs: { touched: llmStats.touched, budget: budget.snapshot() },
           model,
           createdAt: now
         })
@@ -830,13 +848,10 @@ export class MaintenanceService {
     return true
   }
 
-  private addLlmStats(
-    total: MemoryMaintenanceStepResult,
-    next: { touched?: boolean; calls: number; failures: number }
-  ): void {
+  private addLlmStats(total: MemoryMaintenanceStepResult, next: MemoryMaintenanceStepResult): void {
     total.calls += next.calls
     total.failures += next.failures
-    total.touched = total.touched || next.touched === true
+    total.touched = total.touched || next.touched
   }
 
   private didAllAttemptedLlmCallsFail(stats: { calls: number; failures: number }): boolean {

--- a/src/main/memory/services/retrievalService.ts
+++ b/src/main/memory/services/retrievalService.ts
@@ -105,9 +105,8 @@ interface RecallState {
   rawVectorMatches: MemoryVectorMatch[]
   vecCandidates: { memoryId: string; similarity: number }[]
   vectorContext: { embedding: MemoryModelRef; dimensions: number } | null
-}
-
-interface RecallRefillResult {
+  // Output of the latest revalidation round: authoritative rows for every candidate id, the vector
+  // matches whose rows are still live, and the temporally eligible rows that reach fusion.
   authoritativeRows: AgentMemoryRow[]
   structurallyValidVecMatches: Array<{ row: AgentMemoryRow; similarity: number }>
   authoritativeFtsRows: AgentMemoryRow[]
@@ -619,36 +618,6 @@ export class RetrievalService {
     return results
   }
 
-  // Per-request recall state shared by the keyword, vector, refill, and prune stages. Every
-  // stage reads the same fence and read epoch so a cancelled request never reaches assembly.
-  private createRecallState(input: {
-    agentId: string
-    now: number
-    signal?: AbortSignal
-    scopeFilter: readonly MemoryScope[]
-    operationFence: MemoryOperationFence
-    readEpoch: number | null
-    latencyMs: Partial<Record<MemoryRecallLatencyStage, number>>
-    degradations: Set<MemoryRetrievalDegradationCause>
-    keywordQuery: string
-    keywordMatchMode: 'all' | 'any'
-    candidateLimit: number
-    similarityThreshold: number
-  }): RecallState {
-    return {
-      ...input,
-      activeStage: 'idle',
-      ftsCandidates: 0,
-      vectorCandidates: 0,
-      ftsRows: [],
-      vectorCandidateLimit: scopeAwareVectorCandidateLimit(input.candidateLimit),
-      vectorPool: null,
-      rawVectorMatches: [],
-      vecCandidates: [],
-      vectorContext: null
-    }
-  }
-
   private isRecallCurrent(state: RecallState): boolean {
     return (
       this.ctx.canContinueOperation(state.operationFence) &&
@@ -810,16 +779,10 @@ export class RetrievalService {
       temporalMode: MemoryTemporalPolicyMode
       suppressionPolicy: ReturnType<typeof createMemoryTopicSuppressionPolicy> | null
     }
-  ): RecallRefillResult | null {
+  ): boolean {
     const { agentId, now } = state
-    const result: RecallRefillResult = {
-      authoritativeRows: [],
-      structurallyValidVecMatches: [],
-      authoritativeFtsRows: [],
-      authoritativeVecMatches: []
-    }
     while (true) {
-      if (!this.isRecallCurrent(state)) return null
+      if (!this.isRecallCurrent(state)) return false
       throwIfAborted(state.signal)
       const candidateIds = [
         ...state.ftsRows.map((row) => row.id),
@@ -827,7 +790,7 @@ export class RetrievalService {
       ]
       const revalidationStartedAt = performance.now()
       state.activeStage = 'authoritativeRevalidation'
-      result.authoritativeRows = candidateIds.length
+      state.authoritativeRows = candidateIds.length
         ? this.ports.repository.listApplicableByIds(
             agentId,
             [...new Set(candidateIds)],
@@ -837,7 +800,7 @@ export class RetrievalService {
       state.latencyMs.authoritativeRevalidation =
         (state.latencyMs.authoritativeRevalidation ?? 0) +
         (performance.now() - revalidationStartedAt)
-      const rowsById = new Map(result.authoritativeRows.map((row) => [row.id, row]))
+      const rowsById = new Map(state.authoritativeRows.map((row) => [row.id, row]))
       const structurallyValidFtsRows = state.ftsRows
         .map((row) => rowsById.get(row.id))
         .filter((row): row is AgentMemoryRow => isLiveRecallRow(agentId, row))
@@ -845,7 +808,7 @@ export class RetrievalService {
       const vectorFingerprint = vectorContext
         ? embeddingFingerprint(vectorContext.embedding.providerId, vectorContext.embedding.modelId)
         : null
-      result.structurallyValidVecMatches = state.vecCandidates
+      state.structurallyValidVecMatches = state.vecCandidates
         .map((candidate) => {
           const row = rowsById.get(candidate.memoryId)
           return vectorContext && vectorFingerprint
@@ -861,32 +824,32 @@ export class RetrievalService {
         ? structurallyValidFtsRows.filter((row) => !suppressionPolicy.suppresses(row.content))
         : structurallyValidFtsRows
       const directiveEligibleVecMatches = suppressionPolicy
-        ? result.structurallyValidVecMatches.filter(
+        ? state.structurallyValidVecMatches.filter(
             (match) => !suppressionPolicy.suppresses(match.row.content)
           )
-        : result.structurallyValidVecMatches
-      result.authoritativeFtsRows = selectTemporalCandidates(
+        : state.structurallyValidVecMatches
+      state.authoritativeFtsRows = selectTemporalCandidates(
         directiveEligibleFtsRows,
         (row) => row,
         limits.fusionCandidateLimit,
         now,
         limits.temporalMode
       )
-      result.authoritativeVecMatches = selectTemporalCandidates(
+      state.authoritativeVecMatches = selectTemporalCandidates(
         directiveEligibleVecMatches,
         (match) => match.row,
         limits.fusionCandidateLimit,
         now,
         limits.temporalMode
       )
-      state.ftsCandidates = result.authoritativeFtsRows.length
-      state.vectorCandidates = result.authoritativeVecMatches.length
+      state.ftsCandidates = state.authoritativeFtsRows.length
+      state.vectorCandidates = state.authoritativeVecMatches.length
 
       const eligibleIds = new Set([
-        ...result.authoritativeFtsRows.map((row) => row.id),
-        ...result.authoritativeVecMatches.map((match) => match.row.id)
+        ...state.authoritativeFtsRows.map((row) => row.id),
+        ...state.authoritativeVecMatches.map((match) => match.row.id)
       ])
-      if (eligibleIds.size >= limits.effectiveTopK) return result
+      if (eligibleIds.size >= limits.effectiveTopK) return true
 
       const ftsSourceSaturated =
         Boolean(state.keywordQuery) && state.ftsRows.length >= state.candidateLimit
@@ -905,7 +868,7 @@ export class RetrievalService {
         ) {
           state.degradations.add('candidateBudgetExhausted')
         }
-        return result
+        return true
       }
 
       if (canRefillFts) {
@@ -925,12 +888,11 @@ export class RetrievalService {
    */
   private pruneStaleVectors(
     state: RecallState,
-    vectorContext: { embedding: MemoryModelRef; dimensions: number },
-    refill: RecallRefillResult
+    vectorContext: { embedding: MemoryModelRef; dimensions: number }
   ): void {
     const { agentId } = state
-    const liveVectorIds = new Set(refill.structurallyValidVecMatches.map((match) => match.row.id))
-    const applicableIds = new Set(refill.authoritativeRows.map((row) => row.id))
+    const liveVectorIds = new Set(state.structurallyValidVecMatches.map((match) => match.row.id))
+    const applicableIds = new Set(state.authoritativeRows.map((row) => row.id))
     const candidateIds = state.vecCandidates.map((candidate) => candidate.memoryId)
     const unmatchedVectorIds = [
       ...new Set(candidateIds.filter((memoryId) => !applicableIds.has(memoryId)))
@@ -1025,7 +987,10 @@ export class RetrievalService {
           : suppressionTopics.length > 0
             ? DIRECTIVE_RETRIEVAL_CANDIDATE_MULTIPLIER
             : LEGACY_RETRIEVAL_CANDIDATE_MULTIPLIER
-      state = this.createRecallState({
+      const candidateLimit = effectiveTopK * candidateMultiplier
+      // Shared by the keyword, vector, refill, and prune stages; every stage reads the same fence
+      // and read epoch so a cancelled request never reaches assembly.
+      state = {
         agentId,
         now,
         signal: options.signal,
@@ -1034,11 +999,24 @@ export class RetrievalService {
         readEpoch,
         latencyMs,
         degradations,
+        activeStage: 'idle',
+        ftsCandidates: 0,
+        vectorCandidates: 0,
         keywordQuery: (options.keywordQuery ?? normalizedQuery).trim(),
         keywordMatchMode: options.keywordMatchMode ?? 'all',
-        candidateLimit: effectiveTopK * candidateMultiplier,
-        similarityThreshold
-      })
+        candidateLimit,
+        ftsRows: [],
+        similarityThreshold,
+        vectorCandidateLimit: scopeAwareVectorCandidateLimit(candidateLimit),
+        vectorPool: null,
+        rawVectorMatches: [],
+        vecCandidates: [],
+        vectorContext: null,
+        authoritativeRows: [],
+        structurallyValidVecMatches: [],
+        authoritativeFtsRows: [],
+        authoritativeVecMatches: []
+      }
 
       state.activeStage = 'keyword'
       state.ftsRows = this.searchKeywordCandidates(state, state.candidateLimit)
@@ -1057,7 +1035,7 @@ export class RetrievalService {
         outcome = 'cancelled'
         return []
       }
-      const refill = this.refillCandidates(state, {
+      const refilled = this.refillCandidates(state, {
         effectiveTopK,
         fusionCandidateLimit: effectiveTopK * LEGACY_RETRIEVAL_CANDIDATE_MULTIPLIER,
         temporalMode,
@@ -1065,7 +1043,7 @@ export class RetrievalService {
           ? createMemoryTopicSuppressionPolicy(suppressionTopics)
           : null
       })
-      if (!refill) {
+      if (!refilled) {
         outcome = 'cancelled'
         return []
       }
@@ -1077,13 +1055,13 @@ export class RetrievalService {
         this.ctx.canContinueOperation(operationFence)
       ) {
         throwIfAborted(options.signal)
-        this.pruneStaleVectors(state, state.vectorContext, refill)
+        this.pruneStaleVectors(state, state.vectorContext)
       }
 
       const assemblyStartedAt = performance.now()
       state.activeStage = 'assembly'
       throwIfAborted(options.signal)
-      const results = fuse(refill.authoritativeFtsRows, refill.authoritativeVecMatches, {
+      const results = fuse(state.authoritativeFtsRows, state.authoritativeVecMatches, {
         topK: effectiveTopK,
         rrfK,
         weights,

--- a/src/main/memory/services/retrievalService.ts
+++ b/src/main/memory/services/retrievalService.ts
@@ -246,22 +246,6 @@ export class RetrievalService {
     })
   }
 
-  async retrieveForDecision(
-    agentId: string,
-    query: string,
-    now: number,
-    scopeFilter: readonly MemoryScope[] = AGENT_MEMORY_AGENT_SCOPE_FILTER
-  ): Promise<MemoryRecallItem[]> {
-    return this.retrieve(agentId, query, now, false, {
-      purpose: 'decision',
-      keywordQuery: this.buildAgentFacingRecallKeywordQuery(query),
-      keywordMatchMode: 'any',
-      enableInlinePrune: false,
-      excludeConflictParticipants: true,
-      scopeFilter
-    })
-  }
-
   async retrieveForDecisions(
     agentId: string,
     candidates: readonly NormalizedMemoryCandidate[],
@@ -332,35 +316,6 @@ export class RetrievalService {
           ? Array.from(snapshot.vector)
           : undefined
       })
-      // A supplied vector array is a retry snapshot. Undefined slots stay FTS-only so contention
-      // never performs a second embedding provider call after the first attempt failed or omitted one.
-      if (currentEmbedding && queryVectors === undefined) {
-        const missingIndexes = vectors
-          .map((vector, index) => (vector ? -1 : index))
-          .filter((index) => index >= 0)
-        if (missingIndexes.length) {
-          try {
-            const embeddingStartedAt = performance.now()
-            activeStage = 'queryEmbedding'
-            const embedded = await this.ports.embeddingGateway.getEmbeddings(
-              agentId,
-              currentEmbedding.providerId,
-              currentEmbedding.modelId,
-              missingIndexes.map((index) => candidates[index].content),
-              'query-embedding'
-            )
-            missingIndexes.forEach((candidateIndex, embeddedIndex) => {
-              const vector = embedded[embeddedIndex]
-              if (vector?.length) vectors[candidateIndex] = vector
-            })
-            latencyMs.queryEmbedding = performance.now() - embeddingStartedAt
-          } catch (error) {
-            degradations.add('embeddingError')
-            logger.warn(`[Memory] batch query embedding failed for ${agentId}: ${String(error)}`)
-          }
-        }
-      }
-
       const vectorMatches: Array<Array<{ memoryId: string; similarity: number }>> = candidates.map(
         () => []
       )
@@ -378,6 +333,37 @@ export class RetrievalService {
             })
           this.ports.warmEmbeddingConnection(agentId, currentEmbedding)
         } else {
+          // Query embeddings are only worth a provider round trip once the store can answer. A
+          // supplied vector array is a retry snapshot: undefined slots stay FTS-only so contention
+          // never performs a second embedding call after the first attempt failed or omitted one.
+          if (queryVectors === undefined) {
+            const missingIndexes = vectors
+              .map((vector, index) => (vector ? -1 : index))
+              .filter((index) => index >= 0)
+            if (missingIndexes.length) {
+              try {
+                const embeddingStartedAt = performance.now()
+                activeStage = 'queryEmbedding'
+                const embedded = await this.ports.embeddingGateway.getEmbeddings(
+                  agentId,
+                  currentEmbedding.providerId,
+                  currentEmbedding.modelId,
+                  missingIndexes.map((index) => candidates[index].content),
+                  'query-embedding'
+                )
+                missingIndexes.forEach((candidateIndex, embeddedIndex) => {
+                  const vector = embedded[embeddedIndex]
+                  if (vector?.length) vectors[candidateIndex] = vector
+                })
+                latencyMs.queryEmbedding = performance.now() - embeddingStartedAt
+              } catch (error) {
+                degradations.add('embeddingError')
+                logger.warn(
+                  `[Memory] batch query embedding failed for ${agentId}: ${String(error)}`
+                )
+              }
+            }
+          }
           const dimensions = vectors.find((vector) => vector?.length)?.length ?? 0
           const queryIndexes = vectors
             .map((vector, index) => (vector?.length === dimensions ? index : -1))
@@ -612,7 +598,6 @@ export class RetrievalService {
       keywordMatchMode?: 'all' | 'any'
       topKOverride?: number
       enableInlinePrune?: boolean
-      excludeConflictParticipants?: boolean
       degradationCollector?: Set<MemoryRetrievalDegradationCause>
       signal?: AbortSignal
       scopeFilter?: readonly MemoryScope[]
@@ -834,9 +819,7 @@ export class RetrievalService {
         outcome = 'cancelled'
         return []
       }
-      const isEligibleRow = options.excludeConflictParticipants
-        ? isLiveDecisionRow
-        : isLiveRecallRow
+      const isEligibleRow = isLiveRecallRow
       const suppressionPolicy = directiveSuppressionApplies
         ? createMemoryTopicSuppressionPolicy(suppressionTopics)
         : null

--- a/src/main/memory/services/retrievalService.ts
+++ b/src/main/memory/services/retrievalService.ts
@@ -91,6 +91,10 @@ interface RecallState {
   readonly latencyMs: Partial<Record<MemoryRecallLatencyStage, number>>
   readonly degradations: Set<MemoryRetrievalDegradationCause>
   activeStage: MemoryRecallLatencyStage | 'idle'
+  // Eligible candidates after the latest revalidation round; reported even when a later round
+  // is cancelled so diagnostics reflect the work that was actually done.
+  ftsCandidates: number
+  vectorCandidates: number
   readonly keywordQuery: string
   readonly keywordMatchMode: 'all' | 'any'
   candidateLimit: number
@@ -634,6 +638,8 @@ export class RetrievalService {
     return {
       ...input,
       activeStage: 'idle',
+      ftsCandidates: 0,
+      vectorCandidates: 0,
       ftsRows: [],
       vectorCandidateLimit: scopeAwareVectorCandidateLimit(input.candidateLimit),
       vectorPool: null,
@@ -873,6 +879,8 @@ export class RetrievalService {
         now,
         limits.temporalMode
       )
+      state.ftsCandidates = result.authoritativeFtsRows.length
+      state.vectorCandidates = result.authoritativeVecMatches.length
 
       const eligibleIds = new Set([
         ...result.authoritativeFtsRows.map((row) => row.id),
@@ -975,8 +983,6 @@ export class RetrievalService {
     const latencyMs: Partial<Record<MemoryRecallLatencyStage, number>> = {}
     const degradations = options.degradationCollector ?? new Set<MemoryRetrievalDegradationCause>()
     let outcome: MemoryRetrievalOutcome = 'failed'
-    let ftsCandidates = 0
-    let vectorCandidates = 0
     let selected = 0
     let operationFence: MemoryOperationFence | null = null
     let setupStage: MemoryRecallLatencyStage | 'idle' = 'idle'
@@ -1063,8 +1069,6 @@ export class RetrievalService {
         outcome = 'cancelled'
         return []
       }
-      ftsCandidates = refill.authoritativeFtsRows.length
-      vectorCandidates = refill.authoritativeVecMatches.length
       throwIfAborted(options.signal)
 
       if (
@@ -1118,8 +1122,8 @@ export class RetrievalService {
       this.ports.diagnostics?.recordRecall(agentId, {
         purpose: options.purpose,
         latencyMs,
-        ftsCandidates,
-        vectorCandidates,
+        ftsCandidates: state?.ftsCandidates ?? 0,
+        vectorCandidates: state?.vectorCandidates ?? 0,
         selected,
         outcome,
         degradations: [...degradations]

--- a/src/main/memory/services/retrievalService.ts
+++ b/src/main/memory/services/retrievalService.ts
@@ -81,6 +81,35 @@ import {
   type QueryEmbeddingCircuitState
 } from '../infra/queryEmbeddingCircuit'
 
+interface RecallState {
+  readonly agentId: string
+  readonly now: number
+  readonly signal?: AbortSignal
+  readonly scopeFilter: readonly MemoryScope[]
+  readonly operationFence: MemoryOperationFence
+  readonly readEpoch: number | null
+  readonly latencyMs: Partial<Record<MemoryRecallLatencyStage, number>>
+  readonly degradations: Set<MemoryRetrievalDegradationCause>
+  activeStage: MemoryRecallLatencyStage | 'idle'
+  readonly keywordQuery: string
+  readonly keywordMatchMode: 'all' | 'any'
+  candidateLimit: number
+  ftsRows: AgentMemoryRow[]
+  readonly similarityThreshold: number
+  vectorCandidateLimit: number
+  vectorPool: MemoryVectorMatch[] | null
+  rawVectorMatches: MemoryVectorMatch[]
+  vecCandidates: { memoryId: string; similarity: number }[]
+  vectorContext: { embedding: MemoryModelRef; dimensions: number } | null
+}
+
+interface RecallRefillResult {
+  authoritativeRows: AgentMemoryRow[]
+  structurallyValidVecMatches: Array<{ row: AgentMemoryRow; similarity: number }>
+  authoritativeFtsRows: AgentMemoryRow[]
+  authoritativeVecMatches: Array<{ row: AgentMemoryRow; similarity: number }>
+}
+
 const LEGACY_RETRIEVAL_CANDIDATE_MULTIPLIER = 2
 const TEMPORAL_RETRIEVAL_CANDIDATE_MULTIPLIER = 4
 const DIRECTIVE_RETRIEVAL_CANDIDATE_MULTIPLIER = 4
@@ -160,7 +189,7 @@ function throwIfAborted(signal?: AbortSignal): void {
 function vectorStoreDegradation(
   error: unknown,
   health: ReturnType<VectorStoreRetrievalPort['getRecallHealth']>,
-  activeStage: MemoryRecallLatencyStage
+  activeStage: MemoryRecallLatencyStage | 'idle'
 ): MemoryRetrievalDegradationCause {
   if (error instanceof VectorStoreQueryTimeoutError || health === 'suspect') return 'storeTimeout'
   if (
@@ -586,6 +615,345 @@ export class RetrievalService {
     return results
   }
 
+  // Per-request recall state shared by the keyword, vector, refill, and prune stages. Every
+  // stage reads the same fence and read epoch so a cancelled request never reaches assembly.
+  private createRecallState(input: {
+    agentId: string
+    now: number
+    signal?: AbortSignal
+    scopeFilter: readonly MemoryScope[]
+    operationFence: MemoryOperationFence
+    readEpoch: number | null
+    latencyMs: Partial<Record<MemoryRecallLatencyStage, number>>
+    degradations: Set<MemoryRetrievalDegradationCause>
+    keywordQuery: string
+    keywordMatchMode: 'all' | 'any'
+    candidateLimit: number
+    similarityThreshold: number
+  }): RecallState {
+    return {
+      ...input,
+      activeStage: 'idle',
+      ftsRows: [],
+      vectorCandidateLimit: scopeAwareVectorCandidateLimit(input.candidateLimit),
+      vectorPool: null,
+      rawVectorMatches: [],
+      vecCandidates: [],
+      vectorContext: null
+    }
+  }
+
+  private isRecallCurrent(state: RecallState): boolean {
+    return (
+      this.ctx.canContinueOperation(state.operationFence) &&
+      (state.readEpoch === null || this.ctx.isReadEpochCurrent(state.agentId, state.readEpoch))
+    )
+  }
+
+  private searchKeywordCandidates(state: RecallState, limit: number): AgentMemoryRow[] {
+    if (!state.keywordQuery) return []
+    const keywordStartedAt = performance.now()
+    const search = this.ports.repository.searchWithStrategy(
+      state.agentId,
+      state.keywordQuery,
+      limit,
+      { matchMode: state.keywordMatchMode, scopeFilter: state.scopeFilter }
+    )
+    if (search.strategy === 'like-fallback') state.degradations.add('ftsUnavailable')
+    state.latencyMs.keyword =
+      (state.latencyMs.keyword ?? 0) + (performance.now() - keywordStartedAt)
+    return search.rows.filter((row) => row.kind !== 'persona' && row.kind !== 'working')
+  }
+
+  // The exact scan costs the same for any top-K, so one query fetches the whole candidate budget
+  // and adaptive refills widen the visible page locally instead of rescanning the store.
+  private takeVectorCandidates(state: RecallState, limit: number): void {
+    state.vectorCandidateLimit = limit
+    state.rawVectorMatches = state.vectorPool?.slice(0, limit) ?? []
+    state.vecCandidates = []
+    for (const match of state.rawVectorMatches) {
+      const similarity = distanceToSimilarity(match.distance)
+      if (similarity < state.similarityThreshold) continue
+      state.vecCandidates.push({ memoryId: match.memoryId, similarity })
+    }
+  }
+
+  /**
+   * Vector stage: health gate, cold warm-up, breaker-guarded query embedding, one exact scan, and
+   * the ready-certificate re-check before the pool is admitted. Returns false when the execution
+   * fence moved while a provider call was in flight so the caller reports a cancelled recall.
+   * Provider or store failures degrade to FTS unless the fence is already stale, in which case
+   * the error propagates and the outer handler classifies it.
+   */
+  private async recallVectorCandidates(
+    state: RecallState,
+    currentEmbedding: MemoryModelRef,
+    query: string
+  ): Promise<boolean> {
+    const { agentId, operationFence, signal } = state
+    const recallHealth = this.ports.vectorStore.getRecallHealth(agentId)
+    if (recallHealth !== 'available') {
+      state.degradations.add(recallHealth === 'suspect' ? 'storeTimeout' : 'storeUnusable')
+      return true
+    }
+    if (!this.ports.vectorStore.hasReadyCertificate(agentId, currentEmbedding)) {
+      state.degradations.add('vectorCold')
+      void this.ports
+        .warmVectorStore(agentId, currentEmbedding, { delayOpen: true })
+        .catch((error) => {
+          logger.warn(`[Memory] vector warmup failed for ${agentId}: ${String(error)}`)
+        })
+      this.ports.warmEmbeddingConnection(agentId, currentEmbedding)
+      return true
+    }
+    try {
+      const queryEmbedding = this.queryEmbeddingCircuit.start(
+        agentId,
+        currentEmbedding,
+        query,
+        signal
+      )
+      if (queryEmbedding.status === 'circuitOpen') {
+        state.degradations.add('embeddingCircuitOpen')
+        return true
+      }
+      if (queryEmbedding.status === 'capacity') {
+        logger.warn(
+          `[Memory] query embedding already in flight for ${agentId}; vector recall skipped this turn`
+        )
+        return true
+      }
+      const embeddingStartedAt = performance.now()
+      state.activeStage = 'queryEmbedding'
+      // The gateway owns the deadline; its rejection lands in the catch below.
+      const vectors = await queryEmbedding.promise
+      throwIfAborted(signal)
+      state.latencyMs.queryEmbedding = performance.now() - embeddingStartedAt
+      if (!this.ctx.canContinueOperation(operationFence)) return false
+      const vector = vectors[0]
+      if (!vector?.length) return true
+      const vectorStartedAt = performance.now()
+      state.activeStage = 'vector'
+      const matches = await this.ports.vectorStore.query(
+        agentId,
+        currentEmbedding,
+        vector.length,
+        vector,
+        MEMORY_RETRIEVAL_MAX_CANDIDATES
+      )
+      throwIfAborted(signal)
+      state.latencyMs.vector = performance.now() - vectorStartedAt
+      if (!this.ctx.canContinueOperation(operationFence)) return false
+      if (
+        this.ports.vectorStore.hasReadyCertificate(agentId, currentEmbedding) &&
+        this.ctx.canUseCurrentMemoryEmbedding(agentId, currentEmbedding)
+      ) {
+        state.vectorContext = { embedding: currentEmbedding, dimensions: vector.length }
+        state.vectorPool = matches
+        this.takeVectorCandidates(state, state.vectorCandidateLimit)
+        if (!this.ports.isReindexing(agentId)) {
+          void this.ports.backfillEmbeddings(agentId).catch((error) => {
+            logger.warn(`[Memory] backfill failed for ${agentId}: ${String(error)}`)
+          })
+        }
+      } else if (!this.ports.isReindexing(agentId)) {
+        state.degradations.add('revisionChanged')
+        void this.ports.reindexEmbeddings(agentId, true).catch((error) => {
+          logger.warn(`[Memory] store rebuild failed for ${agentId}: ${String(error)}`)
+        })
+      }
+      return true
+    } catch (error) {
+      if (signal?.aborted) throwIfAborted(signal)
+      const executionIsCurrent = this.ctx.canContinueOperation(operationFence)
+      if (!executionIsCurrent && isStaleExecutionCancellation(error, this.ctx.isDisposed)) {
+        return false
+      }
+      const errorName = (error as { name?: string } | null)?.name
+      if (
+        state.activeStage === 'vector' &&
+        errorName !== 'AbortError' &&
+        !(error instanceof VectorStoreLeaseUnavailableError)
+      ) {
+        this.ports.vectorStore.clearReady(agentId)
+      }
+      state.degradations.add(
+        vectorStoreDegradation(
+          error,
+          this.ports.vectorStore.getRecallHealth(agentId),
+          state.activeStage
+        )
+      )
+      logger.warn(`[Memory] vector recall degraded to FTS for ${agentId}: ${String(error)}`)
+      if (!executionIsCurrent) throw error
+      return true
+    }
+  }
+
+  /**
+   * Refill stage: revalidate every candidate against the authoritative rows, apply directive
+   * suppression and temporal eligibility, and widen the FTS page or the local vector page
+   * geometrically until top-K is covered or both sources saturate. Returns null when the fence
+   * or read epoch moved between rounds.
+   */
+  private refillCandidates(
+    state: RecallState,
+    limits: {
+      effectiveTopK: number
+      fusionCandidateLimit: number
+      temporalMode: MemoryTemporalPolicyMode
+      suppressionPolicy: ReturnType<typeof createMemoryTopicSuppressionPolicy> | null
+    }
+  ): RecallRefillResult | null {
+    const { agentId, now } = state
+    const result: RecallRefillResult = {
+      authoritativeRows: [],
+      structurallyValidVecMatches: [],
+      authoritativeFtsRows: [],
+      authoritativeVecMatches: []
+    }
+    while (true) {
+      if (!this.isRecallCurrent(state)) return null
+      throwIfAborted(state.signal)
+      const candidateIds = [
+        ...state.ftsRows.map((row) => row.id),
+        ...state.vecCandidates.map((candidate) => candidate.memoryId)
+      ]
+      const revalidationStartedAt = performance.now()
+      state.activeStage = 'authoritativeRevalidation'
+      result.authoritativeRows = candidateIds.length
+        ? this.ports.repository.listApplicableByIds(
+            agentId,
+            [...new Set(candidateIds)],
+            state.scopeFilter
+          )
+        : []
+      state.latencyMs.authoritativeRevalidation =
+        (state.latencyMs.authoritativeRevalidation ?? 0) +
+        (performance.now() - revalidationStartedAt)
+      const rowsById = new Map(result.authoritativeRows.map((row) => [row.id, row]))
+      const structurallyValidFtsRows = state.ftsRows
+        .map((row) => rowsById.get(row.id))
+        .filter((row): row is AgentMemoryRow => isLiveRecallRow(agentId, row))
+      const vectorContext = state.vectorContext
+      const vectorFingerprint = vectorContext
+        ? embeddingFingerprint(vectorContext.embedding.providerId, vectorContext.embedding.modelId)
+        : null
+      result.structurallyValidVecMatches = state.vecCandidates
+        .map((candidate) => {
+          const row = rowsById.get(candidate.memoryId)
+          return vectorContext && vectorFingerprint
+            ? isCurrentRecallVectorRow(agentId, row, vectorContext.dimensions, vectorFingerprint) &&
+              isLiveRecallRow(agentId, row)
+              ? { row, similarity: candidate.similarity }
+              : null
+            : null
+        })
+        .filter((match): match is { row: AgentMemoryRow; similarity: number } => match !== null)
+      const { suppressionPolicy } = limits
+      const directiveEligibleFtsRows = suppressionPolicy
+        ? structurallyValidFtsRows.filter((row) => !suppressionPolicy.suppresses(row.content))
+        : structurallyValidFtsRows
+      const directiveEligibleVecMatches = suppressionPolicy
+        ? result.structurallyValidVecMatches.filter(
+            (match) => !suppressionPolicy.suppresses(match.row.content)
+          )
+        : result.structurallyValidVecMatches
+      result.authoritativeFtsRows = selectTemporalCandidates(
+        directiveEligibleFtsRows,
+        (row) => row,
+        limits.fusionCandidateLimit,
+        now,
+        limits.temporalMode
+      )
+      result.authoritativeVecMatches = selectTemporalCandidates(
+        directiveEligibleVecMatches,
+        (match) => match.row,
+        limits.fusionCandidateLimit,
+        now,
+        limits.temporalMode
+      )
+
+      const eligibleIds = new Set([
+        ...result.authoritativeFtsRows.map((row) => row.id),
+        ...result.authoritativeVecMatches.map((match) => match.row.id)
+      ])
+      if (eligibleIds.size >= limits.effectiveTopK) return result
+
+      const ftsSourceSaturated =
+        Boolean(state.keywordQuery) && state.ftsRows.length >= state.candidateLimit
+      const vectorSourceSaturated =
+        state.vectorPool !== null &&
+        state.rawVectorMatches.length >= state.vectorCandidateLimit &&
+        state.vecCandidates.length === state.rawVectorMatches.length
+      const nextFtsLimit = nextMemoryRetrievalCandidateLimit(state.candidateLimit)
+      const nextVectorLimit = nextMemoryRetrievalCandidateLimit(state.vectorCandidateLimit)
+      const canRefillFts = ftsSourceSaturated && nextFtsLimit > state.candidateLimit
+      const canRefillVector = vectorSourceSaturated && nextVectorLimit > state.vectorCandidateLimit
+      if (!canRefillFts && !canRefillVector) {
+        if (
+          (ftsSourceSaturated && state.candidateLimit >= MEMORY_RETRIEVAL_MAX_CANDIDATES) ||
+          (vectorSourceSaturated && state.vectorCandidateLimit >= MEMORY_RETRIEVAL_MAX_CANDIDATES)
+        ) {
+          state.degradations.add('candidateBudgetExhausted')
+        }
+        return result
+      }
+
+      if (canRefillFts) {
+        state.candidateLimit = nextFtsLimit
+        state.activeStage = 'keyword'
+        state.ftsRows = this.searchKeywordCandidates(state, state.candidateLimit)
+      }
+      if (canRefillVector) this.takeVectorCandidates(state, nextVectorLimit)
+    }
+  }
+
+  /**
+   * Prune stage: delete vectors whose rows are gone or no longer live. Temporal ineligibility is
+   * not structural deletion (future states can become eligible later), and an unmatched vector may
+   * belong to a valid row outside this request's scope, so misses are resolved against the owner
+   * namespace before anything is deleted.
+   */
+  private pruneStaleVectors(
+    state: RecallState,
+    vectorContext: { embedding: MemoryModelRef; dimensions: number },
+    refill: RecallRefillResult
+  ): void {
+    const { agentId } = state
+    const liveVectorIds = new Set(refill.structurallyValidVecMatches.map((match) => match.row.id))
+    const applicableIds = new Set(refill.authoritativeRows.map((row) => row.id))
+    const candidateIds = state.vecCandidates.map((candidate) => candidate.memoryId)
+    const unmatchedVectorIds = [
+      ...new Set(candidateIds.filter((memoryId) => !applicableIds.has(memoryId)))
+    ]
+    const existingUnmatchedIds = new Set(
+      unmatchedVectorIds.length
+        ? this.ports.repository.listByIds(agentId, unmatchedVectorIds).map((row) => row.id)
+        : []
+    )
+    const deadVectorIds = [
+      ...new Set(
+        candidateIds.filter(
+          (memoryId) =>
+            (applicableIds.has(memoryId) && !liveVectorIds.has(memoryId)) ||
+            (!applicableIds.has(memoryId) && !existingUnmatchedIds.has(memoryId))
+        )
+      )
+    ]
+    if (!deadVectorIds.length) return
+    void this.ports
+      .deletePrunableVectorsForMemoryIds(
+        agentId,
+        vectorContext.embedding,
+        vectorContext.dimensions,
+        deadVectorIds
+      )
+      .catch((error) => {
+        logger.warn(`[Memory] inline vector prune failed: ${String(error)}`)
+      })
+  }
+
   async retrieve(
     agentId: string,
     query: string,
@@ -610,9 +978,9 @@ export class RetrievalService {
     let ftsCandidates = 0
     let vectorCandidates = 0
     let selected = 0
-    let activeStage: MemoryRecallLatencyStage | 'idle' = 'idle'
     let operationFence: MemoryOperationFence | null = null
-    let readEpoch: number | null = null
+    let setupStage: MemoryRecallLatencyStage | 'idle' = 'idle'
+    let state: RecallState | null = null
     try {
       if (!this.ctx.canReadAgentMemory(agentId)) {
         outcome = 'disabled'
@@ -635,362 +1003,83 @@ export class RetrievalService {
         outcome = 'emptyQuery'
         return []
       }
-      const normalizedKeywordQuery = (options.keywordQuery ?? normalizedQuery).trim()
       const directiveSuppressionApplies = directiveSuppressionAppliesToPurpose(options.purpose)
-      activeStage = 'authoritativeRevalidation'
+      setupStage = 'authoritativeRevalidation'
       const suppressionTopics = directiveSuppressionApplies
         ? this.ports.getActiveSuppressionTopics(agentId)
         : []
-      if (directiveSuppressionApplies) readEpoch = this.ctx.captureReadEpoch(agentId)
+      const readEpoch = directiveSuppressionApplies ? this.ctx.captureReadEpoch(agentId) : null
 
       const effectiveTopK =
         options.topKOverride !== undefined ? clampRetrievalTopK(options.topKOverride) : topK
       const temporalMode = temporalPolicyModeForPurpose(options.purpose)
-      const fusionCandidateLimit = effectiveTopK * LEGACY_RETRIEVAL_CANDIDATE_MULTIPLIER
       const candidateMultiplier =
         temporalMode === 'current'
           ? TEMPORAL_RETRIEVAL_CANDIDATE_MULTIPLIER
           : suppressionTopics.length > 0
             ? DIRECTIVE_RETRIEVAL_CANDIDATE_MULTIPLIER
             : LEGACY_RETRIEVAL_CANDIDATE_MULTIPLIER
-      let candidateLimit = effectiveTopK * candidateMultiplier
-      let vectorCandidateLimit = scopeAwareVectorCandidateLimit(candidateLimit)
-      const searchKeywordCandidates = (limit: number): AgentMemoryRow[] => {
-        if (!normalizedKeywordQuery) return []
-        const keywordStartedAt = performance.now()
-        const search = this.ports.repository.searchWithStrategy(
-          agentId,
-          normalizedKeywordQuery,
-          limit,
-          {
-            matchMode: options.keywordMatchMode ?? 'all',
-            scopeFilter
-          }
-        )
-        if (search.strategy === 'like-fallback') degradations.add('ftsUnavailable')
-        latencyMs.keyword = (latencyMs.keyword ?? 0) + (performance.now() - keywordStartedAt)
-        return search.rows.filter((row) => row.kind !== 'persona' && row.kind !== 'working')
-      }
-      activeStage = 'keyword'
-      let ftsRows = searchKeywordCandidates(candidateLimit)
+      state = this.createRecallState({
+        agentId,
+        now,
+        signal: options.signal,
+        scopeFilter,
+        operationFence,
+        readEpoch,
+        latencyMs,
+        degradations,
+        keywordQuery: (options.keywordQuery ?? normalizedQuery).trim(),
+        keywordMatchMode: options.keywordMatchMode ?? 'all',
+        candidateLimit: effectiveTopK * candidateMultiplier,
+        similarityThreshold
+      })
+
+      state.activeStage = 'keyword'
+      state.ftsRows = this.searchKeywordCandidates(state, state.candidateLimit)
       throwIfAborted(options.signal)
 
-      const vecCandidates: { memoryId: string; similarity: number }[] = []
-      let rawVectorMatches: MemoryVectorMatch[] = []
-      let vectorContext: { embedding: MemoryModelRef; dimensions: number } | null = null
-      // The exact scan costs the same for any top-K, so one query fetches the whole candidate
-      // budget and adaptive refills widen the visible page locally instead of rescanning the store.
-      let vectorPool: MemoryVectorMatch[] | null = null
-      const takeVectorCandidates = (limit: number): void => {
-        vectorCandidateLimit = limit
-        rawVectorMatches = vectorPool?.slice(0, limit) ?? []
-        vecCandidates.splice(0, vecCandidates.length)
-        for (const match of rawVectorMatches) {
-          const similarity = distanceToSimilarity(match.distance)
-          if (similarity < similarityThreshold) continue
-          vecCandidates.push({ memoryId: match.memoryId, similarity })
-        }
-      }
       const embedding = config?.memoryEmbedding
       if (embedding?.providerId && embedding?.modelId) {
         const currentEmbedding = { providerId: embedding.providerId, modelId: embedding.modelId }
-        const recallHealth = this.ports.vectorStore.getRecallHealth(agentId)
-        if (recallHealth !== 'available') {
-          degradations.add(recallHealth === 'suspect' ? 'storeTimeout' : 'storeUnusable')
-        } else if (!this.ports.vectorStore.hasReadyCertificate(agentId, currentEmbedding)) {
-          degradations.add('vectorCold')
-          void this.ports
-            .warmVectorStore(agentId, currentEmbedding, { delayOpen: true })
-            .catch((error) => {
-              logger.warn(`[Memory] vector warmup failed for ${agentId}: ${String(error)}`)
-            })
-          this.ports.warmEmbeddingConnection(agentId, currentEmbedding)
-        } else {
-          try {
-            const queryEmbedding = this.queryEmbeddingCircuit.start(
-              agentId,
-              currentEmbedding,
-              normalizedQuery,
-              options.signal
-            )
-            if (queryEmbedding.status === 'circuitOpen') {
-              degradations.add('embeddingCircuitOpen')
-            } else if (queryEmbedding.status === 'capacity') {
-              logger.warn(
-                `[Memory] query embedding already in flight for ${agentId}; vector recall skipped this turn`
-              )
-            } else {
-              const embeddingStartedAt = performance.now()
-              activeStage = 'queryEmbedding'
-              // The gateway owns the deadline; its rejection lands in the catch below.
-              const vectors = await queryEmbedding.promise
-              throwIfAborted(options.signal)
-              latencyMs.queryEmbedding = performance.now() - embeddingStartedAt
-              if (!this.ctx.canContinueOperation(operationFence)) {
-                outcome = 'cancelled'
-                return []
-              }
-              const vector = vectors[0]
-              if (vector?.length) {
-                if (!this.ctx.canContinueOperation(operationFence)) {
-                  outcome = 'cancelled'
-                  return []
-                }
-                const vectorStartedAt = performance.now()
-                activeStage = 'vector'
-                const matches = await this.ports.vectorStore.query(
-                  agentId,
-                  currentEmbedding,
-                  vector.length,
-                  vector,
-                  MEMORY_RETRIEVAL_MAX_CANDIDATES
-                )
-                throwIfAborted(options.signal)
-                latencyMs.vector = performance.now() - vectorStartedAt
-                if (!this.ctx.canContinueOperation(operationFence)) {
-                  outcome = 'cancelled'
-                  return []
-                }
-                if (
-                  this.ports.vectorStore.hasReadyCertificate(agentId, currentEmbedding) &&
-                  this.ctx.canUseCurrentMemoryEmbedding(agentId, currentEmbedding)
-                ) {
-                  if (!this.ctx.canContinueOperation(operationFence)) {
-                    outcome = 'cancelled'
-                    return []
-                  }
-                  vectorContext = { embedding: currentEmbedding, dimensions: vector.length }
-                  vectorPool = matches
-                  takeVectorCandidates(vectorCandidateLimit)
-                  if (
-                    this.ctx.canContinueOperation(operationFence) &&
-                    !this.ports.isReindexing(agentId)
-                  ) {
-                    void this.ports.backfillEmbeddings(agentId).catch((error) => {
-                      logger.warn(`[Memory] backfill failed for ${agentId}: ${String(error)}`)
-                    })
-                  }
-                } else if (
-                  this.ctx.canContinueOperation(operationFence) &&
-                  !this.ports.isReindexing(agentId)
-                ) {
-                  degradations.add('revisionChanged')
-                  void this.ports.reindexEmbeddings(agentId, true).catch((error) => {
-                    logger.warn(`[Memory] store rebuild failed for ${agentId}: ${String(error)}`)
-                  })
-                }
-              }
-            }
-          } catch (error) {
-            if (options.signal?.aborted) throwIfAborted(options.signal)
-            const executionIsCurrent = this.ctx.canContinueOperation(operationFence)
-            if (!executionIsCurrent && isStaleExecutionCancellation(error, this.ctx.isDisposed)) {
-              outcome = 'cancelled'
-              return []
-            }
-            const errorName = (error as { name?: string } | null)?.name
-            if (
-              activeStage === 'vector' &&
-              errorName !== 'AbortError' &&
-              !(error instanceof VectorStoreLeaseUnavailableError)
-            ) {
-              this.ports.vectorStore.clearReady(agentId)
-            }
-            degradations.add(
-              vectorStoreDegradation(
-                error,
-                this.ports.vectorStore.getRecallHealth(agentId),
-                activeStage
-              )
-            )
-            logger.warn(`[Memory] vector recall degraded to FTS for ${agentId}: ${String(error)}`)
-            if (!executionIsCurrent) {
-              outcome = 'cancelled'
-              throw error
-            }
-          }
-        }
-      }
-
-      if (
-        !this.ctx.canContinueOperation(operationFence) ||
-        (readEpoch !== null && !this.ctx.isReadEpochCurrent(agentId, readEpoch))
-      ) {
-        outcome = 'cancelled'
-        return []
-      }
-      const isEligibleRow = isLiveRecallRow
-      const suppressionPolicy = directiveSuppressionApplies
-        ? createMemoryTopicSuppressionPolicy(suppressionTopics)
-        : null
-      let authoritativeRows: AgentMemoryRow[] = []
-      let structurallyValidVecMatches: Array<{ row: AgentMemoryRow; similarity: number }> = []
-      let authoritativeFtsRows: AgentMemoryRow[] = []
-      let authoritativeVecMatches: Array<{ row: AgentMemoryRow; similarity: number }> = []
-
-      while (true) {
-        if (
-          !this.ctx.canContinueOperation(operationFence) ||
-          (readEpoch !== null && !this.ctx.isReadEpochCurrent(agentId, readEpoch))
-        ) {
+        if (!(await this.recallVectorCandidates(state, currentEmbedding, normalizedQuery))) {
           outcome = 'cancelled'
           return []
         }
-        throwIfAborted(options.signal)
-        const candidateIds = [
-          ...ftsRows.map((row) => row.id),
-          ...vecCandidates.map((candidate) => candidate.memoryId)
-        ]
-        const revalidationStartedAt = performance.now()
-        activeStage = 'authoritativeRevalidation'
-        authoritativeRows = candidateIds.length
-          ? this.ports.repository.listApplicableByIds(
-              agentId,
-              [...new Set(candidateIds)],
-              scopeFilter
-            )
-          : []
-        latencyMs.authoritativeRevalidation =
-          (latencyMs.authoritativeRevalidation ?? 0) + (performance.now() - revalidationStartedAt)
-        const rowsById = new Map(authoritativeRows.map((row) => [row.id, row]))
-        const structurallyValidFtsRows = ftsRows
-          .map((row) => rowsById.get(row.id))
-          .filter((row): row is AgentMemoryRow => isEligibleRow(agentId, row))
-        const vectorFingerprint = vectorContext
-          ? embeddingFingerprint(
-              vectorContext.embedding.providerId,
-              vectorContext.embedding.modelId
-            )
-          : null
-        structurallyValidVecMatches = vecCandidates
-          .map((candidate) => {
-            const row = rowsById.get(candidate.memoryId)
-            return vectorContext && vectorFingerprint
-              ? isCurrentRecallVectorRow(
-                  agentId,
-                  row,
-                  vectorContext.dimensions,
-                  vectorFingerprint
-                ) && isEligibleRow(agentId, row)
-                ? { row, similarity: candidate.similarity }
-                : null
-              : null
-          })
-          .filter((match): match is { row: AgentMemoryRow; similarity: number } => match !== null)
-        const directiveEligibleFtsRows = suppressionPolicy
-          ? structurallyValidFtsRows.filter((row) => !suppressionPolicy.suppresses(row.content))
-          : structurallyValidFtsRows
-        const directiveEligibleVecMatches = suppressionPolicy
-          ? structurallyValidVecMatches.filter(
-              (match) => !suppressionPolicy.suppresses(match.row.content)
-            )
-          : structurallyValidVecMatches
-        authoritativeFtsRows = selectTemporalCandidates(
-          directiveEligibleFtsRows,
-          (row) => row,
-          fusionCandidateLimit,
-          now,
-          temporalMode
-        )
-        authoritativeVecMatches = selectTemporalCandidates(
-          directiveEligibleVecMatches,
-          (match) => match.row,
-          fusionCandidateLimit,
-          now,
-          temporalMode
-        )
-        ftsCandidates = authoritativeFtsRows.length
-        vectorCandidates = authoritativeVecMatches.length
-
-        const eligibleIds = new Set([
-          ...authoritativeFtsRows.map((row) => row.id),
-          ...authoritativeVecMatches.map((match) => match.row.id)
-        ])
-        if (eligibleIds.size >= effectiveTopK) break
-
-        const ftsSourceSaturated =
-          Boolean(normalizedKeywordQuery) && ftsRows.length >= candidateLimit
-        const vectorSourceSaturated =
-          vectorPool !== null &&
-          rawVectorMatches.length >= vectorCandidateLimit &&
-          vecCandidates.length === rawVectorMatches.length
-        const nextFtsLimit = nextMemoryRetrievalCandidateLimit(candidateLimit)
-        const nextVectorLimit = nextMemoryRetrievalCandidateLimit(vectorCandidateLimit)
-        const canRefillFts = ftsSourceSaturated && nextFtsLimit > candidateLimit
-        const canRefillVector = vectorSourceSaturated && nextVectorLimit > vectorCandidateLimit
-        if (!canRefillFts && !canRefillVector) {
-          if (
-            (ftsSourceSaturated && candidateLimit >= MEMORY_RETRIEVAL_MAX_CANDIDATES) ||
-            (vectorSourceSaturated && vectorCandidateLimit >= MEMORY_RETRIEVAL_MAX_CANDIDATES)
-          ) {
-            degradations.add('candidateBudgetExhausted')
-          }
-          break
-        }
-
-        if (canRefillFts) {
-          candidateLimit = nextFtsLimit
-          activeStage = 'keyword'
-          ftsRows = searchKeywordCandidates(candidateLimit)
-        }
-        if (canRefillVector) takeVectorCandidates(nextVectorLimit)
       }
+
+      if (!this.isRecallCurrent(state)) {
+        outcome = 'cancelled'
+        return []
+      }
+      const refill = this.refillCandidates(state, {
+        effectiveTopK,
+        fusionCandidateLimit: effectiveTopK * LEGACY_RETRIEVAL_CANDIDATE_MULTIPLIER,
+        temporalMode,
+        suppressionPolicy: directiveSuppressionApplies
+          ? createMemoryTopicSuppressionPolicy(suppressionTopics)
+          : null
+      })
+      if (!refill) {
+        outcome = 'cancelled'
+        return []
+      }
+      ftsCandidates = refill.authoritativeFtsRows.length
+      vectorCandidates = refill.authoritativeVecMatches.length
       throwIfAborted(options.signal)
 
       if (
         options.enableInlinePrune !== false &&
-        vectorContext &&
+        state.vectorContext &&
         this.ctx.canContinueOperation(operationFence)
       ) {
         throwIfAborted(options.signal)
-        // Temporal ineligibility is not structural deletion: future states can become eligible
-        // later, so inline pruning must retain every otherwise-live vector.
-        const liveVectorIds = new Set(structurallyValidVecMatches.map((match) => match.row.id))
-        const applicableIds = new Set(authoritativeRows.map((row) => row.id))
-        const unmatchedVectorIds = [
-          ...new Set(
-            vecCandidates
-              .map((candidate) => candidate.memoryId)
-              .filter((memoryId) => !applicableIds.has(memoryId))
-          )
-        ]
-        // An unmatched vector can belong to a valid row outside this request's scope. Resolve only
-        // those misses against the owner namespace so inline cleanup never deletes another scope's
-        // vector while still removing true orphans.
-        const existingUnmatchedIds = new Set(
-          unmatchedVectorIds.length
-            ? this.ports.repository.listByIds(agentId, unmatchedVectorIds).map((row) => row.id)
-            : []
-        )
-        const deadVectorIds = [
-          ...new Set(
-            vecCandidates
-              .map((candidate) => candidate.memoryId)
-              .filter(
-                (memoryId) =>
-                  (applicableIds.has(memoryId) && !liveVectorIds.has(memoryId)) ||
-                  (!applicableIds.has(memoryId) && !existingUnmatchedIds.has(memoryId))
-              )
-          )
-        ]
-        if (deadVectorIds.length > 0) {
-          void this.ports
-            .deletePrunableVectorsForMemoryIds(
-              agentId,
-              vectorContext.embedding,
-              vectorContext.dimensions,
-              deadVectorIds
-            )
-            .catch((error) => {
-              logger.warn(`[Memory] inline vector prune failed: ${String(error)}`)
-            })
-        }
+        this.pruneStaleVectors(state, state.vectorContext, refill)
       }
 
       const assemblyStartedAt = performance.now()
-      activeStage = 'assembly'
+      state.activeStage = 'assembly'
       throwIfAborted(options.signal)
-      const results = fuse(authoritativeFtsRows, authoritativeVecMatches, {
+      const results = fuse(refill.authoritativeFtsRows, refill.authoritativeVecMatches, {
         topK: effectiveTopK,
         rrfK,
         weights,
@@ -1009,6 +1098,7 @@ export class RetrievalService {
       outcome = 'completed'
       return results
     } catch (error) {
+      const activeStage = state?.activeStage ?? setupStage
       if (operationFence && !this.ctx.canContinueOperation(operationFence)) {
         outcome = 'cancelled'
         if (isStaleExecutionCancellation(error, this.ctx.isDisposed)) return []

--- a/src/main/memory/services/retrievalService.ts
+++ b/src/main/memory/services/retrievalService.ts
@@ -5,7 +5,6 @@ import type {
   MemoryRetrievalOutcome,
   MemoryRetrievalPurpose
 } from '@shared/types/agent-memory'
-import { truncateUnicodeCodePoints } from '@shared/lib/unicodeText'
 
 import {
   buildMemoryProvenanceKey,
@@ -46,12 +45,6 @@ import {
 import {
   DECISION_NEIGHBOR_TOP_S,
   MEMORY_SEARCH_DEFAULT_LIMIT,
-  RECALL_QUERY_EMBEDDING_BREAKER_COOLDOWN_MS,
-  RECALL_QUERY_EMBEDDING_BREAKER_FAILURE_THRESHOLD,
-  RECALL_QUERY_EMBEDDING_BREAKER_FAILURE_WINDOW_MS,
-  RECALL_QUERY_EMBEDDING_MAX_CODE_POINTS,
-  RECALL_QUERY_EMBEDDING_MAX_CONCURRENT,
-  RECALL_QUERY_EMBEDDING_STALE_MS,
   SCOPE_VECTOR_OVERSAMPLE_MULTIPLIER
 } from '../runtimeConstants'
 import {
@@ -82,29 +75,11 @@ import type {
   VectorStoreRetrievalPort,
   WorkingMemoryReadPort
 } from '../ports'
-
-type QueryEmbeddingInFlight = {
-  agentId: string
-  startedAt: number
-  promise: Promise<number[][]>
-  circuit: QueryEmbeddingCircuit
-  recoveryProbe: boolean
-  consumerSignals: Set<AbortSignal | undefined>
-  circuitSettled: boolean
-}
-
-type QueryEmbeddingCircuit = {
-  fingerprint: string
-  failuresInWindow: number
-  failureWindowStartedAt: number | null
-  openUntil: number
-  halfOpenProbe: boolean
-}
-
-type QueryEmbeddingStartResult =
-  | { status: 'started'; entry: QueryEmbeddingInFlight }
-  | { status: 'capacity' }
-  | { status: 'circuitOpen' }
+import {
+  QueryEmbeddingCircuitBreaker,
+  type QueryEmbeddingCircuitDiagnostics,
+  type QueryEmbeddingCircuitState
+} from '../infra/queryEmbeddingCircuit'
 
 const LEGACY_RETRIEVAL_CANDIDATE_MULTIPLIER = 2
 const TEMPORAL_RETRIEVAL_CANDIDATE_MULTIPLIER = 4
@@ -208,8 +183,7 @@ function isStaleExecutionCancellation(error: unknown, isDisposed: boolean): bool
 
 export class RetrievalService {
   private readonly ctx: MemoryRuntimeContext
-  private readonly queryEmbeddingInFlight = new Map<string, Map<string, QueryEmbeddingInFlight>>()
-  private readonly queryEmbeddingCircuits = new Map<string, QueryEmbeddingCircuit>()
+  private readonly queryEmbeddingCircuit: QueryEmbeddingCircuitBreaker
 
   constructor(
     private readonly ports: {
@@ -235,7 +209,7 @@ export class RetrievalService {
         memoryIds: string[]
       ) => Promise<string[]>
       getActiveSuppressionTopics: (agentId: string) => readonly string[]
-      diagnostics?: {
+      diagnostics?: QueryEmbeddingCircuitDiagnostics & {
         recordRecall(
           agentId: string,
           sample: {
@@ -248,15 +222,14 @@ export class RetrievalService {
             degradations: readonly MemoryRetrievalDegradationCause[]
           }
         ): void
-        recordQueryEmbeddingCircuitEvent?(
-          agentId: string,
-          event: 'failure' | 'opened' | 'halfOpen' | 'closed' | 'probeCancelled' | 'skipped'
-        ): void
-        resetQueryEmbeddingCircuit?(agentId: string): void
       }
     }
   ) {
     this.ctx = ports.ctx
+    this.queryEmbeddingCircuit = new QueryEmbeddingCircuitBreaker({
+      embeddingGateway: ports.embeddingGateway,
+      diagnostics: ports.diagnostics
+    })
   }
 
   async recall(
@@ -588,219 +561,6 @@ export class RetrievalService {
     return buildRecallKeywordQuery(selectRecallKeywordTerms(candidates))
   }
 
-  private startQueryEmbedding(
-    agentId: string,
-    embedding: MemoryModelRef,
-    fullQuery: string,
-    signal?: AbortSignal
-  ): QueryEmbeddingStartResult {
-    const query = truncateUnicodeCodePoints(fullQuery, RECALL_QUERY_EMBEDDING_MAX_CODE_POINTS)
-    const fingerprint = embeddingFingerprint(embedding.providerId, embedding.modelId)
-    const key = `${agentId}::${fingerprint}`
-    const now = Date.now()
-    const circuit = this.queryEmbeddingCircuit(agentId, fingerprint)
-    let group = this.queryEmbeddingInFlight.get(key)
-    let replacedStale = false
-    if (group) {
-      for (const [trackedQuery, entry] of group) {
-        if (entry.circuitSettled) {
-          group.delete(trackedQuery)
-        } else if (now - entry.startedAt >= RECALL_QUERY_EMBEDDING_STALE_MS) {
-          this.settleQueryEmbeddingCircuitCancellation(entry)
-          group.delete(trackedQuery)
-          replacedStale = true
-        }
-      }
-      if (group.size === 0) {
-        this.queryEmbeddingInFlight.delete(key)
-        group = undefined
-      }
-    }
-    if (replacedStale) logger.warn(`[Memory] stale query embedding replaced for ${agentId}`)
-
-    if (circuit.halfOpenProbe || circuit.openUntil > now) {
-      this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(agentId, 'skipped')
-      return { status: 'circuitOpen' }
-    }
-
-    const recoveryProbe = circuit.openUntil > 0
-    const existing = group?.get(query)
-    if (!recoveryProbe && existing) {
-      existing.consumerSignals.add(signal)
-      return { status: 'started', entry: existing }
-    }
-    if ((group?.size ?? 0) >= RECALL_QUERY_EMBEDDING_MAX_CONCURRENT) {
-      return { status: 'capacity' }
-    }
-
-    if (recoveryProbe) {
-      circuit.halfOpenProbe = true
-      this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(agentId, 'halfOpen')
-    }
-    if (!group) {
-      group = new Map()
-      this.queryEmbeddingInFlight.set(key, group)
-    }
-
-    let promise: Promise<number[][]>
-    try {
-      promise = this.ports.embeddingGateway.getEmbeddings(
-        agentId,
-        embedding.providerId,
-        embedding.modelId,
-        [query],
-        'query-embedding'
-      )
-    } catch (error) {
-      promise = Promise.reject(error)
-    }
-    const entry: QueryEmbeddingInFlight = {
-      agentId,
-      startedAt: now,
-      promise,
-      circuit,
-      recoveryProbe,
-      consumerSignals: new Set([signal]),
-      circuitSettled: false
-    }
-    group.set(query, entry)
-    void promise
-      .then(
-        () => {
-          if (this.queryEmbeddingConsumersCancelled(entry)) {
-            this.settleQueryEmbeddingCircuitCancellation(entry)
-          } else {
-            this.settleQueryEmbeddingCircuitSuccess(entry)
-          }
-        },
-        (error) => {
-          if (this.queryEmbeddingConsumersCancelled(entry)) {
-            this.settleQueryEmbeddingCircuitCancellation(entry)
-          } else if (this.isQueryEmbeddingCircuitFailure(error)) {
-            this.settleQueryEmbeddingCircuitFailure(entry)
-          } else {
-            this.settleQueryEmbeddingCircuitCancellation(entry)
-          }
-        }
-      )
-      .finally(() => {
-        const currentGroup = this.queryEmbeddingInFlight.get(key)
-        if (currentGroup?.get(query) === entry) {
-          currentGroup.delete(query)
-          if (currentGroup.size === 0) this.queryEmbeddingInFlight.delete(key)
-        }
-      })
-      .catch(() => undefined)
-    return { status: 'started', entry }
-  }
-
-  private queryEmbeddingCircuit(agentId: string, fingerprint: string): QueryEmbeddingCircuit {
-    const existing = this.queryEmbeddingCircuits.get(agentId)
-    if (existing?.fingerprint === fingerprint) return existing
-    if (existing) {
-      this.clearQueryEmbeddingInFlight(agentId)
-      this.ports.diagnostics?.resetQueryEmbeddingCircuit?.(agentId)
-    }
-    const circuit: QueryEmbeddingCircuit = {
-      fingerprint,
-      failuresInWindow: 0,
-      failureWindowStartedAt: null,
-      openUntil: 0,
-      halfOpenProbe: false
-    }
-    this.queryEmbeddingCircuits.set(agentId, circuit)
-    return circuit
-  }
-
-  private queryEmbeddingConsumersCancelled(entry: QueryEmbeddingInFlight): boolean {
-    return (
-      entry.consumerSignals.size > 0 &&
-      [...entry.consumerSignals].every((signal) => signal?.aborted === true)
-    )
-  }
-
-  /**
-   * Every provider failure except a cancellation counts, including 4xx rejections: a persistent
-   * 400 from a misconfigured model or proxy costs a failed round trip on every turn, and only the
-   * breaker bounds that to one probe per cooldown. Query truncation already keeps well-formed
-   * requests inside provider input limits, so a rejection is a health signal, not a request quirk.
-   */
-  private isQueryEmbeddingCircuitFailure(error: unknown): boolean {
-    if (isMemoryProviderDeadlineError(error)) return true
-    return (error as { name?: string } | null)?.name !== 'AbortError'
-  }
-
-  private settleQueryEmbeddingCircuitSuccess(entry: QueryEmbeddingInFlight): void {
-    if (entry.circuitSettled) return
-    entry.circuitSettled = true
-    if (this.queryEmbeddingCircuits.get(entry.agentId) !== entry.circuit) return
-    if (!entry.recoveryProbe && entry.circuit.openUntil > 0) return
-    entry.circuit.failuresInWindow = 0
-    entry.circuit.failureWindowStartedAt = null
-    entry.circuit.openUntil = 0
-    entry.circuit.halfOpenProbe = false
-    this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(entry.agentId, 'closed')
-  }
-
-  private settleQueryEmbeddingCircuitFailure(entry: QueryEmbeddingInFlight): void {
-    if (entry.circuitSettled) return
-    entry.circuitSettled = true
-    const circuit = entry.circuit
-    if (this.queryEmbeddingCircuits.get(entry.agentId) !== circuit) return
-    this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(entry.agentId, 'failure')
-    const now = Date.now()
-    if (entry.recoveryProbe) {
-      circuit.halfOpenProbe = false
-      this.openQueryEmbeddingCircuit(entry.agentId, circuit, now)
-      return
-    }
-    if (circuit.openUntil > now) return
-    if (
-      circuit.failureWindowStartedAt === null ||
-      now - circuit.failureWindowStartedAt > RECALL_QUERY_EMBEDDING_BREAKER_FAILURE_WINDOW_MS
-    ) {
-      circuit.failureWindowStartedAt = now
-      circuit.failuresInWindow = 1
-    } else {
-      circuit.failuresInWindow += 1
-    }
-    if (circuit.failuresInWindow >= RECALL_QUERY_EMBEDDING_BREAKER_FAILURE_THRESHOLD) {
-      this.openQueryEmbeddingCircuit(entry.agentId, circuit, now)
-    }
-  }
-
-  private openQueryEmbeddingCircuit(
-    agentId: string,
-    circuit: QueryEmbeddingCircuit,
-    now: number
-  ): void {
-    circuit.openUntil = now + RECALL_QUERY_EMBEDDING_BREAKER_COOLDOWN_MS
-    this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(agentId, 'opened')
-    logger.warn(`[Memory] query embedding circuit opened for ${agentId}; vector recall paused`)
-  }
-
-  private settleQueryEmbeddingCircuitCancellation(entry: QueryEmbeddingInFlight): void {
-    if (entry.circuitSettled) return
-    entry.circuitSettled = true
-    if (this.queryEmbeddingCircuits.get(entry.agentId) !== entry.circuit) return
-    if (!entry.recoveryProbe) return
-    entry.circuit.halfOpenProbe = false
-    this.ports.diagnostics?.recordQueryEmbeddingCircuitEvent?.(entry.agentId, 'probeCancelled')
-  }
-
-  private clearQueryEmbeddingInFlight(agentId: string): void {
-    for (const key of this.queryEmbeddingInFlight.keys()) {
-      if (key.startsWith(`${agentId}::`)) this.queryEmbeddingInFlight.delete(key)
-    }
-  }
-
-  getQueryEmbeddingCircuitState(agentId: string): 'closed' | 'open' | 'halfOpen' {
-    const circuit = this.queryEmbeddingCircuits.get(agentId)
-    if (!circuit) return 'closed'
-    if (circuit.halfOpenProbe) return 'halfOpen'
-    return circuit.openUntil > 0 ? 'open' : 'closed'
-  }
-
   async searchMemories(
     agentId: string,
     query: string,
@@ -962,7 +722,7 @@ export class RetrievalService {
           this.ports.warmEmbeddingConnection(agentId, currentEmbedding)
         } else {
           try {
-            const queryEmbedding = this.startQueryEmbedding(
+            const queryEmbedding = this.queryEmbeddingCircuit.start(
               agentId,
               currentEmbedding,
               normalizedQuery,
@@ -978,7 +738,7 @@ export class RetrievalService {
               const embeddingStartedAt = performance.now()
               activeStage = 'queryEmbedding'
               // The gateway owns the deadline; its rejection lands in the catch below.
-              const vectors = await queryEmbedding.entry.promise
+              const vectors = await queryEmbedding.promise
               throwIfAborted(options.signal)
               latencyMs.queryEmbedding = performance.now() - embeddingStartedAt
               if (!this.ctx.canContinueOperation(operationFence)) {
@@ -1369,18 +1129,19 @@ export class RetrievalService {
     return { payload, manifest }
   }
 
+  getQueryEmbeddingCircuitState(agentId: string): QueryEmbeddingCircuitState {
+    return this.queryEmbeddingCircuit.state(agentId)
+  }
+
   cleanupAgent(agentId: string): void {
     this.onEmbeddingConfigChanged(agentId)
   }
 
   onEmbeddingConfigChanged(agentId: string): void {
-    this.clearQueryEmbeddingInFlight(agentId)
-    this.queryEmbeddingCircuits.delete(agentId)
-    this.ports.diagnostics?.resetQueryEmbeddingCircuit?.(agentId)
+    this.queryEmbeddingCircuit.reset(agentId)
   }
 
   clearAll(): void {
-    this.queryEmbeddingInFlight.clear()
-    this.queryEmbeddingCircuits.clear()
+    this.queryEmbeddingCircuit.clear()
   }
 }

--- a/src/main/memory/services/rowMutations.ts
+++ b/src/main/memory/services/rowMutations.ts
@@ -17,13 +17,18 @@ import {
   type WriteMemoriesOptions
 } from '../types'
 import type {
+  ClaimOwnership,
   ContentUpdateResult,
   ManualEditFieldFlags,
   MemoryClaimInsertResult,
   MemoryExplicitRelearnResult,
   ProvenanceHitResult
 } from '../domain/types'
-import { isEmbeddingEligibleState } from '../domain/stateModel'
+import {
+  isChallengedDecisionHead,
+  isEmbeddingEligibleState,
+  isLiveDecisionTarget
+} from '../domain/stateModel'
 import { isUniqueConstraintError } from '../context'
 import {
   memoryTemporalMetadataEquals,
@@ -507,6 +512,36 @@ export class MemoryRowMutations {
     }
 
     return { action: 'absorbed' }
+  }
+
+  resolveClaimOwnership(
+    agentId: string,
+    kind: string,
+    content: string,
+    scope: MemoryScope,
+    options: { allowSuperseded: boolean; beforeMutation?: () => void }
+  ): ClaimOwnership {
+    const owner = this.resolveProvenance(agentId, kind, content, scope, options.beforeMutation)
+    return owner ? this.classifyClaimOwner(agentId, owner, options) : { state: 'unowned' }
+  }
+
+  classifyClaimOwner(
+    agentId: string,
+    owner: AgentMemoryRow,
+    options: { allowSuperseded: boolean }
+  ): Exclude<ClaimOwnership, { state: 'unowned' }> {
+    const hit = this.handleProvenanceHit(agentId, owner, {
+      allowDecisionForSuperseded: options.allowSuperseded
+    })
+    if (hit.action === 'absorbed') return { state: 'archived', owner }
+    if (hit.action === 'noop') {
+      return hit.reason === 'duplicate'
+        ? { state: 'duplicate', owner }
+        : { state: 'suppressed', owner, reason: hit.reason }
+    }
+    const head = this.supersedeHead(agentId, owner)
+    if (isChallengedDecisionHead(agentId, head)) return { state: 'challenged', owner, head }
+    return { state: 'superseded', owner, head: isLiveDecisionTarget(agentId, head) ? head : null }
   }
 
   reviveSupersededAfterDecision(

--- a/src/main/memory/services/rowMutations.ts
+++ b/src/main/memory/services/rowMutations.ts
@@ -468,7 +468,7 @@ export class MemoryRowMutations {
         }
   }
 
-  supersedeHead(agentId: string, row: AgentMemoryRow): AgentMemoryRow {
+  private supersedeHead(agentId: string, row: AgentMemoryRow): AgentMemoryRow {
     let current = row
     const seen = new Set<string>([row.id])
     while (current.superseded_by) {
@@ -486,7 +486,7 @@ export class MemoryRowMutations {
     return current
   }
 
-  handleProvenanceHit(
+  private handleProvenanceHit(
     agentId: string,
     existing: AgentMemoryRow,
     options: { allowDecisionForSuperseded?: boolean } = {}

--- a/src/main/memory/services/writeCoordinator.ts
+++ b/src/main/memory/services/writeCoordinator.ts
@@ -2,12 +2,7 @@ import logger from '@shared/logger'
 import { AGENT_MEMORY_AUTO_CONTENT_MAX_CHARS } from '@shared/types/agent-memory'
 import { unicodeCodePointLength } from '@shared/lib/unicodeText'
 
-import {
-  ADD_DECISION,
-  buildDecisionPrompt,
-  parseDecisionResult,
-  type MemoryDecision
-} from '../core/decision'
+import { ADD_DECISION, type MemoryDecision } from '../core/decision'
 import {
   DECISION_BATCH_MAX_BATCHES,
   parseBatchDecisionResults,
@@ -51,6 +46,7 @@ import type {
   WriteMemoriesOptions
 } from '../types'
 import type { MemoryDirectiveInput } from '../domain/directives'
+import type { ClaimOwnership } from '../domain/types'
 import { isLiveDecisionTarget } from '../domain/stateModel'
 import {
   type MemoryModelRef,
@@ -161,33 +157,40 @@ interface IndexedCandidate {
   candidate: NormalizedMemoryCandidate
 }
 
+// Everything a single write shares across preparation, decision, and apply. `options.scope`
+// is already normalized; `beforeMutation` is the caller's dispatch-commit boundary and must run
+// outside any store transaction.
+interface WriteContext {
+  agentId: string
+  scope: MemoryScope
+  options: WriteMemoriesOptions
+  now: number
+  beforeMutation?: () => void
+}
+
 interface PreparedCoordinateCandidate extends IndexedCandidate {
   decisionHeadId: string | null
   neighbors: MemoryRecallItem[]
   queryVector?: MemoryDecisionQueryVectorSnapshot
 }
 
+// A candidate whose provenance already decided its fate: it never reaches recall or the
+// decision model.
+interface ImmediateCandidate extends IndexedCandidate {
+  settled: Exclude<ClaimOwnership, { state: 'unowned' | 'superseded' }> | { state: 'forgotten' }
+}
+
 type PrepareCoordinateCandidateResult =
   | { prepared: PreparedCoordinateCandidate }
-  | {
-      candidateIndex: number
-      candidate: NormalizedMemoryCandidate
-      outcome: MemoryWriteOutcome
-    }
+  | { immediate: ImmediateCandidate }
 
 interface BatchWriteResult {
   outcomes: MemoryWriteOutcome[]
   decisionBudgetFallbacks: number
   failed: boolean
+  error?: unknown
   llmCalls: number
   casRetries: number
-}
-
-interface CandidateApplyPolicy {
-  isRetry: boolean
-  allowInsert: boolean
-  invalidDecisionFallback: 'add' | 'concurrent-update'
-  retryConflict: boolean
 }
 
 type TombstoneReleasePolicy = 'preserve' | 'explicit-user-action'
@@ -204,28 +207,13 @@ function resolveContentMergeTemporalMetadata(
   })
 }
 
-function recallItemFromRow(row: AgentMemoryRow): MemoryRecallItem {
-  const temporal = temporalMetadataFromRow(row)
-  return {
-    id: row.id,
-    decisionRevision: row.decision_revision,
-    kind: row.kind,
-    content: row.content,
-    score: 1,
-    importance: row.importance,
-    sources: { fts: true },
-    sourceSession: row.source_session,
-    sourceEntryIds: null,
-    temporal,
-    breakdown: {
-      similarity: 0,
-      recency: row.last_accessed ?? row.created_at,
-      importance: row.importance,
-      confidence: row.confidence ?? 0,
-      rrf: 1,
-      final: 1
-    }
-  }
+function createWriteContext(
+  options: WriteMemoriesOptions,
+  now: number,
+  beforeMutation?: () => void
+): WriteContext {
+  const scope = normalizeMemoryScope(options.scope)
+  return { agentId: options.agentId, scope, options: { ...options, scope }, now, beforeMutation }
 }
 
 function temporalDecisionAnnotation(
@@ -267,12 +255,6 @@ export class WriteCoordinator {
       policy: MemoryAgentPolicyPort
       textGeneration: MemoryTextGenerationPort
       rows: MemoryWriteMutationPort
-      retrieveForDecision: (
-        agentId: string,
-        query: string,
-        now: number,
-        scopeFilter?: readonly MemoryScope[]
-      ) => Promise<MemoryRecallItem[]>
       retrieveForDecisions: (
         agentId: string,
         candidates: readonly NormalizedMemoryCandidate[],
@@ -415,18 +397,19 @@ export class WriteCoordinator {
         return { ok: false }
       }
       const candidateStats = this.prepareExtractionCandidates(parsed.candidates)
-      const options: WriteMemoriesOptions = {
-        agentId: input.agentId,
-        scope: normalizeMemoryScope(input.scope),
-        sourceSession: input.sourceSession ?? null,
-        sourceEntryIds: input.sourceEntryIds ?? null
-      }
+      const writeContext = createWriteContext(
+        {
+          agentId: input.agentId,
+          scope: input.scope,
+          sourceSession: input.sourceSession ?? null,
+          sourceEntryIds: input.sourceEntryIds ?? null
+        },
+        now
+      )
       const batch = await this.coordinateBatchWrites(
-        input.agentId,
+        writeContext,
         candidateStats.candidates,
         model,
-        options,
-        now,
         operationFence
       )
       llmCalls += batch.llmCalls
@@ -562,59 +545,80 @@ export class WriteCoordinator {
   }
 
   private prepareCoordinateCandidate(
-    agentId: string,
-    indexed: IndexedCandidate,
-    scope: MemoryScope
+    ctx: WriteContext,
+    indexed: IndexedCandidate
   ): PrepareCoordinateCandidateResult {
-    const ownership = this.ports.rows.resolveClaimOwnership(
-      agentId,
-      indexed.candidate.kind,
-      indexed.candidate.content,
-      scope,
-      { allowSuperseded: true }
-    )
-    const immediate = (outcome: MemoryWriteOutcome): PrepareCoordinateCandidateResult => ({
-      candidateIndex: indexed.candidateIndex,
-      candidate: indexed.candidate,
-      outcome
+    const { agentId, scope } = ctx
+    const { kind, content } = indexed.candidate
+    const ownership = this.ports.rows.resolveClaimOwnership(agentId, kind, content, scope, {
+      allowSuperseded: true,
+      beforeMutation: ctx.beforeMutation
     })
     switch (ownership.state) {
-      case 'archived':
-        return immediate({ action: 'updated', id: ownership.owner.id })
-      case 'duplicate':
-        return immediate({ action: 'noop', reason: 'duplicate', id: ownership.owner.id })
-      case 'suppressed':
-        return immediate({ action: 'noop', reason: ownership.reason, id: ownership.owner.id })
-      case 'challenged':
-        return immediate({ action: 'noop', reason: 'conflict', id: ownership.head.id })
+      case 'unowned':
+        // A forgotten claim never reaches recall or the decision model. insertMemory still checks
+        // the tombstone inside its own transaction; this only saves the provider round trips.
+        if (
+          this.ports.repository.hasTombstoneForClaim({
+            agentId,
+            kind,
+            content,
+            provenanceKey: buildScopedMemoryProvenanceKey(agentId, kind, content, scope),
+            scope
+          })
+        ) {
+          return { immediate: { ...indexed, settled: { state: 'forgotten' } } }
+        }
+        return { prepared: { ...indexed, decisionHeadId: null, neighbors: [] } }
       case 'superseded':
         return {
           prepared: { ...indexed, decisionHeadId: ownership.head?.id ?? null, neighbors: [] }
         }
-      case 'unowned':
-        return { prepared: { ...indexed, decisionHeadId: null, neighbors: [] } }
+      default:
+        return { immediate: { ...indexed, settled: ownership } }
     }
   }
 
-  private applyImmediatePrepared(
-    agentId: string,
-    result: PrepareCoordinateCandidateResult,
-    options: WriteMemoriesOptions,
-    now: number,
-    allowInsert: boolean
-  ): MemoryWriteOutcome {
-    if ('prepared' in result) throw new Error('Expected an immediate candidate result')
-    return this.applyCurrentProvenanceOrInsert(agentId, result.candidate, options, now, allowInsert)
+  // Only an archived owner or an enrichable duplicate touch the store; the other settled states
+  // are conservative no-ops, so the dispatch boundary is committed by the row helpers themselves
+  // right before they write.
+  private applyImmediate(ctx: WriteContext, immediate: ImmediateCandidate): MemoryWriteOutcome {
+    const { settled, candidate } = immediate
+    switch (settled.state) {
+      case 'archived':
+        return this.absorbArchivedProvenanceOwner(
+          ctx.agentId,
+          settled.owner,
+          candidate.temporal,
+          ctx.beforeMutation
+        )
+          ? { action: 'updated', id: settled.owner.id }
+          : { action: 'noop', reason: 'concurrent-update', id: settled.owner.id }
+      case 'duplicate':
+        return this.ports.rows.enrichEquivalentClaimTemporalMetadata(
+          ctx.agentId,
+          settled.owner,
+          candidate.temporal,
+          ctx.beforeMutation
+        )
+          ? { action: 'updated', id: settled.owner.id }
+          : { action: 'noop', reason: 'duplicate', id: settled.owner.id }
+      case 'suppressed':
+        return { action: 'noop', reason: settled.reason, id: settled.owner.id }
+      case 'challenged':
+        return { action: 'noop', reason: 'conflict', id: settled.head.id }
+      case 'forgotten':
+        return { action: 'noop', reason: 'forgotten' }
+    }
   }
 
+  // Re-resolves ownership inside the transaction because provider round trips separate the
+  // prepared snapshot from this write. Callers commit the dispatch boundary before entering.
   private applyCurrentProvenanceOrInsert(
-    agentId: string,
-    candidate: NormalizedMemoryCandidate,
-    options: WriteMemoriesOptions,
-    now: number,
-    allowInsert: boolean
+    ctx: WriteContext,
+    candidate: NormalizedMemoryCandidate
   ): MemoryWriteOutcome {
-    const scope = normalizeMemoryScope(options.scope)
+    const { agentId, scope, options, now } = ctx
     let outcome: MemoryWriteOutcome = { action: 'noop', reason: 'concurrent-update' }
     this.ports.repository.runInTransaction(() => {
       const ownership = this.ports.rows.resolveClaimOwnership(
@@ -674,7 +678,6 @@ export class WriteCoordinator {
         case 'unowned':
           break
       }
-      if (!allowInsert) return
       const insert = this.ports.rows.insertMemory(
         agentId,
         candidate,
@@ -693,66 +696,45 @@ export class WriteCoordinator {
     return outcome
   }
 
-  private applyNoNeighborDecision(
-    agentId: string,
-    prepared: PreparedCoordinateCandidate,
-    options: WriteMemoriesOptions,
-    now: number,
-    isRetry: boolean
-  ): MemoryWriteOutcome {
-    if (isRetry) return { action: 'noop', reason: 'concurrent-update' }
-    return this.applyCurrentProvenanceOrInsert(agentId, prepared.candidate, options, now, true)
-  }
-
+  // A prepared candidate is past every local gate; recall and the decision model above have no
+  // side effects, so the dispatch boundary commits here, right before the first store write.
+  // Retries stay conservative: no insert, no fallback ADD, no second retry.
   private applyPreparedCandidate(
-    agentId: string,
-    preparedResult: PrepareCoordinateCandidateResult,
-    retrieved: PreparedCoordinateCandidate | undefined,
+    ctx: WriteContext,
+    prepared: PreparedCoordinateCandidate,
     parsed: { decision: MemoryDecision; valid: boolean } | undefined,
-    options: WriteMemoriesOptions,
-    now: number,
-    policy: CandidateApplyPolicy
+    isRetry: boolean
   ): CoordinateWriteResult {
-    if (!('prepared' in preparedResult)) {
-      return this.applyImmediatePrepared(agentId, preparedResult, options, now, policy.allowInsert)
-    }
-    const prepared = retrieved ?? preparedResult.prepared
+    ctx.beforeMutation?.()
     if (!prepared.neighbors.length) {
-      return this.applyNoNeighborDecision(agentId, prepared, options, now, policy.isRetry)
+      if (isRetry) return { action: 'noop', reason: 'concurrent-update' }
+      return this.applyCurrentProvenanceOrInsert(ctx, prepared.candidate)
     }
-    if (!parsed?.valid && policy.invalidDecisionFallback === 'concurrent-update') {
-      return { action: 'noop', reason: 'concurrent-update' }
-    }
+    if (!parsed?.valid && isRetry) return { action: 'noop', reason: 'concurrent-update' }
     const result = this.applyDecisionAttempt(
-      agentId,
+      ctx,
       prepared.candidate,
       prepared.neighbors,
-      parsed?.valid ? parsed.decision : ADD_DECISION,
-      options,
-      now
+      parsed?.valid ? parsed.decision : ADD_DECISION
     )
-    if (result.action === 'retry' && !policy.retryConflict) {
-      return { action: 'noop', reason: 'concurrent-update' }
-    }
+    if (result.action === 'retry' && isRetry) return { action: 'noop', reason: 'concurrent-update' }
     return result
   }
 
   private async retrievePreparedCandidates(
-    agentId: string,
+    ctx: WriteContext,
     prepared: readonly PreparedCoordinateCandidate[],
-    now: number,
-    scope: MemoryScope,
     queryVectors?: readonly (MemoryDecisionQueryVectorSnapshot | undefined)[]
   ): Promise<PreparedCoordinateCandidate[]> {
     if (!prepared.length) return []
     try {
       const sets = await this.ports.retrieveForDecisions(
-        agentId,
+        ctx.agentId,
         prepared.map((item) => item.candidate),
-        now,
+        ctx.now,
         queryVectors,
         prepared.map((item) => (item.decisionHeadId ? [item.decisionHeadId] : undefined)),
-        [scope]
+        [ctx.scope]
       )
       return prepared.map((item, index) => ({
         ...item,
@@ -807,99 +789,87 @@ export class WriteCoordinator {
     return { decisions, fallbackCandidateIndexes, calls }
   }
 
+  // The single decision kernel for extraction batches and one-off remembers alike: settle
+  // provenance-decided candidates synchronously, recall neighbors and ask the decision model once
+  // for the rest, apply, then give CAS losers one bounded retry that reuses their query vectors.
   private async coordinateBatchWrites(
-    agentId: string,
+    ctx: WriteContext,
     candidates: readonly IndexedCandidate[],
     model: MemoryModelRef,
-    options: WriteMemoriesOptions,
-    now: number,
     operationFence: MemoryOperationFence
   ): Promise<BatchWriteResult> {
-    if (!candidates.length) {
-      return { outcomes: [], decisionBudgetFallbacks: 0, failed: false, llmCalls: 0, casRetries: 0 }
+    const result: BatchWriteResult = {
+      outcomes: [],
+      decisionBudgetFallbacks: 0,
+      failed: false,
+      llmCalls: 0,
+      casRetries: 0
+    }
+    if (!candidates.length) return result
+    const outcomesByIndex = new Map<number, MemoryWriteOutcome>()
+    const fail = (error: unknown, stage: string): void => {
+      logger.warn(`[Memory] candidate ${stage} failed: ${String(error)}`)
+      result.failed = true
+      result.error = error
     }
 
-    const scope = normalizeMemoryScope(options.scope)
-    const preparation = candidates.map((candidate) =>
-      this.prepareCoordinateCandidate(agentId, candidate, scope)
-    )
-    const preparationByIndex = new Map(
-      preparation.map((result) => [
-        'prepared' in result ? result.prepared.candidateIndex : result.candidateIndex,
-        result
-      ])
-    )
-    const preparedInitial = await this.retrievePreparedCandidates(
-      agentId,
-      preparation.flatMap((result) => ('prepared' in result ? [result.prepared] : [])),
-      now,
-      scope
-    )
-    const preparedByIndex = new Map(
-      preparedInitial.map((prepared) => [prepared.candidateIndex, prepared])
-    )
-    const initialDecisionInputs: BatchDecisionInput[] = preparedInitial
-      .filter((prepared) => prepared.neighbors.length > 0)
-      .map((prepared) => toBatchDecisionInput(prepared, now))
-    const initialBatch = await this.requestBatchDecisions(
-      agentId,
-      model,
-      initialDecisionInputs,
-      DECISION_BATCH_MAX_BATCHES,
-      operationFence
-    )
-
-    const outcomesByIndex = new Map<number, MemoryWriteOutcome>()
-    const retryCandidates: PreparedCoordinateCandidate[] = []
-    let decisionCalls = initialBatch.calls
-    let failed = false
-    for (const candidate of candidates) {
+    // Settle immediate candidates before any provider round trip can age their owner snapshot.
+    const toPrepare: PreparedCoordinateCandidate[] = []
+    for (const indexed of candidates) {
       if (!this.ctx.canContinueOperation(operationFence)) break
       try {
-        const preparedResult = preparationByIndex.get(candidate.candidateIndex)
-        if (!preparedResult) continue
-        const result = this.applyPreparedCandidate(
-          agentId,
-          preparedResult,
-          preparedByIndex.get(candidate.candidateIndex),
-          initialBatch.decisions.get(candidate.candidateIndex),
-          options,
-          now,
-          {
-            isRetry: false,
-            allowInsert: true,
-            invalidDecisionFallback: 'add',
-            retryConflict: true
-          }
-        )
-        if (result.action === 'retry') {
-          const retryCandidate =
-            preparedByIndex.get(candidate.candidateIndex) ??
-            ('prepared' in preparedResult ? preparedResult.prepared : null)
-          if (retryCandidate) retryCandidates.push(retryCandidate)
-          else {
-            outcomesByIndex.set(candidate.candidateIndex, {
-              action: 'noop',
-              reason: 'concurrent-update'
-            })
-          }
-        } else outcomesByIndex.set(candidate.candidateIndex, result)
+        const preparation = this.prepareCoordinateCandidate(ctx, indexed)
+        if ('prepared' in preparation) toPrepare.push(preparation.prepared)
+        else
+          outcomesByIndex.set(
+            indexed.candidateIndex,
+            this.applyImmediate(ctx, preparation.immediate)
+          )
       } catch (error) {
-        logger.warn(`[Memory] candidate apply failed: ${String(error)}`)
-        failed = true
+        fail(error, 'preparation')
         break
       }
     }
 
-    const retrySlice = retryCandidates.slice(0, DECISION_RETRY_MAX_CANDIDATES)
-    let casRetries = 0
-    for (const skipped of retryCandidates.slice(DECISION_RETRY_MAX_CANDIDATES)) {
-      outcomesByIndex.set(skipped.candidateIndex, {
-        action: 'noop',
-        reason: 'concurrent-update'
-      })
+    const retryCandidates: PreparedCoordinateCandidate[] = []
+    if (!result.failed && toPrepare.length) {
+      const prepared = await this.retrievePreparedCandidates(ctx, toPrepare)
+      const initialBatch = await this.requestBatchDecisions(
+        ctx.agentId,
+        model,
+        prepared
+          .filter((item) => item.neighbors.length > 0)
+          .map((item) => toBatchDecisionInput(item, ctx.now)),
+        DECISION_BATCH_MAX_BATCHES,
+        operationFence
+      )
+      result.llmCalls += initialBatch.calls
+      result.decisionBudgetFallbacks = initialBatch.fallbackCandidateIndexes.size
+      for (const item of prepared) {
+        if (!this.ctx.canContinueOperation(operationFence)) break
+        try {
+          const applied = this.applyPreparedCandidate(
+            ctx,
+            item,
+            initialBatch.decisions.get(item.candidateIndex),
+            false
+          )
+          if (applied.action === 'retry') retryCandidates.push(item)
+          else outcomesByIndex.set(item.candidateIndex, applied)
+        } catch (error) {
+          fail(error, 'apply')
+          break
+        }
+      }
     }
-    const currentEmbedding = this.ports.policy.resolveAgentConfig(agentId)?.memoryEmbedding
+
+    // CAS losers get one more round, bounded in count and only while the embedding identity that
+    // produced their query vectors is still current; everyone else settles as concurrent-update.
+    const retrySlice = retryCandidates.slice(0, DECISION_RETRY_MAX_CANDIDATES)
+    for (const skipped of retryCandidates.slice(DECISION_RETRY_MAX_CANDIDATES)) {
+      outcomesByIndex.set(skipped.candidateIndex, { action: 'noop', reason: 'concurrent-update' })
+    }
+    const currentEmbedding = this.ports.policy.resolveAgentConfig(ctx.agentId)?.memoryEmbedding
     const retryEligible = retrySlice.filter((candidate) => {
       const snapshot = candidate.queryVector
       const valid =
@@ -915,93 +885,65 @@ export class WriteCoordinator {
       }
       return valid
     })
-    if (!failed && retryEligible.length && this.ctx.canContinueOperation(operationFence)) {
-      const retryPreparation = retryEligible.map((candidate) =>
-        this.prepareCoordinateCandidate(
-          agentId,
-          {
-            candidateIndex: candidate.candidateIndex,
-            candidate: candidate.candidate
-          },
-          scope
-        )
-      )
-      const retryPreparationByIndex = new Map(
-        retryPreparation.map((result) => [
-          'prepared' in result ? result.prepared.candidateIndex : result.candidateIndex,
-          result
-        ])
-      )
-      const retryPreparedBase = retryPreparation.flatMap((result) =>
-        'prepared' in result ? [result.prepared] : []
-      )
+    if (!result.failed && retryEligible.length && this.ctx.canContinueOperation(operationFence)) {
       const oldVectors = new Map(
         retryEligible.map((candidate) => [candidate.candidateIndex, candidate.queryVector])
       )
+      const retryBase: PreparedCoordinateCandidate[] = []
+      for (const candidate of retryEligible) {
+        const preparation = this.prepareCoordinateCandidate(ctx, {
+          candidateIndex: candidate.candidateIndex,
+          candidate: candidate.candidate
+        })
+        if ('prepared' in preparation) retryBase.push(preparation.prepared)
+        else {
+          outcomesByIndex.set(
+            candidate.candidateIndex,
+            this.applyImmediate(ctx, preparation.immediate)
+          )
+        }
+      }
       const retryPrepared = await this.retrievePreparedCandidates(
-        agentId,
-        retryPreparedBase,
-        now,
-        scope,
-        retryPreparedBase.map((candidate) => oldVectors.get(candidate.candidateIndex))
+        ctx,
+        retryBase,
+        retryBase.map((candidate) => oldVectors.get(candidate.candidateIndex))
       )
-      const retryByIndex = new Map(retryPrepared.map((item) => [item.candidateIndex, item]))
-      const retryInputs: BatchDecisionInput[] = retryPrepared
-        .filter((candidate) => candidate.neighbors.length > 0)
-        .map((candidate) => toBatchDecisionInput(candidate, now))
       const retryBatch = await this.requestBatchDecisions(
-        agentId,
+        ctx.agentId,
         model,
-        retryInputs,
+        retryPrepared
+          .filter((candidate) => candidate.neighbors.length > 0)
+          .map((candidate) => toBatchDecisionInput(candidate, ctx.now)),
         1,
         operationFence
       )
-      decisionCalls += retryBatch.calls
-
-      for (const original of retryEligible) {
+      result.llmCalls += retryBatch.calls
+      for (const item of retryPrepared) {
         if (!this.ctx.canContinueOperation(operationFence)) break
         try {
-          const preparedResult = retryPreparationByIndex.get(original.candidateIndex)
-          if (!preparedResult) continue
-          casRetries += 1
-          const retryResult = this.applyPreparedCandidate(
-            agentId,
-            preparedResult,
-            retryByIndex.get(original.candidateIndex),
-            retryBatch.decisions.get(original.candidateIndex),
-            options,
-            now,
-            {
-              isRetry: true,
-              allowInsert: false,
-              invalidDecisionFallback: 'concurrent-update',
-              retryConflict: false
-            }
+          result.casRetries += 1
+          const applied = this.applyPreparedCandidate(
+            ctx,
+            item,
+            retryBatch.decisions.get(item.candidateIndex),
+            true
           )
           outcomesByIndex.set(
-            original.candidateIndex,
-            retryResult.action === 'retry'
-              ? { action: 'noop', reason: 'concurrent-update' }
-              : retryResult
+            item.candidateIndex,
+            applied.action === 'retry' ? { action: 'noop', reason: 'concurrent-update' } : applied
           )
         } catch (error) {
-          logger.warn(`[Memory] candidate retry apply failed: ${String(error)}`)
-          failed = true
+          fail(error, 'retry apply')
           break
         }
       }
     }
 
-    return {
-      outcomes: candidates.flatMap((candidate) => {
-        const outcome = outcomesByIndex.get(candidate.candidateIndex)
-        return outcome ? [outcome] : []
-      }),
-      decisionBudgetFallbacks: initialBatch.fallbackCandidateIndexes.size,
-      failed,
-      llmCalls: decisionCalls,
-      casRetries
-    }
+    result.outcomes = candidates.flatMap((candidate) => {
+      const outcome = outcomesByIndex.get(candidate.candidateIndex)
+      return outcome ? [outcome] : []
+    })
+    return result
   }
 
   private finalizeCommittedExtraction(
@@ -1025,180 +967,14 @@ export class WriteCoordinator {
     this.ports.scheduleConsolidation(input.agentId)
   }
 
-  private async coordinateWrite(
-    agentId: string,
-    candidate: MemoryCandidate,
-    model: MemoryModelRef,
-    options: WriteMemoriesOptions,
-    now: number,
-    operationFence: MemoryOperationFence,
-    beforeMutation?: () => void
-  ): Promise<MemoryWriteOutcome> {
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      const result = await this.coordinateWriteAttempt(
-        agentId,
-        candidate,
-        model,
-        options,
-        now,
-        operationFence,
-        attempt > 0,
-        beforeMutation
-      )
-      if (result.action !== 'retry') return result
-    }
-    return { action: 'noop', reason: 'concurrent-update' }
-  }
-
-  private async coordinateWriteAttempt(
-    agentId: string,
-    candidate: MemoryCandidate,
-    model: MemoryModelRef,
-    options: WriteMemoriesOptions,
-    now: number,
-    operationFence: MemoryOperationFence,
-    isRetry: boolean,
-    beforeMutation?: () => void
-  ): Promise<CoordinateWriteResult> {
-    const normalized = normalizeMemoryCandidate(candidate)
-    if (!normalized) return { action: 'noop', reason: 'empty' }
-    const content = normalized.content
-    const scope = normalizeMemoryScope(options.scope)
-    if (!this.ctx.canContinueOperation(operationFence)) {
-      return { action: 'noop', reason: 'disposed' }
-    }
-
-    const ownership = this.ports.rows.resolveClaimOwnership(
-      agentId,
-      normalized.kind,
-      content,
-      scope,
-      { allowSuperseded: true, beforeMutation }
-    )
-    let decisionHead: AgentMemoryRow | null = null
-    switch (ownership.state) {
-      case 'archived':
-        return this.absorbArchivedProvenanceOwner(
-          agentId,
-          ownership.owner,
-          normalized.temporal,
-          beforeMutation
-        )
-          ? { action: 'updated', id: ownership.owner.id }
-          : { action: 'noop', reason: 'concurrent-update', id: ownership.owner.id }
-      case 'duplicate':
-        return this.ports.rows.enrichEquivalentClaimTemporalMetadata(
-          agentId,
-          ownership.owner,
-          normalized.temporal,
-          beforeMutation
-        )
-          ? { action: 'updated', id: ownership.owner.id }
-          : { action: 'noop', reason: 'duplicate', id: ownership.owner.id }
-      case 'suppressed':
-        return { action: 'noop', reason: ownership.reason, id: ownership.owner.id }
-      case 'challenged':
-        return { action: 'noop', reason: 'conflict', id: ownership.head.id }
-      case 'superseded':
-        decisionHead = ownership.head
-        break
-      case 'unowned':
-        break
-    }
-
-    if (
-      ownership.state === 'unowned' &&
-      this.ports.repository.hasTombstoneForClaim({
-        agentId,
-        kind: normalized.kind,
-        content,
-        provenanceKey: buildScopedMemoryProvenanceKey(agentId, normalized.kind, content, scope),
-        scope
-      })
-    ) {
-      return { action: 'noop', reason: 'forgotten' }
-    }
-
-    beforeMutation?.()
-    let neighbors: MemoryRecallItem[] = []
-    try {
-      const hits = await this.ports.retrieveForDecision(agentId, content, now, [scope])
-      neighbors = hits.slice(0, DECISION_NEIGHBOR_TOP_S)
-      const currentDecisionHead = decisionHead
-        ? this.ports.repository.getById(decisionHead.id)
-        : undefined
-      if (
-        isLiveDecisionTarget(agentId, currentDecisionHead) &&
-        !neighbors.some((neighbor) => neighbor.id === currentDecisionHead.id)
-      ) {
-        neighbors.unshift(recallItemFromRow(currentDecisionHead))
-        neighbors = neighbors.slice(0, DECISION_NEIGHBOR_TOP_S)
-      }
-    } catch (error) {
-      logger.warn(`[Memory] decision neighbor recall failed, adding: ${String(error)}`)
-    }
-    if (!this.ctx.canContinueOperation(operationFence)) {
-      return { action: 'noop', reason: 'disposed' }
-    }
-    if (!neighbors.length) {
-      if (isRetry) return { action: 'noop', reason: 'concurrent-update' }
-      return this.applyCurrentProvenanceOrInsert(agentId, normalized, options, now, true)
-    }
-
-    let decision: MemoryDecision = ADD_DECISION
-    try {
-      const raw = await this.ports.textGeneration.generateText(
-        agentId,
-        model.providerId,
-        model.modelId,
-        buildDecisionPrompt(
-          normalized,
-          neighbors.map((neighbor) => ({
-            content: neighbor.content,
-            temporalAnnotation:
-              neighbor.temporalAnnotation ??
-              (neighbor.temporal ? temporalDecisionAnnotation(neighbor.temporal, now) : undefined)
-          })),
-          {
-            candidateTemporalAnnotation: temporalDecisionAnnotation(normalized.temporal, now)
-          }
-        ),
-        'decision'
-      )
-      const parsed = parseDecisionResult(raw, neighbors.length)
-      const valid =
-        parsed.valid &&
-        (parsed.decision.mergedContent === null ||
-          unicodeCodePointLength(parsed.decision.mergedContent) <=
-            AGENT_MEMORY_AUTO_CONTENT_MAX_CHARS)
-      if (isRetry && !valid) {
-        return { action: 'noop', reason: 'concurrent-update' }
-      }
-      decision = valid ? parsed.decision : ADD_DECISION
-    } catch (error) {
-      if (isRetry) {
-        logger.warn(`[Memory] decision retry failed: ${String(error)}`)
-        return { action: 'noop', reason: 'concurrent-update' }
-      }
-      logger.warn(`[Memory] decision model failed, adding: ${String(error)}`)
-    }
-    if (!this.ctx.canContinueOperation(operationFence)) {
-      return { action: 'noop', reason: 'disposed' }
-    }
-
-    return this.applyDecisionAttempt(agentId, normalized, neighbors, decision, options, now)
-  }
-
   private applyDecisionAttempt(
-    agentId: string,
+    ctx: WriteContext,
     normalized: NormalizedMemoryCandidate,
     neighbors: readonly MemoryRecallItem[],
-    decision: MemoryDecision,
-    options: WriteMemoriesOptions,
-    now: number
+    decision: MemoryDecision
   ): CoordinateWriteResult {
+    const { agentId, scope, options, now } = ctx
     const content = normalized.content
-    const scope = normalizeMemoryScope(options.scope)
     const target = decision.targetIndex !== null ? neighbors[decision.targetIndex] : null
     switch (decision.decision) {
       case 'NOOP':
@@ -1440,7 +1216,7 @@ export class WriteCoordinator {
         }
         break
     }
-    return this.applyCurrentProvenanceOrInsert(agentId, normalized, options, now, true)
+    return this.applyCurrentProvenanceOrInsert(ctx, normalized)
   }
 
   private foldDecisionTargetIntoOwner(
@@ -1578,64 +1354,53 @@ export class WriteCoordinator {
     if (!this.ctx.canWriteAgentMemory(options.agentId)) {
       return { action: 'noop', reason: 'disposed' }
     }
-    const normalizedOptions: WriteMemoriesOptions = {
-      ...options,
-      scope: normalizeMemoryScope(options.scope)
-    }
-    const operationFence = this.ctx.captureOperationFence(options.agentId)
-    const now = this.ctx.now()
+    const normalized = normalizeMemoryCandidate(candidate)
+    if (!normalized) return { action: 'noop', reason: 'empty' }
+    const ctx = createWriteContext(options, this.ctx.now(), beforeMutation)
+    const operationFence = this.ctx.captureOperationFence(ctx.agentId)
     const explicitlyRelearned =
-      tombstoneRelease === 'explicit-user-action'
-        ? this.tryExplicitRelearn(
-            options.agentId,
-            candidate,
-            normalizedOptions,
-            now,
-            beforeMutation
-          )
-        : null
+      tombstoneRelease === 'explicit-user-action' ? this.tryExplicitRelearn(ctx, normalized) : null
     const resolvedModel =
-      explicitlyRelearned || !model ? null : this.ctx.resolveExtractionModel(options.agentId, model)
-    const outcome =
-      explicitlyRelearned ??
-      (resolvedModel
-        ? await this.coordinateWrite(
-            options.agentId,
-            candidate,
-            resolvedModel,
-            normalizedOptions,
-            now,
-            operationFence,
-            beforeMutation
-          )
-        : this.directAddMemory(options.agentId, candidate, normalizedOptions, now, beforeMutation))
+      explicitlyRelearned || !model ? null : this.ctx.resolveExtractionModel(ctx.agentId, model)
+    let outcome: MemoryWriteOutcome
+    if (explicitlyRelearned) {
+      outcome = explicitlyRelearned
+    } else if (resolvedModel) {
+      // A single remember is a one-candidate batch. Apply failures are not partial here, so the
+      // caller's fail-closed contract (for example a journal commit that cannot persist) surfaces.
+      const batch = await this.coordinateBatchWrites(
+        ctx,
+        [{ candidateIndex: 0, candidate: normalized }],
+        resolvedModel,
+        operationFence
+      )
+      if (batch.failed) throw batch.error
+      outcome = batch.outcomes[0] ?? { action: 'noop', reason: 'disposed' }
+    } else {
+      outcome = this.directAddMemory(ctx, normalized)
+    }
     if (!this.ctx.canContinueOperation(operationFence)) {
       return { action: 'noop', reason: 'disposed' }
     }
     if (outcomeTouched(outcome)) {
-      this.ctx.markDomainMutationCommitted(options.agentId)
-      this.ports.markWorkingMemoryDirty(options.agentId)
-      this.ctx.emitChanged(options.agentId, 'extract')
+      this.ctx.markDomainMutationCommitted(ctx.agentId)
+      this.ports.markWorkingMemoryDirty(ctx.agentId)
+      this.ctx.emitChanged(ctx.agentId, 'extract')
       if (outcome.action !== 'challenged') {
-        void this.ports.triggerEmbedding(options.agentId).catch((error) => {
+        void this.ports.triggerEmbedding(ctx.agentId).catch((error) => {
           logger.warn(`[Memory] background embedding failed: ${String(error)}`)
         })
       }
-      this.ports.scheduleConsolidation(options.agentId)
+      this.ports.scheduleConsolidation(ctx.agentId)
     }
     return outcome
   }
 
   private tryExplicitRelearn(
-    agentId: string,
-    candidate: MemoryCandidate,
-    options: WriteMemoriesOptions,
-    now: number,
-    beforeMutation?: () => void
+    ctx: WriteContext,
+    normalized: NormalizedMemoryCandidate
   ): MemoryWriteOutcome | null {
-    const normalized = normalizeMemoryCandidate(candidate)
-    if (!normalized) return null
-    const scope = normalizeMemoryScope(options.scope)
+    const { agentId, scope, options, now } = ctx
     if (
       !this.ports.repository.hasTombstoneForClaim({
         agentId,
@@ -1652,7 +1417,7 @@ export class WriteCoordinator {
     ) {
       return null
     }
-    beforeMutation?.()
+    ctx.beforeMutation?.()
     const result = this.ports.rows.reauthorizeForgottenMemory(
       agentId,
       normalized,
@@ -1665,23 +1430,22 @@ export class WriteCoordinator {
       : null
   }
 
+  // No decision model: dedupe by provenance, respect tombstones, otherwise insert.
   private directAddMemory(
-    agentId: string,
-    candidate: MemoryCandidate,
-    options: WriteMemoriesOptions,
-    now: number,
-    beforeMutation?: () => void
+    ctx: WriteContext,
+    normalized: NormalizedMemoryCandidate
   ): MemoryWriteOutcome {
-    const normalized = normalizeMemoryCandidate(candidate)
-    if (!normalized) return { action: 'noop', reason: 'empty' }
+    const { agentId, scope, options, now } = ctx
     const content = normalized.content
-    const scope = normalizeMemoryScope(options.scope)
     const ownership = this.ports.rows.resolveClaimOwnership(
       agentId,
       normalized.kind,
       content,
       scope,
-      { allowSuperseded: false, beforeMutation }
+      {
+        allowSuperseded: false,
+        beforeMutation: ctx.beforeMutation
+      }
     )
     switch (ownership.state) {
       case 'archived':
@@ -1689,7 +1453,7 @@ export class WriteCoordinator {
           agentId,
           ownership.owner,
           normalized.temporal,
-          beforeMutation
+          ctx.beforeMutation
         )
           ? { action: 'updated', id: ownership.owner.id }
           : { action: 'noop', reason: 'concurrent-update', id: ownership.owner.id }
@@ -1698,7 +1462,7 @@ export class WriteCoordinator {
           agentId,
           ownership.owner,
           normalized.temporal,
-          beforeMutation
+          ctx.beforeMutation
         )
           ? { action: 'updated', id: ownership.owner.id }
           : { action: 'noop', reason: 'duplicate', id: ownership.owner.id }
@@ -1722,7 +1486,7 @@ export class WriteCoordinator {
     ) {
       return { action: 'noop', reason: 'forgotten' }
     }
-    beforeMutation?.()
+    ctx.beforeMutation?.()
     const insert = this.ports.rows.insertMemory(agentId, normalized, content, options, now)
     return insert.action === 'inserted'
       ? { action: 'created', id: insert.id }

--- a/src/main/memory/services/writeCoordinator.ts
+++ b/src/main/memory/services/writeCoordinator.ts
@@ -157,10 +157,10 @@ interface IndexedCandidate {
   candidate: NormalizedMemoryCandidate
 }
 
-// Everything a single write shares across preparation, decision, and apply. `options.scope`
-// is already normalized; `beforeMutation` is the caller's dispatch-commit boundary: it fires at
-// most once, always outside any store transaction, and never for a candidate that a local gate
-// (provenance, tombstone, challenged head) already rejected.
+// Everything a single write shares across preparation, decision, and apply. `options.scope` is
+// already normalized. `beforeMutation` is the caller's dispatch-commit boundary, armed once by the
+// MemoryService facade; the kernel only promises to call it outside any store transaction and never
+// for a candidate that a local gate (provenance, tombstone, challenged head) already rejected.
 interface WriteContext {
   agentId: string
   scope: MemoryScope
@@ -175,15 +175,12 @@ interface PreparedCoordinateCandidate extends IndexedCandidate {
   queryVector?: MemoryDecisionQueryVectorSnapshot
 }
 
-// A candidate whose provenance already decided its fate: it never reaches recall or the
-// decision model.
-interface ImmediateCandidate extends IndexedCandidate {
-  settled: Exclude<ClaimOwnership, { state: 'unowned' | 'superseded' }> | { state: 'forgotten' }
-}
+// Ownership states that settle a candidate on the spot, without recall or a decision.
+type OwnedClaim = Exclude<ClaimOwnership, { state: 'unowned' | 'superseded' }>
 
 type PrepareCoordinateCandidateResult =
   | { prepared: PreparedCoordinateCandidate }
-  | { immediate: ImmediateCandidate }
+  | { settled: OwnedClaim | { state: 'forgotten' } }
 
 interface BatchWriteResult {
   outcomes: MemoryWriteOutcome[]
@@ -200,16 +197,6 @@ interface BatchRun {
   operationFence: MemoryOperationFence
   result: BatchWriteResult
   outcomesByIndex: Map<number, MemoryWriteOutcome>
-}
-
-function collectOutcomes(
-  candidates: readonly IndexedCandidate[],
-  outcomesByIndex: ReadonlyMap<number, MemoryWriteOutcome>
-): MemoryWriteOutcome[] {
-  return candidates.flatMap((candidate) => {
-    const outcome = outcomesByIndex.get(candidate.candidateIndex)
-    return outcome ? [outcome] : []
-  })
 }
 
 function failBatch(run: BatchRun, error: unknown, stage: string): void {
@@ -232,32 +219,13 @@ function resolveContentMergeTemporalMetadata(
   })
 }
 
-// Several write sites may reach the boundary in one call (a legacy re-key, then the row write),
-// and the dispatch journal rejects a second commit for the same call, so the callback is armed once
-// here rather than trusting every caller to wrap it.
-function once(callback?: () => void): (() => void) | undefined {
-  if (!callback) return undefined
-  let fired = false
-  return () => {
-    if (fired) return
-    fired = true
-    callback()
-  }
-}
-
 function createWriteContext(
   options: WriteMemoriesOptions,
   now: number,
   beforeMutation?: () => void
 ): WriteContext {
   const scope = normalizeMemoryScope(options.scope)
-  return {
-    agentId: options.agentId,
-    scope,
-    options: { ...options, scope },
-    now,
-    beforeMutation: once(beforeMutation)
-  }
+  return { agentId: options.agentId, scope, options: { ...options, scope }, now, beforeMutation }
 }
 
 function temporalDecisionAnnotation(
@@ -345,26 +313,12 @@ export class WriteCoordinator {
         { allowSuperseded: false }
       )
       if (ownership.state !== 'unowned') {
-        if (ownership.state === 'archived') {
-          if (
-            this.absorbArchivedProvenanceOwner(
-              options.agentId,
-              ownership.owner,
-              normalized.temporal
-            )
-          ) {
-            created.push(ownership.owner.id)
-            touched = true
-          }
-        } else if (
-          ownership.state === 'duplicate' &&
-          this.ports.rows.enrichEquivalentClaimTemporalMetadata(
-            options.agentId,
-            ownership.owner,
-            normalized.temporal
-          )
-        ) {
+        // Never 'superseded' here: without allowSuperseded a superseded owner reads as duplicate.
+        if (ownership.state === 'superseded') continue
+        const settled = this.settleOwnedClaim(options.agentId, ownership, normalized.temporal)
+        if (settled.action === 'updated') {
           touched = true
+          if (ownership.state === 'archived') created.push(settled.id)
         }
         continue
       }
@@ -602,16 +556,8 @@ export class WriteCoordinator {
       case 'unowned':
         // A forgotten claim never reaches recall or the decision model. insertMemory still checks
         // the tombstone inside its own transaction; this only saves the provider round trips.
-        if (
-          this.ports.repository.hasTombstoneForClaim({
-            agentId,
-            kind,
-            content,
-            provenanceKey: buildScopedMemoryProvenanceKey(agentId, kind, content, scope),
-            scope
-          })
-        ) {
-          return { immediate: { ...indexed, settled: { state: 'forgotten' } } }
+        if (this.isForgottenClaim(agentId, indexed.candidate, scope)) {
+          return { settled: { state: 'forgotten' } }
         }
         return { prepared: { ...indexed, decisionHeadId: null, neighbors: [] } }
       case 'superseded':
@@ -619,41 +565,64 @@ export class WriteCoordinator {
           prepared: { ...indexed, decisionHeadId: ownership.head?.id ?? null, neighbors: [] }
         }
       default:
-        return { immediate: { ...indexed, settled: ownership } }
+        return { settled: ownership }
     }
   }
 
-  // Only an archived owner or an enrichable duplicate touch the store; the other settled states
-  // are conservative no-ops, so the dispatch boundary is committed by the row helpers themselves
-  // right before they write.
-  private applyImmediate(ctx: WriteContext, immediate: ImmediateCandidate): MemoryWriteOutcome {
-    const { settled, candidate } = immediate
-    switch (settled.state) {
+  // The one response to a claim someone already owns: restore an archived owner, fold temporal
+  // metadata into a live duplicate, leave suppressed and challenged chains untouched. Only the two
+  // writing branches reach the dispatch boundary, and they do so right before they write.
+  // Transactional callers omit `beforeMutation` because the boundary cannot run inside their
+  // transaction and has already been committed before they entered it.
+  private settleOwnedClaim(
+    agentId: string,
+    ownership: OwnedClaim,
+    temporal: MemoryTemporalMetadata,
+    beforeMutation?: () => void
+  ): MemoryWriteOutcome {
+    switch (ownership.state) {
       case 'archived':
         return this.absorbArchivedProvenanceOwner(
-          ctx.agentId,
-          settled.owner,
-          candidate.temporal,
-          ctx.beforeMutation
+          agentId,
+          ownership.owner,
+          temporal,
+          beforeMutation
         )
-          ? { action: 'updated', id: settled.owner.id }
-          : { action: 'noop', reason: 'concurrent-update', id: settled.owner.id }
+          ? { action: 'updated', id: ownership.owner.id }
+          : { action: 'noop', reason: 'concurrent-update', id: ownership.owner.id }
       case 'duplicate':
         return this.ports.rows.enrichEquivalentClaimTemporalMetadata(
-          ctx.agentId,
-          settled.owner,
-          candidate.temporal,
-          ctx.beforeMutation
+          agentId,
+          ownership.owner,
+          temporal,
+          beforeMutation
         )
-          ? { action: 'updated', id: settled.owner.id }
-          : { action: 'noop', reason: 'duplicate', id: settled.owner.id }
+          ? { action: 'updated', id: ownership.owner.id }
+          : { action: 'noop', reason: 'duplicate', id: ownership.owner.id }
       case 'suppressed':
-        return { action: 'noop', reason: settled.reason, id: settled.owner.id }
+        return { action: 'noop', reason: ownership.reason, id: ownership.owner.id }
       case 'challenged':
-        return { action: 'noop', reason: 'conflict', id: settled.head.id }
-      case 'forgotten':
-        return { action: 'noop', reason: 'forgotten' }
+        return { action: 'noop', reason: 'conflict', id: ownership.head.id }
     }
+  }
+
+  private isForgottenClaim(
+    agentId: string,
+    candidate: NormalizedMemoryCandidate,
+    scope: MemoryScope
+  ): boolean {
+    return this.ports.repository.hasTombstoneForClaim({
+      agentId,
+      kind: candidate.kind,
+      content: candidate.content,
+      provenanceKey: buildScopedMemoryProvenanceKey(
+        agentId,
+        candidate.kind,
+        candidate.content,
+        scope
+      ),
+      scope
+    })
   }
 
   // Re-resolves ownership inside the transaction because provider round trips separate the
@@ -672,55 +641,19 @@ export class WriteCoordinator {
         scope,
         { allowSuperseded: true }
       )
-      switch (ownership.state) {
-        case 'archived': {
-          const owner = ownership.owner
-          const restored = this.ports.repository.restoreArchivedMemory({
-            agentId,
-            id: owner.id,
-            expectedRevision: owner.decision_revision
-          })
-          if (restored) {
-            const current = this.ports.repository.getById(owner.id)
-            if (current) {
-              this.ports.rows.enrichEquivalentClaimTemporalMetadata(
-                agentId,
-                current,
-                candidate.temporal
-              )
-            }
-          }
-          outcome = restored
-            ? { action: 'updated', id: owner.id }
-            : { action: 'noop', reason: 'concurrent-update' }
-          return
-        }
-        case 'duplicate':
-          outcome = this.ports.rows.enrichEquivalentClaimTemporalMetadata(
-            agentId,
-            ownership.owner,
-            candidate.temporal
-          )
-            ? { action: 'updated', id: ownership.owner.id }
-            : { action: 'noop', reason: 'duplicate', id: ownership.owner.id }
-          return
-        case 'suppressed':
-          outcome = { action: 'noop', reason: ownership.reason, id: ownership.owner.id }
-          return
-        case 'challenged':
-          outcome = { action: 'noop', reason: 'conflict', id: ownership.head.id }
-          return
-        case 'superseded':
-          outcome = this.reviveProvenanceOwner(
-            agentId,
-            ownership.owner,
-            now,
-            candidate.category,
-            candidate.temporal
-          )
-          return
-        case 'unowned':
-          break
+      if (ownership.state === 'superseded') {
+        outcome = this.reviveProvenanceOwner(
+          agentId,
+          ownership.owner,
+          now,
+          candidate.category,
+          candidate.temporal
+        )
+        return
+      }
+      if (ownership.state !== 'unowned') {
+        outcome = this.settleOwnedClaim(agentId, ownership, candidate.temporal)
+        return
       }
       const insert = this.ports.rows.insertMemory(
         agentId,
@@ -847,13 +780,22 @@ export class WriteCoordinator {
       if (!this.ctx.canContinueOperation(run.operationFence)) break
       try {
         const preparation = this.prepareCoordinateCandidate(run.ctx, indexed)
-        if ('prepared' in preparation) prepared.push(preparation.prepared)
-        else {
-          run.outcomesByIndex.set(
-            indexed.candidateIndex,
-            this.applyImmediate(run.ctx, preparation.immediate)
-          )
+        if ('prepared' in preparation) {
+          prepared.push(preparation.prepared)
+          continue
         }
+        const { settled } = preparation
+        run.outcomesByIndex.set(
+          indexed.candidateIndex,
+          settled.state === 'forgotten'
+            ? { action: 'noop', reason: 'forgotten' }
+            : this.settleOwnedClaim(
+                run.ctx.agentId,
+                settled,
+                indexed.candidate.temporal,
+                run.ctx.beforeMutation
+              )
+        )
       } catch (error) {
         failBatch(run, error, stage)
         break
@@ -948,47 +890,48 @@ export class WriteCoordinator {
         retryEligible.map(({ candidateIndex, candidate }) => ({ candidateIndex, candidate })),
         'retry preparation'
       )
-      if (result.failed || !retryBase.length) {
-        result.outcomes = collectOutcomes(candidates, outcomesByIndex)
-        return result
-      }
-      const retryPrepared = await this.retrievePreparedCandidates(
-        ctx,
-        retryBase,
-        retryBase.map((candidate) => oldVectors.get(candidate.candidateIndex))
-      )
-      const retryBatch = await this.requestBatchDecisions(
-        ctx.agentId,
-        model,
-        retryPrepared
-          .filter((candidate) => candidate.neighbors.length > 0)
-          .map((candidate) => toBatchDecisionInput(candidate, ctx.now)),
-        1,
-        operationFence
-      )
-      result.llmCalls += retryBatch.calls
-      for (const item of retryPrepared) {
-        if (!this.ctx.canContinueOperation(operationFence)) break
-        try {
-          result.casRetries += 1
-          const applied = this.applyPreparedCandidate(
-            ctx,
-            item,
-            retryBatch.decisions.get(item.candidateIndex),
-            true
-          )
-          outcomesByIndex.set(
-            item.candidateIndex,
-            applied.action === 'retry' ? { action: 'noop', reason: 'concurrent-update' } : applied
-          )
-        } catch (error) {
-          failBatch(run, error, 'retry apply')
-          break
+      if (!result.failed && retryBase.length) {
+        const retryPrepared = await this.retrievePreparedCandidates(
+          ctx,
+          retryBase,
+          retryBase.map((candidate) => oldVectors.get(candidate.candidateIndex))
+        )
+        const retryBatch = await this.requestBatchDecisions(
+          ctx.agentId,
+          model,
+          retryPrepared
+            .filter((candidate) => candidate.neighbors.length > 0)
+            .map((candidate) => toBatchDecisionInput(candidate, ctx.now)),
+          1,
+          operationFence
+        )
+        result.llmCalls += retryBatch.calls
+        for (const item of retryPrepared) {
+          if (!this.ctx.canContinueOperation(operationFence)) break
+          try {
+            result.casRetries += 1
+            const applied = this.applyPreparedCandidate(
+              ctx,
+              item,
+              retryBatch.decisions.get(item.candidateIndex),
+              true
+            )
+            outcomesByIndex.set(
+              item.candidateIndex,
+              applied.action === 'retry' ? { action: 'noop', reason: 'concurrent-update' } : applied
+            )
+          } catch (error) {
+            failBatch(run, error, 'retry apply')
+            break
+          }
         }
       }
     }
 
-    result.outcomes = collectOutcomes(candidates, outcomesByIndex)
+    result.outcomes = candidates.flatMap((candidate) => {
+      const outcome = outcomesByIndex.get(candidate.candidateIndex)
+      return outcome ? [outcome] : []
+    })
     return result
   }
 
@@ -1447,22 +1390,7 @@ export class WriteCoordinator {
     normalized: NormalizedMemoryCandidate
   ): MemoryWriteOutcome | null {
     const { agentId, scope, options, now } = ctx
-    if (
-      !this.ports.repository.hasTombstoneForClaim({
-        agentId,
-        kind: normalized.kind,
-        content: normalized.content,
-        provenanceKey: buildScopedMemoryProvenanceKey(
-          agentId,
-          normalized.kind,
-          normalized.content,
-          scope
-        ),
-        scope
-      })
-    ) {
-      return null
-    }
+    if (!this.isForgottenClaim(agentId, normalized, scope)) return null
     ctx.beforeMutation?.()
     const result = this.ports.rows.reauthorizeForgottenMemory(
       agentId,
@@ -1493,43 +1421,14 @@ export class WriteCoordinator {
         beforeMutation: ctx.beforeMutation
       }
     )
-    switch (ownership.state) {
-      case 'archived':
-        return this.absorbArchivedProvenanceOwner(
-          agentId,
-          ownership.owner,
-          normalized.temporal,
-          ctx.beforeMutation
-        )
-          ? { action: 'updated', id: ownership.owner.id }
-          : { action: 'noop', reason: 'concurrent-update', id: ownership.owner.id }
-      case 'duplicate':
-        return this.ports.rows.enrichEquivalentClaimTemporalMetadata(
-          agentId,
-          ownership.owner,
-          normalized.temporal,
-          ctx.beforeMutation
-        )
-          ? { action: 'updated', id: ownership.owner.id }
-          : { action: 'noop', reason: 'duplicate', id: ownership.owner.id }
-      case 'suppressed':
-        return { action: 'noop', reason: ownership.reason, id: ownership.owner.id }
-      case 'challenged':
-      case 'superseded':
-        // Unreachable without allowSuperseded; a superseded chain stays a conservative no-op here.
-        return { action: 'noop', reason: 'duplicate', id: ownership.owner.id }
-      case 'unowned':
-        break
+    // Never 'superseded' here: without allowSuperseded a superseded owner reads as duplicate.
+    if (ownership.state === 'superseded') {
+      return { action: 'noop', reason: 'duplicate', id: ownership.owner.id }
     }
-    if (
-      this.ports.repository.hasTombstoneForClaim({
-        agentId,
-        kind: normalized.kind,
-        content,
-        provenanceKey: buildScopedMemoryProvenanceKey(agentId, normalized.kind, content, scope),
-        scope
-      })
-    ) {
+    if (ownership.state !== 'unowned') {
+      return this.settleOwnedClaim(agentId, ownership, normalized.temporal, ctx.beforeMutation)
+    }
+    if (this.isForgottenClaim(agentId, normalized, scope)) {
       return { action: 'noop', reason: 'forgotten' }
     }
     ctx.beforeMutation?.()

--- a/src/main/memory/services/writeCoordinator.ts
+++ b/src/main/memory/services/writeCoordinator.ts
@@ -193,6 +193,30 @@ interface BatchWriteResult {
   casRetries: number
 }
 
+// Mutable bookkeeping for one coordinateBatchWrites call.
+interface BatchRun {
+  ctx: WriteContext
+  operationFence: MemoryOperationFence
+  result: BatchWriteResult
+  outcomesByIndex: Map<number, MemoryWriteOutcome>
+}
+
+function collectOutcomes(
+  candidates: readonly IndexedCandidate[],
+  outcomesByIndex: ReadonlyMap<number, MemoryWriteOutcome>
+): MemoryWriteOutcome[] {
+  return candidates.flatMap((candidate) => {
+    const outcome = outcomesByIndex.get(candidate.candidateIndex)
+    return outcome ? [outcome] : []
+  })
+}
+
+function failBatch(run: BatchRun, error: unknown, stage: string): void {
+  logger.warn(`[Memory] candidate ${stage} failed: ${String(error)}`)
+  run.result.failed = true
+  run.result.error = error
+}
+
 type TombstoneReleasePolicy = 'preserve' | 'explicit-user-action'
 
 function resolveContentMergeTemporalMetadata(
@@ -789,6 +813,35 @@ export class WriteCoordinator {
     return { decisions, fallbackCandidateIndexes, calls }
   }
 
+  // Resolves ownership for each candidate and settles the provenance-decided ones right away,
+  // before any provider round trip can age their owner snapshot. Settling may write (restore or
+  // temporal enrichment), so it runs under the same failure accounting as every other apply.
+  // Returns the candidates that still need neighbors and a decision.
+  private settleImmediateCandidates(
+    run: BatchRun,
+    candidates: readonly IndexedCandidate[],
+    stage: string
+  ): PreparedCoordinateCandidate[] {
+    const prepared: PreparedCoordinateCandidate[] = []
+    for (const indexed of candidates) {
+      if (!this.ctx.canContinueOperation(run.operationFence)) break
+      try {
+        const preparation = this.prepareCoordinateCandidate(run.ctx, indexed)
+        if ('prepared' in preparation) prepared.push(preparation.prepared)
+        else {
+          run.outcomesByIndex.set(
+            indexed.candidateIndex,
+            this.applyImmediate(run.ctx, preparation.immediate)
+          )
+        }
+      } catch (error) {
+        failBatch(run, error, stage)
+        break
+      }
+    }
+    return prepared
+  }
+
   // The single decision kernel for extraction batches and one-off remembers alike: settle
   // provenance-decided candidates synchronously, recall neighbors and ask the decision model once
   // for the rest, apply, then give CAS losers one bounded retry that reuses their query vectors.
@@ -807,30 +860,9 @@ export class WriteCoordinator {
     }
     if (!candidates.length) return result
     const outcomesByIndex = new Map<number, MemoryWriteOutcome>()
-    const fail = (error: unknown, stage: string): void => {
-      logger.warn(`[Memory] candidate ${stage} failed: ${String(error)}`)
-      result.failed = true
-      result.error = error
-    }
+    const run: BatchRun = { ctx, operationFence, result, outcomesByIndex }
 
-    // Settle immediate candidates before any provider round trip can age their owner snapshot.
-    const toPrepare: PreparedCoordinateCandidate[] = []
-    for (const indexed of candidates) {
-      if (!this.ctx.canContinueOperation(operationFence)) break
-      try {
-        const preparation = this.prepareCoordinateCandidate(ctx, indexed)
-        if ('prepared' in preparation) toPrepare.push(preparation.prepared)
-        else
-          outcomesByIndex.set(
-            indexed.candidateIndex,
-            this.applyImmediate(ctx, preparation.immediate)
-          )
-      } catch (error) {
-        fail(error, 'preparation')
-        break
-      }
-    }
-
+    const toPrepare = this.settleImmediateCandidates(run, candidates, 'preparation')
     const retryCandidates: PreparedCoordinateCandidate[] = []
     if (!result.failed && toPrepare.length) {
       const prepared = await this.retrievePreparedCandidates(ctx, toPrepare)
@@ -857,7 +889,7 @@ export class WriteCoordinator {
           if (applied.action === 'retry') retryCandidates.push(item)
           else outcomesByIndex.set(item.candidateIndex, applied)
         } catch (error) {
-          fail(error, 'apply')
+          failBatch(run, error, 'apply')
           break
         }
       }
@@ -889,19 +921,16 @@ export class WriteCoordinator {
       const oldVectors = new Map(
         retryEligible.map((candidate) => [candidate.candidateIndex, candidate.queryVector])
       )
-      const retryBase: PreparedCoordinateCandidate[] = []
-      for (const candidate of retryEligible) {
-        const preparation = this.prepareCoordinateCandidate(ctx, {
-          candidateIndex: candidate.candidateIndex,
-          candidate: candidate.candidate
-        })
-        if ('prepared' in preparation) retryBase.push(preparation.prepared)
-        else {
-          outcomesByIndex.set(
-            candidate.candidateIndex,
-            this.applyImmediate(ctx, preparation.immediate)
-          )
-        }
+      // Ownership may have moved since the first pass, so retried candidates are re-resolved and
+      // may settle immediately instead of asking the model again.
+      const retryBase = this.settleImmediateCandidates(
+        run,
+        retryEligible.map(({ candidateIndex, candidate }) => ({ candidateIndex, candidate })),
+        'retry preparation'
+      )
+      if (result.failed || !retryBase.length) {
+        result.outcomes = collectOutcomes(candidates, outcomesByIndex)
+        return result
       }
       const retryPrepared = await this.retrievePreparedCandidates(
         ctx,
@@ -933,16 +962,13 @@ export class WriteCoordinator {
             applied.action === 'retry' ? { action: 'noop', reason: 'concurrent-update' } : applied
           )
         } catch (error) {
-          fail(error, 'retry apply')
+          failBatch(run, error, 'retry apply')
           break
         }
       }
     }
 
-    result.outcomes = candidates.flatMap((candidate) => {
-      const outcome = outcomesByIndex.get(candidate.candidateIndex)
-      return outcome ? [outcome] : []
-    })
+    result.outcomes = collectOutcomes(candidates, outcomesByIndex)
     return result
   }
 

--- a/src/main/memory/services/writeCoordinator.ts
+++ b/src/main/memory/services/writeCoordinator.ts
@@ -51,6 +51,7 @@ import type {
   WriteMemoriesOptions
 } from '../types'
 import type { MemoryDirectiveInput } from '../domain/directives'
+import { isLiveDecisionTarget } from '../domain/stateModel'
 import {
   type MemoryModelRef,
   type MemoryOperationFence,
@@ -147,29 +148,6 @@ function userAddAuditFromOutcome(outcome: MemoryWriteOutcome): {
     case 'noop':
       return { status: 'skipped', reason: outcome.reason, outputRefs: { action: 'noop' } }
   }
-}
-
-function isLiveDecisionTarget(
-  agentId: string,
-  row: AgentMemoryRow | undefined
-): row is AgentMemoryRow {
-  return (
-    !!row &&
-    row.agent_id === agentId &&
-    row.superseded_by === null &&
-    row.lifecycle_state === 'active' &&
-    row.conflict_state === null
-  )
-}
-
-function isChallengedDecisionHead(agentId: string, row: AgentMemoryRow | undefined): boolean {
-  return (
-    !!row &&
-    row.agent_id === agentId &&
-    row.lifecycle_state === 'active' &&
-    row.superseded_by === null &&
-    row.conflict_state === 'challenged'
-  )
 }
 
 class DecisionRevisionConflictError extends Error {}
@@ -333,25 +311,30 @@ export class WriteCoordinator {
       const normalized = normalizeMemoryCandidate(candidate)
       if (!normalized) continue
       const content = normalized.content
-      const duplicate = this.ports.rows.resolveProvenance(
+      const ownership = this.ports.rows.resolveClaimOwnership(
         options.agentId,
         normalized.kind,
         content,
-        scope
+        scope,
+        { allowSuperseded: false }
       )
-      if (duplicate) {
-        const hit = this.ports.rows.handleProvenanceHit(options.agentId, duplicate)
-        if (hit.action === 'absorbed') {
-          if (this.absorbArchivedProvenanceOwner(options.agentId, duplicate, normalized.temporal)) {
-            created.push(duplicate.id)
+      if (ownership.state !== 'unowned') {
+        if (ownership.state === 'archived') {
+          if (
+            this.absorbArchivedProvenanceOwner(
+              options.agentId,
+              ownership.owner,
+              normalized.temporal
+            )
+          ) {
+            created.push(ownership.owner.id)
             touched = true
           }
         } else if (
-          hit.action === 'noop' &&
-          hit.reason === 'duplicate' &&
+          ownership.state === 'duplicate' &&
           this.ports.rows.enrichEquivalentClaimTemporalMetadata(
             options.agentId,
-            duplicate,
+            ownership.owner,
             normalized.temporal
           )
         ) {
@@ -583,48 +566,33 @@ export class WriteCoordinator {
     indexed: IndexedCandidate,
     scope: MemoryScope
   ): PrepareCoordinateCandidateResult {
-    const content = indexed.candidate.content
-    const duplicate = this.ports.rows.resolveProvenance(
+    const ownership = this.ports.rows.resolveClaimOwnership(
       agentId,
       indexed.candidate.kind,
-      content,
-      scope
+      indexed.candidate.content,
+      scope,
+      { allowSuperseded: true }
     )
-    let decisionHeadId: string | null = null
-    if (duplicate) {
-      const hit = this.ports.rows.handleProvenanceHit(agentId, duplicate, {
-        allowDecisionForSuperseded: true
-      })
-      if (hit.action === 'absorbed') {
+    const immediate = (outcome: MemoryWriteOutcome): PrepareCoordinateCandidateResult => ({
+      candidateIndex: indexed.candidateIndex,
+      candidate: indexed.candidate,
+      outcome
+    })
+    switch (ownership.state) {
+      case 'archived':
+        return immediate({ action: 'updated', id: ownership.owner.id })
+      case 'duplicate':
+        return immediate({ action: 'noop', reason: 'duplicate', id: ownership.owner.id })
+      case 'suppressed':
+        return immediate({ action: 'noop', reason: ownership.reason, id: ownership.owner.id })
+      case 'challenged':
+        return immediate({ action: 'noop', reason: 'conflict', id: ownership.head.id })
+      case 'superseded':
         return {
-          candidateIndex: indexed.candidateIndex,
-          candidate: indexed.candidate,
-          outcome: { action: 'updated', id: duplicate.id }
+          prepared: { ...indexed, decisionHeadId: ownership.head?.id ?? null, neighbors: [] }
         }
-      }
-      if (hit.action === 'noop') {
-        return {
-          candidateIndex: indexed.candidateIndex,
-          candidate: indexed.candidate,
-          outcome: { action: 'noop', reason: hit.reason, id: duplicate.id }
-        }
-      }
-      const head = this.ports.rows.supersedeHead(agentId, duplicate)
-      if (isChallengedDecisionHead(agentId, head)) {
-        return {
-          candidateIndex: indexed.candidateIndex,
-          candidate: indexed.candidate,
-          outcome: { action: 'noop', reason: 'conflict', id: head.id }
-        }
-      }
-      if (isLiveDecisionTarget(agentId, head)) decisionHeadId = head.id
-    }
-    return {
-      prepared: {
-        ...indexed,
-        decisionHeadId,
-        neighbors: []
-      }
+      case 'unowned':
+        return { prepared: { ...indexed, decisionHeadId: null, neighbors: [] } }
     }
   }
 
@@ -649,17 +617,16 @@ export class WriteCoordinator {
     const scope = normalizeMemoryScope(options.scope)
     let outcome: MemoryWriteOutcome = { action: 'noop', reason: 'concurrent-update' }
     this.ports.repository.runInTransaction(() => {
-      const owner = this.ports.rows.resolveProvenance(
+      const ownership = this.ports.rows.resolveClaimOwnership(
         agentId,
         candidate.kind,
         candidate.content,
-        scope
+        scope,
+        { allowSuperseded: true }
       )
-      if (owner) {
-        const hit = this.ports.rows.handleProvenanceHit(agentId, owner, {
-          allowDecisionForSuperseded: true
-        })
-        if (hit.action === 'absorbed') {
+      switch (ownership.state) {
+        case 'archived': {
+          const owner = ownership.owner
           const restored = this.ports.repository.restoreArchivedMemory({
             agentId,
             id: owner.id,
@@ -680,31 +647,32 @@ export class WriteCoordinator {
             : { action: 'noop', reason: 'concurrent-update' }
           return
         }
-        if (hit.action === 'noop') {
-          outcome =
-            hit.reason === 'duplicate' &&
-            this.ports.rows.enrichEquivalentClaimTemporalMetadata(
-              agentId,
-              owner,
-              candidate.temporal
-            )
-              ? { action: 'updated', id: owner.id }
-              : { action: 'noop', reason: hit.reason, id: owner.id }
+        case 'duplicate':
+          outcome = this.ports.rows.enrichEquivalentClaimTemporalMetadata(
+            agentId,
+            ownership.owner,
+            candidate.temporal
+          )
+            ? { action: 'updated', id: ownership.owner.id }
+            : { action: 'noop', reason: 'duplicate', id: ownership.owner.id }
           return
-        }
-        const head = this.ports.rows.supersedeHead(agentId, owner)
-        if (isChallengedDecisionHead(agentId, head)) {
-          outcome = { action: 'noop', reason: 'conflict', id: head.id }
+        case 'suppressed':
+          outcome = { action: 'noop', reason: ownership.reason, id: ownership.owner.id }
           return
-        }
-        outcome = this.reviveProvenanceOwner(
-          agentId,
-          owner,
-          now,
-          candidate.category,
-          candidate.temporal
-        )
-        return
+        case 'challenged':
+          outcome = { action: 'noop', reason: 'conflict', id: ownership.head.id }
+          return
+        case 'superseded':
+          outcome = this.reviveProvenanceOwner(
+            agentId,
+            ownership.owner,
+            now,
+            candidate.category,
+            candidate.temporal
+          )
+          return
+        case 'unowned':
+          break
       }
       if (!allowInsert) return
       const insert = this.ports.rows.insertMemory(
@@ -1100,51 +1068,46 @@ export class WriteCoordinator {
       return { action: 'noop', reason: 'disposed' }
     }
 
-    const duplicate = this.ports.rows.resolveProvenance(
+    const ownership = this.ports.rows.resolveClaimOwnership(
       agentId,
       normalized.kind,
       content,
       scope,
-      beforeMutation
+      { allowSuperseded: true, beforeMutation }
     )
     let decisionHead: AgentMemoryRow | null = null
-    if (duplicate) {
-      const hit = this.ports.rows.handleProvenanceHit(agentId, duplicate, {
-        allowDecisionForSuperseded: true
-      })
-      if (hit.action === 'absorbed') {
+    switch (ownership.state) {
+      case 'archived':
         return this.absorbArchivedProvenanceOwner(
           agentId,
-          duplicate,
+          ownership.owner,
           normalized.temporal,
           beforeMutation
         )
-          ? { action: 'updated', id: duplicate.id }
-          : { action: 'noop', reason: 'concurrent-update', id: duplicate.id }
-      }
-      if (hit.action === 'noop') {
-        if (
-          hit.reason === 'duplicate' &&
-          this.ports.rows.enrichEquivalentClaimTemporalMetadata(
-            agentId,
-            duplicate,
-            normalized.temporal,
-            beforeMutation
-          )
-        ) {
-          return { action: 'updated', id: duplicate.id }
-        }
-        return { action: 'noop', reason: hit.reason, id: duplicate.id }
-      }
-      const head = this.ports.rows.supersedeHead(agentId, duplicate)
-      if (isChallengedDecisionHead(agentId, head)) {
-        return { action: 'noop', reason: 'conflict', id: head.id }
-      }
-      if (isLiveDecisionTarget(agentId, head)) decisionHead = head
+          ? { action: 'updated', id: ownership.owner.id }
+          : { action: 'noop', reason: 'concurrent-update', id: ownership.owner.id }
+      case 'duplicate':
+        return this.ports.rows.enrichEquivalentClaimTemporalMetadata(
+          agentId,
+          ownership.owner,
+          normalized.temporal,
+          beforeMutation
+        )
+          ? { action: 'updated', id: ownership.owner.id }
+          : { action: 'noop', reason: 'duplicate', id: ownership.owner.id }
+      case 'suppressed':
+        return { action: 'noop', reason: ownership.reason, id: ownership.owner.id }
+      case 'challenged':
+        return { action: 'noop', reason: 'conflict', id: ownership.head.id }
+      case 'superseded':
+        decisionHead = ownership.head
+        break
+      case 'unowned':
+        break
     }
 
     if (
-      !duplicate &&
+      ownership.state === 'unowned' &&
       this.ports.repository.hasTombstoneForClaim({
         agentId,
         kind: normalized.kind,
@@ -1495,18 +1458,19 @@ export class WriteCoordinator {
     ) {
       return { action: 'retry' }
     }
-    const hit = this.ports.rows.handleProvenanceHit(agentId, owner, {
-      allowDecisionForSuperseded: true
+    const ownership = this.ports.rows.classifyClaimOwner(agentId, owner, {
+      allowSuperseded: true
     })
-    if (hit.action === 'noop' && hit.reason !== 'duplicate') {
-      return { action: 'noop', reason: hit.reason, id: owner.id }
+    if (ownership.state === 'suppressed') {
+      return { action: 'noop', reason: ownership.reason, id: owner.id }
     }
+    const ownerIsSuperseded = ownership.state === 'superseded' || ownership.state === 'challenged'
+    // Only a live chain head can coincide with the (live) decision target.
+    const ownerHeadIsTarget = ownership.state === 'superseded' && ownership.head?.id === target.id
 
     try {
       this.ports.repository.runInTransaction(() => {
         let ownerRevision = owner.decision_revision
-        const ownerHead =
-          hit.action === 'continue' ? this.ports.rows.supersedeHead(agentId, owner) : undefined
         let retiredHeadId: string | null = null
         if (
           !this.ports.repository.markSupersededIfRevision(
@@ -1518,7 +1482,7 @@ export class WriteCoordinator {
         ) {
           throw new DecisionRevisionConflictError()
         }
-        if (hit.action === 'absorbed') {
+        if (ownership.state === 'archived') {
           if (
             !this.ports.repository.restoreArchivedMemory({
               agentId,
@@ -1530,8 +1494,8 @@ export class WriteCoordinator {
           }
           ownerRevision += 1
         }
-        if (hit.action === 'continue') {
-          if (ownerHead?.id === target.id) {
+        if (ownerIsSuperseded) {
+          if (ownerHeadIsTarget) {
             if (
               !this.ports.repository.reviveSupersededMemory({
                 agentId,
@@ -1712,39 +1676,40 @@ export class WriteCoordinator {
     if (!normalized) return { action: 'noop', reason: 'empty' }
     const content = normalized.content
     const scope = normalizeMemoryScope(options.scope)
-    const duplicate = this.ports.rows.resolveProvenance(
+    const ownership = this.ports.rows.resolveClaimOwnership(
       agentId,
       normalized.kind,
       content,
       scope,
-      beforeMutation
+      { allowSuperseded: false, beforeMutation }
     )
-    if (duplicate) {
-      const hit = this.ports.rows.handleProvenanceHit(agentId, duplicate)
-      if (hit.action === 'absorbed') {
+    switch (ownership.state) {
+      case 'archived':
         return this.absorbArchivedProvenanceOwner(
           agentId,
-          duplicate,
+          ownership.owner,
           normalized.temporal,
           beforeMutation
         )
-          ? { action: 'updated', id: duplicate.id }
-          : { action: 'noop', reason: 'concurrent-update', id: duplicate.id }
-      }
-      if (
-        hit.action === 'noop' &&
-        hit.reason === 'duplicate' &&
-        this.ports.rows.enrichEquivalentClaimTemporalMetadata(
+          ? { action: 'updated', id: ownership.owner.id }
+          : { action: 'noop', reason: 'concurrent-update', id: ownership.owner.id }
+      case 'duplicate':
+        return this.ports.rows.enrichEquivalentClaimTemporalMetadata(
           agentId,
-          duplicate,
+          ownership.owner,
           normalized.temporal,
           beforeMutation
         )
-      ) {
-        return { action: 'updated', id: duplicate.id }
-      }
-      const reason = hit.action === 'noop' ? hit.reason : 'duplicate'
-      return { action: 'noop', reason, id: duplicate.id }
+          ? { action: 'updated', id: ownership.owner.id }
+          : { action: 'noop', reason: 'duplicate', id: ownership.owner.id }
+      case 'suppressed':
+        return { action: 'noop', reason: ownership.reason, id: ownership.owner.id }
+      case 'challenged':
+      case 'superseded':
+        // Unreachable without allowSuperseded; a superseded chain stays a conservative no-op here.
+        return { action: 'noop', reason: 'duplicate', id: ownership.owner.id }
+      case 'unowned':
+        break
     }
     if (
       this.ports.repository.hasTombstoneForClaim({

--- a/src/main/memory/services/writeCoordinator.ts
+++ b/src/main/memory/services/writeCoordinator.ts
@@ -158,8 +158,9 @@ interface IndexedCandidate {
 }
 
 // Everything a single write shares across preparation, decision, and apply. `options.scope`
-// is already normalized; `beforeMutation` is the caller's dispatch-commit boundary and must run
-// outside any store transaction.
+// is already normalized; `beforeMutation` is the caller's dispatch-commit boundary: it fires at
+// most once, always outside any store transaction, and never for a candidate that a local gate
+// (provenance, tombstone, challenged head) already rejected.
 interface WriteContext {
   agentId: string
   scope: MemoryScope
@@ -231,13 +232,32 @@ function resolveContentMergeTemporalMetadata(
   })
 }
 
+// Several write sites may reach the boundary in one call (a legacy re-key, then the row write),
+// and the dispatch journal rejects a second commit for the same call, so the callback is armed once
+// here rather than trusting every caller to wrap it.
+function once(callback?: () => void): (() => void) | undefined {
+  if (!callback) return undefined
+  let fired = false
+  return () => {
+    if (fired) return
+    fired = true
+    callback()
+  }
+}
+
 function createWriteContext(
   options: WriteMemoriesOptions,
   now: number,
   beforeMutation?: () => void
 ): WriteContext {
   const scope = normalizeMemoryScope(options.scope)
-  return { agentId: options.agentId, scope, options: { ...options, scope }, now, beforeMutation }
+  return {
+    agentId: options.agentId,
+    scope,
+    options: { ...options, scope },
+    now,
+    beforeMutation: once(beforeMutation)
+  }
 }
 
 function temporalDecisionAnnotation(

--- a/test/main/memory/embeddingPipeline.test.ts
+++ b/test/main/memory/embeddingPipeline.test.ts
@@ -587,7 +587,10 @@ describe('MemoryService embedding reindex (T5, AC-3.x)', () => {
     // Simulate a sidecar that lost one vector after the row was already marked ready.
     store.vectors.delete(ids[1])
     internals.vectorStoreService.clearReady('a')
-    const reindexSpy = vi.spyOn(presenter, 'reindexEmbeddings')
+    const reindexSpy = vi.spyOn(
+      memoryRuntimeForTests(presenter).embeddingService,
+      'reindexEmbeddings'
+    )
     const resetCallsBefore = resetVectorStore.mock.calls.length
     const embeddingCallsBefore = getEmbeddings.mock.calls.length
 
@@ -918,7 +921,7 @@ describe('MemoryService embedding reindex (T5, AC-3.x)', () => {
 
     // Model configured later. recall reaches a healthy store and kicks the backfill.
     config = { memoryEnabled: true, memoryEmbedding: { providerId: 'p', modelId: 'm' } }
-    const spy = vi.spyOn(presenter, 'backfillEmbeddings')
+    const spy = vi.spyOn(memoryRuntimeForTests(presenter).embeddingService, 'backfillEmbeddings')
     await presenter.recall('a', 'redis')
     await waitForMemoryCondition(() => spy.mock.calls.length > 0)
     expect(spy).toHaveBeenCalledWith('a')
@@ -1325,7 +1328,7 @@ describe('MemoryService embedding reindex (T5, AC-3.x)', () => {
     })
     await store.upsert([{ memoryId: 'fact1', embedding: textToVector('redis fact') }])
 
-    const spy = vi.spyOn(presenter, 'reindexEmbeddings')
+    const spy = vi.spyOn(memoryRuntimeForTests(presenter).embeddingService, 'reindexEmbeddings')
     const results = await presenter.recall('a', 'redis')
 
     // The stale persona must not be read as stale (no reindex), nor surface as a normal memory.
@@ -1399,7 +1402,7 @@ describe('MemoryService embedding reindex (T5, AC-3.x)', () => {
       status: 'fts_only'
     })
 
-    const spy = vi.spyOn(presenter, 'reindexEmbeddings')
+    const spy = vi.spyOn(memoryRuntimeForTests(presenter).embeddingService, 'reindexEmbeddings')
     await presenter.recall('a', 'redis')
     expect(getEmbeddings).not.toHaveBeenCalledWith('p', 'm', ['redis'], expect.any(AbortSignal))
     expect(getEmbeddings).toHaveBeenCalledWith('p', 'm', ['memory warmup'], expect.any(AbortSignal))

--- a/test/main/memory/lifecycleRegression.test.ts
+++ b/test/main/memory/lifecycleRegression.test.ts
@@ -553,7 +553,7 @@ describe('MemoryService lifecycle revival (SDD-8)', () => {
     expect(repo.listByAgent('a')[0]?.status).toBe('fts_only')
 
     config = { memoryEnabled: true, memoryEmbedding: { providerId: 'p', modelId: 'm' } }
-    const spy = vi.spyOn(presenter, 'backfillEmbeddings')
+    const spy = vi.spyOn(memoryRuntimeForTests(presenter).embeddingService, 'backfillEmbeddings')
     await presenter.dispose()
     await presenter.recall('a', 'redis')
 
@@ -788,8 +788,14 @@ describe('MemoryService lifecycle revival (SDD-8)', () => {
     blockCreate = true
     const getByIdSpy = vi.spyOn(repo, 'getById')
     const recordSpy = vi.spyOn(repo, 'recordAccessBatch')
-    const backfillSpy = vi.spyOn(presenter, 'backfillEmbeddings')
-    const reindexSpy = vi.spyOn(presenter, 'reindexEmbeddings')
+    const backfillSpy = vi.spyOn(
+      memoryRuntimeForTests(presenter).embeddingService,
+      'backfillEmbeddings'
+    )
+    const reindexSpy = vi.spyOn(
+      memoryRuntimeForTests(presenter).embeddingService,
+      'reindexEmbeddings'
+    )
     const closeSpy = vi.spyOn(store, 'close')
     const recall = presenter.recall('a', 'redis')
     await new Promise((r) => setTimeout(r, 0)) // background warm is parked inside createVectorStore
@@ -866,7 +872,10 @@ describe('MemoryService lifecycle revival (SDD-8)', () => {
     blockQuery = true
     const getByIdSpy = vi.spyOn(repo, 'getById')
     const recordSpy = vi.spyOn(repo, 'recordAccessBatch')
-    const backfillSpy = vi.spyOn(presenter, 'backfillEmbeddings')
+    const backfillSpy = vi.spyOn(
+      memoryRuntimeForTests(presenter).embeddingService,
+      'backfillEmbeddings'
+    )
     const recall = presenter.recall('a', 'redis')
     await new Promise((r) => setTimeout(r, 0)) // park inside store.query
 
@@ -1138,7 +1147,9 @@ describe('MemoryService lifecycle revival (SDD-8)', () => {
       embeddingDim: 4,
       embeddingModel: 'p:m'
     })
-    const reindexSpy = vi.spyOn(presenter, 'reindexEmbeddings').mockResolvedValue()
+    const reindexSpy = vi
+      .spyOn(memoryRuntimeForTests(presenter).embeddingService, 'reindexEmbeddings')
+      .mockResolvedValue()
 
     expect(await presenter.deleteMemory('a', 'm1')).toEqual({ action: 'applied' })
 

--- a/test/main/memory/maintenanceService.test.ts
+++ b/test/main/memory/maintenanceService.test.ts
@@ -762,6 +762,45 @@ describe('MemoryService offline consolidation (T-B4..T-B6)', () => {
     expect(repo.countDirtySeeds('a')).toBe(2)
   })
 
+  it('keeps reflection accounting when its audit write fails', async () => {
+    const generateText = vi.fn(async (_providerId: string, _modelId: string, prompt: string) => {
+      if (prompt.includes('Choose exactly ONE decision')) throw new Error('decision unavailable')
+      if (prompt.includes('durable, high-level insights')) {
+        return '["user consistently prefers redis"]'
+      }
+      return ''
+    })
+    const { presenter, repo, auditRepo } = makeLLMPresenter(generateText)
+    const now = 1_000 * DAY
+    // Two embedded near-duplicates make the merge step call (and fail) the decision model; the
+    // recent importance below lets reflection run and succeed in the same pass.
+    const firstId = await seedEmbedded(presenter, 'user likes redis a')
+    const secondId = await seedEmbedded(presenter, 'user likes redis b')
+    repo.rows.get(firstId)!.created_at = now
+    repo.rows.get(secondId)!.created_at = now + 1
+    presenter.writeMemoriesSync(
+      Array.from({ length: 6 }, (_, index) => ({
+        kind: 'semantic' as const,
+        content: `durable fact ${index}`,
+        importance: 0.9
+      })),
+      { agentId: 'a' }
+    )
+    const originalInsert = auditRepo.insert.bind(auditRepo)
+    vi.spyOn(auditRepo, 'insert').mockImplementation((row) => {
+      if (row.eventType === 'memory/reflect') throw new Error('audit insert failed')
+      return originalInsert(row)
+    })
+
+    await presenter.runConsolidationPass('a', now)
+
+    expect(decisionCalls(generateText)).toBeGreaterThan(0)
+    expect(auditRepo.getLatestCompletedEventAt('a', 'memory/maintenance_llm')).toBe(now)
+    expect(auditRepo.listByAgent('a')).not.toContainEqual(
+      expect.objectContaining({ reason: 'all-llm-steps-failed' })
+    )
+  })
+
   it('does not keep completed cooldown when heavy maintenance aborts after memory is disabled', async () => {
     const config: DeepChatAgentConfig = { ...embeddingConfig }
     const generateText = vi.fn(async (_p: string, _m: string, prompt: string) => {

--- a/test/main/memory/maintenanceService.test.ts
+++ b/test/main/memory/maintenanceService.test.ts
@@ -1038,7 +1038,9 @@ describe('MemoryService offline consolidation (T-B4..T-B6)', () => {
         return ''
       })
       const { presenter } = makeLLMPresenter(generateText)
-      const passSpy = vi.spyOn(presenter, 'runConsolidationPass').mockResolvedValue()
+      const passSpy = vi
+        .spyOn(memoryRuntimeForTests(presenter).maintenanceService, 'runConsolidationPass')
+        .mockResolvedValue()
 
       const span = (text: string) => ({
         agentId: 'a',
@@ -1079,7 +1081,9 @@ describe('MemoryService offline consolidation (T-B4..T-B6)', () => {
         return ''
       })
       const { presenter } = makeLLMPresenter(generateText)
-      const passSpy = vi.spyOn(presenter, 'runConsolidationPass').mockResolvedValue()
+      const passSpy = vi
+        .spyOn(memoryRuntimeForTests(presenter).maintenanceService, 'runConsolidationPass')
+        .mockResolvedValue()
 
       await presenter.extractAndStore({
         agentId: 'a',
@@ -1120,7 +1124,9 @@ describe('MemoryService offline consolidation (T-B4..T-B6)', () => {
         createVectorStore: async () => new FakeVectorStore(),
         resetVectorStore: async () => undefined
       })
-      const passSpy = vi.spyOn(presenter, 'runConsolidationPass').mockResolvedValue()
+      const passSpy = vi
+        .spyOn(memoryRuntimeForTests(presenter).maintenanceService, 'runConsolidationPass')
+        .mockResolvedValue()
 
       presenter.startBackgroundMaintenance()
       presenter.startBackgroundMaintenance()
@@ -1154,7 +1160,9 @@ describe('MemoryService offline consolidation (T-B4..T-B6)', () => {
         createVectorStore: async () => new FakeVectorStore(),
         resetVectorStore: async () => undefined
       })
-      const passSpy = vi.spyOn(presenter, 'runConsolidationPass').mockResolvedValue()
+      const passSpy = vi
+        .spyOn(memoryRuntimeForTests(presenter).maintenanceService, 'runConsolidationPass')
+        .mockResolvedValue()
 
       presenter.startBackgroundMaintenance()
       await vi.advanceTimersByTimeAsync(30 * 1000)
@@ -1183,7 +1191,9 @@ describe('MemoryService offline consolidation (T-B4..T-B6)', () => {
         createVectorStore: async () => new FakeVectorStore(),
         resetVectorStore: async () => undefined
       })
-      const passSpy = vi.spyOn(presenter, 'runConsolidationPass').mockResolvedValue()
+      const passSpy = vi
+        .spyOn(memoryRuntimeForTests(presenter).maintenanceService, 'runConsolidationPass')
+        .mockResolvedValue()
 
       presenter.startBackgroundMaintenance()
       presenter.onAgentMemoryMaintenanceConfigChanged('agent-a')
@@ -1405,7 +1415,9 @@ describe('MemoryService offline consolidation (T-B4..T-B6)', () => {
         createVectorStore: async () => new FakeVectorStore(),
         resetVectorStore: async () => undefined
       })
-      const passSpy = vi.spyOn(presenter, 'runConsolidationPass').mockResolvedValue()
+      const passSpy = vi
+        .spyOn(memoryRuntimeForTests(presenter).maintenanceService, 'runConsolidationPass')
+        .mockResolvedValue()
 
       presenter.startBackgroundMaintenance()
       await presenter.dispose()
@@ -1433,7 +1445,9 @@ describe('MemoryService offline consolidation (T-B4..T-B6)', () => {
         createVectorStore: async () => new FakeVectorStore(),
         resetVectorStore: async () => undefined
       })
-      const passSpy = vi.spyOn(presenter, 'runConsolidationPass').mockResolvedValue()
+      const passSpy = vi
+        .spyOn(memoryRuntimeForTests(presenter).maintenanceService, 'runConsolidationPass')
+        .mockResolvedValue()
 
       presenter.startBackgroundMaintenance()
       await vi.advanceTimersByTimeAsync(60 * 1000 + 5 * 60 * 1000)
@@ -1458,7 +1472,9 @@ describe('MemoryService offline consolidation (T-B4..T-B6)', () => {
         createVectorStore: async () => new FakeVectorStore(),
         resetVectorStore: async () => undefined
       })
-      const passSpy = vi.spyOn(presenter, 'runConsolidationPass').mockResolvedValue()
+      const passSpy = vi
+        .spyOn(memoryRuntimeForTests(presenter).maintenanceService, 'runConsolidationPass')
+        .mockResolvedValue()
 
       presenter.onAgentMemoryMaintenanceConfigChanged('agent-a')
       presenter.onAgentMemoryMaintenanceConfigChanged('agent-b')
@@ -1520,7 +1536,9 @@ describe('MemoryService offline consolidation (T-B4..T-B6)', () => {
         createVectorStore: async () => new FakeVectorStore(),
         resetVectorStore: async () => undefined
       })
-      const passSpy = vi.spyOn(presenter, 'runConsolidationPass').mockResolvedValue()
+      const passSpy = vi
+        .spyOn(memoryRuntimeForTests(presenter).maintenanceService, 'runConsolidationPass')
+        .mockResolvedValue()
 
       presenter.onAgentMemoryMaintenanceConfigChanged('empty')
       presenter.onAgentMemoryMaintenanceConfigChanged('archived')
@@ -1549,7 +1567,9 @@ describe('MemoryService offline consolidation (T-B4..T-B6)', () => {
         createVectorStore: async () => new FakeVectorStore(),
         resetVectorStore: async () => undefined
       })
-      const passSpy = vi.spyOn(presenter, 'runConsolidationPass').mockResolvedValue()
+      const passSpy = vi
+        .spyOn(memoryRuntimeForTests(presenter).maintenanceService, 'runConsolidationPass')
+        .mockResolvedValue()
 
       await presenter.dispose()
       presenter.onAgentMemoryMaintenanceConfigChanged('agent-a')

--- a/test/main/memory/managementService.test.ts
+++ b/test/main/memory/managementService.test.ts
@@ -1060,8 +1060,14 @@ describe('MemoryService management', () => {
 
       blockQueryEmbedding = true
       const clearReadySpy = vi.spyOn(internals.vectorStoreService, 'clearReady')
-      const backfillSpy = vi.spyOn(presenter, 'backfillEmbeddings')
-      const reindexSpy = vi.spyOn(presenter, 'reindexEmbeddings')
+      const backfillSpy = vi.spyOn(
+        memoryRuntimeForTests(presenter).embeddingService,
+        'backfillEmbeddings'
+      )
+      const reindexSpy = vi.spyOn(
+        memoryRuntimeForTests(presenter).embeddingService,
+        'reindexEmbeddings'
+      )
       const recall = presenter.recall('a', 'Could you explain the redis setup again?')
 
       await vi.advanceTimersByTimeAsync(801)

--- a/test/main/memory/serviceTestSupport.ts
+++ b/test/main/memory/serviceTestSupport.ts
@@ -70,13 +70,15 @@ type MemoryServiceRuntimeTestSeams = {
     ): void
     abandonAgent(agentId: string): void
     cleanupAgent(agentId: string): Promise<void>
+    reindexEmbeddings(agentId: string, force?: boolean): Promise<void>
+    backfillEmbeddings(agentId: string): Promise<void>
   }
   vectorStore: VectorStoreManager
   conflict: Pick<
     ConflictService,
     'repairConflictIntegrity' | 'resolveConflict' | 'runChallengeResolutionPass'
   >
-  maintenance: Pick<MaintenanceService, 'clearCooldown'>
+  maintenance: Pick<MaintenanceService, 'clearCooldown' | 'runConsolidationPass'>
   diagnostics: Pick<MemoryDiagnosticsCollector, 'cleanupAgent' | 'recordRecall'>
 }
 

--- a/test/main/memory/writeCoordinator.test.ts
+++ b/test/main/memory/writeCoordinator.test.ts
@@ -1169,3 +1169,107 @@ describe('writeMemoriesSync insert error classification (C2, AC-2.2)', () => {
     expect(result.ok).toBe(false)
   })
 })
+
+describe('rememberMemory decision-ring contracts', () => {
+  const model = { providerId: 'main', modelId: 'main' }
+  const addDecision = '{"decision":"ADD","targetIndex":null,"mergedContent":null}'
+
+  it('keeps a forgotten claim out of recall, the decision model, and the journal boundary', async () => {
+    const generateText = routedLLM({ decision: addDecision })
+    const { presenter, repo, getEmbeddings } = makeLLMPresenter(generateText)
+    const content = 'user prefers explicit recovery'
+    const forgottenId = await seedEmbedded(presenter, content)
+    await presenter.deleteMemory('a', forgottenId)
+    getEmbeddings.mockClear()
+    generateText.mockClear()
+    const beforeMutation = vi.fn()
+
+    await expect(
+      presenter.rememberMemory(
+        { kind: 'semantic', content },
+        { agentId: 'a' },
+        model,
+        beforeMutation
+      )
+    ).resolves.toEqual({ action: 'noop', reason: 'forgotten' })
+
+    expect(getEmbeddings).not.toHaveBeenCalled()
+    expect(generateText).not.toHaveBeenCalled()
+    expect(beforeMutation).not.toHaveBeenCalled()
+    expect(repo.countByAgent('a')).toBe(0)
+  })
+
+  it('commits the journal boundary once before the first row write and keeps the source session', async () => {
+    const generateText = routedLLM({ decision: addDecision })
+    const { presenter, repo } = makeLLMPresenter(generateText)
+    await seedEmbedded(presenter, 'user likes redis')
+    const order: string[] = []
+    const originalInsert = repo.insertClaimUnlessTombstoned.bind(repo)
+    vi.spyOn(repo, 'insertClaimUnlessTombstoned').mockImplementation((input) => {
+      order.push('mutation')
+      return originalInsert(input)
+    })
+    const beforeMutation = vi.fn(() => order.push('commit'))
+
+    const outcome = await presenter.rememberMemory(
+      { kind: 'semantic', content: 'user prefers redis for caching' },
+      { agentId: 'a', sourceSession: 'session-1' },
+      model,
+      beforeMutation
+    )
+
+    expect(outcome).toMatchObject({ action: 'created' })
+    expect(order).toEqual(['commit', 'mutation'])
+    expect(beforeMutation).toHaveBeenCalledOnce()
+    const createdId = outcome.action === 'created' ? outcome.id : ''
+    expect(repo.getById(createdId)?.source_session).toBe('session-1')
+  })
+
+  it('SUPERSEDE keeps the superseded claim and records the derivation edge', async () => {
+    const generateText = routedLLM({
+      decision: '{"decision":"SUPERSEDE","targetIndex":0,"mergedContent":"user moved to Shanghai"}'
+    })
+    const { presenter, repo } = makeLLMPresenter(generateText)
+    const oldId = await seedEmbedded(presenter, 'user lives in Beijing')
+
+    const outcome = await presenter.rememberMemory(
+      { kind: 'semantic', content: 'user moved to Shanghai' },
+      { agentId: 'a' },
+      model
+    )
+
+    expect(outcome).toMatchObject({ action: 'superseded', supersededId: oldId, created: true })
+    const newId = outcome.action === 'superseded' ? outcome.id : ''
+    expect(repo.getById(oldId)).toMatchObject({
+      superseded_by: newId,
+      content: 'user lives in Beijing'
+    })
+    expect(repo.listDerivationsByChild('a', newId)).toEqual([
+      expect.objectContaining({
+        parent_memory_id: oldId,
+        child_memory_id: newId,
+        derivation_kind: 'supersede'
+      })
+    ])
+  })
+
+  it('extractAndStore reports a forgotten candidate as a no-op without recreating the claim', async () => {
+    const content = 'user prefers explicit recovery'
+    const generateText = routedLLM({
+      extraction: `[{"kind":"semantic","content":"${content}","importance":0.8}]`,
+      decision: addDecision
+    })
+    const { presenter, repo } = makeLLMPresenter(generateText)
+    const forgottenId = await seedEmbedded(presenter, content)
+    await presenter.deleteMemory('a', forgottenId)
+
+    const result = await presenter.extractAndStore({
+      agentId: 'a',
+      spanText: 'User: I prefer explicit recovery',
+      model
+    })
+
+    expect(result).toEqual({ ok: true, createdIds: [] })
+    expect(repo.countByAgent('a')).toBe(0)
+  })
+})

--- a/test/main/memory/writeCoordinator.test.ts
+++ b/test/main/memory/writeCoordinator.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@/memory/core/scoring'
 import type { DeepChatAgentConfig } from '@shared/types/agent-interface'
 import {
+  FakeAuditRepository,
   FakeVectorStore,
   createFakeRepository,
   enabledConfig,
@@ -731,6 +732,98 @@ describe('MemoryService change events (onMemoryChanged)', () => {
       expect.objectContaining({
         sessionId: 'session-1',
         createdIds: chipCreatedIds
+      })
+    )
+  })
+})
+
+describe('extraction batch recovery', () => {
+  it('finalizes committed candidates when a retried candidate fails while settling', async () => {
+    const repo = createFakeRepository()
+    const auditRepo = new FakeAuditRepository()
+    const onMemoryChanged = vi.fn()
+    const retried = 'user changed redis preference'
+    let targetId = ''
+    let decisionRounds = 0
+    const generateText = vi.fn(async (_providerId: string, _modelId: string, prompt: string) => {
+      if (prompt.includes('KEEP or SKIP')) return 'KEEP'
+      if (prompt.includes('JSON array')) {
+        return JSON.stringify([
+          { kind: 'semantic', content: 'first durable fact', importance: 0.9 },
+          { kind: 'semantic', content: retried, importance: 0.8 }
+        ])
+      }
+      if (!prompt.includes('Choose exactly ONE decision')) return ''
+      decisionRounds += 1
+      if (decisionRounds === 1) {
+        // While the model decides, another writer bumps the target revision (forcing a retry) and
+        // leaves an archived claim on the retried candidate's provenance key.
+        repo.updateUserMetadataIfRevision({
+          agentId: 'a',
+          id: targetId,
+          expectedRevision: repo.getById(targetId)!.decision_revision,
+          importance: 0.7
+        })
+        repo.insert({
+          id: 'archived-twin',
+          agentId: 'a',
+          kind: 'semantic',
+          content: retried,
+          status: 'embedded',
+          provenanceKey: buildScopedMemoryProvenanceKey('a', 'semantic', retried, {
+            type: 'agent'
+          })
+        })
+        repo.archiveActiveMemory({ agentId: 'a', id: 'archived-twin', expectedRevision: 1 })
+      }
+      const candidates = [...prompt.matchAll(/^Candidate (\d+) /gmu)]
+      return JSON.stringify(
+        candidates.map((match) => ({
+          candidateIndex: Number(match[1]),
+          decision: 'UPDATE',
+          targetIndex: 0,
+          mergedContent: 'user prefers redis'
+        }))
+      )
+    })
+    const presenter = new MemoryService({
+      repository: repo,
+      auditRepository: auditRepo,
+      resolveAgentConfig: () => enabledConfig,
+      getEmbeddings: async (_p: string, _m: string, texts: string[]) =>
+        texts.map((text) => textToVector(text)),
+      getDimensions: embeddingDimensions,
+      generateText,
+      createVectorStore: async () => new FakeVectorStore(),
+      resetVectorStore: async () => undefined,
+      onMemoryChanged
+    })
+    targetId = await seedEmbedded(presenter, 'user likes redis')
+    vi.spyOn(repo, 'restoreArchivedMemory').mockImplementation(() => {
+      throw new Error('injected restore failure')
+    })
+
+    await expect(
+      presenter.extractAndStore({
+        agentId: 'a',
+        spanText: 'User: two facts, one of them about redis',
+        model: { providerId: 'main', modelId: 'main' },
+        sourceSession: 'session-1'
+      })
+    ).resolves.toEqual({ ok: false })
+
+    expect(decisionRounds).toBe(1)
+    expect(repo.listByAgent('a').some((row) => row.content === 'first durable fact')).toBe(true)
+    expect(onMemoryChanged).toHaveBeenCalledWith(
+      'a',
+      'extract',
+      expect.objectContaining({ sessionId: 'session-1' })
+    )
+    expect(auditRepo.listByAgent('a')).toContainEqual(
+      expect.objectContaining({
+        event_type: 'memory/extract',
+        status: 'failed',
+        reason: 'partial-apply-failed'
       })
     )
   })

--- a/test/main/memory/writeCoordinator.test.ts
+++ b/test/main/memory/writeCoordinator.test.ts
@@ -13,7 +13,7 @@ import {
   makePresenter,
   textToVector
 } from './support/memoryFakes'
-import { makeLLMPresenter, routedLLM, seedEmbedded } from './serviceTestSupport'
+import { decisionCalls, makeLLMPresenter, routedLLM, seedEmbedded } from './serviceTestSupport'
 
 import { MemoryService, embeddingDimensions, waitForMemoryCondition } from './serviceTestSupport'
 
@@ -1225,6 +1225,26 @@ describe('rememberMemory decision-ring contracts', () => {
     expect(repo.getById(createdId)?.source_session).toBe('session-1')
   })
 
+  it('fails closed when the journal boundary throws on the decision ring', async () => {
+    const generateText = routedLLM({ decision: addDecision })
+    const { presenter, repo } = makeLLMPresenter(generateText)
+    await seedEmbedded(presenter, 'user likes redis')
+    const journalError = new Error('journal unavailable')
+
+    await expect(
+      presenter.rememberMemory(
+        { kind: 'semantic', content: 'user prefers redis for caching' },
+        { agentId: 'a' },
+        model,
+        () => {
+          throw journalError
+        }
+      )
+    ).rejects.toBe(journalError)
+
+    expect(repo.countByAgent('a')).toBe(1)
+  })
+
   it('SUPERSEDE keeps the superseded claim and records the derivation edge', async () => {
     const generateText = routedLLM({
       decision: '{"decision":"SUPERSEDE","targetIndex":0,"mergedContent":"user moved to Shanghai"}'
@@ -1253,15 +1273,16 @@ describe('rememberMemory decision-ring contracts', () => {
     ])
   })
 
-  it('extractAndStore reports a forgotten candidate as a no-op without recreating the claim', async () => {
+  it('extractAndStore settles a forgotten candidate before recall or the decision model', async () => {
     const content = 'user prefers explicit recovery'
     const generateText = routedLLM({
       extraction: `[{"kind":"semantic","content":"${content}","importance":0.8}]`,
       decision: addDecision
     })
-    const { presenter, repo } = makeLLMPresenter(generateText)
+    const { presenter, repo, getEmbeddings } = makeLLMPresenter(generateText)
     const forgottenId = await seedEmbedded(presenter, content)
     await presenter.deleteMemory('a', forgottenId)
+    getEmbeddings.mockClear()
 
     const result = await presenter.extractAndStore({
       agentId: 'a',
@@ -1271,5 +1292,43 @@ describe('rememberMemory decision-ring contracts', () => {
 
     expect(result).toEqual({ ok: true, createdIds: [] })
     expect(repo.countByAgent('a')).toBe(0)
+    expect(decisionCalls(generateText)).toBe(0)
+    expect(getEmbeddings).not.toHaveBeenCalled()
+  })
+
+  it('reuses the query vector instead of re-embedding when a stale decision is retried', async () => {
+    let targetId = ''
+    let decisionCallCount = 0
+    const generateText = vi.fn(async (_providerId: string, _modelId: string, prompt: string) => {
+      if (!prompt.includes('Choose exactly ONE decision')) return ''
+      decisionCallCount += 1
+      if (decisionCallCount === 1) {
+        // Another writer bumps the target revision while the model is deciding.
+        repo.updateUserMetadataIfRevision({
+          agentId: 'a',
+          id: targetId,
+          expectedRevision: repo.getById(targetId)!.decision_revision,
+          importance: 0.7
+        })
+      }
+      return '{"decision":"UPDATE","targetIndex":0,"mergedContent":"user prefers redis"}'
+    })
+    const { presenter, repo, getEmbeddings } = makeLLMPresenter(generateText)
+    targetId = await seedEmbedded(presenter, 'user likes redis')
+    getEmbeddings.mockClear()
+
+    const outcome = await presenter.rememberMemory(
+      { kind: 'semantic', content: 'user changed redis preference' },
+      { agentId: 'a' },
+      model
+    )
+
+    expect(outcome).toEqual({ action: 'updated', id: targetId })
+    expect(decisionCallCount).toBe(2)
+    const candidateEmbeddingCalls = getEmbeddings.mock.calls.filter(([, , texts]) =>
+      texts.includes('user changed redis preference')
+    )
+    expect(candidateEmbeddingCalls).toHaveLength(1)
+    expect(repo.getById(targetId)?.content).toBe('user prefers redis')
   })
 })

--- a/test/main/performance/memory/workloadBounds.perf.ts
+++ b/test/main/performance/memory/workloadBounds.perf.ts
@@ -191,7 +191,10 @@ describe('Agent Memory #28 bounded workloads', () => {
       const snapshot = observer.snapshot()
       expect(snapshot.counters.providerCalls).toBe(4)
       expect(snapshot.counters.providerCalls).toBeLessThanOrEqual(5)
-      expect(snapshot.counters.repositoryCalls).toBeLessThanOrEqual(64)
+      // Per unowned candidate: two provenance reads while preparing, one tombstone lookup before
+      // recall, the keyword search, then two provenance reads, the insert and its transaction
+      // when applying; the remainder is the fixed per-batch bookkeeping.
+      expect(snapshot.counters.repositoryCalls).toBeLessThanOrEqual(72)
       expect(snapshot.counters.materializedRows).toBeLessThanOrEqual(72)
     } finally {
       await presenter.dispose()


### PR DESCRIPTION
## Summary

This PR restructures the write, recall and maintenance services of the memory system without changing any schema, migration, Tape fact or anchor name. `rememberMemory` and extraction now share one decision kernel instead of two implementations that had drifted apart; `retrieve` is split into keyword, vector, refill and prune stages over one per-request state; the heavy maintenance steps are an ordered pass table under a scheduler that only owns cooldown, fence, concurrency, budget and audit; the query-embedding breaker is its own class; claim ownership is classified in one place; and three `MemoryService` self-loops in the wiring are gone. Two defects found while reviewing the result are fixed with regression tests. The behavior changes that fall out of the merge are listed below.

## What was wrong

**Two write paths had drifted.** `coordinateWriteAttempt` (single remember) and `coordinateBatchWrites` (extraction) implemented the same provenance, tombstone, recall, decision and apply sequence separately. Only the single path checked the tombstone before recall, so a forgotten candidate in an extraction batch still paid for neighbor recall and a decision call. The single path retried a CAS loss by re-running recall and the decision model; the batch path reused its query vectors. The single path recalled neighbors through the injection path, so the warm-recall breaker that exists to protect first-token latency also gated background writes, and every remember ran the adaptive refill loop for three neighbors.

**Six sites composed the same ownership judgment.** `resolveProvenance`, `handleProvenanceHit`, `supersedeHead` and the challenged/live head checks were spelled out inline six times with different flag combinations, and the response to each state (restore an archived owner, fold temporal metadata into a duplicate, leave suppressed and challenged chains alone) was repeated four more times.

**`retrieve` was one 450-line function.** Keyword search, the breaker-guarded vector stage, the adaptive refill loop with authoritative revalidation, inline vector pruning, fusion and the cancelled/failed classification shared closures and repeated the fence-plus-read-epoch check six times. The breaker itself was two maps and eight private methods on the service and leaked its in-flight entry to callers.

**The maintenance scheduler and its steps were one function.** `runConsolidationPassInternal` spelled out challenge, merge, reflection and persona inline, each with its own try/catch, stat accounting, touched flag, fence check and audit write.

**The facade sat inside the graph it composes.** `EmbeddingPipeline` reached its own reindex/backfill and `MaintenanceService` reached its own consolidation pass through `MemoryService` lambdas, so the timer callback depended on a facade method staying a pass-through.

## What changed

- `coordinateBatchWrites` is the only decision kernel. A remember is a one-candidate batch carrying its dispatch-commit callback in a `WriteContext`. Provenance-settled candidates (archived, duplicate, suppressed, challenged, forgotten) apply synchronously before any provider round trip can age their owner snapshot; unowned candidates check the tombstone before recall; the rest go through `retrieveForDecisions`, one batch decision call, apply, and one bounded retry that reuses query vectors. The commit boundary fires outside every store transaction right before the first row write, which matters because memory and Tape share one SQLite connection and the Execution Journal refuses to commit inside a host transaction. `coordinateWrite`, `retrieveForDecision` and the dead `allowInsert` / `excludeConflictParticipants` switches are removed.
- `MemoryRowMutations.resolveClaimOwnership` / `classifyClaimOwner` return a `ClaimOwnership` union (`unowned`, `archived`, `duplicate`, `suppressed`, `challenged`, `superseded`) and every write site switches on it; `settleOwnedClaim` is the single response to an owned claim and `isForgottenClaim` the single tombstone lookup. `supersedeHead` and `handleProvenanceHit` are private again. The live-target and challenged-head predicates live in `domain/stateModel`.
- `RetrievalService.retrieve` orchestrates `recallVectorCandidates`, `refillCandidates` and `pruneStaleVectors` over a `RecallState` literal; cancellation points, degradation causes and latency accounting are unchanged, and the candidate counts reported on a cancelled recall reflect the last completed round. `QueryEmbeddingCircuitBreaker` (`infra/queryEmbeddingCircuit.ts`) owns the breaker and exposes `start`, `state`, `reset`, `clear`. `retrieveForDecisions` embeds the query only once the vector store is available and has a ready certificate.
- `MaintenanceService` runs `heavyPasses` (challenge, merge, reflection, persona) in order under one budget; each pass returns a uniform step result and is fenced independently. Pass audits go through a fail-open helper so a failed audit insert cannot erase a step's LLM accounting.
- `EmbeddingPipeline` and `MaintenanceService` call their own methods directly; the scheduling tests observe the owner instead of the facade.
- Review fix: the retry-phase settle loop had no failure accounting, so a store error while restoring an archived owner escaped the kernel and skipped the failed audit, the domain-mutation mark and finalization for candidates already written in the same batch. Both preparation passes now run through `settleImmediateCandidates` with the same accounting as apply.
- Review fix: moving the reflection and persona audit writes into their passes meant an audit insert failure dropped the step's call counts and could classify a successful reflection next to a failed merge as all-steps-failed, rolling back the watermark and arming the failure cooldown.

## Behavior changes

- The dispatch commit for the `memory_remember` tool moves from before neighbor recall to right before the first row write, after recall and the decision call. A remember that ends in a NOOP or no-neighbor retry no longer commits a dispatch it never executed. An already-aborted tool call may spend one recall and one decision round before the abort surfaces; the result is discarded.
- Single remembers use the batch decision prompt with one candidate and the batch neighbor recall, so they no longer pass through the warm-recall breaker or the adaptive refill loop.
- A forgotten candidate in an extraction batch costs no embedding or decision call.
- On a cold vector store, decision recall does not embed the query, so a CAS retry in that window stays FTS-only where it previously reused a vector the first round had computed anyway.
- A failure while preparing an extraction batch records the failed `memory/extract` audit and finalizes already-written candidates, the same as a failure during apply.
- `casRetries` counts retried decisions only; a retried candidate that settles on provenance is not a retry.
- Failed heavy maintenance passes log as `<step> pass failed`.

## Docs

No changes. `docs/architecture/memory-system.md` already states the contracts this PR keeps: tombstone lookup inside the insert transaction, breaker scope limited to injection recall, commit boundary outside store transactions, supersede with a derivation edge, and the stop/drain/start maintenance sequence.

## Verification

- `pnpm run format:check`, `pnpm run lint`, `pnpm run i18n`, `pnpm run typecheck`
- `pnpm run test:memory`: 54 files, 928 tests. Six new tests pin the contracts the merge must keep (a forgotten claim never reaches recall, the decision model or the dispatch commit; the commit fires once before the first row write and propagates a journal failure; SUPERSEDE keeps the old claim and its derivation edge; a forgotten extraction candidate settles before recall; a CAS retry reuses its query vector). Two regression tests cover the review fixes and fail with their fix reverted.
- Tape layer boundaries, DeepChat memory coordinator, memory tools and contract suites: 8 files, 143 tests
- `pnpm run test:memory:eval`: 6 tests
- Native memory suites ran their non-gated tests (118 of 334); the SQLite/DuckDB-gated tests need a native rebuild and this PR does not touch the data layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added resilient query processing with request deduplication, concurrency controls, cancellation handling, and recovery after provider failures.
  - Improved memory-claim handling for archived, duplicate, suppressed, challenged, and superseded content.
  - Added more consistent batch decision processing and ownership resolution.

- **Bug Fixes**
  - Improved handling of partial write failures so completed changes are preserved.
  - Preserved maintenance and reflection accounting when individual operations fail.
  - Improved stale or missing embedding recovery during vector-store maintenance.

- **Tests**
  - Expanded coverage for memory extraction, decision processing, embedding recovery, and maintenance failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->