### PR TITLE
feat(skills): discover workspace skills

### DIFF
--- a/docs/architecture/shared-skills/spec.md
+++ b/docs/architecture/shared-skills/spec.md
@@ -17,6 +17,12 @@ DeepChat stores each mutable Skill package once under the global Skills root. A 
 a logical binding to a Skill; no Agent-owned copy or generated link is created. Read-only bundled
 and Plugin-owned Skills stay in their provider roots but appear in the same global list.
 
+[Project Skills](../../features/project-skills/spec.md) are a separate, request-scoped overlay on this
+shared library. They are discovered from the selected workspace, can shadow shared names within
+that workspace, and have no shared assignment or extension state. They are excluded from global
+management, import/export, and deletion. Materialized project sources use default runtime settings
+and cannot inherit credentials from a same-named shared binding.
+
 The renderer exposes only:
 
 - `Skills` for the global list;

--- a/docs/features/project-skills/plan.md
+++ b/docs/features/project-skills/plan.md
@@ -8,7 +8,7 @@
 - [x] Add focused regression protection after implementation; run format, i18n, lint, typecheck,
       and relevant main/renderer suites.
 
-Validation: format, i18n, lint, and main/renderer type checks pass. The selected main suites pass
-677 tests (2 skipped); the selected renderer suites pass 17 tests. Regression coverage includes
+Validation: format, i18n, lint, and main/renderer type checks pass. The full main suite passes
+8531 tests (493 skipped); the selected renderer suites pass 17 tests. Regression coverage includes
 workspace discovery, precedence, unsafe paths, content and credential isolation, session selection,
 shared deletion, and stale composer responses.

--- a/docs/features/project-skills/plan.md
+++ b/docs/features/project-skills/plan.md
@@ -9,6 +9,7 @@
       and relevant main/renderer suites.
 
 Validation: format, i18n, lint, and main/renderer type checks pass. The full main suite passes
-8531 tests (493 skipped); the selected renderer suites pass 17 tests. Regression coverage includes
+8533 tests (493 skipped); the targeted composer suites pass 9 tests. Regression coverage includes
 workspace discovery, precedence, unsafe paths, content and credential isolation, session selection,
-shared deletion, and stale composer responses.
+shared deletion, stale composer responses, focus refresh coalescing, route path validation, and
+project catalog overflow degradation.

--- a/docs/features/project-skills/plan.md
+++ b/docs/features/project-skills/plan.md
@@ -1,0 +1,14 @@
+# Project Skills Implementation
+
+- [x] Add scoped project discovery, catalog composition, and source identity in SkillService.
+- [x] Carry session scope through runtime listing, validation, materialization, and execution.
+- [x] Share the workspace catalog between composer picker and slash suggestions; handle refresh
+      and stale responses without changing layout.
+- [x] Review precedence, isolation, filesystem boundaries, and existing behavior against spec.md.
+- [x] Add focused regression protection after implementation; run format, i18n, lint, typecheck,
+      and relevant main/renderer suites.
+
+Validation: format, i18n, lint, and main/renderer type checks pass. The selected main suites pass
+677 tests (2 skipped); the selected renderer suites pass 17 tests. Regression coverage includes
+workspace discovery, precedence, unsafe paths, content and credential isolation, session selection,
+shared deletion, and stale composer responses.

--- a/docs/features/project-skills/spec.md
+++ b/docs/features/project-skills/spec.md
@@ -1,0 +1,51 @@
+# Project Skills
+
+## Contract
+
+DeepChat discovers skills in the current workspace without importing them into the shared skill
+library. Composer suggestions, the skill picker, system prompt routing, `skill_list`, `skill_view`,
+active skill validation, and execution snapshots use the same workspace scope. Sessions without a
+project keep their existing behavior. ACP agents continue to own their external command catalogs.
+
+## Discovery and precedence
+
+Only the selected workspace is searched, under `.agents/skills`, `.deepchat/skills`, `.claude/skills`,
+`.codex/skills`, and `.cursor/skills`, in that order. The existing SKILL.md parser and bounded folder
+traversal are reused. No ancestor search, arbitrary repository crawl, or external-agent import occurs.
+Missing roots and malformed skills are skipped. Symbolic links cannot escape the selected workspace
+or a skill package. The first project skill with a given name wins; project skills override shared
+skills of the same name within that workspace only.
+
+Project catalogs are read on workspace selection, window focus, and runtime resolution. Requests
+carry explicit scope; no process-wide current project is mutated. Late UI responses cannot replace
+the catalog for another workspace. Project skills are never added to global assignments, exported,
+uninstalled, or edited by skill-management operations. Switching workspace clears pending composer
+skill selection.
+
+## Ownership and interfaces
+
+SkillService owns discovery and composition. Its catalog APIs accept optional workspace context;
+runtime callers pass a session ID and resolve the persisted project directory through the main
+process session port. The renderer catalog route accepts an optional absolute workspace path for
+composers that do not yet have a session. ChatInputBox shares useSkillsData's effective catalog with
+both the picker and slash suggestions. Existing IPC and presentation primitives remain in place.
+
+A project skill carries its project root and `project` source type. Its immutable materialization
+records its actual skill root, content, and script package using existing Tape contracts. Project
+skills use default runtime configuration and never inherit a same-named shared skill's environment,
+script overrides, or plugin ownership. Existing execution permission checks remain authoritative.
+
+## Acceptance
+
+- A valid project SKILL.md appears in both composer entry points and can be selected and loaded.
+- Two workspaces may contain different skills with the same name without mixing content.
+- A project skill can override a shared name without changing shared assignments or credentials.
+- Runtime routing, skill views, support files, and script snapshots resolve the project source.
+- Removing a skill or changing workspace is reflected on refresh; malformed files and escaping
+  symlinks do not expose arbitrary files or prevent valid skills from being listed.
+- Global skill management and sessions without a workspace retain their existing behavior.
+
+## Non-goals
+
+Recursive ancestor discovery, additional settings, project skill editing/import/export, and new
+filesystem watchers are outside this capability.

--- a/docs/features/project-skills/spec.md
+++ b/docs/features/project-skills/spec.md
@@ -16,7 +16,8 @@ Missing roots and malformed skills are skipped. Symbolic links cannot escape the
 or a skill package. The first project skill with a given name wins; project skills override shared
 skills of the same name within that workspace only.
 
-Project catalogs are read on workspace selection, window focus, and runtime resolution. Requests
+Project catalogs are read on workspace selection, window focus, and runtime resolution. Focus events
+reuse an in-flight refresh within a composer; later focus events trigger a fresh request. Requests
 carry explicit scope; no process-wide current project is mutated. Late UI responses cannot replace
 the catalog for another workspace. Project skills are never added to global assignments, exported,
 uninstalled, or edited by skill-management operations. Switching workspace clears pending composer
@@ -34,6 +35,8 @@ A project skill carries its project root and `project` source type. Its immutabl
 records its actual skill root, content, and script package using existing Tape contracts. Project
 skills use default runtime configuration and never inherit a same-named shared skill's environment,
 script overrides, or plugin ownership. Existing execution permission checks remain authoritative.
+Shared and project sources both compare manifest bytes before and after execution-package capture;
+a change during capture rejects materialization. Project catalogs have no persistent cache identity.
 
 ## Acceptance
 

--- a/src/main/agent/deepchat/resources/systemPromptBuilder.ts
+++ b/src/main/agent/deepchat/resources/systemPromptBuilder.ts
@@ -197,7 +197,7 @@ export async function buildSystemPromptAssemblyWithSkills(
   if (skillsEnabled) {
     const metadataStartedAt = Date.now()
     try {
-      const metadataList = sessionAgentId ? await skillService.getMetadataList(sessionAgentId) : []
+      const metadataList = sessionAgentId ? await skillService.getMetadataList(sessionAgentId, { conversationId: sessionId }) : []
       for (const metadata of metadataList) {
         const skillName = metadata?.name?.trim()
         if (skillName) {

--- a/src/main/agent/deepchat/runtime/skillContextMaterializer.ts
+++ b/src/main/agent/deepchat/runtime/skillContextMaterializer.ts
@@ -284,7 +284,8 @@ export class SkillContextMaterializer {
     }
     const resolutions = await this.dependencies.skills.resolveFreshEffectiveSkillContents(
       agentId,
-      ordered.map(({ name }) => name)
+      ordered.map(({ name }) => name),
+      { conversationId: sessionId }
     )
     if (resolutions.length !== ordered.length) {
       throw new Error('Fresh Skill resolution count did not match the request.')

--- a/src/main/agent/deepchat/runtime/toolResolver.ts
+++ b/src/main/agent/deepchat/runtime/toolResolver.ts
@@ -58,6 +58,7 @@ type ToolResolverSkillPort = Pick<
   | 'snapshotPersistedActiveSkillNames'
   | 'revalidateActiveSkillsForAgent'
   | 'validateSkillNames'
+  | 'getMetadataList'
 > &
   SkillMetadataSnapshotPort
 
@@ -373,9 +374,11 @@ export class DeepChatToolResolver {
 
     if (skillsEnabled) {
       try {
-        const metadataSnapshot = this.dependencies.skillService.snapshotCachedMetadataList(agentId, {
-          maxItems: MAX_RUN_TOOL_UNIVERSE_SKILLS
-        })
+        const metadataSnapshot = projectDir?.trim()
+          ? { state: 'ready' as const, skills: await this.dependencies.skillService.getMetadataList(agentId, { conversationId: sessionId }) }
+          : this.dependencies.skillService.snapshotCachedMetadataList(agentId, {
+              maxItems: MAX_RUN_TOOL_UNIVERSE_SKILLS
+            })
         if (metadataSnapshot.state === 'unavailable') {
           throw new Error('Skill metadata catalog has not been discovered.')
         }
@@ -769,7 +772,8 @@ export class DeepChatToolResolver {
             : await this.validateSkillNamesForAgent(
                 scopedAgentId,
                 requestedActiveSkillNames,
-                failClosed
+                failClosed,
+                sessionId
               )
         const profile = this.resolveToolProfile(
           sessionId,
@@ -1056,13 +1060,14 @@ export class DeepChatToolResolver {
       resourceInstance?.getAgentId()?.trim() ||
       this.dependencies.identity.getAgentId(sessionId)?.trim() ||
       null
-    return await this.validateSkillNamesForAgent(agentId, skillNames)
+    return await this.validateSkillNamesForAgent(agentId, skillNames, false, sessionId)
   }
 
   private async validateSkillNamesForAgent(
     agentId: string | null,
     skillNames: string[],
-    failClosed = false
+    failClosed = false,
+    conversationId?: string
   ): Promise<string[]> {
     const normalizedSkillNames = normalizeStringList(skillNames)
     if (!agentId || !this.dependencies.skillSettings.isEnabled()) {
@@ -1078,7 +1083,7 @@ export class DeepChatToolResolver {
 
     try {
       const validatedSkillNames = normalizeStringList(
-        await this.dependencies.skillService.validateSkillNames(agentId, normalizedSkillNames)
+        await this.dependencies.skillService.validateSkillNames(agentId, normalizedSkillNames, { conversationId })
       )
       if (
         failClosed &&

--- a/src/main/app/composition.ts
+++ b/src/main/app/composition.ts
@@ -1455,6 +1455,8 @@ export async function createMainProcessControl(dependencies: {
           })),
       getSessionAgentId: async (sessionId) =>
         (await sessionQuery.getSession(sessionId))?.agentId ?? null,
+      getSessionProjectDir: async (sessionId) =>
+        (await sessionQuery.getSession(sessionId))?.projectDir ?? null,
       listSessions: async () =>
         (await sessionQuery.listSessions({ includeSubagents: true })).map((session) => ({
           id: session.id,

--- a/src/main/skill/index.ts
+++ b/src/main/skill/index.ts
@@ -2003,6 +2003,7 @@ export class SkillService implements SkillServicePort {
         )
       : undefined
     if (freshManifestBytes) {
+      // Both shared and project Skills must keep identical manifest bytes during package capture.
       const confirmedManifestBytes = await this.readStableRegularFile(
         confinedSkillPath,
         SKILL_CONFIG.SKILL_FILE_MAX_SIZE

--- a/src/main/skill/index.ts
+++ b/src/main/skill/index.ts
@@ -19,6 +19,7 @@ import {
 import {
   SkillServicePort,
   SkillMetadata,
+  SkillCatalogScope,
   SkillContent,
   SkillInstallResult,
   SkillFolderNode,
@@ -209,6 +210,7 @@ export interface SkillAgentScopePort {
     Array<{ id: string; enabledSkillNames?: string[] | null; protected?: boolean }>
   >
   getSessionAgentId(sessionId: string): Promise<string | null>
+  getSessionProjectDir?(sessionId: string): Promise<string | null>
   listSessions(): Promise<Array<{ id: string; agentId: string }>>
 }
 
@@ -1235,6 +1237,8 @@ export class SkillService implements SkillServicePort {
         return null
       }
 
+      const stats = await fs.promises.stat(confinedSkillPath)
+      if (!stats.isFile() || stats.size > SKILL_CONFIG.SKILL_FILE_MAX_SIZE) return null
       const content = await fs.promises.readFile(confinedSkillPath, 'utf-8')
       const { data } = matter(content)
 
@@ -1288,15 +1292,46 @@ export class SkillService implements SkillServicePort {
     }
   }
 
-  /**
-   * Get list of all skill metadata (from cache)
-   * Uses discoveryPromise pattern to prevent race conditions
-   */
-  async getMetadataList(agentId: string = BUILTIN_SKILL_AGENT_ID): Promise<SkillMetadata[]> {
+  /** Compose shared metadata with fresh workspace skills without changing the shared cache. */
+  private async getScopedCatalog(
+    agentId: string,
+    scope?: SkillCatalogScope
+  ): Promise<Map<string, SkillMetadata>> {
+    await this.ensureAgentCatalogDiscovered(agentId)
+    const workspacePath = scope?.conversationId
+      ? await this.agentScopePort?.getSessionProjectDir?.(scope.conversationId)
+      : scope?.workspacePath
+    if (!workspacePath?.trim()) return this.getMetadataCacheForAgent(agentId)
+    if (!path.isAbsolute(workspacePath) || workspacePath.includes('\0')) {
+      throw new Error('Skill workspace path must be absolute')
+    }
+    const projectRoot = path.resolve(workspacePath)
+    const projectSkills = new Map<string, SkillMetadata>()
+    for (const directory of ['.agents', '.deepchat', '.claude', '.codex', '.cursor']) {
+      const root = path.join(projectRoot, directory, 'skills')
+      if (!(await this.pathExists(root))) continue
+      if (!(await this.resolvePhysicalSkillPath(projectRoot, root))) continue
+      for (const metadata of await this.discoverSkillsOnMainThread(root)) {
+        if (projectSkills.has(metadata.name)) continue
+        if (!(await this.resolvePhysicalSkillPath(projectRoot, metadata.path))) continue
+        projectSkills.set(metadata.name, { ...metadata, projectRoot })
+      }
+    }
+    // Request-local overlay: one conversation must never mutate another's catalog.
+    return new Map([...this.getMetadataCacheForAgent(agentId), ...projectSkills])
+  }
+
+  async getMetadataList(
+    agentId: string = BUILTIN_SKILL_AGENT_ID,
+    scope?: SkillCatalogScope
+  ): Promise<SkillMetadata[]> {
     const normalizedAgentId = await this.requireAgentScope(agentId)
     await this.ensureAgentCatalogDiscovered(normalizedAgentId)
     await this.ensureAgentBindingsInitialized(normalizedAgentId)
-    return this.getVisibleMetadataFromCache(normalizedAgentId)
+    const catalog = await this.getScopedCatalog(normalizedAgentId, scope)
+    return this.sortSkillMetadata(
+      Array.from(catalog.values()).filter((skill) => this.isSkillVisible(skill, normalizedAgentId))
+    )
   }
 
   /**
@@ -1340,7 +1375,10 @@ export class SkillService implements SkillServicePort {
   }
 
   private isSkillVisible(metadata: SkillMetadata, agentId: string): boolean {
-    return Boolean(metadata) && this.isSkillAssigned(agentId, metadata.name)
+    return (
+      Boolean(metadata) &&
+      (Boolean(metadata.projectRoot) || this.isSkillAssigned(agentId, metadata.name))
+    )
   }
 
   private createDefaultManagementState(): SkillManagementState {
@@ -1787,15 +1825,17 @@ export class SkillService implements SkillServicePort {
   }
 
   async getUnifiedSkillCatalog(
-    agentId: string = BUILTIN_SKILL_AGENT_ID
+    agentId: string = BUILTIN_SKILL_AGENT_ID,
+    scope?: SkillCatalogScope
   ): Promise<UnifiedSkillItem[]> {
     const normalizedAgentId = await this.requireAgentScope(agentId)
     await this.ensureAgentCatalogDiscovered(normalizedAgentId)
     await this.ensureAgentBindingsInitialized(normalizedAgentId)
 
+    const catalog = await this.getScopedCatalog(normalizedAgentId, scope)
     const state = this.getStoredManagementState()
-    return this.sortSkillMetadata(Array.from(this.metadataCache.values()))
-      .filter((skill) => state.agents[normalizedAgentId]?.bindings[skill.name]?.assigned === true)
+    return this.sortSkillMetadata(Array.from(catalog.values()))
+      .filter((skill) => this.isSkillVisible(skill, normalizedAgentId))
       .map((skill) => this.toUnifiedSkillItem(skill, normalizedAgentId, state))
   }
 
@@ -1818,18 +1858,26 @@ export class SkillService implements SkillServicePort {
       .filter(([, agent]) => agent.bindings[skill.name]?.assigned === true)
       .map(([assignedAgentId]) => assignedAgentId)
       .sort((left, right) => left.localeCompare(right))
-    const assigned = state.agents[agentId]?.bindings[skill.name]?.assigned === true
+    const assigned =
+      Boolean(skill.projectRoot) || state.agents[agentId]?.bindings[skill.name]?.assigned === true
     return {
       ...skill,
       agentId,
-      canonicalPath: skill.readOnly || skill.ownerPluginId ? skill.skillRoot : item.canonicalPath,
-      sourceType: skill.readOnly || skill.ownerPluginId ? 'builtin' : item.source.type,
+      canonicalPath:
+        skill.projectRoot || skill.readOnly || skill.ownerPluginId
+          ? skill.skillRoot
+          : item.canonicalPath,
+      sourceType: skill.projectRoot
+        ? 'project'
+        : skill.readOnly || skill.ownerPluginId
+          ? 'builtin'
+          : item.source.type,
       assigned,
       assignedAgentIds: globalView ? assignedAgentIds : [],
       disabled: !assigned,
       deepchatDisabled: !assigned,
       agentLinks: {},
-      mutable: !skill.ownerPluginId && !skill.readOnly
+      mutable: !skill.projectRoot && !skill.ownerPluginId && !skill.readOnly
     }
   }
 
@@ -1889,6 +1937,12 @@ export class SkillService implements SkillServicePort {
     metadata: SkillMetadata,
     freshEvidence: boolean = false
   ): Promise<EffectiveSkillContentBuild | null> {
+    if (
+      metadata.projectRoot &&
+      !(await this.resolvePhysicalSkillPath(metadata.projectRoot, metadata.path))
+    ) {
+      return null
+    }
     const confinedSkillPath = await this.resolvePhysicalSkillPath(metadata.skillRoot, metadata.path)
     if (!confinedSkillPath) {
       logger.warn('[SkillService] Refusing to load a Skill manifest outside its physical root.', {
@@ -1997,11 +2051,12 @@ export class SkillService implements SkillServicePort {
 
   async resolveFreshEffectiveSkillContents(
     agentId: string,
-    names: readonly string[]
+    names: readonly string[],
+    scope?: SkillCatalogScope
   ): Promise<EffectiveSkillContentResolution[]> {
     const normalizedAgentId = await this.requireAgentScope(agentId)
     await this.ensureAgentCatalogDiscovered(normalizedAgentId)
-    const metadataCache = this.getMetadataCacheForAgent(normalizedAgentId)
+    const metadataCache = await this.getScopedCatalog(normalizedAgentId, scope)
 
     const resolutions: EffectiveSkillContentResolution[] = []
     let effectiveContentBytes = 0
@@ -2020,7 +2075,8 @@ export class SkillService implements SkillServicePort {
           throw new Error('manifest could not be loaded safely')
         }
         if (
-          metadataCache.get(name) !== metadata ||
+          (!metadata.projectRoot &&
+            this.getMetadataCacheForAgent(normalizedAgentId).get(name) !== metadata) ||
           !this.isSkillVisible(metadata, normalizedAgentId)
         ) {
           throw new Error('catalog changed while effective content was being resolved')
@@ -2036,7 +2092,8 @@ export class SkillService implements SkillServicePort {
           build
         )
         if (
-          metadataCache.get(name) !== metadata ||
+          (!metadata.projectRoot &&
+            this.getMetadataCacheForAgent(normalizedAgentId).get(name) !== metadata) ||
           !this.isSkillVisible(metadata, normalizedAgentId)
         ) {
           throw new Error('catalog changed while execution package was being snapshotted')
@@ -2380,7 +2437,9 @@ export class SkillService implements SkillServicePort {
       if (folded.has(key)) throw new Error(`execution package path collision: ${file.relativePath}`)
       folded.add(key)
     }
-    const runtimeSnapshot = await this.captureSkillRuntimeSnapshot(agentId, metadata.name)
+    const runtimeSnapshot = metadata.projectRoot
+      ? { extension: createDefaultSkillExtensionConfig(), environmentBindingId: null }
+      : await this.captureSkillRuntimeSnapshot(agentId, metadata.name)
     const scripts = discoveredScripts
       .map((script) => {
         const legacyRelativePath = script.relativePath.replaceAll('/', path.sep)
@@ -2400,7 +2459,8 @@ export class SkillService implements SkillServicePort {
           Buffer.from(right.relativePath, 'utf8')
         )
       )
-    this.assertCurrentSkillRuntimeSnapshot(agentId, metadata.name, runtimeSnapshot)
+    if (!metadata.projectRoot)
+      this.assertCurrentSkillRuntimeSnapshot(agentId, metadata.name, runtimeSnapshot)
     const executionPackage: EffectiveSkillExecutionPackage = {
       files,
       executables: scripts.map(({ relativePath, runtime, enabled }) => ({
@@ -2446,8 +2506,7 @@ export class SkillService implements SkillServicePort {
       | undefined,
     captureExecutionSnapshot: boolean
   ): Promise<RuntimeSkillViewResult> {
-    const metadataCache = this.getMetadataCacheForAgent(agentId)
-    await this.ensureAgentCatalogDiscovered(agentId)
+    const metadataCache = await this.getScopedCatalog(agentId, options)
 
     const metadata = metadataCache.get(name)
     const authorizedForRun = options?.activeSkillNames?.includes(name) === true
@@ -2552,7 +2611,7 @@ export class SkillService implements SkillServicePort {
         : undefined
       if (
         captureExecutionSnapshot &&
-        (metadataCache.get(name) !== metadata ||
+        ((!metadata.projectRoot && this.getMetadataCacheForAgent(agentId).get(name) !== metadata) ||
           (!authorizedForRun && !this.isSkillVisible(metadata, agentId)))
       ) {
         throw new Error('Skill catalog changed while its execution snapshot was being built')
@@ -2601,6 +2660,14 @@ export class SkillService implements SkillServicePort {
   ): RuntimeSkillContentIdentity {
     const state = this.getStoredManagementState()
     const item = state.skills[metadata.name] ?? this.createDefaultSkillItem(metadata.name)
+    if (metadata.projectRoot) {
+      return {
+        agentId,
+        sourceType: 'project',
+        sourceId: metadata.skillRoot,
+        skillName: metadata.name
+      }
+    }
     return {
       agentId,
       sourceType: metadata.readOnly ? 'builtin' : item.source.type,
@@ -4807,7 +4874,12 @@ export class SkillService implements SkillServicePort {
       this.invalidateSkillContent(name)
       for (const session of sessions) {
         const previous = previousSelections.get(session.id) ?? []
-        const next = previous.filter((skillName) => skillName !== name)
+        const scoped = previous.includes(name)
+          ? await this.getScopedCatalog(session.agentId, { conversationId: session.id })
+          : null
+        const next = scoped?.get(name)?.projectRoot
+          ? previous
+          : previous.filter((skillName) => skillName !== name)
         if (!this.areSkillListsEqual(previous, next))
           this.setPersistedNewSessionSkills(session.id, next)
       }
@@ -5295,9 +5367,15 @@ export class SkillService implements SkillServicePort {
     agentId: string,
     name: string,
     expectedBindingId: string | null,
-    expectedSourceId?: string
+    expectedSourceId?: string,
+    expectedSourceType?: SkillSourceType
   ): Promise<Record<string, string>> {
     const normalizedAgentId = await this.requireAgentScope(agentId)
+    if (expectedSourceType === 'project') {
+      if (expectedBindingId !== null)
+        throw new Error('Project Skills cannot use shared environment bindings')
+      return {}
+    }
     const ownerPluginId = this.getStoredManagementState().skills[name]?.ownerPluginId
     const userPluginRoot = path.join(
       app.getPath('userData'),
@@ -5468,7 +5546,9 @@ export class SkillService implements SkillServicePort {
       return []
     }
 
-    const extension = await this.getSkillExtensionForAgent(agentId, metadata.name)
+    const extension = metadata.projectRoot
+      ? createDefaultSkillExtensionConfig()
+      : await this.getSkillExtensionForAgent(agentId, metadata.name)
     const descriptors = (
       await this.collectScriptDescriptors(confinedScriptsDir, metadata.skillRoot)
     ).map((script) => {
@@ -5561,7 +5641,7 @@ export class SkillService implements SkillServicePort {
       const agentId = await this.resolveSessionAgentId(conversationId)
       if (!agentId) return []
       const skills = await this.loadNewSessionSkills(conversationId)
-      const validSkills = await this.validateSkillNames(agentId, skills)
+      const validSkills = await this.validateSkillNames(agentId, skills, { conversationId })
       if (this.retiredSessionSkillScopes.has(conversationId)) return []
       if (!this.areSkillListsEqual(validSkills, skills)) {
         this.setPersistedNewSessionSkills(conversationId, validSkills)
@@ -5623,7 +5703,9 @@ export class SkillService implements SkillServicePort {
       const isNewSession = await this.isNewAgentSession(conversationId)
       const agentId = await this.resolveSessionAgentId(conversationId)
       // Validate skill names against the owning Agent's catalog.
-      const validSkills = agentId ? await this.validateSkillNames(agentId, skills) : []
+      const validSkills = agentId
+        ? await this.validateSkillNames(agentId, skills, { conversationId })
+        : []
       if (this.retiredSessionSkillScopes.has(conversationId)) return []
       if (!isNewSession || !agentId) {
         this.warnLegacySkillRetired(conversationId)
@@ -5684,7 +5766,7 @@ export class SkillService implements SkillServicePort {
     return await this.runActiveSkillMutation(conversationId, async () => {
       if (this.retiredSessionSkillScopes.has(conversationId)) return []
       const persisted = this.getPersistedNewSessionSkills(conversationId)
-      const valid = await this.validateSkillNames(agentId, persisted)
+      const valid = await this.validateSkillNames(agentId, persisted, { conversationId })
       if (this.retiredSessionSkillScopes.has(conversationId)) return []
       if (!this.areSkillListsEqual(persisted, valid)) {
         this.setPersistedNewSessionSkills(conversationId, valid)
@@ -5697,16 +5779,21 @@ export class SkillService implements SkillServicePort {
    * Validate skill names against available skills
    */
   async validateSkillNames(names: string[]): Promise<string[]>
-  async validateSkillNames(agentId: string, names: string[]): Promise<string[]>
+  async validateSkillNames(
+    agentId: string,
+    names: string[],
+    scope?: SkillCatalogScope
+  ): Promise<string[]>
   async validateSkillNames(
     agentIdOrNames: string | string[],
-    maybeNames?: string[]
+    maybeNames?: string[],
+    scope?: SkillCatalogScope
   ): Promise<string[]> {
     const agentId = Array.isArray(agentIdOrNames)
       ? BUILTIN_SKILL_AGENT_ID
       : await this.requireAgentScope(agentIdOrNames)
     const names = Array.isArray(agentIdOrNames) ? agentIdOrNames : (maybeNames ?? [])
-    const available = await this.getMetadataList(agentId)
+    const available = await this.getMetadataList(agentId, scope)
     const availableNames = new Set(available.map((s) => s.name))
     const seen = new Set<string>()
     const validNames: string[] = []
@@ -5734,8 +5821,7 @@ export class SkillService implements SkillServicePort {
   ): Promise<string[]> {
     const agentId = await this.resolveSessionAgentId(conversationId)
     if (!agentId) return []
-    const metadataCache = this.getMetadataCacheForAgent(agentId)
-    await this.ensureAgentCatalogDiscovered(agentId)
+    const metadataCache = await this.getScopedCatalog(agentId, { conversationId })
 
     const activeSkills = activeSkillNamesOverride ?? (await this.getActiveSkills(conversationId))
     const allowedTools: Set<string> = new Set()

--- a/src/main/skill/routes.ts
+++ b/src/main/skill/routes.ts
@@ -115,7 +115,9 @@ export function createSkillRoutes(deps: {
       async (rawInput) => {
         const input = skillsListCatalogRoute.input.parse(rawInput)
         return skillsListCatalogRoute.output.parse({
-          skills: await skillService.getUnifiedSkillCatalog(input.agentId)
+          skills: await skillService.getUnifiedSkillCatalog(input.agentId, {
+            workspacePath: input.workspacePath
+          })
         })
       }
     ],

--- a/src/main/skill/skillExecutionAuthority.ts
+++ b/src/main/skill/skillExecutionAuthority.ts
@@ -202,7 +202,8 @@ export class SkillExecutionAuthorityResolver implements SkillExecutionAuthorityP
       before.payload.agentId,
       before.payload.skillName,
       before.payload.executionPackage.environmentBindingId,
-      before.payload.sourceId
+      before.payload.sourceId,
+      before.payload.sourceType
     )
     const current = this.readAuthority(request)
     assertReadAuthorityUnchanged(before, current)
@@ -229,7 +230,8 @@ export class SkillExecutionAuthorityResolver implements SkillExecutionAuthorityP
       before.payload.agentId,
       before.payload.skillName,
       before.payload.executionPackage.environmentBindingId,
-      before.payload.sourceId
+      before.payload.sourceId,
+      before.payload.sourceType
     )
     if (
       canonicalJsonStringifyData(environment) !== canonicalJsonStringifyData(authority.environment)

--- a/src/main/skill/skillTools.ts
+++ b/src/main/skill/skillTools.ts
@@ -39,7 +39,7 @@ export class SkillTools {
       return buildSkillListResult([], [], [], input)
     }
     const agentId = resolvedAgentId
-    const assignedSkills = await this.skillService.getMetadataList(agentId)
+    const assignedSkills = await this.skillService.getMetadataList(agentId, { conversationId })
     const allSkills = [...assignedSkills]
     if (activeSkillNames !== undefined) {
       const listedNames = new Set(allSkills.map((skill) => skill.name))

--- a/src/main/tool/agentTools/agentToolManager.ts
+++ b/src/main/tool/agentTools/agentToolManager.ts
@@ -25,6 +25,7 @@ import {
   SKILL_RUN_MAX_STDIN_CHARS,
   SKILL_RUN_MAX_TOTAL_ARGUMENT_CHARS,
   SKILL_RUNTIME_VIEW_RESULT_MAX_BYTES,
+  type SkillMetadata,
   type SkillManageResult
 } from '@shared/types/skill'
 import { isDocumentReadMime } from '@/file/mime'
@@ -2296,9 +2297,14 @@ export class AgentToolManager {
 
       ;[activeSkillNames, metadataList] = await Promise.all([
         activeSkillNamesOverride ?? skillService.getActiveSkills(conversationId),
-        activeSkillNamesOverride === undefined
-          ? skillService.getMetadataList(agentId)
-          : skillService.getAllSkills()
+        skillService.getMetadataList(agentId, { conversationId }).then(async (scoped) => {
+          if (activeSkillNamesOverride === undefined) return scoped
+          const byName = new Map<string, SkillMetadata>(
+            (await skillService.getAllSkills()).map((skill) => [skill.name, skill])
+          )
+          for (const skill of scoped) byName.set(skill.name, skill)
+          return Array.from(byName.values())
+        })
       ])
     } catch (error) {
       logger.warn('[AgentToolManager] Failed to resolve active skill roots', {

--- a/src/renderer/api/SkillClient.ts
+++ b/src/renderer/api/SkillClient.ts
@@ -60,8 +60,11 @@ export function createSkillClient(bridge: DeepchatBridge = getDeepchatBridge()) 
     return result.skills
   }
 
-  async function getUnifiedSkillCatalog(agentId: string = BUILTIN_SKILL_AGENT_ID) {
-    const result = await bridge.invoke(skillsListCatalogRoute.name, { agentId })
+  async function getUnifiedSkillCatalog(
+    agentId: string = BUILTIN_SKILL_AGENT_ID,
+    workspacePath?: string
+  ) {
+    const result = await bridge.invoke(skillsListCatalogRoute.name, { agentId, workspacePath })
     return result.skills
   }
 

--- a/src/renderer/src/components/chat-input/composables/useSkillsData.ts
+++ b/src/renderer/src/components/chat-input/composables/useSkillsData.ts
@@ -22,11 +22,17 @@ import { useSkillsStore } from '@/stores/skillsStore'
  */
 export function useSkillsData(
   conversationId: Ref<string | null> | ComputedRef<string | null>,
-  agentId: Ref<string | null> | ComputedRef<string | null>
+  agentId: Ref<string | null> | ComputedRef<string | null>,
+  workspacePath?: Ref<string | null> | ComputedRef<string | null>
 ) {
   const skillClient = createSkillClient()
   const skillsStore = useSkillsStore()
   let unsubscribeSkillSessionChanged: (() => void) | null = null
+  let unsubscribeCatalogChanged: (() => void) | null = null
+  let projectLoadSequence = 0
+  const projectSkills = ref<SkillMetadata[]>([])
+  const projectLoading = ref(false)
+  const normalizedWorkspacePath = computed(() => workspacePath?.value?.trim() || null)
   let activeSkillsLoadSequence = 0
   let activeSkillMutationSequence = 0
 
@@ -42,10 +48,15 @@ export function useSkillsData(
    * All available skills from the store
    */
   const skills = computed<SkillMetadata[]>(() =>
-    skillsStore.getSkillsForAgent(normalizedAgentId.value)
+    normalizedWorkspacePath.value
+      ? projectSkills.value
+      : skillsStore.getSkillsForAgent(normalizedAgentId.value)
   )
   const loading = computed(
-    () => sessionActiveSkillsLoading.value || skillsStore.isSkillsLoading(normalizedAgentId.value)
+    () =>
+      sessionActiveSkillsLoading.value ||
+      projectLoading.value ||
+      skillsStore.isSkillsLoading(normalizedAgentId.value)
   )
 
   /**
@@ -219,6 +230,27 @@ export function useSkillsData(
     }
   }
 
+  const refreshProjectSkills = async () => {
+    const sequence = ++projectLoadSequence
+    const requestedWorkspace = normalizedWorkspacePath.value
+    const requestedAgent = normalizedAgentId.value
+    if (!requestedWorkspace) {
+      projectSkills.value = []
+      projectLoading.value = false
+      return
+    }
+    projectLoading.value = true
+    try {
+      const catalog = await skillClient.getUnifiedSkillCatalog(requestedAgent, requestedWorkspace)
+      if (sequence === projectLoadSequence) projectSkills.value = catalog
+    } catch (error) {
+      if (sequence === projectLoadSequence) projectSkills.value = []
+      console.error('[useSkillsData] Failed to load project skills:', error)
+    } finally {
+      if (sequence === projectLoadSequence) projectLoading.value = false
+    }
+  }
+
   // === Watchers ===
   // Watch for conversation changes and reload active skills
   watch(
@@ -233,16 +265,21 @@ export function useSkillsData(
   )
 
   watch(
-    normalizedAgentId,
-    (nextAgentId, previousAgentId) => {
-      if (previousAgentId && previousAgentId !== nextAgentId) {
+    [normalizedAgentId, normalizedWorkspacePath],
+    ([nextAgentId, nextWorkspace], [previousAgentId, previousWorkspace]) => {
+      projectSkills.value = []
+      if (
+        previousAgentId &&
+        (previousAgentId !== nextAgentId || previousWorkspace !== nextWorkspace)
+      ) {
         pendingSkills.value = []
         activeSkillMutationSequence += 1
         sessionActiveSkills.value = []
         sessionActiveSkillRemoving.value = null
         void loadActiveSkills()
       }
-      void skillsStore.ensureSkillsLoaded(nextAgentId)
+      if (!nextWorkspace) void skillsStore.ensureSkillsLoaded(nextAgentId)
+      void refreshProjectSkills()
     },
     { immediate: true }
   )
@@ -250,9 +287,16 @@ export function useSkillsData(
   // === Lifecycle ===
   onMounted(() => {
     unsubscribeSkillSessionChanged = skillClient.onSessionChanged(handleSkillSessionChanged)
+    unsubscribeCatalogChanged = skillClient.onCatalogChanged(() => {
+      if (normalizedWorkspacePath.value) void refreshProjectSkills()
+    })
+    window.addEventListener('focus', refreshProjectSkills)
   })
 
   onUnmounted(() => {
+    projectLoadSequence += 1
+    unsubscribeCatalogChanged?.()
+    window.removeEventListener('focus', refreshProjectSkills)
     unsubscribeSkillSessionChanged?.()
     unsubscribeSkillSessionChanged = null
   })

--- a/src/renderer/src/components/chat-input/composables/useSkillsData.ts
+++ b/src/renderer/src/components/chat-input/composables/useSkillsData.ts
@@ -3,6 +3,7 @@ import { ref, computed, watch, onMounted, onUnmounted, type Ref, type ComputedRe
 
 // === Types ===
 import type { SkillMetadata } from '@shared/types/skill'
+import type { UnifiedSkillItem } from '@shared/types/skillManagement'
 
 // === Composables ===
 import { createSkillClient } from '@api/SkillClient'
@@ -30,7 +31,7 @@ export function useSkillsData(
   let unsubscribeSkillSessionChanged: (() => void) | null = null
   let unsubscribeCatalogChanged: (() => void) | null = null
   let projectLoadSequence = 0
-  const projectSkills = ref<SkillMetadata[]>([])
+  const projectSkills = ref<UnifiedSkillItem[]>([])
   const projectLoading = ref(false)
   const normalizedWorkspacePath = computed(() => workspacePath?.value?.trim() || null)
   let activeSkillsLoadSequence = 0
@@ -251,6 +252,10 @@ export function useSkillsData(
     }
   }
 
+  const handleWindowFocus = () => {
+    if (!projectLoading.value) void refreshProjectSkills()
+  }
+
   // === Watchers ===
   // Watch for conversation changes and reload active skills
   watch(
@@ -290,13 +295,13 @@ export function useSkillsData(
     unsubscribeCatalogChanged = skillClient.onCatalogChanged(() => {
       if (normalizedWorkspacePath.value) void refreshProjectSkills()
     })
-    window.addEventListener('focus', refreshProjectSkills)
+    window.addEventListener('focus', handleWindowFocus)
   })
 
   onUnmounted(() => {
     projectLoadSequence += 1
     unsubscribeCatalogChanged?.()
-    window.removeEventListener('focus', refreshProjectSkills)
+    window.removeEventListener('focus', handleWindowFocus)
     unsubscribeSkillSessionChanged?.()
     unsubscribeSkillSessionChanged = null
   })

--- a/src/renderer/src/components/chat/ChatInputBox.vue
+++ b/src/renderer/src/components/chat/ChatInputBox.vue
@@ -154,7 +154,11 @@ let editorInstance: Editor | null = null
 const getEditor = () => editorInstance
 const conversationId = computed(() => props.sessionId)
 const skillAgentId = computed(() => props.agentId?.trim() || 'deepchat')
-const skillsData = useSkillsData(conversationId, skillAgentId)
+const skillsData = useSkillsData(
+  conversationId,
+  skillAgentId,
+  computed(() => (props.isAcpSession ? null : props.workspacePath))
+)
 const activeSkillNames = computed(() => skillsData.composerActiveSkills.value)
 
 const removeSessionActiveSkill = async (skillName: string) => {
@@ -172,6 +176,7 @@ const removeSessionActiveSkill = async (skillName: string) => {
 }
 
 const mentions = useChatInputMentions({
+  skills: skillsData.skills,
   getEditor,
   workspacePath: computed(() => props.workspacePath),
   sessionId: computed(() => props.sessionId),

--- a/src/renderer/src/components/chat/composables/useChatInputMentions.ts
+++ b/src/renderer/src/components/chat/composables/useChatInputMentions.ts
@@ -26,7 +26,10 @@ import {
   type SlashSuggestionItem
 } from '../mentions/utils'
 
+import type { SkillMetadata } from '@shared/types/skill'
+
 export interface UseChatInputMentionsOptions {
+  skills?: Ref<SkillMetadata[]>
   getEditor: () => Editor | null
   workspacePath: Ref<string | null>
   sessionId: Ref<string | null>
@@ -204,7 +207,8 @@ export function useChatInputMentions(options: UseChatInputMentionsOptions) {
       })
     }
 
-    for (const skill of skillsStore.getSkillsForAgent(normalizedAgentId.value)) {
+    for (const skill of options.skills?.value ??
+      skillsStore.getSkillsForAgent(normalizedAgentId.value)) {
       items.push({
         id: `skill:${skill.name}`,
         category: 'skill',
@@ -535,7 +539,7 @@ export function useChatInputMentions(options: UseChatInputMentionsOptions) {
       if (previousAgentId && previousAgentId !== nextAgentId) {
         closeDialog()
       }
-      void skillsStore.ensureSkillsLoaded(nextAgentId)
+      if (!options.skills) void skillsStore.ensureSkillsLoaded(nextAgentId)
     },
     { immediate: true }
   )

--- a/src/shared/contracts/routes/skills.routes.ts
+++ b/src/shared/contracts/routes/skills.routes.ts
@@ -229,7 +229,14 @@ export const skillsListMetadataRoute = defineRouteContract({
 export const skillsListCatalogRoute = defineRouteContract({
   name: 'skills.listCatalog',
   input: AgentSkillScopeSchema.extend({
-    workspacePath: z.string().trim().min(1).max(4096).optional()
+    workspacePath: z
+      .string()
+      .trim()
+      .min(1)
+      .max(4096)
+      .regex(/^(?:\/|[A-Za-z]:[\\/]|\\\\)/, 'Workspace path must be absolute')
+      .refine((value) => !value.includes('\0'), 'Workspace path must not contain null bytes')
+      .optional()
   }),
   output: z.object({
     skills: z.array(UnifiedSkillItemSchema)

--- a/src/shared/contracts/routes/skills.routes.ts
+++ b/src/shared/contracts/routes/skills.routes.ts
@@ -56,7 +56,8 @@ export const PublicSkillSchema = z
       'url-install',
       'git-install',
       'adopted',
-      'imported'
+      'imported',
+      'project'
     ]),
     enabled: z.boolean(),
     mutable: z.boolean(),
@@ -227,7 +228,9 @@ export const skillsListMetadataRoute = defineRouteContract({
 
 export const skillsListCatalogRoute = defineRouteContract({
   name: 'skills.listCatalog',
-  input: AgentSkillScopeSchema,
+  input: AgentSkillScopeSchema.extend({
+    workspacePath: z.string().trim().min(1).max(4096).optional()
+  }),
   output: z.object({
     skills: z.array(UnifiedSkillItemSchema)
   })

--- a/src/shared/types/skill.ts
+++ b/src/shared/types/skill.ts
@@ -35,10 +35,13 @@ export const SKILL_RUN_MAX_TOTAL_ARGUMENT_CHARS = 24 * 1024
 export const SKILL_RUN_MAX_STDIN_CHARS = 1024 * 1024
 export const SKILL_RUN_MAX_OUTPUT_BYTES = 16 * 1024 * 1024
 
-/**
- * Skill metadata extracted from SKILL.md frontmatter.
- * Always kept in memory for quick access and semantic matching.
- */
+/** Explicit catalog context; persisted Session scope takes precedence over a composer path. */
+export interface SkillCatalogScope {
+  workspacePath?: string
+  conversationId?: string
+}
+
+/** Skill metadata extracted from SKILL.md frontmatter for discovery and semantic matching. */
 export interface SkillMetadata {
   /** Unique identifier (must match directory name) */
   name: string
@@ -48,6 +51,8 @@ export interface SkillMetadata {
   path: string
   /** Skill root directory path */
   skillRoot: string
+  /** Workspace owning a discovered project skill; never part of the shared library. */
+  projectRoot?: string
   /** Optional category path derived from nested folders under the skills root */
   category?: string | null
   /** Optional platform restrictions declared in SKILL.md */
@@ -376,9 +381,9 @@ export interface SkillServicePort {
   discoverSkills(agentId: string): Promise<SkillMetadata[]>
   refreshAgentCatalog(agentId: string): Promise<SkillMetadata[]>
   getMetadataList(): Promise<SkillMetadata[]>
-  getMetadataList(agentId: string): Promise<SkillMetadata[]>
+  getMetadataList(agentId: string, scope?: SkillCatalogScope): Promise<SkillMetadata[]>
   getUnifiedSkillCatalog(): Promise<UnifiedSkillItem[]>
-  getUnifiedSkillCatalog(agentId: string): Promise<UnifiedSkillItem[]>
+  getUnifiedSkillCatalog(agentId: string, scope?: SkillCatalogScope): Promise<UnifiedSkillItem[]>
   getAllSkills(): Promise<UnifiedSkillItem[]>
   getSkillManagementState(): Promise<SkillManagementState>
   setSkillDeepChatDisabled(name: string, disabled: boolean): Promise<void>
@@ -392,7 +397,8 @@ export interface SkillServicePort {
   loadSkillContent(agentId: string, name: string): Promise<SkillContent | null>
   resolveFreshEffectiveSkillContents(
     agentId: string,
-    names: readonly string[]
+    names: readonly string[],
+    scope?: SkillCatalogScope
   ): Promise<EffectiveSkillContentResolution[]>
   viewSkillForAgent(
     agentId: string,
@@ -509,7 +515,8 @@ export interface SkillServicePort {
     agentId: string,
     name: string,
     expectedBindingId: string | null,
-    expectedSourceId?: string
+    expectedSourceId?: string,
+    expectedSourceType?: SkillSourceType
   ): Promise<Record<string, string>>
   saveSkillExtension(name: string, config: SkillExtensionConfig): Promise<void>
   saveSkillExtensionForAgent(
@@ -530,7 +537,7 @@ export interface SkillServicePort {
   resolveSessionAgentId(conversationId: string): Promise<string | null>
   revalidateActiveSkillsForAgent(conversationId: string, agentId: string): Promise<string[]>
   validateSkillNames(names: string[]): Promise<string[]>
-  validateSkillNames(agentId: string, names: string[]): Promise<string[]>
+  validateSkillNames(agentId: string, names: string[], scope?: SkillCatalogScope): Promise<string[]>
 
   // Tool integration
   getActiveSkillsAllowedTools(

--- a/src/shared/types/skillManagement.ts
+++ b/src/shared/types/skillManagement.ts
@@ -8,7 +8,8 @@ export const SKILL_SOURCE_TYPES = [
   'url-install',
   'git-install',
   'adopted',
-  'imported'
+  'imported',
+  'project'
 ] as const
 
 export type SkillSourceType = (typeof SKILL_SOURCE_TYPES)[number]

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -7745,10 +7745,11 @@ describe('DeepChatAgentHarness', () => {
         activeSkills: ['owned-skill', 'foreign-skill']
       })
 
-      expect(skillService.validateSkillNames).toHaveBeenCalledWith('writer', [
-        'foreign-skill',
-        'owned-skill'
-      ])
+      expect(skillService.validateSkillNames).toHaveBeenCalledWith(
+        'writer',
+        ['foreign-skill', 'owned-skill'],
+        { conversationId: 's1' }
+      )
       const callArgs = (processStream as ReturnType<typeof vi.fn>).mock.calls[0][0]
       expect(callArgs.run.resources.activeSkillNames).toEqual(['owned-skill'])
       expect(callArgs.run.resources.materializedSkillContexts).toHaveLength(1)

--- a/test/main/agent/deepchat/runtime/skillContextMaterializer.test.ts
+++ b/test/main/agent/deepchat/runtime/skillContextMaterializer.test.ts
@@ -102,7 +102,7 @@ describe('SkillContextMaterializer', () => {
       'shared',
       'session-only',
       'message-only'
-    ])
+    ], { conversationId: 'session-1' })
     expect(prepared.items.map(({ scope }) => scope)).toEqual(['session', 'session', 'message'])
   })
 

--- a/test/main/agent/deepchat/runtime/toolResolver.test.ts
+++ b/test/main/agent/deepchat/runtime/toolResolver.test.ts
@@ -747,6 +747,7 @@ describe('DeepChatToolResolver Run definition universe', () => {
     const skillService = {
       getActiveSkills: vi.fn().mockResolvedValue(options?.activeSkills ?? []),
       snapshotPersistedActiveSkillNames: vi.fn(() => options?.activeSkills ?? []),
+      getMetadataList: vi.fn().mockResolvedValue(options?.metadata ?? []),
       snapshotCachedMetadataList: vi.fn(
         (_agentId: string, snapshotOptions: { maxItems: number }) =>
           (options?.metadata?.length ?? 0) > snapshotOptions.maxItems

--- a/test/main/agent/deepchat/runtime/toolResolver.test.ts
+++ b/test/main/agent/deepchat/runtime/toolResolver.test.ts
@@ -1073,7 +1073,7 @@ describe('DeepChatToolResolver Run definition universe', () => {
     })
   })
 
-  it('rejects an oversized Skill catalog without probing missing active Skills', async () => {
+  it.each([null, '/workspace'])('bounds Skill catalogs for projectDir=%s', async (projectDir) => {
     const metadata = Array.from({ length: MAX_RUN_TOOL_UNIVERSE_SKILLS + 1 }, (_, index) => ({
       name: `inactive-${index}`
     }))
@@ -1084,7 +1084,7 @@ describe('DeepChatToolResolver Run definition universe', () => {
 
     const result = await resolver.resolveRunToolDefinitionUniverse(
       'session-1',
-      null,
+      projectDir,
       undefined,
       resourceInstance as any
     )
@@ -1104,6 +1104,7 @@ describe('DeepChatToolResolver Run definition universe', () => {
         issueCodes: ['active-skill-metadata-not-admitted']
       }
     ])
+    expect(result.degradationCounts).toContainEqual({ code: 'skill-limit-exceeded', count: 1 })
     expect(result.degradationCounts).toContainEqual({
       code: 'active-skill-metadata-not-admitted',
       count: 1

--- a/test/main/routes/contracts.test.ts
+++ b/test/main/routes/contracts.test.ts
@@ -41,6 +41,7 @@ import {
   settingsUpdateCommandShellRoute,
   settingsListSystemFontsRoute,
   settingsUpdateRoute,
+  skillsListCatalogRoute,
   sessionsCreateRoute,
   sessionsDeactivateRoute,
   sessionsGetActiveRoute,
@@ -59,6 +60,33 @@ import {
 import { SessionGenerationSettingsPatchSchema } from '@shared/contracts/common'
 
 describe('main kernel contracts', () => {
+  it('accepts only absolute workspace paths for Skill catalogs across platforms', () => {
+    const schema = skillsListCatalogRoute.input
+    expect(schema.parse({ agentId: 'writer' })).toEqual({ agentId: 'writer' })
+    for (const workspacePath of [
+      '/workspace',
+      '/',
+      'C:/workspace',
+      String.raw`C:\workspace`,
+      String.raw`\\server\share`
+    ]) {
+      expect(
+        schema.parse({ agentId: 'writer', workspacePath: ` ${workspacePath} ` }).workspacePath
+      ).toBe(workspacePath)
+    }
+    for (const workspacePath of [
+      '',
+      'project',
+      '../project',
+      '~/project',
+      'C:project',
+      '/project\0',
+      `/${'a'.repeat(4096)}`
+    ]) {
+      expect(schema.safeParse({ agentId: 'writer', workspacePath }).success).toBe(false)
+    }
+  })
+
   it('preserves MCP binding identity and validates MCP App tool metadata', () => {
     expect(
       mcpSamplingRequestEvent.payload.parse({

--- a/test/main/skill/skillExecutionAuthority.test.ts
+++ b/test/main/skill/skillExecutionAuthority.test.ts
@@ -187,7 +187,8 @@ describe('SkillExecutionAuthorityResolver', () => {
         'agent-1',
         'review',
         BINDING_ID,
-        authority.identity.sourceId
+        authority.identity.sourceId,
+        authority.identity.sourceType
       )
     }
   )

--- a/test/main/skill/skillServiceSharedSkills.test.ts
+++ b/test/main/skill/skillServiceSharedSkills.test.ts
@@ -14,6 +14,7 @@ import type {
   StoredSkillManagementState
 } from '@shared/types/skillManagement'
 import { resolveAgentSkillsRoot } from '@/skill/agentSkillRoots'
+import { SkillTools } from '@/skill/skillTools'
 
 vi.unmock('fs')
 vi.unmock('node:fs')
@@ -32,7 +33,7 @@ describe('SkillService shared Skills', () => {
   let skillsRoot: string
   let storedState: StoredSkillManagementState | null
   let agents: Array<{ id: string; enabledSkillNames?: string[] | null; protected?: boolean }>
-  let sessions: Array<{ id: string; agentId: string }>
+  let sessions: Array<{ id: string; agentId: string; projectDir?: string }>
   let activeSkills: Map<string, string[]>
   let stateWriteFailuresRemaining: number
   let service: SkillService
@@ -95,6 +96,8 @@ describe('SkillService shared Skills', () => {
       listDeepChatAgents: async () => structuredClone(agents),
       getSessionAgentId: async (sessionId) =>
         sessions.find((session) => session.id === sessionId)?.agentId ?? null,
+      getSessionProjectDir: async (sessionId) =>
+        sessions.find((session) => session.id === sessionId)?.projectDir ?? null,
       listSessions: async () => structuredClone(sessions)
     }
     return new SkillService(settings, sessionState, watcherService, vi.fn(), agentScope)
@@ -128,6 +131,148 @@ describe('SkillService shared Skills', () => {
     getAppPathSpy.mockRestore()
     fs.rmSync(temporaryRoot, { recursive: true, force: true })
     vi.restoreAllMocks()
+  })
+
+  it('discovers workspace skills without importing them and skips unsafe or invalid manifests', async () => {
+    await migrate()
+    const workspacePath = path.join(temporaryRoot, 'project')
+    const directories = ['.agents', '.deepchat', '.claude', '.codex', '.cursor']
+    for (const directory of directories) {
+      writeSkill(path.join(workspacePath, directory, 'skills'), directory.slice(1), '# Local')
+    }
+    const root = path.join(workspacePath, '.agents', 'skills')
+    const invalid = writeSkill(root, 'invalid', '# Invalid')
+    fs.writeFileSync(path.join(invalid, 'SKILL.md'), 'Missing frontmatter')
+    const oversized = writeSkill(root, 'oversized', 'x'.repeat(6 * 1024 * 1024))
+    const outside = writeSkill(path.join(temporaryRoot, 'outside'), 'escaped', '# Outside')
+    fs.symlinkSync(outside, path.join(root, 'escaped'), 'dir')
+    const sharedBefore = await service.getAllSkills()
+    const stateBefore = structuredClone(storedState)
+
+    const catalog = await service.getUnifiedSkillCatalog('writer', { workspacePath })
+    expect(catalog.map((skill) => skill.name).sort()).toEqual(
+      directories.map((directory) => directory.slice(1)).sort()
+    )
+    expect(catalog.every((skill) => skill.sourceType === 'project' && !skill.mutable)).toBe(true)
+    expect(await service.getAllSkills()).toEqual(sharedBefore)
+    expect(storedState).toEqual(stateBefore)
+    await expect(
+      service.getMetadataList('writer', { workspacePath: '../project' })
+    ).rejects.toThrow('absolute')
+
+    fs.rmSync(path.join(workspacePath, '.claude', 'skills'), { recursive: true })
+    fs.symlinkSync(path.dirname(outside), path.join(workspacePath, '.claude', 'skills'), 'dir')
+    fs.rmSync(path.join(root, 'agents'), { recursive: true })
+    fs.rmSync(oversized, { recursive: true })
+    expect(
+      (await service.getMetadataList('writer', { workspacePath })).map((skill) => skill.name).sort()
+    ).toEqual(['codex', 'cursor', 'deepchat'])
+  })
+
+  it('resolves same-named project skills per session without shared runtime credentials', async () => {
+    const globalRoot = writeSkill(skillsRoot, 'review', '# Global review')
+    await migrate()
+    await service.setSkillAssignment('writer', 'review', true)
+    await service.saveSkillExtensionForAgent('writer', 'review', {
+      ...defaultExtension(),
+      env: { TOKEN: 'global-secret' },
+      scriptOverrides: { 'scripts/run.sh': { enabled: false } }
+    })
+    const projectA = path.join(temporaryRoot, 'project-a')
+    const projectB = path.join(temporaryRoot, 'project-b')
+    const rootA = writeSkill(path.join(projectA, '.agents', 'skills'), 'review', '# Project A')
+    const rootB = writeSkill(path.join(projectB, '.agents', 'skills'), 'review', '# Project B')
+    writeSkill(path.join(projectA, '.claude', 'skills'), 'review', '# Lower priority')
+    fs.mkdirSync(path.join(rootA, 'scripts'))
+    fs.writeFileSync(path.join(rootA, 'scripts/run.sh'), 'echo project-a')
+    fs.mkdirSync(path.join(rootA, 'references'))
+    fs.writeFileSync(path.join(rootA, 'references/guide.md'), 'Project A reference')
+    sessions = [
+      { id: 'a', agentId: 'writer', projectDir: projectA },
+      { id: 'b', agentId: 'writer', projectDir: projectB }
+    ]
+    const stateBefore = structuredClone(storedState)
+    const [a, b] = await Promise.all(
+      sessions.map((session) =>
+        service.resolveFreshEffectiveSkillContents('writer', ['review'], {
+          conversationId: session.id
+        })
+      )
+    )
+    expect(a[0].effectiveContent).toContain('# Project A')
+    expect(b[0].effectiveContent).toContain('# Project B')
+    expect(a[0].identity).toEqual({
+      agentId: 'writer',
+      skillName: 'review',
+      sourceType: 'project',
+      sourceId: rootA
+    })
+    expect(b[0].identity.sourceId).toBe(rootB)
+    expect(a[0].executionPackage.executables).toEqual([
+      { relativePath: 'scripts/run.sh', runtime: 'shell', enabled: true }
+    ])
+    expect(a[0].executionPackage.environmentBindingId).toBeNull()
+    expect(
+      await service.resolveSkillRuntimeEnvironmentBinding(
+        'writer',
+        'review',
+        null,
+        rootA,
+        'project'
+      )
+    ).toEqual({})
+    await expect(
+      service.resolveSkillRuntimeEnvironmentBinding(
+        'writer',
+        'review',
+        'shared-binding',
+        rootA,
+        'project'
+      )
+    ).rejects.toThrow('shared environment')
+    expect((await service.getUnifiedSkillCatalog('writer'))[0].skillRoot).toBe(globalRoot)
+    expect((await service.loadSkillContent('writer', 'review'))?.content).toContain(
+      '# Global review'
+    )
+    expect(storedState).toEqual(stateBefore)
+
+    const tools = new SkillTools(service)
+    const view = await tools.handleSkillView('a', { name: 'review' })
+    expect(view.content).toContain('# Project A')
+    expect(view.contentResolution?.identity.sourceType).toBe('project')
+    expect(
+      (await tools.handleSkillView('a', { name: 'review', file_path: 'references/guide.md' }))
+        .content
+    ).toBe('Project A reference')
+    expect(
+      (await tools.handleSkillView('b', { name: 'review', file_path: 'references/guide.md' }))
+        .success
+    ).toBe(false)
+    await service.setActiveSkills('a', ['review'])
+    await service.deleteSkill('review', ['writer'])
+    expect(await service.getActiveSkills('a')).toEqual(['review'])
+    expect(fs.existsSync(path.join(rootA, 'SKILL.md'))).toBe(true)
+  })
+
+  it('refreshes session selection and skill tools from the persisted workspace', async () => {
+    await migrate()
+    const projectDir = path.join(temporaryRoot, 'project')
+    const root = writeSkill(path.join(projectDir, '.agents', 'skills'), 'local-only', '# Local')
+    sessions = [
+      { id: 'a', agentId: 'writer', projectDir },
+      { id: 'b', agentId: 'writer' }
+    ]
+    await service.setActiveSkills('a', ['local-only'])
+    expect(await service.getActiveSkills('a')).toEqual(['local-only'])
+    expect(await service.setActiveSkills('b', ['local-only'])).toEqual([])
+    const tools = new SkillTools(service)
+    expect(JSON.stringify(await tools.handleSkillList('a'))).toContain('local-only')
+    expect(JSON.stringify(await tools.handleSkillList('b'))).not.toContain('local-only')
+    fs.rmSync(root, { recursive: true })
+    expect(await service.getActiveSkills('a')).toEqual([])
+    await expect(
+      service.resolveFreshEffectiveSkillContents('writer', ['local-only'], { conversationId: 'a' })
+    ).rejects.toThrow('no longer available')
   })
 
   it('keeps official plugin activation available when a user Skill has the same name', async () => {

--- a/test/main/tool/agentTools/agentToolManagerSettings.test.ts
+++ b/test/main/tool/agentTools/agentToolManagerSettings.test.ts
@@ -441,7 +441,9 @@ describe('AgentToolManager DeepChat settings tool gating', () => {
     const roots = await (manager as any).resolveActiveSkillRoots('conv-1')
 
     expect(skillService.resolveSessionAgentId).toHaveBeenCalledWith('conv-1')
-    expect(skillService.getMetadataList).toHaveBeenCalledWith('agent-a')
+    expect(skillService.getMetadataList).toHaveBeenCalledWith('agent-a', {
+      conversationId: 'conv-1'
+    })
     expect(roots).toEqual([])
   })
 

--- a/test/main/tool/agentTools/agentToolManagerSkillAccess.test.ts
+++ b/test/main/tool/agentTools/agentToolManagerSkillAccess.test.ts
@@ -179,7 +179,9 @@ describe('AgentToolManager skill file access', () => {
 
     const rules = await (manager as any).buildProtectedSkillDirectoryRules('conv1', ['skill-a'])
 
-    expect(skillService.getMetadataList).not.toHaveBeenCalled()
+    expect(skillService.getMetadataList).toHaveBeenCalledWith(expect.any(String), {
+      conversationId: 'conv1'
+    })
     expect(skillService.getAllSkills).toHaveBeenCalledOnce()
     expect(rules).toEqual([{ root: skillsDir, allowedDirectories: [skillRoot] }])
   })

--- a/test/renderer/composables/useChatInputSkillScope.test.ts
+++ b/test/renderer/composables/useChatInputSkillScope.test.ts
@@ -7,6 +7,10 @@ import type { UnifiedSkillItem } from '@shared/types/skillManagement'
 vi.mock('pinia', async () => vi.importActual<typeof import('pinia')>('pinia'))
 
 const createSkill = (name: string, description: string): UnifiedSkillItem => ({
+  agentId: 'deepchat',
+  assigned: true,
+  assignedAgentIds: [],
+  disabled: false,
   name,
   description,
   path: `/skills/${name}/SKILL.md`,
@@ -25,77 +29,84 @@ describe('chat input Skill Agent scope', () => {
     setActivePinia(createPinia())
   })
 
-  it('keeps picker and mention suggestions on Agent B when Agent A resolves late', async () => {
-    const catalogResolvers = new Map<string, (skills: UnifiedSkillItem[]) => void>()
-    const skillClient = {
-      getUnifiedSkillCatalog: vi.fn(
-        (agentId: string) =>
-          new Promise<UnifiedSkillItem[]>((resolve) => {
-            catalogResolvers.set(agentId, resolve)
-          })
-      ),
-      getActiveSkills: vi.fn().mockResolvedValue([]),
-      setActiveSkills: vi.fn().mockResolvedValue([]),
-      onCatalogChanged: vi.fn(() => () => undefined),
-      onSessionChanged: vi.fn(() => () => undefined)
-    }
-    vi.doMock('@api/SkillClient', () => ({ createSkillClient: () => skillClient }))
-    vi.doMock('@api/SessionClient', () => ({
-      createSessionClient: () => ({
-        getAcpSessionCommands: vi.fn().mockResolvedValue([]),
-        onAcpCommandsReady: vi.fn(() => () => undefined)
-      })
-    }))
-    vi.doMock('@api/WorkspaceClient', () => ({
-      createWorkspaceClient: () => ({
-        registerWorkspace: vi.fn().mockResolvedValue(undefined),
-        searchFiles: vi.fn().mockResolvedValue([])
-      })
-    }))
-    vi.doMock('@/stores/mcp', () => ({
-      useMcpStore: () => ({
-        visiblePrompts: [],
-        visibleTools: [],
-        pluginTools: [],
-        loadPrompts: vi.fn().mockResolvedValue(undefined),
-        loadTools: vi.fn().mockResolvedValue(undefined),
-        getPrompt: vi.fn()
-      })
-    }))
-
-    const [{ useSkillsData }, { useChatInputMentions }] = await Promise.all([
-      import('@/components/chat-input/composables/useSkillsData'),
-      import('@/components/chat/composables/useChatInputMentions')
-    ])
-    const Harness = defineComponent({
-      props: {
-        agentId: { type: String, required: true }
-      },
-      setup(props) {
-        const agentId = toRef(props, 'agentId')
-        const conversationId = ref<string | null>(null)
-        const skillsData = useSkillsData(conversationId, agentId)
-        const mentionItems = ref<Array<{ id: string; label: string; description?: string }>>([])
-        const mentions = useChatInputMentions({
-          getEditor: () => null,
-          workspacePath: ref(null),
-          sessionId: conversationId,
-          agentId,
-          isAcpSession: ref(false),
-          onCommandSubmit: vi.fn(),
-          onActivateSkill: skillsData.activateSkill
+  it.each(['agent', 'workspace'])(
+    'keeps picker and suggestions in the latest %s scope',
+    async (scope) => {
+      const catalogResolvers = new Map<string, (skills: UnifiedSkillItem[]) => void>()
+      const skillClient = {
+        getUnifiedSkillCatalog: vi.fn(
+          (agentId: string, workspacePath?: string) =>
+            new Promise<UnifiedSkillItem[]>((resolve) => {
+              catalogResolvers.set(workspacePath ?? agentId, resolve)
+            })
+        ),
+        getActiveSkills: vi.fn().mockResolvedValue([]),
+        setActiveSkills: vi.fn().mockResolvedValue([]),
+        onCatalogChanged: vi.fn(() => () => undefined),
+        onSessionChanged: vi.fn(() => () => undefined)
+      }
+      vi.doMock('@api/SkillClient', () => ({ createSkillClient: () => skillClient }))
+      vi.doMock('@api/SessionClient', () => ({
+        createSessionClient: () => ({
+          getAcpSessionCommands: vi.fn().mockResolvedValue([]),
+          onAcpCommandsReady: vi.fn(() => () => undefined)
         })
-        const refreshMentions = () => {
-          mentionItems.value = mentions.slashSuggestion.items({ query: '' })
-        }
+      }))
+      vi.doMock('@api/WorkspaceClient', () => ({
+        createWorkspaceClient: () => ({
+          registerWorkspace: vi.fn().mockResolvedValue(undefined),
+          searchFiles: vi.fn().mockResolvedValue([])
+        })
+      }))
+      vi.doMock('@/stores/mcp', () => ({
+        useMcpStore: () => ({
+          visiblePrompts: [],
+          visibleTools: [],
+          pluginTools: [],
+          loadPrompts: vi.fn().mockResolvedValue(undefined),
+          loadTools: vi.fn().mockResolvedValue(undefined),
+          getPrompt: vi.fn()
+        })
+      }))
 
-        return {
-          pickerSkills: computed(() => skillsData.skills.value),
-          mentionItems,
-          refreshMentions
-        }
-      },
-      template: `
+      const [{ useSkillsData }, { useChatInputMentions }] = await Promise.all([
+        import('@/components/chat-input/composables/useSkillsData'),
+        import('@/components/chat/composables/useChatInputMentions')
+      ])
+      const Harness = defineComponent({
+        props: {
+          agentId: { type: String, required: true },
+          workspacePath: { type: String, default: null }
+        },
+        setup(props) {
+          const agentId = toRef(props, 'agentId')
+          const conversationId = ref<string | null>(null)
+          const workspacePath = toRef(props, 'workspacePath')
+          const skillsData = useSkillsData(conversationId, agentId, workspacePath)
+          const mentionItems = ref<Array<{ id: string; label: string; description?: string }>>([])
+          const mentions = useChatInputMentions({
+            getEditor: () => null,
+            workspacePath,
+            skills: skillsData.skills,
+            sessionId: conversationId,
+            agentId,
+            isAcpSession: ref(false),
+            onCommandSubmit: vi.fn(),
+            onActivateSkill: skillsData.activateSkill
+          })
+          const refreshMentions = () => {
+            mentionItems.value = mentions.slashSuggestion.items({ query: '' })
+          }
+
+          return {
+            pickerSkills: computed(() => skillsData.skills.value),
+            pendingSkills: skillsData.pendingSkills,
+            activateSkill: skillsData.activateSkill,
+            mentionItems,
+            refreshMentions
+          }
+        },
+        template: `
         <div>
           <button data-testid="refresh-mentions" @click="refreshMentions">refresh</button>
           <div
@@ -110,47 +121,70 @@ describe('chat input Skill Agent scope', () => {
           >{{ item.label }}|{{ item.description }}</div>
         </div>
       `
-    })
+      })
 
-    const wrapper = mount(Harness, { props: { agentId: 'agent-a' } })
-    await flushPromises()
-    expect(skillClient.getUnifiedSkillCatalog).toHaveBeenCalledWith('agent-a')
+      const initialProps =
+        scope === 'agent'
+          ? { agentId: 'agent-a' }
+          : { agentId: 'writer', workspacePath: '/project-a' }
+      const nextProps =
+        scope === 'agent'
+          ? { agentId: 'agent-b' }
+          : { agentId: 'writer', workspacePath: '/project-b' }
+      const initialKey = scope === 'agent' ? 'agent-a' : '/project-a'
+      const nextKey = scope === 'agent' ? 'agent-b' : '/project-b'
+      const wrapper = mount(Harness, { props: initialProps })
+      await flushPromises()
+      expect(catalogResolvers.has(initialKey)).toBe(true)
+      await wrapper.vm.activateSkill('shared-skill')
 
-    await wrapper.setProps({ agentId: 'agent-b' })
-    await flushPromises()
-    expect(skillClient.getUnifiedSkillCatalog).toHaveBeenCalledWith('agent-b')
+      await wrapper.setProps(nextProps)
+      await flushPromises()
+      expect(catalogResolvers.has(nextKey)).toBe(true)
+      expect(wrapper.vm.pendingSkills).toEqual([])
 
-    catalogResolvers.get('agent-b')?.([
-      createSkill('shared-skill', 'Agent B description'),
-      createSkill('b-only-skill', 'Only Agent B')
-    ])
-    await flushPromises()
-    await wrapper.get('[data-testid="refresh-mentions"]').trigger('click')
+      catalogResolvers.get(nextKey)?.([
+        createSkill('shared-skill', 'Agent B description'),
+        createSkill('b-only-skill', 'Only Agent B')
+      ])
+      await flushPromises()
+      await wrapper.get('[data-testid="refresh-mentions"]').trigger('click')
 
-    expect(wrapper.get('[data-testid="picker-shared-skill"]').text()).toBe(
-      'shared-skill|Agent B description'
-    )
-    expect(wrapper.get('[data-testid="picker-b-only-skill"]').text()).toBe(
-      'b-only-skill|Only Agent B'
-    )
-    expect(wrapper.get('[data-testid="mention-skill:shared-skill"]').text()).toBe(
-      'shared-skill|Agent B description'
-    )
-    expect(wrapper.get('[data-testid="mention-skill:b-only-skill"]').text()).toBe(
-      'b-only-skill|Only Agent B'
-    )
+      expect(wrapper.get('[data-testid="picker-shared-skill"]').text()).toBe(
+        'shared-skill|Agent B description'
+      )
+      expect(wrapper.get('[data-testid="picker-b-only-skill"]').text()).toBe(
+        'b-only-skill|Only Agent B'
+      )
+      expect(wrapper.get('[data-testid="mention-skill:shared-skill"]').text()).toBe(
+        'shared-skill|Agent B description'
+      )
+      expect(wrapper.get('[data-testid="mention-skill:b-only-skill"]').text()).toBe(
+        'b-only-skill|Only Agent B'
+      )
 
-    catalogResolvers.get('agent-a')?.([createSkill('shared-skill', 'Agent A description')])
-    await flushPromises()
-    await wrapper.get('[data-testid="refresh-mentions"]').trigger('click')
+      catalogResolvers.get(initialKey)?.([createSkill('shared-skill', 'Agent A description')])
+      await flushPromises()
+      await wrapper.get('[data-testid="refresh-mentions"]').trigger('click')
 
-    expect(wrapper.get('[data-testid="picker-shared-skill"]').text()).toBe(
-      'shared-skill|Agent B description'
-    )
-    expect(wrapper.get('[data-testid="mention-skill:shared-skill"]').text()).toBe(
-      'shared-skill|Agent B description'
-    )
-    expect(wrapper.find('[data-testid="picker-b-only-skill"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="mention-skill:b-only-skill"]').exists()).toBe(true)
-  })
+      expect(wrapper.get('[data-testid="picker-shared-skill"]').text()).toBe(
+        'shared-skill|Agent B description'
+      )
+      expect(wrapper.get('[data-testid="mention-skill:shared-skill"]').text()).toBe(
+        'shared-skill|Agent B description'
+      )
+      expect(wrapper.find('[data-testid="picker-b-only-skill"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="mention-skill:b-only-skill"]').exists()).toBe(true)
+      if (scope === 'workspace') {
+        window.dispatchEvent(new Event('focus'))
+        await flushPromises()
+        catalogResolvers.get(nextKey)?.([])
+        await flushPromises()
+        await wrapper.get('[data-testid="refresh-mentions"]').trigger('click')
+        expect(wrapper.find('[data-testid="picker-b-only-skill"]').exists()).toBe(false)
+        expect(wrapper.find('[data-testid="mention-skill:b-only-skill"]').exists()).toBe(false)
+      }
+      wrapper.unmount()
+    }
+  )
 })

--- a/test/renderer/composables/useChatInputSkillScope.test.ts
+++ b/test/renderer/composables/useChatInputSkillScope.test.ts
@@ -136,6 +136,13 @@ describe('chat input Skill Agent scope', () => {
       const wrapper = mount(Harness, { props: initialProps })
       await flushPromises()
       expect(catalogResolvers.has(initialKey)).toBe(true)
+      if (scope === 'workspace') {
+        const requestCount = skillClient.getUnifiedSkillCatalog.mock.calls.length
+        window.dispatchEvent(new Event('focus'))
+        window.dispatchEvent(new Event('focus'))
+        await flushPromises()
+        expect(skillClient.getUnifiedSkillCatalog).toHaveBeenCalledTimes(requestCount)
+      }
       await wrapper.vm.activateSkill('shared-skill')
 
       await wrapper.setProps(nextProps)
@@ -176,8 +183,11 @@ describe('chat input Skill Agent scope', () => {
       expect(wrapper.find('[data-testid="picker-b-only-skill"]').exists()).toBe(true)
       expect(wrapper.find('[data-testid="mention-skill:b-only-skill"]').exists()).toBe(true)
       if (scope === 'workspace') {
+        const requestCount = skillClient.getUnifiedSkillCatalog.mock.calls.length
+        window.dispatchEvent(new Event('focus'))
         window.dispatchEvent(new Event('focus'))
         await flushPromises()
+        expect(skillClient.getUnifiedSkillCatalog).toHaveBeenCalledTimes(requestCount + 1)
         catalogResolvers.get(nextKey)?.([])
         await flushPromises()
         await wrapper.get('[data-testid="refresh-mentions"]').trigger('click')
@@ -185,6 +195,10 @@ describe('chat input Skill Agent scope', () => {
         expect(wrapper.find('[data-testid="mention-skill:b-only-skill"]').exists()).toBe(false)
       }
       wrapper.unmount()
+      const requestCount = skillClient.getUnifiedSkillCatalog.mock.calls.length
+      window.dispatchEvent(new Event('focus'))
+      await flushPromises()
+      expect(skillClient.getUnifiedSkillCatalog).toHaveBeenCalledTimes(requestCount)
     }
   )
 })

--- a/test/renderer/composables/useSkillsData.test.ts
+++ b/test/renderer/composables/useSkillsData.test.ts
@@ -4,6 +4,8 @@ import { defineComponent, toRef } from 'vue'
 
 const skillClient = vi.hoisted(() => ({
   getActiveSkills: vi.fn(),
+  getUnifiedSkillCatalog: vi.fn(),
+  onCatalogChanged: vi.fn(() => () => undefined),
   setActiveSkills: vi.fn(),
   removeActiveSkill: vi.fn(),
   onSessionChanged: vi.fn(() => () => undefined)


### PR DESCRIPTION
Project-local SKILL.md files were absent from both composer suggestions and runtime resolution. Discover skills under the current workspace's `.agents/skills`, `.deepchat/skills`, `.claude/skills`, `.codex/skills`, and `.cursor/skills`, and carry that scope through selection, routing, skill views, and execution snapshots.

Project skills take precedence over shared names within their workspace. They stay outside global skill management and use default runtime settings, so same-named shared credentials and script overrides cannot leak into project execution. Workspace switching discards stale UI responses and pending selections; window focus refreshes discovery, with repeated focus events coalesced while a composer refresh is in flight. The catalog route rejects relative paths and null bytes before service dispatch. Existing layout and keyboard interactions are preserved.

```text
BEFORE                      AFTER
/project-a                  /project-a
/skill                      /skill
+ global-skill              + project-skill
                            + global-skill
```

Validation: format, i18n, lint, and main/renderer type checks passed. The full main suite passed 8533 tests (493 skipped); targeted composer suites passed 9 tests. Regression coverage includes filesystem discovery and unsafe paths, precedence, two-session content isolation, credential isolation, shared deletion, and late composer responses.

Discovery is limited to the selected workspace's conventional skill directories; it refreshes on workspace selection, window focus, and runtime resolution without adding filesystem watchers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace-scoped Project Skills discovered from supported project directories.
  * Project Skills appear in chat skill lists and slash-command suggestions without importing them into the shared library.
  * Project Skills take precedence over same-named shared skills within the workspace.
  * Skill catalogs refresh when switching workspaces, focusing the app, or when catalog changes occur.
* **Behavior Changes**
  * Project Skills use default runtime settings and remain isolated from shared assignments, credentials, and management actions.
  * Sessions without a project and ACP agents retain their existing behavior.
  * Skill resolution now uses conversation context for more accurate session-specific results.
* **Bug Fixes**
  * Improved protection against catalog changes during skill execution-package capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

