### PR TITLE
fix(skills): preserve bodies when resuming

### DIFF
--- a/src/main/agent/deepchat/resources/systemPromptBuilder.ts
+++ b/src/main/agent/deepchat/resources/systemPromptBuilder.ts
@@ -384,6 +384,7 @@ export async function buildSystemPromptAssemblyWithSkills(
       kind: 'pinned_skills',
       sourceRef: 'skills:active',
       content: skillsPrompt,
+      normalize: 'none',
       degradationCodes: pinnedSkillsDegradations
     }),
     createPromptAssemblySection({

--- a/src/main/agent/deepchat/runtime/contextBuilder.ts
+++ b/src/main/agent/deepchat/runtime/contextBuilder.ts
@@ -800,7 +800,7 @@ export function buildUserMessageContent(
   const imageMetadata = shouldBuildImageParts ? '' : buildImageMetadataContext(imagePayloadFiles)
   const resolvedImageContext = buildResolvedImageRepresentationContext(imageFiles)
   const resolvedPdfContext = buildResolvedPdfRepresentationContext(files)
-  const leadingContext = options.leadingContext?.trim() ?? ''
+  const leadingContext = options.leadingContext?.trim() ? options.leadingContext : ''
   const baseText = (
     leadingContext
       ? [

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -1306,8 +1306,10 @@ function makeDeepchatAssistantRow(
   }
 }
 
-function makeRecoveredMessageSkillProjection(agentId: string) {
-  const effectiveContent = 'RECOVERED_SKILL_BODY'
+function makeRecoveredMessageSkillProjection(
+  agentId: string,
+  effectiveContent = 'RECOVERED_SKILL_BODY'
+) {
   return {
     scope: 'message' as const,
     effectiveContent,
@@ -14960,40 +14962,57 @@ describe('DeepChatAgentHarness', () => {
       expect(processStream).not.toHaveBeenCalled()
     })
 
-    it('resumes from the exact materialized Skill without resolving mutable source content', async () => {
-      const skillService = getSkillServiceMock()
-      skillService.getMetadataList.mockResolvedValue([
-        { name: 'runtime-skill', description: 'Runtime skill' }
-      ])
-      skillService.getActiveSkills.mockResolvedValue([])
-      vi.spyOn(SkillContextMaterializer.prototype, 'recoverResume').mockReturnValue({
-        foundSkillManifest: true,
-        projections: [makeRecoveredMessageSkillProjection('deepchat')]
-      })
-      let streamParams: any
-      ;(processStream as ReturnType<typeof vi.fn>).mockImplementationOnce(async (params: any) => {
-        streamParams = params
-        return { status: 'completed' }
-      })
-      await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
-      const assistantRow = installPendingQuestion()
-      assistantRow.metadata = JSON.stringify({
-        runId: '019feecb-8e55-7757-b555-4f53e8b602a7'
-      })
+    it.each(['message', 'session'] as const)(
+      'resumes from the exact materialized %s Skill without trimming its body',
+      async (scope) => {
+        const skillService = getSkillServiceMock()
+        skillService.getMetadataList.mockResolvedValue([
+          { name: 'runtime-skill', description: 'Runtime skill' }
+        ])
+        const effectiveContent = 'RECOVERED_SKILL_BODY \t\r\n\r\n\r\n'
+        const recovered = makeRecoveredMessageSkillProjection('deepchat', effectiveContent)
+        const projection = {
+          ...recovered,
+          scope,
+          context: {
+            ...recovered.context,
+            activationScope: scope,
+            providerRole: scope === 'session' ? ('system' as const) : ('user' as const),
+            sourceEntryIds: scope === 'session' ? [] : recovered.context.sourceEntryIds,
+            deduplicationSource: scope
+          }
+        }
+        skillService.getActiveSkills.mockResolvedValue(scope === 'session' ? ['runtime-skill'] : [])
+        vi.spyOn(SkillContextMaterializer.prototype, 'recoverResume').mockReturnValue({
+          foundSkillManifest: true,
+          projections: [projection]
+        })
+        let streamParams: any
+        ;(processStream as ReturnType<typeof vi.fn>).mockImplementationOnce(async (params: any) => {
+          streamParams = params
+          return { status: 'completed' }
+        })
+        await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+        const assistantRow = installPendingQuestion()
+        assistantRow.metadata = JSON.stringify({
+          runId: '019feecb-8e55-7757-b555-4f53e8b602a7'
+        })
 
-      await expect(answerPendingQuestion()).resolves.toEqual({ resumed: true })
+        await expect(answerPendingQuestion()).resolves.toEqual({ resumed: true })
 
-      const providerText = streamParams.run.messages
-        .map((message: { content?: unknown }) => String(message.content ?? ''))
-        .join('\n')
-      expect(providerText.match(/RECOVERED_SKILL_BODY/g)).toHaveLength(1)
-      expect(String(streamParams.run.messages[0]?.content ?? '')).not.toContain(
-        'RECOVERED_SKILL_BODY'
-      )
-      expect(streamParams.run.resources.materializedSkillContexts).toHaveLength(1)
-      expect(skillService.resolveFreshEffectiveSkillContents).not.toHaveBeenCalled()
-      expect(skillService.loadSkillContent).not.toHaveBeenCalled()
-    })
+        const providerText = streamParams.run.messages
+          .map((message: { content?: unknown }) => String(message.content ?? ''))
+          .join('\n')
+        expect(providerText.match(/RECOVERED_SKILL_BODY/g)).toHaveLength(1)
+        const boundMessage = streamParams.run.messages.find(
+          (message: ChatMessage) => message.role === projection.context.providerRole
+        )
+        expect(boundMessage?.content).toContain(projection.completeBodyFragment)
+        expect(streamParams.run.resources.materializedSkillContexts).toHaveLength(1)
+        expect(skillService.resolveFreshEffectiveSkillContents).not.toHaveBeenCalled()
+        expect(skillService.loadSkillContent).not.toHaveBeenCalled()
+      }
+    )
 
     it('handles question_option and resumes assistant message', async () => {
       const prepareForResumeTurn = vi.spyOn(CompactionService.prototype, 'prepareForResumeTurn')

--- a/test/main/agent/deepchat/resources/systemPromptBuilder.test.ts
+++ b/test/main/agent/deepchat/resources/systemPromptBuilder.test.ts
@@ -494,7 +494,7 @@ describe('DeepChat system prompt builder', () => {
       toolDefinitions: [],
       activeSkillNamesOverride: ['skill-a'],
       sessionActiveSkillNamesOverride: ['skill-a'],
-      sessionSkillBodiesOverride: [{ name: 'skill-a', content: 'exact materialized body' }],
+      sessionSkillBodiesOverride: [{ name: 'skill-a', content: 'exact materialized body \t\n\n\n' }],
       commandShell: POSIX_COMMAND_SHELL,
       resourceInstance: instance
     })
@@ -506,7 +506,7 @@ describe('DeepChat system prompt builder', () => {
         'These Session Skills are persistent context for this conversation. Follow them when relevant.',
         '',
         '### skill-a',
-        'exact materialized body'
+        'exact materialized body \t\n\n\n'
       ].join('\n')
     )
     await expect(


### PR DESCRIPTION
Resuming a tool interaction can fail with `Provider projection clone removed its bound Skill context.` when a materialized Skill body ends with whitespace. Prompt assembly trims that text, so the rebuilt message no longer contains the exact body required by the Skill projection binding.

Preserve Skill section text and non-empty leading user context verbatim. This applies to session and message Skills, including prompt rebuilds, while retaining projection integrity checks and the existing handling of empty context.

Validation:
- Extend the interaction-resume regression to both Skill scopes with trailing spaces, tabs, and CRLFs; require the exact body exactly once without reloading mutable Skill sources. Both cases reproduce the reported error against the unfixed code.
- Verify exact Session Skill overrides with trailing whitespace.
- All 514 tests across the harness, system prompt builder, context builder, Skill materializer, and loop Run suites pass.
- Format, i18n, lint, and Node/renderer typechecks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Whitespace-only leading context is now omitted from user messages instead of being included as an empty-looking context block.
  - Pinned skill content now preserves its original formatting, including trailing spaces and newline characters, when included in assembled prompts.

- **Tests**
  - Expanded coverage verifies exact skill-content preservation and correct behavior when resuming messages or sessions with recovered skill content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->