### PR TITLE
fix(agent): restore live assistant on resume

### DIFF
--- a/src/main/agent/deepchat/runtime/turnCoordinator.ts
+++ b/src/main/agent/deepchat/runtime/turnCoordinator.ts
@@ -1654,29 +1654,25 @@ export class TurnCoordinator {
       let basePromptAssembly = unguardedBasePromptAssembly
       let baseSystemPrompt = basePromptAssembly.prompt
       let resumeTargetOrderSeq: number | undefined
+      const readResumeHistory = () =>
+        runSynchronousPreStreamStep(sessionId, 'tape-ready', () => {
+          const { historyRecords } = this.ports.tapeReconciliation.ensureSessionTapeReady(
+            sessionId,
+            this.ports.messageStore
+          )
+          const target = this.ports.messageStore.getMessage(messageId)
+          if (!target || target.sessionId !== sessionId || target.role !== 'assistant') {
+            throw new Error('Resume target assistant message is no longer available.')
+          }
+          // Paused assistant blocks remain mutable until terminal settlement, so Tape may omit
+          // this message or hold an older revision without the latest interaction response.
+          return [...historyRecords.filter((record) => record.id !== messageId), target].sort(
+            (left, right) => left.orderSeq - right.orderSeq
+          )
+        })
       const preparedInput = await this.ports.inputPreparationCoordinator.prepareExisting({
-        ensureHistory: () =>
-          runSynchronousPreStreamStep(
-            sessionId,
-            'tape-ready',
-            () =>
-              this.ports.tapeReconciliation.ensureSessionTapeReady(
-                sessionId,
-                this.ports.messageStore
-              )
-                .historyRecords
-          ),
-        refreshHistory: () =>
-          runSynchronousPreStreamStep(
-            sessionId,
-            'tape-ready',
-            () =>
-              this.ports.tapeReconciliation.ensureSessionTapeReady(
-                sessionId,
-                this.ports.messageStore
-              )
-                .historyRecords
-          ),
+        ensureHistory: readResumeHistory,
+        refreshHistory: readResumeHistory,
         prepareIntent: async (historyRecords) => {
           if (historyContainsUntrustedAttachmentText(historyRecords)) {
             basePromptAssembly = appendAttachmentTextSafetySection(unguardedBasePromptAssembly)

--- a/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
+++ b/test/main/agent/deepchat/harness/deepChatAgentHarness.test.ts
@@ -15014,6 +15014,69 @@ describe('DeepChatAgentHarness', () => {
       }
     )
 
+    it.each(['missing', 'stale'] as const)(
+      'resumes a Skill turn with a %s Tape assistant using the answered live blocks',
+      async (tapeState) => {
+        const skillService = getSkillServiceMock()
+        skillService.getMetadataList.mockResolvedValue([
+          { name: 'runtime-skill', description: 'Runtime skill' }
+        ])
+        skillService.getActiveSkills.mockResolvedValue([])
+        skillService.loadSkillContent.mockResolvedValue({ content: 'RECOVERED_SKILL_BODY' })
+        await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })
+        installSessionRows([])
+        let messageSequence = 0
+        vi.mocked(nanoid).mockImplementation(() => `resume-message-${++messageSequence}`)
+        let runId = ''
+        let invocation = 0
+        let requestMessages: ChatMessage[] = []
+        ;(processStream as ReturnType<typeof vi.fn>).mockImplementation(async (params: any) => {
+          runId = params.run.runId
+          requestMessages = params.run.messages
+          for await (const _event of params.coreStream(
+            params.run.messages,
+            params.modelId,
+            params.modelConfig,
+            params.temperature,
+            params.maxTokens,
+            params.run.resources.toolDefinitions
+          )) {
+          }
+          return { status: ++invocation === 1 ? 'paused' : 'completed' }
+        })
+
+        const started = await agent.processMessage('s1', {
+          text: 'resume query',
+          activeSkills: ['runtime-skill']
+        })
+        const messageId = started.messageId!
+        if (tapeState === 'stale') {
+          sessionData.transcript.finalizeAssistantMessage(messageId, [
+            { type: 'content', content: 'OLD_REPLY', status: 'success', timestamp: 0 }
+          ])
+        }
+        const assistantRow = installPendingQuestion(messageId, [
+          { type: 'content', content: 'CURRENT_REPLY', status: 'success', timestamp: 0 }
+        ])
+        assistantRow.metadata = JSON.stringify({ runId })
+
+        await expect(answerPendingQuestion(messageId)).resolves.toEqual({ resumed: true })
+
+        expect(llmProvider.providerInstance.coreStream).toHaveBeenCalledTimes(2)
+        expect(requestMessages.find((message) => message.role === 'user')?.content).toContain(
+          'RECOVERED_SKILL_BODY'
+        )
+        expect(requestMessages.find((message) => message.role === 'assistant')).toMatchObject({
+          content: 'CURRENT_REPLY',
+          tool_calls: [expect.objectContaining({ id: 'pending-question' })]
+        })
+        expect(requestMessages.find((message) => message.role === 'tool')).toMatchObject({
+          tool_call_id: 'pending-question',
+          content: 'Yes'
+        })
+      }
+    )
+
     it('handles question_option and resumes assistant message', async () => {
       const prepareForResumeTurn = vi.spyOn(CompactionService.prototype, 'prepareForResumeTurn')
       await agent.initSession('s1', { providerId: 'openai', modelId: 'gpt-4' })


### PR DESCRIPTION
Answering an ask-user interaction can fail with `Provider projection clone removed its bound Skill context.` because paused assistant blocks live in the mutable transcript until terminal settlement. An initialized Tape can omit the assistant message entirely, preventing the resume context builder from identifying its owning user and injecting the selected Skill. A stale Tape revision can also omit the latest question and answer.

Merge the exact target assistant message from the current transcript into Tape history before resume compaction and refresh it after compaction. Validate its session and role, replace any stale revision, and retain the ordering used by context assembly. Other history continues to come from Tape.

Validation:
- Add missing/stale Tape target regressions that materialize a Skill, assemble a real initial provider request, pause, answer a question, and reach the resumed provider request with the Skill, current assistant content, and answer intact.
- Against the unfixed code, the missing-target case reproduces the reported stack; the stale-target case sends the old reply without the answered tool call.
- All 554 tests across the harness, context builder, compaction service, input preparation coordinator, and Skill materializer pass.
- Format, i18n, lint, and Node/renderer typechecks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resuming interrupted conversations when the saved assistant message is missing or outdated.
  * Ensured resumed sessions use the latest assistant response and preserve recovered skill content, live answers, and tool results.
  * Improved conversation history ordering and consistency during resume operations.

* **Tests**
  * Added coverage for resuming skill-based turns with missing or stale saved messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->