### PR TITLE
chore(deps): upgrade markstream-vue to 2.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "electron-vite": "5.0.0",
     "jsdom": "^26.1.0",
     "katex": "^0.16.47",
-    "markstream-vue": "2.0.6",
+    "markstream-vue": "2.0.11",
     "mermaid": "^11.16.1",
     "minimatch": "^10.2.5",
     "monaco-editor": "^0.55.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,8 +321,8 @@ importers:
         specifier: ^0.16.47
         version: 0.16.47
       markstream-vue:
-        specifier: 2.0.6
-        version: 2.0.6(@antv/infographic@0.2.19)(katex@0.16.47)(mermaid@11.16.1)(stream-diffs@0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2)))(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2))
+        specifier: 2.0.11
+        version: 2.0.11(@antv/infographic@0.2.19)(katex@0.16.47)(mermaid@11.16.1)(stream-diffs@0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2)))(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2))
       mermaid:
         specifier: ^11.16.1
         version: 11.16.1
@@ -5331,8 +5331,8 @@ packages:
   markdown-it-task-checkbox@1.0.6:
     resolution: {integrity: sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw==}
 
-  markdown-it-ts@1.1.0:
-    resolution: {integrity: sha512-ycYoj3jeP0zHW9u4vxtSuuq9JaitIRxxYbRtns9D4fDR5mzSpFnb855KclFBGiKFJxVi+8EkMB938oZpdDVc0A==}
+  markdown-it-ts@1.1.2:
+    resolution: {integrity: sha512-17qO3LQLK+JXom5Zt6Z9l7OGWWv9eYquTxdj3xIPGe1OBHdYXrzNYA3xCgCyIj1uItv4jkqbQf6FkaqifKkySw==}
     engines: {node: '>=20.19'}
 
   markdown-it@14.3.0:
@@ -5349,11 +5349,11 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  markstream-core@2.0.6:
-    resolution: {integrity: sha512-kSGNAoTArTu9LxwyfZI+fuxanjhxwPtlW+yJM+5IJhW2jtsH9p7mSpApHC6YtJLnzeXCGS2XlqIoivzIdzy6iA==}
+  markstream-core@2.0.11:
+    resolution: {integrity: sha512-F35jzpU6982HjKPi3bTP8d0TAGXDsQIux1ZlpIU+jQRa/0DCbIC/4AM0UxbOUiHc7bwluaMDMVgQe6uaGTU3PQ==}
 
-  markstream-vue@2.0.6:
-    resolution: {integrity: sha512-87skNadimBbQFZbb6kNgIrCpXr5x63YW4MYkRbWHh/g/1+BHJ2t3iIzEsSIIES1yn29STf4ZLw1ruepZqXZeXg==}
+  markstream-vue@2.0.11:
+    resolution: {integrity: sha512-p7hWU+SSFlfsYAfUPxo0Fg3YfxF/kRF5XT+TdsmF/2xhBagTKvhtfHdX4bE4ZU7PWL8eoAor/L3qhuhlavBkBg==}
     peerDependencies:
       '@antv/infographic': ^0.2.3
       '@terrastruct/d2': '>=0.1.33'
@@ -6401,8 +6401,8 @@ packages:
       vue:
         optional: true
 
-  stream-markdown-parser@1.2.12:
-    resolution: {integrity: sha512-gT6GWlOfNTVGBEM66Me1DZ1cZZ/Mm4tcpJ4br8Zvz2CQhiWueEv+xFBBHCwls/XG4E63DygTd890rDdV+D6JxA==}
+  stream-markdown-parser@1.2.16:
+    resolution: {integrity: sha512-5MEAPd3zxbwvpr8jimBMaptNOPoALvKwUOAVIzXk/92SmOppEN+ZWTinNeFcS219qFjlt08mDLGHW0MDTIlXNA==}
 
   stream-monaco@0.0.49:
     resolution: {integrity: sha512-ksZYJXw45NralnpgWqcptqrgDdbGZaTyYmvATvhlK8eY0tyeTxs0iuQzMTF4cpGf5OlIgkNJOfbFh4M97OozSw==}
@@ -12216,7 +12216,7 @@ snapshots:
 
   markdown-it-task-checkbox@1.0.6: {}
 
-  markdown-it-ts@1.1.0:
+  markdown-it-ts@1.1.2:
     dependencies:
       entities: 8.0.0
       linkify-it: 6.1.0
@@ -12236,14 +12236,14 @@ snapshots:
 
   marked@16.4.2: {}
 
-  markstream-core@2.0.6: {}
+  markstream-core@2.0.11: {}
 
-  markstream-vue@2.0.6(@antv/infographic@0.2.19)(katex@0.16.47)(mermaid@11.16.1)(stream-diffs@0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2)))(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2)):
+  markstream-vue@2.0.11(@antv/infographic@0.2.19)(katex@0.16.47)(mermaid@11.16.1)(stream-diffs@0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2)))(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2)):
     dependencies:
       '@chenglou/pretext': 0.0.8
       '@floating-ui/dom': 1.8.0
-      markstream-core: 2.0.6
-      stream-markdown-parser: 1.2.12
+      markstream-core: 2.0.11
+      stream-markdown-parser: 1.2.16
       vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.16.tsgo.7.0.2)
     optionalDependencies:
       '@antv/infographic': 0.2.19
@@ -13413,7 +13413,7 @@ snapshots:
       - react
       - react-dom
 
-  stream-markdown-parser@1.2.12:
+  stream-markdown-parser@1.2.16:
     dependencies:
       markdown-it-container: 4.0.0
       markdown-it-footnote: 4.0.0
@@ -13421,7 +13421,7 @@ snapshots:
       markdown-it-mark: 4.0.0
       markdown-it-sup: 2.0.0
       markdown-it-task-checkbox: 1.0.6
-      markdown-it-ts: 1.1.0
+      markdown-it-ts: 1.1.2
 
   stream-monaco@0.0.49(monaco-editor@0.55.1):
     dependencies:

--- a/src/renderer/src/components/markdown/MarkdownRenderer.vue
+++ b/src/renderer/src/components/markdown/MarkdownRenderer.vue
@@ -17,7 +17,7 @@
       :themes="codeBlockThemes"
       :code-block-options="codeBlockOptions"
       :mermaid-props="mermaidProps"
-      :fade="false"
+      :fade="segment.fade"
       :batch-rendering="true"
       :initial-render-batch-size="segment.initialBatch"
       :render-batch-size="segment.batchSize"
@@ -207,6 +207,10 @@ const resolvedSmoothStreaming = computed(() => {
   return 'auto' as const
 })
 const resolvedTypewriter = computed(() => (isStreaming.value ? ('simple' as const) : false))
+// Fade (per-node opacity reveal) only applies to content that is still growing:
+// freshly streamed nodes fade in, while historical thread messages (final) and
+// the committed prefix never fade even if something triggers a re-render.
+const resolvedFade = computed(() => isStreaming.value)
 const STREAM_INITIAL_RENDER_BATCH_SIZE = 10
 const STREAM_RENDER_BATCH_SIZE = 14
 const STREAM_RENDER_BATCH_DELAY_MS = 8
@@ -381,6 +385,7 @@ type RenderSegment = {
   codeBlockStream: boolean
   smoothStreaming: boolean | 'auto'
   typewriter: boolean | 'simple'
+  fade: boolean
   nodeVirtual: boolean | 'auto'
   maxLiveNodes: number
   liveNodeBuffer: number
@@ -403,6 +408,7 @@ const renderSegments = computed<RenderSegment[]>(() => {
         codeBlockStream: isStreaming.value,
         smoothStreaming: resolvedSmoothStreaming.value,
         typewriter: resolvedTypewriter.value,
+        fade: resolvedFade.value,
         nodeVirtual: resolvedNodeVirtual.value,
         maxLiveNodes: maxLiveNodes.value,
         liveNodeBuffer: liveNodeBuffer.value,
@@ -424,6 +430,7 @@ const renderSegments = computed<RenderSegment[]>(() => {
       codeBlockStream: false,
       smoothStreaming: false,
       typewriter: false,
+      fade: false,
       nodeVirtual: canVirtualizeNodes.value ? 'auto' : false,
       // Incremental batching only takes effect when virtual live-node limiting is
       // off (markstream-vue gates batching on `maxLiveNodes <= 0`), so the prefix
@@ -445,6 +452,7 @@ const renderSegments = computed<RenderSegment[]>(() => {
       codeBlockStream: true,
       smoothStreaming: resolvedSmoothStreaming.value,
       typewriter: resolvedTypewriter.value,
+      fade: true,
       nodeVirtual: false,
       maxLiveNodes: 0,
       liveNodeBuffer: 0,

--- a/test/renderer/components/MarkstreamDomContract.test.ts
+++ b/test/renderer/components/MarkstreamDomContract.test.ts
@@ -41,6 +41,7 @@ afterAll(() => {
 async function settleRenderer() {
   await nextTick()
   await flushPromises()
+  await new Promise((resolve) => setTimeout(resolve, 50))
   await nextTick()
   await flushPromises()
 }


### PR DESCRIPTION
## Summary

Upgrade `markstream-vue` 2.0.6 → 2.0.11 and enable `fade` together with `smoothStreaming` for newly streamed content.

### Why this upgrade

- 2.0.6 README warned against combining high-frequency `smooth-streaming` with `fade` (repeated opacity restarts); 2.0.11 explicitly supports enabling both together (text reveal via multi-delta `streamedDeltaEls` + `<Transition name="fade">` with `appear` only when not `final`).
- 2.0.11 code-splits heavy nodes (CodeBlockNode, Mermaid, Table, Math) into async chunks loaded on demand.

### Changes

- `package.json` / `pnpm-lock.yaml`: `markstream-vue` 2.0.6 → 2.0.11
- `MarkdownRenderer.vue`: `fade` now flows through render segments — only growing streamed content fades (`tail`/streaming `full` segments), while committed prefixes and final/historical thread messages stay `fade=false`
- `MarkstreamDomContract.test.ts`: `settleRenderer` waits 50 ms so async code-block chunks resolve (flaky failure after 2.0.11 code-splitting)

### BEFORE / AFTER

```
BEFORE (2.0.6, fade hardcoded false)        AFTER (2.0.11, fade gated on streaming)
  history: no fade  ✓                        history: no fade  ✓
  streaming: smooth pacing only              streaming: smooth pacing + new nodes fade in
  upgrade blocker: combining warned          upgrade allows combining
```

### Verification

- typecheck (web + node) ✅
- renderer component tests: 158 files / 1615 tests ✅
- oxfmt + oxlint ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added smoother per-segment fade-in transitions while Markdown content streams.
  - Streaming content tails now consistently fade into view.

- **Bug Fixes**
  - Finalized documents and already committed content no longer display unnecessary fade animations, improving visual stability after rendering completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->