### PR TITLE
fix(provider): refresh settings without lag

### DIFF
--- a/src/renderer/settings/components/ModelProviderSettingsDetail.vue
+++ b/src/renderer/settings/components/ModelProviderSettingsDetail.vue
@@ -265,7 +265,7 @@ const validateApiKey = async () => {
   try {
     const resp = await providerStore.checkProvider(props.provider.id)
     if (resp.isOk) {
-      console.log('验证成功')
+      if (import.meta.env.DEV) console.debug('Provider verification succeeded')
       checkResult.value = true
       showCheckModelDialog.value = true
       // 验证成功后刷新当前provider的模型列表
@@ -274,7 +274,7 @@ const validateApiKey = async () => {
       await modelStore.applyInitialModelRecommendations(props.provider.id)
       return true
     } else {
-      console.log('验证失败', resp.errorMsg)
+      if (import.meta.env.DEV) console.debug('Provider verification failed:', resp.errorMsg)
       checkResult.value = false
       showCheckModelDialog.value = true
       return false
@@ -310,7 +310,7 @@ watch(
 )
 
 const initProviderSettings = async () => {
-  console.log('initData for provider:', props.provider.id)
+  if (import.meta.env.DEV) console.debug('initData for provider:', props.provider.id)
 
   await providerStore.ensureDefaultProvidersReady()
 
@@ -318,7 +318,7 @@ const initProviderSettings = async () => {
   if (props.provider.id === 'azure-openai') {
     try {
       azureApiVersion.value = await providerStore.getAzureApiVersion()
-      console.log('Azure API Version fetched:', azureApiVersion.value)
+      if (import.meta.env.DEV) console.debug('Azure API Version fetched:', azureApiVersion.value)
     } catch (error) {
       console.error('Failed to fetch Azure API Version:', error)
       azureApiVersion.value = '2024-02-01' // Default value on error
@@ -327,7 +327,7 @@ const initProviderSettings = async () => {
 
   // Fetch Gemini Safety Settings if applicable
   if (props.provider.id === 'gemini') {
-    console.log('Fetching Gemini safety settings...')
+    if (import.meta.env.DEV) console.debug('Fetching Gemini safety settings...')
 
     // 先清空现有数据
     Object.keys(geminiSafetyLevels).forEach((key) => {
@@ -340,11 +340,13 @@ const initProviderSettings = async () => {
         const savedValue = (await providerStore.getGeminiSafety(categoryKey)) as
           | string
           | 'HARM_BLOCK_THRESHOLD_UNSPECIFIED'
-        console.log(`Fetched Gemini safety for ${categoryKey}:`, savedValue)
+        if (import.meta.env.DEV)
+          console.debug(`Fetched Gemini safety for ${categoryKey}:`, savedValue)
         geminiSafetyLevels[categoryKey] =
           valueToLevelMap[savedValue as SafetySettingValue] ??
           safetyCategories[categoryKey as SafetyCategoryKey].defaultLevel
-        console.log(`Set Gemini level for ${categoryKey}:`, geminiSafetyLevels[categoryKey])
+        if (import.meta.env.DEV)
+          console.debug(`Set Gemini level for ${categoryKey}:`, geminiSafetyLevels[categoryKey])
       } catch (error) {
         console.error(`Failed to fetch Gemini safety setting for ${categoryKey}:`, error)
         geminiSafetyLevels[categoryKey] =
@@ -352,7 +354,8 @@ const initProviderSettings = async () => {
       }
     }
 
-    console.log('All Gemini safety levels initialized:', JSON.stringify(geminiSafetyLevels))
+    if (import.meta.env.DEV)
+      console.debug('All Gemini safety levels initialized:', JSON.stringify(geminiSafetyLevels))
   }
 }
 
@@ -425,9 +428,10 @@ const handleApiHostChange = async (value: string) => {
 }
 
 const MODEL_TOGGLE_PERF_LOG_PREFIX = '[ModelTogglePerf]'
-const getPerfNow = () => (typeof performance !== 'undefined' ? performance.now() : Date.now())
+const getPerfNow = () =>
+  import.meta.env.DEV ? (typeof performance !== 'undefined' ? performance.now() : Date.now()) : 0
 const logModelTogglePerf = (phase: string, details: Record<string, unknown>) => {
-  if (!uiSettingsStore.traceDebugEnabled) {
+  if (!import.meta.env.DEV || !uiSettingsStore.traceDebugEnabled) {
     return
   }
 
@@ -468,7 +472,7 @@ const handleModelEnabledChange = async (
   }
 
   const storeComplete = getPerfNow()
-  if (!uiSettingsStore.traceDebugEnabled) {
+  if (!import.meta.env.DEV || !uiSettingsStore.traceDebugEnabled) {
     return
   }
 
@@ -536,7 +540,7 @@ const handleAzureApiVersionChange = async (value: string) => {
   if (trimmedValue) {
     azureApiVersion.value = trimmedValue // Update local ref immediately
     await providerStore.setAzureApiVersion(trimmedValue)
-    console.log('Azure API Version updated:', trimmedValue)
+    if (import.meta.env.DEV) console.debug('Azure API Version updated:', trimmedValue)
   }
 }
 
@@ -546,13 +550,14 @@ const handleSafetySettingChange = async (key: SafetyCategoryKey, level: number) 
   if (value) {
     geminiSafetyLevels[key] = level // Update local state immediately when slider changes
     await providerStore.setGeminiSafety(key, value)
-    console.log(`Gemini safety setting for ${key} updated to level ${level} (${value})`)
+    if (import.meta.env.DEV)
+      console.debug(`Gemini safety setting for ${key} updated to level ${level} (${value})`)
   }
 }
 
 // Handler for OAuth success
 const handleOAuthSuccess = async () => {
-  console.log('OAuth authentication successful')
+  if (import.meta.env.DEV) console.debug('OAuth authentication successful')
   await initProviderSettings()
   syncModels()
   // 可以自动验证一次

--- a/src/renderer/settings/components/ProviderApiConfig.vue
+++ b/src/renderer/settings/components/ProviderApiConfig.vue
@@ -169,6 +169,12 @@
             />
           </DcButton>
         </div>
+        <DcInlineError
+          v-if="keyStatusError"
+          data-testid="provider-key-status-error"
+          :error="keyStatusError"
+          class="min-w-0 break-words dark:text-red-400"
+        />
         <div
           v-if="
             keyStatus && (keyStatus.usage !== undefined || keyStatus.limit_remaining !== undefined)
@@ -247,8 +253,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { DcInlineError } from '@dc-ui/components/inline-error'
 import { Label } from '@shadcn/components/ui/label'
 import { Input } from '@shadcn/components/ui/input'
 import { DcButton, DcCopyButton } from '@dc-ui/components/button'
@@ -310,6 +317,7 @@ const emit = defineEmits<{
 const apiKey = ref(props.provider.apiKey || '')
 const apiHost = ref(props.provider.baseUrl || '')
 const keyStatus = ref<KeyStatus | null>(null)
+const keyStatusError = ref('')
 const isRefreshing = ref(false)
 const showApiKey = ref(false)
 const isEditingKey = ref(false)
@@ -441,21 +449,39 @@ const openModelCheckDialog = () => {
   modelCheckStore.openDialog(props.provider.id)
 }
 
-const getKeyStatus = async () => {
-  if (
-    ['ppio', 'openrouter', 'siliconcloud', 'silicon', 'deepseek', '302ai', 'cherryin'].includes(
-      props.provider.id
-    ) &&
-    props.provider.apiKey
-  ) {
-    try {
-      keyStatus.value = await providerClient.getKeyStatus(props.provider.id)
-    } catch (error) {
-      console.error('[ProviderApiConfig] Failed to load key status', error)
-      keyStatus.value = null
+watch(
+  [() => props.provider.id, () => props.provider.apiKey, () => props.provider.baseUrl],
+  async ([providerId, storedApiKey], _previous, onCleanup) => {
+    let cancelled = false
+    onCleanup(() => {
+      cancelled = true
+    })
+    keyStatus.value = null
+    keyStatusError.value = ''
+
+    if (
+      !storedApiKey ||
+      !['ppio', 'openrouter', 'siliconcloud', 'silicon', 'deepseek', '302ai', 'cherryin'].includes(
+        providerId
+      )
+    ) {
+      return
     }
-  }
-}
+
+    try {
+      const status = await providerClient.getKeyStatus(providerId)
+      if (!cancelled) keyStatus.value = status
+    } catch (error) {
+      if (cancelled) return
+      const message = error instanceof Error ? error.message : String(error ?? '')
+      keyStatusError.value =
+        message
+          .replace(/^Error invoking remote method '[^']+': (?:Error: )?/, '')
+          .replaceAll(storedApiKey, '••••••••') || t('settings.provider.dialog.verify.failedDesc')
+    }
+  },
+  { immediate: true }
+)
 
 const refreshModels = async () => {
   if (isRefreshing.value) return
@@ -492,8 +518,4 @@ const refreshModels = async () => {
     isRefreshing.value = false
   }
 }
-
-onMounted(() => {
-  getKeyStatus()
-})
 </script>

--- a/src/renderer/settings/components/ProviderModelList.vue
+++ b/src/renderer/settings/components/ProviderModelList.vue
@@ -277,7 +277,7 @@
     </div>
 
     <div
-      v-if="isLoading"
+      v-if="isLoading || !accessibilityReady"
       class="flex items-center gap-2 rounded-lg border border-dashed border-muted py-4 px-4 text-sm text-muted-foreground"
     >
       <Spinner class="size-4" />
@@ -336,7 +336,7 @@ import AddCustomModelButton from './AddCustomModelButton.vue'
 
 const { t } = useI18n()
 const modelListRoot = ref<HTMLElement | null>(null)
-const { accessibilityEnabled } = useAccessibilitySupport()
+const { accessibilityEnabled, accessibilityReady } = useAccessibilitySupport()
 const [DefineModelRow, ReuseModelRow] = createReusableTemplate<{ item: VirtualModelListItem }>()
 const modelSearchQuery = ref('')
 // Same 180ms debounce as before; replace manual ref + watch + useDebounceFn.
@@ -720,22 +720,18 @@ type VirtualModelListItem =
 
 type VirtualModelItem = Extract<VirtualModelListItem, { type: 'model' }>
 
-const getCachedVirtualItem = <TItem extends VirtualModelListItem>(
-  id: string,
-  factory: () => TItem,
-  apply: (item: TItem) => void
-): TItem => {
-  const existing = virtualItemCache.get(id)
-  if (existing) {
-    const typedExisting = existing as TItem
-    apply(typedExisting)
-    return typedExisting
+const getCachedVirtualItem = <TItem extends VirtualModelListItem>(item: TItem): TItem => {
+  const existing = virtualItemCache.get(item.id) as TItem | undefined
+  if (
+    existing &&
+    (Object.keys(item) as (keyof TItem)[]).every((key) => existing[key] === item[key])
+  ) {
+    return existing
   }
 
-  const nextItem = factory()
-  apply(nextItem)
-  virtualItemCache.set(id, nextItem)
-  return nextItem
+  // Changed rows need a new prop identity, including when the source model is mutated in place.
+  virtualItemCache.set(item.id, item)
+  return item
 }
 
 const syncVirtualItemCache = (activeIds: Set<string>) => {
@@ -747,76 +743,39 @@ const syncVirtualItemCache = (activeIds: Set<string>) => {
 }
 
 const createLabelItem = (label: string) =>
-  getCachedVirtualItem(
-    'label-official',
-    () => ({ id: 'label-official', type: 'label', label, size: LABEL_ITEM_HEIGHT }),
-    (item) => {
-      item.label = label
-      item.size = LABEL_ITEM_HEIGHT
-    }
-  )
+  getCachedVirtualItem({ id: 'label-official', type: 'label', label, size: LABEL_ITEM_HEIGHT })
 
 const createProviderActionsItem = (providerId: string) =>
-  getCachedVirtualItem(
-    `${providerId}-actions`,
-    () => ({
-      id: `${providerId}-actions`,
-      type: 'provider-actions',
-      providerId,
-      size: PROVIDER_ACTIONS_ITEM_HEIGHT
-    }),
-    (item) => {
-      item.providerId = providerId
-      item.size = PROVIDER_ACTIONS_ITEM_HEIGHT
-    }
-  )
+  getCachedVirtualItem({
+    id: `${providerId}-actions`,
+    type: 'provider-actions',
+    providerId,
+    size: PROVIDER_ACTIONS_ITEM_HEIGHT
+  })
 
 const createModelItem = (model: RENDERER_MODEL_META) =>
-  getCachedVirtualItem<VirtualModelItem>(
-    `${model.providerId}-${model.id}`,
-    () => ({
-      id: `${model.providerId}-${model.id}`,
-      type: 'model',
-      size: MODEL_ITEM_HEIGHT,
-      providerId: model.providerId,
-      modelId: model.id,
-      name: model.name,
-      enabled: model.enabled ?? false,
-      vision: model.vision ?? false,
-      functionCall: model.functionCall ?? false,
-      explicitFunctionCall: model.explicitFunctionCall,
-      reasoning: model.reasoning ?? false,
-      enableSearch: model.enableSearch ?? false,
-      typeValue: model.type ?? ModelType.Chat,
-      group: model.group,
-      contextLength: model.contextLength,
-      maxTokens: model.maxTokens,
-      isCustom: model.isCustom ?? false,
-      supportedEndpointTypes: model.supportedEndpointTypes,
-      selectableEndpointTypes: model.selectableEndpointTypes,
-      endpointType: model.endpointType
-    }),
-    (item) => {
-      item.size = MODEL_ITEM_HEIGHT
-      item.providerId = model.providerId
-      item.modelId = model.id
-      item.name = model.name
-      item.enabled = model.enabled ?? false
-      item.vision = model.vision ?? false
-      item.functionCall = model.functionCall ?? false
-      item.explicitFunctionCall = model.explicitFunctionCall
-      item.reasoning = model.reasoning ?? false
-      item.enableSearch = model.enableSearch ?? false
-      item.typeValue = model.type ?? ModelType.Chat
-      item.group = model.group
-      item.contextLength = model.contextLength
-      item.maxTokens = model.maxTokens
-      item.isCustom = model.isCustom ?? false
-      item.supportedEndpointTypes = model.supportedEndpointTypes
-      item.selectableEndpointTypes = model.selectableEndpointTypes
-      item.endpointType = model.endpointType
-    }
-  )
+  getCachedVirtualItem<VirtualModelItem>({
+    id: `${model.providerId}-${model.id}`,
+    type: 'model',
+    size: MODEL_ITEM_HEIGHT,
+    providerId: model.providerId,
+    modelId: model.id,
+    name: model.name,
+    enabled: model.enabled ?? false,
+    vision: model.vision ?? false,
+    functionCall: model.functionCall ?? false,
+    explicitFunctionCall: model.explicitFunctionCall,
+    reasoning: model.reasoning ?? false,
+    enableSearch: model.enableSearch ?? false,
+    typeValue: model.type ?? ModelType.Chat,
+    group: model.group,
+    contextLength: model.contextLength,
+    maxTokens: model.maxTokens,
+    isCustom: model.isCustom ?? false,
+    supportedEndpointTypes: model.supportedEndpointTypes,
+    selectableEndpointTypes: model.selectableEndpointTypes,
+    endpointType: model.endpointType
+  })
 
 const virtualItems = computed<VirtualModelListItem[]>(() => {
   const start = getPerfNow()

--- a/src/renderer/settings/components/ProviderModelList.vue
+++ b/src/renderer/settings/components/ProviderModelList.vue
@@ -348,9 +348,10 @@ const MODEL_ITEM_HEIGHT = 48
 const PROVIDER_ACTIONS_ITEM_HEIGHT = 56
 const modelNameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })
 const MODEL_TOGGLE_PERF_LOG_PREFIX = '[ModelTogglePerf]'
-const getPerfNow = () => (typeof performance !== 'undefined' ? performance.now() : Date.now())
+const getPerfNow = () =>
+  import.meta.env.DEV ? (typeof performance !== 'undefined' ? performance.now() : Date.now()) : 0
 const logModelTogglePerf = (phase: string, details: Record<string, unknown>) => {
-  if (!uiSettingsStore.traceDebugEnabled) {
+  if (!import.meta.env.DEV || !uiSettingsStore.traceDebugEnabled) {
     return
   }
 

--- a/src/renderer/src/composables/useAccessibilitySupport.ts
+++ b/src/renderer/src/composables/useAccessibilitySupport.ts
@@ -5,12 +5,14 @@ import { createDeviceClient } from '@api/DeviceClient'
 // Share one native subscription across the transcript, Markdown, and editor consumers.
 export const useAccessibilitySupport = createSharedComposable(() => {
   const accessibilityEnabled = ref(true)
+  const accessibilityReady = ref(false)
   const deviceClient = createDeviceClient()
   let disposed = false
   let receivedUpdate = false
   const unsubscribe = deviceClient.onAccessibilityChanged((enabled) => {
     receivedUpdate = true
     accessibilityEnabled.value = enabled
+    accessibilityReady.value = true
   })
 
   void deviceClient
@@ -23,11 +25,17 @@ export const useAccessibilitySupport = createSharedComposable(() => {
     .catch((error) => {
       console.warn('[Accessibility] Could not read native support status', error)
     })
+    .finally(() => {
+      if (!disposed) accessibilityReady.value = true
+    })
 
   onScopeDispose(() => {
     disposed = true
     unsubscribe()
   })
 
-  return { accessibilityEnabled: readonly(accessibilityEnabled) }
+  return {
+    accessibilityEnabled: readonly(accessibilityEnabled),
+    accessibilityReady: readonly(accessibilityReady)
+  }
 })

--- a/src/renderer/src/stores/modelStore.ts
+++ b/src/renderer/src/stores/modelStore.ts
@@ -90,9 +90,10 @@ export const useModelStore = defineStore('model', () => {
   )
 
   const MODEL_TOGGLE_PERF_LOG_PREFIX = '[ModelTogglePerf]'
-  const getPerfNow = () => (typeof performance !== 'undefined' ? performance.now() : Date.now())
+  const getPerfNow = () =>
+    import.meta.env.DEV ? (typeof performance !== 'undefined' ? performance.now() : Date.now()) : 0
   const logModelTogglePerf = (phase: string, details: Record<string, unknown>) => {
-    if (!uiSettingsStore.traceDebugEnabled) {
+    if (!import.meta.env.DEV || !uiSettingsStore.traceDebugEnabled) {
       return
     }
 

--- a/src/renderer/src/stores/modelStore.ts
+++ b/src/renderer/src/stores/modelStore.ts
@@ -376,9 +376,24 @@ export const useModelStore = defineStore('model', () => {
     })
   }
 
+  const getUserConfiguredModelIds = async (providerId: string) => {
+    try {
+      const providerIds = [...new Set([providerId, providerId.toLowerCase()])]
+      const configs = await Promise.all(
+        providerIds.map((id) => modelClient.getProviderModelConfigs(id))
+      )
+      return new Set(configs.flat().map(({ modelId }) => modelId))
+    } catch (error) {
+      console.error(`Failed to read model config index for ${providerId}:`, error)
+      // Keep the individual lookup path if the index cannot be loaded.
+      return undefined
+    }
+  }
+
   const applyUserDefinedModelConfig = async (
     model: RENDERER_MODEL_META,
-    providerId: string
+    providerId: string,
+    userConfiguredModelIds?: Set<string>
   ): Promise<RENDERER_MODEL_META> => {
     const normalized: RENDERER_MODEL_META = {
       ...model,
@@ -387,6 +402,14 @@ export const useModelStore = defineStore('model', () => {
       reasoning: model.reasoning ?? false,
       enableSearch: model.enableSearch ?? false,
       type: model.type ?? ModelType.Chat
+    }
+
+    if (
+      userConfiguredModelIds &&
+      !userConfiguredModelIds.has(model.id) &&
+      !userConfiguredModelIds.has(model.id.toLowerCase().replace(/^models\//, ''))
+    ) {
+      return normalized
     }
 
     try {
@@ -612,7 +635,10 @@ export const useModelStore = defineStore('model', () => {
       }
 
       const modelIds = customModelsList.map((model) => model.id)
-      const modelStatusMap = await modelClient.getBatchModelStatus(providerId, modelIds)
+      const [modelStatusMap, userConfiguredModelIds] = await Promise.all([
+        modelClient.getBatchModelStatus(providerId, modelIds),
+        getUserConfiguredModelIds(providerId)
+      ])
 
       const customModelsWithStatus = await Promise.all(
         customModelsList.map(async (model) => {
@@ -621,7 +647,7 @@ export const useModelStore = defineStore('model', () => {
             enabled: modelStatusMap[model.id] ?? true,
             isCustom: true
           }
-          return applyUserDefinedModelConfig(base, providerId)
+          return applyUserDefinedModelConfig(base, providerId, userConfiguredModelIds)
         })
       )
 
@@ -785,7 +811,10 @@ export const useModelStore = defineStore('model', () => {
       }
 
       const modelIds = models.map((model) => model.id)
-      const modelStatusMap = await modelClient.getBatchModelStatus(providerId, modelIds)
+      const [modelStatusMap, userConfiguredModelIds] = await Promise.all([
+        modelClient.getBatchModelStatus(providerId, modelIds),
+        getUserConfiguredModelIds(providerId)
+      ])
 
       const modelsWithStatus = await Promise.all(
         models.map(async (model) => {
@@ -794,7 +823,7 @@ export const useModelStore = defineStore('model', () => {
             enabled: modelStatusMap[model.id] ?? true,
             isCustom: model.isCustom || false
           }
-          return applyUserDefinedModelConfig(base, providerId)
+          return applyUserDefinedModelConfig(base, providerId, userConfiguredModelIds)
         })
       )
 

--- a/test/renderer/components/ProviderApiConfig.test.ts
+++ b/test/renderer/components/ProviderApiConfig.test.ts
@@ -189,6 +189,57 @@ describe('ProviderApiConfig', () => {
     vi.clearAllMocks()
   })
 
+  it('shows key status errors, redacts the key, and clears them after a credential update', async () => {
+    const { wrapper, providerClient } = await setup({ provider: createProvider({ apiKey: '' }) })
+    providerClient.getKeyStatus.mockRejectedValueOnce(
+      new Error(
+        "Error invoking remote method 'deepchat:route:invoke': Error: DeepSeek API key check failed: 401 - invalid secret-key"
+      )
+    )
+    await wrapper.setProps({ provider: createProvider({ apiKey: 'secret-key' }) })
+    await flushPromises()
+    const error = wrapper.get('[data-testid="provider-key-status-error"]')
+    expect(error.attributes('role')).toBe('alert')
+    expect(error.text()).toContain('401')
+    expect(error.text()).not.toContain('secret-key')
+    expect(error.text()).not.toContain('deepchat:route:invoke')
+
+    providerClient.getKeyStatus.mockResolvedValueOnce({ usage: '$1' })
+    await wrapper.setProps({ provider: createProvider({ apiKey: 'replacement-key' }) })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="provider-key-status-error"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('$1')
+  })
+
+  it('ignores late key status responses after switching credentials or providers', async () => {
+    const { wrapper, providerClient } = await setup({ provider: createProvider({ apiKey: '' }) })
+    let rejectOld!: (error: Error) => void
+    providerClient.getKeyStatus.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectOld = reject
+        })
+    )
+    await wrapper.setProps({ provider: createProvider({ apiKey: 'old-key' }) })
+    await wrapper.setProps({ provider: createProvider({ id: 'openai', apiKey: 'other-key' }) })
+    rejectOld(new Error('401 old key failed'))
+    await flushPromises()
+    expect(wrapper.find('[data-testid="provider-key-status-error"]').exists()).toBe(false)
+
+    let resolveOld!: (status: { usage: string }) => void
+    providerClient.getKeyStatus.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOld = resolve
+        })
+    )
+    await wrapper.setProps({ provider: createProvider({ apiKey: 'old-key' }) })
+    await wrapper.setProps({ provider: createProvider({ apiKey: '' }) })
+    resolveOld({ usage: '$999' })
+    await flushPromises()
+    expect(wrapper.text()).not.toContain('$999')
+  })
+
   it('shows a locked Base URL display for built-in providers outside the allowlist', async () => {
     const { wrapper, providerClient } = await setup()
 

--- a/test/renderer/components/ProviderModelList.test.ts
+++ b/test/renderer/components/ProviderModelList.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, ref } from 'vue'
+import { defineComponent, reactive, ref } from 'vue'
 import { flushPromises, mount } from '@vue/test-utils'
 import { ModelType } from '../../../src/shared/model'
 
@@ -56,122 +56,199 @@ const ModelConfigItemStub = defineComponent({
     modelName: {
       type: String,
       required: true
-    }
+    },
+    enabled: Boolean
   },
-  template: '<div class="model-item" :data-model-id="modelId">{{ modelName }}</div>'
+  template:
+    '<button class="model-item" :data-model-id="modelId" role="switch" :aria-checked="enabled">{{ modelName }}</button>'
 })
 
 afterEach(() => {
   vi.clearAllMocks()
 })
 
-describe('ProviderModelList', () => {
-  it('filters by capability and type, then switches sorting from status to name', async () => {
-    vi.resetModules()
+async function setup(ready = true) {
+  vi.resetModules()
 
-    const modelStore = {
-      removeCustomModel: vi.fn().mockResolvedValue(undefined),
-      enableAllModels: vi.fn(),
-      disableAllModels: vi.fn()
-    }
+  const modelStore = {
+    removeCustomModel: vi.fn().mockResolvedValue(undefined),
+    enableAllModels: vi.fn(),
+    disableAllModels: vi.fn()
+  }
 
-    vi.doMock('@/stores/modelStore', () => ({
-      useModelStore: () => modelStore
-    }))
-    vi.doMock('@/stores/uiSettingsStore', () => ({
-      useUiSettingsStore: () => ({
-        traceDebugEnabled: false
-      })
-    }))
-    const accessibilityEnabled = ref(false)
-    vi.doMock('@/composables/useAccessibilitySupport', () => ({
-      useAccessibilitySupport: () => ({ accessibilityEnabled })
-    }))
-    vi.doMock('@vueuse/core', async (importOriginal) => ({
-      ...(await importOriginal<typeof import('@vueuse/core')>()),
-      refDebounced: (source: unknown) => source,
-      useDebounceFn: (fn: (...args: unknown[]) => unknown) => fn,
-      useElementSize: () => ({ height: ref(48) })
-    }))
-    vi.doMock('vue-i18n', () => ({
-      useI18n: () => ({
-        t: (key: string, params?: Record<string, number | string>) => {
-          if (key === 'model.filter.visibleCount') {
-            return `visible:${params?.visible}/${params?.total}`
-          }
-          return key
+  vi.doMock('@/stores/modelStore', () => ({
+    useModelStore: () => modelStore
+  }))
+  vi.doMock('@/stores/uiSettingsStore', () => ({
+    useUiSettingsStore: () => ({
+      traceDebugEnabled: false
+    })
+  }))
+  const accessibilityEnabled = ref(false)
+  const accessibilityReady = ref(ready)
+  vi.doMock('@/composables/useAccessibilitySupport', () => ({
+    useAccessibilitySupport: () => ({ accessibilityEnabled, accessibilityReady })
+  }))
+  vi.doMock('@vueuse/core', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@vueuse/core')>()),
+    refDebounced: (source: unknown) => source,
+    useDebounceFn: (fn: (...args: unknown[]) => unknown) => fn,
+    useElementSize: () => ({ height: ref(48) })
+  }))
+  vi.doMock('vue-i18n', () => ({
+    useI18n: () => ({
+      t: (key: string, params?: Record<string, number | string>) => {
+        if (key === 'model.filter.visibleCount') {
+          return `visible:${params?.visible}/${params?.total}`
         }
-      })
-    }))
-
-    const ProviderModelList = (
-      await import('../../../src/renderer/settings/components/ProviderModelList.vue')
-    ).default
-
-    const wrapper = mount(ProviderModelList, {
-      props: {
-        providerModels: [
-          {
-            providerId: 'anthropic',
-            models: [
-              {
-                id: 'zeta-vision',
-                name: 'Zeta Vision',
-                group: 'default',
-                providerId: 'anthropic',
-                enabled: true,
-                vision: true,
-                type: ModelType.Chat
-              },
-              {
-                id: 'alpha-vision',
-                name: 'Alpha Vision',
-                group: 'default',
-                providerId: 'anthropic',
-                enabled: false,
-                vision: true,
-                type: ModelType.Chat
-              },
-              {
-                id: 'beta-embedding',
-                name: 'Beta Embedding',
-                group: 'default',
-                providerId: 'anthropic',
-                enabled: true,
-                type: ModelType.Embedding
-              }
-            ]
-          }
-        ],
-        customModels: [
-          {
-            id: 'custom-reasoner',
-            name: 'Custom Reasoner',
-            group: 'default',
-            providerId: 'anthropic',
-            enabled: true,
-            reasoning: true,
-            type: ModelType.Chat,
-            isCustom: true
-          }
-        ],
-        providers: [{ id: 'anthropic', name: 'Anthropic' }],
-        isLoading: false
-      },
-      global: {
-        stubs: {
-          Input: InputStub,
-          DcButton: ButtonStub,
-          Badge: passthrough('Badge'),
-          Popover: passthrough('Popover'),
-          PopoverContent: passthrough('PopoverContent'),
-          PopoverTrigger: passthrough('PopoverTrigger'),
-          RecycleScroller: RecycleScrollerStub,
-          AddCustomModelButton: passthrough('AddCustomModelButton'),
-          ModelConfigItem: ModelConfigItemStub,
-          Icon: true
-        }
+        return key
       }
+    })
+  }))
+
+  const ProviderModelList = (
+    await import('../../../src/renderer/settings/components/ProviderModelList.vue')
+  ).default
+
+  const providerModels = reactive([
+    {
+      providerId: 'anthropic',
+      models: [
+        {
+          id: 'zeta-vision',
+          name: 'Zeta Vision',
+          group: 'default',
+          providerId: 'anthropic',
+          enabled: true,
+          vision: true,
+          type: ModelType.Chat
+        },
+        {
+          id: 'alpha-vision',
+          name: 'Alpha Vision',
+          group: 'default',
+          providerId: 'anthropic',
+          enabled: false,
+          vision: true,
+          type: ModelType.Chat
+        }
+      ]
+    }
+  ])
+  const wrapper = mount(ProviderModelList, {
+    props: {
+      providerModels,
+      customModels: [],
+      providers: [{ id: 'anthropic', name: 'Anthropic' }],
+      isLoading: false
+    },
+    global: {
+      stubs: {
+        Input: InputStub,
+        DcButton: ButtonStub,
+        Badge: passthrough('Badge'),
+        Popover: passthrough('Popover'),
+        PopoverContent: passthrough('PopoverContent'),
+        PopoverTrigger: passthrough('PopoverTrigger'),
+        RecycleScroller: RecycleScrollerStub,
+        AddCustomModelButton: passthrough('AddCustomModelButton'),
+        ModelConfigItem: ModelConfigItemStub,
+        Icon: true
+      }
+    }
+  })
+  await flushPromises()
+  return { wrapper, providerModels, accessibilityEnabled, accessibilityReady }
+}
+
+describe('ProviderModelList', () => {
+  it('waits for native accessibility status before mounting model rows', async () => {
+    const { wrapper, accessibilityEnabled, accessibilityReady } = await setup(false)
+    accessibilityEnabled.value = true
+    await flushPromises()
+    expect(wrapper.findAll('[data-model-id]')).toHaveLength(0)
+    accessibilityEnabled.value = false
+    accessibilityReady.value = true
+    await flushPromises()
+    expect(wrapper.findAll('[data-model-id]')).toHaveLength(2)
+    expect(wrapper.find('[data-testid="accessible-model-list"]').exists()).toBe(false)
+  })
+
+  it.each([false, true])(
+    'updates visible switches in place (accessibility: %s)',
+    async (accessible) => {
+      const { wrapper, providerModels, accessibilityEnabled } = await setup()
+      accessibilityEnabled.value = accessible
+      await flushPromises()
+      const first = () => wrapper.get('[data-model-id="zeta-vision"]')
+      const second = () => wrapper.get('[data-model-id="alpha-vision"]')
+      expect(first().attributes('aria-checked')).toBe('true')
+      providerModels[0].models[0].enabled = false
+      await flushPromises()
+      expect(first().attributes('aria-checked')).toBe('false')
+      // A failed persistence write rolls the same model back without remounting the list.
+      providerModels[0].models[0].enabled = true
+      providerModels[0].models[1].enabled = true
+      await flushPromises()
+      expect(first().attributes('aria-checked')).toBe('true')
+      expect(second().attributes('aria-checked')).toBe('true')
+      for (const model of providerModels[0].models) model.enabled = false
+      await flushPromises()
+      expect(first().attributes('aria-checked')).toBe('false')
+      expect(second().attributes('aria-checked')).toBe('false')
+    }
+  )
+
+  it('filters by capability and type, then switches sorting from status to name', async () => {
+    const { wrapper, accessibilityEnabled } = await setup()
+    await wrapper.setProps({
+      providerModels: [
+        {
+          providerId: 'anthropic',
+          models: [
+            {
+              id: 'zeta-vision',
+              name: 'Zeta Vision',
+              group: 'default',
+              providerId: 'anthropic',
+              enabled: true,
+              vision: true,
+              type: ModelType.Chat
+            },
+            {
+              id: 'alpha-vision',
+              name: 'Alpha Vision',
+              group: 'default',
+              providerId: 'anthropic',
+              enabled: false,
+              vision: true,
+              type: ModelType.Chat
+            },
+            {
+              id: 'beta-embedding',
+              name: 'Beta Embedding',
+              group: 'default',
+              providerId: 'anthropic',
+              enabled: true,
+              type: ModelType.Embedding
+            }
+          ]
+        }
+      ],
+      customModels: [
+        {
+          id: 'custom-reasoner',
+          name: 'Custom Reasoner',
+          group: 'default',
+          providerId: 'anthropic',
+          enabled: true,
+          reasoning: true,
+          type: ModelType.Chat,
+          isCustom: true
+        }
+      ],
+      providers: [{ id: 'anthropic', name: 'Anthropic' }],
+      isLoading: false
     })
 
     await flushPromises()

--- a/test/renderer/composables/useAccessibilitySupport.test.ts
+++ b/test/renderer/composables/useAccessibilitySupport.test.ts
@@ -24,7 +24,9 @@ describe('native accessibility support', () => {
       const firstSupport = first.run(() => useAccessibilitySupport())!
       const secondSupport = second.run(() => useAccessibilitySupport())!
       expect(on).toHaveBeenCalledOnce()
+      expect(firstSupport.accessibilityReady.value).toBe(false)
       publish({ enabled: true })
+      expect(firstSupport.accessibilityReady.value).toBe(true)
       resolveSnapshot({ info: { accessibilitySupportEnabled: false } })
       await flushPromises()
       expect(firstSupport.accessibilityEnabled.value).toBe(true)
@@ -41,4 +43,27 @@ describe('native accessibility support', () => {
       window.deepchat = originalBridge
     }
   })
+  it.each([false, true])(
+    'settles readiness after the native lookup (failed: %s)',
+    async (failed) => {
+      const originalBridge = window.deepchat
+      window.deepchat = {
+        invoke: failed
+          ? vi.fn().mockRejectedValue(new Error('device unavailable'))
+          : vi.fn().mockResolvedValue({ info: { accessibilitySupportEnabled: false } }),
+        on: vi.fn(() => vi.fn())
+      } as unknown as DeepchatBridge
+      const scope = effectScope()
+      try {
+        const support = scope.run(() => useAccessibilitySupport())!
+        expect(support.accessibilityReady.value).toBe(false)
+        await flushPromises()
+        expect(support.accessibilityReady.value).toBe(true)
+        expect(support.accessibilityEnabled.value).toBe(failed)
+      } finally {
+        scope.stop()
+        window.deepchat = originalBridge
+      }
+    }
+  )
 })

--- a/test/renderer/stores/modelStore.test.ts
+++ b/test/renderer/stores/modelStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { reactive, ref } from 'vue'
+import type { ModelConfig } from '../../../src/shared/types/provider'
 import { ModelType } from '../../../src/shared/model'
 
 const createQueryCache = () => {
@@ -33,7 +34,7 @@ const setupStore = async (overrides?: {
     refreshAgentModels: vi.fn()
   }
   const modelConfigStore = {
-    getModelConfig: vi.fn(async () => null)
+    getModelConfig: vi.fn(async (): Promise<ModelConfig | null> => null)
   }
   const modelClient = {
     getDbProviderModels: vi.fn(async () => []),
@@ -41,6 +42,7 @@ const setupStore = async (overrides?: {
     getCustomModels: vi.fn(async () => []),
     getBatchModelStatus: vi.fn(async () => ({})),
     getModelList: vi.fn(async () => []),
+    getProviderModelConfigs: vi.fn(async () => []),
     updateModelStatus: vi.fn(async () => undefined),
     addCustomModel: vi.fn(async () => undefined),
     removeCustomModel: vi.fn(async () => true),
@@ -106,6 +108,7 @@ const setupStore = async (overrides?: {
   return {
     store,
     agentModelStore,
+    modelConfigStore,
     modelClient,
     providerStore
   }
@@ -126,6 +129,54 @@ const flushMicrotasks = async (times: number = 6) => {
 }
 
 describe('modelStore.refreshProviderModels', () => {
+  it('loads a large catalog without per-model config requests and preserves user overrides', async () => {
+    const models = Array.from({ length: 500 }, (_, index) => ({
+      id: `model-${index}`,
+      name: `Model ${index}`,
+      providerId: 'openai',
+      group: 'default'
+    }))
+    const { store, modelClient, modelConfigStore } = await setupStore({
+      modelClient: {
+        getDbProviderModels: vi.fn(async () => models),
+        getProviderModelConfigs: vi.fn(async () => [
+          { modelId: 'model-1', config: { vision: true } }
+        ])
+      }
+    })
+    modelConfigStore.getModelConfig.mockResolvedValue({
+      isUserDefined: true,
+      vision: true,
+      functionCall: true,
+      reasoning: false,
+      maxTokens: 4096,
+      contextLength: 32000,
+      type: ModelType.Chat
+    })
+
+    await store.ensureProviderModelsReady('openai')
+    expect(store.allProviderModels.value[0].models).toHaveLength(500)
+    expect(
+      store.allProviderModels.value[0].models.find((model) => model.id === 'model-1')?.vision
+    ).toBe(true)
+    expect(modelConfigStore.getModelConfig).toHaveBeenCalledExactlyOnceWith('model-1', 'openai')
+    expect(modelClient.getProviderModelConfigs).toHaveBeenCalledTimes(1)
+    await store.ensureProviderModelsReady('openai')
+    expect(modelClient.getProviderModelConfigs).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves individual config lookup when the bulk index fails', async () => {
+    const { store, modelConfigStore } = await setupStore({
+      modelClient: {
+        getDbProviderModels: vi.fn(async () => [{ id: 'model-1', providerId: 'openai' }]),
+        getProviderModelConfigs: vi.fn().mockRejectedValue(new Error('index unavailable'))
+      }
+    })
+    await store.ensureProviderModelsReady('openai')
+    expect(modelConfigStore.getModelConfig).toHaveBeenCalledExactlyOnceWith('model-1', 'openai')
+    expect(store.allProviderModels.value[0].models).toHaveLength(1)
+  })
+
   it('registers typed model listeners without legacy provider-db subscriptions', async () => {
     const { store, modelClient } = await setupStore()
 


### PR DESCRIPTION
Provider settings can stall when switching providers, retain stale model switches after a successful update, and hide API key status failures such as DeepSeek 401 responses.

- Wait for native accessibility status before mounting model rows, avoiding a full catalog render followed by virtualization. Keep the full accessible list when required and retain the accessible fallback if the native lookup fails.
- Replace changed virtual row snapshots so model status updates and rollback reach the visible switches immediately.
- Read the provider configuration index before requesting individual model configurations, retaining user overrides and falling back to individual reads if the index fails.
- Show key status errors below the API key, redact the stored key, reload when credentials change, and ignore stale responses after navigation or credential replacement.

- Restrict provider initialization and model-toggle diagnostics to development builds. Performance tracing also requires the existing trace setting; production builds skip the timing and paint-wait probes.

### UI

```text
BEFORE                            AFTER
API Key [********9b2a]             API Key [********9b2a]
                                  ! 401: API key invalid

Model A [ON] --click--> [ON]       Model A [ON] --click--> [OFF]
  Refreshes after switching          Updates immediately;
  away and back                     rolls back on save failure
```

### Validation

- 76 tests pass across provider components, model store, and native accessibility support.
- Format, i18n, lint, and Node/renderer typechecks pass. The 36 tests covering the logging change also pass.
- Production Electron/Vite build passes; emitted renderer JavaScript contains no model-toggle or provider-initialization diagnostic markers.
- Four new model-switch/key-error regression cases fail against the original implementation.
- Real Chromium component fixture: mouse and keyboard toggles, virtual scrolling, and key error display checked at two viewport sizes and in light/dark themes.
- In the isolated 500-model browser fixture, provider-switch median decreased from 658 ms to 97 ms across three runs per condition, with 16 rendered rows. This measures component mounting with a simulated native accessibility lookup, rather than end-to-end Electron startup or provider network latency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline, sanitized error messages for provider API key status checks.
  * Added loading feedback while accessibility settings are initializing.
  * Improved model configuration refreshes to preserve user-defined overrides.

* **Bug Fixes**
  * Prevented outdated credential or provider responses from overwriting current status.
  * Improved model list updates and loading behavior when accessibility information is delayed.
  * Preserved model loading when configuration lookups fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
