### PR TITLE
fix(install): download Electron in postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "pnpm run typecheck && electron-vite build && pnpm run cli:build",
     "cli:build": "node scripts/build-cli.mjs",
     "release:ff": "node scripts/release-fast-forward.mjs",
-    "postinstall": "electron-builder install-app-deps",
+    "postinstall": "install-electron && electron-builder install-app-deps",
     "hooks:install": "git config core.hooksPath .githooks",
     "build:unpack": "pnpm run build && electron-builder --dir",
     "plugin:validate": "node scripts/plugin.mjs validate",


### PR DESCRIPTION
Fresh clones can fail on `pnpm run dev` with `Error: Electron uninstall`: Electron 43 no longer downloads its binary during dependency installation, while electron-vite 5 reads `electron/path.txt` directly and bypasses Electron's lazy downloader.

Run Electron's bundled `install-electron` command in the project `postinstall`, before the existing `electron-builder install-app-deps`. A normal `pnpm install` now prepares the executable and its path file; repeated installs reuse the existing binary.

Validation:
- Verified an isolated Electron 43.6.0 package initially had neither `path.txt` nor `dist`; a frozen pnpm install running the new installer command created both, and `electron --version` returned `v43.6.0`.
- Ran the full project `pnpm run postinstall`, including native dependency rebuilds.
- Passed format, i18n, lint, and Node/renderer typechecks.
- Passed 28 tests in the pnpm installation workflow and package contract suites.

Reference: [Electron binary installation](https://www.electronjs.org/docs/latest/tutorial/installation#binary-download-step).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved application setup reliability by ensuring required desktop components are available before native dependencies are installed.
  - This helps streamline installation and reduce setup-related failures during project initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->