### PR TITLE
feat: add optional You.com search integration

### DIFF
--- a/src/main/mcp/settings.ts
+++ b/src/main/mcp/settings.ts
@@ -281,6 +281,17 @@ const DEFAULT_MCP_SERVERS = {
       customHeaders: {
         Authorization: 'Bearer YOUR_MCP_TOKEN'
       }
+    },
+    'youcom-search': {
+      command: '',
+      args: [],
+      env: {},
+      descriptions:
+        'You.com web search MCP (keyless free profile, no API key required). For the full authenticated tools, replace the URL with https://api.you.com/mcp and set an Authorization: Bearer header with a key from https://you.com/platform/api-keys.',
+      icons: '🌐',
+      disable: false,
+      type: 'http' as MCPServerType,
+      baseUrl: 'https://api.you.com/mcp?profile=free'
     }
   } satisfies Record<string, Omit<MCPServerConfig, 'enabled'>>,
   mcpEnabled: false // MCP functionality is disabled by default

--- a/test/main/mcp/settings.test.ts
+++ b/test/main/mcp/settings.test.ts
@@ -153,6 +153,22 @@ describe('McpSettings', () => {
     })
   })
 
+  it('adds the disabled You.com search MCP server (keyless free profile) for existing users', async () => {
+    const { McpSettings } = await loadHelper('darwin')
+    const helper = new McpSettings()
+    const mcpStore = (helper as any).mcpStore
+
+    mcpStore.set('mcpServers', {})
+
+    const servers = await helper.getMcpServers()
+
+    expect(servers['youcom-search']).toMatchObject({
+      type: 'http',
+      baseUrl: 'https://api.you.com/mcp?profile=free',
+      enabled: false
+    })
+  })
+
   it('does not recreate the Apple built-in server after the user removed it', async () => {
     const { McpSettings } = await loadHelper('darwin')
     const helper = new McpSettings()


### PR DESCRIPTION
## Summary

- add the You.com web search MCP (`https://api.you.com/mcp?profile=free`) as a **disabled-by-default** built-in HTTP server in `DEFAULT_MCP_SERVERS`, following the same shape as the `mcd-mcp` entry from #2071
- the free profile endpoint is keyless, so the server works as soon as a user enables it in MCP settings — no token placeholder needed
- the entry description documents how to switch to the authenticated endpoint (`https://api.you.com/mcp` + `Authorization: Bearer` header) for the full tool set
- add a regression test in `test/main/mcp/settings.test.ts` mirroring the `mcd-mcp` test, asserting the entry is present and `enabled: false` for existing users

## Why

DeepChat already ships built-in remote MCP servers (`nowledge-mem`, `mcd-mcp`), so a web-search entry fits the existing catalog. The You.com free-profile MCP exposes a `you-search` tool (ranked results with URLs and snippets) plus `you-contents` (page content extraction), which complements the in-memory Bocha/Brave search servers for users who don't have those API keys. I kept this fully opt-in: the entry is not in `DEFAULT_ENABLED_SERVER_NAMES`, so nothing changes for existing users until they enable it.

## Validation

- `npx vitest run test/main/mcp/settings.test.ts` — 9/9 pass (8 existing + new)
- `pnpm run typecheck` (node + web) — clean
- `npx oxlint src/main/mcp/settings.ts test/main/mcp/settings.test.ts` — 0 warnings, 0 errors
- live endpoint check: `initialize` + `tools/list` against `https://api.you.com/mcp?profile=free` over Streamable HTTP returns the `you-search` tool

No UI screenshots since the entry only appears in the existing MCP settings list (same rendering path as `mcd-mcp`) — happy to attach a settings-page screenshot if useful.

Happy to adjust the entry name, icon, or description wording if you'd prefer something else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the You.com search MCP server using its free, keyless profile by default.
  - Advanced authenticated tools can be enabled by configuring a custom endpoint and authorization header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->