### PR TITLE
feat(mcp): add Serply search server

### DIFF
--- a/src/main/mcp/settings.ts
+++ b/src/main/mcp/settings.ts
@@ -292,6 +292,20 @@ const DEFAULT_MCP_SERVERS = {
       disable: false,
       type: 'http' as MCPServerType,
       baseUrl: 'https://api.you.com/mcp?profile=free'
+    },
+    'serply-search': {
+      command: '',
+      args: [],
+      env: {},
+      descriptions:
+        'Serply web search MCP (Google, Bing, News, Scholar, Jobs, Maps, Videos, Amazon Shopping, and page scraping). Requires an API key from https://serply.io, set in the X-Api-Key header. Tool reference: https://serply.io/docs.',
+      icons: '🔍',
+      disable: false,
+      type: 'http' as MCPServerType,
+      baseUrl: 'https://api.serply.io/mcp',
+      customHeaders: {
+        'X-Api-Key': 'YOUR_SERPLY_API_KEY'
+      }
     }
   } satisfies Record<string, Omit<MCPServerConfig, 'enabled'>>,
   mcpEnabled: false // MCP functionality is disabled by default

--- a/test/main/mcp/settings.test.ts
+++ b/test/main/mcp/settings.test.ts
@@ -169,6 +169,25 @@ describe('McpSettings', () => {
     })
   })
 
+  it('adds the disabled Serply search MCP server with a key placeholder for existing users', async () => {
+    const { McpSettings } = await loadHelper('darwin')
+    const helper = new McpSettings()
+    const mcpStore = (helper as any).mcpStore
+
+    mcpStore.set('mcpServers', {})
+
+    const servers = await helper.getMcpServers()
+
+    expect(servers['serply-search']).toMatchObject({
+      type: 'http',
+      baseUrl: 'https://api.serply.io/mcp',
+      customHeaders: {
+        'X-Api-Key': 'YOUR_SERPLY_API_KEY'
+      },
+      enabled: false
+    })
+  })
+
   it('does not recreate the Apple built-in server after the user removed it', async () => {
     const { McpSettings } = await loadHelper('darwin')
     const helper = new McpSettings()


### PR DESCRIPTION
Disclosure: I work with Serply (https://serply.io), the provider added by this PR.

## Summary

Adds `serply-search` to `DEFAULT_MCP_SERVERS` as a disabled-by-default built-in HTTP
MCP server, so users can paste an API key and switch it on instead of hand-writing a
server config.

Serply is a hosted SERP API. One endpoint exposes nine tools: Google, Bing, News,
Scholar, Jobs, Maps and Video search, Amazon Shopping search, and page scraping.

The entry follows the existing `mcd-mcp` shape for a keyed third-party HTTP server:
`type: 'http'`, a `baseUrl`, and a `customHeaders` placeholder the user replaces.
It is not in `DEFAULT_ENABLED_SERVER_NAMES`, so it ships listed but off, exactly like
the You.com and McDonald's entries.

Two files, 33 added lines, no dependencies, no changes to existing entries.

## Testing

Quality gates, all clean on this branch:

```
pnpm run format:check   All matched files use the correct format (3003 files)
pnpm run lint           agent-cleanup guard, alert-dialog guard, oxlint: exit 0
pnpm run typecheck      typecheck:node exit 0, typecheck:web exit 0
pnpm run test:main      642 files passed, 9064 tests passed, 0 failed
```

The new Vitest case in `test/main/mcp/settings.test.ts` mirrors the McDonald's and
You.com cases: it asserts an existing user with an empty `mcpServers` store picks up
the entry on upgrade with `enabled: false` and the header placeholder intact.

I also connected to the endpoint with the same client and transport this app uses,
`Client` plus `StreamableHTTPClientTransport` with `requestInit.headers`, reading the
URL and header straight out of the new catalog entry:

```
entry baseUrl      : https://api.serply.io/mcp
entry header name  : X-Api-Key
entry placeholder  : YOUR_SERPLY_API_KEY
server             : {"name":"serply-mcp-server","version":"1.29.0"}
tools              : 9 -> google_search, google_maps_search, bing_search,
                     google_video_search, google_news_search, google_jobs_search,
                     google_scholar_search, amazon_product_search, scrape_url
google_search      : ok, 788 chars

3 results for "electron mcp client"

1. laststance/electron-mcp-server - GitHub
   https://github.com/laststance/electron-mcp-server
   A powerful Model Context Protocol (MCP) server that provides comprehensive
   Electron application automation, debugging, and observability capabilities.
```

Behaviour worth knowing before merge, measured against the live endpoint:

- With no `X-Api-Key` header the connection is refused with HTTP 401 and a message
  telling the user to supply a Serply API key.
- With the placeholder left unchanged, `initialize` and `tools/list` succeed and the
  first tool call returns `isError: true` with `{"detail":"Invalid API key"}`. So a
  user who enables the server before pasting a key gets a clear error naming the
  cause rather than a silent failure.

No renderer strings were added, so `pnpm run i18n` was not needed. Docs for the tools
are at https://serply.io/docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Serply Search MCP server to the default server configuration.
  - Configured the server with its API endpoint and API key placeholder.

- **Compatibility**
  - Existing users receive the Serply Search server in a disabled state, allowing activation after providing a valid API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->